### PR TITLE
Convert ScriptCanvas_* automated tests to use prefab system

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main.py
@@ -346,6 +346,9 @@ class TestAutomation(EditorTestSuite):
     class Physics_UndoRedoWorksOnEntityWithPhysComponents(EditorSharedTest):
         from .tests import Physics_UndoRedoWorksOnEntityWithPhysComponents as test_module
 
+    class ScriptCanvas_ShapeCast(EditorSharedTest):
+        from .tests.script_canvas import ScriptCanvas_ShapeCast as test_module
+
 
 @pytest.mark.SUITE_main
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
@@ -358,10 +361,6 @@ class TestAutomationNoPrefab(EditorTestSuite):
     @staticmethod
     def get_number_parallel_editors():
         return 16
-
-    @pytest.mark.xfail(reason="AssertionError: Failed to open level: ScriptCanvas_ShapeCast does not exist or is invalid")
-    class ScriptCanvas_ShapeCast(EditorSharedTest):
-        from .tests.script_canvas import ScriptCanvas_ShapeCast as test_module
 
     @pytest.mark.xfail(reason="AssertionError: Failed to open level: ForceRegion_SliceFileInstantiates does not exist or is invalid")
     class ForceRegion_SliceFileInstantiates(EditorSharedTest):

--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
@@ -208,7 +208,7 @@ class TestAutomation(TestAutomationBase):
     @revert_physics_config
     def test_ScriptCanvas_ShapeCast(self, request, workspace, editor, launcher_platform):
         from .tests.script_canvas import ScriptCanvas_ShapeCast as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @revert_physics_config
     def test_RigidBody_InitialAngularVelocity(self, request, workspace, editor, launcher_platform):

--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
@@ -343,7 +343,7 @@ class TestAutomation(TestAutomationBase):
                       'AutomatedTesting/Registry', search_subdirs=True)
     def test_ScriptCanvas_PreUpdateEvent(self, request, workspace, editor, launcher_platform):
         from .tests.script_canvas import ScriptCanvas_PreUpdateEvent as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @revert_physics_config
     def test_ForceRegion_PxMeshShapedForce(self, request, workspace, editor, launcher_platform):

