### PR TITLE
Remove redundant transmission parameters from LightingData

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedSurface_ForwardPass.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedSurface_ForwardPass.azsli
@@ -176,17 +176,6 @@ PbrLightingOutput ForwardPassPS_Common(VSOutput IN, bool isFrontFace, out float 
     lightingData.specularResponse = FresnelSchlickWithRoughness(lightingData.NdotV, surface.specularF0, surface.roughnessLinear);
     lightingData.diffuseResponse = 1.0 - lightingData.specularResponse;
 
-    // ------- Thin Object Light Transmission -------
-
-    // Shrink (absolute) offset towards the normal opposite direction to ensure correct shadow map projection
-    lightingData.shrinkFactor = surface.transmission.transmissionParams.x;
-
-    // Angle offset for subsurface scattering through thin objects
-    lightingData.transmissionNdLBias = surface.transmission.transmissionParams.y;
-
-    // Attenuation applied to hide artifacts due to low-res shadow maps
-    lightingData.distanceAttenuation = surface.transmission.transmissionParams.z;
-
     if(o_clearCoat_feature_enabled)
     {
         // Clear coat layer has fixed IOR = 1.5 and transparent => F0 = (1.5 - 1)^2 / (1.5 + 1)^2 = 0.04

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Skin.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Skin.azsl
@@ -342,17 +342,6 @@ PbrLightingOutput SkinPS_Common(VSOutput IN)
     lightingData.specularResponse = FresnelSchlickWithRoughness(lightingData.NdotV, surface.specularF0, surface.roughnessLinear);
     lightingData.diffuseResponse = 1.0 - lightingData.specularResponse;
 
-    // ------- Thin Object Light Transmission -------
-
-    // Shrink (absolute) offset towards the normal opposite direction to ensure correct shadow map projection
-    lightingData.shrinkFactor = surface.transmission.transmissionParams.x;
-
-    // Angle offset for subsurface scattering through thin objects
-    lightingData.transmissionNdLBias = surface.transmission.transmissionParams.y;
-
-    // Attenuation applied to hide artifacts due to low-res shadow maps 
-    lightingData.distanceAttenuation = surface.transmission.transmissionParams.z;
-
     // ------- Occlusion -------
     
     lightingData.diffuseAmbientOcclusion = GetOcclusionInput(MaterialSrg::m_diffuseOcclusionMap, MaterialSrg::m_sampler, IN.m_uv[MaterialSrg::m_diffuseOcclusionMapUvIndex], MaterialSrg::m_diffuseOcclusionFactor, o_diffuseOcclusion_useTexture);

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/BackLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/BackLighting.azsli
@@ -75,11 +75,14 @@ float3 GetBackLighting(Surface surface, LightingData lightingData, float3 lightI
                 }
 
                 // Irradiance arround surface point. 
-                // Albedo at front (surface point) is used to approximate irradiance at the back of the object (observation 4 in [Jimenez J. et al, 2010])
-                // Increase angle of influence to smooth transition regions
-                float3 E = surface.albedo * saturate(lightingData.transmissionNdLBias + dot(-surface.normal, dirToLight));
+                // Albedo at front (surface point) is used to approximate irradiance at the back of the 
+                // object (observation 4 in [Jimenez J. et al, 2010])
+                // Increase angle of influence to avoid dark transition regions
+                // (surface.transmission.transmissionParams.y <-- transmission NdL Bias)
+                float3 E = surface.albedo * saturate(surface.transmission.transmissionParams.y + dot(-surface.normal, dirToLight));
 
-                // Transmission distance modulated by hardcoded constant C and the thickness exposed parameter (in this case modulating the distance traversed by the light inside the object)
+                // Transmission distance modulated by hardcoded constant C and the thickness exposed parameter 
+                // (in this case modulating the distance traversed by the light inside the object)
                 const float C = 300.0f;
                 float s = transmissionDistance * C * surface.transmission.thickness;
                 
@@ -95,7 +98,8 @@ float3 GetBackLighting(Surface surface, LightingData lightingData, float3 lightI
 #endif
 
                 // Distance attenuation applied to hide artifacts due to low-res projected areas onto shadowmaps (might need some work in the future)
-                result /= max(1.0, attenuationDistance * attenuationDistance * lightingData.distanceAttenuation);
+                // (surface.transmission.transmissionParams.z <-- distance attenuation)
+                result /= max(1.0, attenuationDistance * attenuationDistance * surface.transmission.transmissionParams.z);
             }
             break;
     }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/BackLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/BackLighting.azsli
@@ -58,7 +58,7 @@ float3 GetBackLighting(Surface surface, LightingData lightingData, float3 lightI
             {
                 thickness = max(transmissionDistance, transmission.thickness);
                 float transmittance = pow( saturate( dot( lightingData.dirToCamera, -normalize( dirToLight + surface.normal * transmission.GetDistortion() ) ) ), transmission.GetPower() ) * transmission.GetScale();
-                float lamberAttenuation = exp(-thickness * surface.transmission.GetAttenuationCoefficient()) * saturate(1.0 - thickness);
+                float lamberAttenuation = exp(-thickness * transmission.GetAttenuationCoefficient()) * saturate(1.0 - thickness);
                 result = transmittance * lamberAttenuation * lightIntensity;
             }
             break;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/BackLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/BackLighting.azsli
@@ -44,7 +44,7 @@ float3 GetBackLighting(Surface surface, LightingData lightingData, float3 lightI
 #if ENABLE_TRANSMISSION
 
     float thickness = 0.0; 
-    float4 transmissionParams = surface.transmission.transmissionParams;
+    TransmissionSurfaceData transmission = surface.transmission;
 
     switch(o_transmission_mode)
     {
@@ -56,9 +56,9 @@ float3 GetBackLighting(Surface surface, LightingData lightingData, float3 lightI
             // https://colinbarrebrisebois.com/2011/03/07/gdc-2011-approximating-translucency-for-a-fast-cheap-and-convincing-subsurface-scattering-look/
 
             {
-                thickness = max(transmissionDistance, surface.transmission.thickness);
-                float transmittance = pow( saturate( dot( lightingData.dirToCamera, -normalize( dirToLight + surface.normal * transmissionParams.z ) ) ), transmissionParams.y ) * transmissionParams.w;
-                float lamberAttenuation = exp(-thickness * transmissionParams.x) * saturate(1.0 - thickness);
+                thickness = max(transmissionDistance, transmission.thickness);
+                float transmittance = pow( saturate( dot( lightingData.dirToCamera, -normalize( dirToLight + surface.normal * transmission.GetDistortion() ) ) ), transmission.GetPower() ) * transmission.GetScale();
+                float lamberAttenuation = exp(-thickness * surface.transmission.GetAttenuationCoefficient()) * saturate(1.0 - thickness);
                 result = transmittance * lamberAttenuation * lightIntensity;
             }
             break;
@@ -78,28 +78,26 @@ float3 GetBackLighting(Surface surface, LightingData lightingData, float3 lightI
                 // Albedo at front (surface point) is used to approximate irradiance at the back of the 
                 // object (observation 4 in [Jimenez J. et al, 2010])
                 // Increase angle of influence to avoid dark transition regions
-                // (surface.transmission.transmissionParams.y <-- transmission NdL Bias)
-                float3 E = surface.albedo * saturate(surface.transmission.transmissionParams.y + dot(-surface.normal, dirToLight));
+                float3 E = surface.albedo * saturate(transmission.GetTransmissionNdLBias() + dot(-surface.normal, dirToLight));
 
                 // Transmission distance modulated by hardcoded constant C and the thickness exposed parameter 
                 // (in this case modulating the distance traversed by the light inside the object)
                 const float C = 300.0f;
-                float s = transmissionDistance * C * surface.transmission.thickness;
+                float s = transmissionDistance * C * transmission.thickness;
                 
                 // Use scattering color to weight thin object transmission color
-                const float3 invScattering = rcp(max(surface.transmission.scatterDistance, float(0.00001)));
+                const float3 invScattering = rcp(max(transmission.scatterDistance, float(0.00001)));
                 
 #ifndef USE_HUMAN_SKIN_PROFILE
                 // Generic profile based on scatter color
-                result = TransmissionKernel(s, invScattering) * lightIntensity * E * transmissionParams.w;
+                result = TransmissionKernel(s, invScattering) * lightIntensity * E * transmission.GetScale();
 #else // USE_HUMAN_SKIN_PROFILE
                 // Profile specific to human skin
-                result = T(s) * lightIntensity * E * transmissionParams.w;
+                result = T(s) * lightIntensity * E * transmission.GetScale();
 #endif
 
                 // Distance attenuation applied to hide artifacts due to low-res projected areas onto shadowmaps (might need some work in the future)
-                // (surface.transmission.transmissionParams.z <-- distance attenuation)
-                result /= max(1.0, attenuationDistance * attenuationDistance * surface.transmission.transmissionParams.z);
+                result /= max(1.0, attenuationDistance * attenuationDistance * transmission.GetDistanceAttenuation());
             }
             break;
     }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/LightingData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/LightingData.azsli
@@ -29,15 +29,6 @@ class LightingData
     // Direction light shadow coordinates
     float3 shadowCoords[ViewSrg::MaxCascadeCount];
 
-    // (N . L) to accept below (N . L = 0) in scattering through thin objects
-    float transmissionNdLBias; 
-    
-    // Shrink (absolute) offset towards the normal opposite direction to ensure correct shadow map projection
-    float shrinkFactor;
-
-    // Attenuation applied to hide artifacts due to low-res shadow maps 
-    float distanceAttenuation;
-
     // Normalized direction from surface to camera
     float3 dirToCamera;
     

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
@@ -41,10 +41,9 @@ void ApplyDirectionalLights(Surface surface, inout LightingData lightingData)
         else if (o_transmission_mode == TransmissionMode::ThinObject) 
         {
             // Fetch and use shrinked positions for thin object transmission to ensure they fall onto the object when querying
-            // (surface.transmission.transmissionParams.x <-- shrink factor)
             DirectionalLightShadow::GetShadowCoords(
                 shadowIndex,
-                surface.position - surface.transmission.transmissionParams.x * surface.vertexNormal,
+                surface.position - surface.transmission.GetShrinkFactor() * surface.vertexNormal,
                 surface.normal,
                 lightingData.shadowCoords);
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
@@ -41,9 +41,10 @@ void ApplyDirectionalLights(Surface surface, inout LightingData lightingData)
         else if (o_transmission_mode == TransmissionMode::ThinObject) 
         {
             // Fetch and use shrinked positions for thin object transmission to ensure they fall onto the object when querying
+            // (surface.transmission.transmissionParams.x <-- shrink factor)
             DirectionalLightShadow::GetShadowCoords(
                 shadowIndex,
-                surface.position - lightingData.shrinkFactor * surface.vertexNormal,
+                surface.position - surface.transmission.transmissionParams.x * surface.vertexNormal,
                 surface.normal,
                 lightingData.shadowCoords);
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
@@ -100,8 +100,7 @@ void ApplyDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingDat
             }
             else if (o_transmission_mode == TransmissionMode::ThinObject)
             {
-                // (surface.transmission.transmissionParams.x <-- shrink factor)
-                transmissionDistance = ProjectedShadow::GetThickness(light.m_shadowIndex, surface.position - surface.transmission.transmissionParams.x * surface.vertexNormal);
+                transmissionDistance = ProjectedShadow::GetThickness(light.m_shadowIndex, surface.position - surface.transmission.GetShrinkFactor() * surface.vertexNormal);
             }
 #endif
         }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
@@ -100,7 +100,8 @@ void ApplyDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingDat
             }
             else if (o_transmission_mode == TransmissionMode::ThinObject)
             {
-                transmissionDistance = ProjectedShadow::GetThickness(light.m_shadowIndex, surface.position - lightingData.shrinkFactor * surface.vertexNormal);
+                // (surface.transmission.transmissionParams.x <-- shrink factor)
+                transmissionDistance = ProjectedShadow::GetThickness(light.m_shadowIndex, surface.position - surface.transmission.transmissionParams.x * surface.vertexNormal);
             }
 #endif
         }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
@@ -109,7 +109,8 @@ void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingD
             }
             else if (o_transmission_mode == TransmissionMode::ThinObject)
             {
-                transmissionDistance = ProjectedShadow::GetThickness(shadowIndex, surface.position - lightingData.shrinkFactor * surface.vertexNormal);
+                // (surface.transmission.transmissionParams.x <-- shrink factor)
+                transmissionDistance = ProjectedShadow::GetThickness(shadowIndex, surface.position - surface.transmission.transmissionParams.x * surface.vertexNormal);
             }
 #endif
         }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
