### PR TITLE
Motion Matching: Performance improvement for calculating joint velocities

### DIFF
--- a/Gems/MotionMatching/Code/Source/Feature.cpp
+++ b/Gems/MotionMatching/Code/Source/Feature.cpp
@@ -106,29 +106,22 @@ namespace EMotionFX::MotionMatching
         const float halfTimeRange = timeRange * 0.5f;
         const float startTime = originalTime - halfTimeRange;
         const float frameDelta = timeRange / numSamples;
+        const float motionDuration = motionInstance->GetMotion()->GetDuration();
 
         AZ::Vector3 accumulatedVelocity = AZ::Vector3::CreateZero();
 
         for (size_t sampleIndex = 0; sampleIndex < numSamples + 1; ++sampleIndex)
         {
             float sampleTime = startTime + sampleIndex * frameDelta;
-            if (sampleTime < 0.0f)
-            {
-                sampleTime = 0.0f;
-            }
-            if (sampleTime >= motionInstance->GetMotion()->GetDuration())
-            {
-                sampleTime = motionInstance->GetMotion()->GetDuration();
-            }
+            sampleTime = AZ::GetClamp(sampleTime, 0.0f, motionDuration);
+            motionInstance->SetCurrentTime(sampleTime);
 
             if (sampleIndex == 0)
             {
-                motionInstance->SetCurrentTime(sampleTime);
                 motionInstance->GetMotion()->Update(bindPose, &prevPose->GetPose(), motionInstance);
                 continue;
             }
 
-            motionInstance->SetCurrentTime(sampleTime);
             motionInstance->GetMotion()->Update(bindPose, &currentPose->GetPose(), motionInstance);
 
             const Transform inverseJointWorldTransform = currentPose->GetPose().GetWorldSpaceTransform(relativeToJointIndex).Inversed();

--- a/Gems/MotionMatching/Code/Source/MotionMatchingInstance.h
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingInstance.h
@@ -12,8 +12,6 @@
 #include <AzCore/Memory/Memory.h>
 #include <AzCore/RTTI/RTTI.h>
 
-#include <AzFramework/Entity/EntityDebugDisplayBus.h>
-
 #include <EMotionFX/Source/EMotionFXConfig.h>
 #include <Feature.h>
 #include <TrajectoryHistory.h>
@@ -115,7 +113,5 @@ namespace EMotionFX::MotionMatching
         /// Buffers used for FindLowestCostFrameIndex().
         AZStd::vector<float> m_tempCosts;
         AZStd::vector<float> m_minCosts;
-
-        AZStd::vector<AzFramework::DebugDisplayRequests*> m_debugDisplays;
     };
 } // namespace EMotionFX::MotionMatching

--- a/Gems/MotionMatching/Code/Source/PoseDataJointVelocities.h
+++ b/Gems/MotionMatching/Code/Source/PoseDataJointVelocities.h
@@ -15,9 +15,7 @@
 
 namespace EMotionFX::MotionMatching
 {
-    /**
-     * Extends a given pose with joint-relative linear and angular velocities.
-     **/
+    //! Extends a given pose with joint-relative linear and angular velocities.
     class EMFX_API PoseDataJointVelocities
         : public PoseData
     {
@@ -32,6 +30,8 @@ namespace EMotionFX::MotionMatching
 
         void LinkToActorInstance(const ActorInstance* actorInstance) override;
         void LinkToActor(const Actor* actor) override;
+
+        //! Zero all linear and angular velocities.
         void Reset() override;
 
         void CopyFrom(const PoseData* from) override;


### PR DESCRIPTION
* Profiling the latest version showed that calculating the joint velocities took a significant amount of time. After diving it turned out that we're sampling the animation too often, so consolidating that and sampling it only once decreased the time needed to calculate the joint velocities for the current pose significantly.
* Removed an unneeded/unused variable from the motion matching instance.
* Replaced a condition in the base feature with a clamp to simplify the code.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>