### PR TITLE
[development] prevent the move operation in AZStd::vector::erase when the start/end iterators are the same

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/containers/vector.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/vector.h
@@ -849,10 +849,13 @@ namespace AZStd
 #endif
 
             size_type offset = firstPtr - m_start;
-            // unless we have 1 elements we have memory overlapping, so we need to use move.
-            pointer newLast = AZStd::move(lastPtr, m_last, firstPtr);
-            Internal::destroy<pointer>::range(newLast, m_last);
-            m_last = newLast;
+            if (firstPtr != lastPtr)
+            {
+                // unless we have 1 elements we have memory overlapping, so we need to use move.
+                pointer newLast = AZStd::move(lastPtr, m_last, firstPtr);
+                Internal::destroy<pointer>::range(newLast, m_last);
+                m_last = newLast;
+            }
             return iterator(AZSTD_POINTER_ITERATOR_PARAMS(m_start)) + offset;
         }
 


### PR DESCRIPTION
The introduction of #5735 exposed a case where undefined behaviour was being allowed to occur in the range based version of `AZStd::vector::erase`.  This was discovered in the Profiler gem ImGui visualizer through the use of `AZStd::upper_bound` not finding the desired value and returning `begin()` thus producing `vector::erase(begin(), begin())`.  Rather than patching that instance (#8306), this change is to fix the root issue.

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>