### PR TITLE
Add Treemap ImGui widget and Atom memory viz

### DIFF
--- a/Gems/Atom/Utils/Code/CMakeLists.txt
+++ b/Gems/Atom/Utils/Code/CMakeLists.txt
@@ -26,6 +26,7 @@ ly_add_target(
             Gem::Atom_RPI.Public
             Gem::ImGui.imguilib
             3rdParty::libpng
+            Gem::ProfilerImGui
 )
 
 if(PAL_TRAIT_BUILD_HOST_TOOLS)

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -18,6 +18,8 @@
 #include <AzCore/std/containers/variant.h>
 #include <AzCore/std/string/string.h>
 
+#include <Profiler/ImGuiTreemap.h>
+
 namespace AZ
 {
     namespace Render
@@ -260,10 +262,14 @@ namespace AZ
         public:
             // Draw the overall GPU memory profiling window.
             void DrawGpuMemoryWindow(bool& draw);
+            ~ImGuiGpuMemoryView();
 
         private:
             // Draw the heap usage pie chart
             void DrawPieChart(const AZ::RHI::MemoryStatistics::Heap& heap);
+
+            // Update allocations and pools in the device and heap treemap widgets.
+            void UpdateTreemaps();
 
             // Update the saved pointers in m_tableRows according to new data/filters
             void UpdateTableRows();
@@ -305,6 +311,11 @@ namespace AZ
             AZStd::vector<ResourceTableRow> m_resourceTableRows;
             AZStd::vector<AZ::RHI::MemoryStatistics::Pool> m_savedPools;
             AZStd::vector<AZ::RHI::MemoryStatistics::Heap> m_savedHeaps;
+
+            Profiler::ImGuiTreemap* m_hostTreemap = nullptr;
+            Profiler::ImGuiTreemap* m_deviceTreemap = nullptr;
+            bool m_showHostTreemap = false;
+            bool m_showDeviceTreemap = false;
         };
 
         class ImGuiGpuProfiler

--- a/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
+++ b/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
@@ -1459,21 +1459,6 @@ namespace AZ
                 using Profiler::TreemapNode;
                 AZStd::vector<TreemapNode> hostNodes;
                 AZStd::vector<TreemapNode> deviceNodes;
