### PR TITLE
Atom Tools: displaying full file path in create document dialog plus bug fixes

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -36,7 +36,7 @@ namespace AtomToolsFramework
     AZStd::string GetSaveFilePath(const AZStd::string& initialPath, const AZStd::string& title = "Document");
     AZStd::vector<AZStd::string> GetOpenFilePaths(const QRegExp& filter, const AZStd::string& title = "Document");
     AZStd::string GetUniqueFilePath(const AZStd::string& initialPath);
-    AZStd::string GetUniqueDefaultSaveFilePath(const AZStd::string& baseName);
+    AZStd::string GetUniqueDefaultSaveFilePath(const AZStd::string& extension);
     AZStd::string GetUniqueDuplicateFilePath(const AZStd::string& initialPath);
     bool ValidateDocumentPath(AZStd::string& path);
     bool LaunchTool(const QString& baseName, const QStringList& arguments);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
@@ -74,10 +74,7 @@ namespace AtomToolsFramework
                             : QObject::tr("Create %1...").arg(documentType.m_documentTypeName.c_str());
 
                         menu->addAction(createActionName, [entries, documentType, this]() {
-                            const auto& defaultPath = GetUniqueFilePath(AZStd::string::format(
-                                "%s/Assets/untitled.%s", AZ::Utils::GetProjectPath().c_str(),
-                                documentType.GetDefaultExtensionToSave().c_str()));
-
+                            const auto& defaultPath = GetUniqueDefaultSaveFilePath(documentType.GetDefaultExtensionToSave().c_str());
                             const auto& savePath = GetSaveFilePath(defaultPath);
                             if (!savePath.empty())
                             {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -410,8 +410,7 @@ namespace AtomToolsFramework
         }
 
         const auto& documentType = documentTypes[documentTypeIndex];
-        CreateDocumentDialog dialog(
-            documentType, QString(AZ::Utils::GetProjectPath().c_str()) + AZ_CORRECT_FILESYSTEM_SEPARATOR + "Assets", this);
+        CreateDocumentDialog dialog(documentType, AZStd::string::format("%s/Assets", AZ::Utils::GetProjectPath().c_str()).c_str(), this);
         dialog.adjustSize();
 
         if (dialog.exec() == QDialog::Accepted && !dialog.m_sourcePath.isEmpty() && !dialog.m_targetPath.isEmpty())

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/CreateDocumentDialog.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/CreateDocumentDialog.cpp
@@ -64,7 +64,7 @@ namespace AtomToolsFramework
 
         // Select a default location and unique name for the new document
         UpdateTargetPath(QFileInfo(GetUniqueFilePath(
-            AZStd::string::format("%s/Assets/untitled.%s", m_initialPath.toUtf8().constData(), supportedExtensions.front().toUtf8().constData())).c_str()));
+            AZStd::string::format("%s/untitled.%s", m_initialPath.toUtf8().constData(), supportedExtensions.front().toUtf8().constData())).c_str()));
 
         // When the file selection button is pressed, open a file dialog to select where the document will be saved
         QObject::connect(m_targetSelectionBrowser, &AzQtComponents::BrowseEdit::attachedButtonTriggered, m_targetSelectionBrowser, [this, supportedExtensions]() {
@@ -117,7 +117,7 @@ namespace AtomToolsFramework
         if (!fileInfo.absoluteFilePath().isEmpty())
         {
             m_targetPath = fileInfo.absoluteFilePath();
-            m_targetSelectionBrowser->setText(fileInfo.fileName());
+            m_targetSelectionBrowser->setText(m_targetPath);
         }
     }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -144,9 +144,9 @@ namespace AtomToolsFramework
         return fileInfo.absoluteFilePath().toUtf8().constData();
     }
 
-    AZStd::string GetUniqueDefaultSaveFilePath(const AZStd::string& baseName)
+    AZStd::string GetUniqueDefaultSaveFilePath(const AZStd::string& extension)
     {
-        return GetUniqueFilePath(AZStd::string::format("%s/Assets/%s", AZ::Utils::GetProjectPath().c_str(), baseName.c_str()));
+        return GetUniqueFilePath(AZStd::string::format("%s/Assets/untitled.%s", AZ::Utils::GetProjectPath().c_str(), extension.c_str()));
     }
 
     AZStd::string GetUniqueDuplicateFilePath(const AZStd::string& initialPath)

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/ViewportSettingsInspector/ViewportSettingsInspector.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/ViewportSettingsInspector/ViewportSettingsInspector.cpp
@@ -98,9 +98,7 @@ namespace MaterialEditor
 
     void ViewportSettingsInspector::CreateModelPreset()
     {
-        const AZStd::string defaultPath =
-            AtomToolsFramework::GetUniqueDefaultSaveFilePath(AZStd::string::format("untitled.%s", AZ::Render::ModelPreset::Extension));
-
+        const AZStd::string defaultPath = AtomToolsFramework::GetUniqueDefaultSaveFilePath(AZ::Render::ModelPreset::Extension);
         const AZStd::string savePath = AtomToolsFramework::GetSaveFilePath(defaultPath);
         if (!savePath.empty())
         {
@@ -156,8 +154,7 @@ namespace MaterialEditor
 
         if (defaultPath.empty())
         {
-            defaultPath =
-                AtomToolsFramework::GetUniqueDefaultSaveFilePath(AZStd::string::format("untitled.%s", AZ::Render::ModelPreset::Extension));
+            defaultPath = AtomToolsFramework::GetUniqueDefaultSaveFilePath(AZ::Render::ModelPreset::Extension);
         }
 
         const AZStd::string savePath = AtomToolsFramework::GetSaveFilePath(defaultPath);
@@ -202,9 +199,7 @@ namespace MaterialEditor
 
     void ViewportSettingsInspector::CreateLightingPreset()
     {
-        const AZStd::string defaultPath =
-            AtomToolsFramework::GetUniqueDefaultSaveFilePath(AZStd::string::format("untitled.%s", AZ::Render::LightingPreset::Extension));
-
+        const AZStd::string defaultPath = AtomToolsFramework::GetUniqueDefaultSaveFilePath(AZ::Render::LightingPreset::Extension);
         const AZStd::string savePath = AtomToolsFramework::GetSaveFilePath(defaultPath);
         if (!savePath.empty())
         {
@@ -260,8 +255,7 @@ namespace MaterialEditor
 
         if (defaultPath.empty())
         {
-            defaultPath = AtomToolsFramework::GetUniqueDefaultSaveFilePath(
-                AZStd::string::format("untitled.%s", AZ::Render::LightingPreset::Extension));
+            defaultPath = AtomToolsFramework::GetUniqueDefaultSaveFilePath(AZ::Render::LightingPreset::Extension);
         }
 
         const AZStd::string savePath = AtomToolsFramework::GetSaveFilePath(defaultPath);


### PR DESCRIPTION
This will display the absolute filepath of the document being created instead of just the file name.
This also fixes a bug where /Assets was being added twice to the default create document path.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>