### PR TITLE
Add Atom memory CSV capture save and load

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -262,9 +262,13 @@ namespace AZ
         public:
             // Draw the overall GPU memory profiling window.
             void DrawGpuMemoryWindow(bool& draw);
+            ImGuiGpuMemoryView();
             ~ImGuiGpuMemoryView();
 
         private:
+            // Collate data from RHI and update memory view tables and treemap
+            void PerformCapture();
+
             // Draw the heap usage pie chart
             void DrawPieChart(const AZ::RHI::MemoryStatistics::Heap& heap);
 
@@ -279,6 +283,10 @@ namespace AZ
             // Sort the table according to the appropriate column.
             void SortPoolTable(ImGuiTableSortSpecs* sortSpecs);
             void SortResourceTable(ImGuiTableSortSpecs* sortSpecs);
+
+            // Save and load data to and from CSV files
+            void SaveToCSV();
+            void LoadFromCSV(const AZStd::string& fileName);
 
             struct PoolTableRow
             {
@@ -316,6 +324,12 @@ namespace AZ
             Profiler::ImGuiTreemap* m_deviceTreemap = nullptr;
             bool m_showHostTreemap = false;
             bool m_showDeviceTreemap = false;
+
+            AZStd::string m_memoryCapturePath;
+            AZStd::string m_loadedCapture;
+            char m_captureInput[AZ::IO::MaxPathLength] = { '\0' };
+            size_t m_captureSelection = 0;
+            bool m_showingLoadedCapture = false;
         };
 
         class ImGuiGpuProfiler

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -326,10 +326,10 @@ namespace AZ
             bool m_showDeviceTreemap = false;
 
             AZStd::string m_memoryCapturePath;
-            AZStd::string m_loadedCapture;
+            AZStd::string m_loadedCapturePath;
+            AZStd::string m_captureMessage;
             char m_captureInput[AZ::IO::MaxPathLength] = { '\0' };
             size_t m_captureSelection = 0;
-            bool m_showingLoadedCapture = false;
         };
 
         class ImGuiGpuProfiler

--- a/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
+++ b/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
@@ -1521,7 +1521,7 @@ namespace AZ
 
                 if (!m_captureMessage.empty())
                 {
-                    ImGui::Text(m_captureMessage.c_str());
+                    ImGui::Text("%s", m_captureMessage.c_str());
                 }
 
                 if (m_hostTreemap)
