### PR TITLE
Fix Multiplayer Editor Flaky Tests

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/tests/Multiplayer_AutoComponent_NetworkInput.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/tests/Multiplayer_AutoComponent_NetworkInput.py
@@ -70,7 +70,7 @@ def Multiplayer_AutoComponent_NetworkInput():
 
     level_name = "AutoComponent_NetworkInput"
     helper.init_idle()
-
+    general.set_cvar_integer('editorsv_port', 33452)
 
     # 1) Open Level
     helper.open_level("Multiplayer", level_name)

--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/tests/Multiplayer_AutoComponent_RPC.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/tests/Multiplayer_AutoComponent_RPC.py
@@ -47,7 +47,8 @@ def Multiplayer_AutoComponent_RPC():
     level_name = "AutoComponent_RPC"
 
     helper.init_idle()
-
+    general.set_cvar_integer('editorsv_port', 33453)
+    
     # 1) Open Level
     helper.open_level("Multiplayer", level_name)
 

--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/tests/Multiplayer_BasicConnectivity_Connects.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/tests/Multiplayer_BasicConnectivity_Connects.py
@@ -55,7 +55,6 @@ def Multiplayer_BasicConnectivity_Connects():
         player_id = general.find_game_entity("Player")
         Report.critical_result(TestConstants.find_network_player, player_id.IsValid())
 
-
     # Exit game mode
     helper.exit_game_mode(TestConstants.exit_game_mode)
 

--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/tests/Multiplayer_BasicConnectivity_Connects.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/tests/Multiplayer_BasicConnectivity_Connects.py
@@ -45,6 +45,7 @@ def Multiplayer_BasicConnectivity_Connects():
 
     # 1) Open Level
     helper.open_level("Multiplayer", level_name)
+    general.set_cvar_integer('editorsv_port', 33454)
 
     with Tracer() as section_tracer:
         # 2) Enter game mode
@@ -53,7 +54,8 @@ def Multiplayer_BasicConnectivity_Connects():
         # 3) Make sure the network player was spawned
         player_id = general.find_game_entity("Player")
         Report.critical_result(TestConstants.find_network_player, player_id.IsValid())
-    
+
+
     # Exit game mode
     helper.exit_game_mode(TestConstants.exit_game_mode)
 

--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/tests/Multiplayer_SimpleNetworkLevelEntity.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/tests/Multiplayer_SimpleNetworkLevelEntity.py
@@ -38,7 +38,6 @@ def Multiplayer_SimpleNetworkLevelEntity():
     from editor_python_test_tools.utils import Tracer
 
     from editor_python_test_tools.utils import TestHelper as helper
-    from ly_remote_console.remote_console_commands import RemoteConsole as RemoteConsole
 
     level_name = "SimpleNetworkLevelEntity"
 
@@ -46,6 +45,7 @@ def Multiplayer_SimpleNetworkLevelEntity():
 
     # 1) Open Level
     helper.open_level("Multiplayer", level_name)
+    general.set_cvar_integer('editorsv_port', 33455)
 
     with Tracer() as section_tracer:
         # 2) Enter game mode

--- a/AutomatedTesting/Levels/Multiplayer/AutoComponent_NetworkInput/AutoComponent_NetworkInput.prefab
+++ b/AutomatedTesting/Levels/Multiplayer/AutoComponent_NetworkInput/AutoComponent_NetworkInput.prefab
@@ -17,7 +17,12 @@
             },
             "Component_[14126657869720434043]": {
                 "$type": "EditorEntitySortComponent",
-                "Id": 14126657869720434043
+                "Id": 14126657869720434043,
+                "Child Entity Order": [
+                    "Entity_[1176639161715]",
+                    "Entity_[676622459613]",
+                    "Entity_[676622459613]"
+                ]
             },
             "Component_[15230859088967841193]": {
                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -152,37 +157,7 @@
                 },
                 "Component_[5182430712893438093]": {
                     "$type": "EditorMaterialComponent",
-                    "Id": 5182430712893438093,
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 803645540
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 803645540
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 803645540
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 803645540
-                                }
-                            }
-                        ]
-                    ]
+                    "Id": 5182430712893438093
                 },
                 "Component_[5675108321710651991]": {
                     "$type": "AZ::Render::EditorMeshComponent",
@@ -231,7 +206,7 @@
                     "Controller": {
                         "Configuration": {
                             "Field of View": 55.0,
-                            "EditorEntityId": 12554887233631987164
+                            "EditorEntityId": 8018936598036423587
                         }
                     }
                 },
