### PR TITLE
[development] added guard to prevent valid assert triggered in the Profiler gem ImGui window

### DIFF
--- a/Gems/Profiler/Code/Source/ImGuiCpuProfiler.cpp
+++ b/Gems/Profiler/Code/Source/ImGuiCpuProfiler.cpp
@@ -790,8 +790,11 @@ namespace Profiler
         const AZStd::sys_time_t deleteBeforeTick = AZStd::GetTimeNowTicks() - frameToFrameTime * m_framesToCollect;
 
         // Remove old frame boundary data
-        auto firstBoundaryToKeepItr = AZStd::upper_bound(m_frameEndTicks.begin(), m_frameEndTicks.end(), deleteBeforeTick);
-        m_frameEndTicks.erase(m_frameEndTicks.begin(), firstBoundaryToKeepItr);
+        if (auto firstBoundaryToKeepItr = AZStd::upper_bound(m_frameEndTicks.begin(), m_frameEndTicks.end(), deleteBeforeTick);
+            firstBoundaryToKeepItr != m_frameEndTicks.begin())
+        {
+            m_frameEndTicks.erase(m_frameEndTicks.begin(), firstBoundaryToKeepItr);
+        }
 
         // Remove old region data for each thread
         for (auto& [threadId, savedRegions] : m_savedData)


### PR DESCRIPTION
When the call to `AZStd::upper_bound` doesn't find a match and returns `m_frameEndTicks.begin()`, the following call to `erase` will perform an in place move on the entire internal array where the starting source and destination pointers are equal.  This is considered undefined behaviour, specifically when `memcpy` is used and thankfully caught by some validity checks added in #5735. 

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>