### PR TITLE
More reentrancy detection

### DIFF
--- a/Gems/GradientSignal/Code/Include/GradientSignal/GradientSampler.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/GradientSampler.h
@@ -108,10 +108,7 @@ namespace GradientSignal
 
         {
             // Block other threads from accessing the surface data bus while we are in GetValue (which may call into the SurfaceData bus).
-            // We lock our surface data mutex *before* checking / setting "isRequestInProgress" so that we prevent race conditions
-            // that create false detection of cyclic dependencies when multiple requests occur on different threads simultaneously.
-            // (One case where this was previously able to occur was in rapid updating of the Preview widget on the GradientSurfaceDataComponent
-            // in the Editor when moving the threshold sliders back and forth rapidly)
+            // This prevents lock inversion deadlocks between this calling Gradient->Surface and something else calling Surface->Gradient.
             auto& surfaceDataContext = SurfaceData::SurfaceDataSystemRequestBus::GetOrCreateContext(false);
             typename SurfaceData::SurfaceDataSystemRequestBus::Context::DispatchLockGuard scopeLock(surfaceDataContext.m_contextMutex);
 
@@ -175,10 +172,7 @@ namespace GradientSignal
 
         {
             // Block other threads from accessing the surface data bus while we are in GetValue (which may call into the SurfaceData bus).
-            // We lock our surface data mutex *before* checking / setting "isRequestInProgress" so that we prevent race conditions
-            // that create false detection of cyclic dependencies when multiple requests occur on different threads simultaneously.
-            // (One case where this was previously able to occur was in rapid updating of the Preview widget on the
-            // GradientSurfaceDataComponent in the Editor when moving the threshold sliders back and forth rapidly)
+            // This prevents lock inversion deadlocks between this calling Gradient->Surface and something else calling Surface->Gradient.
             auto& surfaceDataContext = SurfaceData::SurfaceDataSystemRequestBus::GetOrCreateContext(false);
             typename SurfaceData::SurfaceDataSystemRequestBus::Context::DispatchLockGuard scopeLock(surfaceDataContext.m_contextMutex);
 

--- a/Gems/LmbrCentral/Code/Source/Shape/ReferenceShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/ReferenceShapeComponent.cpp
@@ -156,46 +156,51 @@ namespace LmbrCentral
 
     void ReferenceShapeComponent::OnEntityActivated([[maybe_unused]] const AZ::EntityId& entityId)
     {
-        LmbrCentral::ShapeComponentNotificationsBus::Event(
-            GetEntityId(),
-            &LmbrCentral::ShapeComponentNotificationsBus::Events::OnShapeChanged,
-            LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
+        if (AllowNotification())
+        {
+            LmbrCentral::ShapeComponentNotificationsBus::Event(
+                GetEntityId(), &LmbrCentral::ShapeComponentNotificationsBus::Events::OnShapeChanged,
+                LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
+        }
     }
 
     void ReferenceShapeComponent::OnEntityDeactivated([[maybe_unused]] const AZ::EntityId& entityId)
     {
-        LmbrCentral::ShapeComponentNotificationsBus::Event(
-            GetEntityId(),
-            &LmbrCentral::ShapeComponentNotificationsBus::Events::OnShapeChanged,
-            LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
+        if (AllowNotification())
+        {
+            LmbrCentral::ShapeComponentNotificationsBus::Event(
+                GetEntityId(), &LmbrCentral::ShapeComponentNotificationsBus::Events::OnShapeChanged,
+                LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
+        }
     }
 
     void ReferenceShapeComponent::OnTransformChanged([[maybe_unused]] const AZ::Transform& local, [[maybe_unused]] const AZ::Transform& world)
     {
-        LmbrCentral::ShapeComponentNotificationsBus::Event(
-            GetEntityId(),
-            &LmbrCentral::ShapeComponentNotificationsBus::Events::OnShapeChanged,
-            LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons::TransformChanged);
+        if (AllowNotification())
+        {
+            LmbrCentral::ShapeComponentNotificationsBus::Event(
+                GetEntityId(), &LmbrCentral::ShapeComponentNotificationsBus::Events::OnShapeChanged,
+                LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons::TransformChanged);
+        }
     }
 
     void ReferenceShapeComponent::OnShapeChanged([[maybe_unused]] LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons reasons)
     {
-        LmbrCentral::ShapeComponentNotificationsBus::Event(
-            GetEntityId(),
-            &LmbrCentral::ShapeComponentNotificationsBus::Events::OnShapeChanged,
-            LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
+        if (AllowNotification())
+        {
+            LmbrCentral::ShapeComponentNotificationsBus::Event(
+                GetEntityId(), &LmbrCentral::ShapeComponentNotificationsBus::Events::OnShapeChanged,
+                LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
+        }
     }
 
     AZ::Crc32 ReferenceShapeComponent::GetShapeType()
     {
         AZ::Crc32 result = {};
 
-        AZ_WarningOnce("Shape", !m_isRequestInProgress, "Detected cyclic dependencies with shape entity references");
         if (AllowRequest())
         {
-            m_isRequestInProgress = true;
             LmbrCentral::ShapeComponentRequestsBus::EventResult(result, m_configuration.m_shapeEntityId, &LmbrCentral::ShapeComponentRequestsBus::Events::GetShapeType);
-            m_isRequestInProgress = false;
         }
 
         return result;
@@ -205,12 +210,9 @@ namespace LmbrCentral
     {
         AZ::Aabb result = AZ::Aabb::CreateNull();
 
-        AZ_WarningOnce("Shape", !m_isRequestInProgress, "Detected cyclic dependencies with shape entity references");
         if (AllowRequest())
         {
-            m_isRequestInProgress = true;
             LmbrCentral::ShapeComponentRequestsBus::EventResult(result, m_configuration.m_shapeEntityId, &LmbrCentral::ShapeComponentRequestsBus::Events::GetEncompassingAabb);
-            m_isRequestInProgress = false;
         }
 
         return result;
@@ -221,12 +223,9 @@ namespace LmbrCentral
         transform = AZ::Transform::CreateIdentity();
         bounds = AZ::Aabb::CreateNull();
 
-        AZ_WarningOnce("Shape", !m_isRequestInProgress, "Detected cyclic dependencies with shape entity references");
         if (AllowRequest())
         {
-            m_isRequestInProgress = true;
             LmbrCentral::ShapeComponentRequestsBus::Event(m_configuration.m_shapeEntityId, &LmbrCentral::ShapeComponentRequestsBus::Events::GetTransformAndLocalBounds, transform, bounds);
-            m_isRequestInProgress = false;
         }
     }
 
@@ -234,12 +233,9 @@ namespace LmbrCentral
     {
         bool result = false;
 
-        AZ_WarningOnce("Shape", !m_isRequestInProgress, "Detected cyclic dependencies with shape entity references");
         if (AllowRequest())
         {
-            m_isRequestInProgress = true;
             LmbrCentral::ShapeComponentRequestsBus::EventResult(result, m_configuration.m_shapeEntityId, &LmbrCentral::ShapeComponentRequestsBus::Events::IsPointInside, point);
-            m_isRequestInProgress = false;
         }
 
         return result;
@@ -249,12 +245,9 @@ namespace LmbrCentral
     {
         float result = FLT_MAX;
 
-        AZ_WarningOnce("Shape", !m_isRequestInProgress, "Detected cyclic dependencies with shape entity references");
         if (AllowRequest())
         {
-            m_isRequestInProgress = true;
             LmbrCentral::ShapeComponentRequestsBus::EventResult(result, m_configuration.m_shapeEntityId, &LmbrCentral::ShapeComponentRequestsBus::Events::DistanceFromPoint, point);
-            m_isRequestInProgress = false;
         }
 
         return result;
@@ -264,12 +257,9 @@ namespace LmbrCentral
     {
         float result = FLT_MAX;
 
-        AZ_WarningOnce("Shape", !m_isRequestInProgress, "Detected cyclic dependencies with shape entity references");
         if (AllowRequest())
         {
-            m_isRequestInProgress = true;
             LmbrCentral::ShapeComponentRequestsBus::EventResult(result, m_configuration.m_shapeEntityId, &LmbrCentral::ShapeComponentRequestsBus::Events::DistanceSquaredFromPoint, point);
-            m_isRequestInProgress = false;
         }
 
         return result;
@@ -279,12 +269,9 @@ namespace LmbrCentral
     {
         AZ::Vector3 result = AZ::Vector3::CreateZero();
 
-        AZ_WarningOnce("Shape", !m_isRequestInProgress, "Detected cyclic dependencies with shape entity references");
         if (AllowRequest())
         {
-            m_isRequestInProgress = true;
             LmbrCentral::ShapeComponentRequestsBus::EventResult(result, m_configuration.m_shapeEntityId, &LmbrCentral::ShapeComponentRequestsBus::Events::GenerateRandomPointInside, randomDistribution);
-            m_isRequestInProgress = false;
         }
 
         return result;
@@ -294,12 +281,9 @@ namespace LmbrCentral
     {
         bool result = false;
 
-        AZ_WarningOnce("Shape", !m_isRequestInProgress, "Detected cyclic dependencies with shape entity references");
         if (AllowRequest())
         {
-            m_isRequestInProgress = true;
             LmbrCentral::ShapeComponentRequestsBus::EventResult(result, m_configuration.m_shapeEntityId, &LmbrCentral::ShapeComponentRequestsBus::Events::IntersectRay, src, dir, distance);
-            m_isRequestInProgress = false;
         }
 
         return result;
@@ -307,7 +291,22 @@ namespace LmbrCentral
 
     bool ReferenceShapeComponent::AllowRequest() const
     {
-        return !m_isRequestInProgress && m_configuration.m_shapeEntityId.IsValid() && m_configuration.m_shapeEntityId != GetEntityId();
+        AZ_WarningOnce(
+            "Shape", !LmbrCentral::ShapeComponentRequestsBus::HasReentrantEBusUseThisThread(),
+            "Detected cyclic dependencies with shape entity references");
+
+        return !LmbrCentral::ShapeComponentRequestsBus::HasReentrantEBusUseThisThread() && m_configuration.m_shapeEntityId.IsValid() &&
+            m_configuration.m_shapeEntityId != GetEntityId();
+    }
+
+    bool ReferenceShapeComponent::AllowNotification() const
+    {
+        AZ_WarningOnce(
+            "Shape", !LmbrCentral::ShapeComponentNotificationsBus::HasReentrantEBusUseThisThread(),
+            "Detected cyclic dependencies with shape entity references");
+
+        return !LmbrCentral::ShapeComponentNotificationsBus::HasReentrantEBusUseThisThread() && m_configuration.m_shapeEntityId.IsValid() &&
+            m_configuration.m_shapeEntityId != GetEntityId();
     }
 
     AZ::EntityId ReferenceShapeComponent::GetShapeEntityId() const

--- a/Gems/LmbrCentral/Code/Source/Shape/ReferenceShapeComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/ReferenceShapeComponent.h
@@ -94,8 +94,8 @@ namespace LmbrCentral
 
     private:
         ReferenceShapeConfig m_configuration;
-        bool m_isRequestInProgress = false; //prevent recursion in case user attaches cyclic dependences
         bool AllowRequest() const;
+        bool AllowNotification() const;
         void SetupDependencies();
     };
 }

--- a/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.cpp
@@ -160,10 +160,13 @@ namespace Terrain
     {
         float maxSample = 0.0f;
         terrainExists = false;
-        AZ_WarningOnce("Terrain", !m_isRequestInProgress, "Detected cyclic dependencies with terrain height entity references");
-        if (!m_isRequestInProgress)
+
+        AZ_WarningOnce(
+            "Terrain", !Terrain::TerrainAreaHeightRequestBus::HasReentrantEBusUseThisThread(),
+            "Detected cyclic dependencies with terrain height entity references");
+
+        if (!Terrain::TerrainAreaHeightRequestBus::HasReentrantEBusUseThisThread())
         {
-            m_isRequestInProgress = true;
             GradientSignal::GradientSampleParams params(inPosition);
 
             // Right now, when the list contains multiple entries, we will use the highest point from each gradient.
@@ -185,7 +188,6 @@ namespace Terrain
                     maxSample = AZ::GetMax(maxSample, sample);
                 }
             }
-            m_isRequestInProgress = false;
         }
 
         const float height = AZ::Lerp(m_cachedShapeBounds.GetMin().GetZ(), m_cachedShapeBounds.GetMax().GetZ(), maxSample);
@@ -198,12 +200,12 @@ namespace Terrain
         AZ_Assert(
             inOutPositionList.size() == terrainExistsList.size(), "The position list size doesn't match the terrainExists list size.");
 
-        AZ_WarningOnce("Terrain", !m_isRequestInProgress, "Detected cyclic dependences with terrain height entity references");
+        AZ_WarningOnce(
+            "Terrain", !Terrain::TerrainAreaHeightRequestBus::HasReentrantEBusUseThisThread(),
+            "Detected cyclic dependencies with terrain height entity references");
 
-        if (!m_isRequestInProgress)
+        if (!Terrain::TerrainAreaHeightRequestBus::HasReentrantEBusUseThisThread())
         {
-            m_isRequestInProgress = true;
-
             // Start by initializing all our terrainExists flags to false.
             AZStd::fill(terrainExistsList.begin(), terrainExistsList.end(), false);
 
@@ -245,8 +247,6 @@ namespace Terrain
                     inOutPositionList[index].SetZ(AZ::GetClamp(height, m_cachedMinWorldHeight, m_cachedMaxWorldHeight));
                 }
             }
-
-            m_isRequestInProgress = false;
         }
     }
 

--- a/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.h
@@ -95,9 +95,6 @@ namespace Terrain
         float m_cachedHeightQueryResolution{ 1.0f };
         AZ::Aabb m_cachedShapeBounds;
 
-        // prevent recursion in case user attaches cyclic dependences
-        mutable bool m_isRequestInProgress{ false }; 
-
         LmbrCentral::DependencyMonitor m_dependencyMonitor;
     };
 }

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
@@ -271,10 +271,7 @@ namespace Terrain
         pixels.reserve(updateWidth * updateHeight);
         {
             // Block other threads from accessing the surface data bus while we are in GetHeightFromFloats (which may call into the SurfaceData bus).
-            // We lock our surface data mutex *before* checking / setting "isRequestInProgress" so that we prevent race conditions
-            // that create false detection of cyclic dependencies when multiple requests occur on different threads simultaneously.
-            // (One case where this was previously able to occur was in rapid updating of the Preview widget on the
-            // GradientSurfaceDataComponent in the Editor when moving the threshold sliders back and forth rapidly)
+            // This prevents lock inversion deadlocks between this calling Gradient->Surface and something else calling Surface->Gradient.
 
             auto& surfaceDataContext = SurfaceData::SurfaceDataSystemRequestBus::GetOrCreateContext(false);
             typename SurfaceData::SurfaceDataSystemRequestBus::Context::DispatchLockGuard scopeLock(surfaceDataContext.m_contextMutex);

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -1368,10 +1368,7 @@ void TerrainSystem::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*time*/)
     if (terrainSettingsChanged || m_terrainHeightDirty || m_terrainSurfacesDirty)
     {
         // Block other threads from accessing the surface data bus while we are in GetValue (which may call into the SurfaceData bus).
-        // We lock our surface data mutex *before* checking / setting "isRequestInProgress" so that we prevent race conditions
-        // that create false detection of cyclic dependencies when multiple requests occur on different threads simultaneously.
-        // (One case where this was previously able to occur was in rapid updating of the Preview widget on the
-        // GradientSurfaceDataComponent in the Editor when moving the threshold sliders back and forth rapidly)
+        // This prevents lock inversion deadlocks between this calling Gradient->Surface and something else calling Surface->Gradient.
         auto& surfaceDataContext = SurfaceData::SurfaceDataSystemRequestBus::GetOrCreateContext(false);
         typename SurfaceData::SurfaceDataSystemRequestBus::Context::DispatchLockGuard scopeLock(surfaceDataContext.m_contextMutex);
 

--- a/Gems/Vegetation/Code/Source/Components/AreaBlenderComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/AreaBlenderComponent.cpp
@@ -224,10 +224,10 @@ namespace Vegetation
 
         bool result = true;
 
-        AZ_WarningOnce("Vegetation", !AreaBlenderRequestBus::HasReentrantEBusUseThisThread(),
+        AZ_WarningOnce("Vegetation", !AreaRequestBus::HasReentrantEBusUseThisThread(),
             "Detected cyclic dependencies with vegetation entity references");
 
-        if (!AreaBlenderRequestBus::HasReentrantEBusUseThisThread())
+        if (!AreaRequestBus::HasReentrantEBusUseThisThread())
         {
             //build a "modifier stack" of contributing entity ids considering inherit and propagate flags
             EntityIdStack emptyIds;
@@ -264,10 +264,10 @@ namespace Vegetation
         }
 
         AZ_WarningOnce(
-            "Vegetation", !AreaBlenderRequestBus::HasReentrantEBusUseThisThread(),
+            "Vegetation", !AreaRequestBus::HasReentrantEBusUseThisThread(),
             "Detected cyclic dependencies with vegetation entity references");
 
-        if (!AreaBlenderRequestBus::HasReentrantEBusUseThisThread())
+        if (!AreaRequestBus::HasReentrantEBusUseThisThread())
         {
             //build a "modifier stack" of contributing entity ids considering inherit and propagate flags
             EntityIdStack emptyIds;
@@ -295,10 +295,10 @@ namespace Vegetation
         AZ_PROFILE_FUNCTION(Entity);
 
         AZ_WarningOnce(
-            "Vegetation", !AreaBlenderRequestBus::HasReentrantEBusUseThisThread(),
+            "Vegetation", !AreaRequestBus::HasReentrantEBusUseThisThread(),
             "Detected cyclic dependencies with vegetation entity references");
 
-        if (!AreaBlenderRequestBus::HasReentrantEBusUseThisThread())
+        if (!AreaRequestBus::HasReentrantEBusUseThisThread())
         {
             for (const auto& entityId : m_configuration.m_vegetationAreaIds)
             {
@@ -321,10 +321,10 @@ namespace Vegetation
         }
 
         AZ_WarningOnce(
-            "Vegetation", !AreaBlenderRequestBus::HasReentrantEBusUseThisThread(),
+            "Vegetation", !AreaInfoBus::HasReentrantEBusUseThisThread(),
             "Detected cyclic dependencies with vegetation entity references");
 
-        if (!AreaBlenderRequestBus::HasReentrantEBusUseThisThread())
+        if (!AreaInfoBus::HasReentrantEBusUseThisThread())
         {
             for (const auto& entityId : m_configuration.m_vegetationAreaIds)
             {
@@ -346,10 +346,10 @@ namespace Vegetation
         AZ::u32 count = 0;
 
         AZ_WarningOnce(
-            "Vegetation", !AreaBlenderRequestBus::HasReentrantEBusUseThisThread(),
+            "Vegetation", !AreaInfoBus::HasReentrantEBusUseThisThread(),
             "Detected cyclic dependencies with vegetation entity references");
 
-        if (!AreaBlenderRequestBus::HasReentrantEBusUseThisThread())
+        if (!AreaInfoBus::HasReentrantEBusUseThisThread())
         {
             for (const auto& entityId : m_configuration.m_vegetationAreaIds)
             {

--- a/Gems/Vegetation/Code/Source/Components/AreaBlenderComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/AreaBlenderComponent.cpp
@@ -224,11 +224,11 @@ namespace Vegetation
 
         bool result = true;
 
-        AZ_WarningOnce("Vegetation", !m_isRequestInProgress, "Detected cyclic dependencies with vegetation entity references");
-        if (!m_isRequestInProgress)
-        {
-            m_isRequestInProgress = true;
+        AZ_WarningOnce("Vegetation", !AreaBlenderRequestBus::HasReentrantEBusUseThisThread(),
+            "Detected cyclic dependencies with vegetation entity references");
 
+        if (!AreaBlenderRequestBus::HasReentrantEBusUseThisThread())
+        {
             //build a "modifier stack" of contributing entity ids considering inherit and propagate flags
             EntityIdStack emptyIds;
             EntityIdStack& processedIds = m_configuration.m_inheritBehavior && m_configuration.m_propagateBehavior ? stackIds : emptyIds;
@@ -250,7 +250,6 @@ namespace Vegetation
                     break;
                 }
             }
-            m_isRequestInProgress = false;
         }
         return result;
     }
@@ -264,11 +263,12 @@ namespace Vegetation
             return;
         }
 
-        AZ_WarningOnce("Vegetation", !m_isRequestInProgress, "Detected cyclic dependencies with vegetation entity references");
-        if (!m_isRequestInProgress)
-        {
-            m_isRequestInProgress = true;
+        AZ_WarningOnce(
+            "Vegetation", !AreaBlenderRequestBus::HasReentrantEBusUseThisThread(),
+            "Detected cyclic dependencies with vegetation entity references");
 
+        if (!AreaBlenderRequestBus::HasReentrantEBusUseThisThread())
+        {
             //build a "modifier stack" of contributing entity ids considering inherit and propagate flags
             EntityIdStack emptyIds;
             EntityIdStack& processedIds = m_configuration.m_inheritBehavior && m_configuration.m_propagateBehavior ? stackIds : emptyIds;
@@ -287,7 +287,6 @@ namespace Vegetation
                 AreaNotificationBus::Event(entityId, &AreaNotificationBus::Events::OnAreaDisconnect);
                 VEG_PROFILE_METHOD(DebugNotificationBus::TryQueueBroadcast(&DebugNotificationBus::Events::FillAreaEnd, entityId, AZStd::chrono::system_clock::now(), aznumeric_cast<AZ::u32>(context.m_availablePoints.size())));
             }
-            m_isRequestInProgress = false;
         }
     }
 
@@ -295,17 +294,18 @@ namespace Vegetation
     {
         AZ_PROFILE_FUNCTION(Entity);
 
-        AZ_WarningOnce("Vegetation", !m_isRequestInProgress, "Detected cyclic dependencies with vegetation entity references");
-        if (!m_isRequestInProgress)
+        AZ_WarningOnce(
+            "Vegetation", !AreaBlenderRequestBus::HasReentrantEBusUseThisThread(),
+            "Detected cyclic dependencies with vegetation entity references");
+
+        if (!AreaBlenderRequestBus::HasReentrantEBusUseThisThread())
         {
-            m_isRequestInProgress = true;
             for (const auto& entityId : m_configuration.m_vegetationAreaIds)
             {
                 AreaNotificationBus::Event(entityId, &AreaNotificationBus::Events::OnAreaConnect);
                 AreaRequestBus::Event(entityId, &AreaRequestBus::Events::UnclaimPosition, handle);
                 AreaNotificationBus::Event(entityId, &AreaNotificationBus::Events::OnAreaDisconnect);
             }
-            m_isRequestInProgress = false;
         }
     }
 
@@ -320,10 +320,12 @@ namespace Vegetation
             LmbrCentral::ShapeComponentRequestsBus::EventResult(bounds, GetEntityId(), &LmbrCentral::ShapeComponentRequestsBus::Events::GetEncompassingAabb);
         }
 
-        AZ_WarningOnce("Vegetation", !m_isRequestInProgress, "Detected cyclic dependencies with vegetation entity references");
-        if (!m_isRequestInProgress)
+        AZ_WarningOnce(
+            "Vegetation", !AreaBlenderRequestBus::HasReentrantEBusUseThisThread(),
+            "Detected cyclic dependencies with vegetation entity references");
+
+        if (!AreaBlenderRequestBus::HasReentrantEBusUseThisThread())
         {
-            m_isRequestInProgress = true;
             for (const auto& entityId : m_configuration.m_vegetationAreaIds)
             {
                 if (entityId != GetEntityId())
@@ -333,7 +335,6 @@ namespace Vegetation
                     bounds.AddAabb(operationBounds);
                 }
             }
-            m_isRequestInProgress = false;
         }
         return bounds;
     }
@@ -344,10 +345,12 @@ namespace Vegetation
 
         AZ::u32 count = 0;
 
-        AZ_WarningOnce("Vegetation", !m_isRequestInProgress, "Detected cyclic dependencies with vegetation entity references");
-        if (!m_isRequestInProgress)
+        AZ_WarningOnce(
+            "Vegetation", !AreaBlenderRequestBus::HasReentrantEBusUseThisThread(),
+            "Detected cyclic dependencies with vegetation entity references");
+
+        if (!AreaBlenderRequestBus::HasReentrantEBusUseThisThread())
         {
-            m_isRequestInProgress = true;
             for (const auto& entityId : m_configuration.m_vegetationAreaIds)
             {
                 if (entityId != GetEntityId())
@@ -357,7 +360,6 @@ namespace Vegetation
                     count += operationCount;
                 }
             }
-            m_isRequestInProgress = false;
         }
         return count;
     }

--- a/Gems/Vegetation/Code/Source/Components/AreaBlenderComponent.h
+++ b/Gems/Vegetation/Code/Source/Components/AreaBlenderComponent.h
@@ -100,7 +100,6 @@ namespace Vegetation
     private:
         AreaBlenderConfig m_configuration;
         LmbrCentral::DependencyMonitor m_dependencyMonitor;
-        mutable bool m_isRequestInProgress = false; //prevent recursion in case user attaches cyclic dependences
 
         void SetupDependencies();
     };


### PR DESCRIPTION
Fixed the cyclic dependency checks for the following components:
* Shape Reference
* Terrain Height Gradient List
* Vegetation Area Blender

These now use the thread-local method for detection, which means that they won't falsely trigger with simultaneous API usage from different threads.