### PR TITLE
Display Mapper P1 test expansion

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
@@ -63,6 +63,23 @@ MESH_LOD_TYPE = {
     'specific lod': 2,
 }
 
+# Display Mapper type
+DISPLAY_MAPPER_OPERATION_TYPE = {
+    'Aces': 0,
+    'AcesLut': 1,
+    'Passthrough': 2,
+    'GammaSRGB': 3,
+    'Reinhard': 4,
+}
+
+# Display Mapper presets
+DISPLAY_MAPPER_PRESET = {
+    '48Nits': 0,
+    '1000Nits': 1,
+    '2000Nits': 2,
+    '4000Nits': 3,
+}
+
 # Level list used in Editor Level Load Test
 # WARNING: "Sponza" level is sandboxed due to an intermittent failure.
 LEVEL_LIST = ["hermanubis", "hermanubis_high", "macbeth_shaderballs", "PbrMaterialChart", "ShadowTest"]
@@ -312,16 +329,42 @@ class AtomComponentProperties:
     def display_mapper(property: str = 'name') -> str:
         """
         Display Mapper level component properties.
+          - 'Type' specifies the Display Mapper type from atom_constants.py DISPLAY_MAPPER_OPERATION_TYPE
           - 'Enable LDR color grading LUT' toggles the use of LDR color grading LUT
           - 'LDR color Grading LUT' is the Low Definition Range (LDR) color grading for Look-up Textures (LUT) which is
-            an Asset.id value corresponding to a lighting asset file.
+            an Asset.id value corresponding to a LUT asset file.
+          - 'Override Defaults' toggle enables parameter overrides for ACES settings (bool)
+          - 'Alter Surround' toggle applies gamma adjustments for dim surround (bool)
+          - 'Alter Desaturation' toggle applies desaturation adjustment for luminance differences (bool)
+          - 'Alter CAT D60 to D65' toggles conversion referencing black luminance level constant (bool)
+          - 'Preset Selection' select from a list of presets from atom_constants.py DISPLAY_MAPPER_PRESET
+          - 'Cinema Limit (black)' reference black
+          - 'Cinema Limit (white)' reference white
+          - 'Min Point (luminance)' linear extension below this value
+          - 'Mid Point (luminance)' middle gray value
+          - 'Max Point (luminance)' linear extension above this value
+          - 'Surround Gamma' applied to compensate for the condition of the viewing environment
+          - 'Gamma' value applied as the basic Gamma curve Opto-Electrical Transfer Function (OETF)
         :param property: From the last element of the property tree path. Default 'name' for component name string.
         :return: Full property path OR component name if no property specified.
         """
         properties = {
             'name': 'Display Mapper',
+            'Type': 'Controller|Configuration|Type',
             'Enable LDR color grading LUT': 'Controller|Configuration|Enable LDR color grading LUT',
             'LDR color Grading LUT': 'Controller|Configuration|LDR color Grading LUT',
+            'Override Defaults': 'Controller|Configuration|ACES Parameters|Override Defaults',
+            'Alter Surround': 'Controller|Configuration|ACES Parameters|Alter Surround',
+            'Alter Desaturation': 'Controller|Configuration|ACES Parameters|Alter Desaturation',
+            'Alter CAT D60 to D65': 'Controller|Configuration|ACES Parameters|Alter CAT D60 to D65',
+            'Preset Selection': 'Controller|Configuration|ACES Parameters|Load Preset|Preset Selection',
+            'Cinema Limit (black)': 'Controller|Configuration|ACES Parameters|Cinema Limit (black)',
+            'Cinema Limit (white)': 'Controller|Configuration|ACES Parameters|Cinema Limit (white)',
+            'Min Point (luminance)': 'Controller|Configuration|ACES Parameters|Min Point (luminance)',
+            'Mid Point (luminance)': 'Controller|Configuration|ACES Parameters|Mid Point (luminance)',
+            'Max Point (luminance)': 'Controller|Configuration|ACES Parameters|Max Point (luminance)',
+            'Surround Gamma': 'Controller|Configuration|ACES Parameters|Surround Gamma',
+            'Gamma': 'Controller|Configuration|ACES Parameters|Gamma',
         }
         return properties[property]
 

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
@@ -9,25 +9,68 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 class Tests:
     creation_undo = (
         "UNDO level component addition success",
-        "UNDO level component addition failed")
+        "P0: UNDO level component addition failed")
     creation_redo = (
         "REDO Level component addition success",
-        "REDO Level component addition failed")
+        "P0: REDO Level component addition failed")
     display_mapper_component = (
         "Level has a Display Mapper component",
-        "Level failed to find Display Mapper component")
+        "P0: Level failed to find Display Mapper component")
     ldr_color_grading_lut = (
         "LDR color Grading LUT asset set",
-        "LDR color Grading LUT asset could not be set")
+        "P0: LDR color Grading LUT asset could not be set")
     enable_ldr_color_grading_lut = (
         "Enable LDR color grading LUT set",
-        "Enable LDR color grading LUT could not be set")
+        "P0: Enable LDR color grading LUT could not be set")
     enter_game_mode = (
         "Entered game mode",
-        "Failed to enter game mode")
+        "P0: Failed to enter game mode")
     exit_game_mode = (
         "Exited game mode",
-        "Couldn't exit game mode")
+        "P0: Couldn't exit game mode")
+    override_defaults = (
+        "Override Defaults property set",
+        "P1: Override Defaults property failed to be set correctly")
+    alter_surround = (
+        "Alter Surround property set",
+        "P1: Alter Surround property failed to be set correctly")
+    alter_desaturation = (
+        "Alter Desaturation property set",
+        "P1: Alter Desaturation property failed to be set correctly")
+    alter_cat = (
+        "Alter CAT D60 to D65 property set",
+        "P1: Alter CAT D60 to D65 property failed to be set correctly")
+    black_level_min = (
+        "Cinema Limit (black) property set to minimum value",
+        "P1: Cinema Limit (black) property failed to take minimum value")
+    black_level_max = (
+        "Cinema Limit (black) property set to maximum value",
+        "P1: Cinema Limit (black) property failed to take maximum value")
+    white_level_min = (
+        "Cinema Limit (white) property set to minimum value",
+        "P1: Cinema Limit (white) property failed to take minimum value")
+    white_level_max = (
+        "Cinema Limit (white) property set to maximum value",
+        "P1: Cinema Limit (white) property failed to take maximum value")
+    luminance_level_min = (
+        "Min Point (luminance) property set",
+        "P1: Min Point (luminance) property failed to set expected value")
+    luminance_level_mid = (
+        "Mid Point (luminance) property set",
+        "P1: Mid Point (luminance) property failed to set expected value")
+    luminance_level_max = (
+        "Max Point (luminance) property set",
+        "P1: Max Point (luminance) property failed to set expected value")
+    surround_gamma = (
+        "Surround Gamma property set",
+        "P1: Surround Gamma property failed to set expected value")
+    gamma = (
+        "Gamma property set",
+        "P1: Gamma property failed to set expected value")
+
+
+# IsClose tolerance defaults to , 1e-9, but float values in some tests need a looser tolerance
+TOLERANCE = 1e-6
 
 
 def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
@@ -48,20 +91,36 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
     2) UNDO the level component addition.
     3) REDO the level component addition.
     4) Set LDR color Grading LUT asset.
