### PR TITLE
[XCB] Fix swapped mouse button assignments

### DIFF
--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.h
@@ -121,9 +121,9 @@ namespace AzFramework
             case XCB_BUTTON_INDEX_1:
                 return &InputDeviceMouse::Button::Left;
             case XCB_BUTTON_INDEX_2:
-                return &InputDeviceMouse::Button::Right;
-            case XCB_BUTTON_INDEX_3:
                 return &InputDeviceMouse::Button::Middle;
+            case XCB_BUTTON_INDEX_3:
+                return &InputDeviceMouse::Button::Right;
             case XCB_BUTTON_INDEX_4:
                 isWheel = true;
                 direction = 1.0f;

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbInputDeviceMouseTests.cpp
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbInputDeviceMouseTests.cpp
@@ -186,9 +186,9 @@ namespace AzFramework
                 case XCB_BUTTON_INDEX_1:
                     return InputDeviceMouse::Button::Left;
                 case XCB_BUTTON_INDEX_2:
-                    return InputDeviceMouse::Button::Right;
-                case XCB_BUTTON_INDEX_3:
                     return InputDeviceMouse::Button::Middle;
+                case XCB_BUTTON_INDEX_3:
+                    return InputDeviceMouse::Button::Right;
             }
             return InputChannelId{};
         }
@@ -200,9 +200,9 @@ namespace AzFramework
             case XCB_BUTTON_INDEX_1:
                 return { InputDeviceMouse::Button::Right, InputDeviceMouse::Button::Middle, InputDeviceMouse::Button::Other1, InputDeviceMouse::Button::Other2 };
             case XCB_BUTTON_INDEX_2:
-                return { InputDeviceMouse::Button::Left, InputDeviceMouse::Button::Middle, InputDeviceMouse::Button::Other1, InputDeviceMouse::Button::Other2 };
-            case XCB_BUTTON_INDEX_3:
                 return { InputDeviceMouse::Button::Left, InputDeviceMouse::Button::Right, InputDeviceMouse::Button::Other1, InputDeviceMouse::Button::Other2 };
+            case XCB_BUTTON_INDEX_3:
+                return { InputDeviceMouse::Button::Left, InputDeviceMouse::Button::Middle, InputDeviceMouse::Button::Other1, InputDeviceMouse::Button::Other2 };
             case XCB_BUTTON_INDEX_4:
                 return { InputDeviceMouse::Button::Left, InputDeviceMouse::Button::Right, InputDeviceMouse::Button::Middle, InputDeviceMouse::Button::Other2 };
             case XCB_BUTTON_INDEX_5:


### PR DESCRIPTION
XCB_BUTTON_INDEX_2 corresponds with the middle mouse button, and INDEX_3
to the right button, not the other way around. Verified with `xev`.

Fixes #7342 .

Signed-off-by: Chris Burel <burelc@amazon.com>