### PR TITLE
Atom Tools: Making SMC project/gem configuration and inclusion match ME

### DIFF
--- a/Code/Framework/AzCore/AzCore/Name/NameDictionary.h
+++ b/Code/Framework/AzCore/AzCore/Name/NameDictionary.h
@@ -16,11 +16,6 @@
 #include <AzCore/Memory/OSAllocator.h>
 #include <AzCore/Name/Name.h>
 
-namespace MaterialEditor
-{
-    class MaterialEditorCoreComponent;
-}
-
 namespace UnitTest
 {
     class NameDictionaryTester;

--- a/Gems/Atom/Tools/CMakeLists.txt
+++ b/Gems/Atom/Tools/CMakeLists.txt
@@ -6,4 +6,3 @@
 #
 #
 
-add_subdirectory(ShaderManagementConsole)

--- a/Gems/Atom/Tools/ShaderManagementConsole/CMakeLists.txt
+++ b/Gems/Atom/Tools/ShaderManagementConsole/CMakeLists.txt
@@ -6,4 +6,8 @@
 #
 #
 
+set(gem_path ${CMAKE_CURRENT_LIST_DIR})
+set(gem_json ${gem_path}/gem.json)
+o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
+
 add_subdirectory(Code)

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/CMakeLists.txt
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/CMakeLists.txt
@@ -49,6 +49,10 @@ ly_add_target(
 
 ly_set_gem_variant_to_load(TARGETS ShaderManagementConsole VARIANTS Tools)
 
+# Add a 'builders' alias to allow the ShaderManagementConsole root gem path to be added to the generated
+# cmake_dependencies.<project>.assetprocessor.setreg to allow the asset scan folder for it to be added
+ly_create_alias(NAME ShaderManagementConsole.Builders NAMESPACE Gem)
+
 # Add build dependency to Editor for the ShaderManagementConsole application since
 # Editor opens up the ShaderManagementConsole
 ly_add_dependencies(Editor Gem::ShaderManagementConsole)

--- a/Gems/Atom/Tools/ShaderManagementConsole/gem.json
+++ b/Gems/Atom/Tools/ShaderManagementConsole/gem.json
@@ -1,0 +1,25 @@
+{
+    "gem_name": "ShaderManagementConsole",
+    "display_name": "Atom Shader Management Console",
+    "license": "Apache-2.0 Or MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
+    "origin": "Open 3D Engine - o3de.org",
+    "origin_url": "https://github.com/o3de/o3de",
+    "type": "Tool",
+    "summary": "Tool for generating and inspecting shader variant lists",
+    "canonical_tags": [
+        "Gem"
+    ],
+    "user_tags": [],
+    "requirements": "",
+    "documentation_url": "",
+    "dependencies": [
+        "AtomToolsFramework",
+        "Atom_RPI",
+        "Atom_RHI",
+        "Atom_Feature_Common",
+        "ImageProcessingAtom",
+        "Atom_Component_DebugCamera",
+        "CommonFeaturesAtom"
+    ]
+}

--- a/Gems/Atom/Tools/ShaderManagementConsole/preview.png
+++ b/Gems/Atom/Tools/ShaderManagementConsole/preview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de0e6e480ece5b423222f4feacf56553d73713fe9afea8bbc9a2660a3cd54ec7
+size 1232

--- a/Gems/Atom/gem.json
+++ b/Gems/Atom/gem.json
@@ -25,7 +25,8 @@
         "RHI",
         "RPI",
         "Tools/AtomToolsFramework",
-        "Tools/MaterialEditor"
+        "Tools/MaterialEditor",
+        "Tools/ShaderManagementConsole"
     ],
     "dependencies": [
         "Atom_Feature_Common",
@@ -36,6 +37,7 @@
         "Atom_RPI",
         "AtomToolsFramework",
         "MaterialEditor",
+        "ShaderManagementConsole",
         "Atom_AtomBridge"
     ]
 }

--- a/Gems/AtomLyIntegration/AtomBridge/Code/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/CMakeLists.txt
@@ -117,6 +117,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             Gem::AtomViewportDisplayInfo
             Gem::AtomViewportDisplayIcons.Editor
             Gem::MaterialEditor.Builders
+            Gem::ShaderManagementConsole.Builders
     )
 
 

--- a/Gems/AtomLyIntegration/AtomBridge/gem.json
+++ b/Gems/AtomLyIntegration/AtomBridge/gem.json
@@ -31,6 +31,7 @@
         "ImageProcessingAtom",
         "AtomToolsFramework",
         "AtomViewportDisplayIcons",
-        "MaterialEditor"
+        "MaterialEditor",
+        "ShaderManagementConsole"
     ]
 }


### PR DESCRIPTION
ME project configuration has changed over time, going back and forth between being a gem and not.
SMC is a lesser known tool and was probably missed whenever those changes were made.
The goal of this change is to make them consistent and for other tools to follow the same pattern.
If the method for including one changes then they should all change.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>