### PR TITLE
Fixed nesting of Settings for the AssetProcessor in Templates

### DIFF
--- a/Templates/AssetGem/Template/Registry/assetprocessor_settings.setreg
+++ b/Templates/AssetGem/Template/Registry/assetprocessor_settings.setreg
@@ -1,15 +1,17 @@
 {
     "Amazon": {
         "AssetProcessor": {
-            "ScanFolder ${Name}/Assets": {
-                "watch": "@GEMROOT:${Name}@/Assets",
-                "recursive": 1,
-                "order": 101
-            },
-            "ScanFolder ${Name}/Registry": {
-                "watch": "@GEMROOT:${Name}@/Registry",
-                "recursive": 1,
-                "order": 102
+            "Settings": {
+                "ScanFolder ${Name}/Assets": {
+                    "watch": "@GEMROOT:${Name}@/Assets",
+                    "recursive": 1,
+                    "order": 101
+                },
+                "ScanFolder ${Name}/Registry": {
+                    "watch": "@GEMROOT:${Name}@/Registry",
+                    "recursive": 1,
+                    "order": 102
+                }
             }
         }
     }

--- a/Templates/CppToolGem/Template/Registry/assetprocessor_settings.setreg
+++ b/Templates/CppToolGem/Template/Registry/assetprocessor_settings.setreg
@@ -1,15 +1,17 @@
 {
     "Amazon": {
         "AssetProcessor": {
-            "ScanFolder ${Name}/Assets": {
-                "watch": "@GEMROOT:${Name}@/Assets",
-                "recursive": 1,
-                "order": 101
-            },
-            "ScanFolder ${Name}/Registry": {
-                "watch": "@GEMROOT:${Name}@/Registry",
-                "recursive": 1,
-                "order": 102
+            "Settings": {
+                "ScanFolder ${Name}/Assets": {
+                    "watch": "@GEMROOT:${Name}@/Assets",
+                    "recursive": 1,
+                    "order": 101
+                },
+                "ScanFolder ${Name}/Registry": {
+                    "watch": "@GEMROOT:${Name}@/Registry",
+                    "recursive": 1,
+                    "order": 102
+                }
             }
         }
     }

--- a/Templates/DefaultGem/Template/Registry/assetprocessor_settings.setreg
+++ b/Templates/DefaultGem/Template/Registry/assetprocessor_settings.setreg
@@ -1,15 +1,17 @@
 {
     "Amazon": {
         "AssetProcessor": {
-            "ScanFolder ${Name}/Assets": {
-                "watch": "@GEMROOT:${Name}@/Assets",
-                "recursive": 1,
-                "order": 101
-            },
-            "ScanFolder ${Name}/Registry": {
-                "watch": "@GEMROOT:${Name}@/Registry",
-                "recursive": 1,
-                "order": 102
+            "Settings": {
+                "ScanFolder ${Name}/Assets": {
+                    "watch": "@GEMROOT:${Name}@/Assets",
+                    "recursive": 1,
+                    "order": 101
+                },
+                "ScanFolder ${Name}/Registry": {
+                    "watch": "@GEMROOT:${Name}@/Registry",
+                    "recursive": 1,
+                    "order": 102
+                }
             }
         }
     }

--- a/Templates/DefaultProject/Template/Gem/Registry/assetprocessor_settings.setreg
+++ b/Templates/DefaultProject/Template/Gem/Registry/assetprocessor_settings.setreg
@@ -1,15 +1,17 @@
 {
     "Amazon": {
         "AssetProcessor": {
-            "ScanFolder ${Name}/Assets": {
-                "watch": "@GEMROOT:${Name}@/Assets",
-                "recursive": 1,
-                "order": 101
-            },
-            "ScanFolder ${Name}/Registry": {
-                "watch": "@GEMROOT:${Name}@/Registry",
-                "recursive": 1,
-                "order": 102
+            "Settings": {
+                "ScanFolder ${Name}/Assets": {
+                    "watch": "@GEMROOT:${Name}@/Assets",
+                    "recursive": 1,
+                    "order": 101
+                },
+                "ScanFolder ${Name}/Registry": {
+                    "watch": "@GEMROOT:${Name}@/Registry",
+                    "recursive": 1,
+                    "order": 102
+                }
             }
         }
     }

--- a/Templates/DefaultProject/Template/Registry/assetprocessor_settings.setreg
+++ b/Templates/DefaultProject/Template/Registry/assetprocessor_settings.setreg
@@ -1,20 +1,22 @@
 {
     "Amazon": {
         "AssetProcessor": {
-            "ScanFolder Project/ShaderLib": {
-                "watch": "@PROJECTROOT@/ShaderLib",
-                "recursive": 1,
-                "order": 1
-            },
-            "ScanFolder Project/Shaders": {
-                "watch": "@PROJECTROOT@/Shaders",
-                "recurisve": 1,
-                "order": 2
-            },
-            "ScanFolder Project/Registry": {
-                "watch": "@PROJECTROOT@/Registry",
-                "recursive": 1,
-                "order": 3
+            "Settings": {
+                "ScanFolder Project/ShaderLib": {
+                    "watch": "@PROJECTROOT@/ShaderLib",
+                    "recursive": 1,
+                    "order": 1
+                },
+                "ScanFolder Project/Shaders": {
+                    "watch": "@PROJECTROOT@/Shaders",
+                    "recurisve": 1,
+                    "order": 2
+                },
+                "ScanFolder Project/Registry": {
+                    "watch": "@PROJECTROOT@/Registry",
+                    "recursive": 1,
+                    "order": 3
+                }
             }
         }
     }

--- a/Templates/MinimalProject/Template/Gem/Registry/assetprocessor_settings.setreg
+++ b/Templates/MinimalProject/Template/Gem/Registry/assetprocessor_settings.setreg
@@ -1,20 +1,17 @@
 {
     "Amazon": {
         "AssetProcessor": {
-            "ScanFolder Project/ShaderLib": {
-                "watch": "@PROJECTROOT@/ShaderLib",
-                "recursive": 1,
-                "order": 1
-            },
-            "ScanFolder Project/Shaders": {
-                "watch": "@PROJECTROOT@/Shaders",
-                "recurisve": 1,
-                "order": 2
-            },
-            "ScanFolder Project/Registry": {
-                "watch": "@PROJECTROOT@/Registry",
-                "recursive": 1,
-                "order": 3
+            "Settings": {
+                "ScanFolder ${Name}/Assets": {
+                    "watch": "@GEMROOT:${Name}@/Assets",
+                    "recursive": 1,
+                    "order": 101
+                },
+                "ScanFolder ${Name}/Registry": {
+                    "watch": "@GEMROOT:${Name}@/Registry",
+                    "recursive": 1,
+                    "order": 102
+                }
             }
         }
     }

--- a/Templates/MinimalProject/Template/Registry/assetprocessor_settings.setreg
+++ b/Templates/MinimalProject/Template/Registry/assetprocessor_settings.setreg
@@ -1,20 +1,22 @@
 {
     "Amazon": {
         "AssetProcessor": {
-            "ScanFolder Project/ShaderLib": {
-                "watch": "@PROJECTROOT@/ShaderLib",
-                "recursive": 1,
-                "order": 1
-            },
-            "ScanFolder Project/Shaders": {
-                "watch": "@PROJECTROOT@/Shaders",
-                "recurisve": 1,
-                "order": 2
-            },
-            "ScanFolder Project/Registry": {
-                "watch": "@PROJECTROOT@/Registry",
-                "recursive": 1,
-                "order": 3
+            "Settings": {
+                "ScanFolder Project/ShaderLib": {
+                    "watch": "@PROJECTROOT@/ShaderLib",
+                    "recursive": 1,
+                    "order": 1
+                },
+                "ScanFolder Project/Shaders": {
+                    "watch": "@PROJECTROOT@/Shaders",
+                    "recurisve": 1,
+                    "order": 2
+                },
+                "ScanFolder Project/Registry": {
+                    "watch": "@PROJECTROOT@/Registry",
+                    "recursive": 1,
+                    "order": 3
+                }
             }
         }
     }

--- a/Templates/PythonToolGem/Template/Registry/assetprocessor_settings.setreg
+++ b/Templates/PythonToolGem/Template/Registry/assetprocessor_settings.setreg
@@ -1,15 +1,17 @@
 {
     "Amazon": {
         "AssetProcessor": {
-            "ScanFolder ${Name}/Assets": {
-                "watch": "@GEMROOT:${Name}@/Assets",
-                "recursive": 1,
-                "order": 101
-            },
-            "ScanFolder ${Name}/Registry": {
-                "watch": "@GEMROOT:${Name}@/Registry",
-                "recursive": 1,
-                "order": 102
+            "Settings": {
+                "ScanFolder ${Name}/Assets": {
+                    "watch": "@GEMROOT:${Name}@/Assets",
+                    "recursive": 1,
+                    "order": 101
+                },
+                "ScanFolder ${Name}/Registry": {
+                    "watch": "@GEMROOT:${Name}@/Registry",
+                    "recursive": 1,
+                    "order": 102
+                }
             }
         }
     }


### PR DESCRIPTION
The templates had the ScanFolder entries under the incorrect key of
"/Amazon/AssetProcessor" instead of "/Amazon/AssetProcessor/Settings".

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>