-                for (auto& pool : m_savedPools)
-                {
-                    size_t hostBytes = pool.m_memoryUsage.GetHeapMemoryUsage(RHI::HeapMemoryLevel::Host).m_residentInBytes;
-                    size_t deviceBytes = pool.m_memoryUsage.GetHeapMemoryUsage(RHI::HeapMemoryLevel::Device).m_residentInBytes;
-                    if (hostBytes > 0)
-                    {
-                        hostNodes.push_back();
-                        hostNodes.back().m_name = pool.m_name;
-                    }
-                    else if (deviceBytes > 0)
-                    {
-                        deviceNodes.push_back();
-                        deviceNodes.back().m_name = pool.m_name;
-                    }
-                }
 
                 for (auto& pool : m_savedPools)
                 {
@@ -1484,6 +1469,8 @@ namespace AZ
 
                     TreemapNode* poolNode = nullptr;
 
+                    // Resource pools are each associated with either a device-local heap, or a host heap. Identify the association and
+                    // add constiuent buffers and textures as sub-nodes in the corresponding treemap.
                     if (hostBytes > 0)
                     {
                         hostNodes.push_back();

--- a/Gems/Profiler/Code/Include/Profiler/ImGuiTreemap.h
+++ b/Gems/Profiler/Code/Include/Profiler/ImGuiTreemap.h
@@ -14,35 +14,35 @@
 
 namespace Profiler
 {
-    // TreemapNodes support arbitrary child counts and nesting levels. Each node will show up in the final visualization with an
-    // area proportional to the node's weight.
+    //! TreemapNodes support arbitrary child counts and nesting levels. Each node will show up in the final visualization with an
+    //! area proportional to the node's weight.
     struct TreemapNode
     {
-        // The name of the treemap node
+        //! The name of the treemap node
         AZ::Name m_name;
 
-        // Nodes may be classified by an additional group label, which may be used to color the node in the final visualization.
-        // For example, you might want to highlight all blocks in a treemap that are a particular filetype, or show "Texture2D" 
-        // allocations as the same color.
+        //! Nodes may be classified by an additional group label, which may be used to color the node in the final visualization.
+        //! For example, you might want to highlight all blocks in a treemap that are a particular filetype, or show "Texture2D" 
+        //! allocations as the same color.
         AZ::Name m_group;
 
-        // If left empty, a tooltip will be automatically generated containing the name and weight (with associated unit label)
+        //! If left empty, a tooltip will be automatically generated containing the name and weight (with associated unit label)
         AZStd::string m_tooltip;
 
-        // The weight must be positive definite and should only be specified *on the leaves* (e.g. m_children is nullptr)
-        // The weight may be specified on parent nodes (e.g. to assist in weight normalization of the leaves) but note that
-        // this value will be overwritten
+        //! The weight must be positive definite and should only be specified *on the leaves* (e.g. m_children is nullptr)
+        //! The weight may be specified on parent nodes (e.g. to assist in weight normalization of the leaves) but note that
+        //! this value will be overwritten
         float m_weight = 0.f;
 
-        // ADVANCED
-        // The tag can be used to filter this node from displaying or not in the visualization. For example, we may tag all
-        // unused memory regions as 0x1, and later use a mask of 0x0 to omit unused memory from the display. By default, all
-        // nodes are shown (0xffffffff mask). To show select nodes, use the ImGuiTreemap::AddMask method to set a mask to a
-        // particular label. The expression to determine if a node should be included or not is (mask & m_tag > 0). That is,
-        // this node will be shown if any of the mask bits coincide with any of the tag bits.
+        //! ADVANCED
+        //! The tag can be used to filter this node from displaying or not in the visualization. For example, we may tag all
+        //! unused memory regions as 0x1, and later use a mask of 0x0 to omit unused memory from the display. By default, all
+        //! nodes are shown (0xffffffff mask). To show select nodes, use the ImGuiTreemap::AddMask method to set a mask to a
+        //! particular label. The expression to determine if a node should be included or not is (mask & m_tag > 0). That is,
+        //! this node will be shown if any of the mask bits coincide with any of the tag bits.
         uint32_t m_tag = 0;
 
-        // Count and pointer to an array of m_childCount children. May be left default-initialized for leaf nodes
+        //! Count and pointer to an array of m_childCount children. May be left default-initialized for leaf nodes
         AZStd::vector<TreemapNode> m_children;
 
     private:
@@ -59,9 +59,9 @@ namespace Profiler
         int m_extent[2];
     };
 
-    // A treemap is a 2D visualization of entries designed to emphasize relative size differences. It
-    // is commonly used to visualize disk space utilization, but extends naturally to understanding
-    // memory allocations, archive data, and more.
+    //! A treemap is a 2D visualization of entries designed to emphasize relative size differences. It
+    //! is commonly used to visualize disk space utilization, but extends naturally to understanding
+    //! memory allocations, archive data, and more.
     class ImGuiTreemap
     {
     public:
@@ -70,33 +70,49 @@ namespace Profiler
         //! Retrieve the Treemap name
         virtual const AZ::Name& GetName() const = 0;
 
-        //! Set Treemap name (used in UI titlebar display)
+        //! Set Treemap name
+        //! @param name The name to display in the ImGui titlebar
         virtual void SetName(char const* name) = 0;
+
+        //! Set Treemap name
+        //! @param name The name to display in the ImGui titlebar
         virtual void SetName(AZ::Name name) = 0;
 
-        //! Set unit label (e.g. lbs, square footage, MB, etc.)
+        //! Set unit label
+        //! @param unitLabel The unit label (e.g. lbs, square footage, MB, etc.) is shown in tooltips and node descriptions
         virtual void SetUnitLabel(char const* unitLabel) = 0;
 
         //! Supply the root nodes of the treemap. This is required to supply data to the treemap.
-        //! Note that the treemap takes ownership of the data.
+        //! @param roots A vector of treemap nodes that constitute the top-level nodes in the visualization.
+        //! Note that the treemap takes ownership of the data. This function may be invoked as often as needed
+        //! to modify the data the treemap contains.
         virtual void SetRoots(AZStd::vector<TreemapNode>&& roots) = 0;
 
-        //! ADVANCED
+        //! (ADVANCED)
         //! Add a UI radio button that renders only nodes possessing a tag that is either 0 or passes the mask
+        //! @param label The UI label used to select this mask
+        //! @param mask When this mask is active, nodes with a non-zero tag will be included for display if (tag & mask) is non-zero
         virtual void AddMask(const char* label, uint32_t mask) = 0;
 
         //! Submit ImGui directives to draw the treemap
+        //! @param x Horizontal offset
+        //! @param y Vertical offset
+        //! @param w UI width
+        //! @param h UI height
         virtual void Render(int x, int y, int w, int h) = 0;
 
-        //! Weigh entries and perform layout. This occurs automatically on `Render` but is exposed here if you wish
-        //! to perform a layout in advance. Note that previously computed scores and the computed layout are cached
-        //! until entries are modified, added, removed, or the window size is changed.
+        //! Weigh entries and perform layout.
+        //! This occurs automatically on `Render` but is exposed here if you wish to perform a layout in advance.
+        //! Note that previously computed scores and the computed layout are cached until entries are modified,
+        //! added, removed, or the window size is changed.
+        //! @param w UI width
+        //! @param h UI height
         virtual void WeighAndComputeLayout(int w, int h) = 0;
     };
 
-    // Usage: Create a treemap using the factory interface like so:
-    //     Profiler::ImGuiTreemapFactory::Interface::Get()->Create(AZ::Name{ "My Treemap" }, "MiB");
-    // When you no longer need the treemap, pass the created treemap to the Destroy method.
+    //! Usage: Create a treemap using the factory interface like so:
+    //!     Profiler::ImGuiTreemapFactory::Interface::Get()->Create(AZ::Name{ "My Treemap" }, "MiB");
+    //! When you no longer need the treemap, pass the created treemap to the Destroy method.
     class ImGuiTreemapFactory
     {
     public:
@@ -106,7 +122,15 @@ namespace Profiler
 
         virtual ~ImGuiTreemapFactory() = default;
 
+        //! Create an ImGuiTreemap with managed lifetime given the specified name and unit label (threadsafe)
+        //! @param name Treemap name (shows up in the UI titlebar)
+        //! @param unitLabel Unit label
+        //! This shows up after node weights are displayed, e.g. "382 degrees centigrade" if unitLabel == "degrees centigrade"
+        //! and the node weight is 382)
         virtual ImGuiTreemap& Create(AZ::Name name, const char* unitLabel) = 0;
+
+        //! Destroys a previously created treemap (threadsafe)
+        //! @param treemap Pointer to the treemap created previously
         virtual void Destroy(ImGuiTreemap* treemap) = 0;
     };
 } // namespace Profiler

--- a/Gems/Profiler/Code/Include/Profiler/ImGuiTreemap.h
+++ b/Gems/Profiler/Code/Include/Profiler/ImGuiTreemap.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Name/Name.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/Interface/Interface.h>
+#include <imgui/imgui.h>
+
+namespace Profiler
+{
+    // TreemapNodes support arbitrary child counts and nesting levels
+    struct TreemapNode
+    {
+        // The name of the treemap node
+        AZ::Name m_name;
+
+        // Nodes may be classified by an additional group label, which may be used to color the node in the final visualization.
+        // For example, you might want to highlight all blocks in a treemap that are a particular filetype, or show "Texture2D" 
+        // allocations as the same color.
+        AZ::Name m_group;
+
+        // If left empty, a tooltip will be automatically generated containing the name and weight (with associated unit label)
+        AZStd::string m_tooltip;
+
+        // The weight must be positive definite and should only be specified *on the leaves* (e.g. m_children is nullptr)
+        // The weight may be specified on parent nodes (e.g. to assist in weight normalization of the leaves) but note that
+        // this value will be overwritten
+        float m_weight = -1.f;
+
+        // ADVANCED
+        // The tag can be used to filter this node from displaying or not in the visualization. For example, we may tag all
+        // unused memory regions as 0x1, and later use a mask of 0x0 to omit unused memory from the display. By default, all
+        // nodes are shown (0xffffffff mask). To show select nodes, use the ImGuiTreemap::AddMask method to set a mask to a
+        // particular label. The expression to determine if a node should be included or not is (mask & m_tag > 0). That is,
+        // this node will be shown if any of the mask bits coincide with any of the tag bits.
+        uint32_t m_tag = 0;
+
+        // Count and pointer to an array of m_childCount children. May be left default-initialized for leaf nodes
+        AZStd::vector<TreemapNode> m_children;
+
+    private:
+        // Private data is modified during treemap generation and not intended to be modified by the user
+        friend class ImGuiTreemapImpl;
+
+        TreemapNode* m_parent;
+        double m_area = 0.f;
+        float m_hue;
+        float m_saturation;
+        float m_value;
+        int m_level = 0;
+        int m_offset[2];
+        int m_extent[2];
+    };
+
+    // A treemap is a 2D visualization of entries designed to emphasize relative size differences. It
+    // is commonly used to visualize disk space utilization, but extends naturally to understanding
+    // memory allocations, archive data, and more.
+    class ImGuiTreemap
+    {
+    public:
+        virtual ~ImGuiTreemap() = default;
+
+        //! Retrieve the Treemap name
+        virtual const AZ::Name& GetName() const = 0;
+
+        //! Set Treemap name (used in UI titlebar display)
+        virtual void SetName(char const* name) = 0;
+        virtual void SetName(AZ::Name name) = 0;
+
+        //! Set unit label (e.g. lbs, square footage, MB, etc.)
+        virtual void SetUnitLabel(char const* unitLabel) = 0;
+
+        //! Add a UI radio button that renders only nodes possessing a tag that is either 0 or passes the mask
+        virtual void AddMask(const char* label, uint32_t mask) = 0;
+
+        //! Supply the root nodes of the treemap.
+        virtual void SetRoots(AZStd::vector<TreemapNode>&& roots) = 0;
+
+        //! Submit ImGui directives to draw the treemap
+        virtual void Render(int x, int y, int w, int h) = 0;
+
+        //! Weigh entries and perform layout. This occurs automatically on `Render` but is exposed here if you wish
+        //! to perform a layout in advance. Note that previously computed scores and the computed layout are cached
+        //! until entries are modified, added, removed, or the window size is changed.
+        virtual void WeighAndComputeLayout(int x, int y, int w, int h) = 0;
+    };
+
+    class ImGuiTreemapFactory
+    {
+    public:
+        using Interface = AZ::Interface<ImGuiTreemapFactory>;
+
+        AZ_RTTI(ImGuiTreemapFactory, "{90BCA753-6152-4942-8A81-DD14196A6811}");
+
+        virtual ~ImGuiTreemapFactory() = default;
+
+        virtual ImGuiTreemap& Create(AZ::Name name, const char* unitLabel) = 0;
+        virtual void Destroy(ImGuiTreemap* treemap) = 0;
+    };
+} // namespace Profiler

--- a/Gems/Profiler/Code/Include/Profiler/ImGuiTreemap.h
+++ b/Gems/Profiler/Code/Include/Profiler/ImGuiTreemap.h
@@ -31,7 +31,7 @@ namespace Profiler
         // The weight must be positive definite and should only be specified *on the leaves* (e.g. m_children is nullptr)
         // The weight may be specified on parent nodes (e.g. to assist in weight normalization of the leaves) but note that
         // this value will be overwritten
-        float m_weight = -1.f;
+        float m_weight = 0.f;
 
         // ADVANCED
         // The tag can be used to filter this node from displaying or not in the visualization. For example, we may tag all

--- a/Gems/Profiler/Code/Include/Profiler/ImGuiTreemap.h
+++ b/Gems/Profiler/Code/Include/Profiler/ImGuiTreemap.h
@@ -14,7 +14,8 @@
 
 namespace Profiler
 {
-    // TreemapNodes support arbitrary child counts and nesting levels
+    // TreemapNodes support arbitrary child counts and nesting levels. Each node will show up in the final visualization with an
+    // area proportional to the node's weight.
     struct TreemapNode
     {
         // The name of the treemap node
@@ -76,11 +77,13 @@ namespace Profiler
         //! Set unit label (e.g. lbs, square footage, MB, etc.)
         virtual void SetUnitLabel(char const* unitLabel) = 0;
 
+        //! Supply the root nodes of the treemap. This is required to supply data to the treemap.
+        //! Note that the treemap takes ownership of the data.
+        virtual void SetRoots(AZStd::vector<TreemapNode>&& roots) = 0;
+
+        //! ADVANCED
         //! Add a UI radio button that renders only nodes possessing a tag that is either 0 or passes the mask
         virtual void AddMask(const char* label, uint32_t mask) = 0;
-
-        //! Supply the root nodes of the treemap.
-        virtual void SetRoots(AZStd::vector<TreemapNode>&& roots) = 0;
 
         //! Submit ImGui directives to draw the treemap
         virtual void Render(int x, int y, int w, int h) = 0;
@@ -88,9 +91,12 @@ namespace Profiler
         //! Weigh entries and perform layout. This occurs automatically on `Render` but is exposed here if you wish
         //! to perform a layout in advance. Note that previously computed scores and the computed layout are cached
         //! until entries are modified, added, removed, or the window size is changed.
-        virtual void WeighAndComputeLayout(int x, int y, int w, int h) = 0;
+        virtual void WeighAndComputeLayout(int w, int h) = 0;
     };
 
+    // Usage: Create a treemap using the factory interface like so:
+    //     Profiler::ImGuiTreemapFactory::Interface::Get()->Create(AZ::Name{ "My Treemap" }, "MiB");
+    // When you no longer need the treemap, pass the created treemap to the Destroy method.
     class ImGuiTreemapFactory
     {
     public:

--- a/Gems/Profiler/Code/Source/ImGuiTreemap.cpp
+++ b/Gems/Profiler/Code/Source/ImGuiTreemap.cpp
@@ -28,7 +28,8 @@ namespace Profiler
         hash *= 1103515245u;
         hash += 12345u;
 
-        outHue = static_cast<float>(hash) / 0xffffffff;
+        // The explicit cast of the uint32 max quantity is needed because on cast, the value increases by 1.
+        outHue = static_cast<float>(hash) / static_cast<float>(0xffffffff);
 
         outSaturation = 0.7f;
     }

--- a/Gems/Profiler/Code/Source/ImGuiTreemap.cpp
+++ b/Gems/Profiler/Code/Source/ImGuiTreemap.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
 #define PROFILER_IMGUI_DLL
 #include "ImGuiTreemapImpl.h"
 

--- a/Gems/Profiler/Code/Source/ImGuiTreemap.cpp
+++ b/Gems/Profiler/Code/Source/ImGuiTreemap.cpp
@@ -27,8 +27,6 @@ using AZ::Name;
 
 namespace Profiler
 {
-    static constexpr int MinNodeExtent = 10;
-
     static void NameToHueSaturation(AZ::Name name, float& outHue, float& outSaturation)
     {
         uint32_t hash = AZ::Crc32{ name.GetStringView() };

--- a/Gems/Profiler/Code/Source/ImGuiTreemap.cpp
+++ b/Gems/Profiler/Code/Source/ImGuiTreemap.cpp
@@ -166,8 +166,9 @@ namespace Profiler
             bool focused = ImGui::IsWindowFocused();
 
             // Add 20 pixel gutter to bottom
-            WeighAndComputeLayout(
-                static_cast<int>(cx + wx), static_cast<int>(cy + wy), static_cast<int>(ww - cx), static_cast<int>(wh - cy) - 20);
+            float treemapOffset[2] = { cx + wx, cy + wy };
+
+            WeighAndComputeLayout(static_cast<int>(ww - cx), static_cast<int>(wh - cy) - 20);
 
             const auto [mx, my] = ImGui::GetMousePos();
 
@@ -183,7 +184,7 @@ namespace Profiler
                         continue;
                     }
 
-                    ImVec2 topLeft{ static_cast<float>(node->m_offset[0]), static_cast<float>(node->m_offset[1]) };
+                    ImVec2 topLeft{ static_cast<float>(node->m_offset[0]) + treemapOffset[0], static_cast<float>(node->m_offset[1]) + treemapOffset[1] };
                     ImVec2 nodeExtent{ static_cast<float>(node->m_extent[0]), static_cast<float>(node->m_extent[1]) };
 
                     if (node->m_children.empty())
@@ -266,10 +267,10 @@ namespace Profiler
         ImGui::End();
     }
 
-    void ImGuiTreemapImpl::WeighAndComputeLayout(int x, int y, int w, int h)
+    void ImGuiTreemapImpl::WeighAndComputeLayout(int w, int h)
     {
         WeighNodes();
-        ComputeLayout(x, y, w, h);
+        ComputeLayout(w, h);
         AssignColors();
         m_dirty = false;
     }
@@ -604,9 +605,9 @@ namespace Profiler
         }
     }
 
-    void ImGuiTreemapImpl::ComputeLayout(int x, int y, int w, int h)
+    void ImGuiTreemapImpl::ComputeLayout(int w, int h)
     {
-        if (m_lastExtent[0] == w && m_lastExtent[1] == h && m_lastOffset[0] == x && m_lastOffset[1] == y)
+        if (m_lastExtent[0] == w && m_lastExtent[1] == h)
         {
             return;
         }
@@ -616,8 +617,8 @@ namespace Profiler
         // (archive link: https://web.archive.org/web/20220224165104/https://www.win.tue.nl/~vanwijk/stm.pdf)
         // After function completion, every node will have a computed offset and extent
 
-        m_root.m_offset[0] = x;
-        m_root.m_offset[1] = y;
+        m_root.m_offset[0] = 0;
+        m_root.m_offset[1] = 0;
         m_root.m_extent[0] = w;
         m_root.m_extent[1] = h;
 
@@ -651,8 +652,6 @@ namespace Profiler
 
         m_lastExtent[0] = w;
         m_lastExtent[1] = h;
-        m_lastOffset[0] = x;
-        m_lastOffset[1] = y;
     }
 
 } // namespace Profiler

