### PR TITLE
Clear dirty entities after entity deletions to avoid double deletes

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main.py
@@ -343,6 +343,9 @@ class TestAutomation(EditorTestSuite):
     class ForceRegion_ParentChildForcesCombineForces(EditorSharedTest):
         from .tests.force_region import ForceRegion_ParentChildForcesCombineForces as test_module
 
+    class Physics_UndoRedoWorksOnEntityWithPhysComponents(EditorSharedTest):
+        from .tests import Physics_UndoRedoWorksOnEntityWithPhysComponents as test_module
+
 
 @pytest.mark.SUITE_main
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
@@ -355,10 +358,6 @@ class TestAutomationNoPrefab(EditorTestSuite):
     @staticmethod
     def get_number_parallel_editors():
         return 16
-
-    @pytest.mark.xfail(reason="AssertionError: No run data for test: Physics_UndoRedoWorksOnEntityWithPhysComponents.")
-    class Physics_UndoRedoWorksOnEntityWithPhysComponents(EditorSharedTest):
-        from .tests import Physics_UndoRedoWorksOnEntityWithPhysComponents as test_module
 
     @pytest.mark.xfail(reason="AssertionError: Failed to open level: ScriptCanvas_ShapeCast does not exist or is invalid")
     class ScriptCanvas_ShapeCast(EditorSharedTest):

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/Physics_UndoRedoWorksOnEntityWithPhysComponents.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/Physics_UndoRedoWorksOnEntityWithPhysComponents.py
@@ -71,11 +71,13 @@ def Physics_UndoRedoWorksOnEntityWithPhysComponents():
 
         # 4) Undo deletion
         general.undo()
+        general.idle_wait_frames(1)
         entity_id = general.find_editor_entity(entity_name)
         Report.result(Tests.deletion_undone, entity_id.IsValid())
 
         # 5) Redo deletion
         general.redo()
+        general.idle_wait_frames(1)
         entity_id = general.find_editor_entity(entity_name)
         Report.result(Tests.deletion_redone, not entity_id.IsValid())
 

--- a/AutomatedTesting/Levels/Physics/Physics_UndoRedoWorksOnEntityWithPhysComponents/Physics_UndoRedoWorksOnEntityWithPhysComponents.prefab
+++ b/AutomatedTesting/Levels/Physics/Physics_UndoRedoWorksOnEntityWithPhysComponents/Physics_UndoRedoWorksOnEntityWithPhysComponents.prefab
@@ -39,7 +39,7 @@
             "Component_[7874177159288365422]": {
                 "$type": "EditorEntitySortComponent",
                 "Id": 7874177159288365422,
-				"Child Entity Order": [
+                "Child Entity Order": [
                     "Entity_[272441195238]",
                     "Entity_[281031129830]"
                 ]

--- a/AutomatedTesting/Levels/Physics/Physics_UndoRedoWorksOnEntityWithPhysComponents/Physics_UndoRedoWorksOnEntityWithPhysComponents.prefab
+++ b/AutomatedTesting/Levels/Physics/Physics_UndoRedoWorksOnEntityWithPhysComponents/Physics_UndoRedoWorksOnEntityWithPhysComponents.prefab
@@ -38,7 +38,11 @@
             },
             "Component_[7874177159288365422]": {
                 "$type": "EditorEntitySortComponent",
-                "Id": 7874177159288365422
+                "Id": 7874177159288365422,
+				"Child Entity Order": [
+                    "Entity_[272441195238]",
+                    "Entity_[281031129830]"
+                ]
             },
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
@@ -69,16 +73,7 @@
                 },
                 "Component_[14036484285432839222]": {
                     "$type": "EditorInspectorComponent",
-                    "Id": 14036484285432839222,
-                    "ComponentOrderEntryArray": [
-                        {
-                            "ComponentId": 9432950532896492451
-                        },
-                        {
-                            "ComponentId": 16094906495473882735,
-                            "SortIndex": 1
-                        }
-                    ]
+                    "Id": 14036484285432839222
                 },
                 "Component_[17819059404707659501]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -183,16 +178,7 @@
                 },
                 "Component_[835379130070315979]": {
                     "$type": "EditorInspectorComponent",
-                    "Id": 835379130070315979,
-                    "ComponentOrderEntryArray": [
-                        {
-                            "ComponentId": 783042921254971957
-                        },
-                        {
-                            "ComponentId": 3161673553656035328,
-                            "SortIndex": 1
-                        }
-                    ]
+                    "Id": 835379130070315979
                 }
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -1298,6 +1298,9 @@ namespace AzToolsFramework
             Prefab::PrefabDom instanceDomAfter;
             m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomAfter, commonOwningInstance->get());
 
+            AzToolsFramework::ToolsApplicationRequestBus::Broadcast(
+                &AzToolsFramework::ToolsApplicationRequestBus::Events::ClearDirtyEntities);
+
             // In order to undo DeleteSelected, we have to create a selection command which selects the current selection
             // and then add the deletion as children.
             // Commands always execute themselves first and then their children (when going forwards)


### PR DESCRIPTION
This PR clears the dirty entities after an entity deletion action is completed. This is done due to the prefab undo cache trying to iterate through the dirty entities to identify changes. However, the prefab template would have already been updated by that point, resulting in bad patches.

Ideally these should have been already caught by the PrefabDeleteTests but the PrefabTestFixture doesn't add all the default editor components for entities. I've tried to update that but it would also require change the core behavior of how deletes are implemented. So, I'll be tackling that problem in a subsequent PR. For now, entity deletions will not generate bad patches and this fixes https://github.com/o3de/o3de/pull/8050 and https://github.com/o3de/o3de/issues/7946 and https://github.com/o3de/o3de/issues/4863