-    5) Set Enable LDR color grading LUT property True
-    6) Enter/Exit game mode.
-    7) Look for errors and asserts.
+    5) Set the Display Mapper Operation Type enumerated in DISPLAY_MAPPER_OPERATION_TYPE for each type
+    6) Set Enable LDR color grading LUT property True
+    7) Set Override Defaults to False then True
+    8) Set Alter Surround to True then False
+    9) Set Alter Desaturation to True then False
+    10) Set 'Alter CAT D60 to D65' to True then False
+    11) 'Cinema Limit (black)' max value which is dynamic based on Cinema Limit (white) then min value
+    12) Set 'Cinema Limit (white)' maximum value then minimum, and finally back to default
+    13) 'Min Point (luminance)' set high and low value
+    14) 'Mid Point (luminance)' set high and low value then set default
+    15) 'Max Point (luminance)' set high and low value then set default
+    16) 'Surround Gamma' set high and low value
+    17) 'Gamma' set high and low value
+    18) Enter/Exit game mode.
+    19) Select and load each preset
+    20) Look for errors and asserts.
 
     :return: None
     """
     import os
 
+    import azlmbr.bus as bus
     import azlmbr.legacy.general as general
+    import azlmbr.render as render
 
+    from azlmbr.math import Math_IsClose
     from editor_python_test_tools.asset_utils import Asset
     from editor_python_test_tools.editor_entity_utils import EditorLevelEntity
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
-    from Atom.atom_utils.atom_constants import AtomComponentProperties
+    from Atom.atom_utils.atom_constants import AtomComponentProperties, DISPLAY_MAPPER_PRESET, DISPLAY_MAPPER_OPERATION_TYPE
 
     with Tracer() as error_tracer:
         # Test setup begins.
@@ -89,7 +148,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
         Report.result(Tests.creation_redo, EditorLevelEntity.has_component(AtomComponentProperties.display_mapper()))
 
         # 4. Set LDR color Grading LUT asset.
-        display_mapper_asset_path = os.path.join("TestData", "test.lightingpreset.azasset")
+        display_mapper_asset_path = os.path.join("LookupTables", "LUT_Sepia.azasset")
         display_mapper_asset = Asset.find_asset_by_path(display_mapper_asset_path, False)
         display_mapper_component.set_component_property_value(
             AtomComponentProperties.display_mapper('LDR color Grading LUT'), display_mapper_asset.id)
@@ -98,20 +157,202 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
             display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('LDR color Grading LUT')) == display_mapper_asset.id)
 
-        # 5. Set Enable LDR color grading LUT property True
+        for operation_type in DISPLAY_MAPPER_OPERATION_TYPE.keys():
+            # 5. Set the Display Mapper Operation Type enumerated in DISPLAY_MAPPER_OPERATION_TYPE for each type
+            # Type property cannot be set currently. as a workaround we are calling an ebus to set the operation type
+            # display_mapper_component.set_component_property_value(
+            #     AtomComponentProperties.display_mapper('Type'), DISPLAY_MAPPER_OPERATION_TYPE[operation_type])
+            render.DisplayMapperComponentRequestBus(
+                bus.Broadcast, "SetDisplayMapperOperationType", DISPLAY_MAPPER_OPERATION_TYPE[operation_type])
+            general.idle_wait_frames(3)
+            set_type = render.DisplayMapperComponentRequestBus(bus.Broadcast, "GetDisplayMapperOperationType")
+            Report.info(f"DiplayMapperOperationType: {set_type}")
+
+            # 6. Set Enable LDR color grading LUT property True
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Enable LDR color grading LUT'), True)
+            Report.result(
+                Tests.enable_ldr_color_grading_lut,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Enable LDR color grading LUT')) is True)
+
+
+            # 7. Set Override Defaults to False
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Override Defaults'), False)
+            Report.result(
+                Tests.override_defaults,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Override Defaults')) is False)
+            # Set Override Defaults to True
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Override Defaults'), True)
+            Report.result(
+                Tests.override_defaults,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Override Defaults')) is True)
+
+            # 8. Set Alter Surround to True
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Alter Surround'), True)
+            Report.result(
+                Tests.alter_surround,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Alter Surround')) is True)
+            # Set Alter Surround to False
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Alter Surround'), False)
+            Report.result(
+                Tests.alter_surround,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Alter Surround')) is False)
+
+            # 9. Set Alter Desaturation to True
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Alter Desaturation'), True)
+            Report.result(
+                Tests.alter_desaturation,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Alter Desaturation')) is True)
+            # Set Alter Desaturation to False
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Alter Desaturation'), False)
+            Report.result(
+                Tests.alter_desaturation,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Alter Desaturation')) is False)
+
+            # 10. Set 'Alter CAT D60 to D65' to True
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Alter CAT D60 to D65'), True)
+            Report.result(
+                Tests.alter_cat,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Alter CAT D60 to D65')) is True)
+            # Set 'Alter CAT D60 to D65' to False
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Alter CAT D60 to D65'), False)
+            Report.result(
+                Tests.alter_cat,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Alter CAT D60 to D65')) is False)
+
+            general.idle_wait_frames(1)
+
+            # 11. 'Cinema Limit (black)' max value which is dynamic based on Cinema Limit (white) then min value
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (black)'), value=48.0)
+            Report.result(Tests.black_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (black)')), 48.0, TOLERANCE))
+            # 'Cinema Limit (black)' min value
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (black)'), value=0.02)
+            Report.info(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (black)')))
+            Report.result(Tests.black_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (black)')), 0.02, TOLERANCE))
+
+            # 12. Set 'Cinema Limit (white)' maximum value then minimum, and finally back to default
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=4000.0)
+            Report.result(Tests.white_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (white)')), 4000.0, TOLERANCE))
+            # Set minimum value which is dynamic based on Cinema Limit (black)
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=0.02)
+            Report.info(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (white)')))
+            Report.result(Tests.white_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (white)')), 0.02, TOLERANCE))
+            # Reset this to the default 48
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=48.0)
+
+            # 13. 'Min Point (luminance)' set high and low value
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Min Point (luminance)'), value=4.8)
+            Report.info(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Min Point (luminance)')))
+            Report.result(Tests.luminance_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Min Point (luminance)')), 4.8, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Min Point (luminance)'), value=0.002)
+            Report.result(Tests.luminance_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Min Point (luminance)')), 0.002, TOLERANCE))
+
+            # 14. 'Mid Point (luminance)' set high and low value then set default
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=1005.0)
+            Report.result(Tests.luminance_level_mid, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Mid Point (luminance)')), 1005.0, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=0.002)
+            Report.result(Tests.luminance_level_mid, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Mid Point (luminance)')), 0.002, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=4.8)
+
+            # 15. 'Max Point (luminance)' set high and low value then set default
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Max Point (luminance)'), value=4000.0)
+            Report.result(Tests.luminance_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Max Point (luminance)')), 4000.0, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Max Point (luminance)'), value=0.002)
+            Report.result(Tests.luminance_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Max Point (luminance)')), 0.002, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Max Point (luminance)'), value=1005.7191162)
+
+            # 16. 'Surround Gamma' set high and low value
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Surround Gamma'), value=1.2)
+            Report.result(Tests.surround_gamma, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Surround Gamma')), 1.2, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Surround Gamma'), value=0.6)
+            Report.result(Tests.surround_gamma, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Surround Gamma')), 0.6, TOLERANCE))
+
+            # 17. 'Gamma' set high and low value
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Gamma'), value=4.0)
+            Report.result(Tests.gamma, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Gamma')), 4.0, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Gamma'), value=0.2)
+            Report.result(Tests.gamma, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Gamma')), 0.2, TOLERANCE))
+
+            # 18. Enter/Exit game mode.
+            TestHelper.enter_game_mode(Tests.enter_game_mode)
+            general.idle_wait_frames(1)
+            TestHelper.exit_game_mode(Tests.exit_game_mode)
+
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Enable LDR color grading LUT'), False)
+
         display_mapper_component.set_component_property_value(
             AtomComponentProperties.display_mapper('Enable LDR color grading LUT'), True)
-        Report.result(
-            Tests.enable_ldr_color_grading_lut,
-            display_mapper_component.get_component_property_value(
-                AtomComponentProperties.display_mapper('Enable LDR color grading LUT')) is True)
 
-        # 6. Enter/Exit game mode.
-        TestHelper.enter_game_mode(Tests.enter_game_mode)
-        general.idle_wait_frames(1)
-        TestHelper.exit_game_mode(Tests.exit_game_mode)
+        cinema_limit_white_presets = [48.0, 184.3200073, 368.6400146, 737.2800293]
+        for preset in DISPLAY_MAPPER_PRESET.keys():
+            # 19. Select and load each preset
+            # Preset Selection cannot be set or loaded currently; as a workaround we are calling an ebus to load preset
+            # display_mapper_component.set_component_property_value(
+            #     AtomComponentProperties.display_mapper('Preset Selection'), DISPLAY_MAPPER_PRESET[preset])
+            render.DisplayMapperComponentRequestBus(bus.Broadcast, "LoadPreset", DISPLAY_MAPPER_PRESET[preset])
+            general.idle_wait_frames(1)
+            # check some value to confirm preset loaded
+            test_preset = (f"Preset {preset} loaded expected value",
+                      f"P1: Preset {preset} failed to load values as expected")
+            Report.result(test_preset, Math_IsClose(
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Cinema Limit (white)')),
+                cinema_limit_white_presets[DISPLAY_MAPPER_PRESET[preset]], TOLERANCE))
 
-        # 7. Look for errors and asserts.
+
+        # 20. Look for errors and asserts.
         TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
         for error_info in error_tracer.errors:
             Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
@@ -67,6 +67,9 @@ class Tests:
     gamma = (
         "Gamma property set",
         "P1: Gamma property failed to set expected value")
+    display_mapper_type = (
+        "Display Mapper Operation Type is correctly set",
+        "P1: Display Mapper Operation type is not as expected")
 
 
 # IsClose tolerance defaults to , 1e-9, but float values in some tests need a looser tolerance
@@ -93,17 +96,17 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
     4) Set LDR color Grading LUT asset.
     5) Set the Display Mapper Operation Type enumerated in DISPLAY_MAPPER_OPERATION_TYPE for each type
     6) Set Enable LDR color grading LUT property True
-    7) Set Override Defaults to False then True
-    8) Set Alter Surround to True then False
-    9) Set Alter Desaturation to True then False
-    10) Set 'Alter CAT D60 to D65' to True then False
-    11) 'Cinema Limit (black)' max value which is dynamic based on Cinema Limit (white) then min value
-    12) Set 'Cinema Limit (white)' maximum value then minimum, and finally back to default
-    13) 'Min Point (luminance)' set high and low value
-    14) 'Mid Point (luminance)' set high and low value then set default
-    15) 'Max Point (luminance)' set high and low value then set default
-    16) 'Surround Gamma' set high and low value
-    17) 'Gamma' set high and low value
+    7) Toggle Override Defaults
+    8) Toggle Alter Surround
+    9) Toggle Alter Desaturation
+    10) Toggle 'Alter CAT D60 to D65'
+    11) Set 'Cinema Limit (black)' max value which is dynamic based on Cinema Limit (white) then min value
+    12) Set 'Cinema Limit (white)' max value then min, and finally back to default
+    13) Set 'Min Point (luminance)' to high and low value
+    14) Set 'Mid Point (luminance)' to high and low value then set default
+    15) Set 'Max Point (luminance)' to high and low value then set default
+    16) Set 'Surround Gamma' to high and low value
+    17) Set 'Gamma' to high and low value
     18) Enter/Exit game mode.
     19) Select and load each preset
     20) Look for errors and asserts.
@@ -167,6 +170,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
             general.idle_wait_frames(3)
             set_type = render.DisplayMapperComponentRequestBus(bus.Broadcast, "GetDisplayMapperOperationType")
             Report.info(f"DiplayMapperOperationType: {set_type}")
+            Report.result(Tests.display_mapper_type, set_type == DISPLAY_MAPPER_OPERATION_TYPE[operation_type])
 
             # 6. Set Enable LDR color grading LUT property True
             display_mapper_component.set_component_property_value(
@@ -176,14 +180,15 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Enable LDR color grading LUT')) is True)
 
-
-            # 7. Set Override Defaults to False
+            # 7. Toggle Override Defaults
+            # Set Override Defaults to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Override Defaults'), False)
             Report.result(
                 Tests.override_defaults,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Override Defaults')) is False)
+					
             # Set Override Defaults to True
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Override Defaults'), True)
@@ -192,13 +197,15 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Override Defaults')) is True)
 
-            # 8. Set Alter Surround to True
+            # 8. Toggle Alter Surround
+            # Set Alter Surround to True
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter Surround'), True)
             Report.result(
                 Tests.alter_surround,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter Surround')) is True)
+					
             # Set Alter Surround to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter Surround'), False)
@@ -207,13 +214,15 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter Surround')) is False)
 
-            # 9. Set Alter Desaturation to True
+            # 9. Toggle Alter Desaturation
+            # Set Alter Desaturation to True
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter Desaturation'), True)
             Report.result(
                 Tests.alter_desaturation,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter Desaturation')) is True)
+					
             # Set Alter Desaturation to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter Desaturation'), False)
@@ -222,13 +231,15 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter Desaturation')) is False)
 
-            # 10. Set 'Alter CAT D60 to D65' to True
+            # 10. Toggle 'Alter CAT D60 to D65'
+            # Set 'Alter CAT D60 to D65' to True
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter CAT D60 to D65'), True)
             Report.result(
                 Tests.alter_cat,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter CAT D60 to D65')) is True)
+					
             # Set 'Alter CAT D60 to D65' to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter CAT D60 to D65'), False)
@@ -239,86 +250,106 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
 
             general.idle_wait_frames(1)
 
-            # 11. 'Cinema Limit (black)' max value which is dynamic based on Cinema Limit (white) then min value
+            # 11. Set 'Cinema Limit (black)' max value which is dynamic based on Cinema Limit (white) then min value
+            # set max value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (black)'), value=48.0)
             Report.result(Tests.black_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (black)')), 48.0, TOLERANCE))
-            # 'Cinema Limit (black)' min value
+				
+            # set min value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (black)'), value=0.02)
-            Report.info(display_mapper_component.get_component_property_value(
-                AtomComponentProperties.display_mapper('Cinema Limit (black)')))
             Report.result(Tests.black_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (black)')), 0.02, TOLERANCE))
 
-            # 12. Set 'Cinema Limit (white)' maximum value then minimum, and finally back to default
+            # 12. Set 'Cinema Limit (white)' maximum value then min, and finally back to default
+            # set max value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=4000.0)
             Report.result(Tests.white_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)')), 4000.0, TOLERANCE))
-            # Set minimum value which is dynamic based on Cinema Limit (black)
+				
+            # Set min value which is dynamic based on Cinema Limit (black)
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=0.02)
-            Report.info(display_mapper_component.get_component_property_value(
-                AtomComponentProperties.display_mapper('Cinema Limit (white)')))
             Report.result(Tests.white_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)')), 0.02, TOLERANCE))
-            # Reset this to the default 48
+				
+            # Reset this to the default 48 so following cycles don't impact Cinema Limit (Black)
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=48.0)
 
-            # 13. 'Min Point (luminance)' set high and low value
+            # 13. Set 'Min Point (luminance)' to high and low value
+            # set high value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)'), value=4.8)
             Report.info(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)')))
             Report.result(Tests.luminance_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)')), 4.8, TOLERANCE))
+				
+            # set low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)'), value=0.002)
             Report.result(Tests.luminance_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)')), 0.002, TOLERANCE))
 
-            # 14. 'Mid Point (luminance)' set high and low value then set default
+            # 14. Set 'Mid Point (luminance)' to high and low value then set default
+            # set high value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=1005.0)
             Report.result(Tests.luminance_level_mid, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)')), 1005.0, TOLERANCE))
+				
+            # set low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=0.002)
             Report.result(Tests.luminance_level_mid, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)')), 0.002, TOLERANCE))
+				
+            # restore the default since as this impacts the range of 'Min Point (luminance)'
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=4.8)
 
-            # 15. 'Max Point (luminance)' set high and low value then set default
+            # 15. Set 'Max Point (luminance)' to high and low value then set default
+            # set a high value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)'), value=4000.0)
             Report.result(Tests.luminance_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)')), 4000.0, TOLERANCE))
+				
+            # set a low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)'), value=0.002)
             Report.result(Tests.luminance_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)')), 0.002, TOLERANCE))
+				
+            # restore the default since this impacts the range of 'Mid Point (luminance)'
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)'), value=1005.7191162)
 
-            # 16. 'Surround Gamma' set high and low value
+            # 16. Set 'Surround Gamma' to high and low value
+            # set a high value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Surround Gamma'), value=1.2)
             Report.result(Tests.surround_gamma, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Surround Gamma')), 1.2, TOLERANCE))
+				
+            # set a low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Surround Gamma'), value=0.6)
             Report.result(Tests.surround_gamma, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Surround Gamma')), 0.6, TOLERANCE))
 
-            # 17. 'Gamma' set high and low value
+            # 17. Set 'Gamma' to high and low value
+            # set a high value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Gamma'), value=4.0)
             Report.result(Tests.gamma, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Gamma')), 4.0, TOLERANCE))
+				
+            # set a low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Gamma'), value=0.2)
             Report.result(Tests.gamma, Math_IsClose(display_mapper_component.get_component_property_value(
@@ -339,6 +370,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
         for preset in DISPLAY_MAPPER_PRESET.keys():
             # 19. Select and load each preset
             # Preset Selection cannot be set or loaded currently; as a workaround we are calling an ebus to load preset
+            # A fix is in progress
             # display_mapper_component.set_component_property_value(
             #     AtomComponentProperties.display_mapper('Preset Selection'), DISPLAY_MAPPER_PRESET[preset])
             render.DisplayMapperComponentRequestBus(bus.Broadcast, "LoadPreset", DISPLAY_MAPPER_PRESET[preset])

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
@@ -383,7 +383,6 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                     AtomComponentProperties.display_mapper('Cinema Limit (white)')),
                 cinema_limit_white_presets[DISPLAY_MAPPER_PRESET[preset]], TOLERANCE))
 
-
         # 20. Look for errors and asserts.
         TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
         for error_info in error_tracer.errors:

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
@@ -188,7 +188,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 Tests.override_defaults,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Override Defaults')) is False)
-					
+
             # Set Override Defaults to True
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Override Defaults'), True)
@@ -205,7 +205,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 Tests.alter_surround,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter Surround')) is True)
-					
+
             # Set Alter Surround to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter Surround'), False)
@@ -222,7 +222,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 Tests.alter_desaturation,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter Desaturation')) is True)
-					
+
             # Set Alter Desaturation to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter Desaturation'), False)
@@ -239,7 +239,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 Tests.alter_cat,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter CAT D60 to D65')) is True)
-					
+
             # Set 'Alter CAT D60 to D65' to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter CAT D60 to D65'), False)
@@ -256,7 +256,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Cinema Limit (black)'), value=48.0)
             Report.result(Tests.black_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (black)')), 48.0, TOLERANCE))
-				
+
             # set min value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (black)'), value=0.02)
@@ -269,13 +269,13 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=4000.0)
             Report.result(Tests.white_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)')), 4000.0, TOLERANCE))
-				
+
             # Set min value which is dynamic based on Cinema Limit (black)
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=0.02)
             Report.result(Tests.white_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)')), 0.02, TOLERANCE))
-				
+
             # Reset this to the default 48 so following cycles don't impact Cinema Limit (Black)
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=48.0)
@@ -288,7 +288,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Min Point (luminance)')))
             Report.result(Tests.luminance_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)')), 4.8, TOLERANCE))
-				
+
             # set low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)'), value=0.002)
@@ -301,13 +301,13 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=1005.0)
             Report.result(Tests.luminance_level_mid, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)')), 1005.0, TOLERANCE))
-				
+
             # set low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=0.002)
             Report.result(Tests.luminance_level_mid, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)')), 0.002, TOLERANCE))
-				
+
             # restore the default since as this impacts the range of 'Min Point (luminance)'
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=4.8)
@@ -318,13 +318,13 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Max Point (luminance)'), value=4000.0)
             Report.result(Tests.luminance_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)')), 4000.0, TOLERANCE))
-				
+
             # set a low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)'), value=0.002)
             Report.result(Tests.luminance_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)')), 0.002, TOLERANCE))
-				
+
             # restore the default since this impacts the range of 'Mid Point (luminance)'
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)'), value=1005.7191162)
@@ -335,7 +335,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Surround Gamma'), value=1.2)
             Report.result(Tests.surround_gamma, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Surround Gamma')), 1.2, TOLERANCE))
-				
+
             # set a low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Surround Gamma'), value=0.6)
@@ -348,7 +348,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Gamma'), value=4.0)
             Report.result(Tests.gamma, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Gamma')), 4.0, TOLERANCE))
-				
+
             # set a low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Gamma'), value=0.2)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DisplayMapperAdded.py
@@ -229,7 +229,7 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 Tests.override_defaults,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Override Defaults')) is False)
-					
+
             # Set Override Defaults to True
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Override Defaults'), True)
@@ -246,7 +246,7 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 Tests.alter_surround,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter Surround')) is True)
-					
+
             # Set Alter Surround to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter Surround'), False)
@@ -263,7 +263,7 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 Tests.alter_desaturation,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter Desaturation')) is True)
-					
+
             # Set Alter Desaturation to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter Desaturation'), False)
@@ -280,7 +280,7 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 Tests.alter_cat,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter CAT D60 to D65')) is True)
-					
+
             # Set 'Alter CAT D60 to D65' to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter CAT D60 to D65'), False)
@@ -297,7 +297,7 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Cinema Limit (black)'), value=48.0)
             Report.result(Tests.black_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (black)')), 48.0, TOLERANCE))
-				
+
             # set min value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (black)'), value=0.02)
@@ -310,13 +310,13 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=4000.0)
             Report.result(Tests.white_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)')), 4000.0, TOLERANCE))
-				
+
             # Set min value which is dynamic based on Cinema Limit (black)
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=0.02)
             Report.result(Tests.white_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)')), 0.02, TOLERANCE))
-				
+
             # Reset this to the default 48 so following cycles don't impact Cinema Limit (Black)
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=48.0)
@@ -329,7 +329,7 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Min Point (luminance)')))
             Report.result(Tests.luminance_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)')), 4.8, TOLERANCE))
-				
+
             # set low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)'), value=0.002)
@@ -342,13 +342,13 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=1005.0)
             Report.result(Tests.luminance_level_mid, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)')), 1005.0, TOLERANCE))
-				
+
             # set low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=0.002)
             Report.result(Tests.luminance_level_mid, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)')), 0.002, TOLERANCE))
-				
+
             # restore the default since as this impacts the range of 'Min Point (luminance)'
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=4.8)
@@ -359,13 +359,13 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Max Point (luminance)'), value=4000.0)
             Report.result(Tests.luminance_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)')), 4000.0, TOLERANCE))
-				
+
             # set a low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)'), value=0.002)
             Report.result(Tests.luminance_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)')), 0.002, TOLERANCE))
-				
+
             # restore the default since this impacts the range of 'Mid Point (luminance)'
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)'), value=1005.7191162)
@@ -376,7 +376,7 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Surround Gamma'), value=1.2)
             Report.result(Tests.surround_gamma, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Surround Gamma')), 1.2, TOLERANCE))
-				
+
             # set a low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Surround Gamma'), value=0.6)
@@ -389,7 +389,7 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 AtomComponentProperties.display_mapper('Gamma'), value=4.0)
             Report.result(Tests.gamma, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Gamma')), 4.0, TOLERANCE))
-				
+
             # set a low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Gamma'), value=0.2)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DisplayMapperAdded.py
@@ -418,7 +418,7 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
             general.idle_wait_frames(1)
             # check some value to confirm preset loaded
             test_preset = (f"Preset {preset} loaded expected value",
-                      f"P1: Preset {preset} failed to load values as expected")
+                           f"P1: Preset {preset} failed to load values as expected")
             Report.result(test_preset, Math_IsClose(
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Cinema Limit (white)')),

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DisplayMapperAdded.py
@@ -9,43 +9,86 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 class Tests:
     creation_undo = (
         "UNDO Entity creation success",
-        "UNDO Entity creation failed")
+        "P0: UNDO Entity creation failed")
     creation_redo = (
         "REDO Entity creation success",
-        "REDO Entity creation failed")
+        "P0: REDO Entity creation failed")
     display_mapper_creation = (
         "Display Mapper Entity successfully created",
-        "Display Mapper Entity failed to be created")
+        "P0: Display Mapper Entity failed to be created")
     display_mapper_component = (
         "Entity has a Display Mapper component",
-        "Entity failed to find Display Mapper component")
+        "P0: Entity failed to find Display Mapper component")
     enter_game_mode = (
         "Entered game mode",
-        "Failed to enter game mode")
+        "P0: Failed to enter game mode")
     exit_game_mode = (
         "Exited game mode",
-        "Couldn't exit game mode")
+        "P0: Couldn't exit game mode")
     is_visible = (
         "Entity is visible",
-        "Entity was not visible")
+        "P0: Entity was not visible")
     is_hidden = (
         "Entity is hidden",
-        "Entity was not hidden")
+        "P0: Entity was not hidden")
     ldr_color_grading_lut = (
         "LDR color Grading LUT asset set",
-        "LDR color Grading LUT asset could not be set")
+        "P0: LDR color Grading LUT asset could not be set")
     enable_ldr_color_grading_lut = (
         "Enable LDR color grading LUT set",
-        "Enable LDR color grading LUT could not be set")
+        "P0: Enable LDR color grading LUT could not be set")
     entity_deleted = (
         "Entity deleted",
-        "Entity was not deleted")
+        "P0: Entity was not deleted")
     deletion_undo = (
         "UNDO deletion success",
-        "UNDO deletion failed")
+        "P0: UNDO deletion failed")
     deletion_redo = (
         "REDO deletion success",
-        "REDO deletion failed")
+        "P0: REDO deletion failed")
+    override_defaults = (
+        "Override Defaults property set",
+        "P1: Override Defaults property failed to be set correctly")
+    alter_surround = (
+        "Alter Surround property set",
+        "P1: Alter Surround property failed to be set correctly")
+    alter_desaturation = (
+        "Alter Desaturation property set",
+        "P1: Alter Desaturation property failed to be set correctly")
+    alter_cat = (
+        "Alter CAT D60 to D65 property set",
+        "P1: Alter CAT D60 to D65 property failed to be set correctly")
+    black_level_min = (
+        "Cinema Limit (black) property set to minimum value",
+        "P1: Cinema Limit (black) property failed to take minimum value")
+    black_level_max = (
+        "Cinema Limit (black) property set to maximum value",
+        "P1: Cinema Limit (black) property failed to take maximum value")
+    white_level_min = (
+        "Cinema Limit (white) property set to minimum value",
+        "P1: Cinema Limit (white) property failed to take minimum value")
+    white_level_max = (
+        "Cinema Limit (white) property set to maximum value",
+        "P1: Cinema Limit (white) property failed to take maximum value")
+    luminance_level_min = (
+        "Min Point (luminance) property set",
+        "P1: Min Point (luminance) property failed to set expected value")
+    luminance_level_mid = (
+        "Mid Point (luminance) property set",
+        "P1: Mid Point (luminance) property failed to set expected value")
+    luminance_level_max = (
+        "Max Point (luminance) property set",
+        "P1: Max Point (luminance) property failed to set expected value")
+    surround_gamma = (
+        "Surround Gamma property set",
+        "P1: Surround Gamma property failed to set expected value")
+    gamma = (
+        "Gamma property set",
+        "P1: Gamma property failed to set expected value")
+
+
+# IsClose tolerance defaults to , 1e-9, but float values in some tests need a looser tolerance
+TOLERANCE = 1e-6
 
 
 def AtomEditorComponents_DisplayMapper_AddedToEntity():
@@ -67,25 +110,41 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
     3) UNDO the entity creation and component addition.
     4) REDO the entity creation and component addition.
     5) Set LDR color Grading LUT asset.
-    6) Set Enable LDR color grading LUT property True
-    7) Enter/Exit game mode.
-    8) Test IsHidden.
-    9) Test IsVisible.
-    10) Delete Display Mapper entity.
-    11) UNDO deletion.
-    12) REDO deletion.
-    13) Look for errors and asserts.
+    6) Set the Display Mapper Operation Type enumerated in DISPLAY_MAPPER_OPERATION_TYPE for each type
+    7) Set Enable LDR color grading LUT property True
+    8) Set Override Defaults to False then True
+    9) Set Alter Surround to True then False
+    10) Set Alter Desaturation to True then False
+    11) Set 'Alter CAT D60 to D65' to True then False
+    12) 'Cinema Limit (black)' max value which is dynamic based on Cinema Limit (white) then min value
+    13) Set 'Cinema Limit (white)' maximum value then minimum, and finally back to default
+    14) 'Min Point (luminance)' set high and low value
+    15) 'Mid Point (luminance)' set high and low value then set default
+    16) 'Max Point (luminance)' set high and low value then set default
+    17) 'Surround Gamma' set high and low value
+    18) 'Gamma' set high and low value
+    19) Enter/Exit game mode.
+    20) Select and load each preset
+    21) Test IsHidden.
+    22) Test IsVisible.
+    23) Delete Display Mapper entity.
+    24) UNDO deletion.
+    25) REDO deletion.
+    26) Look for errors and asserts.
 
     :return: None
     """
     import os
 