--- a/Gems/Profiler/Code/Source/ImGuiTreemap.cpp
+++ b/Gems/Profiler/Code/Source/ImGuiTreemap.cpp
@@ -1,0 +1,645 @@
+#define PROFILER_IMGUI_DLL
+#include "ImGuiTreemapImpl.h"
+
+#include <AzCore/Debug/Trace.h>
+#include <AzCore/std/sort.h>
+#include <AzCore/std/parallel/scoped_lock.h>
+#include <AzCore/Math/Crc.h>
+#include <imgui/imgui.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+
+using AZ::Name;
+
+#define CHECK_STACK_EMPTY()                                                                                                                \
+    AZ_Assert(                                                                                                                             \
+        m_stack.empty(),                                                                                                                   \
+        "The treemap stack was empty at the start of a traversal. This indicates a bug in the treemap implementation, so please file a "   \
+        "ticket and/or notify sig-core.")
+
+namespace Profiler
+{
+    static constexpr int MinNodeExtent = 10;
+
+    static void NameToHueSaturation(AZ::Name name, float& outHue, float& outSaturation)
+    {
+        uint32_t hash = AZ::Crc32{ name.GetStringView() };
+        // Apply one round of LCG (constants from glibc)
+        hash *= 1103515245u;
+        hash += 12345u;
+
+        outHue = static_cast<float>(hash) / 0xffffffff;
+
+        outSaturation = 0.7f;
+    }
+
+    ImGuiTreemap& ImGuiTreemapFactoryImpl::Create(AZ::Name name, const char* unitLabel)
+    {
+        AZStd::scoped_lock lock{ m_mutex };
+        AZ_Assert(!m_treemaps.contains(name), "Attempting to create treemap %s but it already exists!", name.GetCStr());
+        ImGuiTreemap& treemap = m_treemaps.emplace(name).first->second;
+        treemap.SetName(AZStd::move(name));
+        treemap.SetUnitLabel(unitLabel);
+        return treemap;
+    }
+
+    void ImGuiTreemapFactoryImpl::Destroy(ImGuiTreemap* treemap)
+    {
+        AZStd::scoped_lock lock{ m_mutex };
+        AZ_Assert(
+            m_treemaps.contains(treemap->GetName()), "Attempting to destroy treemap %s but it doesn't exist!",
+            treemap->GetName().GetCStr());
+        m_treemaps.erase(treemap->GetName());
+    }
+
+    const Name& ImGuiTreemapImpl::GetName() const
+    {
+        return m_name;
+    }
+
+    void ImGuiTreemapImpl::SetName(char const* name)
+    {
+        m_name = Name{ name };
+    }
+
+    void ImGuiTreemapImpl::SetName(Name name)
+    {
+        m_name = AZStd::move(name);
+    }
+
+    void ImGuiTreemapImpl::SetUnitLabel(const char* unitLabel)
+    {
+        m_unitLabel = unitLabel;
+    }
+
+    void ImGuiTreemapImpl::AddMask(const char* label, uint32_t mask)
+    {
+        m_masks[label] = mask;
+    }
+
+    void ImGuiTreemapImpl::SetRoots(AZStd::vector<TreemapNode>&& roots)
+    {
+        m_root.m_children = AZStd::move(roots);
+        m_groups.clear();
+        m_dirty = true;
+        // Reset extent to trigger re-layout
+        m_lastExtent[0] = 0;
+        m_selectedNode = nullptr;
+        m_currentMask = 0xffffffff;
+    }
+
+    void ImGuiTreemapImpl::Render(int x, int y, int w, int h)
+    {
+        if (m_root.m_children.empty())
+        {
+            ImGui::Begin(m_name.IsEmpty() ? "Unnamed treemap" : m_name.GetCStr());
+            ImGui::End();
+            return;
+        }
+
+        ImVec2 offset{ static_cast<float>(x), static_cast<float>(y) };
+        ImGui::SetNextWindowPos(offset, ImGuiCond_Once);
+        ImVec2 extent{ static_cast<float>(w), static_cast<float>(h) };
+        ImGui::SetNextWindowSize(extent, ImGuiCond_Once);
+
+        if (ImGui::Begin(m_name.IsEmpty() ? "Unnamed treemap" : m_name.GetCStr()))
+        {
+            ImGui::Text("Total weight: %f %s", m_root.m_weight, m_unitLabel);
+            if (!m_groups.empty())
+            {
+                ImGui::Text("Highlight Group");
+            }
+            for (auto& group : m_groups)
+            {
+                ImGui::SameLine();
+                ImGui::Checkbox(group.first.GetCStr(), &group.second.m_active);
+            }
+
+            if (!m_masks.empty())
+            {
+                if (ImGui::RadioButton("Display All", m_currentMask == 0xffffffff))
+                {
+                    m_currentMask = 0xffffffff;
+                    m_dirty = true;
+                    m_lastExtent[0] = 0;
+                    m_selectedNode = nullptr;
+                }
+
+                for (auto& mask : m_masks)
+                {
+                    ImGui::SameLine();
+                    if (ImGui::RadioButton(mask.first, m_currentMask == mask.second))
+                    {
+                        m_currentMask = mask.second;
+                        m_dirty = true;
+                        m_lastExtent[0] = 0;
+                        m_selectedNode = nullptr;
+                    }
+                }
+            }
+
+            if (m_selectedNode)
+            {
+                ImGui::Text(
+                    "Selected node: %s (%f %s)", m_selectedNode->m_name.IsEmpty() ? "[unnamed]" : m_selectedNode->m_name.GetCStr(),
+                    m_selectedNode->m_weight, m_unitLabel);
+            }
+            else
+            {
+                ImGui::Text("No node selected");
+            }
+            ImGui::Separator();
+
+            ImDrawList* drawList = ImGui::GetWindowDrawList();
+            const auto [cx, cy] = ImGui::GetCursorPos();
+            const auto [wx, wy] = ImGui::GetWindowPos();
+            const auto [ww, wh] = ImGui::GetWindowSize();
+            bool focused = ImGui::IsWindowFocused();
+
+            // Add 20 pixel gutter to bottom
+            WeighAndComputeLayout(
+                static_cast<int>(cx + wx), static_cast<int>(cy + wy), static_cast<int>(ww - cx), static_cast<int>(wh - cy) - 20);
+
+            const auto [mx, my] = ImGui::GetMousePos();
+
+            AZStd::vector<TreemapNode*> tooltipNodes;
+
+            // Draw nodes starting at the top level (ignoring the root) and descend down
+            for (auto it = m_levelSets.begin() + 1; it != m_levelSets.end(); ++it)
+            {
+                for (TreemapNode* node : *it)
+                {
+                    if (node->m_area < 1e-5 || (node->m_tag != 0 && (node->m_tag & m_currentMask) == 0))
+                    {
+                        continue;
+                    }
+
+                    ImVec2 topLeft{ static_cast<float>(node->m_offset[0]), static_cast<float>(node->m_offset[1]) };
+                    ImVec2 nodeExtent{ static_cast<float>(node->m_extent[0]), static_cast<float>(node->m_extent[1]) };
+
+                    if (node->m_children.empty())
+                    {
+                        // Shrink leaf nodes with an additional 2 pixel gutter
+                        topLeft.x += 2;
+                        topLeft.y += 2;
+                        nodeExtent.x -= 4;
+                        nodeExtent.y -= 4;
+                    }
+
+                    ImVec2 bottomRight{ topLeft.x + nodeExtent.x, topLeft.y + nodeExtent.y };
+                    float r;
+                    float g;
+                    float b;
+                    float saturationShift = 0.f;
+
+                    if (focused && mx > topLeft.x && mx < bottomRight.x && my > topLeft.y && my < bottomRight.y)
+                    {
+                        // Mouse is hovering over this node. Add it as a node to display in the tooltip
+                        saturationShift += 0.15f;
+                        tooltipNodes.push_back(node);
+
+                        if (focused && ImGui::IsMouseClicked(ImGuiMouseButton_Left) && node->m_children.empty())
+                        {
+                            if (m_selectedNode == node)
+                            {
+                                m_selectedNode = nullptr;
+                            }
+                            else
+                            {
+                                m_selectedNode = node;
+                            }
+                        }
+                    }
+
+                    bool selected = m_selectedNode == node;
+
+                    if (!node->m_group.IsEmpty() && m_groups[node->m_group].m_active)
+                    {
+                        const GroupConfig& groupConfig = m_groups[node->m_group];
+                        ImGui::ColorConvertHSVtoRGB(
+                            groupConfig.m_hue, groupConfig.m_saturation + saturationShift, selected ? 1.f : node->m_value, r, g, b);
+                    }
+                    else
+                    {
+                        ImGui::ColorConvertHSVtoRGB(
+                            node->m_hue, node->m_saturation + saturationShift, selected ? 1.f : node->m_value, r, g, b);
+                    }
+
+                    drawList->AddRectFilled(topLeft, bottomRight, ImColor{ r, g, b }, 2.f, ImDrawFlags_RoundCornersAll);
+                }
+            }
+
+            if (!tooltipNodes.empty())
+            {
+                ImGui::BeginTooltip();
+                for (TreemapNode* node : tooltipNodes)
+                {
+                    if (!node->m_tooltip.empty())
+                    {
+                        ImGui::Text("%s", node->m_tooltip.c_str());
+                    }
+                    else if (!node->m_name.IsEmpty())
+                    {
+                        ImGui::Text("%s (%f %s)", node->m_name.GetCStr(), node->m_weight, m_unitLabel);
+                    }
+                    else
+                    {
+                        ImGui::Text("[unnamed] (%f)", node->m_weight, m_unitLabel);
+                    }
+                }
+                ImGui::EndTooltip();
+            }
+        }
+        ImGui::End();
+    }
+
+    void ImGuiTreemapImpl::WeighAndComputeLayout(int x, int y, int w, int h)
+    {
+        WeighNodes();
+        ComputeLayout(x, y, w, h);
+        AssignColors();
+        m_dirty = false;
+    }
+
+    void ImGuiTreemapImpl::WeighNodes()
+    {
+        // The goal of this function is to ensure that every node in the tree starting with m_root has the
+        // following data initialized:
+        // - m_parent (pointer to the parent node)
+        // - m_level (depth of the node (e.g. distance from the root node)
+        // - m_weight (cumulative some of weights of all children, descending to the leaves)
+        //
+        // In addition, this function computes the values in m_levelWeights, which is the sum of the weights
+        // for all nodes at each depth level in the tree
+
+        if (!m_dirty)
+        {
+            return;
+        }
+
+        // Flatten the tree via BFS into different levels.
+        for (auto& nodes : m_levelSets)
+        {
+            nodes.clear();
+        }
+
+        CHECK_STACK_EMPTY();
+        m_stack.emplace_back(&m_root);
+        m_levelWeights.clear();
+
+        while (!m_stack.empty())
+        {
+            TreemapNode* node = m_stack.back();
+            m_stack.pop_back();
+
+            if (node->m_children.empty())
+            {
+                AZ_Warning(
+                    "Profiler::ImGuiTreemap", node->m_weight >= 0.f,
+                    "Treemap node %s in treemap %s has a negative weight. Only weights >= 0.f are premitted.",
+                    node->m_name.IsEmpty() ? "[unnamed]" : node->m_name.GetCStr(), m_name.GetCStr());
+                if (node->m_weight < 0.f)
+                {
+                    // Clamp the node weight below to zero to ensure negative weights don't throw off the algorithm
+                    node->m_weight = 0.f;
+                }
+            }
+            else
+            {
+                node->m_weight = 0.f;
+
+                if (node->m_tag == 0 || (m_currentMask & node->m_tag) > 0)
+                {
+                    for (TreemapNode& child : node->m_children)
+                    {
+                        child.m_level = node->m_level + 1;
+                        child.m_parent = node;
+                        m_stack.emplace_back(&child);
+                    }
+                }
+            }
+
+            if (!node->m_group.IsEmpty())
+            {
+                auto it = m_groups.find(node->m_group);
+                if (it == m_groups.end())
+                {
+                    GroupConfig& config = m_groups.try_emplace(node->m_group).first->second;
+                    NameToHueSaturation(node->m_group, config.m_hue, config.m_saturation);
+                }
+            }
+
+            if (m_levelSets.size() < node->m_level + 1)
+            {
+                m_levelSets.resize(node->m_level + 1);
+            }
+            // Track this node in one of the top level vectors. For non-leaf nodes we'll need to
+            // accumulate its weight to its parent after all children are accounted for.
+            m_levelSets[node->m_level].emplace_back(node);
+        }
+
+        // At this point, we've visited every node in the tree and initialized for the weights of all
+        // non-leaf nodes. Now we have to accumulate values for the intermediate nodes, starting from the
+        // last level working our way to the front.
+        // Note that levels[0] is a single node vector containing m_root so we skip this level in our
+        // traversal (it has no parent).
+
+        auto end = m_levelSets.rend() - 1;
+        for (auto it = m_levelSets.rbegin(); it != end; ++it)
+        {
+            for (TreemapNode* node : *it)
+            {
+                if (node->m_tag == 0 || (m_currentMask & node->m_tag) > 0)
+                {
+                    node->m_parent->m_weight += node->m_weight;
+                }
+            }
+        }
+
+        // Weights are determined for the root node and every intermediate node, so we can now determine
+        // the weight sums across all nodes of a given level. Notice that the sums for the leaf nodes have
+        // already been accumulated at this point.
+        m_levelWeights.resize(m_levelSets.size());
+        int level = 0;
+        for (const auto& nodes : m_levelSets)
+        {
+            float& sum = m_levelWeights[level];
+            for (TreemapNode* node : nodes)
+            {
+                if (node->m_tag == 0 || (m_currentMask & node->m_tag) > 0)
+                {
+                    sum += node->m_weight;
+                }
+            }
+            ++level;
+        }
+    }
+
+    void ImGuiTreemapImpl::AssignColors()
+    {
+        // Here we determine the color for each node, taking into account any selection filters and cursor
+        // hover state.
+
+        if (!m_dirty)
+        {
+            return;
+        }
+
+        CHECK_STACK_EMPTY();
+
+        for (TreemapNode& node : m_root.m_children)
+        {
+            m_stack.push_back(&node);
+        }
+
+        while (!m_stack.empty())
+        {
+            TreemapNode& node = *m_stack.back();
+            m_stack.pop_back();
+
+            float hue;
+            float saturation;
+
+            if (node.m_parent == &m_root)
+            {
+                // We're looking at one of the user-supplied root nodes. Use the name to determine chromaticity
+                NameToHueSaturation(node.m_name, hue, saturation);
+            }
+            else
+            {
+                // We're an intermediate or leaf node, not marked by a highlighted group so simply derive
+                // chromaticity from the parent node.
+
+                hue = node.m_parent->m_hue;
+                saturation = node.m_parent->m_saturation;
+            }
+
+            node.m_hue = hue;
+            node.m_saturation = saturation;
+
+            // The value in the HSV color is based on the depth of this node in the tree, remapped to the
+            // [0.4, 0.8] range (subtract 1 from node level to ignore root level).
+            node.m_value = 0.4f * static_cast<float>(node.m_level - 1) / m_levelWeights.size() + 0.4f;
+
+            for (TreemapNode& child : node.m_children)
+            {
+                m_stack.push_back(&child);
+            }
+        }
+    }
+
+    // This is the function referred to as "worst" in the Squarified paper. The idea is to determine how the
+    // element aspect ratio changes if an element is added to row. The grade refers to the worst aspect ratio
+    // among existing elements in the row. The sum, min, and max values correspond to areas within the row.
+    static double GradeRow(double sum, double min, double max, int extent)
+    {
+        // The multiplication and division order here is somewhat haphazard but done this way to improve precision
+        return AZStd::max(extent / sum * extent / sum * max, sum / extent * sum / extent / min);
+    }
+
+    void ImGuiTreemapImpl::SquarifyChildren(TreemapNode& node)
+    {
+        // The paper indicates better layouts were produced when sorting entries in descending weight order
+        AZStd::vector<TreemapNode*> children;
+        children.reserve(node.m_children.size() + 1);
+        for (TreemapNode& child : node.m_children)
+        {
+            if (child.m_tag == 0 || (m_currentMask & child.m_tag) > 0)
+            {
+                children.push_back(&child);
+            }
+        }
+
+        // This dummy node at the end is needed to finalize the last row (which will be the last child node
+        // occupying the row by itself).
+        TreemapNode endSentinel;
+        endSentinel.m_weight = 0.f;
+        children.push_back(&endSentinel);
+
+        AZStd::sort(
+            children.begin(), children.end(),
+            [](const TreemapNode* lhs, const TreemapNode* rhs)
+            {
+                return lhs->m_weight > rhs->m_weight;
+            });
+
+        // Shrink the frame corresponding to a node to ensure there's a 2 pixel gutter.
+        int rowExtent[2] = { node.m_extent[0] - 4, node.m_extent[1] - 4 };
+        int rowOffset[2] = { node.m_offset[0] + 2, node.m_offset[1] + 2 };
+        bool horizontal = rowExtent[1] > rowExtent[0];
+        // The "extent" here tracks the extent along the rows orientation. The row we lay out entries within could be oriented vertically
+        // depending on the aspect ratio.
+        int extent = horizontal ? rowExtent[0] : rowExtent[1];
+
+        AZStd::vector<TreemapNode*> row;
+        double rowArea = 0.f;
+        double rowMinArea = 0.f;
+        double rowMaxArea = 0.f;
+        double grade = 0.f;
+
+        // The aspect ratios are computed with respect to element areas, so compute those areas here
+        double scale = rowExtent[0] * rowExtent[1] / node.m_weight;
+        for (TreemapNode* child : children)
+        {
+            child->m_area = child->m_weight * scale;
+        }
+
+        for (auto it = children.begin(); it != children.end(); /* iterator conditionally incremented in loop body */)
+        {
+            TreemapNode& child = **it;
+
+            // If the row is empty, unconditionally start a new row.
+            if (row.empty())
+            {
+                row.push_back(&child);
+                rowArea = child.m_area;
+                rowMinArea = child.m_area;
+                rowMaxArea = child.m_area;
+                grade = GradeRow(rowArea, rowMinArea, rowMaxArea, extent);
+                ++it;
+                continue;
+            }
+
+            // Check if this node belongs in the current row, or if we should start a new one
+            double gradeIfAdded =
+                GradeRow(rowArea + child.m_area, AZStd::min(child.m_area, rowMinArea), AZStd::max(child.m_area, rowMaxArea), extent);
+
+            if (gradeIfAdded < grade)
+            {
+                grade = gradeIfAdded;
+
+                // Adding this node improves the aspect ratio (nudges it closer to 1, aka makes it more like
+                // a square) so we should append it to the current row
+                row.push_back(&child);
+                rowArea += child.m_area;
+                if (child.m_area < rowMinArea)
+                {
+                    rowMinArea = child.m_area;
+                }
+                if (child.m_area > rowMaxArea)
+                {
+                    rowMaxArea = child.m_area;
+                }
+                ++it;
+                continue;
+            }
+
+            // We're starting a new row, which means we need to finalize the layout of the current row.
+
+            // Extent in the direction perpendicular to the orientation of the row
+            int secondaryExtent = static_cast<int>(rowArea / extent);
+
+            int offset[2] = { rowOffset[0], rowOffset[1] };
+
+            for (TreemapNode* rowNode : row)
+            {
+                if (secondaryExtent <= 1)
+                {
+                    // These nodes are too small to display
+                    rowNode->m_area = 0.0;
+                }
+
+                int nodeExtent = static_cast<int>(rowNode->m_area / secondaryExtent);
+
+                rowNode->m_offset[0] = offset[0];
+                rowNode->m_offset[1] = offset[1];
+
+                if (horizontal)
+                {
+                    rowNode->m_extent[0] = nodeExtent;
+                    rowNode->m_extent[1] = secondaryExtent;
+                    offset[0] += nodeExtent;
+                }
+                else
+                {
+                    rowNode->m_extent[1] = nodeExtent;
+                    rowNode->m_extent[0] = secondaryExtent;
+                    offset[1] += nodeExtent;
+                }
+
+                // Clamp node position within row top left boundary
+                rowNode->m_offset[0] = AZStd::clamp(rowNode->m_offset[0], rowOffset[0], rowOffset[0] + rowExtent[0]);
+                rowNode->m_offset[1] = AZStd::clamp(rowNode->m_offset[1], rowOffset[1], rowOffset[1] + rowExtent[1]);
+
+                // Clamp node extent based on row bottom right boundary
+                if (rowNode->m_offset[0] + rowNode->m_extent[0] > rowOffset[0] + rowExtent[0])
+                {
+                    rowNode->m_extent[0] = rowOffset[0] + rowExtent[0] - rowNode->m_offset[0];
+                }
+                if (rowNode->m_offset[1] + rowNode->m_extent[1] > rowOffset[1] + rowExtent[1])
+                {
+                    rowNode->m_extent[1] = rowOffset[1] + rowExtent[1] - rowNode->m_offset[1];
+                }
+            }
+
+            if (horizontal)
+            {
+                rowExtent[1] -= secondaryExtent;
+                rowOffset[1] += secondaryExtent;
+            }
+            else
+            {
+                rowExtent[0] -= secondaryExtent;
+                rowOffset[0] += secondaryExtent;
+            }
+
+            horizontal = rowExtent[1] > rowExtent[0];
+            extent = horizontal ? rowExtent[0] : rowExtent[1];
+
+            row.clear();
+            // NOTE: we don't increment the iterator here. Since this node will be used to initialize the next row.
+        }
+    }
+
+    void ImGuiTreemapImpl::ComputeLayout(int x, int y, int w, int h)
+    {
+        if (m_lastExtent[0] == w && m_lastExtent[1] == h && m_lastOffset[0] == x && m_lastOffset[1] == y)
+        {
+            return;
+        }
+
+        // This function implements the "Squarified Treemap" algorithm as documented here:
+        // https://www.win.tue.nl/~vanwijk/stm.pdf
+        // (archive link: https://web.archive.org/web/20220224165104/https://www.win.tue.nl/~vanwijk/stm.pdf)
+        // After function completion, every node will have a computed offset and extent
+
+        m_root.m_offset[0] = x;
+        m_root.m_offset[1] = y;
+        m_root.m_extent[0] = w;
+        m_root.m_extent[1] = h;
+
+        // One modification to the paper implementation is that layout generation is done using a stack
+        // instead of recursion
+        CHECK_STACK_EMPTY();
+        m_stack.push_back(&m_root);
+
+        while (!m_stack.empty())
+        {
+            TreemapNode* node = m_stack.back();
+            m_stack.pop_back();
+
+            if (!node->m_children.empty())
+            {
+                SquarifyChildren(*node);
+
+                for (TreemapNode& child : node->m_children)
+                {
+                    // Leaf nodes don't need to be pushed onto the stack
+                    if (!child.m_children.empty())
+                    {
+                        if (node->m_tag == 0 || (m_currentMask & child.m_tag) > 0)
+                        {
+                            m_stack.push_back(&child);
+                        }
+                    }
+                }
+            }
+        }
+
+        m_lastExtent[0] = w;
+        m_lastExtent[1] = h;
+        m_lastOffset[0] = x;
+        m_lastOffset[1] = y;
+    }
+
+} // namespace Profiler