--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
@@ -329,7 +329,7 @@ class TestAutomation(TestAutomationBase):
                       'AutomatedTesting/Registry', search_subdirs=True)
     def test_ScriptCanvas_PostUpdateEvent(self, request, workspace, editor, launcher_platform):
         from .tests.script_canvas import ScriptCanvas_PostUpdateEvent as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @revert_physics_config
     @fm.file_override('physxsystemconfiguration.setreg','Material_Restitution.setreg_override',

--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_PostUpdateEvent/ScriptCanvas_PostUpdateEvent.prefab
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_PostUpdateEvent/ScriptCanvas_PostUpdateEvent.prefab
@@ -1,0 +1,241 @@
+{
+    "ContainerEntity": {
+        "Id": "Entity_[1146574390643]",
+        "Name": "Level",
+        "Components": {
+            "Component_[10641544592923449938]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 10641544592923449938
+            },
+            "Component_[12039882709170782873]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 12039882709170782873
+            },
+            "Component_[12265484671603697631]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12265484671603697631
+            },
+            "Component_[14126657869720434043]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 14126657869720434043,
+                "Child Entity Order": [
+                    "Entity_[685792073826]",
+                    "Entity_[690087041122]",
+                    "Entity_[690087041122]"
+                ]
+            },
+            "Component_[15230859088967841193]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 15230859088967841193,
+                "Parent Entity": ""
+            },
+            "Component_[16239496886950819870]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 16239496886950819870
+            },
+            "Component_[5688118765544765547]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 5688118765544765547
+            },
+            "Component_[6545738857812235305]": {
+                "$type": "SelectionComponent",
+                "Id": 6545738857812235305
+            },
+            "Component_[7247035804068349658]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 7247035804068349658
+            },
+            "Component_[9307224322037797205]": {
+                "$type": "EditorLockComponent",
+                "Id": 9307224322037797205
+            },
+            "Component_[9562516168917670048]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 9562516168917670048
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[685792073826]": {
+            "Id": "Entity_[685792073826]",
+            "Name": "Lead_Sphere",
+            "Components": {
+                "Component_[14753075596286387799]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14753075596286387799
+                },
+                "Component_[2090157847897755777]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2090157847897755777
+                },
+                "Component_[3089047201950641866]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3089047201950641866
+                },
+                "Component_[3579818455250395378]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 3579818455250395378
+                },
+                "Component_[6256160302408150419]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 6256160302408150419,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[6476665396161717311]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6476665396161717311
+                },
+                "Component_[7664645500077632739]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7664645500077632739
+                },
+                "Component_[814064025896096382]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 814064025896096382,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            529.0,
+                            460.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[8618382466780330975]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8618382466780330975
+                },
+                "Component_[8677912716346686227]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8677912716346686227
+                },
+                "Component_[8764181259049062453]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 8764181259049062453,
+                    "GameView": true
+                },
+                "Component_[9411963977784128279]": {
+                    "$type": "SelectionComponent",
+                    "Id": 9411963977784128279
+                }
+            }
+        },
+        "Entity_[690087041122]": {
+            "Id": "Entity_[690087041122]",
+            "Name": "Follow_Sphere",
+            "Components": {
+                "Component_[10191964386490468665]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10191964386490468665
+                },
+                "Component_[13644829332582485785]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13644829332582485785
+                },
+                "Component_[1371298756551434568]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 1371298756551434568,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[14195810861113588815]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 14195810861113588815
+                },
+                "Component_[14386482779441223248]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14386482779441223248
+                },
+                "Component_[17490370173786146920]": {
+                    "$type": "EditorScriptCanvasComponent",
+                    "Id": 17490370173786146920,
+                    "m_name": "ScriptCanvas_PostUpdateEvent.scriptcanvas",
+                    "runtimeDataOverrides": {
+                        "source": {
+                            "id": "{A84C14B8-00DA-5994-B308-C3E948EA846B}",
+                            "path": "D:/ly/o3de/o3de/AutomatedTesting/ScriptCanvas/ScriptCanvas_PostUpdateEvent.scriptcanvas"
+                        },
+                        "entityId": [
+                            [
+                                {
+                                    "m_id": "{D7EA7F53-7ADC-4D2D-BEAC-A92CC18F5744}"
+                                },
+                                ""
+                            ]
+                        ],
+                        "overrides": [
+                            {
+                                "Datum": {
+                                    "scriptCanvasType": {
+                                        "m_type": 1
+                                    },
+                                    "isNullPointer": false,
+                                    "$type": "EntityId",
+                                    "value": "Entity_[685792073826]"
+                                },
+                                "InputControlVisibility": {
+                                    "Value": 850104567
+                                },
+                                "VariableId": {
+                                    "m_id": "{D7EA7F53-7ADC-4D2D-BEAC-A92CC18F5744}"
+                                },
+                                "VariableName": "Lead_Sphere",
+                                "InitialValueSource": 1
+                            }
+                        ]
+                    },
+                    "sourceHandle": {
+                        "id": "{A84C14B8-00DA-5994-B308-C3E948EA846B}",
+                        "path": "D:/ly/o3de/o3de/AutomatedTesting/ScriptCanvas/ScriptCanvas_PostUpdateEvent.scriptcanvas"
+                    }
+                },
+                "Component_[1926820364687477033]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1926820364687477033
+                },
+                "Component_[3528539223980727498]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3528539223980727498
+                },
+                "Component_[4667205757688164900]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4667205757688164900,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            528.0,
+                            460.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[7530264394337498888]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 7530264394337498888,
+                    "GameView": true
+                },
+                "Component_[7616146901252588815]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7616146901252588815
+                },
+                "Component_[8947287747513494656]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8947287747513494656
+                },
+                "Component_[909391968707840306]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 909391968707840306
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_PreUpdateEvent/ScriptCanvas_PreUpdateEvent.prefab
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_PreUpdateEvent/ScriptCanvas_PreUpdateEvent.prefab
@@ -1,0 +1,241 @@
+{
+    "ContainerEntity": {
+        "Id": "Entity_[1146574390643]",
+        "Name": "Level",
+        "Components": {
+            "Component_[10641544592923449938]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 10641544592923449938
+            },
+            "Component_[12039882709170782873]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 12039882709170782873
+            },
+            "Component_[12265484671603697631]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12265484671603697631
+            },
+            "Component_[14126657869720434043]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 14126657869720434043,
+                "Child Entity Order": [
+                    "Entity_[3471072164802]",
+                    "Entity_[3475367132098]",
+                    "Entity_[3475367132098]"
+                ]
+            },
+            "Component_[15230859088967841193]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 15230859088967841193,
+                "Parent Entity": ""
+            },
+            "Component_[16239496886950819870]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 16239496886950819870
+            },
+            "Component_[5688118765544765547]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 5688118765544765547
+            },
+            "Component_[6545738857812235305]": {
+                "$type": "SelectionComponent",
+                "Id": 6545738857812235305
+            },
+            "Component_[7247035804068349658]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 7247035804068349658
+            },
+            "Component_[9307224322037797205]": {
+                "$type": "EditorLockComponent",
+                "Id": 9307224322037797205
+            },
+            "Component_[9562516168917670048]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 9562516168917670048
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[3471072164802]": {
+            "Id": "Entity_[3471072164802]",
+            "Name": "Lead_Sphere",
+            "Components": {
+                "Component_[14189072670236783763]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 14189072670236783763,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[14314510952700783109]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14314510952700783109
+                },
+                "Component_[14520344038848580325]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14520344038848580325
+                },
+                "Component_[15157710638605984134]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15157710638605984134
+                },
+                "Component_[15316465728754935294]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15316465728754935294,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            506.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[2093139418532355567]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2093139418532355567
+                },
+                "Component_[2464330864690418546]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2464330864690418546
+                },
+                "Component_[5216793746790137850]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 5216793746790137850,
+                    "GameView": true
+                },
+                "Component_[7410314268057597763]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7410314268057597763
+                },
+                "Component_[8015257745663474523]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8015257745663474523
+                },
+                "Component_[8725343263381115924]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8725343263381115924
+                },
+                "Component_[9541491219664351647]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9541491219664351647
+                }
+            }
+        },
+        "Entity_[3475367132098]": {
+            "Id": "Entity_[3475367132098]",
+            "Name": "Follow_Sphere",
+            "Components": {
+                "Component_[10007142190190264828]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10007142190190264828
+                },
+                "Component_[10347637197594593368]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10347637197594593368,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.09999752044677734,
+                            4.010498523712158
+                        ]
+                    }
+                },
+                "Component_[10530320140087110053]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 10530320140087110053
+                },
+                "Component_[12547072754894329685]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 12547072754894329685,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[1472544706006206360]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1472544706006206360
+                },
+                "Component_[1663549013227483422]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 1663549013227483422,
+                    "GameView": true
+                },
+                "Component_[1693737542692436123]": {
+                    "$type": "SelectionComponent",
+                    "Id": 1693737542692436123
+                },
+                "Component_[2125309057659962822]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2125309057659962822
+                },
+                "Component_[2201317185984104658]": {
+                    "$type": "EditorScriptCanvasComponent",
+                    "Id": 2201317185984104658,
+                    "m_name": "ScriptCanvas_PreUpdateEvent.scriptcanvas",
+                    "runtimeDataOverrides": {
+                        "source": {
+                            "id": "{AF457B3F-F8FF-56C2-8F55-BC08DB5708CA}",
+                            "path": "D:/ly/o3de/o3de/AutomatedTesting/ScriptCanvas/ScriptCanvas_PreUpdateEvent.scriptcanvas"
+                        },
+                        "entityId": [
+                            [
+                                {
+                                    "m_id": "{92A5EF6E-28AA-4CD0-9E48-7E34F4DBDFA4}"
+                                },
+                                ""
+                            ]
+                        ],
+                        "overrides": [
+                            {
+                                "Datum": {
+                                    "scriptCanvasType": {
+                                        "m_type": 1
+                                    },
+                                    "isNullPointer": false,
+                                    "$type": "EntityId",
+                                    "value": "Entity_[3471072164802]"
+                                },
+                                "InputControlVisibility": {
+                                    "Value": 850104567
+                                },
+                                "VariableId": {
+                                    "m_id": "{92A5EF6E-28AA-4CD0-9E48-7E34F4DBDFA4}"
+                                },
+                                "VariableName": "Lead_Sphere",
+                                "InitialValueSource": 1
+                            }
+                        ]
+                    },
+                    "sourceHandle": {
+                        "id": "{AF457B3F-F8FF-56C2-8F55-BC08DB5708CA}",
+                        "path": "D:/ly/o3de/o3de/AutomatedTesting/ScriptCanvas/ScriptCanvas_PreUpdateEvent.scriptcanvas"
+                    }
+                },
+                "Component_[2475469114429091404]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2475469114429091404
+                },
+                "Component_[3770057459779889302]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3770057459779889302
+                },
+                "Component_[3980410458285722690]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3980410458285722690
+                },
+                "Component_[4435905377541853589]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4435905377541853589
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_ShapeCast/ScriptCanvas_ShapeCast.prefab
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_ShapeCast/ScriptCanvas_ShapeCast.prefab
@@ -1,0 +1,552 @@
+{
+    "ContainerEntity": {
+        "Id": "Entity_[1146574390643]",
+        "Name": "Level",
+        "Components": {
+            "Component_[10641544592923449938]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 10641544592923449938
+            },
+            "Component_[12039882709170782873]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 12039882709170782873
+            },
+            "Component_[12265484671603697631]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12265484671603697631
+            },
+            "Component_[14126657869720434043]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 14126657869720434043,
+                "Child Entity Order": [
+                    "Entity_[4308872773539]",
+                    "Entity_[4313167740835]",
+                    "Entity_[4317462708131]",
+                    "Entity_[4734074535843]",
+                    "Entity_[23962643120035]",
+                    "Entity_[23962643120035]"
+                ]
+            },
+            "Component_[15230859088967841193]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 15230859088967841193,
+                "Parent Entity": ""
+            },
+            "Component_[16239496886950819870]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 16239496886950819870
+            },
+            "Component_[5688118765544765547]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 5688118765544765547
+            },
+            "Component_[6545738857812235305]": {
+                "$type": "SelectionComponent",
+                "Id": 6545738857812235305
+            },
+            "Component_[7247035804068349658]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 7247035804068349658
+            },
+            "Component_[9307224322037797205]": {
+                "$type": "EditorLockComponent",
+                "Id": 9307224322037797205
+            },
+            "Component_[9562516168917670048]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 9562516168917670048
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[23962643120035]": {
+            "Id": "Entity_[23962643120035]",
+            "Name": "Ball_1",
+            "Components": {
+                "Component_[10718865603549021445]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10718865603549021445
+                },
+                "Component_[12568407252667243687]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 12568407252667243687,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[1376042232041121916]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1376042232041121916
+                },
+                "Component_[15877340025609671362]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15877340025609671362
+                },
+                "Component_[2032039373032407514]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 2032039373032407514,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[2117255492580954035]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2117255492580954035
+                },
+                "Component_[2312521646346912663]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2312521646346912663,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            503.0,
+                            534.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[371898267487847971]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 371898267487847971
+                },
+                "Component_[4625940934755910581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4625940934755910581
+                },
+                "Component_[4786621950874084787]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 4786621950874084787
+                },
+                "Component_[5610376654139269801]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5610376654139269801
+                },
+                "Component_[6976208599052048677]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6976208599052048677
+                },
+                "Component_[8578817167761761574]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 8578817167761761574
+                }
+            }
+        },
+        "Entity_[4308872773539]": {
+            "Id": "Entity_[4308872773539]",
+            "Name": "Notification_Entity_0",
+            "Components": {
+                "Component_[11522822826183195075]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11522822826183195075,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            513.0,
+                            535.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[13094918459901794482]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 13094918459901794482,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[13915270940298740443]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13915270940298740443
+                },
+                "Component_[17116239055708220604]": {
+                    "$type": "SelectionComponent",
+                    "Id": 17116239055708220604
+                },
+                "Component_[3787664585042240824]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3787664585042240824
+                },
+                "Component_[4086816948371374059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4086816948371374059
+                },
+                "Component_[5332874589285554408]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 5332874589285554408,
+                    "GameView": true
+                },
+                "Component_[5409444705308385970]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5409444705308385970
+                },
+                "Component_[670590858924973306]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 670590858924973306
+                },
+                "Component_[6780153559256295851]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6780153559256295851
+                },
+                "Component_[7094561755868279565]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7094561755868279565
+                },
+                "Component_[8657018001767479553]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8657018001767479553
+                }
+            }
+        },
+        "Entity_[4313167740835]": {
+            "Id": "Entity_[4313167740835]",
+            "Name": "Notification_Entity_1",
+            "Components": {
+                "Component_[10151707066588744065]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10151707066588744065
+                },
+                "Component_[1224558831380788743]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 1224558831380788743,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[12923635907153736428]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12923635907153736428
+                },
+                "Component_[13408653050858118006]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 13408653050858118006,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            513.0,
+                            530.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[14808220072538868622]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14808220072538868622
+                },
+                "Component_[16999534067628517498]": {
+                    "$type": "SelectionComponent",
+                    "Id": 16999534067628517498
+                },
+                "Component_[4196774804048742498]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 4196774804048742498
+                },
+                "Component_[4264319953016898324]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 4264319953016898324
+                },
+                "Component_[5705052188242694554]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 5705052188242694554,
+                    "GameView": true
+                },
+                "Component_[5883453253063426973]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5883453253063426973
+                },
+                "Component_[779910625643228267]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 779910625643228267
+                },
+                "Component_[9568097440051102810]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9568097440051102810
+                }
+            }
+        },
+        "Entity_[4317462708131]": {
+            "Id": "Entity_[4317462708131]",
+            "Name": "Notification_Entity_2",
+            "Components": {
+                "Component_[10834535806755744697]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10834535806755744697
+                },
+                "Component_[11733603195635517290]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11733603195635517290
+                },
+                "Component_[13436815763256138423]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13436815763256138423
+                },
+                "Component_[14988803005899232254]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 14988803005899232254
+                },
+                "Component_[15409841372969746299]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 15409841372969746299,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[16363600763279831845]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16363600763279831845
+                },
+                "Component_[16986472143931883165]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 16986472143931883165
+                },
+                "Component_[2350930216931319315]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 2350930216931319315,
+                    "GameView": true
+                },
+                "Component_[5334017701952514153]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5334017701952514153,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            513.0,
+                            525.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[5602623956449910665]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5602623956449910665
+                },
+                "Component_[8264319843087656671]": {
+                    "$type": "SelectionComponent",
+                    "Id": 8264319843087656671
+                },
+                "Component_[9217782195448602935]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9217782195448602935
+                }
+            }
+        },
+        "Entity_[4734074535843]": {
+            "Id": "Entity_[4734074535843]",
+            "Name": "Ball_0",
+            "Components": {
+                "Component_[10536504638319016061]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10536504638319016061
+                },
+                "Component_[10708611228814902713]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10708611228814902713
+                },
+                "Component_[10782200720174863851]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 10782200720174863851,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[11119018995301643381]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11119018995301643381
+                },
+                "Component_[12271673441840413023]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12271673441840413023,
+                    "Parent Entity": "Entity_[1146574390643]",
+                    "Transform Data": {
+                        "Translate": [
+                            503.0,
+                            529.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[14043536323099427217]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14043536323099427217
+                },
+                "Component_[16854408935712206569]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16854408935712206569
+                },
+                "Component_[17566298559450165512]": {
+                    "$type": "EditorScriptCanvasComponent",
+                    "Id": 17566298559450165512,
+                    "m_name": "ScriptCanvas_ShapeCast.scriptcanvas",
+                    "runtimeDataOverrides": {
+                        "source": {
+                            "id": "{F66636BB-9400-51AD-9330-0E43853B8658}",
+                            "path": "D:/ly/o3de/o3de/AutomatedTesting/ScriptCanvas/ScriptCanvas_ShapeCast.scriptcanvas"
+                        },
+                        "entityId": [
+                            [
+                                {
+                                    "m_id": "{21C8C1BE-C6C4-4D88-988D-9D4BEF7B4D43}"
+                                },
+                                ""
+                            ],
+                            [
+                                {
+                                    "m_id": "{68A8A01F-FFAE-44F1-8EDC-F541E39EA861}"
+                                },
+                                ""
+                            ],
+                            [
+                                {
+                                    "m_id": "{808276F3-B926-455D-8AB3-2244801B0E9B}"
+                                },
+                                ""
+                            ],
+                            [
+                                {
+                                    "m_id": "{CE65BD1B-54A7-4184-8EF9-C39F7E7D621E}"
+                                },
+                                ""
+                            ]
+                        ],
+                        "overrides": [
+                            {
+                                "Datum": {
+                                    "scriptCanvasType": {
+                                        "m_type": 1
+                                    },
+                                    "isNullPointer": false,
+                                    "$type": "EntityId",
+                                    "value": "Entity_[4317462708131]"
+                                },
+                                "InputControlVisibility": {
+                                    "Value": 850104567
+                                },
+                                "VariableId": {
+                                    "m_id": "{21C8C1BE-C6C4-4D88-988D-9D4BEF7B4D43}"
+                                },
+                                "VariableName": "Notification_Entity_2",
+                                "InitialValueSource": 1
+                            },
+                            {
+                                "Datum": {
+                                    "scriptCanvasType": {
+                                        "m_type": 1
+                                    },
+                                    "isNullPointer": false,
+                                    "$type": "EntityId",
+                                    "value": "Entity_[4308872773539]"
+                                },
+                                "InputControlVisibility": {
+                                    "Value": 850104567
+                                },
+                                "VariableId": {
+                                    "m_id": "{68A8A01F-FFAE-44F1-8EDC-F541E39EA861}"
+                                },
+                                "VariableName": "Notification_Entity_0",
+                                "InitialValueSource": 1
+                            },
+                            {
+                                "Datum": {
+                                    "scriptCanvasType": {
+                                        "m_type": 1
+                                    },
+                                    "isNullPointer": false,
+                                    "$type": "EntityId",
+                                    "value": "Entity_[4313167740835]"
+                                },
+                                "InputControlVisibility": {
+                                    "Value": 850104567
+                                },
+                                "VariableId": {
+                                    "m_id": "{808276F3-B926-455D-8AB3-2244801B0E9B}"
+                                },
+                                "VariableName": "Notification_Entity_1",
+                                "InitialValueSource": 1
+                            },
+                            {
+                                "Datum": {
+                                    "scriptCanvasType": {
+                                        "m_type": 1
+                                    },
+                                    "isNullPointer": false,
+                                    "$type": "EntityId",
+                                    "value": "Entity_[4734074535843]"
+                                },
+                                "InputControlVisibility": {
+                                    "Value": 850104567
+                                },
+                                "VariableId": {
+                                    "m_id": "{CE65BD1B-54A7-4184-8EF9-C39F7E7D621E}"
+                                },
+                                "VariableName": "Ball_0",
+                                "InitialValueSource": 1
+                            }
+                        ]
+                    },
+                    "sourceHandle": {
+                        "id": "{F66636BB-9400-51AD-9330-0E43853B8658}",
+                        "path": "D:/ly/o3de/o3de/AutomatedTesting/ScriptCanvas/ScriptCanvas_ShapeCast.scriptcanvas"
+                    }
+                },
+                "Component_[2441765979509816766]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2441765979509816766
+                },
+                "Component_[2901626916252900497]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2901626916252900497
+                },
+                "Component_[321356713209153479]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 321356713209153479,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[328028103147008058]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 328028103147008058
+                },
+                "Component_[580440336818078941]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 580440336818078941
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/ScriptCanvas/ScriptCanvas_PostUpdateEvent.scriptcanvas
+++ b/AutomatedTesting/ScriptCanvas/ScriptCanvas_PostUpdateEvent.scriptcanvas
@@ -5,22 +5,49 @@
     "ClassData": {
         "m_scriptCanvas": {
             "Id": {
-                "id": 7246990957034
+                "id": 40381660073307
             },
             "Name": "ScriptCanvas_PostUpdateEvent",
             "Components": {
                 "Component_[7859303221537826322]": {
                     "$type": "EditorGraphVariableManagerComponent",
-                    "Id": 7859303221537826322
+                    "Id": 7859303221537826322,
+                    "m_variableData": {
+                        "m_nameVariableMap": [
+                            {
+                                "Key": {
+                                    "m_id": "{D7EA7F53-7ADC-4D2D-BEAC-A92CC18F5744}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "isOverloadedStorage": false,
+                                        "scriptCanvasType": {
+                                            "m_type": 1
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "EntityId",
+                                        "value": {
+                                            "id": 2901262558
+                                        }
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{D7EA7F53-7ADC-4D2D-BEAC-A92CC18F5744}"
+                                    },
+                                    "VariableName": "Lead_Sphere",
+                                    "InitialValueSource": 1
+                                }
+                            }
+                        ]
+                    }
                 },
                 "Component_[8048615284941550971]": {
-                    "$type": "{4D755CA9-AB92-462C-B24F-0B3376F19967} Graph",
+                    "$type": "EditorGraph",
                     "Id": 8048615284941550971,
                     "m_graphData": {
                         "m_nodes": [
                             {
                                 "Id": {
-                                    "id": 7255580891626
+                                    "id": 40407429877083
                                 },
                                 "Name": "SC-EventNode(Postsimulate event)",
                                 "Components": {
@@ -43,7 +70,7 @@
                                                     {
                                                         "$type": "RestrictedNodeContract",
                                                         "m_nodeId": {
-                                                            "id": 7259875858922
+                                                            "id": 40398839942491
                                                         }
                                                     }
                                                 ],
@@ -135,7 +162,7 @@
                                                     {
                                                         "$type": "RestrictedNodeContract",
                                                         "m_nodeId": {
-                                                            "id": 7259875858922
+                                                            "id": 40398839942491
                                                         }
                                                     }
                                                 ],
@@ -149,7 +176,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 4,
                                                     "m_azType": "{F429F985-AF00-529B-8449-16E56694E5F9}"
@@ -169,7 +195,78 @@
                             },
                             {
                                 "Id": {
-                                    "id": 7264170826218
+                                    "id": 46690967031131
+                                },
+                                "Name": "SC Node(GetVariable)",
+                                "Components": {
+                                    "Component_[12328876539573925158]": {
+                                        "$type": "GetVariableNode",
+                                        "Id": 12328876539573925158,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{B4E99A8C-AB7E-43FD-A001-B41DFCFCCA02}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "toolTip": "When signaled sends the property referenced by this node to a Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{E65B0A03-663C-43A7-BCB0-D15012CBFE28}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled after the referenced property has been pushed to the Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A8EAAAA0-EBFD-4397-ACA1-3A28515F969B}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "EntityId",
+                                                "DisplayDataType": {
+                                                    "m_type": 1
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "m_variableId": {
+                                            "m_id": "{D7EA7F53-7ADC-4D2D-BEAC-A92CC18F5744}"
+                                        },
+                                        "m_variableDataOutSlotId": {
+                                            "m_id": "{A8EAAAA0-EBFD-4397-ACA1-3A28515F969B}"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 40403134909787
                                 },
                                 "Name": "SC-Node(SetWorldTranslation)",
                                 "Components": {
@@ -244,7 +341,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -253,10 +349,9 @@
                                                 "value": {
                                                     "id": 2901262558
                                                 },
-                                                "label": "Source"
+                                                "label": "World Translation"
                                             },
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 8
                                                 },
@@ -267,7 +362,7 @@
                                                     0.0,
                                                     0.0
                                                 ],
-                                                "label": "Translation"
+                                                "label": "Vector3: 1"
                                             }
                                         ],
                                         "methodType": 0,
@@ -282,7 +377,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 7259875858922
+                                    "id": 40398839942491
                                 },
                                 "Name": "SC-Node(GetOnPostsimulateEvent)",
                                 "Components": {
@@ -353,7 +448,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 7268465793514
+                                    "id": 40394544975195
                                 },
                                 "Name": "EBusEventHandler",
                                 "Components": {
@@ -532,7 +627,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -595,7 +689,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 7251285924330
+                                    "id": 40390250007899
                                 },
                                 "Name": "SC-Node(OperatorAdd)",
                                 "Components": {
@@ -815,7 +909,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 8
                                                 },
@@ -829,7 +922,6 @@
                                                 "label": "Vector3"
                                             },
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 8
                                                 },
@@ -848,7 +940,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 7272760760810
+                                    "id": 40385955040603
                                 },
                                 "Name": "SC-Node(GetWorldTranslation)",
                                 "Components": {
@@ -925,7 +1017,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -934,7 +1025,7 @@
                                                 "value": {
                                                     "id": 281697622333
                                                 },
-                                                "label": "Source"
+                                                "label": "EntityID: 0"
                                             }
                                         ],
                                         "methodType": 0,