@@ -405,30 +380,12 @@
                 "Component_[5855590796136709437]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 5855590796136709437,
-                    "ChildEntityOrderEntryArray": [
-                        {
-                            "EntityId": "Entity_[1155164325235]"
-                        },
-                        {
-                            "EntityId": "Entity_[1180934129011]",
-                            "SortIndex": 1
-                        },
-                        {
-                            "EntityId": "",
-                            "SortIndex": 2
-                        },
-                        {
-                            "EntityId": "Entity_[1168049227123]",
-                            "SortIndex": 3
-                        },
-                        {
-                            "EntityId": "Entity_[1163754259827]",
-                            "SortIndex": 4
-                        },
-                        {
-                            "EntityId": "Entity_[1159459292531]",
-                            "SortIndex": 5
-                        }
+                    "Child Entity Order": [
+                        "Entity_[1155164325235]",
+                        "Entity_[1180934129011]",
+                        "Entity_[1168049227123]",
+                        "Entity_[1163754259827]",
+                        "Entity_[1159459292531]"
                     ]
                 },
                 "Component_[9277695270015777859]": {
@@ -518,6 +475,81 @@
                 "Component_[931091830724002070]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 931091830724002070
+                }
+            }
+        },
+        "Entity_[676622459613]": {
+            "Id": "Entity_[676622459613]",
+            "Name": "NetworkPlayerSpawner",
+            "Components": {
+                "Component_[10346403779008557067]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10346403779008557067
+                },
+                "Component_[11854688408988212225]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 11854688408988212225
+                },
+                "Component_[12469905821673007931]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12469905821673007931,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.006507891230285168,
+                            0.10000038146972656,
+                            3.999903678894043
+                        ]
+                    }
+                },
+                "Component_[12474153384840539361]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12474153384840539361
+                },
+                "Component_[14731433038666602795]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14731433038666602795
+                },
+                "Component_[15430089019523939834]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 15430089019523939834,
+                    "m_template": {
+                        "$type": "NetBindComponent"
+                    }
+                },
+                "Component_[16836418117507086687]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 16836418117507086687,
+                    "m_template": {
+                        "$type": "NetworkPlayerSpawnerComponent",
+                        "SpawnableAsset": {
+                            "assetId": {
+                                "guid": "{3CB1E0CC-FB4E-5D2F-9802-300417759CF4}",
+                                "subId": 738868766
+                            },
+                            "assetHint": "levels/multiplayer/autocomponent_networkinput/player.network.spawnable"
+                        }
+                    }
+                },
+                "Component_[17074092285133318646]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17074092285133318646
+                },
+                "Component_[18183016330648511236]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 18183016330648511236
+                },
+                "Component_[2178402855911939657]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2178402855911939657
+                },
+                "Component_[5252322463735354580]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5252322463735354580
+                },
+                "Component_[7865688749308954935]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7865688749308954935
                 }
             }
         }

