### PR TITLE
Atom Tools: Support different views for each document type

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocument.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocument.h
@@ -31,12 +31,11 @@ namespace AtomToolsFramework
         static void Reflect(AZ::ReflectContext* context);
 
         AtomToolsDocument() = default;
-        AtomToolsDocument(const AZ::Crc32& toolId);
+        AtomToolsDocument(const AZ::Crc32& toolId, const DocumentTypeInfo& documentTypeInfo);
         virtual ~AtomToolsDocument();
 
         // AtomToolsDocumentRequestBus::Handler overrides...
-        static DocumentTypeInfo BuildDocumentTypeInfo();
-        DocumentTypeInfo GetDocumentTypeInfo() const override;
+        const DocumentTypeInfo& GetDocumentTypeInfo() const override;
         DocumentObjectInfoVector GetObjectInfo() const override;
         const AZ::Uuid& GetId() const override;
         const AZStd::string& GetAbsolutePath() const override;
@@ -74,6 +73,8 @@ namespace AtomToolsFramework
         virtual bool ReopenRestoreState();
 
         const AZ::Crc32 m_toolId = {};
+
+        const DocumentTypeInfo m_documentTypeInfo = {};
 
         //! The unique id of this document, used for all bus notifications and requests.
         const AZ::Uuid m_id = AZ::Uuid::CreateRandom();

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentInspector.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentInspector.h
@@ -38,11 +38,6 @@ namespace AtomToolsFramework
         //! Set a prefix string for storing registry settings 
         void SetDocumentSettingsPrefix(const AZStd::string& prefix);
 
-        using NodeIndicatorFunction = AZStd::function<const char*(const AzToolsFramework::InstanceDataNode*)>;
-
-        //! Set a function that will be used to determine what, if any, icon should be displayed next to a property in the inspector
-        void SetIndicatorFunction(const NodeIndicatorFunction& indicatorFunction);
-
         // InspectorRequestBus::Handler overrides...
         void Reset() override;
 
@@ -64,8 +59,6 @@ namespace AtomToolsFramework
         bool m_editInProgress = {};
 
         AZ::Uuid m_documentId = AZ::Uuid::CreateNull();
-
-        NodeIndicatorFunction m_nodeIndicatorFunction;
 
         AZStd::string m_documentSettingsPrefix = "/O3DE/AtomToolsFramework/AtomToolsDocumentInspector";
     };

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
@@ -15,6 +15,8 @@
 #include <AzQtComponents/Components/Widgets/TabWidget.h>
 #endif
 
