### PR TITLE
Update Multiplayer Tests to Store their Cached Folder Level Assets

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
@@ -20,12 +20,36 @@ class TestAutomation(EditorTestSuite):
     class test_Multiplayer_AutoComponent_NetworkInput(EditorSingleTest):
         from .tests import Multiplayer_AutoComponent_NetworkInput as test_module
 
+        @classmethod
+        def setup(cls, instance, request, workspace, editor, editor_test_results, launcher_platform):
+            level_cache_folder_path = os.path.join(workspace.paths.platform_cache(), "levels", "multiplayer", "autocomponent_networkinput")
+            if os.path.exists(level_cache_folder_path):
+                workspace.artifact_manager.save_artifact(level_cache_folder_path)
+
     class test_Multiplayer_AutoComponent_RPC(EditorSingleTest):
         from .tests import Multiplayer_AutoComponent_RPC as test_module
+
+        @classmethod
+        def setup(cls, instance, request, workspace, editor, editor_test_results, launcher_platform):
+            level_cache_folder_path = os.path.join(workspace.paths.platform_cache(), "levels", "multiplayer", "autocomponent_rpc")
+            if os.path.exists(level_cache_folder_path):
+                workspace.artifact_manager.save_artifact(level_cache_folder_path)
 
     class test_Multiplayer_BasicConnectivity_Connects(EditorSingleTest):
         from .tests import Multiplayer_BasicConnectivity_Connects as test_module
 
+        @classmethod
+        def setup(cls, instance, request, workspace, editor, editor_test_results, launcher_platform):
+            level_cache_folder_path = os.path.join(workspace.paths.platform_cache(), "levels", "multiplayer", "basicconnectivity_connects")
+            if os.path.exists(level_cache_folder_path):
+                workspace.artifact_manager.save_artifact(level_cache_folder_path)
+
     class test_Multiplayer_SimpleNetworkLevelEntity(EditorSingleTest):
         from .tests import Multiplayer_SimpleNetworkLevelEntity as test_module
+
+        @classmethod
+        def setup(cls, instance, request, workspace, editor, editor_test_results, launcher_platform):
+            level_cache_folder_path = os.path.join(workspace.paths.platform_cache(), "levels", "multiplayer", "simplenetworklevelentity")
+            if os.path.exists(level_cache_folder_path):
+                workspace.artifact_manager.save_artifact(level_cache_folder_path)
 

--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
@@ -13,6 +13,14 @@ from ly_test_tools.o3de.editor_test import EditorTestSuite, EditorSingleTest
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../automatedtesting_shared')
 
+def save_multiplayer_level_cache_folder_artifact(workspace, multiplayer_level):
+    level_cache_folder_path = os.path.join(workspace.paths.platform_cache(), "levels", "multiplayer", multiplayer_level)
+
+    if os.path.exists(level_cache_folder_path):
+        workspace.artifact_manager.save_artifact(level_cache_folder_path)
+    else:
+        pytest.fail(f"Failed to find level asset cache for '{multiplayer_level}', located here: '{level_cache_folder_path}'! Make sure AssetProcessor successfully built the level.")
+
 @pytest.mark.SUITE_main
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
@@ -22,34 +30,26 @@ class TestAutomation(EditorTestSuite):
 
         @classmethod
         def setup(cls, instance, request, workspace, editor, editor_test_results, launcher_platform):
-            level_cache_folder_path = os.path.join(workspace.paths.platform_cache(), "levels", "multiplayer", "autocomponent_networkinput")
-            if os.path.exists(level_cache_folder_path):
-                workspace.artifact_manager.save_artifact(level_cache_folder_path)
+            save_multiplayer_level_cache_folder_artifact(workspace, "autocomponent_networkinput")
 
     class test_Multiplayer_AutoComponent_RPC(EditorSingleTest):
         from .tests import Multiplayer_AutoComponent_RPC as test_module
 
         @classmethod
         def setup(cls, instance, request, workspace, editor, editor_test_results, launcher_platform):
-            level_cache_folder_path = os.path.join(workspace.paths.platform_cache(), "levels", "multiplayer", "autocomponent_rpc")
-            if os.path.exists(level_cache_folder_path):
-                workspace.artifact_manager.save_artifact(level_cache_folder_path)
+            save_multiplayer_level_cache_folder_artifact(workspace, "autocomponent_rpc")
 
     class test_Multiplayer_BasicConnectivity_Connects(EditorSingleTest):
         from .tests import Multiplayer_BasicConnectivity_Connects as test_module
 
         @classmethod
         def setup(cls, instance, request, workspace, editor, editor_test_results, launcher_platform):
-            level_cache_folder_path = os.path.join(workspace.paths.platform_cache(), "levels", "multiplayer", "basicconnectivity_connects")
-            if os.path.exists(level_cache_folder_path):
-                workspace.artifact_manager.save_artifact(level_cache_folder_path)
+            save_multiplayer_level_cache_folder_artifact(workspace, "basicconnectivity_connects")
 
     class test_Multiplayer_SimpleNetworkLevelEntity(EditorSingleTest):
         from .tests import Multiplayer_SimpleNetworkLevelEntity as test_module
 
         @classmethod
         def setup(cls, instance, request, workspace, editor, editor_test_results, launcher_platform):
-            level_cache_folder_path = os.path.join(workspace.paths.platform_cache(), "levels", "multiplayer", "simplenetworklevelentity")
-            if os.path.exists(level_cache_folder_path):
-                workspace.artifact_manager.save_artifact(level_cache_folder_path)
+            save_multiplayer_level_cache_folder_artifact(workspace, "simplenetworklevelentity")
 

--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
@@ -8,11 +8,12 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 import pytest
 import os
-import sys
 from ly_test_tools.o3de.editor_test import EditorTestSuite, EditorSingleTest
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../automatedtesting_shared')
 
+# Saves the level cache folder.
+# These artifacts will be saved in the test results so developers can access the level assets
+# to debug should the test ever fail.
 def save_multiplayer_level_cache_folder_artifact(workspace, multiplayer_level):
     level_cache_folder_path = os.path.join(workspace.paths.platform_cache(), "levels", "multiplayer", multiplayer_level)
 


### PR DESCRIPTION
Update Multiplayer tests to store their cached level assets (which contains the spawnable player and scripts) inside the test artifacts. This way we can compare assets if any tests become flaky

Level cache is around 140KB per test, but gets compressed and stored around 30KB
Tested by running AutomatedTesting for multiplayer and seeing the newly add level folders inside the TestResults artifacts.

Signed-off-by: Gene Walters <genewalt@amazon.com>