### PR TITLE
Added editorsv_hidden switch.

### DIFF
--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -35,6 +35,8 @@ namespace Multiplayer
         "Whether Editor should launch a server when the server address is localhost");
     AZ_CVAR(AZ::CVarFixedString, editorsv_process, "", nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
         "The server executable that should be run. Empty to use the current project's ServerLauncher");
+    AZ_CVAR(bool, editorsv_hidden, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
+        "The server executable launches hidden without a window. Best used with editorsv_rhi_override set to null.");
     AZ_CVAR(AZ::CVarFixedString, editorsv_serveraddr, AZ::CVarFixedString(LocalHost), nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "The address of the server to connect to");
     AZ_CVAR(AZ::CVarFixedString, editorsv_rhi_override, "", nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
         "Override the default rendering hardware interface (rhi) when launching the Editor server. For example, you may be running an Editor using 'dx12', but want to launch a headless server using 'null'. If empty the server will launch using the same rhi as the Editor.");
@@ -269,7 +271,7 @@ namespace Multiplayer
             server_rhi.GetCStr(),
             static_cast<uint16_t>(editorsv_port)
         );
-        processLaunchInfo.m_showWindow = true;
+        processLaunchInfo.m_showWindow = !editorsv_hidden;
         processLaunchInfo.m_processPriority = AzFramework::ProcessPriority::PROCESSPRIORITY_NORMAL;
 
         // Launch the Server


### PR DESCRIPTION
CTRL+G starts 3x faster when using editorsv_hidden=true and editorsv_rhi_override=null compared to default setting.

On my machine SampleBase level in o3de-multiplayersample launches in 5 seconds with hidden and rhi=null, and 15 seconds without these settings. 

Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>