### PR TITLE
Updating the Sponza and ReferenceMaterials CMake targets.

### DIFF
--- a/Gems/AtomContent/CMakeLists.txt
+++ b/Gems/AtomContent/CMakeLists.txt
@@ -7,5 +7,5 @@
 #
 
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
-    ly_create_alias(NAME AtomContent.Builders NAMESPACE Gem TARGETS Gem::AtomContent_ReferenceMaterials.Builders Gem::AtomContent_Sponza.Builders)
+    ly_create_alias(NAME AtomContent.Builders NAMESPACE Gem TARGETS Gem::ReferenceMaterials.Builders Gem::Sponza.Builders)
 endif()

--- a/Gems/AtomContent/ReferenceMaterials/CMakeLists.txt
+++ b/Gems/AtomContent/ReferenceMaterials/CMakeLists.txt
@@ -5,8 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #
-
-# This will export its "SourcePaths" to the generated "cmake_dependencies.<project>.assetbuilder.setreg"
+# This will export the ReferenceMaterials Buliders module to the generated "cmake_dependencies.<project>.assetbuilder.setreg"
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
-    ly_create_alias(NAME AtomContent_ReferenceMaterials.Builders NAMESPACE Gem)
+    ly_create_alias(NAME ReferenceMaterials.Builders NAMESPACE Gem)
 endif()

--- a/Gems/AtomContent/Sponza/CMakeLists.txt
+++ b/Gems/AtomContent/Sponza/CMakeLists.txt
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #
-# This will export its "SourcePaths" to the generated "cmake_dependencies.<project>.assetbuilder.setreg"
+# This will export the Sponza Buliders module to the generated "cmake_dependencies.<project>.assetbuilder.setreg"
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
-    ly_create_alias(NAME AtomContent_Sponza.Builders NAMESPACE Gem)
+    ly_create_alias(NAME Sponza.Builders NAMESPACE Gem)
 endif()


### PR DESCRIPTION
The AtomContent_Sponza and AtomContent_ReferenceMaterials CMake targets
have been updated to match the names of the Gems.

This allows using the gems in the enabled_gems.cmake list to activate
the gem variants based off of the name Sponza and ReferenceMaterials.

relates https://github.com/o3de/o3de-atom-sampleviewer/pull/365

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>