@@ -109,8 +109,7 @@ void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingD
             }
             else if (o_transmission_mode == TransmissionMode::ThinObject)
             {
-                // (surface.transmission.transmissionParams.x <-- shrink factor)
-                transmissionDistance = ProjectedShadow::GetThickness(shadowIndex, surface.position - surface.transmission.transmissionParams.x * surface.vertexNormal);
+                transmissionDistance = ProjectedShadow::GetThickness(shadowIndex, surface.position - surface.transmission.GetShrinkFactor() * surface.vertexNormal);
             }
 #endif
         }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Surfaces/TransmissionSurfaceData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Surfaces/TransmissionSurfaceData.azsli
@@ -19,17 +19,25 @@ class TransmissionSurfaceData
 
     void InitializeToZero();
 
-    // Thick mode getters
+    // ----- Thick mode getters -----
+
     float GetAttenuationCoefficient() { return transmissionParams.x; }
     float GetPower() { return transmissionParams.y; }
     float GetDistortion() { return transmissionParams.z; }
 
-    // Thin mode getters
+    // ----- Thin mode getters -----
+
+    // Shrink (absolute) offset towards the normal opposite direction to ensure correct shadow map projection
     float GetShrinkFactor() { return transmissionParams.x; }
+
+    // (N . L) to accept below (N . L = 0) in scattering through thin objects
     float GetTransmissionNdLBias() { return transmissionParams.y; }