+class QMenu;
+
 namespace AtomToolsFramework
 {
     //! AtomToolsDocumentMainWindow is a bridge between the base main window class and the document system. It has actions and menus for
@@ -36,17 +38,24 @@ namespace AtomToolsFramework
         //! Helper function to get the absolute path for a document represented by the document ID
         QString GetDocumentPath(const AZ::Uuid& documentId) const;
 
-        //! Retrieves the document ID from a tab with the given index
+        //! Retrieves the document ID from a tab with the index
         AZ::Uuid GetDocumentTabId(const int tabIndex) const;
 
-        //! If one does not already exist, this creates a new tab for the specified document ID with the provided label and tooltip
-        void AddDocumentTab(const AZ::Uuid& documentId, const AZStd::string& label, const AZStd::string& toolTip);
+        //! Searches for the tab index corresponding to the document ID, returning -1 if not found
+        int GetDocumentTabIndex(const AZ::Uuid& documentId) const;
 
-        //! Destroys the tab and view associated with the given document ID
+        //! Determine if a tab exists for the document ID
+        bool HasDocumentTab(const AZ::Uuid& documentId) const;
+
+        //! If one does not already exist, this creates a new tab for a document using the file name as the label and full path as the
+        //! tooltip
+        bool AddDocumentTab(const AZ::Uuid& documentId, QWidget* viewWidget);
+
+        //! Destroys the tab and view associated with the document ID
         void RemoveDocumentTab(const AZ::Uuid& documentId);
 
-        //! Updates the displayed text and tooltip for a tab associated with a given document ID
-        void UpdateDocumentTab(const AZ::Uuid& documentId, const AZStd::string& label, const AZStd::string& toolTip, bool isModified);
+        //! Updates the displayed text and tooltip for a tab associated with a document ID
+        void UpdateDocumentTab(const AZ::Uuid& documentId);
 
         //! Select the document tab to the left of the current document tab. If the first document is selected then the selection wraps
         //! around to the last one.
@@ -56,11 +65,11 @@ namespace AtomToolsFramework
         //! around to the first one.
         void SelectNextDocumentTab();
 
-        //! Creates a widget that will be displayed beneath the tab for the specified document
-        virtual QWidget* CreateDocumentTabView(const AZ::Uuid& documentId);
-
         //! Forces a context menu to appear above the selected tab, populated with actions for the associated document ID
         virtual void OpenDocumentTabContextMenu();
+
+        //! Insert items into the tab context menu for the document ID
+        virtual void PopulateTabContextMenu(const AZ::Uuid& documentId, QMenu& menu);
 
         //! Requests a source and target path for creating a new document based on another
         virtual bool GetCreateDocumentParams(AZStd::string& openPath, AZStd::string& savePath);
@@ -75,6 +84,7 @@ namespace AtomToolsFramework
         // AtomToolsDocumentNotificationBus::Handler overrides...
         void OnDocumentOpened(const AZ::Uuid& documentId) override;
         void OnDocumentClosed(const AZ::Uuid& documentId) override;
+        void OnDocumentDestroyed(const AZ::Uuid& documentId) override;
         void OnDocumentModified(const AZ::Uuid& documentId) override;
         void OnDocumentUndoStateChanged(const AZ::Uuid& documentId) override;
         void OnDocumentSaved(const AZ::Uuid& documentId) override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h
@@ -41,10 +41,6 @@ namespace AtomToolsFramework
         //! @param documentId unique id of document for which the notification is sent
         virtual void OnDocumentSaved([[maybe_unused]] const AZ::Uuid& documentId) {}
 
-        //! Signal that a document was selected
-        //! @param documentId unique id of document for which the notification is sent
-        virtual void OnDocumentSelected([[maybe_unused]] const AZ::Uuid& documentId) {}
-
         //! Signal that a document was modified
         //! @param documentId unique id of document for which the notification is sent
         virtual void OnDocumentModified([[maybe_unused]] const AZ::Uuid& documentId) {}

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentObjectInfo.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentObjectInfo.h
@@ -10,7 +10,13 @@
 
 #include <AzCore/Math/Uuid.h>
 #include <AzCore/std/containers/vector.h>
+#include <AzCore/std/functional.h>
 #include <AzCore/std/string/string.h>
+
+namespace AzToolsFramework
+{
+    class InstanceDataNode;
+}
 
 namespace AtomToolsFramework
 {
@@ -24,6 +30,7 @@ namespace AtomToolsFramework
         AZStd::string m_description;
         AZ::Uuid m_objectType = AZ::Uuid::CreateNull();
         void* m_objectPtr = {};
+        AZStd::function<const char*(const AzToolsFramework::InstanceDataNode*)> m_nodeIndicatorFunction;
     };
 
     using DocumentObjectInfoVector = AZStd::vector<DocumentObjectInfo>;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentRequestBus.h
@@ -25,12 +25,8 @@ namespace AtomToolsFramework
 
         virtual ~AtomToolsDocumentRequests() = default;
 
-        //! Static function used to describe the document implementing this interface. Every leaf document class needs to implement this
-        //! function for registration with the document system.
-        static DocumentTypeInfo BuildDocumentTypeInfo() { return DocumentTypeInfo(); }
-
-        //! Virtual function to retrieve the document type info for the leaf document class.
-        virtual DocumentTypeInfo GetDocumentTypeInfo() const = 0;
+        //! Get the document type info that was used to create this document.
+        virtual const DocumentTypeInfo& GetDocumentTypeInfo() const = 0;
 
         //! Returns a container describing all reflected objects contained in a document
         virtual DocumentObjectInfoVector GetObjectInfo() const = 0;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystem.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystem.h
@@ -61,8 +61,6 @@ namespace AtomToolsFramework
         void QueueReopenDocuments();
         void ReopenDocuments();
 
-        AZ::Uuid OpenDocumentImpl(const AZStd::string& sourcePath, bool checkIfAlreadyOpen);
-
         const AZ::Crc32 m_toolId = {};
         DocumentTypeInfoVector m_documentTypes;
         AZStd::unordered_map<AZ::Uuid, AZStd::shared_ptr<AtomToolsDocumentRequests>> m_documentMap;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentTypeInfo.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentTypeInfo.h
@@ -14,6 +14,8 @@
 #include <AzCore/std/functional.h>
 #include <AzCore/std/string/string.h>
 
+class QWidget;
+
 namespace AtomToolsFramework
 {
     class AtomToolsDocumentRequests;
@@ -26,22 +28,28 @@ namespace AtomToolsFramework
     struct DocumentTypeInfo final
     {
         //! Function type used for instantiating a document described by this type.
-        using FactoryCallback = AZStd::function<AtomToolsDocumentRequests*(const AZ::Crc32&)>;
+        using DocumentFactoryCallback = AZStd::function<AtomToolsDocumentRequests*(const AZ::Crc32&, const DocumentTypeInfo&)>;
+
+        //! Function type used for instantiating different views of document data.
+        using DocumentViewFactoryCallback = AZStd::function<bool(const AZ::Crc32&, const AZ::Uuid&)>;
 
         //! A pair of strings representing a file type description and extension.
-        using ExtensionInfo = AZStd::pair<AZStd::string, AZStd::string>;
+        using DocumentExtensionInfo = AZStd::pair<AZStd::string, AZStd::string>;
 
         //! Container of registered file types used for an action.
-        using ExtensionInfoVector = AZStd::vector<ExtensionInfo>;
+        using DocumentExtensionInfoVector = AZStd::vector<DocumentExtensionInfo>;
 
         //! Invokes the factory callback to create an instance of a document class.
         AtomToolsDocumentRequests* CreateDocument(const AZ::Crc32& toolId) const;
+
+        //! Invokes the view factory callback to create document views.
+        bool CreateDocumentView(const AZ::Crc32& toolId, const AZ::Uuid& documentId) const;
 
         //! Helper functions use determine if a file path or extension is supported for an operation.
         bool IsSupportedExtensionToCreate(const AZStd::string& path) const;
         bool IsSupportedExtensionToOpen(const AZStd::string& path) const;
         bool IsSupportedExtensionToSave(const AZStd::string& path) const;
-        bool IsSupportedExtension(const ExtensionInfoVector& supportedExtensions, const AZStd::string& path) const;
+        bool IsSupportedExtension(const DocumentExtensionInfoVector& supportedExtensions, const AZStd::string& path) const;
 
         //! Retrieves the first registered, or default, extension for saving this document type.
         AZStd::string GetDefaultExtensionToSave() const;
@@ -49,13 +57,16 @@ namespace AtomToolsFramework
         //! A string used for displaying and searching for this document type.
         AZStd::string m_documentTypeName;
 
-        //! Factory function for creating an instance of the associated document.
-        FactoryCallback m_documentFactoryCallback;
+        //! Factory function for creating an instance of the document.
+        DocumentFactoryCallback m_documentFactoryCallback;
+
+        //! Factory function for creating views of the document.
+        DocumentViewFactoryCallback m_documentViewFactoryCallback;
 
         //! Containers for extensions supported by each of the common operations.
-        ExtensionInfoVector m_supportedExtensionsToCreate;
-        ExtensionInfoVector m_supportedExtensionsToOpen;
-        ExtensionInfoVector m_supportedExtensionsToSave;
+        DocumentExtensionInfoVector m_supportedExtensionsToCreate;
+        DocumentExtensionInfoVector m_supportedExtensionsToOpen;
+        DocumentExtensionInfoVector m_supportedExtensionsToSave;
 
         //! Used to make the initial selection in the create document dialog.
         AZ::Data::AssetId m_defaultAssetIdToCreate;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -24,18 +24,21 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnin
 AZ_POP_DISABLE_WARNING
 
 class QImage;
+class QWidget;
 
 namespace AtomToolsFramework
 {
     using LoadImageAsyncCallback = AZStd::function<void(const QImage&)>;
     void LoadImageAsync(const AZStd::string& path, LoadImageAsyncCallback callback);
 
+    QWidget* GetToolMainWindow();
     AZStd::string GetDisplayNameFromPath(const AZStd::string& path);
     AZStd::string GetSaveFilePath(const AZStd::string& initialPath, const AZStd::string& title = "Document");
     AZStd::vector<AZStd::string> GetOpenFilePaths(const QRegExp& filter, const AZStd::string& title = "Document");
     AZStd::string GetUniqueFilePath(const AZStd::string& initialPath);
     AZStd::string GetUniqueDefaultSaveFilePath(const AZStd::string& baseName);
     AZStd::string GetUniqueDuplicateFilePath(const AZStd::string& initialPath);
+    bool ValidateDocumentPath(AZStd::string& path);
     bool LaunchTool(const QString& baseName, const QStringList& arguments);
 
     //! Generate a file path that is relative to either the source asset root or the export path

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
@@ -61,7 +61,10 @@ namespace AtomToolsFramework
 
         QPointer<AzQtComponents::FancyDocking> m_advancedDockManager = {};
         AzQtComponents::WindowDecorationWrapper* m_mainWindowWrapper = {};
+
         bool m_shownBefore = {};
+
+        QByteArray m_defaultWindowState;
 
         QLabel* m_statusMessage = {};
         QLabel* m_statusBarFps = {};

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -326,7 +326,8 @@ namespace AtomToolsFramework
         if (!failedAssets.empty())
         {
             QMessageBox::critical(
-                activeWindow(), QString("Failed to compile critical assets"),
+                GetToolMainWindow(),
+                QString("Failed to compile critical assets"),
                 QString("Failed to compile the following critical assets:\n%1\n%2")
                 .arg(failedAssets.join(",\n"))
                 .arg("Make sure this is an Atom project."));

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowser.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowser.cpp
@@ -92,7 +92,7 @@ namespace AtomToolsFramework
         AZ::TickBus::Handler::BusDisconnect();
 
         m_pathToSelect = absolutePath;
-        if (!m_pathToSelect.empty() && AzFramework::StringFunc::Path::Normalize(m_pathToSelect))
+        if (ValidateDocumentPath(m_pathToSelect))
         {
             // Selecting a new asset in the browser is not guaranteed to happen immediately.
             // The asset browser model notifications are sent before the model is updated.
@@ -113,7 +113,7 @@ namespace AtomToolsFramework
         if (promptToOpenMultipleFiles && promptToOpenMultipleFilesThreshold <= entries.size())
         {
             QMessageBox::StandardButton result = QMessageBox::question(
-                QApplication::activeWindow(),
+                GetToolMainWindow(),
                 tr("Attemptng to open %1 files").arg(entries.size()),
                 tr("Would you like to open anyway?"),
                 QMessageBox::Yes | QMessageBox::No);
@@ -202,7 +202,7 @@ namespace AtomToolsFramework
         AZ_UNUSED(time);
         AZ_UNUSED(deltaTime);
 
-        if (m_pathToSelect.empty())
+        if (!ValidateDocumentPath(m_pathToSelect))
         {
             AZ::TickBus::Handler::BusDisconnect();
             m_pathToSelect.clear();
@@ -219,8 +219,7 @@ namespace AtomToolsFramework
             if (entry)
             {
                 AZStd::string sourcePath = entry->GetFullPath();
-                AzFramework::StringFunc::Path::Normalize(sourcePath);
-                if (m_pathToSelect == sourcePath)
+                if (ValidateDocumentPath(sourcePath) && AZ::StringFunc::Equal(m_pathToSelect, sourcePath))
                 {
                     // Once the selection is confirmed, cancel the operation and disconnect
                     AZ::TickBus::Handler::BusDisconnect();

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowserInteractions.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowserInteractions.cpp
@@ -175,12 +175,10 @@ namespace AtomToolsFramework
         bool isActive = false;
         SourceControlConnectionRequestBus::BroadcastResult(isActive, &SourceControlConnectionRequests::IsActive);
 
-        if (isActive)
+        AZStd::string path = entry->GetFullPath();
+        if (isActive && ValidateDocumentPath(path))
         {
             menu->addSeparator();
-
-            AZStd::string path = entry->GetFullPath();
-            AzFramework::StringFunc::Path::Normalize(path);
 
             QMenu* sourceControlMenu = menu->addMenu("Source Control");
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocument.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocument.cpp
@@ -9,6 +9,7 @@
 #include <Atom/RPI.Edit/Common/AssetUtils.h>
 #include <AtomToolsFramework/Document/AtomToolsDocument.h>
 #include <AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h>
+#include <AtomToolsFramework/Util/Util.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
@@ -50,8 +51,9 @@ namespace AtomToolsFramework
         }
     }
 
-    AtomToolsDocument::AtomToolsDocument(const AZ::Crc32& toolId)
+    AtomToolsDocument::AtomToolsDocument(const AZ::Crc32& toolId, const DocumentTypeInfo& documentTypeInfo)
         : m_toolId(toolId)
+        , m_documentTypeInfo(documentTypeInfo)
     {
         AtomToolsDocumentRequestBus::Handler::BusConnect(m_id);
         AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentCreated, m_id);
@@ -64,14 +66,9 @@ namespace AtomToolsFramework
         AzToolsFramework::AssetSystemBus::Handler::BusDisconnect();
     }
 
-    DocumentTypeInfo AtomToolsDocument::BuildDocumentTypeInfo()
+    const DocumentTypeInfo& AtomToolsDocument::GetDocumentTypeInfo() const
     {
-        return AtomToolsDocumentRequestBus::Handler::BuildDocumentTypeInfo();
-    }
-
-    DocumentTypeInfo AtomToolsDocument::GetDocumentTypeInfo() const
-    {
-        return BuildDocumentTypeInfo();
+        return m_documentTypeInfo;
     }
 
     DocumentObjectInfoVector AtomToolsDocument::GetObjectInfo() const
@@ -94,15 +91,9 @@ namespace AtomToolsFramework
         Clear();
 
         m_absolutePath = loadPath;
-        if (!AzFramework::StringFunc::Path::Normalize(m_absolutePath))
+        if (!ValidateDocumentPath(m_absolutePath))
         {
-            AZ_Error("AtomToolsDocument", false, "Document path could not be normalized: '%s'.", m_absolutePath.c_str());
-            return OpenFailed();
-        }
-
-        if (AzFramework::StringFunc::Path::IsRelative(m_absolutePath.c_str()))
-        {
-            AZ_Error("AtomToolsDocument", false, "Document path must be absolute: '%s'.", m_absolutePath.c_str());
+            AZ_Error("AtomToolsDocument", false, "Document path is not valid: '%s'.", m_absolutePath.c_str());
             return OpenFailed();
         }
 
@@ -155,15 +146,9 @@ namespace AtomToolsFramework
         }
 
         m_savePathNormalized = m_absolutePath;
-        if (!AzFramework::StringFunc::Path::Normalize(m_savePathNormalized))
+        if (!ValidateDocumentPath(m_savePathNormalized))
         {
-            AZ_Error("AtomToolsDocument", false, "Document save path could not be normalized: '%s'.", m_savePathNormalized.c_str());
-            return SaveFailed();
-        }
-
-        if (AzFramework::StringFunc::Path::IsRelative(m_savePathNormalized.c_str()))
-        {
-            AZ_Error("AtomToolsDocument", false, "Document save path must be absolute: '%s'.", m_savePathNormalized.c_str());
+            AZ_Error("AtomToolsDocument", false, "Document save path is not valid: '%s'.", m_savePathNormalized.c_str());
             return SaveFailed();
         }
 
@@ -191,15 +176,9 @@ namespace AtomToolsFramework
         }
 
         m_savePathNormalized = savePath;
-        if (!AzFramework::StringFunc::Path::Normalize(m_savePathNormalized))
+        if (!ValidateDocumentPath(m_savePathNormalized))
         {
-            AZ_Error("AtomToolsDocument", false, "Document save path could not be normalized: '%s'.", m_savePathNormalized.c_str());
-            return SaveFailed();
-        }
-
-        if (AzFramework::StringFunc::Path::IsRelative(m_savePathNormalized.c_str()))
-        {
-            AZ_Error("AtomToolsDocument", false, "Document save path must be absolute: '%s'.", m_savePathNormalized.c_str());
+            AZ_Error("AtomToolsDocument", false, "Document save path is not valid: '%s'.", m_savePathNormalized.c_str());
             return SaveFailed();
         }
 
@@ -221,15 +200,9 @@ namespace AtomToolsFramework
         }
 
         m_savePathNormalized = savePath;
-        if (!AzFramework::StringFunc::Path::Normalize(m_savePathNormalized))
+        if (!ValidateDocumentPath(m_savePathNormalized))
         {
-            AZ_Error("AtomToolsDocument", false, "Document save path could not be normalized: '%s'.", m_savePathNormalized.c_str());
-            return SaveFailed();
-        }
-
-        if (AzFramework::StringFunc::Path::IsRelative(m_savePathNormalized.c_str()))
-        {
-            AZ_Error("AtomToolsDocument", false, "Document save path must be absolute: '%s'.", m_savePathNormalized.c_str());
+            AZ_Error("AtomToolsDocument", false, "Document save path is not valid: '%s'.", m_savePathNormalized.c_str());
             return SaveFailed();
         }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
@@ -74,13 +74,17 @@ namespace AtomToolsFramework
                             : QObject::tr("Create %1...").arg(documentType.m_documentTypeName.c_str());
 
                         menu->addAction(createActionName, [entries, documentType, this]() {
-                            const AZStd::string defaultPath = GetUniqueFilePath(AZStd::string::format(
+                            const auto& defaultPath = GetUniqueFilePath(AZStd::string::format(
                                 "%s/Assets/untitled.%s", AZ::Utils::GetProjectPath().c_str(),
                                 documentType.GetDefaultExtensionToSave().c_str()));
 
-                            AtomToolsDocumentSystemRequestBus::Event(
-                                m_toolId, &AtomToolsDocumentSystemRequestBus::Events::CreateDocumentFromFilePath,
-                                entries.front()->GetFullPath(), GetSaveFilePath(defaultPath));
+                            const auto& savePath = GetSaveFilePath(defaultPath);
+                            if (!savePath.empty())
+                            {
+                                AtomToolsDocumentSystemRequestBus::Event(
+                                    m_toolId, &AtomToolsDocumentSystemRequestBus::Events::CreateDocumentFromFilePath,
+                                    entries.front()->GetFullPath(), savePath);
+                            }
                         });
                     }
                 }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentInspector.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentInspector.cpp
@@ -50,7 +50,7 @@ namespace AtomToolsFramework
                             AZStd::string::format("%s/%s", groupSettingsPrefix.c_str(), objectInfo.m_name.c_str()));
                         auto propertyGroupWidget = new InspectorPropertyGroupWidget(
                             objectInfo.m_objectPtr, objectInfo.m_objectPtr, objectInfo.m_objectType, this, this, groupSaveStateKey, {},
-                            m_nodeIndicatorFunction, 0);
+                            objectInfo.m_nodeIndicatorFunction, 0);
 
                         AddGroup(objectInfo.m_name, objectInfo.m_displayName, objectInfo.m_description, propertyGroupWidget);
                         SetGroupVisible(objectInfo.m_name, objectInfo.m_visible);
@@ -66,11 +66,6 @@ namespace AtomToolsFramework
     void AtomToolsDocumentInspector::SetDocumentSettingsPrefix(const AZStd::string& prefix)
     {
         m_documentSettingsPrefix = prefix;
-    }
-
-    void AtomToolsDocumentInspector::SetIndicatorFunction(const NodeIndicatorFunction& indicatorFunction)
-    {
-        m_nodeIndicatorFunction = indicatorFunction;
     }
 
     void AtomToolsDocumentInspector::Reset()

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -186,10 +186,7 @@ namespace AtomToolsFramework
 
         insertPostion = !m_menuView->actions().empty() ? m_menuView->actions().front() : nullptr;
 
-        m_actionPreviousTab = CreateAction(
-            "&Previous Tab",
-            [this]()
-            {
+        m_actionPreviousTab = CreateAction("&Previous Tab", [this]() {
             SelectPrevDocumentTab();
         }, Qt::CTRL | Qt::SHIFT | Qt::Key_Tab); //QKeySequence::PreviousChild is mapped incorrectly in Qt
         m_menuView->insertAction(insertPostion, m_actionPreviousTab);
@@ -258,74 +255,84 @@ namespace AtomToolsFramework
         return AZ::Uuid::CreateNull();
     }
 
-    void AtomToolsDocumentMainWindow::AddDocumentTab(
-        const AZ::Uuid& documentId, const AZStd::string& label, const AZStd::string& toolTip)
+    int AtomToolsDocumentMainWindow::GetDocumentTabIndex(const AZ::Uuid& documentId) const
     {
-        // Blocking signals from the tab bar so the currentChanged signal is not sent while a document is already being opened.
-        // This prevents the OnDocumentOpened notification from being sent recursively.
-        const QSignalBlocker blocker(m_tabWidget);
-
-        // If a tab for this document already exists then select it instead of creating a new one
         for (int tabIndex = 0; tabIndex < m_tabWidget->count(); ++tabIndex)
         {
             if (documentId == GetDocumentTabId(tabIndex))
             {
-                m_tabWidget->setCurrentIndex(tabIndex);
-                m_tabWidget->repaint();
-                return;
+                return tabIndex;
             }
         }
+        return -1;
+    }
 
-        const int tabIndex = m_tabWidget->addTab(CreateDocumentTabView(documentId), label.c_str());
+    bool AtomToolsDocumentMainWindow::HasDocumentTab(const AZ::Uuid& documentId) const
+    {
+        return GetDocumentTabIndex(documentId) >= 0;
+    }
 
-        // The user can manually reorder tabs which will invalidate any association by index.
-        // We need to store the document ID with the tab using the tab instead of a separate mapping.
-        m_tabWidget->tabBar()->setTabData(tabIndex, QVariant(documentId.ToString<QString>()));
-        m_tabWidget->setTabToolTip(tabIndex, toolTip.c_str());
-        m_tabWidget->setCurrentIndex(tabIndex);
-        m_tabWidget->setVisible(true);
-        m_tabWidget->repaint();
+    bool AtomToolsDocumentMainWindow::AddDocumentTab(const AZ::Uuid& documentId, QWidget* viewWidget)
+    {
+        if (!documentId.IsNull() && viewWidget)
+        {
+            // Blocking signals from the tab bar so the currentChanged signal is not sent while a document is already being opened.
+            // This prevents the OnDocumentOpened notification from being sent recursively.
+            const QSignalBlocker blocker(m_tabWidget);
+
+            // If a tab for this document already exists then select it instead of creating a new one
+            if (const int tabIndex = GetDocumentTabIndex(documentId); tabIndex >= 0)
+            {
+                m_tabWidget->setVisible(true);
+                m_tabWidget->setCurrentIndex(tabIndex);
+                UpdateDocumentTab(documentId);
+                delete viewWidget;
+                return false;
+            }
+
+            // The user can manually reorder tabs which will invalidate any association by index.
+            // We need to store the document ID with the tab using the tab instead of a separate mapping.
+            const int tabIndex = m_tabWidget->addTab(viewWidget, QString());
+            m_tabWidget->tabBar()->setTabData(tabIndex, QVariant(documentId.ToString<QString>()));
+            m_tabWidget->setVisible(true);
+            m_tabWidget->setCurrentIndex(tabIndex);
+            UpdateDocumentTab(documentId);
+            return true;
+        }
+
+        delete viewWidget;
+        return false;
     }
 
     void AtomToolsDocumentMainWindow::RemoveDocumentTab(const AZ::Uuid& documentId)
     {
-        // We are not blocking signals here because we want closing tabs to close the associated document
-        // and automatically select the next document.
-        for (int tabIndex = 0; tabIndex < m_tabWidget->count(); ++tabIndex)
+        // We are not blocking signals here because we want closing tabs to close the document and automatically select the next document.
+        if (const int tabIndex = GetDocumentTabIndex(documentId); tabIndex >= 0)
         {
-            if (documentId == GetDocumentTabId(tabIndex))
-            {
-                m_tabWidget->removeTab(tabIndex);
-                m_tabWidget->setVisible(m_tabWidget->count() > 0);
-                m_tabWidget->repaint();
-                break;
-            }
+            m_tabWidget->removeTab(tabIndex);
+            m_tabWidget->setVisible(m_tabWidget->count() > 0);
+            m_tabWidget->repaint();
         }
     }
 
-    void AtomToolsDocumentMainWindow::UpdateDocumentTab(
-        const AZ::Uuid& documentId, const AZStd::string& label, const AZStd::string& toolTip, bool isModified)
+    void AtomToolsDocumentMainWindow::UpdateDocumentTab(const AZ::Uuid& documentId)
     {
         // Whenever a document is opened, saved, or modified we need to update the tab label
-        if (!documentId.IsNull())
+        if (const int tabIndex = GetDocumentTabIndex(documentId); tabIndex >= 0)
         {
-            // Because tab order and indexes can change from user interactions, we cannot store a map
-            // between a tab index and document ID.
-            // We must iterate over all of the tabs to find the one associated with this document.
-            for (int tabIndex = 0; tabIndex < m_tabWidget->count(); ++tabIndex)
-            {
-                if (documentId == GetDocumentTabId(tabIndex))
-                {
-                    // We use an asterisk prepended to the file name to denote modified document
-                    // Appending is standard and preferred but the tabs elide from the
-                    // end (instead of middle) and cut it off
-                    const AZStd::string modifiedLabel = isModified ? "* " + label : label;
-                    m_tabWidget->setTabText(tabIndex, modifiedLabel.c_str());
-                    m_tabWidget->setTabToolTip(tabIndex, toolTip.c_str());
-                    m_tabWidget->repaint();
-                    break;
-                }
-            }
+            bool isModified = false;
+            AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
+            AZStd::string absolutePath;
+            AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+            AZStd::string filename;
+            AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
+
+            // We use an asterisk prepended to the file name to denote modified document.
+            // Appending is standard and preferred but the tabs elide from the end (instead of middle) and cut it off.
+            const AZStd::string label = isModified ? "* " + filename : filename;
+            m_tabWidget->setTabText(tabIndex, label.c_str());
+            m_tabWidget->setTabToolTip(tabIndex, absolutePath.c_str());
+            m_tabWidget->repaint();
         }
     }
 
@@ -346,43 +353,30 @@ namespace AtomToolsFramework
         }
     }
 
-    QWidget* AtomToolsDocumentMainWindow::CreateDocumentTabView(const AZ::Uuid& documentId)
-    {
-        AZ_UNUSED(documentId);
-        auto contentWidget = new QWidget(centralWidget());
-        contentWidget->setContentsMargins(0, 0, 0, 0);
-        contentWidget->setFixedSize(0, 0);
-        return contentWidget;
-    }
-
     void AtomToolsDocumentMainWindow::OpenDocumentTabContextMenu()
     {
         const QTabBar* tabBar = m_tabWidget->tabBar();
         const QPoint position = tabBar->mapFromGlobal(QCursor::pos());
         const int clickedTabIndex = tabBar->tabAt(position);
-        const int currentTabIndex = tabBar->currentIndex();
-        if (clickedTabIndex >= 0)
+        if (const AZ::Uuid documentId = GetDocumentTabId(clickedTabIndex); !documentId.IsNull())
         {
-            QMenu tabMenu;
-            const QString selectActionName = (currentTabIndex == clickedTabIndex) ? "Select in Browser" : "Select";
-            tabMenu.addAction(selectActionName, [this, clickedTabIndex]() {
-                const AZ::Uuid documentId = GetDocumentTabId(clickedTabIndex);
-                AtomToolsDocumentNotificationBus::Event(
-                    m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
-            });
-            tabMenu.addAction("Close", [this, clickedTabIndex]() {
-                const AZ::Uuid documentId = GetDocumentTabId(clickedTabIndex);
-                AtomToolsDocumentSystemRequestBus::Event(
-                    m_toolId, &AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
-            });
-            auto closeOthersAction = tabMenu.addAction("Close Others", [this, clickedTabIndex]() {
-                const AZ::Uuid documentId = GetDocumentTabId(clickedTabIndex);
-                AtomToolsDocumentSystemRequestBus::Event(
-                    m_toolId, &AtomToolsDocumentSystemRequestBus::Events::CloseAllDocumentsExcept, documentId);
-            });
-            closeOthersAction->setEnabled(tabBar->count() > 1);
-            tabMenu.exec(QCursor::pos());
+            QMenu menu;
+            PopulateTabContextMenu(documentId, menu);
+            menu.exec(QCursor::pos());
         }
+    }
+
+    void AtomToolsDocumentMainWindow::PopulateTabContextMenu(const AZ::Uuid& documentId, QMenu& menu)
+    {
+        menu.addAction("Select", [this, documentId]() {
+            AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
+        });
+        menu.addAction("Close", [this, documentId]() {
+            AtomToolsDocumentSystemRequestBus::Event(m_toolId, &AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
+        });
+        menu.addAction("Close Others", [this, documentId]() {
+            AtomToolsDocumentSystemRequestBus::Event(m_toolId, &AtomToolsDocumentSystemRequestBus::Events::CloseAllDocumentsExcept, documentId);
+        })->setEnabled(m_tabWidget->tabBar()->count() > 1);
     }
 
     bool AtomToolsDocumentMainWindow::GetCreateDocumentParams(AZStd::string& openPath, AZStd::string& savePath)
@@ -456,28 +450,18 @@ namespace AtomToolsFramework
 
     void AtomToolsDocumentMainWindow::OnDocumentOpened(const AZ::Uuid& documentId)
     {
+        UpdateDocumentTab(documentId);
+
         bool isOpen = false;
         AtomToolsDocumentRequestBus::EventResult(isOpen, documentId, &AtomToolsDocumentRequestBus::Events::IsOpen);
         bool canSave = false;
         AtomToolsDocumentRequestBus::EventResult(canSave, documentId, &AtomToolsDocumentRequestBus::Events::CanSave);
-        bool isModified = false;
-        AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
         bool canUndo = false;
         AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsDocumentRequestBus::Events::CanUndo);
         bool canRedo = false;
         AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsDocumentRequestBus::Events::CanRedo);
         AZStd::string absolutePath;
         AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
-        AZStd::string filename;
-        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
-
-        // Update UI to display the new document
-        if (!documentId.IsNull() && isOpen)
-        {
-            // Create a new tab for the document ID and assign it's label to the file name of the document.
-            AddDocumentTab(documentId, filename, absolutePath);
-            UpdateDocumentTab(documentId, filename, absolutePath, isModified);
-        }
 
         const bool hasTabs = m_tabWidget->count() > 0;
 
@@ -488,8 +472,8 @@ namespace AtomToolsFramework
         m_actionCloseAll->setEnabled(hasTabs);
         m_actionCloseOthers->setEnabled(hasTabs);
 
-        m_actionSave->setEnabled(isOpen && canSave);
-        m_actionSaveAsCopy->setEnabled(isOpen && canSave);
+        m_actionSave->setEnabled(canSave);
+        m_actionSaveAsCopy->setEnabled(canSave);
         m_actionSaveAsChild->setEnabled(isOpen);
         m_actionSaveAll->setEnabled(hasTabs);
 
@@ -503,10 +487,9 @@ namespace AtomToolsFramework
 
         ActivateWindow();
 
-        const QString documentPath = GetDocumentPath(documentId);
-        if (!documentPath.isEmpty())
+        if (isOpen && !absolutePath.empty())
         {
-            SetStatusMessage(tr("Document opened: %1").arg(documentPath));
+            SetStatusMessage(tr("Document opened: %1").arg(absolutePath.c_str()));
         }
     }
 
@@ -516,15 +499,14 @@ namespace AtomToolsFramework
         SetStatusMessage(tr("Document closed: %1").arg(GetDocumentPath(documentId)));
     }
 
+    void AtomToolsDocumentMainWindow::OnDocumentDestroyed(const AZ::Uuid& documentId)
+    {
+        RemoveDocumentTab(documentId);
+    }
+
     void AtomToolsDocumentMainWindow::OnDocumentModified(const AZ::Uuid& documentId)
     {
-        bool isModified = false;
-        AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
-        AZStd::string absolutePath;
-        AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
-        AZStd::string filename;
-        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
-        UpdateDocumentTab(documentId, filename, absolutePath, isModified);
+        UpdateDocumentTab(documentId);
     }
 
     void AtomToolsDocumentMainWindow::OnDocumentUndoStateChanged(const AZ::Uuid& documentId)
@@ -542,16 +524,9 @@ namespace AtomToolsFramework
 
     void AtomToolsDocumentMainWindow::OnDocumentSaved(const AZ::Uuid& documentId)
     {
-        bool isModified = false;
-        AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
-        AZStd::string absolutePath;
-        AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
-        AZStd::string filename;
-        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
-        UpdateDocumentTab(documentId, filename, absolutePath, isModified);
+        UpdateDocumentTab(documentId);
         SetStatusMessage(tr("Document saved: %1").arg(GetDocumentPath(documentId)));
     }
-
 
     void AtomToolsDocumentMainWindow::closeEvent(QCloseEvent* closeEvent)
     {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
@@ -103,6 +103,7 @@ namespace AtomToolsFramework
 
         const AZ::Uuid documentId = document->GetId();
         m_documentMap.emplace(documentId, document.release());
+        documentType.CreateDocumentView(m_toolId, documentId);
         return documentId;
     }
 
@@ -132,20 +133,60 @@ namespace AtomToolsFramework
 
     AZ::Uuid AtomToolsDocumentSystem::CreateDocumentFromFilePath(const AZStd::string& sourcePath, const AZStd::string& targetPath)
     {
-        const AZ::Uuid documentId = OpenDocumentImpl(sourcePath, false);
+        TraceRecorder traceRecorder(m_maxMessageBoxLineCount);
+
+        AZStd::string requestedPath = sourcePath;
+        if (!ValidateDocumentPath(requestedPath))
+        {
+            QMessageBox::critical(
+                GetToolMainWindow(),
+                QObject::tr("Document could not be created"),
+                QObject::tr("Document path is invalid:\n%1").arg(requestedPath.c_str()));
+            return AZ::Uuid::CreateNull();
+        }
+
+        AZ::Uuid documentId = CreateDocumentFromFileType(requestedPath);
         if (documentId.IsNull())
         {
+            QMessageBox::critical(
+                GetToolMainWindow(),
+                QObject::tr("Document could not be created"),
+                QObject::tr("Failed to create: \n%1\n\n%2").arg(requestedPath.c_str()).arg(traceRecorder.GetDump().c_str()));
             return AZ::Uuid::CreateNull();
         }
 
-        if (!SaveDocumentAsChild(documentId, targetPath))
+        bool openResult = false;
+        AtomToolsDocumentRequestBus::EventResult(openResult, documentId, &AtomToolsDocumentRequestBus::Events::Open, requestedPath);
+        if (!openResult)
         {
-            CloseDocument(documentId);
+            QMessageBox::critical(
+                GetToolMainWindow(),
+                QObject::tr("Document could not be opened"),
+                QObject::tr("Failed to open: \n%1\n\n%2").arg(requestedPath.c_str()).arg(traceRecorder.GetDump().c_str()));
+            DestroyDocument(documentId);
             return AZ::Uuid::CreateNull();
         }
 
-        // Send document open notification after creating new one
-        AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
+        if (!targetPath.empty())
+        {
+            if (!SaveDocumentAsChild(documentId, targetPath))
+            {
+                CloseDocument(documentId);
+                return AZ::Uuid::CreateNull();
+            }
+
+            // Send document open notification after creating new one
+            AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
+        }
+
+        if (traceRecorder.GetWarningCount(true) > 0)
+        {
+            QMessageBox::warning(
+                GetToolMainWindow(),
+                QObject::tr("Document opened with warnings"),
+                QObject::tr("Warnings encountered: \n%1\n\n%2").arg(requestedPath.c_str()).arg(traceRecorder.GetDump().c_str()));
+        }
+
         return documentId;
     }
 
@@ -156,7 +197,31 @@ namespace AtomToolsFramework
 
     AZ::Uuid AtomToolsDocumentSystem::OpenDocument(const AZStd::string& sourcePath)
     {
-        return OpenDocumentImpl(sourcePath, true);
+        AZStd::string requestedPath = sourcePath;
+        if (!ValidateDocumentPath(requestedPath))
+        {
+            QMessageBox::critical(
+                GetToolMainWindow(),
+                QObject::tr("Document could not be opened"),
+                QObject::tr("Document path is invalid:\n%1").arg(requestedPath.c_str()));
+            return AZ::Uuid::CreateNull();
+        }
+
+        // Determine if the file is already open and select it
+        for (const auto& documentPair : m_documentMap)
+        {
+            AZStd::string openDocumentPath;
+            AtomToolsDocumentRequestBus::EventResult(
+                openDocumentPath, documentPair.first, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+            if (AZ::StringFunc::Equal(openDocumentPath, requestedPath))
+            {
+                AtomToolsDocumentNotificationBus::Event(
+                    m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentPair.first);
+                return documentPair.first;
+            }
+        }
+
+        return CreateDocumentFromFilePath(requestedPath, {});
     }
 
     bool AtomToolsDocumentSystem::CloseDocument(const AZ::Uuid& documentId)
@@ -177,7 +242,8 @@ namespace AtomToolsFramework
         AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
         if (isModified)
         {
-            auto selection = QMessageBox::question(QApplication::activeWindow(),
+            auto selection = QMessageBox::question(
+                GetToolMainWindow(),
                 QObject::tr("Document has unsaved changes"),
                 QObject::tr("Do you want to save changes to\n%1?").arg(documentPath.c_str()),
                 QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
@@ -203,7 +269,7 @@ namespace AtomToolsFramework
         if (!closeResult)
         {
             QMessageBox::critical(
-                QApplication::activeWindow(),
+                GetToolMainWindow(),
                 QObject::tr("Document could not be closed"),
                 QObject::tr("Failed to close: \n%1\n\n%2").arg(documentPath.c_str()).arg(traceRecorder.GetDump().c_str()));
             return false;
@@ -251,9 +317,7 @@ namespace AtomToolsFramework
         AZStd::string saveDocumentPath;
         AtomToolsDocumentRequestBus::EventResult(saveDocumentPath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
 
-        if (saveDocumentPath.empty() ||
-            !AzFramework::StringFunc::Path::Normalize(saveDocumentPath) ||
-            AzFramework::StringFunc::Path::IsRelative(saveDocumentPath.c_str()))
+        if (!ValidateDocumentPath(saveDocumentPath))
         {
             return false;
         }
@@ -262,7 +326,7 @@ namespace AtomToolsFramework
         if (saveInfo.exists() && !saveInfo.isWritable())
         {
             QMessageBox::critical(
-                QApplication::activeWindow(),
+                GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Document could not be overwritten:\n%1").arg(saveDocumentPath.c_str()));
             return false;
@@ -275,7 +339,7 @@ namespace AtomToolsFramework
         if (!result)
         {
             QMessageBox::critical(
-                QApplication::activeWindow(),
+                GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Failed to save: \n%1\n\n%2").arg(saveDocumentPath.c_str()).arg(traceRecorder.GetDump().c_str()));
             return false;
@@ -287,9 +351,7 @@ namespace AtomToolsFramework
     bool AtomToolsDocumentSystem::SaveDocumentAsCopy(const AZ::Uuid& documentId, const AZStd::string& targetPath)
     {
         AZStd::string saveDocumentPath = targetPath;
-        if (saveDocumentPath.empty() ||
-            !AzFramework::StringFunc::Path::Normalize(saveDocumentPath) ||
-            AzFramework::StringFunc::Path::IsRelative(saveDocumentPath.c_str()))
+        if (!ValidateDocumentPath(saveDocumentPath))
         {
             return false;
         }
@@ -297,7 +359,8 @@ namespace AtomToolsFramework
         const QFileInfo saveInfo(saveDocumentPath.c_str());
         if (saveInfo.exists() && !saveInfo.isWritable())
         {
-            QMessageBox::critical(QApplication::activeWindow(),
+            QMessageBox::critical(
+                GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Document could not be overwritten:\n%1").arg(saveDocumentPath.c_str()));
             return false;
@@ -310,7 +373,7 @@ namespace AtomToolsFramework
         if (!result)
         {
             QMessageBox::critical(
-                QApplication::activeWindow(),
+                GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Failed to save: \n%1\n\n%2").arg(saveDocumentPath.c_str()).arg(traceRecorder.GetDump().c_str()));
             return false;
@@ -322,9 +385,7 @@ namespace AtomToolsFramework
     bool AtomToolsDocumentSystem::SaveDocumentAsChild(const AZ::Uuid& documentId, const AZStd::string& targetPath)
     {
         AZStd::string saveDocumentPath = targetPath;
-        if (saveDocumentPath.empty() ||
-            !AzFramework::StringFunc::Path::Normalize(saveDocumentPath) ||
-            AzFramework::StringFunc::Path::IsRelative(saveDocumentPath.c_str()))
+        if (!ValidateDocumentPath(saveDocumentPath))
         {
             return false;
         }
@@ -333,7 +394,7 @@ namespace AtomToolsFramework
         if (saveInfo.exists() && !saveInfo.isWritable())
         {
             QMessageBox::critical(
-                QApplication::activeWindow(),
+                GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Document could not be overwritten:\n%1").arg(saveDocumentPath.c_str()));
             return false;
@@ -346,7 +407,7 @@ namespace AtomToolsFramework
         if (!result)
         {
             QMessageBox::critical(
-                QApplication::activeWindow(),
+                GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Failed to save: \n%1\n\n%2").arg(saveDocumentPath.c_str()).arg(traceRecorder.GetDump().c_str()));
             return false;
@@ -417,7 +478,7 @@ namespace AtomToolsFramework
             AtomToolsDocumentRequestBus::EventResult(documentPath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
 
             if (enableHotReloadPrompts &&
-                (QMessageBox::question(QApplication::activeWindow(),
+                (QMessageBox::question(GetToolMainWindow(),
                 QObject::tr("Document was externally modified"),
                 QObject::tr("Would you like to reopen the document:\n%1?").arg(documentPath.c_str()),
                 QMessageBox::Yes | QMessageBox::No) != QMessageBox::Yes))
@@ -432,7 +493,7 @@ namespace AtomToolsFramework
             if (!openResult)
             {
                 QMessageBox::critical(
-                    QApplication::activeWindow(),
+                    GetToolMainWindow(),
                     QObject::tr("Document could not be opened"),
                     QObject::tr("Failed to open: \n%1\n\n%2").arg(documentPath.c_str()).arg(traceRecorder.GetDump().c_str()));
                 CloseDocument(documentId);
@@ -445,7 +506,7 @@ namespace AtomToolsFramework
             AtomToolsDocumentRequestBus::EventResult(documentPath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
 
             if (enableHotReloadPrompts &&
-                (QMessageBox::question(QApplication::activeWindow(),
+                (QMessageBox::question(GetToolMainWindow(),
                 QObject::tr("Document dependencies have changed"),
                 QObject::tr("Would you like to update the document with these changes:\n%1?").arg(documentPath.c_str()),
                 QMessageBox::Yes | QMessageBox::No) != QMessageBox::Yes))
@@ -460,7 +521,7 @@ namespace AtomToolsFramework
             if (!openResult)
             {
                 QMessageBox::critical(
-                    QApplication::activeWindow(),
+                    GetToolMainWindow(),
                     QObject::tr("Document could not be opened"),
                     QObject::tr("Failed to open: \n%1\n\n%2").arg(documentPath.c_str()).arg(traceRecorder.GetDump().c_str()));
                 CloseDocument(documentId);
@@ -470,69 +531,5 @@ namespace AtomToolsFramework
         m_documentIdsWithDependencyChanges.clear();
         m_documentIdsWithExternalChanges.clear();
         m_queueReopenDocuments = false;
-    }
-
-    AZ::Uuid AtomToolsDocumentSystem::OpenDocumentImpl(const AZStd::string& sourcePath, bool checkIfAlreadyOpen)
-    {
-        AZStd::string requestedPath = sourcePath;
-        if (requestedPath.empty() ||
-            !AzFramework::StringFunc::Path::Normalize(requestedPath) ||
-            AzFramework::StringFunc::Path::IsRelative(requestedPath.c_str()))
-        {
-            QMessageBox::critical(QApplication::activeWindow(),
-                QObject::tr("Document could not be opened"),
-                QObject::tr("Document path is invalid:\n%1").arg(requestedPath.c_str()));
-            return AZ::Uuid::CreateNull();
-        }
-
-        // Determine if the file is already open and select it
-        if (checkIfAlreadyOpen)
-        {
-            for (const auto& documentPair : m_documentMap)
-            {
-                AZStd::string openDocumentPath;
-                AtomToolsDocumentRequestBus::EventResult(openDocumentPath, documentPair.first, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
-                if (openDocumentPath == requestedPath)
-                {
-                    AtomToolsDocumentNotificationBus::Event(
-                        m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentPair.first);
-                    return documentPair.first;
-                }
-            }
-        }
-
-        TraceRecorder traceRecorder(m_maxMessageBoxLineCount);
-
-        AZ::Uuid documentId = CreateDocumentFromFileType(requestedPath);
-        if (documentId.IsNull())
-        {
-            QMessageBox::critical(
-                QApplication::activeWindow(),
-                QObject::tr("Document could not be opened"),
-                QObject::tr("Failed to create: \n%1\n\n%2").arg(requestedPath.c_str()).arg(traceRecorder.GetDump().c_str()));
-            return AZ::Uuid::CreateNull();
-        }
-
-        bool openResult = false;
-        AtomToolsDocumentRequestBus::EventResult(openResult, documentId, &AtomToolsDocumentRequestBus::Events::Open, requestedPath);
-        if (!openResult)
-        {
-            QMessageBox::critical(
-                QApplication::activeWindow(),
-                QObject::tr("Document could not be opened"),
-                QObject::tr("Failed to open: \n%1\n\n%2").arg(requestedPath.c_str()).arg(traceRecorder.GetDump().c_str()));
-            DestroyDocument(documentId);
-            return AZ::Uuid::CreateNull();
-        }
-
-        if (traceRecorder.GetWarningCount(true) > 0)
-        {
-            QMessageBox::warning(
-                QApplication::activeWindow(),
-                QObject::tr("Document opened with warnings"),
-                QObject::tr("Warnings encountered: \n%1\n\n%2").arg(requestedPath.c_str()).arg(traceRecorder.GetDump().c_str()));
-        }
-
-        return documentId;
     }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentTypeInfo.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentTypeInfo.cpp
@@ -14,7 +14,12 @@ namespace AtomToolsFramework
 {
     AtomToolsDocumentRequests* DocumentTypeInfo::CreateDocument(const AZ::Crc32& toolId) const
     {
-        return m_documentFactoryCallback ? m_documentFactoryCallback(toolId) : nullptr;
+        return m_documentFactoryCallback ? m_documentFactoryCallback(toolId, *this) : nullptr;
+    }
+
+    bool DocumentTypeInfo::CreateDocumentView(const AZ::Crc32& toolId, const AZ::Uuid& documentId) const
+    {
+        return m_documentViewFactoryCallback ? m_documentViewFactoryCallback(toolId, documentId) : false;
     }
 
     bool DocumentTypeInfo::IsSupportedExtensionToCreate(const AZStd::string& path) const
@@ -32,7 +37,7 @@ namespace AtomToolsFramework
         return IsSupportedExtension(m_supportedExtensionsToSave, path);
     }
 
-    bool DocumentTypeInfo::IsSupportedExtension(const ExtensionInfoVector& supportedExtensions, const AZStd::string& path) const
+    bool DocumentTypeInfo::IsSupportedExtension(const DocumentExtensionInfoVector& supportedExtensions, const AZStd::string& path) const
     {
         return AZStd::any_of(
             supportedExtensions.begin(), supportedExtensions.end(),

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/InspectorWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/InspectorWidget.cpp
@@ -57,6 +57,7 @@ namespace AtomToolsFramework
                 ;
         }
     }
+
     InspectorWidget::InspectorWidget(QWidget* parent)
         : QWidget(parent)
         , m_ui(new Ui::InspectorWidget)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -20,6 +20,7 @@
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzQtComponents/Components/Widgets/FileDialog.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
+#include <AzToolsFramework/API/EditorWindowRequestBus.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/AssetSelectionModel.h>
@@ -62,6 +63,14 @@ namespace AtomToolsFramework
         job->Start();
     }
 
+    QWidget* GetToolMainWindow()
+    {
+        QWidget* mainWindow = QApplication::activeWindow();
+        AzToolsFramework::EditorWindowRequestBus::BroadcastResult(
+            mainWindow, &AzToolsFramework::EditorWindowRequestBus::Events::GetAppMainWindow);
+        return mainWindow;
+    }
+
     AZStd::string GetDisplayNameFromPath(const AZStd::string& path)
     {
         QFileInfo fileInfo(path.c_str());
@@ -81,7 +90,7 @@ namespace AtomToolsFramework
         const QString initialExt(initialFileInfo.completeSuffix());
 
         const QFileInfo selectedFileInfo(AzQtComponents::FileDialog::GetSaveFileName(
-            QApplication::activeWindow(),
+            GetToolMainWindow(),
             QObject::tr("Save %1").arg(title.c_str()),
             initialFileInfo.absoluteFilePath(),
             QString("Files (*.%1)").arg(initialExt)));
@@ -94,7 +103,7 @@ namespace AtomToolsFramework
 
         if (!selectedFileInfo.absoluteFilePath().endsWith(initialExt))
         {
-            QMessageBox::critical(QApplication::activeWindow(), "Error", QString("File name must have .%1 extension.").arg(initialExt));
+            QMessageBox::critical(GetToolMainWindow(), "Error", QString("File name must have .%1 extension.").arg(initialExt));
             return AZStd::string();
         }
 
@@ -111,7 +120,7 @@ namespace AtomToolsFramework
         selection.SetMultiselect(true);
 
         AzToolsFramework::AssetBrowser::AssetBrowserComponentRequestBus::Broadcast(
-            &AzToolsFramework::AssetBrowser::AssetBrowserComponentRequests::PickAssets, selection, QApplication::activeWindow());
+            &AzToolsFramework::AssetBrowser::AssetBrowserComponentRequests::PickAssets, selection, GetToolMainWindow());
 
         AZStd::vector<AZStd::string> results;
         results.reserve(selection.GetResults().size());
@@ -143,6 +152,11 @@ namespace AtomToolsFramework
     AZStd::string GetUniqueDuplicateFilePath(const AZStd::string& initialPath)
     {
         return GetSaveFilePath(GetUniqueFilePath(initialPath), "Duplicate File");
+    }
+
+    bool ValidateDocumentPath(AZStd::string& path)
+    {
+        return !path.empty() && AzFramework::StringFunc::Path::Normalize(path) && !AzFramework::StringFunc::Path::IsRelative(path.c_str());
     }
 
     bool LaunchTool(const QString& baseName, const QStringList& arguments)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -81,6 +81,7 @@ namespace AtomToolsFramework
         if (!m_shownBefore)
         {
             m_shownBefore = true;
+            m_defaultWindowState = m_advancedDockManager->saveState();
             m_mainWindowWrapper->showFromSettings();
             const AZStd::string windowState =
                 AtomToolsFramework::GetSettingsObject("/O3DE/AtomToolsFramework/MainWindow/WindowState", AZStd::string());
@@ -118,10 +119,11 @@ namespace AtomToolsFramework
             return false;
         }
 
-        auto dockWidget = new AzQtComponents::StyledDockWidget(name.c_str());
+        auto dockWidget = new AzQtComponents::StyledDockWidget(name.c_str(), this);
         dockWidget->setObjectName(QString("%1_DockWidget").arg(name.c_str()));
         dockWidget->setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetFloatable | QDockWidget::DockWidgetMovable);
-        widget->setObjectName(name.c_str());
+        widget->setObjectName(QString("%1_Widget").arg(name.c_str()));
+        widget->setWindowTitle(name.c_str());
         widget->setParent(dockWidget);
         widget->setMinimumSize(QSize(300, 300));
         dockWidget->setWidget(widget);
@@ -222,6 +224,11 @@ namespace AtomToolsFramework
         m_menuEdit->addAction("&Settings...", [this]() {
             OpenSettings();
         }, QKeySequence::Preferences);
+
+        m_menuView->addAction("Default Layout", [this]() {
+            m_advancedDockManager->restoreState(m_defaultWindowState);
+        });
+        m_menuView->addSeparator();
 
         m_menuHelp->addAction("&Help...", [this]() {
             OpenHelp();

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.h
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.h
@@ -36,12 +36,11 @@ namespace MaterialEditor
         static void Reflect(AZ::ReflectContext* context);
 
         MaterialDocument() = default;
-        MaterialDocument(const AZ::Crc32& toolId);
+        MaterialDocument(const AZ::Crc32& toolId, const AtomToolsFramework::DocumentTypeInfo& documentTypeInfo);
         virtual ~MaterialDocument();
 
         // AtomToolsFramework::AtomToolsDocument overrides...
         static AtomToolsFramework::DocumentTypeInfo BuildDocumentTypeInfo();
-        AtomToolsFramework::DocumentTypeInfo GetDocumentTypeInfo() const override;
         AtomToolsFramework::DocumentObjectInfoVector GetObjectInfo() const override;
         bool Open(const AZStd::string& loadPath) override;
         bool Save() override;

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/MaterialEditorApplication.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/MaterialEditorApplication.cpp
@@ -71,9 +71,16 @@ namespace MaterialEditor
     {
         Base::StartCommon(systemEntity);
 
+        // Overriding default document type info to provide a custom view
+        auto documentTypeInfo = MaterialDocument::BuildDocumentTypeInfo();
+        documentTypeInfo.m_documentViewFactoryCallback = [this]([[maybe_unused]] const AZ::Crc32& toolId, const AZ::Uuid& documentId) {
+            auto emptyWidget = new QWidget(m_window.get());
+            emptyWidget->setContentsMargins(0, 0, 0, 0);
+            emptyWidget->setFixedSize(0, 0);
+            return m_window->AddDocumentTab(documentId, emptyWidget);
+        };
         AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Event(
-            m_toolId, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Handler::RegisterDocumentType,
-            MaterialDocument::BuildDocumentTypeInfo());
+            m_toolId, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Handler::RegisterDocumentType, documentTypeInfo);
 
         m_viewportSettingsSystem.reset(aznew MaterialViewportSettingsSystem(m_toolId));
 

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportWidget.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportWidget.cpp
@@ -22,12 +22,12 @@
 #include <Atom/RPI.Public/Material/Material.h>
 #include <Atom/RPI.Public/Pass/Specific/SwapChainPass.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>
+#include <Atom/RPI.Public/RPIUtils.h>
 #include <Atom/RPI.Public/RenderPipeline.h>
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/ViewportContext.h>
 #include <Atom/RPI.Public/ViewportContextBus.h>
 #include <Atom/RPI.Public/WindowContext.h>
-#include <Atom/RPI.Public/RPIUtils.h>
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 #include <AtomCore/Instance/InstanceDatabase.h>
 #include <AtomLyIntegration/CommonFeatures/Grid/GridComponentConfig.h>
@@ -72,7 +72,7 @@ namespace MaterialEditor
         const AZ::Name defaultContextName = viewportContextManager->GetDefaultViewportContextName();
         viewportContextManager->RenameViewportContext(GetViewportContext(), defaultContextName);
 
-        // Create a custom entity context for the entities in this viewport 
+        // Create a custom entity context for the entities in this viewport
         m_entityContext = AZStd::make_unique<AzFramework::EntityContext>();
         m_entityContext->InitContext();
 
@@ -95,18 +95,18 @@ namespace MaterialEditor
         m_frameworkScene->SetSubsystem(m_entityContext.get());
 
         // Load the render pipeline asset
-        AZStd::optional<AZ::RPI::RenderPipelineDescriptor> mainPipelineDesc =
-            AZ::RPI::GetRenderPipelineDescriptorFromAsset(m_mainPipelineAssetPath, AZStd::string::format("_%i", GetViewportContext()->GetId()));
+        AZStd::optional<AZ::RPI::RenderPipelineDescriptor> mainPipelineDesc = AZ::RPI::GetRenderPipelineDescriptorFromAsset(
+            m_mainPipelineAssetPath, AZStd::string::format("_%i", GetViewportContext()->GetId()));
         AZ_Assert(mainPipelineDesc.has_value(), "Invalid render pipeline descriptor from asset %s", m_mainPipelineAssetPath.c_str());
 
-        // TODO etApplicationMultisampleState should only be called once per application and will need to consider scenarios with multiple
-        // viewports and pipelines
-        // The default pipeline determines the initial MSAA state for the application
+        // TODO SetApplicationMultisampleState should only be called once per application and will need to consider multiple viewports and
+        // pipelines. The default pipeline determines the initial MSAA state for the application.
         AZ::RPI::RPISystemInterface::Get()->SetApplicationMultisampleState(mainPipelineDesc.value().m_renderSettings.m_multisampleState);
         mainPipelineDesc.value().m_renderSettings.m_multisampleState = AZ::RPI::RPISystemInterface::Get()->GetApplicationMultisampleState();
 
         // Create a render pipeline from the specified asset for the window context and add the pipeline to the scene
-        m_renderPipeline = AZ::RPI::RenderPipeline::CreateRenderPipelineForWindow(mainPipelineDesc.value(), *GetViewportContext()->GetWindowContext().get());
+        m_renderPipeline = AZ::RPI::RenderPipeline::CreateRenderPipelineForWindow(
+            mainPipelineDesc.value(), *GetViewportContext()->GetWindowContext().get());
         m_scene->AddRenderPipeline(m_renderPipeline);
 
         // Create the BRDF texture generation pipeline

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <AtomToolsFramework/DynamicProperty/DynamicProperty.h>
-#include <AtomToolsFramework/Util/MaterialPropertyUtil.h>
 #include <AtomToolsFramework/Util/Util.h>
 #include <Viewport/MaterialViewportWidget.h>
 #include <Window/MaterialEditorWindow.h>
@@ -39,19 +38,9 @@ namespace MaterialEditor
 
         m_materialInspector = new AtomToolsFramework::AtomToolsDocumentInspector(m_toolId, this);
         m_materialInspector->SetDocumentSettingsPrefix("/O3DE/Atom/MaterialEditor/MaterialInspector");
-        m_materialInspector->SetIndicatorFunction(
-            [](const AzToolsFramework::InstanceDataNode* node)
-            {
-                const auto property = AtomToolsFramework::FindAncestorInstanceDataNodeByType<AtomToolsFramework::DynamicProperty>(node);
-                if (property && !AtomToolsFramework::ArePropertyValuesEqual(property->GetValue(), property->GetConfig().m_parentValue))
-                {
-                    return ":/Icons/changed_property.svg";
-                }
-                return ":/Icons/blank.png";
-            });
 
         AddDockWidget("Inspector", m_materialInspector, Qt::RightDockWidgetArea, Qt::Vertical);
-        AddDockWidget("Viewport Settings", new ViewportSettingsInspector(m_toolId), Qt::LeftDockWidgetArea, Qt::Vertical);
+        AddDockWidget("Viewport Settings", new ViewportSettingsInspector(m_toolId, this), Qt::LeftDockWidgetArea, Qt::Vertical);
         SetDockWidgetVisible("Viewport Settings", false);
 
         OnDocumentOpened(AZ::Uuid::CreateNull());

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/ViewportSettingsInspector/ViewportSettingsInspector.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/ViewportSettingsInspector/ViewportSettingsInspector.cpp
@@ -122,7 +122,7 @@ namespace MaterialEditor
         AtomToolsFramework::AssetSelectionGrid dialog("Model Preset Browser", [](const AZ::Data::AssetInfo& assetInfo) {
             return assetInfo.m_assetType == AZ::RPI::AnyAsset::RTTI_Type() &&
                 AZ::StringFunc::EndsWith(assetInfo.m_relativePath.c_str(), AZ::Render::ModelPreset::Extension);
-        }, QSize(itemSize, itemSize), QApplication::activeWindow());
+        }, QSize(itemSize, itemSize), AtomToolsFramework::GetToolMainWindow());
 
         AZ::Data::AssetId assetId;
         MaterialViewportSettingsRequestBus::EventResult(
@@ -226,7 +226,7 @@ namespace MaterialEditor
         AtomToolsFramework::AssetSelectionGrid dialog("Lighting Preset Browser", [](const AZ::Data::AssetInfo& assetInfo) {
             return assetInfo.m_assetType == AZ::RPI::AnyAsset::RTTI_Type() &&
                 AZ::StringFunc::EndsWith(assetInfo.m_relativePath.c_str(), AZ::Render::LightingPreset::Extension);
-        }, QSize(itemSize, itemSize), QApplication::activeWindow());
+        }, QSize(itemSize, itemSize), AtomToolsFramework::GetToolMainWindow());
 
         AZ::Data::AssetId assetId;
         MaterialViewportSettingsRequestBus::EventResult(

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
@@ -49,8 +49,9 @@ namespace ShaderManagementConsole
         }
     }
 
-    ShaderManagementConsoleDocument::ShaderManagementConsoleDocument(const AZ::Crc32& toolId)
-        : AtomToolsFramework::AtomToolsDocument(toolId)
+    ShaderManagementConsoleDocument::ShaderManagementConsoleDocument(
+        const AZ::Crc32& toolId, const AtomToolsFramework::DocumentTypeInfo& documentTypeInfo)
+        : AtomToolsFramework::AtomToolsDocument(toolId, documentTypeInfo)
     {
         ShaderManagementConsoleDocumentRequestBus::Handler::BusConnect(m_id);
     }
@@ -113,19 +114,15 @@ namespace ShaderManagementConsole
 
     AtomToolsFramework::DocumentTypeInfo ShaderManagementConsoleDocument::BuildDocumentTypeInfo()
     {
-        AtomToolsFramework::DocumentTypeInfo documentType = AtomToolsDocument::BuildDocumentTypeInfo();
+        AtomToolsFramework::DocumentTypeInfo documentType;
         documentType.m_documentTypeName = "Shader Variant List";
-        documentType.m_documentFactoryCallback = [](const AZ::Crc32& toolId) { return aznew ShaderManagementConsoleDocument(toolId); };
+        documentType.m_documentFactoryCallback = [](const AZ::Crc32& toolId, const AtomToolsFramework::DocumentTypeInfo& documentTypeInfo) {
+            return aznew ShaderManagementConsoleDocument(toolId, documentTypeInfo); };
         documentType.m_supportedExtensionsToCreate.push_back({ "Shader", AZ::RPI::ShaderSourceData::Extension });
         documentType.m_supportedExtensionsToOpen.push_back({ "Shader", AZ::RPI::ShaderSourceData::Extension });
         documentType.m_supportedExtensionsToOpen.push_back({ "Shader Variant List", AZ::RPI::ShaderVariantListSourceData::Extension });
         documentType.m_supportedExtensionsToSave.push_back({ "Shader Variant List", AZ::RPI::ShaderVariantListSourceData::Extension });
         return documentType;
-    }
-
-    AtomToolsFramework::DocumentTypeInfo ShaderManagementConsoleDocument::GetDocumentTypeInfo() const
-    {
-        return BuildDocumentTypeInfo();
     }
 
     AtomToolsFramework::DocumentObjectInfoVector ShaderManagementConsoleDocument::GetObjectInfo() const

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.h
@@ -32,12 +32,11 @@ namespace ShaderManagementConsole
         static void Reflect(AZ::ReflectContext* context);
 
         ShaderManagementConsoleDocument() = default;
-        ShaderManagementConsoleDocument(const AZ::Crc32& toolId);
+        ShaderManagementConsoleDocument(const AZ::Crc32& toolId, const AtomToolsFramework::DocumentTypeInfo& documentTypeInfo);
         ~ShaderManagementConsoleDocument();
 
         // AtomToolsFramework::AtomToolsDocument overrides...
         static AtomToolsFramework::DocumentTypeInfo BuildDocumentTypeInfo();
-        AtomToolsFramework::DocumentTypeInfo GetDocumentTypeInfo() const override;
         AtomToolsFramework::DocumentObjectInfoVector GetObjectInfo() const override;
         bool Open(const AZStd::string& loadPath) override;
         bool Save() override;

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/ShaderManagementConsoleApplication.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/ShaderManagementConsoleApplication.cpp
@@ -12,6 +12,7 @@
 #include <ShaderManagementConsole_Traits_Platform.h>
 
 #include <Document/ShaderManagementConsoleDocument.h>
+#include <Window/ShaderManagementConsoleTableView.h>
 #include <Window/ShaderManagementConsoleWindow.h>
 
 void InitShaderManagementConsoleResources()
@@ -70,9 +71,13 @@ namespace ShaderManagementConsole
     {
         Base::StartCommon(systemEntity);
 
+        // Overriding default document type info to provide a custom view
+        auto documentTypeInfo = ShaderManagementConsoleDocument::BuildDocumentTypeInfo();
+        documentTypeInfo.m_documentViewFactoryCallback = [this](const AZ::Crc32& toolId, const AZ::Uuid& documentId) {
+            return m_window->AddDocumentTab(documentId, new ShaderManagementConsoleTableView(toolId, documentId, m_window.get()));
+        };
         AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Event(
-            m_toolId, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Handler::RegisterDocumentType,
-            ShaderManagementConsoleDocument::BuildDocumentTypeInfo());
+            m_toolId, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Handler::RegisterDocumentType, documentTypeInfo);
 
         m_window.reset(aznew ShaderManagementConsoleWindow(m_toolId));
         m_window->show();

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleTableView.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleTableView.cpp
@@ -103,4 +103,3 @@ namespace ShaderManagementConsole
 } // namespace ShaderManagementConsole
 
 #include <Window/moc_ShaderManagementConsoleTableView.cpp>
-#include "ShaderManagementConsoleTableView.h"

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
@@ -11,7 +11,6 @@
 #include <Atom/RPI.Reflect/Shader/ShaderAsset.h>
 #include <AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h>
 #include <AzCore/Utils/Utils.h>
-#include <Window/ShaderManagementConsoleTableView.h>
 #include <Window/ShaderManagementConsoleWindow.h>
 
 #include <QFileDialog>
@@ -34,11 +33,6 @@ namespace ShaderManagementConsole
         m_actionSaveAsChild->setEnabled(false);
 
         OnDocumentOpened(AZ::Uuid::CreateNull());
-    }
-
-    QWidget* ShaderManagementConsoleWindow::CreateDocumentTabView(const AZ::Uuid& documentId)
-    {
-        return new ShaderManagementConsoleTableView(m_toolId, documentId, centralWidget());
     }
 } // namespace ShaderManagementConsole
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
@@ -24,8 +24,5 @@ namespace ShaderManagementConsole
 
         ShaderManagementConsoleWindow(const AZ::Crc32& toolId, QWidget* parent = 0);
         ~ShaderManagementConsoleWindow() = default;
-
-    protected:
-        QWidget* CreateDocumentTabView(const AZ::Uuid& documentId) override;
     };
 } // namespace ShaderManagementConsole


### PR DESCRIPTION
•	Previously, there was an assumption that each tool would only work with one document type, with the same type of view for each document, that would be automatically mounted to a tab widget in the main window. That was accomplished by overriding a virtual factory function on a derived main window class to instantiate the view widget for each document tab.
•	This change gets rid of the virtual function and replaces it with a callback function on the document type info structure. For each document type, the callback can be set up to add tabs, create widgets, or create any other kind of visual or non-visual view for the document data.
•	The create view callback is invoked whenever a document is created and added to the document system.
•	For now, existing views will manage themselves by listening to document notifications, cleaning up when documents are closed or destroyed.
•	The function for configuring value comparisons and inspector indicators was moved to the document object info structure.
•	Utility functions were added for validating file paths and retrieving the application main window.
•	This also fixes a bug where a ghost inspector panel would appear floating select the main window whenever the material editor was launched.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>