### PR TITLE
Add VRAM usage metrics to viewport debug display

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryStatistics.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryStatistics.h
@@ -89,6 +89,9 @@ namespace AZ
 
             /// The list of pools.
             AZStd::vector<Pool> m_pools;
+
+            /// Indicates if detailed memory statistics were captured
+            bool m_detailedCapture;
         };
     }
 }

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
@@ -455,6 +455,12 @@ namespace AZ
             if (CheckBitsAny(m_compileRequest.m_statisticsFlags, FrameSchedulerStatisticsFlags::GatherMemoryStatistics))
             {
                 m_device->CompileMemoryStatistics(m_memoryStatistics, MemoryStatisticsReportFlags::Detail);
+                m_memoryStatistics.m_detailedCapture = true;
+            }
+            else
+            {
+                m_device->CompileMemoryStatistics(m_memoryStatistics, MemoryStatisticsReportFlags::Basic);
+                m_memoryStatistics.m_detailedCapture = false;
             }
 
             m_device->UpdateCpuTimingStatistics();
@@ -588,10 +594,7 @@ namespace AZ
 
         const MemoryStatistics* FrameScheduler::GetMemoryStatistics() const
         {
-            return
-                CheckBitsAny(m_compileRequest.m_statisticsFlags, FrameSchedulerStatisticsFlags::GatherMemoryStatistics)
-                ? &m_memoryStatistics
-                : nullptr;
+            return &m_memoryStatistics;
         }
 
         const TransientAttachmentStatistics* FrameScheduler::GetTransientAttachmentStatistics() const

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
@@ -59,6 +59,7 @@ namespace AZ
             void DrawRendererInfo();
             void DrawCameraInfo();
             void DrawPassInfo();
+            void DrawMemoryInfo();
             void DrawFramerate();
 
             static constexpr float BaseFontSize = 0.7f;


### PR DESCRIPTION
This commit modifies `FrameScheduler::EndFrame` to collect basic memory
statistics unconditionally unless more details statistics are requested.
This operation is O(N) in the number of resource pools available which
doesn't amount to more than a dozen or so so this has no measurable
impact on frame time.

The line display changes color to yellow and red depending on usage
relative to VRAM available on the current physical device.

![image](https://user-images.githubusercontent.com/87345238/158009936-28276f76-a711-44d7-b6b8-bf95c253e133.png)