+    import azlmbr.bus as bus
     import azlmbr.legacy.general as general
+    import azlmbr.render as render
 
+    from azlmbr.math import Math_IsClose
     from editor_python_test_tools.asset_utils import Asset
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
-    from Atom.atom_utils.atom_constants import AtomComponentProperties
+    from Atom.atom_utils.atom_constants import AtomComponentProperties, DISPLAY_MAPPER_PRESET, DISPLAY_MAPPER_OPERATION_TYPE
 
     with Tracer() as error_tracer:
         # Test setup begins.
@@ -129,52 +188,233 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
         Report.result(Tests.creation_redo, display_mapper_entity.exists())
 
         # 5. Set LDR color Grading LUT asset.
-        display_mapper_asset_path = os.path.join("TestData", "test.lightingpreset.azasset")
+        display_mapper_asset_path = os.path.join("LookupTables", "LUT_Sepia.azasset")
         display_mapper_asset = Asset.find_asset_by_path(display_mapper_asset_path, False)
         display_mapper_component.set_component_property_value(
-            AtomComponentProperties.display_mapper("LDR color Grading LUT"), display_mapper_asset.id)
+            AtomComponentProperties.display_mapper('LDR color Grading LUT'), display_mapper_asset.id)
         Report.result(
             Tests.ldr_color_grading_lut,
             display_mapper_component.get_component_property_value(
-                AtomComponentProperties.display_mapper("LDR color Grading LUT")) == display_mapper_asset.id)
+                AtomComponentProperties.display_mapper('LDR color Grading LUT')) == display_mapper_asset.id)
 