--- a/AutomatedTesting/Levels/Multiplayer/BasicConnectivity_Connects/BasicConnectivity_Connects.prefab
+++ b/AutomatedTesting/Levels/Multiplayer/BasicConnectivity_Connects/BasicConnectivity_Connects.prefab
@@ -17,7 +17,11 @@
             },
             "Component_[14126657869720434043]": {
                 "$type": "EditorEntitySortComponent",
-                "Id": 14126657869720434043
+                "Id": 14126657869720434043,
+                "Child Entity Order": [
+                    "Entity_[1176639161715]",
+                    "Entity_[934973135879]"
+                ]
             },
             "Component_[15230859088967841193]": {
                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -201,7 +205,7 @@
                     "Controller": {
                         "Configuration": {
                             "Field of View": 55.0,
-                            "EditorEntityId": 8929576024571800510
+                            "EditorEntityId": 17756184092220188299
                         }
                     }
                 },
@@ -444,30 +448,13 @@
                 "Component_[5855590796136709437]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 5855590796136709437,
-                    "ChildEntityOrderEntryArray": [
-                        {
-                            "EntityId": "Entity_[1155164325235]"
-                        },
-                        {
-                            "EntityId": "Entity_[1180934129011]",
-                            "SortIndex": 1
-                        },
-                        {
-                            "EntityId": "Entity_[1172344194419]",
-                            "SortIndex": 2
-                        },
-                        {
-                            "EntityId": "Entity_[1168049227123]",
-                            "SortIndex": 3
-                        },
-                        {
-                            "EntityId": "Entity_[1163754259827]",
-                            "SortIndex": 4
-                        },
-                        {
-                            "EntityId": "Entity_[1159459292531]",
-                            "SortIndex": 5
-                        }
+                    "Child Entity Order": [
+                        "Entity_[1155164325235]",
+                        "Entity_[1180934129011]",
+                        "Entity_[1172344194419]",
+                        "Entity_[1168049227123]",
+                        "Entity_[1163754259827]",
+                        "Entity_[1159459292531]"
                     ]
                 },
                 "Component_[9277695270015777859]": {
@@ -559,23 +546,81 @@
                     "Id": 931091830724002070
                 }
             }
-        }
-    },
-    "Instances": {
-        "Instance_[450137905015]": {
-            "Source": "Levels/Multiplayer/BasicConnectivity_Connects/Player.prefab",
-            "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/Component_[14438229160106431107]/Parent Entity",
-                    "value": "../Entity_[1146574390643]"
+        },
+        "Entity_[934973135879]": {
+            "Id": "Entity_[934973135879]",
+            "Name": "NetworkPlayerSpawner",
+            "Components": {
+                "Component_[10073073412761793204]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 10073073412761793204,
+                    "m_template": {
+                        "$type": "NetworkPlayerSpawnerComponent",
+                        "SpawnableAsset": {
+                            "assetId": {
+                                "guid": "{B022C510-8CD6-5ED5-825E-3FCA67D48A7E}",
+                                "subId": 738868766
+                            },
+                            "assetHint": "levels/multiplayer/basicconnectivity_connects/player.network.spawnable"
+                        }
+                    }
                 },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/Component_[14438229160106431107]/Transform Data/Translate/1",
-                    "value": 10.0
+                "Component_[11031619423549867263]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 11031619423549867263
+                },
+                "Component_[12540211635700590833]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12540211635700590833,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            1.0597752332687378,
+                            0.10000038146972656,
+                            1.7889275550842285
+                        ]
+                    }
+                },
+                "Component_[15519127561316685789]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15519127561316685789
+                },
+                "Component_[16045283820530631537]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16045283820530631537
+                },
+                "Component_[17354453761187497860]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17354453761187497860
+                },
+                "Component_[1877501581777517517]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1877501581777517517
+                },
+                "Component_[3971819454540172560]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3971819454540172560
+                },
+                "Component_[4542112105449182550]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4542112105449182550
+                },
+                "Component_[4723626109100132447]": {
+                    "$type": "SelectionComponent",
+                    "Id": 4723626109100132447
+                },
+                "Component_[5108899024798646009]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5108899024798646009
+                },
+                "Component_[7037421293728728360]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 7037421293728728360,
+                    "m_template": {
+                        "$type": "NetBindComponent"
+                    }
                 }
-            ]
+            }
         }
     }
 }