@@ -1752,8 +1752,10 @@ namespace AZ
 
         // C4702: Unreachable code
         // MSVC 2022 believes that `return true;` below is unreacahable, which is not true.
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4702)
+#endif
         template <typename T>
         bool parseCSVField(const AZStd::string& field, T& out)
         {
@@ -1790,7 +1792,9 @@ namespace AZ
 
             return true;
         }
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
         void ImGuiGpuMemoryView::LoadFromCSV(const AZStd::string& fileName)
         {

--- a/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
+++ b/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
@@ -16,10 +16,16 @@
 #include <Atom/RPI.Public/Scene.h>
 
 #include <Profiler/ImGuiTreemap.h>
+#include <imgui/imgui_internal.h>
 
+#include <AzCore/IO/SystemFile.h>
+#include <AzCore/Utils/Utils.h>
 #include <AzCore/std/sort.h>
 
+#include <cstdio>
+#include <filesystem>
 #include <inttypes.h>
+#include <sstream>
 
 namespace AZ
 {
@@ -1067,6 +1073,19 @@ namespace AZ
 
         // --- ImGuiGpuMemoryView ---
 
+        ImGuiGpuMemoryView::ImGuiGpuMemoryView()
+        {
+            std::filesystem::path path = AZ::Utils::GetO3deLogsDirectory().c_str();
+            path /= "MemoryCaptures";
+
+            if (!std::filesystem::exists(path))
+            {
+                std::filesystem::create_directory(path);
+            }
+
+            m_memoryCapturePath = path.string().c_str();
+        }
+
         ImGuiGpuMemoryView::~ImGuiGpuMemoryView()
         {
             if (m_hostTreemap)
@@ -1349,6 +1368,23 @@ namespace AZ
             ImGui::EndChild();
         }
 
+        void ImGuiGpuMemoryView::PerformCapture()
+        {
+            // Collect and save new GPU memory usage data
+            auto* rhiSystem = AZ::RHI::RHISystemInterface::Get();
+            const auto* memoryStatistics = rhiSystem->GetMemoryStatistics();
+            if (memoryStatistics)
+            {
+                m_savedPools = memoryStatistics->m_pools;
+                m_savedHeaps = memoryStatistics->m_heaps;
+
+                // Collect the data into TableRows, ignoring depending on flags
+                UpdateTableRows();
+
+                UpdateTreemaps();
+            }
+        }
+
         void ImGuiGpuMemoryView::DrawGpuMemoryWindow(bool& draw)
         {
             // Enable GPU memory instrumentation while the window is open. Called every draw frame, but just a bitwise operation so overhead should be low.
@@ -1366,18 +1402,131 @@ namespace AZ
             {
                 if (ImGui::Button("Capture"))
                 {
-                    // Collect and save new GPU memory usage data
-                    const auto* memoryStatistics = rhiSystem->GetMemoryStatistics();
-                    if (memoryStatistics) 
+                    m_showingLoadedCapture = false;
+                    PerformCapture();
+                }
+
+                ImGui::SameLine();
+
+                if (ImGui::Button("Save to CSV"))
+                {
+                    if (m_savedPools.empty())
                     {
-                        m_savedPools = memoryStatistics->m_pools;
-                        m_savedHeaps = memoryStatistics->m_heaps;
-
-                        // Collect the data into TableRows, ignoring depending on flags 
-                        UpdateTableRows();
-
-                        UpdateTreemaps();
+                        PerformCapture();
                     }
+
+                    SaveToCSV();
+                }
+                ImGui::SameLine();
+                constexpr static const char* LoadMemoryCaptureTitle = "Select or input memory capture csv file";
+                if (ImGui::Button("Load from CSV"))
+                {
+                    m_captureInput[0] = '\0';
+                    m_captureSelection = 0;
+                    ImGui::OpenPopup(LoadMemoryCaptureTitle);
+                }
+
+                // Always center this window when appearing
+                ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+                ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+
+                if (ImGui::BeginPopupModal(LoadMemoryCaptureTitle, nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+                {
+                    struct CaptureInfo
+                    {
+                        AZStd::string path;
+                        std::filesystem::file_time_type time;
+                    };
+                    AZStd::vector<CaptureInfo> captures;
+
+                    // Enumerate files in the capture folder
+                    for (const std::filesystem::directory_entry& entry : std::filesystem::directory_iterator{ m_memoryCapturePath.c_str() })
+                    {
+                        if (entry.is_regular_file())
+                        {
+                            if (entry.path().extension() == ".csv")
+                            {
+                                captures.push_back(CaptureInfo{ entry.path().string().c_str(), entry.last_write_time() });
+                            }
+                        }
+                    }
+
+                    if (captures.empty())
+                    {
+                        ImGui::Text("No captures found in %s", m_memoryCapturePath.c_str());
+                    }
+                    else
+                    {
+                        ImGui::Text("Displaying %zu captures found in %s", captures.size(), m_memoryCapturePath.c_str());
+
+                        // Sort captures in reverse-chronological order
+                        AZStd::sort(
+                            captures.begin(), captures.end(),
+                            [](const CaptureInfo& lhs, const CaptureInfo& rhs)
+                            {
+                                return rhs.time < lhs.time;
+                            });
+
+                        // Display 10 entries in a scrolling list box
+                        if (ImGui::BeginListBox(
+                                "Memory Captures",
+                                ImVec2{ ImGui::GetMainViewport()->Size.x * 0.8f, 10 * ImGui::GetTextLineHeightWithSpacing() }))
+                        {
+                            for (size_t i = 0; i != captures.size(); ++i)
+                            {
+                                bool selected = i == m_captureSelection;
+                                if (ImGui::Selectable(captures[i].path.c_str(), selected))
+                                {
+                                    m_captureSelection = i;
+                                }
+
+                                if (selected)
+                                {
+                                    ImGui::SetItemDefaultFocus();
+                                }
+                            }
+                            ImGui::EndListBox();
+                        }
+
+                        if (ImGui::Button("Open"))
+                        {
+                            LoadFromCSV(captures[m_captureSelection].path);
+                            ImGui::CloseCurrentPopup();
+                        }
+                    }
+
+                    // In addition to the directory selection above, provide a means to input a path directly
+                    ImGui::InputText("File Path", m_captureInput, AZ::IO::MaxPathLength);
+                    AZStd::string manualInput{ m_captureInput };
+                    if (manualInput.empty())
+                    {
+                        ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.6f);
+                        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+                    }
+
+                    if (ImGui::Button("Open File"))
+                    {
+                        LoadFromCSV(manualInput);
+                        ImGui::CloseCurrentPopup();
+                    }
+
+                    if (manualInput.empty())
+                    {
+                        ImGui::PopItemFlag();
+                        ImGui::PopStyleVar();
+                    }
+
+                    if (ImGui::Button("Cancel"))
+                    {
+                        ImGui::CloseCurrentPopup();
+                    }
+
+                    ImGui::EndPopup();
+                }
+
+                if (m_showingLoadedCapture)
+                {
+                    ImGui::Text("Viewing data loaded from %s", m_loadedCapture.c_str());
                 }
 
                 if (m_hostTreemap)
@@ -1533,6 +1682,242 @@ namespace AZ
                 m_hostTreemap->SetRoots(AZStd::move(hostNodes));
                 m_deviceTreemap->SetRoots(AZStd::move(deviceNodes));
             }
+        }
+
+        static constexpr const char* MemoryCSVHeader =
+            "\"Pool Name\", \"Memory Type (0 == Host : 1 == Device)\", \"Allocation Name\", \"Allocation Type (0 == Buffer : "
+            "1 == Texture)\", \"Byte Size\", \"Flags\"\n";
+        static constexpr const char* MemoryCSVRowFormat = "%s, %i, %s, %i, %" PRIu64 ", %" PRIu32 "\n";
+        static constexpr const int MemoryCSVColumnCount = 6;
+
+        void ImGuiGpuMemoryView::SaveToCSV()
+        {
+            time_t ltime;
+            time(&ltime);
+            tm today;
+#if AZ_TRAIT_USE_SECURE_CRT_FUNCTIONS
+            localtime_s(&today, &ltime);
+#else
+            today = *localtime(&ltime);
+#endif
+            char sTemp[128];
+            strftime(sTemp, sizeof(sTemp), "%Y%m%d.%H%M%S", &today);
+
+            AZStd::string filename = AZStd::string::format("%s/AtomMemory_%s.csv", m_memoryCapturePath.c_str(), sTemp);
+
+            AZ::IO::SystemFile fileOut;
+            // We're ok overwriting a file here because the File Save dialog prompts for overwriting already
+            if (!fileOut.Open(filename.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY))
+            {
+                AZ_Error("ImGuiGpuMemoryView", false, "Failed to open file %s for writing", filename.c_str());
+                return;
+            }
+
+            AZStd::string line = MemoryCSVHeader;
+
+            fileOut.Write(line.data(), line.size());
+
+            // Iterate through each resource pool and save individual allocations as separate rows in the CSV file
+            for (const auto& pool : m_savedPools)
+            {
+                int memoryType;
+                if (pool.m_memoryUsage.GetHeapMemoryUsage(RHI::HeapMemoryLevel::Host).m_residentInBytes > 0)
+                {
+                    memoryType = 0;
+                }
+                else if (pool.m_memoryUsage.GetHeapMemoryUsage(RHI::HeapMemoryLevel::Device).m_residentInBytes > 0)
+                {
+                    memoryType = 1;
+                }
+                else
+                {
+                    continue;
+                }
+
+                for (const auto& buffer : pool.m_buffers)
+                {
+                    line = AZStd::string::format(
+                        MemoryCSVRowFormat, pool.m_name.GetCStr(), memoryType, buffer.m_name.GetCStr(), 0, buffer.m_sizeInBytes,
+                        static_cast<uint32_t>(buffer.m_bindFlags));
+                    fileOut.Write(line.data(), line.size());
+                }
+
+                for (const auto& image : pool.m_images)
+                {
+                    line = AZStd::string::format(
+                        MemoryCSVRowFormat, pool.m_name.GetCStr(), memoryType, image.m_name.GetCStr(), 1, image.m_sizeInBytes,
+                        static_cast<uint32_t>(image.m_bindFlags));
+                    fileOut.Write(line.data(), line.size());
+                }
+            }
+        }
+
+        template <typename T>
+        bool parseCSVField(std::istringstream& stream, std::string& field, T& out, char delimiter = ',')
+        {
+            if (std::getline(stream, field, delimiter))
+            {
+                if constexpr (AZStd::is_same_v<T, int>)
+                {
+                    if (sscanf_s(field.c_str(), "%i", &out) != 1)
+                    {
+                        return false;
+                    }
+                }
+                else if constexpr (AZStd::is_same_v<T, uint32_t>)
+                {
+                    if (sscanf_s(field.c_str(), "%" PRIu32, &out) != 1)
+                    {
+                        return false;
+                    }
+                }
+                else if constexpr (AZStd::is_same_v<T, uint64_t>)
+                {
+                    if (sscanf_s(field.c_str(), "%" PRIu64, &out) != 1)
+                    {
+                        return false;
+                    }
+                }
+                else if constexpr (AZStd::is_same_v<T, AZ::Name>)
+                {
+                    out = AZ::Name{ field.c_str() };
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        void ImGuiGpuMemoryView::LoadFromCSV(const AZStd::string& fileName)
+        {
+            AZ::IO::SystemFile fileIn;
+
+            if (!fileIn.Open(fileName.c_str(), AZ::IO::SystemFile::SF_OPEN_READ_ONLY))
+            {
+                return;
+            }
+
+            std::string data;
+            data.resize(fileIn.Length());
+
+            fileIn.Read(fileIn.Length(), data.data());
+
+            std::istringstream lines{ data.c_str() };
+
+            std::string line;
+            if (!std::getline(lines, line))
+            {
+                AZ_Error("ImGuiGpuMemoryView", false, "Attempted to load memory data from %s but file was empty", fileName.c_str());
+                return;
+            }
+
+            if (line + '\n' != MemoryCSVHeader)
+            {
+                AZ_Error(
+                    "ImGuiGpuMemoryView", false, "Attempted to load memory data from %s but the CSV header (%s) did not match",
+                    fileName.c_str(), MemoryCSVHeader);
+                return;
+            }
+
+            m_showingLoadedCapture = true;
+            m_loadedCapture = fileName;
+            m_savedHeaps.clear();
+            m_savedHeaps.resize(2);
+            m_savedHeaps[0].m_name = AZ::Name{ "Host Heap" };
+            m_savedHeaps[0].m_heapMemoryType = RHI::HeapMemoryLevel::Host;
+            m_savedHeaps[1].m_name = AZ::Name{ "Device Heap" };
+            m_savedHeaps[1].m_heapMemoryType = RHI::HeapMemoryLevel::Device;
+
+            m_savedPools.clear();
+            AZStd::unordered_map<AZ::Name, AZ::RHI::MemoryStatistics::Pool> pools;
+
+            while (std::getline(lines, line))
+            {
+                std::istringstream lineStream{ line };
+                AZ::Name poolName;
+                int memoryType;
+                AZ::Name resourceName;
+                int resourceType;
+                uint64_t byteSize;
+                uint32_t bindFlags;
+
+                std::string field;
+
+                if (parseCSVField(lineStream, field, poolName) && parseCSVField(lineStream, field, memoryType) &&
+                    parseCSVField(lineStream, field, resourceName) && parseCSVField(lineStream, field, resourceType) &&
+                    parseCSVField(lineStream, field, byteSize) && parseCSVField(lineStream, field, bindFlags, '\n'))
+                {
+                    RHI::MemoryStatistics::Pool* pool;
+
+                    auto it = pools.find(poolName);
+                    if (it == pools.end())
+                    {
+                        pool = &pools.try_emplace(poolName).first->second;
+                        pool->m_name = AZStd::move(poolName);
+                    }
+                    else
+                    {
+                        pool = &it->second;
+                    }
+
+                    if (memoryType != 0 && memoryType != 1)
+                    {
+                        // Unknown memory type
+                        AZ_Error(
+                            "ImGuiGpuMemoryView", false,
+                            "Attempted to load memory data from %s but an unknown memory type was detected (indicating invalid file "
+                            "format)",
+                            fileName.c_str());
+                        return;
+                    }
+
+                    if (resourceType == 0 /* buffer */)
+                    {
+                        RHI::MemoryStatistics::Buffer buffer;
+                        buffer.m_name = AZStd::move(resourceName);
+                        buffer.m_bindFlags = static_cast<RHI::BufferBindFlags>(bindFlags);
+                        buffer.m_sizeInBytes = byteSize;
+                        pool->m_buffers.push_back(AZStd::move(buffer));
+                    }
+                    else if (resourceType == 1 /* image */)
+                    {
+                        RHI::MemoryStatistics::Image image;
+                        image.m_name = AZStd::move(resourceName);
+                        image.m_bindFlags = static_cast<RHI::ImageBindFlags>(bindFlags);
+                        image.m_sizeInBytes = byteSize;
+                        pool->m_images.push_back(AZStd::move(image));
+                    }
+
+                    pool->m_memoryUsage.m_memoryUsagePerLevel[memoryType].m_residentInBytes += byteSize;
+                    pool->m_memoryUsage.m_memoryUsagePerLevel[memoryType].m_reservedInBytes += byteSize;
+
+                    // NOTE: This information isn't strictly accurate because we're reconstructing data from a list of
+                    // allocations.
+                    m_savedHeaps[memoryType].m_memoryUsage.m_reservedInBytes += byteSize;
+                    m_savedHeaps[memoryType].m_memoryUsage.m_residentInBytes += byteSize;
+                }
+                else
+                {
+                    AZ_Error(
+                        "ImGuiGpuMemoryView", false,
+                        "Attempted to load memory data from %s but a parse error occurred (indicating invalid file "
+                        "format)",
+                        fileName.c_str());
+                    return;
+                }
+            }
+
+            for (auto& pool : pools)
+            {
+                m_savedPools.push_back(AZStd::move(pool.second));
+            }
+
+            UpdateTableRows();
+            UpdateTreemaps();
         }
 
         // --- ImGuiGpuProfiler ---

--- a/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
+++ b/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
@@ -1678,7 +1678,6 @@ namespace AZ
             "Pool Name, Memory Type (0 == Host : 1 == Device), Allocation Name, Allocation Type (0 == Buffer : "
             "1 == Texture), Byte Size, Flags\n";
         static constexpr const char* MemoryCSVRowFormat = "%s, %i, %s, %i, %" PRIu64 ", %" PRIu32 "\n";
-        static constexpr const int MemoryCSVColumnCount = 6;
 
         void ImGuiGpuMemoryView::SaveToCSV()
         {
@@ -1696,7 +1695,6 @@ namespace AZ
             AZStd::string filename = AZStd::string::format("%s/AtomMemory_%s.csv", m_memoryCapturePath.c_str(), sTemp);
 
             AZ::IO::SystemFile fileOut;
-            // We're ok overwriting a file here because the File Save dialog prompts for overwriting already
             if (!fileOut.Open(filename.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY))
             {
                 AZ_Error("ImGuiGpuMemoryView", false, "Failed to open file %s for writing", filename.c_str());


### PR DESCRIPTION
This commit provides an ImGUI-based interface to save allocation data to
file in the `.o3de/Logs/MemoryCaptures` path and load captures taken
previously.

## User Flow

The "GPU Memory Profiler" window has two new buttons: "Save to CSV" and "Load from CSV" as shown below:
![image](https://user-images.githubusercontent.com/87345238/158468381-d12b1eda-1c3b-428b-9ef3-e01b1dfc6d65.png)

Initially, if no captures are available, hitting the "Load from CSV" button will display the following dialog:
![image](https://user-images.githubusercontent.com/87345238/158468296-9b4947b4-2bfb-422c-9dd9-8f482b20ada2.png)

When hitting "Save to CSV" a capture will be taken unless an active capture already exists, in which case a timestamp marked file will be saved to `.o3d3/Logs/MemoryCaptures`. If memory captures exist in that folder, they will display in the selection dialog when "Load from CSV" is pressed as below:
![image](https://user-images.githubusercontent.com/87345238/158468858-6da44d7e-3383-4372-8a3d-272f99f10dea.png)

After selection of a CSV capture, data will be viewable as with a runtime capture, with an additional text message "Viewing data loaded from ..." as seen below:
![image](https://user-images.githubusercontent.com/87345238/158469045-761e64f7-80be-4802-be5f-aac023ff4ffc.png)


Signed-off-by: Jeremy Ong <jcong@amazon.com>