--- a/Gems/Profiler/Code/Source/ImGuiTreemapImpl.h
+++ b/Gems/Profiler/Code/Source/ImGuiTreemapImpl.h
@@ -61,6 +61,9 @@ namespace Profiler
         };
         AZStd::unordered_map<AZ::Name, GroupConfig> m_groups;
 
+        // This set of nodes are reset each frame and used to store treemap nodes beneath the user cursor
+        AZStd::vector<TreemapNode*> m_tooltipNodes;
+
         TreemapNode* m_selectedNode = nullptr;
 
         // A common pattern in the implementation is to use a stack to traverse the tree via BFS. Keeping

--- a/Gems/Profiler/Code/Source/ImGuiTreemapImpl.h
+++ b/Gems/Profiler/Code/Source/ImGuiTreemapImpl.h
@@ -28,12 +28,12 @@ namespace Profiler
         void AddMask(const char* label, uint32_t mask) override;
         void SetRoots(AZStd::vector<TreemapNode>&& roots) override;
         void Render(int x, int y, int w, int h) override;
-        void WeighAndComputeLayout(int x, int y, int w, int h) override;
+        void WeighAndComputeLayout(int w, int h) override;
 
     private:
         void WeighNodes();
         void AssignColors();
-        void ComputeLayout(int x, int y, int w, int h);
+        void ComputeLayout(int w, int h);
         void SquarifyChildren(TreemapNode& node);
 
         AZ::Name m_name;