--- a/AutomatedTesting/Levels/Multiplayer/BasicConnectivity_Connects/Player.prefab
+++ b/AutomatedTesting/Levels/Multiplayer/BasicConnectivity_Connects/Player.prefab
@@ -3,114 +3,154 @@
         "Id": "ContainerEntity",
         "Name": "Player",
         "Components": {
-            "Component_[10518577910351346732]": {
-                "$type": "EditorLockComponent",
-                "Id": 10518577910351346732
-            },
-            "Component_[10982887273490848966]": {
+            "Component_[10619524260581991743]": {
                 "$type": "EditorDisabledCompositionComponent",
-                "Id": 10982887273490848966
+                "Id": 10619524260581991743
             },
-            "Component_[12400551793021799684]": {
-                "$type": "SelectionComponent",
-                "Id": 12400551793021799684
-            },
-            "Component_[1257365873906714292]": {
-                "$type": "EditorEntityIconComponent",
-                "Id": 1257365873906714292
-            },
-            "Component_[13311663931994949767]": {
-                "$type": "EditorOnlyEntityComponent",
-                "Id": 13311663931994949767
-            },
-            "Component_[14438229160106431107]": {
+            "Component_[10767909540864545699]": {
                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                "Id": 14438229160106431107,
+                "Id": 10767909540864545699,
                 "Parent Entity": ""
             },
-            "Component_[14636573223251575153]": {
-                "$type": "EditorVisibilityComponent",
-                "Id": 14636573223251575153
-            },
-            "Component_[18139850826775373128]": {
-                "$type": "EditorEntitySortComponent",
-                "Id": 18139850826775373128
-            },
-            "Component_[18149872971727933150]": {
-                "$type": "EditorInspectorComponent",
-                "Id": 18149872971727933150
-            },
-            "Component_[3361461948531668955]": {
-                "$type": "EditorPrefabComponent",
-                "Id": 3361461948531668955
-            },
-            "Component_[5198421115432838729]": {
+            "Component_[11669120088295209374]": {
                 "$type": "EditorPendingCompositionComponent",
-                "Id": 5198421115432838729
+                "Id": 11669120088295209374
+            },
+            "Component_[13289728458705755789]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 13289728458705755789
+            },
+            "Component_[14101977847199425751]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 14101977847199425751
+            },
+            "Component_[15715539527872274191]": {
+                "$type": "SelectionComponent",
+                "Id": 15715539527872274191
+            },
+            "Component_[15761374724436296369]": {
+                "$type": "EditorLockComponent",
+                "Id": 15761374724436296369
+            },
+            "Component_[1652405264767977526]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 1652405264767977526,
+                "Child Entity Order": [
+                    "Entity_[947858037767]"
+                ]
+            },
+            "Component_[4578072907682805882]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 4578072907682805882
+            },
+            "Component_[6580804236204641669]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 6580804236204641669
+            },
+            "Component_[6816224697352708806]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 6816224697352708806
             }
         }
     },
     "Entities": {
-        "Entity_[458727839607]": {
-            "Id": "Entity_[458727839607]",
-            "Name": "Dummy",
+        "Entity_[947858037767]": {
+            "Id": "Entity_[947858037767]",
+            "Name": "Player",
             "Components": {
-                "Component_[10453091667729858383]": {
-                    "$type": "EditorLockComponent",
-                    "Id": 10453091667729858383
-                },
-                "Component_[15287888392848689630]": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 15287888392848689630
-                },
-                "Component_[15410933204460181490]": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 15410933204460181490,
-                    "ComponentOrderEntryArray": [
-                        {
-                            "ComponentId": 868882495636022739
-                        },
-                        {
-                            "ComponentId": 517239536919559179,
-                            "SortIndex": 1
-                        }
-                    ]
-                },
-                "Component_[17682830444684716936]": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 17682830444684716936
-                },
-                "Component_[18433579260689698157]": {
+                "Component_[13712606897971357683]": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 18433579260689698157
+                    "Id": 13712606897971357683
                 },
-                "Component_[2684999590909523769]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2684999590909523769
+                "Component_[14185285384516213599]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14185285384516213599
                 },
