### PR TITLE
Fix runtime shape drawing in Editor.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorVisibleEntityDataCache.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorVisibleEntityDataCache.cpp
@@ -117,10 +117,30 @@ namespace AzToolsFramework
     static EntityData EntityDataFromEntityId(const AZ::EntityId entityId)
     {
         bool visible = false;
-        EditorEntityInfoRequestBus::EventResult(visible, entityId, &EditorEntityInfoRequestBus::Events::IsVisible);
-
         bool locked = false;
-        EditorEntityInfoRequestBus::EventResult(locked, entityId, &EditorEntityInfoRequestBus::Events::IsLocked);
+        bool iconHidden = false;
+
+        // Check to see if the given entity is an Editor entity or a Runtime entity.
+        bool isEditorEntity = false;
+        AzToolsFramework::EditorEntityContextRequestBus::BroadcastResult(
+            isEditorEntity, &AzToolsFramework::EditorEntityContextRequests::IsEditorEntity, entityId);
+
+        if (isEditorEntity)
+        {
+            EditorEntityInfoRequestBus::EventResult(visible, entityId, &EditorEntityInfoRequestBus::Events::IsVisible);
+            EditorEntityInfoRequestBus::EventResult(locked, entityId, &EditorEntityInfoRequestBus::Events::IsLocked);
+            EditorEntityIconComponentRequestBus::EventResult(
+                iconHidden, entityId, &EditorEntityIconComponentRequests::IsEntityIconHiddenInViewport);
+        }
+        else
+        {
+            // If this is a runtime entity, default visible / locked / iconHidden to true. This will cause the entity to be displayed
+            // but not selectable assuming it is listening to the debug display bus.
+
+            visible = true;
+            locked = true;
+            iconHidden = true;
+        }
 
         bool inFocus = false;
         if (auto focusModeInterface = AZ::Interface<FocusModeInterface>::Get())
@@ -133,10 +153,6 @@ namespace AzToolsFramework
         {
             descendantOfClosedContainer = containerEntityInterface->IsUnderClosedContainerEntity(entityId);
         }
-
-        bool iconHidden = false;
-        EditorEntityIconComponentRequestBus::EventResult(
-            iconHidden, entityId, &EditorEntityIconComponentRequests::IsEntityIconHiddenInViewport);
 
         AZ::Transform worldFromLocal = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(worldFromLocal, entityId, &AZ::TransformBus::Events::GetWorldTM);


### PR DESCRIPTION
If runtime shape components with debug drawing are spawned in the Editor (for example thru the dynamic vegetation system), they weren't previously being drawn. This was due to the fact that debug drawing in the Editor outside of game mode in controlled through Editor entity visibility, which queries the EditorEntityInfo to see if the entity is visible. Runtime entities don't have EditorEntityInfo, so they were invisible by default. This change makes them visible but not selectable.

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>