### PR TITLE
Fix slow response while undoing multiple selected entities changes

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -797,7 +797,7 @@ namespace AzToolsFramework
     {
         if (IsEntitySelected(entityId))
         {
-            UpdateContents(); // immediately refresh
+            QueuePropertyRefresh();
         }
     }
 


### PR DESCRIPTION
Bug fix for #3016.

When the user undoes changes for a larger group of selected entities (20+) the Editor noticeably hitches. This increases with the number of entities. At 40+ the hitch is multiple seconds and can cause the Editor to stop responding.

Root cause of this issue:

- Current system will destroy and recreate all these entities.
- While an entity destroyed, **Entity::Reset** is called and **OnEntityDestroyed** notification was sent.
- **EntityPropertyEditor::UpdateContents** is called every time when a selected entity gets destroyed, so the property editor will repeatedly refresh 20+ times, causing the very slow response.

Solution:
Replace **UpdateContents** with **QueuePropertyRefresh** so that we only refresh property editor once at next tick for multiple **UpdateContents** calls.

Before this fix undo 32 entities takes 60+ seconds. After this fix it only takes less than one second.

Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>