### PR TITLE
Fixes linking issues with game and server launchers in release monolithic mode

### DIFF
--- a/Code/Legacy/CryCommon/ISystem.h
+++ b/Code/Legacy/CryCommon/ISystem.h
@@ -1053,7 +1053,10 @@ void* GetModuleShutdownISystemSymbol();
 //   Interface of the DLL.
 extern "C"
 {
-    CRYSYSTEM_API ISystem* CreateSystemInterface(const SSystemInitParams& initParams);
+#if !defined(AZ_MONOLITHIC_BUILD)
+    CRYSYSTEM_API
+#endif
+    ISystem* CreateSystemInterface(const SSystemInitParams& initParams);
 }
 
 // Description:

--- a/Code/Legacy/CrySystem/DllMain.cpp
+++ b/Code/Legacy/CrySystem/DllMain.cpp
@@ -63,7 +63,10 @@ AZ_POP_DISABLE_WARNING
 
 extern "C"
 {
-CRYSYSTEM_API ISystem* CreateSystemInterface(const SSystemInitParams& startupParams)
+#if !defined(AZ_MONOLITHIC_BUILD)
+CRYSYSTEM_API
+#endif
+ISystem* CreateSystemInterface(const SSystemInitParams& startupParams)
 {
     CSystem* pSystem = NULL;
 


### PR DESCRIPTION
Game and server launches failed to compile in release mode with -DLY_MONOLITHIC_GAME=ON

#Fixes #8308

```
Launcher.Static.lib(unity_0_cxx.obj) : error LNK2019: unresolved external symbol __imp_CreateSystemInterface referenced in function "enum O3DELauncher::ReturnCode __cdecl O3DELauncher::Run(struct O3DELauncher::PlatformMainInfo const &)" (?Run@O3DELauncher@@YA?AW4ReturnCode@1@AEBUPlatformMainInfo@1@@Z)
```

Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>