### PR TITLE
Fixes ctrl-g crash with an installer when the server launcher is not found. Clarified error message.

### DIFF
--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -237,17 +237,20 @@ namespace Multiplayer
 
         AZ_Error(
             "MultiplayerEditor", processLaunchInfo.m_launchResult != AzFramework::ProcessLauncher::ProcessLaunchResult::PLR_MissingFile,
-            "LaunchEditorServer failed! The ServerLauncher binary is missing! (%s)  Please build server launcher.", serverPath.c_str())
+            "LaunchEditorServer failed! The ServerLauncher binary is missing! (%s)  Please build server launcher or specify using editorsv_process.", serverPath.c_str());
 
-        // Stop the previous server if one exists
-        if (m_serverProcessWatcher)
+        if (outProcess)
         {
-            AZ::TickBus::Handler::BusDisconnect();
-            m_serverProcessWatcher->TerminateProcess(0);
+            // Stop the previous server if one exists
+            if (m_serverProcessWatcher)
+            {
+                AZ::TickBus::Handler::BusDisconnect();
+                m_serverProcessWatcher->TerminateProcess(0);
+            }
+            m_serverProcessWatcher.reset(outProcess);
+            m_serverProcessTracePrinter = AZStd::make_unique<ProcessCommunicatorTracePrinter>(m_serverProcessWatcher->GetCommunicator(), "EditorServer");
+            AZ::TickBus::Handler::BusConnect();
         }
-        m_serverProcessWatcher.reset(outProcess);
-        m_serverProcessTracePrinter = AZStd::make_unique<ProcessCommunicatorTracePrinter>(m_serverProcessWatcher->GetCommunicator(), "EditorServer");
-        AZ::TickBus::Handler::BusConnect();
     }
 
     void MultiplayerEditorSystemComponent::OnGameEntitiesStarted()

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
@@ -85,6 +85,7 @@ namespace Multiplayer
 
     private:
         void LaunchEditorServer();
+        bool FindServerLauncher(AZ::IO::FixedMaxPath& serverPath);
         
         //! EditorEvents::Handler overrides
         //! @{


### PR DESCRIPTION
Fixes #8230

Test with a local install build.

When the server launcher isn't found, a more useful error is printed, for example:
 
[Error] (MultiplayerEditor) - The ServerLauncher binary is missing! (), (C:\git\o3de\install\bin\Windows\profile\Default\MyProject.ServerLauncher.exe) and (C:\git\myproject\build\bin\profile\MyProject.ServerLauncher.exe) were tried. Please build server launcher or specify using editorsv_process.

Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>