### PR TITLE
Add propagation benchmarks for adding, removing and updating component 

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabBenchmarkFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabBenchmarkFixture.cpp
@@ -50,7 +50,7 @@ namespace Benchmark
         SetupPrefabSystem();
     }
 
-    void BM_Prefab::internalSetUp(const benchmark::State& state)
+    void BM_Prefab::SetupHarness(const ::benchmark::State& state)
     {
         AZ::Debug::TraceMessageBus::Handler::BusConnect();
 
@@ -59,7 +59,7 @@ namespace Benchmark
         SetupPrefabSystem();
     }
 
-    void BM_Prefab::internalTearDown(const benchmark::State& state)
+    void BM_Prefab::TeardownHarness(const ::benchmark::State& state)
     {
         m_paths = {};
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabBenchmarkFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabBenchmarkFixture.cpp
@@ -50,7 +50,7 @@ namespace Benchmark
         SetupPrefabSystem();
     }
 
-    void BM_Prefab::SetupHarness(const ::benchmark::State& state)
+    void BM_Prefab::SetupHarness(const benchmark::State& state)
     {
         AZ::Debug::TraceMessageBus::Handler::BusConnect();
 
@@ -59,7 +59,7 @@ namespace Benchmark
         SetupPrefabSystem();
     }
 
