### PR TITLE
Lytesttools project path bug fix

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/_internal/managers/abstract_resource_locator.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/managers/abstract_resource_locator.py
@@ -73,15 +73,16 @@ def _find_project_json(engine_root, project):
             except KeyError as err:
                 logger.warning(f"Project key could not be found due to error: {err}")
 
-    # Check relative to defined build directory, for external projects which configure through SDK settings
-    if not project_json:
-        project_json = find_ancestor_file(target_file_name='project.json',
-                                          start_path=ly_test_tools._internal.pytest_plugin.build_directory)
     # Check internally for a project bundled with the engine
     if not project_json:
         check_project_json = os.path.join(engine_root, project, 'project.json')
         if os.path.isfile(check_project_json):
             project_json = check_project_json
+
+    # Check relative to defined build directory, for external projects which configure through SDK settings
+    if not project_json:
+        project_json = find_ancestor_file(target_file_name='project.json',
+                                          start_path=ly_test_tools._internal.pytest_plugin.build_directory)
 
     if not project_json:
         raise OSError(f"Unable to find the project directory for project: ${project}")

--- a/Tools/LyTestTools/ly_test_tools/_internal/managers/abstract_resource_locator.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/managers/abstract_resource_locator.py
@@ -45,9 +45,12 @@ def _find_engine_root(initial_path):
 
 
 def _find_project_json(engine_root, project):
-    # type (None) -> str
+    # type (str, str) -> str
     """
     Find the project.json file for this project.
+
+    :param engine_root: The root of the O3DE directory where engine.json exists
+    :param project: The name of the O3DE project
     :return: Full path to the project.json file
     """
     project_json = None

--- a/Tools/LyTestTools/ly_test_tools/environment/file_system.py
+++ b/Tools/LyTestTools/ly_test_tools/environment/file_system.py
@@ -456,6 +456,7 @@ def find_ancestor_file(target_file_name, start_path=os.getcwd()):
             current_path = parent_path
         else:
             # Found the file we wanted
+            candidate_path = os.path.abspath(candidate_path)
             break
 
     if not os.path.exists(candidate_path):

--- a/Tools/LyTestTools/ly_test_tools/environment/file_system.py
+++ b/Tools/LyTestTools/ly_test_tools/environment/file_system.py
@@ -442,7 +442,7 @@ def find_ancestor_file(target_file_name, start_path=os.getcwd()):
     :param start_path: Optional path to start looking for the file.
     :return: Path to the file or None if not found.
     """
-    current_path = os.path.normpath(start_path)
+    current_path = os.path.abspath(start_path)
     candidate_path = os.path.join(current_path, target_file_name)
 
     # Limit the number of directories to traverse, to avoid infinite loop in path cycles
@@ -456,7 +456,6 @@ def find_ancestor_file(target_file_name, start_path=os.getcwd()):
             current_path = parent_path
         else:
             # Found the file we wanted
-            candidate_path = os.path.abspath(candidate_path)
             break
 
     if not os.path.exists(candidate_path):

--- a/Tools/LyTestTools/tests/unit/test_abstract_resource_locator.py
+++ b/Tools/LyTestTools/tests/unit/test_abstract_resource_locator.py
@@ -57,6 +57,13 @@ class TestFindProjectJson(object):
 
         assert project == mock_project_json
 
+    @mock.patch('os.path.isfile', mock.MagicMock(side_effect=[False, True]))
+    @mock.patch('json.load', mock.MagicMock())
+    def test_FindProjectJson_EngineRoot_ReturnsProjectJson(self):
+        project = abstract_resource_locator._find_project_json(mock_engine_root, mock_project)
+
+        assert project == os.path.join(mock_engine_root, mock_project_json)
+
 
 @mock.patch('ly_test_tools._internal.managers.abstract_resource_locator.os.path.abspath',
             mock.MagicMock(return_value=mock_initial_path))

--- a/Tools/LyTestTools/tests/unit/test_file_system.py
+++ b/Tools/LyTestTools/tests/unit/test_file_system.py
@@ -900,3 +900,14 @@ class TestReduceFileName(unittest.TestCase):
 
         with pytest.raises(TypeError):
             file_system.reduce_file_name_length(file_name=target_name)
+
+class TestFindAncestorFile(unittest.TestCase):
+
+    @mock.patch('os.path.exists', mock.MagicMock(side_effect=[False, False, True, True]))
+    def test_Find_OneLevel_ReturnsPath(self):
+        mock_file = 'mock_file.txt'
+        mock_start_path = os.path.join('foo1', 'foo2', 'foo3')
+        expected = os.path.abspath(os.path.join('foo1', mock_file))
+
+        actual = file_system.find_ancestor_file(mock_file, mock_start_path)
+        assert actual == expected


### PR DESCRIPTION
Fixes an edge case when a relative build directory that exists in the project folder is provided to LyTestTools.

Tested the bug locally and ran unit tests.