### PR TITLE
Use system default OpenSSL on Linux

### DIFF
--- a/cmake/3rdParty/Platform/Android/BuiltInPackages_android.cmake
+++ b/cmake/3rdParty/Platform/Android/BuiltInPackages_android.cmake
@@ -6,6 +6,8 @@
 #
 #
 
+# this file allows you to specify all 3p packages (provided by O3DE or the operating system) for Android.
+
 # shared by other platforms:
 ly_associate_package(PACKAGE_NAME md5-2.0-multiplatform              TARGETS md5       PACKAGE_HASH 29e52ad22c78051551f78a40c2709594f0378762ae03b417adca3f4b700affdf)
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform TARGETS RapidJSON PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
@@ -6,6 +6,8 @@
 #
 #
 
+# this file allows you to specify all 3p packages (provided by O3DE or the operating system) for Linux.
+
 # shared by other platforms:
 ly_associate_package(PACKAGE_NAME md5-2.0-multiplatform                             TARGETS md5                         PACKAGE_HASH 29e52ad22c78051551f78a40c2709594f0378762ae03b417adca3f4b700affdf)
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
@@ -34,7 +34,6 @@ ly_associate_package(PACKAGE_NAME qt-5.15.2-rev6-linux                          
 ly_associate_package(PACKAGE_NAME png-1.6.37-rev2-linux                             TARGETS PNG                         PACKAGE_HASH 5c82945a1648905a5c4c5cee30dfb53a01618da1bf58d489610636c7ade5adf5)
 ly_associate_package(PACKAGE_NAME libsamplerate-0.2.1-rev2-linux                    TARGETS libsamplerate               PACKAGE_HASH 41643c31bc6b7d037f895f89d8d8d6369e906b92eff42b0fe05ee6a100f06261)
 ly_associate_package(PACKAGE_NAME OpenMesh-8.1-rev3-linux                           TARGETS OpenMesh                    PACKAGE_HASH 805bd0b24911bb00c7f575b8c3f10d7ea16548a5014c40811894a9445f17a126)
-ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1b-rev2-linux                         TARGETS OpenSSL                     PACKAGE_HASH b779426d1e9c5ddf71160d5ae2e639c3b956e0fb5e9fcaf9ce97c4526024e3bc)
 ly_associate_package(PACKAGE_NAME OpenEXR-3.1.3-rev2-linux                          TARGETS OpenEXR                     PACKAGE_HASH d6f5fb9b40ccd636537fe69154f4737742eb9e14edf11218644d0a55df87b046)
 ly_associate_package(PACKAGE_NAME DirectXShaderCompilerDxc-1.6.2112-o3de-rev1-linux TARGETS DirectXShaderCompilerDxc    PACKAGE_HASH ac9f98e0e3b07fde0f9bbe1e6daa386da37699819cde06dcc8d3235421f6e977)
 ly_associate_package(PACKAGE_NAME SPIRVCross-2021.04.29-rev1-linux                  TARGETS SPIRVCross                  PACKAGE_HASH 7889ee5460a688e9b910c0168b31445c0079d363affa07b25d4c8aeb608a0b80)
@@ -47,3 +46,7 @@ ly_associate_package(PACKAGE_NAME lz4-1.9.3-vcpkg-rev4-linux                    
 ly_associate_package(PACKAGE_NAME pyside2-5.15.2-rev2-linux                         TARGETS pyside2                     PACKAGE_HASH 7589c397c8224d0c3ad691ff02e1afd55d9a1f9de1967c14eb8105dd2b0c4dd1)
 ly_associate_package(PACKAGE_NAME SQLite-3.37.2-rev1-linux                          TARGETS SQLite                      PACKAGE_HASH bee80d6c6db3e312c1f4f089c90894436ea9c9b74d67256d8c1fb00d4d81fe46)
 ly_associate_package(PACKAGE_NAME AwsIotDeviceSdkCpp-1.15.2-rev1-linux              TARGETS AwsIotDeviceSdkCpp          PACKAGE_HASH 83fc1711404d3e5b2faabb1134e97cc92b748d8b87ff4ea99599d8c750b8eff0)
+
+# Use system default OpenSSL library instead of maintaining an O3DE version for Linux
+include(${CMAKE_CURRENT_LIST_DIR}/OpenSSL_linux.cmake)
+

--- a/cmake/3rdParty/Platform/Linux/OpenSSL_linux.cmake
+++ b/cmake/3rdParty/Platform/Linux/OpenSSL_linux.cmake
@@ -1,0 +1,19 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Use system default OpenSSL library instead of maintaining an O3DE version for Linux
+find_package(OpenSSL)
+if (NOT OpenSSL_FOUND)
+   message(FATAL_ERROR "Compiling on linux requires the development headers for OpenSSL.  Try using your package manager to install the OpenSSL development libraries following https://wiki.openssl.org/index.php/Libssl_API")
+else()
+    # OpenSSL targets should be considered as provided by the system
+    set_target_properties(OpenSSL::SSL OpenSSL::Crypto PROPERTIES LY_SYSTEM_LIBRARY TRUE)
+
+    # Alias the O3DE name to the official name
+    add_library(3rdParty::OpenSSL ALIAS OpenSSL::SSL)
+endif()

--- a/cmake/3rdParty/Platform/Linux/cmake_linux_files.cmake
+++ b/cmake/3rdParty/Platform/Linux/cmake_linux_files.cmake
@@ -9,4 +9,5 @@
 set(FILES
     BuiltInPackages_linux.cmake
     Wwise_linux.cmake
+    OpenSSL_linux.cmake
 )

--- a/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
+++ b/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
@@ -6,6 +6,8 @@
 #
 #
 
+# this file allows you to specify all 3p packages (provided by O3DE or the operating system) for Mac.
+
 # shared by other platforms:
 ly_associate_package(PACKAGE_NAME md5-2.0-multiplatform                             TARGETS md5                         PACKAGE_HASH 29e52ad22c78051551f78a40c2709594f0378762ae03b417adca3f4b700affdf)
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)

--- a/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
+++ b/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
@@ -6,6 +6,8 @@
 #
 #
 
+# this file allows you to specify all 3p packages (provided by O3DE or the operating system) for Windows.
+
 # shared by other platforms:
 ly_associate_package(PACKAGE_NAME md5-2.0-multiplatform                                 TARGETS md5                         PACKAGE_HASH 29e52ad22c78051551f78a40c2709594f0378762ae03b417adca3f4b700affdf)
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                    TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)

--- a/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
+++ b/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
@@ -6,6 +6,8 @@
 #
 #
 
+# this file allows you to specify all 3p packages (provided by O3DE or the operating system) for iOS.
+
 # shared by other platforms:
 ly_associate_package(PACKAGE_NAME md5-2.0-multiplatform              TARGETS md5        PACKAGE_HASH 29e52ad22c78051551f78a40c2709594f0378762ae03b417adca3f4b700affdf)
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform TARGETS RapidJSON  PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

On Linux, O3DE will use the system default OpenSSL instead of shipping the OpenSSL package since the system default library gets kept up to date by the Linux community whenever there’s a security problem. Note that O3DE 3rd party system will still ship OpenSSL packages for all the other platforms (Windows, Mac, Android and iOS).

Test Done:
- Built MultiplayerSample successfully on Linux
- Ran AzNetworking tests on Linux
- Tested the client and server connection via self-signed cert using MultiplayerSample (Linux client -> Windows server). Connection was established successfully and got the "Certificate validation passed" message. The linux game launcher crashed due to some other unrelated asset issues after connected.

fixes #4898