+
+    // Attenuation applied to hide artifacts due to low-res shadow maps 
     float GetDistanceAttenuation() { return transmissionParams.z; }
 
-    // Common getters
+    // ----- Common getters -----
+
     float GetScale() { return transmissionParams.w; }
 };
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Surfaces/TransmissionSurfaceData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Surfaces/TransmissionSurfaceData.azsli
@@ -18,6 +18,19 @@ class TransmissionSurfaceData
     float3 scatterDistance;          //!< scatter distance (same as in MaterialSrg) > 
 
     void InitializeToZero();
+
+    // Thick mode getters
+    float GetAttenuationCoefficient() { return transmissionParams.x; }
+    float GetPower() { return transmissionParams.y; }
+    float GetDistortion() { return transmissionParams.z; }
+
+    // Thin mode getters
+    float GetShrinkFactor() { return transmissionParams.x; }
+    float GetTransmissionNdLBias() { return transmissionParams.y; }
+    float GetDistanceAttenuation() { return transmissionParams.z; }
+
+    // Common getters
+    float GetScale() { return transmissionParams.w; }
 };
 
 void TransmissionSurfaceData::InitializeToZero()


### PR DESCRIPTION
Some of the parameters introduced in https://github.com/o3de/o3de/pull/6428 (`shrinkFactor`,`transmissionNdLBias`,`distanceAttenuation`) were stored in both `surface.transmission.transmissionParams` and `LightingData` structures. 
The context in which these were used had both structures available, so the parameters can be removed from one of the structures. In this case, it makes more sense to remove it from `LightingData`, since these are surface specific properties, and also to reduce the number of useless registers in `LightingData`, because a non-transmissive material is not going to use them.

Signed-off-by: Santi Paprika <santi.gonzalez@huawei.com>