-        # 6. Set Enable LDR color grading LUT property True
+        for operation_type in DISPLAY_MAPPER_OPERATION_TYPE.keys():
+            # 6. Set the Display Mapper Operation Type enumerated in DISPLAY_MAPPER_OPERATION_TYPE for each type
+            # Type property cannot be set currently. as a workaround we are calling an ebus to set the operation type
+            # display_mapper_component.set_component_property_value(
+            #     AtomComponentProperties.display_mapper('Type'), DISPLAY_MAPPER_OPERATION_TYPE[operation_type])
+            render.DisplayMapperComponentRequestBus(
+                bus.Broadcast, "SetDisplayMapperOperationType", DISPLAY_MAPPER_OPERATION_TYPE[operation_type])
+            general.idle_wait_frames(3)
+            set_type = render.DisplayMapperComponentRequestBus(bus.Broadcast, "GetDisplayMapperOperationType")
+            Report.info(f"DiplayMapperOperationType: {set_type}")
+
+            # 7. Set Enable LDR color grading LUT property True
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Enable LDR color grading LUT'), True)
+            Report.result(
+                Tests.enable_ldr_color_grading_lut,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Enable LDR color grading LUT')) is True)
+
+
+            # 8. Set Override Defaults to False
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Override Defaults'), False)
+            Report.result(
+                Tests.override_defaults,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Override Defaults')) is False)
+            # Set Override Defaults to True
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Override Defaults'), True)
+            Report.result(
+                Tests.override_defaults,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Override Defaults')) is True)
+
+            # 9. Set Alter Surround to True
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Alter Surround'), True)
+            Report.result(
+                Tests.alter_surround,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Alter Surround')) is True)
+            # Set Alter Surround to False
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Alter Surround'), False)
+            Report.result(
+                Tests.alter_surround,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Alter Surround')) is False)
+
+            # 10. Set Alter Desaturation to True
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Alter Desaturation'), True)
+            Report.result(
+                Tests.alter_desaturation,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Alter Desaturation')) is True)
+            # Set Alter Desaturation to False
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Alter Desaturation'), False)
+            Report.result(
+                Tests.alter_desaturation,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Alter Desaturation')) is False)
+
+            # 11. Set 'Alter CAT D60 to D65' to True
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Alter CAT D60 to D65'), True)
+            Report.result(
+                Tests.alter_cat,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Alter CAT D60 to D65')) is True)
+            # Set 'Alter CAT D60 to D65' to False
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Alter CAT D60 to D65'), False)
+            Report.result(
+                Tests.alter_cat,
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Alter CAT D60 to D65')) is False)
+
+            general.idle_wait_frames(1)
+
+            # 12. 'Cinema Limit (black)' max value which is dynamic based on Cinema Limit (white) then min value
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (black)'), value=48.0)
+            Report.result(Tests.black_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (black)')), 48.0, TOLERANCE))
+            # 'Cinema Limit (black)' min value
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (black)'), value=0.02)
+            Report.info(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (black)')))
+            Report.result(Tests.black_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (black)')), 0.02, TOLERANCE))
+
+            # 13. Set 'Cinema Limit (white)' maximum value then minimum, and finally back to default
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=4000.0)
+            Report.result(Tests.white_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (white)')), 4000.0, TOLERANCE))
+            # Set minimum value which is dynamic based on Cinema Limit (black)
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=0.02)
+            Report.info(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (white)')))
+            Report.result(Tests.white_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (white)')), 0.02, TOLERANCE))
+            # Reset this to the default 48
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=48.0)
+
+            # 14. 'Min Point (luminance)' set high and low value
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Min Point (luminance)'), value=4.8)
+            Report.info(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Min Point (luminance)')))
+            Report.result(Tests.luminance_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Min Point (luminance)')), 4.8, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Min Point (luminance)'), value=0.002)
+            Report.result(Tests.luminance_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Min Point (luminance)')), 0.002, TOLERANCE))
+
+            # 15. 'Mid Point (luminance)' set high and low value then set default
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=1005.0)
+            Report.result(Tests.luminance_level_mid, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Mid Point (luminance)')), 1005.0, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=0.002)
+            Report.result(Tests.luminance_level_mid, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Mid Point (luminance)')), 0.002, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=4.8)
+
+            # 16. 'Max Point (luminance)' set high and low value then set default
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Max Point (luminance)'), value=4000.0)
+            Report.result(Tests.luminance_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Max Point (luminance)')), 4000.0, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Max Point (luminance)'), value=0.002)
+            Report.result(Tests.luminance_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Max Point (luminance)')), 0.002, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Max Point (luminance)'), value=1005.7191162)
+
+            # 17. 'Surround Gamma' set high and low value
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Surround Gamma'), value=1.2)
+            Report.result(Tests.surround_gamma, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Surround Gamma')), 1.2, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Surround Gamma'), value=0.6)
+            Report.result(Tests.surround_gamma, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Surround Gamma')), 0.6, TOLERANCE))
+
+            # 18. 'Gamma' set high and low value
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Gamma'), value=4.0)
+            Report.result(Tests.gamma, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Gamma')), 4.0, TOLERANCE))
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Gamma'), value=0.2)
+            Report.result(Tests.gamma, Math_IsClose(display_mapper_component.get_component_property_value(
+                AtomComponentProperties.display_mapper('Gamma')), 0.2, TOLERANCE))
+
+            # 19. Enter/Exit game mode.
+            TestHelper.enter_game_mode(Tests.enter_game_mode)
+            general.idle_wait_frames(1)
+            TestHelper.exit_game_mode(Tests.exit_game_mode)
+
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Enable LDR color grading LUT'), False)
+
         display_mapper_component.set_component_property_value(
             AtomComponentProperties.display_mapper('Enable LDR color grading LUT'), True)
-        Report.result(
-            Tests.enable_ldr_color_grading_lut,
-            display_mapper_component.get_component_property_value(
-                AtomComponentProperties.display_mapper('Enable LDR color grading LUT')) is True)
 
-        # 7. Enter/Exit game mode.
-        TestHelper.enter_game_mode(Tests.enter_game_mode)
-        general.idle_wait_frames(1)
-        TestHelper.exit_game_mode(Tests.exit_game_mode)
+        cinema_limit_white_presets = [48.0, 184.3200073, 368.6400146, 737.2800293]
+        for preset in DISPLAY_MAPPER_PRESET.keys():
+            # 20. Select and load each preset
+            # Preset Selection cannot be set or loaded currently; as a workaround we are calling an ebus to load preset
+            # display_mapper_component.set_component_property_value(
+            #     AtomComponentProperties.display_mapper('Preset Selection'), DISPLAY_MAPPER_PRESET[preset])
+            render.DisplayMapperComponentRequestBus(bus.Broadcast, "LoadPreset", DISPLAY_MAPPER_PRESET[preset])
+            general.idle_wait_frames(1)
+            # check some value to confirm preset loaded
+            test_preset = (f"Preset {preset} loaded expected value",
+                      f"P1: Preset {preset} failed to load values as expected")
+            Report.result(test_preset, Math_IsClose(
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Cinema Limit (white)')),
+                cinema_limit_white_presets[DISPLAY_MAPPER_PRESET[preset]], TOLERANCE))
 
-        # 8. Test IsHidden.
+        # 21. Test IsHidden.
         display_mapper_entity.set_visibility_state(False)
         Report.result(Tests.is_hidden, display_mapper_entity.is_hidden() is True)
 
-        # 9. Test IsVisible.
+        # 22. Test IsVisible.
         display_mapper_entity.set_visibility_state(True)
         general.idle_wait_frames(1)
         Report.result(Tests.is_visible, display_mapper_entity.is_visible() is True)
 
-        # 10. Delete Display Mapper entity.
+        # 23. Delete Display Mapper entity.
         display_mapper_entity.delete()
         Report.result(Tests.entity_deleted, not display_mapper_entity.exists())
 
-        # 11. UNDO deletion.
+        # 24. UNDO deletion.
         general.undo()
         general.idle_wait_frames(1)
         Report.result(Tests.deletion_undo, display_mapper_entity.exists())
 
-        # 12. REDO deletion.
+        # 25. REDO deletion.
         general.redo()
         general.idle_wait_frames(1)
         Report.result(Tests.deletion_redo, not display_mapper_entity.exists())
 
-        # 13. Look for errors and asserts.
+        # 26. Look for errors and asserts.
         TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
         for error_info in error_tracer.errors:
             Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DisplayMapperAdded.py
@@ -85,6 +85,9 @@ class Tests:
     gamma = (
         "Gamma property set",
         "P1: Gamma property failed to set expected value")
+    display_mapper_type = (
+        "Display Mapper Operation Type is correctly set",
+        "P1: Display Mapper Operation type is not as expected")
 
 
 # IsClose tolerance defaults to , 1e-9, but float values in some tests need a looser tolerance
@@ -112,17 +115,17 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
     5) Set LDR color Grading LUT asset.
     6) Set the Display Mapper Operation Type enumerated in DISPLAY_MAPPER_OPERATION_TYPE for each type
     7) Set Enable LDR color grading LUT property True
-    8) Set Override Defaults to False then True
-    9) Set Alter Surround to True then False
-    10) Set Alter Desaturation to True then False
-    11) Set 'Alter CAT D60 to D65' to True then False
-    12) 'Cinema Limit (black)' max value which is dynamic based on Cinema Limit (white) then min value
-    13) Set 'Cinema Limit (white)' maximum value then minimum, and finally back to default
-    14) 'Min Point (luminance)' set high and low value
-    15) 'Mid Point (luminance)' set high and low value then set default
-    16) 'Max Point (luminance)' set high and low value then set default
-    17) 'Surround Gamma' set high and low value
-    18) 'Gamma' set high and low value
+    8) Toggle Override Defaults
+    9) Toggle Alter Surround
+    10) Toggle Alter Desaturation
+    11) Toggle 'Alter CAT D60 to D65'
+    12) Set 'Cinema Limit (black)' max value which is dynamic based on Cinema Limit (white) then min value
+    13) Set 'Cinema Limit (white)' max value then min, and finally back to default
+    14) Set 'Min Point (luminance)' to high and low value
+    15) Set 'Mid Point (luminance)' to high and low value then set default
+    16) Set 'Max Point (luminance)' to high and low value then set default
+    17) Set 'Surround Gamma' to high and low value
+    18) Set 'Gamma' to high and low value
     19) Enter/Exit game mode.
     20) Select and load each preset
     21) Test IsHidden.
