### PR TITLE
Fix KdTree's TriangleIndices type to have fields in the same order on all platforms

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelKdTree.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelKdTree.h
@@ -25,7 +25,7 @@ namespace AZ
         {
         public:
 
-            using TriangleIndices = AZStd::tuple<uint32_t, uint32_t, uint32_t>;
+            struct TriangleIndices { uint32_t index1, index2, index3; };
             using ObjectIdTriangleIndices = AZStd::tuple<AZ::u8, TriangleIndices>;
 
             ModelKdTree() = default;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelKdTree.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelKdTree.cpp
@@ -120,13 +120,9 @@ namespace AZ
                     entireBoundBox.AddPoint({positionBuffer[positionIndex], positionBuffer[positionIndex + 1], positionBuffer[positionIndex + 2]});
                 }
 
-                // The view returned by GetIndexBuffer returns a tuple<uint32_t, uint32_t, uint32_t>, in order to read
-                // 3 values at a time from the raw index buffer. It uses a reinterpret_cast to accomplish this. The
-                // cast results in the order of the indices being reversed, which is why they are read [third, second,
-                // first] here.
-                for (const auto& [thirdIndex, secondIndex, firstIndex] : GetIndexBuffer(*m_meshes[meshIndex].m_mesh))
+                for (const TriangleIndices& triangleIndices : GetIndexBuffer(*m_meshes[meshIndex].m_mesh))
                 {
-                    indices.emplace_back(meshIndex, TriangleIndices{firstIndex, secondIndex, thirdIndex});
+                    indices.emplace_back(meshIndex, triangleIndices);
                 }
             }
 


### PR DESCRIPTION
The Atom buffers are stored as `uint8_t` arrays, and then reinterpret
casted to the desired type. The TriangleIndices type exists to read 3
indexes at a time from a given index buffer. Previously, this type was
implemented using a `std::tuple` of three `uint32_t`s. However, MSVC uses
a different layout for their `tuple` compared to the implementation in
libc++. To test this, I made this small program:

```cpp
#include <iostream>
#include <memory>
#include <tuple>

int main()
{
    std::tuple<uint32_t, uint32_t, uint32_t> mytuple {5, 42, 128};
    std::cout << "mytuple is at " << std::addressof(mytuple) << "\n";
    std::cout << "Element 1 is at " << std::addressof(std::get<0>(mytuple)) << "\n";
    std::cout << "Element 2 is at " << std::addressof(std::get<1>(mytuple)) << "\n";
    std::cout << "Element 3 is at " << std::addressof(std::get<2>(mytuple)) << "\n";
    return 0;
}
```

Output on Mac is:
```
mytuple is at 0x7ff7bb627990
Element 1 is at 0x7ff7bb627990
Element 2 is at 0x7ff7bb627994
Element 3 is at 0x7ff7bb627998
```

Output on Windows is:
```
mytuple is at 0000008D96D8F878
Element 1 is at 0000008D96D8F880
Element 2 is at 0000008D96D8F87C
Element 3 is at 0000008D96D8F878
```

From this we can see that the ordering of the elements is reversed on
Windows.

To ensure that the order is consistent on all platforms, this change makes
the `TriangleIndices` type a simple struct instead.

Closes #8170.

Signed-off-by: Chris Burel <burelc@amazon.com>