@@ -70,7 +70,6 @@ namespace Profiler
         // the stack around as a member variable avoids unnecessary allocations and maintains a reservation
         // that matches the maximum size the stack expands to.
         AZStd::vector<TreemapNode*> m_stack;
-        int m_lastOffset[2] = { 0, 0 };
         int m_lastExtent[2] = { 0, 0 };
         uint32_t m_currentMask = 0xffffffff;
         bool m_dirty = true;

--- a/Gems/Profiler/Code/Source/ImGuiTreemapImpl.h
+++ b/Gems/Profiler/Code/Source/ImGuiTreemapImpl.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Name/Name.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/parallel/mutex.h>
+#include <Profiler/ImGuiTreemap.h>
+
+namespace Profiler
+{
+    class ImGuiTreemapImpl : public ImGuiTreemap
+    {
+    public:
+        ~ImGuiTreemapImpl() override = default;
+
+        const AZ::Name& GetName() const override;
+        void SetName(const char* name) override;
+        void SetName(AZ::Name name) override;
+        void SetUnitLabel(const char* unitLabel) override;
+        void AddMask(const char* label, uint32_t mask) override;
+        void SetRoots(AZStd::vector<TreemapNode>&& roots) override;
+        void Render(int x, int y, int w, int h) override;
+        void WeighAndComputeLayout(int x, int y, int w, int h) override;
+
+    private:
+        void WeighNodes();
+        void AssignColors();
+        void ComputeLayout(int x, int y, int w, int h);
+        void SquarifyChildren(TreemapNode& node);
+
+        AZ::Name m_name;
+
+        const char* m_unitLabel;
+
+        TreemapNode m_root;
+
+        // Stores pointers to nodes at the same depth level. This is needed for both weight normalization
+        // and back-to-front drawing for ImGui
+        AZStd::vector<AZStd::vector<TreemapNode*>> m_levelSets;
+
+        // Masks are used to include or exclude nodes from the treemap
+        AZStd::unordered_map<const char*, uint32_t> m_masks;
+
+        // The total sum of all weights for nodes occupying a given depth in the tree
+        AZStd::vector<float> m_levelWeights;
+
+        // The set of groups used to tag constituent nodes
+        struct GroupConfig
+        {
+            bool m_active = false;
+            float m_hue;
+            float m_saturation;
+        };
+        AZStd::unordered_map<AZ::Name, GroupConfig> m_groups;
+
+        TreemapNode* m_selectedNode = nullptr;
+
+        // A common pattern in the implementation is to use a stack to traverse the tree via BFS. Keeping
+        // the stack around as a member variable avoids unnecessary allocations and maintains a reservation
+        // that matches the maximum size the stack expands to.
+        AZStd::vector<TreemapNode*> m_stack;
+        int m_lastOffset[2] = { 0, 0 };
+        int m_lastExtent[2] = { 0, 0 };
+        uint32_t m_currentMask = 0xffffffff;
+        bool m_dirty = true;
+    };
+
+    class ImGuiTreemapFactoryImpl : public ImGuiTreemapFactory
+    {
+     public:
+        ImGuiTreemap& Create(AZ::Name name, const char* unitLabel) override;
+        void Destroy(ImGuiTreemap* treemap) override;
+
+     private:
+        AZStd::mutex m_mutex;
+        AZStd::unordered_map<AZ::Name, ImGuiTreemapImpl> m_treemaps;
+    };
+}

