### PR TITLE
Marking ComponentCRUD test as xfail

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
@@ -63,6 +63,7 @@ class TestAutomationAutoTestMode(EditorTestSuite):
     class test_AssetBrowser_TreeNavigation(EditorSharedTest):
         from .EditorScripts import AssetBrowser_TreeNavigation as test_module
 
+    @pytest.mark.xfail(reason="Unknown failure. Investigation blocked by https://github.com/o3de/o3de/issues/8108")
     class test_ComponentCRUD_Add_Delete_Components(EditorSharedTest):
         from .EditorScripts import ComponentCRUD_Add_Delete_Components as test_module
 


### PR DESCRIPTION
Test is intermittently failing for an unknown reason when run on Jenkins. A ticket was logged to correct the results reporting to help identify the root cause of the test failure (#8108). Marking the test xfail until this can be fully investigated as it causes no cascading failures in its test class.

Signed-off-by: jckand-amzn <82226555+jckand-amzn@users.noreply.github.com>