### PR TITLE
Focus Mode | Show helpers even when they're not selectable, but keep the current behavior for icons.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorHelpers.cpp
@@ -293,21 +293,12 @@ namespace AzToolsFramework
         const bool iconsVisible = IconsVisible(viewportInfo.m_viewportId);
         const bool helpersVisible = HelpersVisible(viewportInfo.m_viewportId);
 
-        auto displayCheck = [this](const size_t entityCacheIndex, const AZ::EntityId entityId)
-        {
-            if (!m_entityDataCache->IsVisibleEntityVisible(entityCacheIndex) || !IsSelectableInViewport(entityId))
-            {
-                return false;
-            }
-            return true;
-        };
-
         if (helpersVisible)
         {
             for (size_t entityCacheIndex = 0; entityCacheIndex < m_entityDataCache->VisibleEntityDataCount(); ++entityCacheIndex)
             {
                 if (const AZ::EntityId entityId = m_entityDataCache->GetVisibleEntityId(entityCacheIndex);
-                    displayCheck(entityCacheIndex, entityId))
+                    m_entityDataCache->IsVisibleEntityVisible(entityCacheIndex))
                 {
                     // notify components to display
                     DisplayComponents(entityId, viewportInfo, debugDisplay);
@@ -326,7 +317,7 @@ namespace AzToolsFramework
             for (size_t entityCacheIndex = 0; entityCacheIndex < m_entityDataCache->VisibleEntityDataCount(); ++entityCacheIndex)
             {
                 if (const AZ::EntityId entityId = m_entityDataCache->GetVisibleEntityId(entityCacheIndex);
-                    displayCheck(entityCacheIndex, entityId))
+                    m_entityDataCache->IsVisibleEntityVisible(entityCacheIndex) && IsSelectableInViewport(entityId))
                 {
                     if (m_entityDataCache->IsVisibleEntityIconHidden(entityCacheIndex) ||
                         (m_entityDataCache->IsVisibleEntitySelected(entityCacheIndex) && !showIconCheck(entityId)))


### PR DESCRIPTION
Restores previous behavior for editor helpers - makes them always visible, while the current editor hides them if they're owned by entities in a closed prefab. Behavior for icons stay the same (icons are only shown for entities that are actually directly selectable).

Before
![shapeVisibility_before](https://user-images.githubusercontent.com/82231674/157780663-e36beeea-e42f-4b25-816b-1ece79366b90.gif)

After
![shapeVisibility_after](https://user-images.githubusercontent.com/82231674/157780669-85405ec0-d8f2-433e-b020-d5fc4eed7f5a.gif)

Will discuss the change with UX before this is submitted.

FYI @rainbj @amzn-leenguy 