-                "Component_[517239536919559179]": {
+                "Component_[14730902992871951742]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 14730902992871951742,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            0.7306077480316162
+                        ]
+                    }
+                },
+                "Component_[15517427972705016208]": {
                     "$type": "GenericComponentWrapper",
-                    "Id": 517239536919559179,
+                    "Id": 15517427972705016208,
+                    "m_template": {
+                        "$type": "Multiplayer::NetworkTransformComponent"
+                    }
+                },
+                "Component_[17721112078670262128]": {
+                    "$type": "SelectionComponent",
+                    "Id": 17721112078670262128
+                },
+                "Component_[17853708611391850432]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17853708611391850432
+                },
+                "Component_[3565294849358003010]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 3565294849358003010,
                     "m_template": {
                         "$type": "NetBindComponent"
                     }
                 },
-                "Component_[5980561685482761342]": {
+                "Component_[4289289028388475797]": {
                     "$type": "EditorDisabledCompositionComponent",
-                    "Id": 5980561685482761342
+                    "Id": 4289289028388475797
                 },
-                "Component_[6553553408068929590]": {
+                "Component_[4319038144067700384]": {
                     "$type": "EditorVisibilityComponent",
-                    "Id": 6553553408068929590
+                    "Id": 4319038144067700384
                 },
-                "Component_[8307469961954670365]": {
+                "Component_[4954705715309862853]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 4954705715309862853,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{1EE46427-D1C2-5698-B30D-B4CCF46B15CD}",
+                                    "subId": 274434668
+                                },
+                                "assetHint": "objects/_primitives/_sphere_1x1.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[5761080619636122432]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5761080619636122432
+                },
+                "Component_[7275913000784913278]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7275913000784913278,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 14730902992871951742
+                        },
+                        {
+                            "ComponentId": 3565294849358003010,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4954705715309862853,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 15517427972705016208,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[7604884123405324379]": {
                     "$type": "EditorOnlyEntityComponent",
-                    "Id": 8307469961954670365
-                },
-                "Component_[868882495636022739]": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 868882495636022739,
-                    "Parent Entity": "ContainerEntity"
+                    "Id": 7604884123405324379
                 }
             }
         }

--- a/AutomatedTesting/Levels/Multiplayer/SimpleNetworkLevelEntity/SimpleNetworkLevelEntity.prefab
+++ b/AutomatedTesting/Levels/Multiplayer/SimpleNetworkLevelEntity/SimpleNetworkLevelEntity.prefab
@@ -20,7 +20,9 @@
                 "Id": 14126657869720434043,
                 "Child Entity Order": [
                     "Entity_[1176639161715]",
-                    "Entity_[806656324666]"
+                    "Entity_[806656324666]",
+                    "Entity_[466169062109]",
+                    "Entity_[466169062109]"
                 ]
             },
             "Component_[15230859088967841193]": {
@@ -205,7 +207,7 @@
                     "Controller": {
                         "Configuration": {
                             "Field of View": 55.0,
-                            "EditorEntityId": 9021008456353177945
+                            "EditorEntityId": 8018936598036423587
                         }
                     }
                 },
@@ -477,6 +479,81 @@
                 }
             }
         },
