### PR TITLE
[EMotionFX/Mac] Fix test failures from bogus Qt warnings in AnimGraphModel tests

### DIFF
--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/AnimGraphModelTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/AnimGraphModelTests.cpp
@@ -138,6 +138,10 @@ namespace EMotionFX
             case QtWarningMsg:
             case QtCriticalMsg:
             case QtFatalMsg:
+                if (msg.contains("has active key-value observers (KVO)! These will stop working now that the window is recreated, and will result in exceptions when the observers are removed"))
+                {
+                    break;
+                }
                 FAIL() << msg.toStdString();
                 break;
             }


### PR DESCRIPTION
The current version of Qt used on Mac will emit a warning sometimes when a
window is recreated. This warning isn't affecting the functionality of the
EMotionFX window. However, because `QAbstractItemModelTester`, uses Qt
warnings to show where the model is inconsistent, the tests turn all
Qt warnings into Google Test failures. This allows the tests to ensure that
the `AnimGraphModel` conforms to the QAbstractItemModel API contract, but
has the side effect of bubbling up *any* Qt warning as a test failure. In
this case, this warning from Qt does not indicate any test failure, so we
filter it out.

Furthermore, that warning itself has [already been removed upstream][1],
and cherry-picked into 5.15.

[1]: https://github.com/qt/qtbase/commit/b58d6831de79ad21463e20c079093667918ee626

Signed-off-by: Chris Burel <burelc@amazon.com>