### PR TITLE
Motion Matching: Use facing direction option + a few fixes

### DIFF
--- a/Gems/MotionMatching/Code/Source/BlendTreeMotionMatchNode.cpp
+++ b/Gems/MotionMatching/Code/Source/BlendTreeMotionMatchNode.cpp
@@ -32,9 +32,10 @@ namespace EMotionFX::MotionMatching
         : AnimGraphNode()
     {
         // Setup the input ports.
-        InitInputPorts(2);
+        InitInputPorts(3);
         SetupInputPort("Goal Pos", INPUTPORT_TARGETPOS, MCore::AttributeVector3::TYPE_ID, PORTID_INPUT_TARGETPOS);
         SetupInputPort("Goal Facing Dir", INPUTPORT_TARGETFACINGDIR, MCore::AttributeVector3::TYPE_ID, PORTID_INPUT_TARGETFACINGDIR);
+        SetupInputPort("Use Facing Dir", INPUTPORT_USEFACINGDIR, MCore::AttributeBool::TYPE_ID, PORTID_INPUT_USEFACINGDIR);
 
         // Setup the output ports.
         InitOutputPorts(1);
@@ -186,8 +187,10 @@ namespace EMotionFX::MotionMatching
         AZ::Vector3 targetFacingDir = AZ::Vector3::CreateAxisY();
         TryGetInputVector3(animGraphInstance, INPUTPORT_TARGETFACINGDIR, targetFacingDir);
 
+        bool useFacingDir = GetInputNumberAsBool(animGraphInstance, INPUTPORT_USEFACINGDIR);
+
         MotionMatching::MotionMatchingInstance* instance = uniqueData->m_instance;
-        instance->Update(timePassedInSeconds, targetPos, targetFacingDir, m_trajectoryQueryMode, m_pathRadius, m_pathSpeed);
+        instance->Update(timePassedInSeconds, targetPos, targetFacingDir, useFacingDir, m_trajectoryQueryMode, m_pathRadius, m_pathSpeed);
 
         // set the current time to the new calculated time
         uniqueData->ClearInheritFlags();

--- a/Gems/MotionMatching/Code/Source/BlendTreeMotionMatchNode.h
+++ b/Gems/MotionMatching/Code/Source/BlendTreeMotionMatchNode.h
@@ -29,6 +29,7 @@ namespace EMotionFX::MotionMatching
         {
             INPUTPORT_TARGETPOS = 0,
             INPUTPORT_TARGETFACINGDIR = 1,
+            INPUTPORT_USEFACINGDIR = 2,
             OUTPUTPORT_POSE = 0
         };
 
@@ -36,6 +37,7 @@ namespace EMotionFX::MotionMatching
         {
             PORTID_INPUT_TARGETPOS = 0,
             PORTID_INPUT_TARGETFACINGDIR = 1,
+            PORTID_INPUT_USEFACINGDIR = 2,
             PORTID_OUTPUT_POSE = 0
         };
 

--- a/Gems/MotionMatching/Code/Source/Feature.h
+++ b/Gems/MotionMatching/Code/Source/Feature.h
@@ -85,12 +85,14 @@ namespace EMotionFX::MotionMatching
         // Feature cost
         struct EMFX_API FrameCostContext
         {
-            FrameCostContext(const FeatureMatrix& featureMatrix, const Pose& currentPose)
-                : m_featureMatrix(featureMatrix)
+            FrameCostContext(const FrameDatabase& frameDatabase, const FeatureMatrix& featureMatrix, const Pose& currentPose)
+                : m_frameDatabase(frameDatabase)
+                , m_featureMatrix(featureMatrix)
                 , m_currentPose(currentPose)
             {
             }
 
+            const FrameDatabase& m_frameDatabase;
             const FeatureMatrix& m_featureMatrix;
             const ActorInstance* m_actorInstance = nullptr;
             const Pose& m_currentPose; //! Current actor instance pose.

--- a/Gems/MotionMatching/Code/Source/MotionMatchingInstance.h
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingInstance.h
@@ -57,7 +57,14 @@ namespace EMotionFX::MotionMatching
         // DebugDrawRequestBus::Handler overrides
         void DebugDraw(AzFramework::DebugDisplayRequests& debugDisplay) override;
 
-        void Update(float timePassedInSeconds, const AZ::Vector3& targetPos, const AZ::Vector3& targetFacingDir, TrajectoryQuery::EMode mode, float pathRadius, float pathSpeed);
+        void Update(
+            float timePassedInSeconds,
+            const AZ::Vector3& targetPos,
+            const AZ::Vector3& targetFacingDir,
+            bool useTargetFacingDir,
+            TrajectoryQuery::EMode mode,
+            float pathRadius,
+            float pathSpeed);
         void PostUpdate(float timeDelta);
         void Output(Pose& outputPose);
 

--- a/Gems/MotionMatching/Code/Source/MotionMatchingSystemComponent.cpp
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingSystemComponent.cpp
@@ -105,13 +105,15 @@ namespace EMotionFX::MotionMatching
         MotionMatchingRequestBus::Handler::BusConnect();
         AZ::TickBus::Handler::BusConnect();
 
-        // Register the motion matching anim graph node
-        EMotionFX::AnimGraphObject* motionMatchNodeObject = EMotionFX::AnimGraphObjectFactory::Create(azrtti_typeid<EMotionFX::MotionMatching::BlendTreeMotionMatchNode>());
-        auto motionMatchNode = azdynamic_cast<EMotionFX::MotionMatching::BlendTreeMotionMatchNode*>(motionMatchNodeObject);
-        if (motionMatchNode)
+        // Register the motion matching anim graph node.
         {
-            EMotionFX::Integration::EMotionFXRequestBus::Broadcast(&EMotionFX::Integration::EMotionFXRequests::RegisterAnimGraphObjectType, motionMatchNode);
-            delete motionMatchNode;
+            EMotionFX::AnimGraphObject* animGraphObject = EMotionFX::AnimGraphObjectFactory::Create(azrtti_typeid<EMotionFX::MotionMatching::BlendTreeMotionMatchNode>());
+            auto animGraphNode = azdynamic_cast<EMotionFX::MotionMatching::BlendTreeMotionMatchNode*>(animGraphObject);
+            if (animGraphNode)
+            {
+                EMotionFX::Integration::EMotionFXRequestBus::Broadcast(&EMotionFX::Integration::EMotionFXRequests::RegisterAnimGraphObjectType, animGraphNode);
+            }
+            delete animGraphObject;
         }
 
         // Register the joint velocities pose data.

--- a/Gems/MotionMatching/Code/Source/TrajectoryQuery.h
+++ b/Gems/MotionMatching/Code/Source/TrajectoryQuery.h
@@ -45,6 +45,7 @@ namespace EMotionFX::MotionMatching
             EMode mode,
             const AZ::Vector3& targetPos,
             const AZ::Vector3& targetFacingDir,
+            bool useTargetFacingDir,
             float timeDelta,
             float pathRadius,
             float pathSpeed);
@@ -62,7 +63,8 @@ namespace EMotionFX::MotionMatching
         void PredictFutureTrajectory(const ActorInstance& actorInstance,
             const FeatureTrajectory* trajectoryFeature,
             const AZ::Vector3& targetPos,
-            const AZ::Vector3& targetFacingDir);
+            const AZ::Vector3& targetFacingDir,
+            bool useTargetFacingDir);
 
         AZStd::vector<ControlPoint> m_pastControlPoints;
         AZStd::vector<ControlPoint> m_futureControlPoints;


### PR DESCRIPTION
* Using the updated time for calculating the joint velocities
* Force use target facing direction if joystick is in dead-zone
* Added new port to MM anim graph node for using the target facing direction