### PR TITLE
Convert AtomFeatureIntegrationBenchmark level to prefab.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Benchmark_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Benchmark_GPU.py
@@ -52,7 +52,7 @@ class TestPerformanceBenchmarkSuite(object):
             halt_on_unexpected=True,
             cfg_args=[level],
             null_renderer=False,
-            enable_prefab_system=False,
+            enable_prefab_system=True,
         )
 
         aggregator = BenchmarkDataAggregator(workspace, logger, 'periodic')

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Benchmark_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Benchmark_GPU.py
@@ -52,7 +52,6 @@ class TestPerformanceBenchmarkSuite(object):
             halt_on_unexpected=True,
             cfg_args=[level],
             null_renderer=False,
-            enable_prefab_system=True,
         )
 
         aggregator = BenchmarkDataAggregator(workspace, logger, 'periodic')

--- a/AutomatedTesting/Levels/AtomFeatureIntegrationBenchmark/AtomFeatureIntegrationBenchmark.ly
+++ b/AutomatedTesting/Levels/AtomFeatureIntegrationBenchmark/AtomFeatureIntegrationBenchmark.ly
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5232563c3ff322669808ac4daeda3d822e4ef8c9c87db0fa245f0f9c9c34aada
-size 23379

--- a/AutomatedTesting/Levels/AtomFeatureIntegrationBenchmark/AtomFeatureIntegrationBenchmark.prefab
+++ b/AutomatedTesting/Levels/AtomFeatureIntegrationBenchmark/AtomFeatureIntegrationBenchmark.prefab
@@ -1,0 +1,8281 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "AtomFeatureIntegrationBenchmark",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[1564590643049]": {
+            "Id": "Entity_[1564590643049]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            5.964076042175293,
+                            -1.6033048629760742,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[1568885610345]": {
+            "Id": "Entity_[1568885610345]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            3.964076042175293,
+                            -1.6033048629760742,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[1573180577641]": {
+            "Id": "Entity_[1573180577641]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            1.964076042175293,
+                            -1.6033048629760742,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[1577475544937]": {
+            "Id": "Entity_[1577475544937]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            7.964076042175293,
+                            -1.6033048629760742,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[1581770512233]": {
+            "Id": "Entity_[1581770512233]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -2.0572211742401123,
+                            -1.6895170211791992,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[1586065479529]": {
+            "Id": "Entity_[1586065479529]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -4.057221412658691,
+                            -1.6895170211791992,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[1590360446825]": {
+            "Id": "Entity_[1590360446825]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -6.057221412658691,
+                            -1.6895170211791992,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[1594655414121]": {
+            "Id": "Entity_[1594655414121]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.057221200317144394,
+                            -1.6895170211791992,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[1616130250601]": {
+            "Id": "Entity_[1616130250601]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -9.93610954284668,
+                            -1.7573094367980957,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[1620425217897]": {
+            "Id": "Entity_[1620425217897]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -8.015495300292969,
+                            -1.7333474159240723,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[392064571241]": {
+            "Id": "Entity_[392064571241]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            2.0,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[396359538537]": {
+            "Id": "Entity_[396359538537]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[422081973788]": {
+            "Id": "Entity_[422081973788]",
+            "Name": "Default Atom Environment",
+            "Components": {
+                "Component_[13303603694346343704]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 13303603694346343704,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.7855145931243896,
+                            -5.15239143371582,
+                            34.0
+                        ]
+                    }
+                },
+                "Component_[14493356997294756208]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14493356997294756208,
+                    "Child Entity Order": [
+                        "Entity_[602517968745]",
+                        "Entity_[589633066857]",
+                        "Entity_[739956922217]",
+                        "Entity_[718482085737]",
+                        "Entity_[619697837929]",
+                        "Entity_[392064571241]",
+                        "Entity_[520913590121]",
+                        "Entity_[748546856809]",
+                        "Entity_[439261842972]",
+                        "Entity_[641172674409]",
+                        "Entity_[757136791401]",
+                        "Entity_[529503524713]",
+                        "Entity_[559568295785]",
+                        "Entity_[787201562473]",
+                        "Entity_[460784047977]",
+                        "Entity_[688417314665]",
+                        "Entity_[1568885610345]",
+                        "Entity_[658352543593]",
+                        "Entity_[778611627881]",
+                        "Entity_[550978361193]",
+                        "Entity_[679827380073]",
+                        "Entity_[1590360446825]",
+                        "Entity_[452194113385]",
+                        "Entity_[808676398953]",
+                        "Entity_[581043132265]",
+                        "Entity_[709892151145]",
+                        "Entity_[611107903337]",
+                        "Entity_[722777053033]",
+                        "Entity_[443556810268]",
+                        "Entity_[645467641705]",
+                        "Entity_[752841824105]",
+                        "Entity_[525208557417]",
+                        "Entity_[1573180577641]",
+                        "Entity_[662647510889]",
+                        "Entity_[782906595177]",
+                        "Entity_[555273328489]",
+                        "Entity_[684122347369]",
+                        "Entity_[456489080681]",
+                        "Entity_[1594655414121]",
+                        "Entity_[812971366249]",
+                        "Entity_[585338099561]",
+                        "Entity_[714187118441]",
+                        "Entity_[516618622825]",
+                        "Entity_[744251889513]",
+                        "Entity_[434966875676]",
+                        "Entity_[636877707113]",
+                        "Entity_[615402870633]",
+                        "Entity_[692712281961]",
+                        "Entity_[465079015273]",
+                        "Entity_[593928034153]",
+                        "Entity_[791496529769]",
+                        "Entity_[563863263081]",
+                        "Entity_[396359538537]",
+                        "Entity_[623992805225]",
+                        "Entity_[731366987625]",
+                        "Entity_[632582739817]",
+                        "Entity_[533798492009]",
+                        "Entity_[761431758697]",
+                        "Entity_[1564590643049]",
+                        "Entity_[654057576297]",
+                        "Entity_[774316660585]",
+                        "Entity_[546683393897]",
+                        "Entity_[576748164969]",
+                        "Entity_[804381431657]",
+                        "Entity_[770021693289]",
+                        "Entity_[542388426601]",
+                        "Entity_[671237445481]",
+                        "Entity_[1581770512233]",
+                        "Entity_[443604178793]",
+                        "Entity_[572453197673]",
+                        "Entity_[800086464361]",
+                        "Entity_[765726725993]",
+                        "Entity_[538093459305]",
+                        "Entity_[666942478185]",
+                        "Entity_[1577475544937]",
+                        "Entity_[439309211497]",
+                        "Entity_[1586065479529]",
+                        "Entity_[675532412777]",
+                        "Entity_[447899146089]",
+                        "Entity_[795791497065]",
+                        "Entity_[568158230377]",
+                        "Entity_[697007249257]",
+                        "Entity_[469373982569]",
+                        "Entity_[598223001449]",
+                        "Entity_[701302216553]",
+                        "Entity_[447851777564]",
+                        "Entity_[649762609001]",
+                        "Entity_[426376941084]",
+                        "Entity_[628287772521]",
+                        "Entity_[727072020329]",
+                        "Entity_[735661954921]",
+                        "Entity_[606812936041]",
+                        "Entity_[705597183849]",
+                        "Entity_[1616130250601]",
+                        "Entity_[1620425217897]"
+                    ]
+                },
+                "Component_[15183124544900222183]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15183124544900222183
+                },
+                "Component_[1647665885974438860]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1647665885974438860,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 13303603694346343704
+                        }
+                    ]
+                },
+                "Component_[17706604357479749488]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17706604357479749488
+                },
+                "Component_[5572332528938280636]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5572332528938280636
+                },
+                "Component_[5888073848030378416]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5888073848030378416
+                },
+                "Component_[5952087034759134145]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5952087034759134145
+                },
+                "Component_[7124769840496726761]": {
+                    "$type": "SelectionComponent",
+                    "Id": 7124769840496726761
+                },
+                "Component_[860335504056945556]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 860335504056945556
+                }
+            }
+        },
+        "Entity_[426376941084]": {
+            "Id": "Entity_[426376941084]",
+            "Name": "Camera",
+            "Components": {
+                "Component_[14162999235291135003]": {
+                    "$type": "{CA11DA46-29FF-4083-B5F6-E02C3A8C3A3D} EditorCameraComponent",
+                    "Id": 14162999235291135003,
+                    "Controller": {
+                        "Configuration": {
+                            "Field of View": 40.0,
+                            "EditorEntityId": 426376941084
+                        }
+                    }
+                },
+                "Component_[15081159578479463882]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15081159578479463882
+                },
+                "Component_[16358579932969588932]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16358579932969588932
+                },
+                "Component_[3449960602874386]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3449960602874386
+                },
+                "Component_[3992492101054640323]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3992492101054640323,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0076545001938939095,
+                            -3.7797365188598633,
+                            1.3762092590332031
+                        ],
+                        "Rotate": [
+                            -10.542465209960938,
+                            -0.020966699346899986,
+                            0.11265590041875839
+                        ],
+                        "Scale": [
+                            0.9999998807907104,
+                            1.0,
+                            1.0
+                        ]
+                    }
+                },
+                "Component_[3999639652332361230]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3999639652332361230,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3992492101054640323
+                        },
+                        {
+                            "ComponentId": 14162999235291135003,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[5346775805231066521]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5346775805231066521
+                },
+                "Component_[5655590898979636444]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5655590898979636444
+                },
+                "Component_[6382904369155550790]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6382904369155550790
+                },
+                "Component_[8571301705060553136]": {
+                    "$type": "SelectionComponent",
+                    "Id": 8571301705060553136
+                },
+                "Component_[9671887534776935819]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9671887534776935819
+                }
+            }
+        },
+        "Entity_[434966875676]": {
+            "Id": "Entity_[434966875676]",
+            "Name": "Grid",
+            "Components": {
+                "Component_[10261913238028760630]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 10261913238028760630
+                },
+                "Component_[12613586836844037441]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12613586836844037441,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9682616939352681902
+                        },
+                        {
+                            "ComponentId": 17200941983250517670,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[13634795112837311064]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13634795112837311064
+                },
+                "Component_[15642253313297976912]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15642253313297976912
+                },
+                "Component_[17200941983250517670]": {
+                    "$type": "AZ::Render::EditorGridComponent",
+                    "Id": 17200941983250517670
+                },
+                "Component_[2586156335281509029]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2586156335281509029
+                },
+                "Component_[3608746250677435201]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3608746250677435201
+                },
+                "Component_[5518065691447587961]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5518065691447587961
+                },
+                "Component_[5904675121834583525]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5904675121834583525
+                },
+                "Component_[8395441168976661179]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 8395441168976661179
+                },
+                "Component_[9682616939352681902]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9682616939352681902,
+                    "Parent Entity": "Entity_[422081973788]"
+                }
+            }
+        },
+        "Entity_[439261842972]": {
+            "Id": "Entity_[439261842972]",
+            "Name": "GlobalSky",
+            "Components": {
+                "Component_[10332660484145119873]": {
+                    "$type": "AZ::Render::EditorHDRiSkyboxComponent",
+                    "Id": 10332660484145119873,
+                    "Controller": {
+                        "Configuration": {
+                            "CubemapAsset": {
+                                "assetId": {
+                                    "guid": "{215E47FD-D181-5832-B1AB-91673ABF6399}",
+                                    "subId": 1000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_skyboxcm.exr.streamingimage"
+                            },
+                            "Exposure": 1.0
+                        }
+                    }
+                },
+                "Component_[11920880790709496746]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11920880790709496746
+                },
+                "Component_[12952232878016107351]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12952232878016107351,
+                    "Parent Entity": "Entity_[422081973788]"
+                },
+                "Component_[1371996851098627205]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1371996851098627205
+                },
+                "Component_[1505253063981186092]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1505253063981186092
+                },
+                "Component_[1509808064392572438]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1509808064392572438
+                },
+                "Component_[15702817444318959685]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15702817444318959685
+                },
+                "Component_[16802543556595886839]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16802543556595886839,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 12952232878016107351
+                        },
+                        {
+                            "ComponentId": 3987893510736782289,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 10332660484145119873,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[3688925937489095277]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3688925937489095277
+                },
+                "Component_[3987893510736782289]": {
+                    "$type": "AZ::Render::EditorImageBasedLightComponent",
+                    "Id": 3987893510736782289,
+                    "Controller": {
+                        "Configuration": {
+                            "diffuseImageAsset": {
+                                "assetId": {
+                                    "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                                    "subId": 3000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_ibldiffuse.exr.streamingimage"
+                            },
+                            "specularImageAsset": {
+                                "assetId": {
+                                    "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                                    "subId": 2000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_iblspecular.exr.streamingimage"
+                            },
+                            "exposure": 1.0
+                        }
+                    }
+                },
+                "Component_[580609154998111404]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 580609154998111404
+                },
+                "Component_[8849815262247255063]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8849815262247255063
+                }
+            }
+        },
+        "Entity_[439309211497]": {
+            "Id": "Entity_[439309211497]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            2.0,
+                            2.0,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[443556810268]": {
+            "Id": "Entity_[443556810268]",
+            "Name": "Ground",
+            "Components": {
+                "Component_[10300371515023602081]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10300371515023602081
+                },
+                "Component_[10750522924528825861]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10750522924528825861
+                },
+                "Component_[12706188704735343212]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12706188704735343212
+                },
+                "Component_[13808409990050818205]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13808409990050818205
+                },
+                "Component_[14186351150034224116]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14186351150034224116
+                },
+                "Component_[1573925864469983995]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 1573925864469983995,
+                    "Parent Entity": "Entity_[422081973788]"
+                },
+                "Component_[17864202697797706305]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 17864202697797706305,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{0CD745C0-6AA8-569A-A68A-73A3270986C4}",
+                                    "subId": 277889906
+                                },
+                                "assetHint": "objects/groudplane/groundplane_512x512m.azmodel"
+                            },
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[1809844524913497810]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1809844524913497810
+                },
+                "Component_[337457869483948875]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 337457869483948875,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 1573925864469983995
+                        },
+                        {
+                            "ComponentId": 17864202697797706305,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 7751505222023007382,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[3906065428856629485]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3906065428856629485
+                },
+                "Component_[6470446722747338650]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6470446722747338650
+                },
+                "Component_[7751505222023007382]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 7751505222023007382,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {},
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{0CD745C0-6AA8-569A-A68A-73A3270986C4}",
+                                                "subId": 803645540
+                                            },
+                                            "assetHint": "objects/groudplane/groundplane_512x512m_groundplane_10871786180989855844.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 803645540
+                                    },
+                                    "Value": {}
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "Entity_[443604178793]": {
+            "Id": "Entity_[443604178793]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            2.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[447851777564]": {
+            "Id": "Entity_[447851777564]",
+            "Name": "Sun",
+            "Components": {
+                "Component_[12256845872556267458]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12256845872556267458,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.8976694345474243,
+                            0.0,
+                            0.0
+                        ],
+                        "Rotate": [
+                            -76.1310043334961,
+                            -0.8470587730407715,
+                            -15.810285568237305
+                        ]
+                    }
+                },
+                "Component_[12853017703306734296]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12853017703306734296
+                },
+                "Component_[14000115616297019236]": {
+                    "$type": "AZ::Render::EditorDirectionalLightComponent",
+                    "Id": 14000115616297019236,
+                    "Controller": {
+                        "Configuration": {
+                            "Intensity": 1.0,
+                            "CameraEntityId": "",
+                            "ShadowFilterMethod": 1
+                        }
+                    }
+                },
+                "Component_[14676903636088758323]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14676903636088758323
+                },
+                "Component_[15785473599508150979]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15785473599508150979
+                },
+                "Component_[16405599729441718679]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16405599729441718679
+                },
+                "Component_[16665614856018488123]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16665614856018488123
+                },
+                "Component_[3986162720704884578]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3986162720704884578,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 12256845872556267458
+                        },
+                        {
+                            "ComponentId": 14000115616297019236,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[45357996206716862]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 45357996206716862
+                },
+                "Component_[4763659870697442399]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4763659870697442399
+                },
+                "Component_[6128433265673423961]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6128433265673423961
+                }
+            }
+        },
+        "Entity_[447899146089]": {
+            "Id": "Entity_[447899146089]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            4.0,
+                            2.0,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[452194113385]": {
+            "Id": "Entity_[452194113385]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            4.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[456489080681]": {
+            "Id": "Entity_[456489080681]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            6.0,
+                            2.0,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[460784047977]": {
+            "Id": "Entity_[460784047977]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            6.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[465079015273]": {
+            "Id": "Entity_[465079015273]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            8.0,
+                            2.0,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[469373982569]": {
+            "Id": "Entity_[469373982569]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            8.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[516618622825]": {
+            "Id": "Entity_[516618622825]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            8.094816207885742,
+                            6.073142051696777,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[520913590121]": {
+            "Id": "Entity_[520913590121]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.09481599926948547,
+                            6.073142051696777,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[525208557417]": {
+            "Id": "Entity_[525208557417]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            4.094816207885742,
+                            4.073142051696777,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[529503524713]": {
+            "Id": "Entity_[529503524713]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.09481599926948547,
+                            4.073142051696777,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[533798492009]": {
+            "Id": "Entity_[533798492009]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            6.094815731048584,
+                            6.073142051696777,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[538093459305]": {
+            "Id": "Entity_[538093459305]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            4.094816207885742,
+                            6.073142051696777,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[542388426601]": {
+            "Id": "Entity_[542388426601]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            2.094815969467163,
+                            6.073142051696777,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[546683393897]": {
+            "Id": "Entity_[546683393897]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            8.094816207885742,
+                            4.073142051696777,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[550978361193]": {
+            "Id": "Entity_[550978361193]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            6.094815731048584,
+                            4.073142051696777,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[555273328489]": {
+            "Id": "Entity_[555273328489]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            2.094815969467163,
+                            4.073142051696777,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[559568295785]": {
+            "Id": "Entity_[559568295785]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -7.842479705810547,
+                            -0.08511350303888321,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[563863263081]": {
+            "Id": "Entity_[563863263081]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -3.747663974761963,
+                            5.988028526306152,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[568158230377]": {
+            "Id": "Entity_[568158230377]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.8424797058105469,
+                            1.914886474609375,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[572453197673]": {
+            "Id": "Entity_[572453197673]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -5.747663497924805,
+                            3.9880285263061523,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[576748164969]": {
+            "Id": "Entity_[576748164969]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -7.747663497924805,
+                            3.9880285263061523,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[581043132265]": {
+            "Id": "Entity_[581043132265]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -9.842479705810547,
+                            1.914886474609375,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[585338099561]": {
+            "Id": "Entity_[585338099561]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -5.842479705810547,
+                            -0.08511350303888321,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[589633066857]": {
+            "Id": "Entity_[589633066857]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -7.747663497924805,
+                            5.988028526306152,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[593928034153]": {
+            "Id": "Entity_[593928034153]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -9.842479705810547,
+                            -0.08511350303888321,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[598223001449]": {
+            "Id": "Entity_[598223001449]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -3.842479705810547,
+                            1.914886474609375,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[602517968745]": {
+            "Id": "Entity_[602517968745]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.7476634979248047,
+                            5.988028526306152,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[606812936041]": {
+            "Id": "Entity_[606812936041]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.7476634979248047,
+                            3.9880285263061523,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[611107903337]": {
+            "Id": "Entity_[611107903337]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -5.842479705810547,
+                            1.914886474609375,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[615402870633]": {
+            "Id": "Entity_[615402870633]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -5.747663497924805,
+                            5.988028526306152,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[619697837929]": {
+            "Id": "Entity_[619697837929]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -7.842479705810547,
+                            1.914886474609375,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[623992805225]": {
+            "Id": "Entity_[623992805225]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.8424797058105469,
+                            -0.08511350303888321,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[628287772521]": {
+            "Id": "Entity_[628287772521]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -9.747663497924805,
+                            3.9880285263061523,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[632582739817]": {
+            "Id": "Entity_[632582739817]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -3.842479705810547,
+                            -0.08511350303888321,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[636877707113]": {
+            "Id": "Entity_[636877707113]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -9.747663497924805,
+                            5.988028526306152,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[641172674409]": {
+            "Id": "Entity_[641172674409]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -3.747663974761963,
+                            3.9880285263061523,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[645467641705]": {
+            "Id": "Entity_[645467641705]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -5.755631446838379,
+                            8.026985168457031,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[649762609001]": {
+            "Id": "Entity_[649762609001]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -5.660815238952637,
+                            14.100127220153809,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[654057576297]": {
+            "Id": "Entity_[654057576297]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -9.755631446838379,
+                            10.026985168457031,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[658352543593]": {
+            "Id": "Entity_[658352543593]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -5.755631446838379,
+                            10.026985168457031,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[662647510889]": {
+            "Id": "Entity_[662647510889]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -3.660815715789795,
+                            12.100127220153809,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[666942478185]": {
+            "Id": "Entity_[666942478185]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -7.660815238952637,
+                            12.100127220153809,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[671237445481]": {
+            "Id": "Entity_[671237445481]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.6608152389526367,
+                            12.100127220153809,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[675532412777]": {
+            "Id": "Entity_[675532412777]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -9.660815238952637,
+                            14.100127220153809,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[679827380073]": {
+            "Id": "Entity_[679827380073]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -5.660815238952637,
+                            12.100127220153809,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[684122347369]": {
+            "Id": "Entity_[684122347369]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.6608152389526367,
+                            14.100127220153809,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[688417314665]": {
+            "Id": "Entity_[688417314665]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -3.755631446838379,
+                            8.026985168457031,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[692712281961]": {
+            "Id": "Entity_[692712281961]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.755631446838379,
+                            10.026985168457031,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[697007249257]": {
+            "Id": "Entity_[697007249257]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -3.755631446838379,
+                            10.026985168457031,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[701302216553]": {
+            "Id": "Entity_[701302216553]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -9.660815238952637,
+                            12.100127220153809,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[705597183849]": {
+            "Id": "Entity_[705597183849]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -3.660815715789795,
+                            14.100127220153809,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[709892151145]": {
+            "Id": "Entity_[709892151145]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -9.755631446838379,
+                            8.026985168457031,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[714187118441]": {
+            "Id": "Entity_[714187118441]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.755631446838379,
+                            8.026985168457031,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[718482085737]": {
+            "Id": "Entity_[718482085737]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -7.755631446838379,
+                            8.026985168457031,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[722777053033]": {
+            "Id": "Entity_[722777053033]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -7.660815238952637,
+                            14.100127220153809,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[727072020329]": {
+            "Id": "Entity_[727072020329]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -7.755631446838379,
+                            10.026985168457031,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[731366987625]": {
+            "Id": "Entity_[731366987625]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            7.986235618591309,
+                            12.246960639953613,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[735661954921]": {
+            "Id": "Entity_[735661954921]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.013764400035142899,
+                            12.246960639953613,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[739956922217]": {
+            "Id": "Entity_[739956922217]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            1.9862356185913086,
+                            12.246960639953613,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[744251889513]": {
+            "Id": "Entity_[744251889513]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            5.891419410705566,
+                            10.173818588256836,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[748546856809]": {
+            "Id": "Entity_[748546856809]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            1.8914194107055664,
+                            10.173818588256836,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[752841824105]": {
+            "Id": "Entity_[752841824105]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            5.98623514175415,
+                            12.246960639953613,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[757136791401]": {
+            "Id": "Entity_[757136791401]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            7.891419410705566,
+                            10.173818588256836,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[761431758697]": {
+            "Id": "Entity_[761431758697]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            1.9862356185913086,
+                            14.246960639953613,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[765726725993]": {
+            "Id": "Entity_[765726725993]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            3.8914194107055664,
+                            10.173818588256836,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[770021693289]": {
+            "Id": "Entity_[770021693289]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            5.891419410705566,
+                            8.173818588256836,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[774316660585]": {
+            "Id": "Entity_[774316660585]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            1.8914194107055664,
+                            8.173818588256836,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[778611627881]": {
+            "Id": "Entity_[778611627881]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.10858059674501419,
+                            10.173818588256836,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[782906595177]": {
+            "Id": "Entity_[782906595177]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            7.986235618591309,
+                            14.246960639953613,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[787201562473]": {
+            "Id": "Entity_[787201562473]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            7.891419410705566,
+                            8.173818588256836,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[791496529769]": {
+            "Id": "Entity_[791496529769]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            3.9862356185913086,
+                            14.246960639953613,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[795791497065]": {
+            "Id": "Entity_[795791497065]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            3.9862356185913086,
+                            12.246960639953613,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[800086464361]": {
+            "Id": "Entity_[800086464361]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.10858059674501419,
+                            8.173818588256836,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[804381431657]": {
+            "Id": "Entity_[804381431657]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            3.8914194107055664,
+                            8.173818588256836,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[808676398953]": {
+            "Id": "Entity_[808676398953]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.013764400035142899,
+                            14.246960639953613,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        },
+        "Entity_[812971366249]": {
+            "Id": "Entity_[812971366249]",
+            "Name": "Shaderball",
+            "Components": {
+                "Component_[10923115151304706844]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10923115151304706844
+                },
+                "Component_[11584601375049398197]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11584601375049398197
+                },
+                "Component_[13943942964321373168]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13943942964321373168
+                },
+                "Component_[16575018698753922781]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 16575018698753922781,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            },
+                            "ExcludeFromReflectionCubeMaps": true,
+                            "LodOverride": 255
+                        }
+                    }
+                },
+                "Component_[168045347833164355]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 168045347833164355
+                },
+                "Component_[17063224558106026575]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17063224558106026575
+                },
+                "Component_[17065327108808778363]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17065327108808778363
+                },
+                "Component_[17302862295003345881]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17302862295003345881,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4993170367452717571
+                        },
+                        {
+                            "ComponentId": 16575018698753922781,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4993170367452717571]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4993170367452717571,
+                    "Parent Entity": "Entity_[422081973788]",
+                    "Transform Data": {
+                        "Translate": [
+                            5.98623514175415,
+                            14.246960639953613,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[5289291410702493741]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5289291410702493741
+                },
+                "Component_[6871857201096355436]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6871857201096355436
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/AtomFeatureIntegrationBenchmark/filelist.xml
+++ b/AutomatedTesting/Levels/AtomFeatureIntegrationBenchmark/filelist.xml
@@ -1,6 +1,0 @@
-<download name="AtomFeatureIntegrationBenchmark" type="Map">
- <index src="filelist.xml" dest="filelist.xml"/>
- <files>
-  <file src="level.pak" dest="level.pak" size="154A" md5="da50266269914f05d06d80f0025953fc"/>
- </files>
-</download>

--- a/AutomatedTesting/Levels/AtomFeatureIntegrationBenchmark/level.pak
+++ b/AutomatedTesting/Levels/AtomFeatureIntegrationBenchmark/level.pak
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e075be2cb7cf5aa98e3503c1119b94c3098b35500c98c4db32d025c9e1afa52d
-size 5450


### PR DESCRIPTION
- Converts the AtomFeatureIntegrationBenchmark into a prefab as slices are no longer used.
- Fixes the groundplane asset error and re-adds the groundplane material by doing so.
- Test passes after conversion:
```
C:\git\o3de>C:\git\o3de\python\runtime\python-3.7.12-rev1-windows\python\python.exe -m pytest -vv -s --build-directory="C:\git\o3de\build\bin\profile" C:\git\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Benchmark_GPU.py

==== 2 passed in 177.80s (0:02:57) ====
```