--- a/Gems/Profiler/Code/Source/ProfilerImGuiSystemComponent.cpp
+++ b/Gems/Profiler/Code/Source/ProfilerImGuiSystemComponent.cpp
@@ -8,6 +8,8 @@
 
 #include <ProfilerImGuiSystemComponent.h>
 
+#include "ImGuiTreemapImpl.h"
+
 #include <AzCore/Debug/ProfilerBus.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
@@ -61,12 +63,22 @@ namespace Profiler
         {
             ProfilerImGuiInterface::Register(this);
         }
+
+        if (!ImGuiTreemapFactory::Interface::Get())
+        {
+            ImGuiTreemapFactory::Interface::Register(&m_imguiTreemapFactory);
+        }
 #endif // defined(IMGUI_ENABLED)
     }
 
     ProfilerImGuiSystemComponent::~ProfilerImGuiSystemComponent()
     {
 #if defined(IMGUI_ENABLED)
+        if (ImGuiTreemapFactory::Interface::Get() == &m_imguiTreemapFactory)
+        {
+            ImGuiTreemapFactory::Interface::Unregister(&m_imguiTreemapFactory);
+        }
+
         if (ProfilerImGuiInterface::Get() == this)
         {
             ProfilerImGuiInterface::Unregister(this);

--- a/Gems/Profiler/Code/Source/ProfilerImGuiSystemComponent.h
+++ b/Gems/Profiler/Code/Source/ProfilerImGuiSystemComponent.h
@@ -12,6 +12,8 @@
 
 #include <ImGuiCpuProfiler.h>
 
+#include "ImGuiTreemapImpl.h"
+
 #include <AzCore/Component/Component.h>
 
 #if defined(IMGUI_ENABLED)

--- a/Gems/Profiler/Code/Source/ProfilerImGuiSystemComponent.h
+++ b/Gems/Profiler/Code/Source/ProfilerImGuiSystemComponent.h
@@ -57,6 +57,7 @@ namespace Profiler
 
     private:
 #if defined(IMGUI_ENABLED)
+        ImGuiTreemapFactoryImpl m_imguiTreemapFactory;
         ImGuiCpuProfiler m_imguiCpuProfiler;
         bool m_showCpuProfiler{ false };
 #endif // defined(IMGUI_ENABLED)

--- a/Gems/Profiler/Code/profiler_imgui_shared_files.cmake
+++ b/Gems/Profiler/Code/profiler_imgui_shared_files.cmake
@@ -7,8 +7,11 @@
 #
 
 set(FILES
+    Include/Profiler/ImGuiTreemap.h
+    Include/Profiler/ProfilerImGuiBus.h
     Source/ImGuiCpuProfiler.cpp
     Source/ImGuiCpuProfiler.h
+    Source/ImGuiTreemap.cpp
     Source/ProfilerImGuiModule.cpp
     Source/ProfilerImGuiSystemComponent.cpp
     Source/ProfilerImGuiSystemComponent.h

--- a/Gems/Profiler/Code/profiler_imgui_shared_files.cmake
+++ b/Gems/Profiler/Code/profiler_imgui_shared_files.cmake
@@ -12,6 +12,7 @@ set(FILES
     Source/ImGuiCpuProfiler.cpp
     Source/ImGuiCpuProfiler.h
     Source/ImGuiTreemap.cpp
+    Source/ImGuiTreemapImpl.h
     Source/ProfilerImGuiModule.cpp
     Source/ProfilerImGuiSystemComponent.cpp
     Source/ProfilerImGuiSystemComponent.h


### PR DESCRIPTION
The Profiler gem now exposes an ImGuiTreemap interface which can be
instantiated through a factory AZ::Interface. The entirety of the interface
is contained in [this header](https://github.com/o3de/o3de/pull/8224/files#diff-ec7ab3a76952f596f7051930f222f7ced8b541ad0f39421d53c232083b82593a).

The treemap accepts a tree of TreemapNodes, with arbitrary levels of
nesting. Each node can be named, associated with a weight, a group,
and several other features.

The ImGuiTreemap exposes a Render method to render a new ImGui window
displaying all nodes. The relative weights are the node are proportional
to the node area onscreen. The widget exposes the following features:

- Hierarchical HSV based coloring scheme
- Hover and selection support to display tooltips and node information
- Ability to highlight all nodes assigned to a user-supplied group
- Ability to make nodes visible or invisible based on user-supplied mask
- Automatic resize support and operates at realtime/interactive rates
- Data and layout are cached to avoid unnecessary computation

The Atom ImGuiGpuProfiler was extended to support treemap visualization
for both device and host memory heaps.

![image](https://user-images.githubusercontent.com/87345238/157619380-59c1ade4-9d01-43f3-8d9e-48e1957cd50f.png)
![image](https://user-images.githubusercontent.com/87345238/157619493-ddc06c5b-82a9-44c0-b4d4-40d726e7dacd.png)