@@ -953,7 +1044,7 @@
                         "m_connections": [
                             {
                                 "Id": {
-                                    "id": 7277055728106
+                                    "id": 40411724844379
                                 },
                                 "Name": "srcEndpoint=(GetWorldTranslation: Result: Vector3), destEndpoint=(Add (+): Value)",
                                 "Components": {
@@ -962,7 +1053,7 @@
                                         "Id": 242178999561252379,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 7272760760810
+                                                "id": 40385955040603
                                             },
                                             "slotId": {
                                                 "m_id": "{1225D555-C7F9-45E8-B625-A2FFC71A60D6}"
@@ -970,7 +1061,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 7251285924330
+                                                "id": 40390250007899
                                             },
                                             "slotId": {
                                                 "m_id": "{1BDE6B10-A2C0-42D3-B954-EC8F756D9854}"
@@ -981,7 +1072,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 7281350695402
+                                    "id": 40416019811675
                                 },
                                 "Name": "srcEndpoint=(GetWorldTranslation: Out), destEndpoint=(Add (+): In)",
                                 "Components": {
@@ -990,7 +1081,7 @@
                                         "Id": 3863909945377931474,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 7272760760810
+                                                "id": 40385955040603
                                             },
                                             "slotId": {
                                                 "m_id": "{EEBEB400-B5D6-4025-87D8-3DE1EFCCE26A}"
@@ -998,7 +1089,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 7251285924330
+                                                "id": 40390250007899
                                             },
                                             "slotId": {
                                                 "m_id": "{365919DD-D8DE-4209-A5B7-1EBF1B84E58C}"
@@ -1009,7 +1100,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 7285645662698
+                                    "id": 40420314778971
                                 },
                                 "Name": "srcEndpoint=(Add (+): Out), destEndpoint=(SetWorldTranslation: In)",
                                 "Components": {
@@ -1018,7 +1109,7 @@
                                         "Id": 11373809959868110927,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 7251285924330
+                                                "id": 40390250007899
                                             },
                                             "slotId": {
                                                 "m_id": "{4A7D3757-64E3-47D7-B7AF-B27165154631}"
@@ -1026,7 +1117,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 7264170826218
+                                                "id": 40403134909787
                                             },
                                             "slotId": {
                                                 "m_id": "{6F5CB726-93B1-42EB-B489-2A9C4EEAE97A}"
@@ -1037,7 +1128,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 7289940629994
+                                    "id": 40424609746267
                                 },
                                 "Name": "srcEndpoint=(Add (+): Result), destEndpoint=(SetWorldTranslation: Vector3: 1)",
                                 "Components": {
@@ -1046,7 +1137,7 @@
                                         "Id": 6872695239256977190,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 7251285924330
+                                                "id": 40390250007899
                                             },
                                             "slotId": {
                                                 "m_id": "{982F1726-1327-49B5-BEB1-D64D9FC7C0D6}"
@@ -1054,7 +1145,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 7264170826218
+                                                "id": 40403134909787
                                             },
                                             "slotId": {
                                                 "m_id": "{903CDBDF-A22B-477B-AA16-8FDC81255835}"
@@ -1065,7 +1156,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 7294235597290
+                                    "id": 40428904713563
                                 },
                                 "Name": "srcEndpoint=(GetOnPostsimulateEvent: Result: Event<>), destEndpoint=(Postsimulate event: Postsimulate event)",
                                 "Components": {
@@ -1074,7 +1165,7 @@
                                         "Id": 14941476969640620853,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 7259875858922
+                                                "id": 40398839942491
                                             },
                                             "slotId": {
                                                 "m_id": "{5331CDE9-F1F6-4EA0-A8E8-DCB099CF5212}"
@@ -1082,7 +1173,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 7255580891626
+                                                "id": 40407429877083
                                             },
                                             "slotId": {
                                                 "m_id": "{491F4CF1-420C-447C-9347-1286E513D99D}"
@@ -1093,7 +1184,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 7298530564586
+                                    "id": 40433199680859
                                 },
                                 "Name": "srcEndpoint=(GetOnPostsimulateEvent: Out), destEndpoint=(Postsimulate event: Connect)",
                                 "Components": {
@@ -1102,7 +1193,7 @@
                                         "Id": 14053430938252148760,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 7259875858922
+                                                "id": 40398839942491
                                             },
                                             "slotId": {
                                                 "m_id": "{F2AFC1DB-F1B3-4A0A-ABC4-FAFB09CC0EDB}"
@@ -1110,7 +1201,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 7255580891626
+                                                "id": 40407429877083
                                             },
                                             "slotId": {
                                                 "m_id": "{298E1FBB-EA4C-461A-BDBD-B143B6240DDA}"
@@ -1121,7 +1212,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 7302825531882
+                                    "id": 40437494648155
                                 },
                                 "Name": "srcEndpoint=(EntityBus Handler: ExecutionSlot:OnEntityActivated), destEndpoint=(GetOnPostsimulateEvent: In)",
                                 "Components": {
@@ -1130,7 +1221,7 @@
                                         "Id": 2413811060506403971,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 7268465793514
+                                                "id": 40394544975195
                                             },
                                             "slotId": {
                                                 "m_id": "{A2CD891C-F7F3-4F87-95C6-3F08456A39C8}"
@@ -1138,7 +1229,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 7259875858922
+                                                "id": 40398839942491
                                             },
                                             "slotId": {
                                                 "m_id": "{8B02A209-89DE-40B9-882E-851A1C82CFEE}"
@@ -1149,16 +1240,16 @@
                             },
                             {
                                 "Id": {
-                                    "id": 7307120499178
+                                    "id": 49495580675419
                                 },
-                                "Name": "srcEndpoint=(Postsimulate event: OnEvent), destEndpoint=(GetWorldTranslation: In)",
+                                "Name": "srcEndpoint=(Postsimulate event: OnEvent), destEndpoint=(Get Variable: In)",
                                 "Components": {
-                                    "Component_[1592781785499451182]": {
+                                    "Component_[17360774642051297545]": {
                                         "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 1592781785499451182,
+                                        "Id": 17360774642051297545,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 7255580891626
+                                                "id": 40407429877083
                                             },
                                             "slotId": {
                                                 "m_id": "{9412D23F-5C3C-4BAE-9434-FEF63C61D19F}"
@@ -1166,10 +1257,66 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 7272760760810
+                                                "id": 46690967031131
+                                            },
+                                            "slotId": {
+                                                "m_id": "{B4E99A8C-AB7E-43FD-A001-B41DFCFCCA02}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 49774753549659
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(GetWorldTranslation: In)",
+                                "Components": {
+                                    "Component_[898415393263645818]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 898415393263645818,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 46690967031131
+                                            },
+                                            "slotId": {
+                                                "m_id": "{E65B0A03-663C-43A7-BCB0-D15012CBFE28}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 40385955040603
                                             },
                                             "slotId": {
                                                 "m_id": "{8D0B9B7A-415D-44B1-B66F-A6C859CDF068}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 50114055966043
+                                },
+                                "Name": "srcEndpoint=(Get Variable: EntityId), destEndpoint=(GetWorldTranslation: EntityID: 0)",
+                                "Components": {
+                                    "Component_[15726494460066747229]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 15726494460066747229,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 46690967031131
+                                            },
+                                            "slotId": {
+                                                "m_id": "{A8EAAAA0-EBFD-4397-ACA1-3A28515F969B}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 40385955040603
+                                            },
+                                            "slotId": {
+                                                "m_id": "{4D8E536D-BAF4-4AAC-A88E-6B082D58420A}"
                                             }
                                         }
                                     }
@@ -1180,21 +1327,23 @@
                     "m_assetType": "{3E2AC8CD-713F-453E-967F-29517F331784}",
                     "versionData": {
                         "_grammarVersion": 1,
-                        "_runtimeVersion": 1
+                        "_runtimeVersion": 1,
+                        "_fileVersion": 1
                     },
+                    "m_variableCounter": 1,
                     "GraphCanvasData": [
                         {
                             "Key": {
-                                "id": 7246990957034
+                                "id": 40381660073307
                             },
                             "Value": {
                                 "ComponentData": {
                                     "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
                                         "$type": "SceneComponentSaveData",
                                         "ViewParams": {
-                                            "Scale": 1.0498028,
-                                            "AnchorX": -413.4109802246094,
-                                            "AnchorY": -143.83653259277344
+                                            "Scale": 0.5163740342005915,
+                                            "AnchorX": -1198.743408203125,
+                                            "AnchorY": -633.2619018554688
                                         }
                                     }
                                 }
@@ -1202,7 +1351,38 @@
                         },
                         {
                             "Key": {
-                                "id": 7251285924330
+                                "id": 40385955040603
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            180.0,
+                                            80.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{9CC9588E-0054-4615-B627-F8D04CAD5970}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 40390250007899
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1232,38 +1412,41 @@
                         },
                         {
                             "Key": {
-                                "id": 7255580891626
+                                "id": 40394544975195
                             },
                             "Value": {
                                 "ComponentData": {
                                     "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                         "$type": "NodeSaveData"
                                     },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "HandlerNodeTitlePalette"
-                                    },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            -140.0,
-                                            80.0
+                                            -1080.0,
+                                            -80.0
+                                        ]
+                                    },
+                                    "{9E81C95F-89C0-4476-8E82-63CCC4E52E04}": {
+                                        "$type": "EBusHandlerNodeDescriptorSaveData",
+                                        "EventIds": [
+                                            {
+                                                "Value": 245425936
+                                            }
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".azeventhandler"
+                                        "$type": "StylingComponentSaveData"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{5BF8EBFB-0DC5-4708-B618-671B47FB9B94}"
+                                        "PersistentId": "{ABEA26C6-312E-4CDB-A78B-22FFFD0C1621}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 7259875858922
+                                "id": 40398839942491
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1277,8 +1460,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            -500.0,
-                                            100.0
+                                            -740.0,
+                                            40.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1294,7 +1477,7 @@
                         },
                         {
                             "Key": {
-                                "id": 7264170826218
+                                "id": 40403134909787
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1325,62 +1508,62 @@
                         },
                         {
                             "Key": {
-                                "id": 7268465793514
+                                "id": 40407429877083
                             },
                             "Value": {
                                 "ComponentData": {
                                     "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                         "$type": "NodeSaveData"
                                     },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "HandlerNodeTitlePalette"
+                                    },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            -880.0,
-                                            40.0
-                                        ]
-                                    },
-                                    "{9E81C95F-89C0-4476-8E82-63CCC4E52E04}": {
-                                        "$type": "EBusHandlerNodeDescriptorSaveData",
-                                        "EventIds": [
-                                            {
-                                                "Value": 245425936
-                                            }
+                                            -440.0,
+                                            20.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".azeventhandler"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{ABEA26C6-312E-4CDB-A78B-22FFFD0C1621}"
+                                        "PersistentId": "{5BF8EBFB-0DC5-4708-B618-671B47FB9B94}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 7272760760810
+                                "id": 46690967031131
                             },
                             "Value": {
                                 "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            180.0,
-                                            120.0
+                                            -140.0,
+                                            60.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
                                         "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
+                                        "SubStyle": ".getVariable"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{9CC9588E-0054-4615-B627-F8D04CAD5970}"
+                                        "PersistentId": "{E442F3B0-118B-4C7E-9471-5B782E2BEE62}"
                                     }
                                 }
                             }
@@ -1430,6 +1613,10 @@
                             },
                             {
                                 "Key": 13774516556399355685,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 18319381388256150565,
                                 "Value": 1
                             }
                         ]

--- a/AutomatedTesting/ScriptCanvas/ScriptCanvas_PreUpdateEvent.scriptcanvas
+++ b/AutomatedTesting/ScriptCanvas/ScriptCanvas_PreUpdateEvent.scriptcanvas
@@ -5,22 +5,49 @@
     "ClassData": {
         "m_scriptCanvas": {
             "Id": {
-                "id": 80662787523977
+                "id": 2834251534506
             },
             "Name": "ScriptCanvas_PreUpdateEvent",
             "Components": {
                 "Component_[7859303221537826322]": {
                     "$type": "EditorGraphVariableManagerComponent",
-                    "Id": 7859303221537826322
+                    "Id": 7859303221537826322,
+                    "m_variableData": {
+                        "m_nameVariableMap": [
+                            {
+                                "Key": {
+                                    "m_id": "{92A5EF6E-28AA-4CD0-9E48-7E34F4DBDFA4}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "isOverloadedStorage": false,
+                                        "scriptCanvasType": {
+                                            "m_type": 1
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "EntityId",
+                                        "value": {
+                                            "id": 2901262558
+                                        }
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{92A5EF6E-28AA-4CD0-9E48-7E34F4DBDFA4}"
+                                    },
+                                    "VariableName": "Lead_Sphere",
+                                    "InitialValueSource": 1
+                                }
+                            }
+                        ]
+                    }
                 },
                 "Component_[8048615284941550971]": {
-                    "$type": "{4D755CA9-AB92-462C-B24F-0B3376F19967} Graph",
+                    "$type": "EditorGraph",
                     "Id": 8048615284941550971,
                     "m_graphData": {
                         "m_nodes": [
                             {
                                 "Id": {
-                                    "id": 80688557327753
+                                    "id": 2860021338282
                                 },
                                 "Name": "EBusEventHandler",
                                 "Components": {
@@ -261,7 +288,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 80684262360457
+                                    "id": 2855726370986
                                 },
                                 "Name": "SC-Node(GetOnPresimulateEvent)",
                                 "Components": {
@@ -332,7 +359,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 80675672425865
+                                    "id": 2851431403690
                                 },
                                 "Name": "SC-Node(OperatorAdd)",
                                 "Components": {
@@ -583,7 +610,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 80671377458569
+                                    "id": 2847136436394
                                 },
                                 "Name": "SC-Node(SetWorldTranslation)",
                                 "Components": {
@@ -666,7 +693,7 @@
                                                 "value": {
                                                     "id": 2901262558
                                                 },
-                                                "label": "Source"
+                                                "label": "World Translation"
                                             },
                                             {
                                                 "scriptCanvasType": {
@@ -679,7 +706,7 @@
                                                     0.0,
                                                     0.0
                                                 ],
-                                                "label": "Translation"
+                                                "label": "Vector3: 1"
                                             }
                                         ],
                                         "methodType": 0,
@@ -694,7 +721,78 @@
                             },
                             {
                                 "Id": {
-                                    "id": 80667082491273
+                                    "id": 10247365087402
+                                },
+                                "Name": "SC Node(GetVariable)",
+                                "Components": {
+                                    "Component_[3307946318028756314]": {
+                                        "$type": "GetVariableNode",
+                                        "Id": 3307946318028756314,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{2D153B94-2184-401E-8CD4-27BB7673E9C3}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "toolTip": "When signaled sends the property referenced by this node to a Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{54FFAB5D-2181-4BE0-BD71-9E6554182DFA}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled after the referenced property has been pushed to the Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{23ABF99F-2231-4612-9C43-4635E2B448B1}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "EntityId",
+                                                "DisplayDataType": {
+                                                    "m_type": 1
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "m_variableId": {
+                                            "m_id": "{92A5EF6E-28AA-4CD0-9E48-7E34F4DBDFA4}"
+                                        },
+                                        "m_variableDataOutSlotId": {
+                                            "m_id": "{23ABF99F-2231-4612-9C43-4635E2B448B1}"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 2842841469098
                                 },
                                 "Name": "SC-Node(GetWorldTranslation)",
                                 "Components": {
@@ -779,7 +877,7 @@
                                                 "value": {
                                                     "id": 284799455595
                                                 },
-                                                "label": "Source"
+                                                "label": "EntityID: 0"
                                             }
                                         ],
                                         "methodType": 0,
@@ -796,7 +894,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 80679967393161
+                                    "id": 2838546501802
                                 },
                                 "Name": "SC-EventNode(Presimulate event)",
                                 "Components": {
@@ -819,7 +917,7 @@
                                                     {
                                                         "$type": "RestrictedNodeContract",
                                                         "m_nodeId": {
-                                                            "id": 80684262360457
+                                                            "id": 2855726370986
                                                         }
                                                     }
                                                 ],
@@ -930,7 +1028,7 @@
                                                     {
                                                         "$type": "RestrictedNodeContract",
                                                         "m_nodeId": {
-                                                            "id": 80684262360457
+                                                            "id": 2855726370986
                                                         }
                                                     }
                                                 ],
@@ -966,9 +1064,33 @@
                                                 },
                                                 {
                                                     "m_id": "{141AA0B1-CA62-45CF-9ED2-FB55354FA26F}"
+                                                },
+                                                {
+                                                    "m_id": "{141AA0B1-CA62-45CF-9ED2-FB55354FA26F}"
+                                                },
+                                                {
+                                                    "m_id": "{141AA0B1-CA62-45CF-9ED2-FB55354FA26F}"
+                                                },
+                                                {
+                                                    "m_id": "{141AA0B1-CA62-45CF-9ED2-FB55354FA26F}"
+                                                },
+                                                {
+                                                    "m_id": "{141AA0B1-CA62-45CF-9ED2-FB55354FA26F}"
                                                 }
                                             ],
                                             "m_parameterNames": [
+                                                {
+                                                    "m_id": "{141AA0B1-CA62-45CF-9ED2-FB55354FA26F}"
+                                                },
+                                                {
+                                                    "m_id": "{141AA0B1-CA62-45CF-9ED2-FB55354FA26F}"
+                                                },
+                                                {
+                                                    "m_id": "{141AA0B1-CA62-45CF-9ED2-FB55354FA26F}"
+                                                },
+                                                {
+                                                    "m_id": "{141AA0B1-CA62-45CF-9ED2-FB55354FA26F}"
+                                                },
                                                 {
                                                     "m_id": "{141AA0B1-CA62-45CF-9ED2-FB55354FA26F}"
                                                 },
@@ -993,7 +1115,7 @@
                         "m_connections": [
                             {
                                 "Id": {
-                                    "id": 80692852295049
+                                    "id": 2864316305578
                                 },
                                 "Name": "srcEndpoint=(GetWorldTranslation: Result: Vector3), destEndpoint=(Add (+): Value)",
                                 "Components": {
@@ -1002,7 +1124,7 @@
                                         "Id": 14061883664044186409,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 80667082491273
+                                                "id": 2842841469098
                                             },
                                             "slotId": {
                                                 "m_id": "{1225D555-C7F9-45E8-B625-A2FFC71A60D6}"
@@ -1010,7 +1132,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 80675672425865
+                                                "id": 2851431403690
                                             },
                                             "slotId": {
                                                 "m_id": "{0B1A1CA1-9D6A-4402-8953-E62C9329D70A}"
@@ -1021,7 +1143,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 80697147262345
+                                    "id": 2868611272874
                                 },
                                 "Name": "srcEndpoint=(GetWorldTranslation: Out), destEndpoint=(Add (+): In)",
                                 "Components": {
@@ -1030,7 +1152,7 @@
                                         "Id": 9507558893143824342,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 80667082491273
+                                                "id": 2842841469098
                                             },
                                             "slotId": {
                                                 "m_id": "{EEBEB400-B5D6-4025-87D8-3DE1EFCCE26A}"
@@ -1038,7 +1160,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 80675672425865
+                                                "id": 2851431403690
                                             },
                                             "slotId": {
                                                 "m_id": "{F2AB1C73-D779-4306-A336-96D085EFD20C}"
@@ -1049,7 +1171,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 80701442229641
+                                    "id": 2872906240170
                                 },
                                 "Name": "srcEndpoint=(Add (+): Out), destEndpoint=(SetWorldTranslation: In)",
                                 "Components": {
@@ -1058,7 +1180,7 @@
                                         "Id": 15133880696098216097,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 80675672425865
+                                                "id": 2851431403690
                                             },
                                             "slotId": {
                                                 "m_id": "{8C84B74E-F975-4957-8039-19E7719327AD}"
@@ -1066,7 +1188,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 80671377458569
+                                                "id": 2847136436394
                                             },
                                             "slotId": {
                                                 "m_id": "{6F5CB726-93B1-42EB-B489-2A9C4EEAE97A}"
@@ -1077,7 +1199,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 80705737196937
+                                    "id": 2877201207466
                                 },
                                 "Name": "srcEndpoint=(Add (+): Result), destEndpoint=(SetWorldTranslation: Vector3: 1)",
                                 "Components": {
@@ -1086,7 +1208,7 @@
                                         "Id": 11733116393313919050,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 80675672425865
+                                                "id": 2851431403690
                                             },
                                             "slotId": {
                                                 "m_id": "{540EF6ED-F6B9-4BCE-A7A9-8271DE09E28E}"
@@ -1094,7 +1216,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 80671377458569
+                                                "id": 2847136436394
                                             },
                                             "slotId": {
                                                 "m_id": "{903CDBDF-A22B-477B-AA16-8FDC81255835}"
@@ -1105,7 +1227,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 80710032164233
+                                    "id": 2881496174762
                                 },
                                 "Name": "srcEndpoint=(GetOnPresimulateEvent: Result: Event<float >), destEndpoint=(Presimulate event: Presimulate event)",
                                 "Components": {
@@ -1114,7 +1236,7 @@
                                         "Id": 8351382586130482188,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 80684262360457
+                                                "id": 2855726370986
                                             },
                                             "slotId": {
                                                 "m_id": "{13AE2AAB-FBEB-4851-A148-325652B1FDC1}"
@@ -1122,7 +1244,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 80679967393161
+                                                "id": 2838546501802
                                             },
                                             "slotId": {
                                                 "m_id": "{477D1D40-3833-46BB-8DC7-E4DCCF688E99}"
@@ -1133,7 +1255,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 80714327131529
+                                    "id": 2885791142058
                                 },
                                 "Name": "srcEndpoint=(GetOnPresimulateEvent: Out), destEndpoint=(Presimulate event: Connect)",
                                 "Components": {
@@ -1142,7 +1264,7 @@
                                         "Id": 14628666297034614869,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 80684262360457
+                                                "id": 2855726370986
                                             },
                                             "slotId": {
                                                 "m_id": "{235F1C50-06B0-4793-BD83-C9F3E8B28479}"
@@ -1150,7 +1272,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 80679967393161
+                                                "id": 2838546501802
                                             },
                                             "slotId": {
                                                 "m_id": "{785642C6-C68F-4C78-B388-DB2032C55B8B}"
@@ -1161,7 +1283,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 80718622098825
+                                    "id": 2890086109354
                                 },
                                 "Name": "srcEndpoint=(EntityBus Handler: ExecutionSlot:OnEntityActivated), destEndpoint=(GetOnPresimulateEvent: In)",
                                 "Components": {
@@ -1170,7 +1292,7 @@
                                         "Id": 16571789671982644265,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 80688557327753
+                                                "id": 2860021338282
                                             },
                                             "slotId": {
                                                 "m_id": "{6AAE0625-E567-448A-85EC-002727CB0C9B}"
@@ -1178,7 +1300,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 80684262360457
+                                                "id": 2855726370986
                                             },
                                             "slotId": {
                                                 "m_id": "{671D1A67-1F82-4BB4-9287-099AA81073DF}"
@@ -1189,16 +1311,16 @@
                             },
                             {
                                 "Id": {
-                                    "id": 80722917066121
+                                    "id": 13309676769450
                                 },
-                                "Name": "srcEndpoint=(Presimulate event: OnEvent), destEndpoint=(GetWorldTranslation: In)",
+                                "Name": "srcEndpoint=(Presimulate event: OnEvent), destEndpoint=(Get Variable: In)",
                                 "Components": {
-                                    "Component_[2247867446063002806]": {
+                                    "Component_[14520711773356075033]": {
                                         "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 2247867446063002806,
+                                        "Id": 14520711773356075033,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 80679967393161
+                                                "id": 2838546501802
                                             },
                                             "slotId": {
                                                 "m_id": "{CECB84BC-6AC2-4C51-A38A-63FE7E01A056}"
@@ -1206,10 +1328,66 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 80667082491273
+                                                "id": 10247365087402
+                                            },
+                                            "slotId": {
+                                                "m_id": "{2D153B94-2184-401E-8CD4-27BB7673E9C3}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 13777828204714
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(GetWorldTranslation: In)",
+                                "Components": {
+                                    "Component_[5043486131847537579]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 5043486131847537579,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 10247365087402
+                                            },
+                                            "slotId": {
+                                                "m_id": "{54FFAB5D-2181-4BE0-BD71-9E6554182DFA}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 2842841469098
                                             },
                                             "slotId": {
                                                 "m_id": "{8D0B9B7A-415D-44B1-B66F-A6C859CDF068}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 14057001078954
+                                },
+                                "Name": "srcEndpoint=(Get Variable: EntityId), destEndpoint=(GetWorldTranslation: EntityID: 0)",
+                                "Components": {
+                                    "Component_[480123052169415480]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 480123052169415480,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 10247365087402
+                                            },
+                                            "slotId": {
+                                                "m_id": "{23ABF99F-2231-4612-9C43-4635E2B448B1}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 2842841469098
+                                            },
+                                            "slotId": {
+                                                "m_id": "{4D8E536D-BAF4-4AAC-A88E-6B082D58420A}"
                                             }
                                         }
                                     }
@@ -1220,22 +1398,23 @@
                     "m_assetType": "{3E2AC8CD-713F-453E-967F-29517F331784}",
                     "versionData": {
                         "_grammarVersion": 1,
-                        "_runtimeVersion": 1
+                        "_runtimeVersion": 1,
+                        "_fileVersion": 1
                     },
-                    "m_variableCounter": 2,
+                    "m_variableCounter": 3,
                     "GraphCanvasData": [
                         {
                             "Key": {
-                                "id": 80662787523977
+                                "id": 2834251534506
                             },
                             "Value": {
                                 "ComponentData": {
                                     "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
                                         "$type": "SceneComponentSaveData",
                                         "ViewParams": {
-                                            "Scale": 0.7791539,
-                                            "AnchorX": -1672.326904296875,
-                                            "AnchorY": -143.74566650390625
+                                            "Scale": 0.6078507850429057,
+                                            "AnchorX": -1977.458984375,
+                                            "AnchorY": -190.8363037109375
                                         }
                                     }
                                 }
@@ -1243,7 +1422,38 @@
                         },
                         {
                             "Key": {
-                                "id": 80667082491273
+                                "id": 2838546501802
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "HandlerNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -1960.0,
+                                            200.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".azeventhandler"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{23D34A34-DB1F-4E79-A120-B50777838FE0}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 2842841469098
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1257,7 +1467,7 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            -1380.0,
+                                            -1320.0,
                                             180.0
                                         ]
                                     },
@@ -1274,7 +1484,7 @@
                         },
                         {
                             "Key": {
-                                "id": 80671377458569
+                                "id": 2847136436394
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1305,7 +1515,7 @@
                         },
                         {
                             "Key": {
-                                "id": 80675672425865
+                                "id": 2851431403690
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1335,38 +1545,7 @@
                         },
                         {
                             "Key": {
-                                "id": 80679967393161
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "HandlerNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            -1720.0,
-                                            140.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".azeventhandler"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{23D34A34-DB1F-4E79-A120-B50777838FE0}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 80684262360457
+                                "id": 2855726370986
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1380,8 +1559,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            -2080.0,
-                                            140.0
+                                            -2300.0,
+                                            200.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1397,7 +1576,7 @@
                         },
                         {
                             "Key": {
-                                "id": 80688557327753
+                                "id": 2860021338282
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1407,7 +1586,7 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            -2420.0,
+                                            -2640.0,
                                             100.0
                                         ]
                                     },
@@ -1425,6 +1604,37 @@
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
                                         "PersistentId": "{FBA5ADF8-A282-4C7F-A3FF-265E075EE6CA}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 10247365087402
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -1640.0,
+                                            220.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".getVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{1F6A608D-6077-49A5-8E43-AEF4AE7E4FB9}"
                                     }
                                 }
                             }
@@ -1471,6 +1681,10 @@
                             },
                             {
                                 "Key": 5842116761103598202,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 6717906085631085282,
                                 "Value": 1
                             },
                             {

--- a/AutomatedTesting/ScriptCanvas/ScriptCanvas_ShapeCast.scriptcanvas
+++ b/AutomatedTesting/ScriptCanvas/ScriptCanvas_ShapeCast.scriptcanvas
@@ -5,18 +5,160 @@
     "ClassData": {
         "m_scriptCanvas": {
             "Id": {
-                "id": 8672351796498
+                "id": 5215110872995
             },
             "Name": "ScriptCanvas_ShapeCast",
             "Components": {
                 "Component_[1715830487162451505]": {
-                    "$type": "{4D755CA9-AB92-462C-B24F-0B3376F19967} Graph",
+                    "$type": "EditorGraph",
                     "Id": 1715830487162451505,
                     "m_graphData": {
                         "m_nodes": [
                             {
                                 "Id": {
-                                    "id": 8685236698386
+                                    "id": 20238906474403
+                                },
+                                "Name": "SC Node(GetVariable)",
+                                "Components": {
+                                    "Component_[11326322072288203138]": {
+                                        "$type": "GetVariableNode",
+                                        "Id": 11326322072288203138,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{3EC3D187-BBF8-46D8-A53A-F339F5E1F279}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "toolTip": "When signaled sends the property referenced by this node to a Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{0A8C143A-B9AD-4008-B2F5-B5865372F03E}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled after the referenced property has been pushed to the Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{DD96C116-BC28-4B79-A7C4-64C06A595335}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "EntityId",
+                                                "DisplayDataType": {
+                                                    "m_type": 1
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "m_variableId": {
+                                            "m_id": "{21C8C1BE-C6C4-4D88-988D-9D4BEF7B4D43}"
+                                        },
+                                        "m_variableDataOutSlotId": {
+                                            "m_id": "{DD96C116-BC28-4B79-A7C4-64C06A595335}"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 17094990413731
+                                },
+                                "Name": "SC Node(GetVariable)",
+                                "Components": {
+                                    "Component_[12417336209578830168]": {
+                                        "$type": "GetVariableNode",
+                                        "Id": 12417336209578830168,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{0C43335E-979B-4845-B331-879CA6F9EFCA}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "toolTip": "When signaled sends the property referenced by this node to a Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{6DAE792B-4C02-476E-9E52-25763494920C}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled after the referenced property has been pushed to the Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{3088EDE1-F508-4849-89D3-552FC271FD9B}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "EntityId",
+                                                "DisplayDataType": {
+                                                    "m_type": 1
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "m_variableId": {
+                                            "m_id": "{808276F3-B926-455D-8AB3-2244801B0E9B}"
+                                        },
+                                        "m_variableDataOutSlotId": {
+                                            "m_id": "{3088EDE1-F508-4849-89D3-552FC271FD9B}"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 5249470611363
                                 },
                                 "Name": "SC-Node((NodeFunctionGenericMultiReturn<t_Func, t_Traits, function>)<{tuple<bool Vector3 Vector3 float EntityId Crc32 >(float const  Sp)",
                                 "Components": {
@@ -273,7 +415,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -283,7 +424,6 @@
                                                 "label": "Number: Distance"
                                             },
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 7
                                                 },
@@ -306,7 +446,6 @@
                                                 "label": "Transform: Pose"
                                             },
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 8
                                                 },
@@ -320,7 +459,6 @@
                                                 "label": "Vector3: Direction"
                                             },
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -330,7 +468,6 @@
                                                 "label": "Number: Radius"
                                             },
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -340,7 +477,6 @@
                                                 "label": "String: Collision group"
                                             },
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -358,7 +494,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 8676646763794
+                                    "id": 5240880676771
                                 },
                                 "Name": "SC-Node(Start)",
                                 "Components": {
@@ -388,7 +524,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 8706711534866
+                                    "id": 5236585709475
                                 },
                                 "Name": "SC-Node(TimeDelayNodeableNode)",
                                 "Components": {
@@ -476,7 +612,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -529,7 +664,78 @@
                             },
                             {
                                 "Id": {
-                                    "id": 8698121600274
+                                    "id": 5232290742179
+                                },
+                                "Name": "SC Node(GetVariable)",
+                                "Components": {
+                                    "Component_[4117441348115001046]": {
+                                        "$type": "GetVariableNode",
+                                        "Id": 4117441348115001046,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{0A179385-7E1B-428C-B2E8-7CE492D0BB05}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "toolTip": "When signaled sends the property referenced by this node to a Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{FB3A5F73-C500-4111-ADC7-7DDBB33E1370}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled after the referenced property has been pushed to the Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{F938A38E-929F-4472-A88E-F80D5ABE96C5}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "EntityId",
+                                                "DisplayDataType": {
+                                                    "m_type": 1
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "m_variableId": {
+                                            "m_id": "{CE65BD1B-54A7-4184-8EF9-C39F7E7D621E}"
+                                        },
+                                        "m_variableDataOutSlotId": {
+                                            "m_id": "{F938A38E-929F-4472-A88E-F80D5ABE96C5}"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 5227995774883
                                 },
                                 "Name": "SC-Node(DrawSphereAtLocation)",
                                 "Components": {
@@ -638,7 +844,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 8
                                                 },
@@ -649,20 +854,18 @@
                                                     0.0,
                                                     0.0
                                                 ],
-                                                "label": "Vector3: 0"
+                                                "label": "Position"
                                             },
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
                                                 "isNullPointer": false,
                                                 "$type": "double",
                                                 "value": 0.5,
-                                                "label": "Number: 1"
+                                                "label": "Radius"
                                             },
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 12
                                                 },
@@ -674,17 +877,16 @@
                                                     0.0,
                                                     0.3921568989753723
                                                 ],
-                                                "label": "Color: 2"
+                                                "label": "Color"
                                             },
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
                                                 "isNullPointer": false,
                                                 "$type": "double",
                                                 "value": 10.0,
-                                                "label": "Number: 3"
+                                                "label": "Duration"
                                             }
                                         ],
                                         "methodType": 0,
@@ -699,7 +901,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 8702416567570
+                                    "id": 5223700807587
                                 },
                                 "Name": "SC-Node(SetGravityEnabled)",
                                 "Components": {
@@ -774,7 +976,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -783,17 +984,16 @@
                                                 "value": {
                                                     "id": 6946861790754
                                                 },
-                                                "label": "Source"
+                                                "label": "Enabled"
                                             },
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
                                                 "isNullPointer": false,
                                                 "$type": "bool",
                                                 "value": true,
-                                                "label": "Enabled"
+                                                "label": "Boolean: 1"
                                             }
                                         ],
                                         "methodType": 0,
@@ -808,7 +1008,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 8680941731090
+                                    "id": 5253765578659
                                 },
                                 "Name": "SC-Node(SetGravityEnabled)",
                                 "Components": {
@@ -883,7 +1083,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -892,17 +1091,16 @@
                                                 "value": {
                                                     "id": 6951156758050
                                                 },
-                                                "label": "Source"
+                                                "label": "Enabled"
                                             },
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
                                                 "isNullPointer": false,
                                                 "$type": "bool",
                                                 "value": true,
-                                                "label": "Enabled"
+                                                "label": "Boolean: 1"
                                             }
                                         ],
                                         "methodType": 0,
@@ -917,7 +1115,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 8689531665682
+                                    "id": 5219405840291
                                 },
                                 "Name": "SC-Node(SetGravityEnabled)",
                                 "Components": {
@@ -992,7 +1190,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -1001,17 +1198,16 @@
                                                 "value": {
                                                     "id": 20016447272482
                                                 },
-                                                "label": "Source"
+                                                "label": "Enabled"
                                             },
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
                                                 "isNullPointer": false,
                                                 "$type": "bool",
                                                 "value": true,
-                                                "label": "Enabled"
+                                                "label": "Boolean: 1"
                                             }
                                         ],
                                         "methodType": 0,
@@ -1026,7 +1222,78 @@
                             },
                             {
                                 "Id": {
-                                    "id": 8693826632978
+                                    "id": 13534462525347
+                                },
+                                "Name": "SC Node(GetVariable)",
+                                "Components": {
+                                    "Component_[6529852967091881963]": {
+                                        "$type": "GetVariableNode",
+                                        "Id": 6529852967091881963,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{3642EAFE-6548-4250-A548-C05A28DB261F}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "toolTip": "When signaled sends the property referenced by this node to a Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{F387D0B0-0F98-474F-B270-CF7138EF68CF}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled after the referenced property has been pushed to the Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{019F98FD-3EFF-4F1B-BB85-33E2BA9BC329}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "EntityId",
+                                                "DisplayDataType": {
+                                                    "m_type": 1
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "m_variableId": {
+                                            "m_id": "{68A8A01F-FFAE-44F1-8EDC-F541E39EA861}"
+                                        },
+                                        "m_variableDataOutSlotId": {
+                                            "m_id": "{019F98FD-3EFF-4F1B-BB85-33E2BA9BC329}"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 5245175644067
                                 },
                                 "Name": "SC-Node(GetWorldTM)",
                                 "Components": {
@@ -1103,7 +1370,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -1112,7 +1378,7 @@
                                                 "value": {
                                                     "id": 285423519414
                                                 },
-                                                "label": "Source"
+                                                "label": "EntityID: 0"
                                             }
                                         ],
                                         "methodType": 0,
@@ -1131,35 +1397,7 @@
                         "m_connections": [
                             {
                                 "Id": {
-                                    "id": 8711006502162
-                                },
-                                "Name": "srcEndpoint=(TimeDelay: Done), destEndpoint=(GetWorldTM: In)",
-                                "Components": {
-                                    "Component_[7737581004071114865]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 7737581004071114865,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 8706711534866
-                                            },
-                                            "slotId": {
-                                                "m_id": "{BB866532-A9E2-4F6B-8BDE-573FF19978BD}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 8693826632978
-                                            },
-                                            "slotId": {
-                                                "m_id": "{94D6DD7F-0835-4AF2-8C0D-F5C04A627F09}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 8715301469458
+                                    "id": 5258060545955
                                 },
                                 "Name": "srcEndpoint=(SphereCastWithGroup: Out), destEndpoint=(DrawSphereAtLocation: In)",
                                 "Components": {
@@ -1168,7 +1406,7 @@
                                         "Id": 2579605655438959770,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 8685236698386
+                                                "id": 5249470611363
                                             },
                                             "slotId": {
                                                 "m_id": "{D46CC4A2-380E-4E42-B0A1-176DBC19420B}"
@@ -1176,7 +1414,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 8698121600274
+                                                "id": 5227995774883
                                             },
                                             "slotId": {
                                                 "m_id": "{2D4EE0B2-CB04-450A-BF88-0865D83DAD43}"
@@ -1187,35 +1425,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 8719596436754
-                                },
-                                "Name": "srcEndpoint=(SphereCastWithGroup: Out), destEndpoint=(SetGravityEnabled: In)",
-                                "Components": {
-                                    "Component_[10204073618203833060]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 10204073618203833060,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 8685236698386
-                                            },
-                                            "slotId": {
-                                                "m_id": "{D46CC4A2-380E-4E42-B0A1-176DBC19420B}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 8680941731090
-                                            },
-                                            "slotId": {
-                                                "m_id": "{EFE54C57-C69A-416B-B679-F324C5F8220A}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 8723891404050
+                                    "id": 5266650480547
                                 },
                                 "Name": "srcEndpoint=(SphereCastWithGroup: Position: Vector3), destEndpoint=(DrawSphereAtLocation: Vector3: 0)",
                                 "Components": {
@@ -1224,7 +1434,7 @@
                                         "Id": 8680294304213498063,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 8685236698386
+                                                "id": 5249470611363
                                             },
                                             "slotId": {
                                                 "m_id": "{3EBC2F40-052C-4AB9-85CF-BFDE6ADFE237}"
@@ -1232,7 +1442,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 8698121600274
+                                                "id": 5227995774883
                                             },
                                             "slotId": {
                                                 "m_id": "{130E7595-7F23-4DB4-9F63-F65F59802520}"
@@ -1243,7 +1453,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 8728186371346
+                                    "id": 5270945447843
                                 },
                                 "Name": "srcEndpoint=(GetWorldTM: Result: Transform), destEndpoint=(SphereCastWithGroup: Transform: Pose)",
                                 "Components": {
@@ -1252,7 +1462,7 @@
                                         "Id": 17208443392918658715,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 8693826632978
+                                                "id": 5245175644067
                                             },
                                             "slotId": {
                                                 "m_id": "{63CFCFFA-AD2D-4BCF-B5F4-E632DE8546AD}"
@@ -1260,7 +1470,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 8685236698386
+                                                "id": 5249470611363
                                             },
                                             "slotId": {
                                                 "m_id": "{D8D3B073-1ACD-4170-A3C0-495E673F409A}"
@@ -1271,35 +1481,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 8732481338642
-                                },
-                                "Name": "srcEndpoint=(DrawSphereAtLocation: Out), destEndpoint=(SetGravityEnabled: In)",
-                                "Components": {
-                                    "Component_[15585314878063913195]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 15585314878063913195,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 8698121600274
-                                            },
-                                            "slotId": {
-                                                "m_id": "{26873BC3-2AB5-428A-92EE-1AD26052194E}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 8702416567570
-                                            },
-                                            "slotId": {
-                                                "m_id": "{EFE54C57-C69A-416B-B679-F324C5F8220A}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 8736776305938
+                                    "id": 5279535382435
                                 },
                                 "Name": "srcEndpoint=(On Graph Start: Out), destEndpoint=(TimeDelay: Start)",
                                 "Components": {
@@ -1308,7 +1490,7 @@
                                         "Id": 6013147305095983432,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 8676646763794
+                                                "id": 5240880676771
                                             },
                                             "slotId": {
                                                 "m_id": "{F85C0F22-59F0-4829-A3B2-958CA6E475B7}"
@@ -1316,7 +1498,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 8706711534866
+                                                "id": 5236585709475
                                             },
                                             "slotId": {
                                                 "m_id": "{C2787E3E-CFBF-4891-B913-996173AB5E2C}"
@@ -1327,16 +1509,16 @@
                             },
                             {
                                 "Id": {
-                                    "id": 8741071273234
+                                    "id": 5288125317027
                                 },
-                                "Name": "srcEndpoint=(GetWorldTM: Out), destEndpoint=(SetGravityEnabled: In)",
+                                "Name": "srcEndpoint=(GetWorldTM: Out), destEndpoint=(SphereCastWithGroup: In)",
                                 "Components": {
-                                    "Component_[12606540412460381315]": {
+                                    "Component_[2294691910181778131]": {
                                         "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 12606540412460381315,
+                                        "Id": 2294691910181778131,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 8693826632978
+                                                "id": 5245175644067
                                             },
                                             "slotId": {
                                                 "m_id": "{AF7BF67F-4EFD-4B17-8D9E-28D360E229C4}"
@@ -1344,7 +1526,119 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 8689531665682
+                                                "id": 5249470611363
+                                            },
+                                            "slotId": {
+                                                "m_id": "{D7AC77DA-32BA-4741-86AB-CDA656A7760C}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 5292420284323
+                                },
+                                "Name": "srcEndpoint=(TimeDelay: Done), destEndpoint=(Get Variable: In)",
+                                "Components": {
+                                    "Component_[3011448744317591056]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 3011448744317591056,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 5236585709475
+                                            },
+                                            "slotId": {
+                                                "m_id": "{BB866532-A9E2-4F6B-8BDE-573FF19978BD}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 5232290742179
+                                            },
+                                            "slotId": {
+                                                "m_id": "{0A179385-7E1B-428C-B2E8-7CE492D0BB05}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 5296715251619
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(GetWorldTM: In)",
+                                "Components": {
+                                    "Component_[10042701176636710299]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 10042701176636710299,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 5232290742179
+                                            },
+                                            "slotId": {
+                                                "m_id": "{FB3A5F73-C500-4111-ADC7-7DDBB33E1370}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 5245175644067
+                                            },
+                                            "slotId": {
+                                                "m_id": "{94D6DD7F-0835-4AF2-8C0D-F5C04A627F09}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 5301010218915
+                                },
+                                "Name": "srcEndpoint=(Get Variable: EntityId), destEndpoint=(GetWorldTM: EntityID: 0)",
+                                "Components": {
+                                    "Component_[17926260461271952961]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 17926260461271952961,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 5232290742179
+                                            },
+                                            "slotId": {
+                                                "m_id": "{F938A38E-929F-4472-A88E-F80D5ABE96C5}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 5245175644067
+                                            },
+                                            "slotId": {
+                                                "m_id": "{B22FC7CE-DFE3-4118-B98E-F99EA94A7160}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 15643291467683
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(SetGravityEnabled: In)",
+                                "Components": {
+                                    "Component_[9424408437279651746]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 9424408437279651746,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 13534462525347
+                                            },
+                                            "slotId": {
+                                                "m_id": "{F387D0B0-0F98-474F-B270-CF7138EF68CF}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 5219405840291
                                             },
                                             "slotId": {
                                                 "m_id": "{EFE54C57-C69A-416B-B679-F324C5F8220A}"
@@ -1355,16 +1649,44 @@
                             },
                             {
                                 "Id": {
-                                    "id": 8745366240530
+                                    "id": 15883809636259
                                 },
-                                "Name": "srcEndpoint=(GetWorldTM: Out), destEndpoint=(SphereCastWithGroup: In)",
+                                "Name": "srcEndpoint=(Get Variable: EntityId), destEndpoint=(SetGravityEnabled: EntityID: 0)",
                                 "Components": {
-                                    "Component_[2294691910181778131]": {
+                                    "Component_[6158557141666425674]": {
                                         "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 2294691910181778131,
+                                        "Id": 6158557141666425674,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 8693826632978
+                                                "id": 13534462525347
+                                            },
+                                            "slotId": {
+                                                "m_id": "{019F98FD-3EFF-4F1B-BB85-33E2BA9BC329}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 5219405840291
+                                            },
+                                            "slotId": {
+                                                "m_id": "{346B23A2-69F8-4055-916C-E5285627347B}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 16145802641315
+                                },
+                                "Name": "srcEndpoint=(GetWorldTM: Out), destEndpoint=(Get Variable: In)",
+                                "Components": {
+                                    "Component_[12130582316666300333]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 12130582316666300333,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 5245175644067
                                             },
                                             "slotId": {
                                                 "m_id": "{AF7BF67F-4EFD-4B17-8D9E-28D360E229C4}"
@@ -1372,10 +1694,178 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 8685236698386
+                                                "id": 13534462525347
                                             },
                                             "slotId": {
-                                                "m_id": "{D7AC77DA-32BA-4741-86AB-CDA656A7760C}"
+                                                "m_id": "{3642EAFE-6548-4250-A548-C05A28DB261F}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 18589639032739
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(SetGravityEnabled: In)",
+                                "Components": {
+                                    "Component_[318300586540786845]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 318300586540786845,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 17094990413731
+                                            },
+                                            "slotId": {
+                                                "m_id": "{6DAE792B-4C02-476E-9E52-25763494920C}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 5253765578659
+                                            },
+                                            "slotId": {
+                                                "m_id": "{EFE54C57-C69A-416B-B679-F324C5F8220A}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 18821567266723
+                                },
+                                "Name": "srcEndpoint=(Get Variable: EntityId), destEndpoint=(SetGravityEnabled: EntityID: 0)",
+                                "Components": {
+                                    "Component_[9430562056503841406]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 9430562056503841406,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 17094990413731
+                                            },
+                                            "slotId": {
+                                                "m_id": "{3088EDE1-F508-4849-89D3-552FC271FD9B}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 5253765578659
+                                            },
+                                            "slotId": {
+                                                "m_id": "{346B23A2-69F8-4055-916C-E5285627347B}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 19925373861795
+                                },
+                                "Name": "srcEndpoint=(SphereCastWithGroup: Out), destEndpoint=(Get Variable: In)",
+                                "Components": {
+                                    "Component_[15349799780172634796]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 15349799780172634796,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 5249470611363
+                                            },
+                                            "slotId": {
+                                                "m_id": "{D46CC4A2-380E-4E42-B0A1-176DBC19420B}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 17094990413731
+                                            },
+                                            "slotId": {
+                                                "m_id": "{0C43335E-979B-4845-B331-879CA6F9EFCA}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 21686310453155
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(SetGravityEnabled: In)",
+                                "Components": {
+                                    "Component_[18367976363921272849]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 18367976363921272849,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 20238906474403
+                                            },
+                                            "slotId": {
+                                                "m_id": "{0A8C143A-B9AD-4008-B2F5-B5865372F03E}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 5223700807587
+                                            },
+                                            "slotId": {
+                                                "m_id": "{EFE54C57-C69A-416B-B679-F324C5F8220A}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 21961188360099
+                                },
+                                "Name": "srcEndpoint=(Get Variable: EntityId), destEndpoint=(SetGravityEnabled: EntityID: 0)",
+                                "Components": {
+                                    "Component_[9476956280909456176]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 9476956280909456176,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 20238906474403
+                                            },
+                                            "slotId": {
+                                                "m_id": "{DD96C116-BC28-4B79-A7C4-64C06A595335}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 5223700807587
+                                            },
+                                            "slotId": {
+                                                "m_id": "{346B23A2-69F8-4055-916C-E5285627347B}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 22541008945059
+                                },
+                                "Name": "srcEndpoint=(DrawSphereAtLocation: Out), destEndpoint=(Get Variable: In)",
+                                "Components": {
+                                    "Component_[9440011931593614450]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 9440011931593614450,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 5227995774883
+                                            },
+                                            "slotId": {
+                                                "m_id": "{26873BC3-2AB5-428A-92EE-1AD26052194E}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 20238906474403
+                                            },
+                                            "slotId": {
+                                                "m_id": "{3EC3D187-BBF8-46D8-A53A-F339F5E1F279}"
                                             }
                                         }
                                     }
@@ -1386,21 +1876,23 @@
                     "m_assetType": "{3E2AC8CD-713F-453E-967F-29517F331784}",
                     "versionData": {
                         "_grammarVersion": 1,
-                        "_runtimeVersion": 1
+                        "_runtimeVersion": 1,
+                        "_fileVersion": 1
                     },
+                    "m_variableCounter": 4,
                     "GraphCanvasData": [
                         {
                             "Key": {
-                                "id": 8672351796498
+                                "id": 5215110872995
                             },
                             "Value": {
                                 "ComponentData": {
                                     "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
                                         "$type": "SceneComponentSaveData",
                                         "ViewParams": {
-                                            "Scale": 0.21511092130869494,
-                                            "AnchorX": -832.1288452148438,
-                                            "AnchorY": -418.3887939453125
+                                            "Scale": 0.7486663060005163,
+                                            "AnchorX": -754.6753540039063,
+                                            "AnchorY": 528.9406127929688
                                         }
                                     }
                                 }
@@ -1408,38 +1900,7 @@
                         },
                         {
                             "Key": {
-                                "id": 8676646763794
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "TimeNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            -680.0,
-                                            320.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".time"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{329A591F-9482-44F3-93AA-1F135C714680}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 8680941731090
+                                "id": 5219405840291
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1453,68 +1914,7 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            960.0,
-                                            40.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{1E66D38D-9F4F-4A41-8989-494911B8ECE1}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 8685236698386
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "DefaultNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            320.0,
-                                            300.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{146B2DD0-7DD3-4114-B288-9BFF68E8E573}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 8689531665682
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            320.0,
+                                            560.0,
                                             40.0
                                         ]
                                     },
@@ -1531,7 +1931,7 @@
                         },
                         {
                             "Key": {
-                                "id": 8693826632978
+                                "id": 5223700807587
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1545,7 +1945,7 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            -200.0,
+                                            1680.0,
                                             300.0
                                         ]
                                     },
@@ -1555,14 +1955,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{C8023DDA-EC97-47D0-B8DA-B4A5D4F2FAB6}"
+                                        "PersistentId": "{C25726FB-502F-4D29-8F8F-704F4C7EA764}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 8698121600274
+                                "id": 5227995774883
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1593,7 +1993,7 @@
                         },
                         {
                             "Key": {
-                                "id": 8702416567570
+                                "id": 5232290742179
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1602,29 +2002,29 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            1440.0,
+                                            -400.0,
                                             320.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
                                         "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
+                                        "SubStyle": ".getVariable"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{C25726FB-502F-4D29-8F8F-704F4C7EA764}"
+                                        "PersistentId": "{A66D853E-7C67-4519-A76B-00F611431E88}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 8706711534866
+                                "id": 5236585709475
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1638,8 +2038,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            -520.0,
-                                            300.0
+                                            -780.0,
+                                            280.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1651,16 +2051,244 @@
                                     }
                                 }
                             }
+                        },
+                        {
+                            "Key": {
+                                "id": 5240880676771
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "TimeNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -1000.0,
+                                            300.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".time"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{329A591F-9482-44F3-93AA-1F135C714680}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 5245175644067
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -200.0,
+                                            300.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{C8023DDA-EC97-47D0-B8DA-B4A5D4F2FAB6}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 5249470611363
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            320.0,
+                                            300.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{146B2DD0-7DD3-4114-B288-9BFF68E8E573}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 5253765578659
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1360.0,
+                                            40.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{1E66D38D-9F4F-4A41-8989-494911B8ECE1}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 13534462525347
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            260.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".getVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{DAAB3768-124B-4D46-A6E5-A30D960BDBF9}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 17094990413731
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1000.0,
+                                            80.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".getVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{DFABD67C-6AC0-4163-9714-433C21C40961}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 20238906474403
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1380.0,
+                                            320.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".getVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{ED71D946-B25A-4B7B-ACCE-931857982D8C}"
+                                    }
+                                }
+                            }
                         }
                     ],
                     "StatisticsHelper": {
                         "InstanceCounter": [
+                            {
+                                "Key": 1238435541489256750,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 1530075997606242131,
+                                "Value": 1
+                            },
                             {
                                 "Key": 4199610336680704683,
                                 "Value": 1
                             },
                             {
                                 "Key": 6462358712820489356,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 11683136551319553940,
                                 "Value": 1
                             },
                             {
@@ -1676,6 +2304,10 @@
                                 "Value": 1
                             },
                             {
+                                "Key": 14853801818435530236,
+                                "Value": 1
+                            },
+                            {
                                 "Key": 16812277148590053560,
                                 "Value": 1
                             }
@@ -1684,7 +2316,99 @@
                 },
                 "Component_[7390341204452664972]": {
                     "$type": "EditorGraphVariableManagerComponent",
-                    "Id": 7390341204452664972
+                    "Id": 7390341204452664972,
+                    "m_variableData": {
+                        "m_nameVariableMap": [
+                            {
+                                "Key": {
+                                    "m_id": "{21C8C1BE-C6C4-4D88-988D-9D4BEF7B4D43}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "scriptCanvasType": {
+                                            "m_type": 1
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "EntityId",
+                                        "value": {
+                                            "id": 2901262558
+                                        }
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{21C8C1BE-C6C4-4D88-988D-9D4BEF7B4D43}"
+                                    },
+                                    "VariableName": "Notification_Entity_2",
+                                    "InitialValueSource": 1
+                                }
+                            },
+                            {
+                                "Key": {
+                                    "m_id": "{68A8A01F-FFAE-44F1-8EDC-F541E39EA861}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "scriptCanvasType": {
+                                            "m_type": 1
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "EntityId",
+                                        "value": {
+                                            "id": 2901262558
+                                        }
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{68A8A01F-FFAE-44F1-8EDC-F541E39EA861}"
+                                    },
+                                    "VariableName": "Notification_Entity_0",
+                                    "InitialValueSource": 1
+                                }
+                            },
+                            {
+                                "Key": {
+                                    "m_id": "{808276F3-B926-455D-8AB3-2244801B0E9B}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "scriptCanvasType": {
+                                            "m_type": 1
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "EntityId",
+                                        "value": {
+                                            "id": 2901262558
+                                        }
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{808276F3-B926-455D-8AB3-2244801B0E9B}"
+                                    },
+                                    "VariableName": "Notification_Entity_1",
+                                    "InitialValueSource": 1
+                                }
+                            },
+                            {
+                                "Key": {
+                                    "m_id": "{CE65BD1B-54A7-4184-8EF9-C39F7E7D621E}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "scriptCanvasType": {
+                                            "m_type": 1
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "EntityId",
+                                        "value": {
+                                            "id": 2901262558
+                                        }
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{CE65BD1B-54A7-4184-8EF9-C39F7E7D621E}"
+                                    },
+                                    "VariableName": "Ball_0",
+                                    "InitialValueSource": 1
+                                }
+                            }
+                        ]
+                    }
                 }
             }
         }


### PR DESCRIPTION
Converted the following tests:

- ScriptCanvas_PostUpdateEvent 
- ScriptCanvas_PreUpdateEvent 
- ScriptCanvas_ShapeCast

Here are commands used for testing:
```
python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Physics\TestSuite_Periodic.py::TestAutomation::test_ScriptCanvas_PostUpdateEvent --build-directory windows_vs2019\bin\profile
```
```
python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Physics\TestSuite_Periodic.py::TestAutomation::test_ScriptCanvas_PreUpdateEvent --build-directory windows_vs2019\bin\profile
```
```
python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Physics\TestSuite_Periodic.py::TestAutomation::test_ ScriptCanvas_ShapeCast --build-directory windows_vs2019\bin\profile
```
```
python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Physics\TestSuite_Main.py::TestAutomation --build-directory windows_vs2019\bin\profile
```

Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>