+        "Entity_[466169062109]": {
+            "Id": "Entity_[466169062109]",
+            "Name": "NetworkingPlayerSpawner",
+            "Components": {
+                "Component_[11502128595337799037]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11502128595337799037
+                },
+                "Component_[11502915893635796786]": {
+                    "$type": "SelectionComponent",
+                    "Id": 11502915893635796786
+                },
+                "Component_[14358528516538932766]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 14358528516538932766
+                },
+                "Component_[16107734271145281127]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 16107734271145281127
+                },
+                "Component_[2218100293944000608]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 2218100293944000608,
+                    "m_template": {
+                        "$type": "NetworkPlayerSpawnerComponent",
+                        "SpawnableAsset": {
+                            "assetId": {
+                                "guid": "{30CDFFDB-7EA6-51ED-82CC-C425595E28B7}",
+                                "subId": 738868766
+                            },
+                            "assetHint": "levels/multiplayer/simplenetworklevelentity/player.network.spawnable"
+                        }
+                    }
+                },
+                "Component_[2302363447431428478]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 2302363447431428478,
+                    "m_template": {
+                        "$type": "NetBindComponent"
+                    }
+                },
+                "Component_[2774627029910399896]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2774627029910399896
+                },
+                "Component_[2997530550377249423]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2997530550377249423
+                },
+                "Component_[3432128600507943997]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3432128600507943997
+                },
+                "Component_[4505391358486745947]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 4505391358486745947
+                },
+                "Component_[564035604613919796]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 564035604613919796,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.10000228881835938,
+                            3.999903678894043
+                        ]
+                    }
+                },
+                "Component_[7697210733715986886]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7697210733715986886
+                }
+            }
+        },
         "Entity_[806656324666]": {
             "Id": "Entity_[806656324666]",
             "Name": "NetEntity",
@@ -485,16 +562,15 @@
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 10272449525230713408,
                     "m_name": "SimpleNetworkLevelEntity.scriptcanvas",
-                    "runtimeDataIsValid": true,
                     "runtimeDataOverrides": {
                         "source": {
                             "id": "{C8F17F94-1225-5FFB-A89F-7C5546FF9DD2}",
-                            "path": "C:/prj/o3de/AutomatedTesting/Levels/Multiplayer/SimpleNetworkLevelEntity/SimpleNetworkLevelEntity.scriptcanvas"
+                            "path": "/home/gene/prj/o3de/AutomatedTesting/Levels/Multiplayer/SimpleNetworkLevelEntity/SimpleNetworkLevelEntity.scriptcanvas"
                         }
                     },
                     "sourceHandle": {
                         "id": "{C8F17F94-1225-5FFB-A89F-7C5546FF9DD2}",
-                        "path": "C:/prj/o3de/AutomatedTesting/Levels/Multiplayer/SimpleNetworkLevelEntity/SimpleNetworkLevelEntity.scriptcanvas"
+                        "path": "/home/gene/prj/o3de/AutomatedTesting/Levels/Multiplayer/SimpleNetworkLevelEntity/SimpleNetworkLevelEntity.scriptcanvas"
                     }
                 },
                 "Component_[12604265186664827718]": {

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -221,11 +221,21 @@ namespace Multiplayer
             server_rhi = static_cast<AZ::CVarFixedString>(editorsv_rhi_override);
         }
         
+        const auto console = AZ::Interface<AZ::IConsole>::Get();
+        uint16_t editorsv_port = DefaultServerEditorPort;
+        if (console->GetCvarValue("editorsv_port", editorsv_port) != AZ::GetValueResult::Success)
+        {
+            AZ_Assert(false,
+                "MultiplayerEditorSystemComponent::LaunchEditorServer failed! Could not find the editorsv_port cvar; the editor won't be able to connect to editor-server! Please update this code to use a valid cvar!")
+        }
+
+
         processLaunchInfo.m_commandlineParameters = AZStd::string::format(
-            R"("%s" --project-path "%s" --editorsv_isDedicated true --rhi "%s")",
+            R"("%s" --project-path "%s" --editorsv_isDedicated true --bg_ConnectToAssetProcessor false --rhi "%s" --editorsv_port %i)",
             serverPath.c_str(),
             AZ::Utils::GetProjectPath().c_str(),
-            server_rhi.GetCStr()
+            server_rhi.GetCStr(),
+            editorsv_port
         );
         processLaunchInfo.m_showWindow = true;
         processLaunchInfo.m_processPriority = AzFramework::ProcessPriority::PROCESSPRIORITY_NORMAL;

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -220,22 +220,13 @@ namespace Multiplayer
         {
             server_rhi = static_cast<AZ::CVarFixedString>(editorsv_rhi_override);
         }
