### PR TITLE
[LYN-10823] Asset Processor: Fixed crash on shutdown caused by startup error collector

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
@@ -152,6 +152,8 @@ ApplicationManager::BeforeRunStatus GUIApplicationManager::BeforeRun()
 
 void GUIApplicationManager::Destroy()
 {
+    m_startupErrorCollector = nullptr;
+
     if (m_mainWindow)
     {
         delete m_mainWindow;


### PR DESCRIPTION
If asset processor encountered a fatal error on startup before finishing start up, attempting to shutdown would not show the error and would crash AP instead due to startupErrorCollector being invoked after everything else has shutdown.  Fix was to invoke the error display (by destroy the collector) first.

Signed-off-by: amzn-mike <80125227+amzn-mike@users.noreply.github.com>