### PR TITLE
[Linux] Set Icon for Project Manager Executable

### DIFF
--- a/Code/Tools/ProjectManager/Source/Application.cpp
+++ b/Code/Tools/ProjectManager/Source/Application.cpp
@@ -22,6 +22,7 @@
 #include <QDir>
 #include <QMessageBox>
 #include <QInputDialog>
+#include <QIcon>
 
 namespace O3DE::ProjectManager
 {
@@ -68,6 +69,9 @@ namespace O3DE::ProjectManager
         {
             AZ_Warning("ProjectManager", false, "Failed to init logging");
         }
+
+        // Set window icon after QGuiApplication is created otherwise QPixmap for the icon fails to intialize
+        QApplication::setWindowIcon(QIcon(":/ProjectManager-Icon.ico"));
 
         m_pythonBindings = AZStd::make_unique<PythonBindings>(GetEngineRoot());
 


### PR DESCRIPTION
Tested on Ubuntu 20. Also tested on Windows to ensure the icon was still set properly there.

![linux_icon](https://user-images.githubusercontent.com/52797929/158648197-df4e083a-3b2d-4b23-b32b-d95a511beda9.png)


Signed-off-by: nggieber <52797929+AMZN-nggieber@users.noreply.github.com>