-        
-        const auto console = AZ::Interface<AZ::IConsole>::Get();
-        uint16_t editorsv_port = DefaultServerEditorPort;
-        if (console->GetCvarValue("editorsv_port", editorsv_port) != AZ::GetValueResult::Success)
-        {
-            AZ_Assert(false,
-                "MultiplayerEditorSystemComponent::LaunchEditorServer failed! Could not find the editorsv_port cvar; the editor won't be able to connect to editor-server! Please update this code to use a valid cvar!")
-        }
-
 
         processLaunchInfo.m_commandlineParameters = AZStd::string::format(
             R"("%s" --project-path "%s" --editorsv_isDedicated true --bg_ConnectToAssetProcessor false --rhi "%s" --editorsv_port %i)",
             serverPath.c_str(),
             AZ::Utils::GetProjectPath().c_str(),
             server_rhi.GetCStr(),
-            editorsv_port
+            static_cast<uint16_t>(editorsv_port)
         );
         processLaunchInfo.m_showWindow = true;
         processLaunchInfo.m_processPriority = AzFramework::ProcessPriority::PROCESSPRIORITY_NORMAL;

--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test_utils.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test_utils.py
@@ -25,7 +25,7 @@ def kill_all_ly_processes(include_asset_processor: bool = True) -> None:
     :return: None
     """
     LY_PROCESSES = [
-        'Editor', 'Profiler', 'RemoteConsole', 'o3de'
+        'Editor', 'Profiler', 'RemoteConsole', 'o3de', 'AutomatedTesting.ServerLauncher'
     ]
     AP_PROCESSES = [
         'AssetProcessor', 'AssetProcessorBatch', 'AssetBuilder'

--- a/Tools/LyTestTools/tests/unit/test_editor_test_utils.py
+++ b/Tools/LyTestTools/tests/unit/test_editor_test_utils.py
@@ -17,7 +17,7 @@ class TestEditorTestUtils(unittest.TestCase):
 
     @mock.patch('ly_test_tools.environment.process_utils.kill_processes_named')
     def test_KillAllLyProcesses_IncludeAP_CallsCorrectly(self, mock_kill_processes_named):
-        process_list = ['Editor', 'Profiler', 'RemoteConsole', 'o3de', 'AssetProcessor', 'AssetProcessorBatch',
+        process_list = ['Editor', 'Profiler', 'RemoteConsole', 'o3de', 'AutomatedTesting.ServerLauncher', 'AssetProcessor', 'AssetProcessorBatch',
                         'AssetBuilder']
 
         editor_test_utils.kill_all_ly_processes(include_asset_processor=True)
@@ -25,7 +25,7 @@ class TestEditorTestUtils(unittest.TestCase):
 
     @mock.patch('ly_test_tools.environment.process_utils.kill_processes_named')
     def test_KillAllLyProcesses_NotIncludeAP_CallsCorrectly(self, mock_kill_processes_named):
-        process_list = ['Editor', 'Profiler', 'RemoteConsole', 'o3de']
+        process_list = ['Editor', 'Profiler', 'RemoteConsole', 'o3de', 'AutomatedTesting.ServerLauncher']
         ap_process_list = ['AssetProcessor', 'AssetProcessorBatch', 'AssetBuilder']
 
         editor_test_utils.kill_all_ly_processes(include_asset_processor=False)


### PR DESCRIPTION
- Update Multiplayer editor test python scripts to use a range of server ports. When running tests rapidly on Linux, the Editor takes time to free up the port even after the app release it... cycling over ports give the test a free port that wasn't recently in use
- Update tests to use the new Network Player Spawner component
- Ran the tests and see they all succeed on Linux
`python/python.sh -m pytest --build-directory ./build/bin/profile/ ./AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Sandbox.py::TestAutomation`