### PR TITLE
Atom Tools: fixing issues opening and saving documents in shader management console

### DIFF
--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/MaterialEditorApplication.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/MaterialEditorApplication.cpp
@@ -39,6 +39,7 @@ namespace MaterialEditor
 
         QApplication::setOrganizationName("O3DE");
         QApplication::setApplicationName("O3DE Material Editor");
+        QApplication::setWindowIcon(QIcon(":/Icons/application.svg"));
 
         AzToolsFramework::EditorWindowRequestBus::Handler::BusConnect();
     }

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.cpp
@@ -22,8 +22,6 @@ namespace MaterialEditor
     MaterialEditorWindow::MaterialEditorWindow(const AZ::Crc32& toolId, QWidget* parent)
         : Base(toolId, parent)
     {
-        QApplication::setWindowIcon(QIcon(":/Icons/application.svg"));
-
         m_toolBar = new MaterialEditorToolBar(m_toolId, this);
         m_toolBar->setObjectName("ToolBar");
         addToolBar(m_toolBar);

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
@@ -119,9 +119,11 @@ namespace ShaderManagementConsole
         documentType.m_documentFactoryCallback = [](const AZ::Crc32& toolId, const AtomToolsFramework::DocumentTypeInfo& documentTypeInfo) {
             return aznew ShaderManagementConsoleDocument(toolId, documentTypeInfo); };
         documentType.m_supportedExtensionsToCreate.push_back({ "Shader", AZ::RPI::ShaderSourceData::Extension });
+        documentType.m_supportedExtensionsToCreate.push_back({ "Shader Variant List", AZ::RPI::ShaderVariantListSourceData::Extension });
         documentType.m_supportedExtensionsToOpen.push_back({ "Shader", AZ::RPI::ShaderSourceData::Extension });
         documentType.m_supportedExtensionsToOpen.push_back({ "Shader Variant List", AZ::RPI::ShaderVariantListSourceData::Extension });
         documentType.m_supportedExtensionsToSave.push_back({ "Shader Variant List", AZ::RPI::ShaderVariantListSourceData::Extension });
+        documentType.m_supportedAssetTypesToCreate.insert(azrtti_typeid<AZ::RPI::ShaderAsset>());
         return documentType;
     }
 
@@ -305,6 +307,11 @@ namespace ShaderManagementConsole
                 stableId++;
             }
         }
+
+        // Even though the data originated from a different file source it has now been transformed into a shader variant list so update the
+        // extension to match. This will allow the document to be resaved immediately without doing a save as child or derived type when
+        // loaded from a shader source file.
+        AzFramework::StringFunc::Path::ReplaceExtension(m_absolutePath, AZ::RPI::ShaderVariantListSourceData::Extension);
 
         SetShaderVariantListSourceData(shaderVariantListSourceData);
         return IsOpen() ? OpenSucceeded() : OpenFailed();

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/ShaderManagementConsoleApplication.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/ShaderManagementConsoleApplication.cpp
@@ -40,6 +40,7 @@ namespace ShaderManagementConsole
 
         QApplication::setOrganizationName("O3DE");
         QApplication::setApplicationName("O3DE Shader Management Console");
+        QApplication::setWindowIcon(QIcon(":/Icons/application.svg"));
 
         AzToolsFramework::EditorWindowRequestBus::Handler::BusConnect();
     }

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
@@ -22,15 +22,7 @@ namespace ShaderManagementConsole
     ShaderManagementConsoleWindow::ShaderManagementConsoleWindow(const AZ::Crc32& toolId, QWidget* parent)
         : Base(toolId, parent)
     {
-        QApplication::setWindowIcon(QIcon(":/Icons/application.svg"));
-
         m_assetBrowser->SetFilterState("", AZ::RPI::ShaderAsset::Group, true);
-
-        // Disable unused actions
-        m_actionNew->setVisible(false);
-        m_actionNew->setEnabled(false);
-        m_actionSaveAsChild->setVisible(false);
-        m_actionSaveAsChild->setEnabled(false);
 
         OnDocumentOpened(AZ::Uuid::CreateNull());
     }


### PR DESCRIPTION
automatically updating the document extension to shader variant list when opening from a shader source file

Signed-off-by: Guthrie Adams <guthadam@amazon.com>