-    void BM_Prefab::TeardownHarness(const ::benchmark::State& state)
+    void BM_Prefab::TeardownHarness(const benchmark::State& state)
     {
         m_paths = {};
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabBenchmarkFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabBenchmarkFixture.h
@@ -20,35 +20,41 @@ namespace Benchmark
 {
     using namespace UnitTest::PrefabTestUtils;
 
+    class PrefabBenchmarkHarness
+    {
+        virtual void SetupHarness(const ::benchmark::State& state) = 0;
+        virtual void TeardownHarness(const ::benchmark::State& state) = 0;
+    };
+
     class BM_Prefab
         : public UnitTest::AllocatorsBenchmarkFixture
+        , public PrefabBenchmarkHarness
         , public UnitTest::TraceBusRedirector
     {
-        void internalSetUp(const benchmark::State& state);
-        void internalTearDown(const benchmark::State& state);
+    public:
+        void SetupHarness(const ::benchmark::State& state) override;
+        void TeardownHarness(const ::benchmark::State& state) override;
 
     protected:
         void SetUp(const benchmark::State& state) override
         {
-            internalSetUp(state);
+            SetupHarness(state);
         }
         void SetUp(benchmark::State& state) override
         {
-            internalSetUp(state);
+            SetupHarness(state);
         }
 
         void TearDown(const benchmark::State& state) override
         {
-            internalTearDown(state);
+            TeardownHarness(state);
         }
         void TearDown(benchmark::State& state) override
         {
-            internalTearDown(state);
+            TeardownHarness(state);
         }
 
-        AZ::Entity* CreateEntity(
-            const char* entityName,
-            const AZ::EntityId& parentId = AZ::EntityId());
+        AZ::Entity* CreateEntity(const char* entityName, const AZ::EntityId& parentId = AZ::EntityId());
         void CreateEntities(const unsigned int entityCount, AZStd::vector<AZ::Entity*>& entities);
         void SetEntityParent(const AZ::EntityId& entityId, const AZ::EntityId& parentId);
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabBenchmarkFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabBenchmarkFixture.h
@@ -22,8 +22,8 @@ namespace Benchmark
 
     class PrefabBenchmarkHarness
     {
-        virtual void SetupHarness(const ::benchmark::State& state) = 0;
-        virtual void TeardownHarness(const ::benchmark::State& state) = 0;
+        virtual void SetupHarness(const benchmark::State& state) = 0;
+        virtual void TeardownHarness(const benchmark::State& state) = 0;
     };
 
     class BM_Prefab
@@ -32,8 +32,8 @@ namespace Benchmark
         , public UnitTest::TraceBusRedirector
     {
     public:
-        void SetupHarness(const ::benchmark::State& state) override;
-        void TeardownHarness(const ::benchmark::State& state) override;
+        void SetupHarness(const benchmark::State& state) override;
+        void TeardownHarness(const benchmark::State& state) override;
 
     protected:
         void SetUp(const benchmark::State& state) override

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleEntityBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleEntityBenchmarks.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#if defined(HAVE_BENCHMARK)
+
+#include <AzToolsFramework/Prefab/PrefabDomUtils.h>
+#include <AzToolsFramework/ToolsComponents/EditorInspectorComponent.h>
+#include <Prefab/Benchmark/PrefabBenchmarkFixture.h>
+
+
+namespace Benchmark
+{
+    using namespace AzToolsFramework::Prefab;
+
+    //! This class captures benchmarks for propagating changes to a single prefab instance with multiple entities that are side-by-side.
+    class SingleInstanceMultipleEntityBenchmarks : public Benchmark::BM_Prefab
+    {
+    protected:
+        void SetupHarness(const benchmark::State& state) override
+        {
+            BM_Prefab::SetupHarness(state);
+            CreateFakePaths(1);
+            const auto& templatePath = m_paths.front();
+            const unsigned int numEntities = static_cast<unsigned int>(state.range());
+
+            AZStd::vector<AZ::Entity*> entities;
+            for (unsigned int i = 1; i < numEntities; i++)
+            {
+                entities.emplace_back(CreateEntity("Entity"));
+            }
+
+            m_entityModify= CreateEntity("Entity", AZ::EntityId());
+            entities.emplace_back(m_entityModify);
+
+            instanceCreated = m_prefabSystemComponent->CreatePrefab(entities, {}, templatePath);
+            TemplateId templateToInstantiateId = instanceCreated->GetTemplateId();
+
+            // We need 2 prefab instances: One to make the original change to; And one to propagate that change to.
+            instanceToUseForPropagation = m_prefabSystemComponent->InstantiatePrefab(templateToInstantiateId);
+        }
+
+        void TeardownHarness(const benchmark::State& state) override
+        {
+            instanceCreated.reset();
+            instanceToUseForPropagation.reset();
+            BM_Prefab::TeardownHarness(state);
+        }
+
+    protected:
+        void UpdateTemplate()
+        {
+            PrefabDom updatedPrefabDom;
+            PrefabDomUtils::StoreInstanceInPrefabDom(*instanceCreated, updatedPrefabDom);
+            PrefabDom& enclosingTemplatePrefabDom = m_prefabSystemComponent->FindTemplateDom(instanceCreated->GetTemplateId());
+            enclosingTemplatePrefabDom.CopyFrom(updatedPrefabDom, enclosingTemplatePrefabDom.GetAllocator());
+            m_instanceUpdateExecutorInterface->AddTemplateInstancesToQueue(instanceCreated->GetTemplateId(), *instanceCreated);
+        }
+
+        AZ::Entity* m_entityModify;
+        AZStd::unique_ptr<Instance> instanceCreated;
+        AZStd::unique_ptr<Instance> instanceToUseForPropagation;
+    };
+
+    BENCHMARK_DEFINE_F(SingleInstanceMultipleEntityBenchmarks, PropagateUpdateComponentChange)(::benchmark::State& state)
+    {
+        for (auto _ : state)
+        {
+            state.PauseTiming();
+            float worldX = 0.0f;
+            AZ::TransformBus::EventResult(worldX, m_entityModify->GetId(), &AZ::TransformInterface::GetWorldX);
+
+            // Move the entity and update the template to capture this transform component change.
+            AZ::TransformBus::Event(m_entityModify->GetId(), &AZ::TransformInterface::SetWorldX, worldX + 1);
+            UpdateTemplate();
+            state.ResumeTiming();
+
+            m_instanceUpdateExecutorInterface->UpdateTemplateInstancesInQueue();
+        }
+
+        state.SetComplexityN(state.range());
+    }
+
+    BENCHMARK_REGISTER_F(SingleInstanceMultipleEntityBenchmarks, PropagateUpdateComponentChange)
+        ->RangeMultiplier(10)
+        ->Range(100, 10000)
+        ->Unit(benchmark::kMillisecond)
+        ->Complexity();
+    
+    BENCHMARK_DEFINE_F(SingleInstanceMultipleEntityBenchmarks, PropagateAddComponentChange)(::benchmark::State& state)
+    {
+        m_entityModify->Deactivate();
+        for (auto _ : state)
+        {
+            state.PauseTiming();
+            ASSERT_EQ(m_entityModify->GetComponents().size(), 1);
+
+            // Add another component and update the template to capture this change.
+            AZ::Component* inspectorComponent = m_entityModify->CreateComponent<AzToolsFramework::Components::EditorInspectorComponent>();
+            ASSERT_EQ(m_entityModify->GetComponents().size(), 2);
+            UpdateTemplate();
+            state.ResumeTiming();
+
+            m_instanceUpdateExecutorInterface->UpdateTemplateInstancesInQueue();
+            state.PauseTiming();
+
+            // Remove the second component added. This will make sure that when multiple iterations are done, we will always be going from
+            // one components to two components.
+            m_entityModify->RemoveComponent(inspectorComponent);
+            ASSERT_EQ(m_entityModify->GetComponents().size(), 1);
+            delete inspectorComponent;
+            inspectorComponent = nullptr;
+            UpdateTemplate();
+        }
+
+        state.SetComplexityN(state.range());
+    }
+
+    BENCHMARK_REGISTER_F(SingleInstanceMultipleEntityBenchmarks, PropagateAddComponentChange)
+        ->RangeMultiplier(10)
+        ->Range(100, 10000)
+        ->Unit(benchmark::kMillisecond)
+        ->Complexity();
+    
+    BENCHMARK_DEFINE_F(SingleInstanceMultipleEntityBenchmarks, PropagateRemoveComponentChange)(::benchmark::State& state)
+    {
+        m_entityModify->Deactivate();
+
+        for (auto _ : state)
+        {
+            state.PauseTiming();
+            const AZStd::vector<AZ::Component*>& components = m_entityModify->GetComponents();
+            ASSERT_EQ(m_entityModify->GetComponents().size(), 1);
+            AZ::Component* transformComponent = components.front();
+            m_entityModify->RemoveComponent(transformComponent);
+            delete transformComponent;
+            transformComponent = nullptr;
+            ASSERT_EQ(m_entityModify->GetComponents().size(), 0);
+            UpdateTemplate();
+            state.ResumeTiming();
+
+            m_instanceUpdateExecutorInterface->UpdateTemplateInstancesInQueue();
+            state.PauseTiming();
+
+            // Add the component back. This will make sure that when multiple iterations are done, we will always be going from
+            // zero components to one component.
+            m_entityModify->CreateComponent(AZ::TransformComponentTypeId);
+            ASSERT_EQ(m_entityModify->GetComponents().size(), 1);
+            UpdateTemplate();
+        }
+
+        state.SetComplexityN(state.range());
+    }
+
+    BENCHMARK_REGISTER_F(SingleInstanceMultipleEntityBenchmarks, PropagateRemoveComponentChange)
+        ->RangeMultiplier(10)
+        ->Range(100, 10000)
+        ->Unit(benchmark::kMillisecond)
+        ->Complexity();
+        
+} // namespace Benchmark
+
+#endif

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleEntityBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleEntityBenchmarks.cpp
@@ -65,7 +65,7 @@ namespace Benchmark
         AZStd::unique_ptr<Instance> instanceToUseForPropagation;
     };
 
-    BENCHMARK_DEFINE_F(SingleInstanceMultipleEntityBenchmarks, PropagateUpdateComponentChange)(::benchmark::State& state)
+    BENCHMARK_DEFINE_F(SingleInstanceMultipleEntityBenchmarks, PropagateUpdateComponentChange)(benchmark::State& state)
     {
         for (auto _ : state)
         {
@@ -90,7 +90,7 @@ namespace Benchmark
         ->Unit(benchmark::kMillisecond)
         ->Complexity();
     
-    BENCHMARK_DEFINE_F(SingleInstanceMultipleEntityBenchmarks, PropagateAddComponentChange)(::benchmark::State& state)
+    BENCHMARK_DEFINE_F(SingleInstanceMultipleEntityBenchmarks, PropagateAddComponentChange)(benchmark::State& state)
     {
         m_entityModify->Deactivate();
         for (auto _ : state)
@@ -125,7 +125,7 @@ namespace Benchmark
         ->Unit(benchmark::kMillisecond)
         ->Complexity();
     
-    BENCHMARK_DEFINE_F(SingleInstanceMultipleEntityBenchmarks, PropagateRemoveComponentChange)(::benchmark::State& state)
+    BENCHMARK_DEFINE_F(SingleInstanceMultipleEntityBenchmarks, PropagateRemoveComponentChange)(benchmark::State& state)
     {
         m_entityModify->Deactivate();
 

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -65,6 +65,7 @@ set(FILES
     Prefab/Benchmark/PrefabInstantiateBenchmarks.cpp
     Prefab/Benchmark/PrefabLoadBenchmarks.cpp
     Prefab/Benchmark/PrefabUpdateInstancesBenchmarks.cpp
+    Prefab/Benchmark/Propagation/SingleInstanceMultipleEntityBenchmarks.cpp
     Prefab/Benchmark/SpawnableCreateBenchmarks.cpp
     Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h
     Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.cpp


### PR DESCRIPTION
Added propagation benchmarks for adding, removing and updating component. These can be used to identify how long it will take to update a prefab with a large number of entities. 

```
Run on (20 X 3312 MHz CPU s)
CPU Caches:
  L1 Data 32K (x10)
  L1 Instruction 32K (x10)
  L2 Unified 1048K (x10)
  L3 Unified 14417K (x1)
----------------------------------------------------------------------------------------------------------------------
Benchmark                                                                            Time             CPU   Iterations
----------------------------------------------------------------------------------------------------------------------
SingleInstanceMultipleEntityBenchmarks/PropagateUpdateComponentChange/100         24.6 ms         22.9 ms           28
SingleInstanceMultipleEntityBenchmarks/PropagateUpdateComponentChange/1000         258 ms          255 ms            3
SingleInstanceMultipleEntityBenchmarks/PropagateUpdateComponentChange/10000       3432 ms         3422 ms            1
SingleInstanceMultipleEntityBenchmarks/PropagateUpdateComponentChange_BigO    25830.71 NlgN   25751.59 NlgN
SingleInstanceMultipleEntityBenchmarks/PropagateUpdateComponentChange_RMS            0 %             0 %
SingleInstanceMultipleEntityBenchmarks/PropagateAddComponentChange/100            78.9 ms         78.1 ms            7
SingleInstanceMultipleEntityBenchmarks/PropagateAddComponentChange/1000            554 ms          547 ms            1
SingleInstanceMultipleEntityBenchmarks/PropagateAddComponentChange/10000          7351 ms         7359 ms            1
SingleInstanceMultipleEntityBenchmarks/PropagateAddComponentChange_BigO       55325.85 NlgN   55383.51 NlgN
SingleInstanceMultipleEntityBenchmarks/PropagateAddComponentChange_RMS               1 %             1 %
SingleInstanceMultipleEntityBenchmarks/PropagateRemoveComponentChange/100         89.1 ms         87.5 ms           10
SingleInstanceMultipleEntityBenchmarks/PropagateRemoveComponentChange/1000         838 ms          836 ms            2
SingleInstanceMultipleEntityBenchmarks/PropagateRemoveComponentChange/10000       7141 ms         7156 ms            1
SingleInstanceMultipleEntityBenchmarks/PropagateRemoveComponentChange_BigO   715361.45 N     716831.87 N
SingleInstanceMultipleEntityBenchmarks/PropagateRemoveComponentChange_RMS            3 %             3 %
OKAY AzRunBenchmarks() returned 0
Returning code: 0
```

These will be helpful to measure performance gains with any future optimizations. Ran the same benchmarks against [Prefab/SelectiveDeserialization](https://github.com/aws-lumberyard-dev/o3de/tree/Prefab/SelectiveDeserialization) branch and got the below results:
```
Run on (20 X 3312 MHz CPU s)
CPU Caches:
  L1 Data 32K (x10)
  L1 Instruction 32K (x10)
  L2 Unified 1048K (x10)
  L3 Unified 14417K (x1)
----------------------------------------------------------------------------------------------------------------------
Benchmark                                                                            Time             CPU   Iterations
----------------------------------------------------------------------------------------------------------------------
SingleInstanceMultipleEntityBenchmarks/PropagateUpdateComponentChange/100         1.10 ms         1.00 ms          747
SingleInstanceMultipleEntityBenchmarks/PropagateUpdateComponentChange/1000        16.4 ms         17.4 ms           45
SingleInstanceMultipleEntityBenchmarks/PropagateUpdateComponentChange/10000        744 ms          734 ms            1
SingleInstanceMultipleEntityBenchmarks/PropagateUpdateComponentChange_BigO        7.44 N^2        7.34 N^2
SingleInstanceMultipleEntityBenchmarks/PropagateUpdateComponentChange_RMS            2 %             2 %
SingleInstanceMultipleEntityBenchmarks/PropagateAddComponentChange/100            6.11 ms         6.70 ms          112
SingleInstanceMultipleEntityBenchmarks/PropagateAddComponentChange/1000           90.0 ms         96.6 ms           11
SingleInstanceMultipleEntityBenchmarks/PropagateAddComponentChange/10000          2801 ms         2812 ms            1
SingleInstanceMultipleEntityBenchmarks/PropagateAddComponentChange_BigO          28.01 N^2       28.13 N^2
SingleInstanceMultipleEntityBenchmarks/PropagateAddComponentChange_RMS               4 %             4 %
SingleInstanceMultipleEntityBenchmarks/PropagateRemoveComponentChange/100         5.90 ms         5.30 ms          112
SingleInstanceMultipleEntityBenchmarks/PropagateRemoveComponentChange/1000        88.8 ms         89.5 ms           11
SingleInstanceMultipleEntityBenchmarks/PropagateRemoveComponentChange/10000       2699 ms         2703 ms            1
SingleInstanceMultipleEntityBenchmarks/PropagateRemoveComponentChange_BigO       27.00 N^2       27.04 N^2
SingleInstanceMultipleEntityBenchmarks/PropagateRemoveComponentChange_RMS            4 %             4 %
OKAY AzRunBenchmarks() returned 0
Returning code: 0
```