@@ -200,6 +203,7 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
         for operation_type in DISPLAY_MAPPER_OPERATION_TYPE.keys():
             # 6. Set the Display Mapper Operation Type enumerated in DISPLAY_MAPPER_OPERATION_TYPE for each type
             # Type property cannot be set currently. as a workaround we are calling an ebus to set the operation type
+            # A fix is in progress
             # display_mapper_component.set_component_property_value(
             #     AtomComponentProperties.display_mapper('Type'), DISPLAY_MAPPER_OPERATION_TYPE[operation_type])
             render.DisplayMapperComponentRequestBus(
@@ -207,6 +211,7 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
             general.idle_wait_frames(3)
             set_type = render.DisplayMapperComponentRequestBus(bus.Broadcast, "GetDisplayMapperOperationType")
             Report.info(f"DiplayMapperOperationType: {set_type}")
+            Report.result(Tests.display_mapper_type, set_type == DISPLAY_MAPPER_OPERATION_TYPE[operation_type])
 
             # 7. Set Enable LDR color grading LUT property True
             display_mapper_component.set_component_property_value(
@@ -216,14 +221,15 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Enable LDR color grading LUT')) is True)
 
-
-            # 8. Set Override Defaults to False
+            # 8. Toggle Override Defaults
+            # Set Override Defaults to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Override Defaults'), False)
             Report.result(
                 Tests.override_defaults,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Override Defaults')) is False)
+					
             # Set Override Defaults to True
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Override Defaults'), True)
@@ -232,13 +238,15 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Override Defaults')) is True)
 
-            # 9. Set Alter Surround to True
+            # 9. Toggle Alter Surround
+            # Set Alter Surround to True
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter Surround'), True)
             Report.result(
                 Tests.alter_surround,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter Surround')) is True)
+					
             # Set Alter Surround to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter Surround'), False)
@@ -247,13 +255,15 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter Surround')) is False)
 
-            # 10. Set Alter Desaturation to True
+            # 10. Toggle Alter Desaturation
+            # Set Alter Desaturation to True
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter Desaturation'), True)
             Report.result(
                 Tests.alter_desaturation,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter Desaturation')) is True)
+					
             # Set Alter Desaturation to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter Desaturation'), False)
@@ -262,13 +272,15 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter Desaturation')) is False)
 
-            # 11. Set 'Alter CAT D60 to D65' to True
+            # 11. Toggle 'Alter CAT D60 to D65'
+            # Set 'Alter CAT D60 to D65' to True
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter CAT D60 to D65'), True)
             Report.result(
                 Tests.alter_cat,
                 display_mapper_component.get_component_property_value(
                     AtomComponentProperties.display_mapper('Alter CAT D60 to D65')) is True)
+					
             # Set 'Alter CAT D60 to D65' to False
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Alter CAT D60 to D65'), False)
@@ -279,86 +291,106 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
 
             general.idle_wait_frames(1)
 
-            # 12. 'Cinema Limit (black)' max value which is dynamic based on Cinema Limit (white) then min value
+            # 12. Set 'Cinema Limit (black)' max value which is dynamic based on Cinema Limit (white) then min value
+            # set max value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (black)'), value=48.0)
             Report.result(Tests.black_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (black)')), 48.0, TOLERANCE))
-            # 'Cinema Limit (black)' min value
+				
+            # set min value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (black)'), value=0.02)
-            Report.info(display_mapper_component.get_component_property_value(
-                AtomComponentProperties.display_mapper('Cinema Limit (black)')))
             Report.result(Tests.black_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (black)')), 0.02, TOLERANCE))
 
-            # 13. Set 'Cinema Limit (white)' maximum value then minimum, and finally back to default
+            # 13. Set 'Cinema Limit (white)' maximum value then min, and finally back to default
+            # set max value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=4000.0)
             Report.result(Tests.white_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)')), 4000.0, TOLERANCE))
-            # Set minimum value which is dynamic based on Cinema Limit (black)
+				
+            # Set min value which is dynamic based on Cinema Limit (black)
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=0.02)
-            Report.info(display_mapper_component.get_component_property_value(
-                AtomComponentProperties.display_mapper('Cinema Limit (white)')))
             Report.result(Tests.white_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)')), 0.02, TOLERANCE))
-            # Reset this to the default 48
+				
+            # Reset this to the default 48 so following cycles don't impact Cinema Limit (Black)
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Cinema Limit (white)'), value=48.0)
 
-            # 14. 'Min Point (luminance)' set high and low value
+            # 14. Set 'Min Point (luminance)' to high and low value
+            # set high value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)'), value=4.8)
             Report.info(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)')))
             Report.result(Tests.luminance_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)')), 4.8, TOLERANCE))
+				
+            # set low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)'), value=0.002)
             Report.result(Tests.luminance_level_min, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Min Point (luminance)')), 0.002, TOLERANCE))
 
-            # 15. 'Mid Point (luminance)' set high and low value then set default
+            # 15. Set 'Mid Point (luminance)' to high and low value then set default
+            # set high value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=1005.0)
             Report.result(Tests.luminance_level_mid, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)')), 1005.0, TOLERANCE))
+				
+            # set low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=0.002)
             Report.result(Tests.luminance_level_mid, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)')), 0.002, TOLERANCE))
+				
+            # restore the default since as this impacts the range of 'Min Point (luminance)'
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Mid Point (luminance)'), value=4.8)
 
-            # 16. 'Max Point (luminance)' set high and low value then set default
+            # 16. Set 'Max Point (luminance)' to high and low value then set default
+            # set a high value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)'), value=4000.0)
             Report.result(Tests.luminance_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)')), 4000.0, TOLERANCE))
+				
+            # set a low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)'), value=0.002)
             Report.result(Tests.luminance_level_max, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)')), 0.002, TOLERANCE))
+				
+            # restore the default since this impacts the range of 'Mid Point (luminance)'
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Max Point (luminance)'), value=1005.7191162)
 
-            # 17. 'Surround Gamma' set high and low value
+            # 17. Set 'Surround Gamma' to high and low value
+            # set a high value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Surround Gamma'), value=1.2)
             Report.result(Tests.surround_gamma, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Surround Gamma')), 1.2, TOLERANCE))
+				
+            # set a low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Surround Gamma'), value=0.6)
             Report.result(Tests.surround_gamma, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Surround Gamma')), 0.6, TOLERANCE))
 
-            # 18. 'Gamma' set high and low value
+            # 18. Set 'Gamma' to high and low value
+            # set a high value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Gamma'), value=4.0)
             Report.result(Tests.gamma, Math_IsClose(display_mapper_component.get_component_property_value(
                 AtomComponentProperties.display_mapper('Gamma')), 4.0, TOLERANCE))
+				
+            # set a low value
             display_mapper_component.set_component_property_value(
                 AtomComponentProperties.display_mapper('Gamma'), value=0.2)
             Report.result(Tests.gamma, Math_IsClose(display_mapper_component.get_component_property_value(
@@ -379,6 +411,7 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
         for preset in DISPLAY_MAPPER_PRESET.keys():
             # 20. Select and load each preset
             # Preset Selection cannot be set or loaded currently; as a workaround we are calling an ebus to load preset
+            # A fix is in progress
             # display_mapper_component.set_component_property_value(
             #     AtomComponentProperties.display_mapper('Preset Selection'), DISPLAY_MAPPER_PRESET[preset])
             render.DisplayMapperComponentRequestBus(bus.Broadcast, "LoadPreset", DISPLAY_MAPPER_PRESET[preset])


### PR DESCRIPTION
Display Mapper LUT access updated to a valid LUT
P1 tests added to both game and level component versions of Display Mapper

currently it is not possible to set type or load a preset, but work-arounds have been used in these tests.

.\python\python.cmd -m pytest --build-directory atom_dev/bin/profile  .\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main.py
================================================= test session starts
platform win32 -- Python 3.7.12, pytest-5.3.2, py-1.11.0, pluggy-0.13.1
rootdir: D:\workspace\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 29 items

AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main.py ..............................[100%]

================================================== warnings summary
tools\lytesttools\ly_test_tools\o3de\editor_test.py:333
  d:\workspace\o3de\tools\lytesttools\ly_test_tools\o3de\editor_test.py:333: PytestCollectionWarning: cannot collect test class 'TestData' because it has a __init__ constructor (from: AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py::TestAutomation)
    class TestData:

AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py::TestMaterialEditorBasicTests::test_MaterialEditorBasicTests[windows-MaterialEditor-windows_generic-AutomatedTesting]
  d:\workspace\o3de\tools\lytesttools\ly_test_tools\_internal\pytest_plugin\test_tools_fixtures.py:298: DeprecationWarning: This method is deprecated and will be removed on 3/31/22. Please use another helper method instead.
    return ly_test_tools.launchers.launcher_helper.create_generic_launcher(workspace, launcher_platform, exe_file_name)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===================================== 30 passed, 2 warnings in 121.95s (0:02:01)

Signed-off-by: Scott Murray <scottmur@amazon.com>