### PR TITLE
Updating expected distance for glass surface and updated failure messaging

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/TerrainPhysicsCollider_MaterialMapping_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/TerrainPhysicsCollider_MaterialMapping_Works.py
@@ -55,7 +55,7 @@ def TerrainPhysicsCollider_MaterialMapping_Works():
     rubber_distance = rubber_finish.GetDistance(rubber_start)
 
     # Report results on distance traveled and validate that the Cube on the glass surface travels further
-    expected_glass_distance = 7.0
+    expected_glass_distance = 5.0
     expected_rubber_distance = 2.0
     material_interaction = (
         f"PhysicsCube_Glass moved {glass_distance:.3f}m, to PhysicsCube_Rubber's {rubber_distance:.3f}m",

--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/TerrainPhysicsCollider_MaterialMapping_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/TerrainPhysicsCollider_MaterialMapping_Works.py
@@ -55,11 +55,15 @@ def TerrainPhysicsCollider_MaterialMapping_Works():
     rubber_distance = rubber_finish.GetDistance(rubber_start)
 
     # Report results on distance traveled and validate that the Cube on the glass surface travels further
+    expected_glass_distance = 7.0
+    expected_rubber_distance = 2.0
     material_interaction = (
-        f"PhysicsCube_Glass traveled {glass_distance:.3f}m, to PhysicsCube_Rubber's {rubber_distance:.3f}m",
-        f"PhysicsCube_Rubber traveled {rubber_distance:.3f}m, greater than PhysicsCube_Glass's {glass_distance:.3f}m"
+        f"PhysicsCube_Glass moved {glass_distance:.3f}m, to PhysicsCube_Rubber's {rubber_distance:.3f}m",
+        f"PhysicsCube_Rubber: Moved {rubber_distance:.3f}m, expected < {expected_rubber_distance}m. "
+        f"PhysicsCube_Glass: Moved {glass_distance:.3f}m, expected > {expected_glass_distance}m"
     )
-    Report.result(material_interaction, glass_distance > 8.0 and rubber_distance < 2.0)
+    Report.result(material_interaction, glass_distance > expected_glass_distance and
+                  rubber_distance < expected_rubber_distance)
 
     # Exit Game Mode
     helper.exit_game_mode(Tests.exit_game_mode)


### PR DESCRIPTION
Tested against new expected value and a higher than expected value for glass distance to verify failure messaging.

Test Passed
------------
|  Output  |
------------
Starting test TerrainPhysicsCollider_MaterialMapping_Works...
Test TerrainPhysicsCollider_MaterialMapping_Works finished.
Report:
[SUCCESS] Success: Entered Game Mode
[SUCCESS] Success: PhysicsCube_Glass moved 12.013m, to PhysicsCube_Rubber's 0.029m
[SUCCESS] Success: Exited Game Mode
Test result:  SUCCESS

Signed-off-by: jckand-amzn <82226555+jckand-amzn@users.noreply.github.com>