### PR TITLE
Parallel terrain components

### DIFF
--- a/Gems/Terrain/Code/Include/Terrain/Ebuses/TerrainAreaSurfaceRequestBus.h
+++ b/Gems/Terrain/Code/Include/Terrain/Ebuses/TerrainAreaSurfaceRequestBus.h
@@ -23,6 +23,11 @@ namespace Terrain
         ////////////////////////////////////////////////////////////////////////
         // EBusTraits
         using MutexType = AZStd::recursive_mutex;
+
+        // This bus will not lock during an EBus call. This lets us run multiple queries in parallel, but it also means
+        // that anything that implements this EBus will need to ensure that queries can't be in the middle of running at the
+        // same time as bus connects / disconnects.
+        static const bool LocklessDispatch = true;
         ////////////////////////////////////////////////////////////////////////
 
         virtual ~TerrainAreaSurfaceRequests() = default;

--- a/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.cpp
@@ -20,6 +20,7 @@
 #include <GradientSignal/Ebuses/GradientRequestBus.h>
 #include <SurfaceData/SurfaceDataProviderRequestBus.h>
 
+AZ_DECLARE_BUDGET(Terrain);
 
 namespace Terrain
 {
@@ -122,6 +123,9 @@ namespace Terrain
 
     void TerrainHeightGradientListComponent::Deactivate()
     {
+        // Ensure that we only deactivate when no queries are actively running.
+        AZStd::unique_lock lock(m_queryMutex);
+
         m_dependencyMonitor.Reset();
         AzFramework::Terrain::TerrainDataNotificationBus::Handler::BusDisconnect();
         Terrain::TerrainAreaHeightRequestBus::Handler::BusDisconnect();
@@ -158,6 +162,9 @@ namespace Terrain
         AZ::Vector3& outPosition,
         bool& terrainExists)
     {
+        // Allow multiple queries to run simultaneously, but prevent them from running in parallel with activation / deactivation.
+        AZStd::shared_lock lock(m_queryMutex);
+
         float maxSample = 0.0f;
         terrainExists = false;
 
@@ -198,6 +205,11 @@ namespace Terrain
     void TerrainHeightGradientListComponent::GetHeights(
         AZStd::span<AZ::Vector3> inOutPositionList, AZStd::span<bool> terrainExistsList)
     {
+        AZ_PROFILE_FUNCTION(Terrain);
+
+        // Allow multiple queries to run simultaneously, but prevent them from running in parallel with activation / deactivation.
+        AZStd::shared_lock lock(m_queryMutex);
+
         AZ_Assert(
             inOutPositionList.size() == terrainExistsList.size(), "The position list size doesn't match the terrainExists list size.");
 
@@ -256,29 +268,33 @@ namespace Terrain
 
     void TerrainHeightGradientListComponent::OnCompositionChanged()
     {
-        RefreshMinMaxHeights();
-        TerrainSystemServiceRequestBus::Broadcast(
-            &TerrainSystemServiceRequestBus::Events::RefreshArea, GetEntityId(),
-            AzFramework::Terrain::TerrainDataNotifications::HeightData);
-    }
+        // We query the shape and world bounds prior to locking the queryMutex to help reduce the chances of deadlocks between
+        // threads due to the EBus call mutexes.
 
-    void TerrainHeightGradientListComponent::RefreshMinMaxHeights()
-    {
         // Get the height range of our height provider based on the shape component.
-        LmbrCentral::ShapeComponentRequestsBus::EventResult(m_cachedShapeBounds, GetEntityId(), &LmbrCentral::ShapeComponentRequestsBus::Events::GetEncompassingAabb);
+        AZ::Aabb shapeBounds = AZ::Aabb::CreateNull();
+        LmbrCentral::ShapeComponentRequestsBus::EventResult(
+            shapeBounds, GetEntityId(), &LmbrCentral::ShapeComponentRequestsBus::Events::GetEncompassingAabb);
 
         // Get the height range of the entire world
-        m_cachedHeightQueryResolution = 1.0f;
-        AzFramework::Terrain::TerrainDataRequestBus::BroadcastResult(
-            m_cachedHeightQueryResolution, &AzFramework::Terrain::TerrainDataRequestBus::Events::GetTerrainHeightQueryResolution);
-
         AZ::Aabb worldBounds = AZ::Aabb::CreateNull();
         AzFramework::Terrain::TerrainDataRequestBus::BroadcastResult(
             worldBounds, &AzFramework::Terrain::TerrainDataRequestBus::Events::GetTerrainAabb);
 
-        // Save off the min/max heights so that we don't have to re-query them on every single height query.
-        m_cachedMinWorldHeight = worldBounds.GetMin().GetZ();
-        m_cachedMaxWorldHeight = worldBounds.GetMax().GetZ();
+        // Ensure that we only change our cached data and terrain registration status when no queries are actively running.
+        {
+            AZStd::unique_lock lock(m_queryMutex);
+
+            m_cachedShapeBounds = shapeBounds;
+
+            // Save off the min/max heights so that we don't have to re-query them on every single height query.
+            m_cachedMinWorldHeight = worldBounds.GetMin().GetZ();
+            m_cachedMaxWorldHeight = worldBounds.GetMax().GetZ();
+
+            TerrainSystemServiceRequestBus::Broadcast(
+                &TerrainSystemServiceRequestBus::Events::RefreshArea, GetEntityId(),
+                AzFramework::Terrain::TerrainDataNotifications::HeightData);
+        }
     }
 
     void TerrainHeightGradientListComponent::OnTerrainDataChanged(

--- a/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.h
@@ -16,6 +16,7 @@
 #include <AzCore/Jobs/JobFunction.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Aabb.h>
+#include <AzCore/std/parallel/shared_mutex.h>
 
 #include <LmbrCentral/Dependency/DependencyMonitor.h>
 #include <LmbrCentral/Dependency/DependencyNotificationBus.h>
@@ -88,13 +89,14 @@ namespace Terrain
     private:
         TerrainHeightGradientListConfig m_configuration;
 
-        void RefreshMinMaxHeights();
-
         float m_cachedMinWorldHeight{ 0.0f };
         float m_cachedMaxWorldHeight{ 0.0f };
-        float m_cachedHeightQueryResolution{ 1.0f };
         AZ::Aabb m_cachedShapeBounds;
 
         LmbrCentral::DependencyMonitor m_dependencyMonitor;
+
+        // The TerrainAreaHeightRequestBus has lockless dispatch, so make sure that queries don't happen at the same
+        // time as bus connects / disconnects.
+        AZStd::shared_mutex m_queryMutex;
     };
 }

--- a/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
@@ -23,6 +23,8 @@
 #include <AzFramework/Terrain/TerrainDataRequestBus.h>
 #include <AzFramework/Physics/HeightfieldProviderBus.h>
 
+AZ_DECLARE_BUDGET(Terrain);
+
 namespace Terrain
 {
     void TerrainPhysicsSurfaceMaterialMapping::Reflect(AZ::ReflectContext* context)
@@ -259,7 +261,7 @@ namespace Terrain
 
     void TerrainPhysicsColliderComponent::GenerateHeightsInBounds(AZStd::vector<float>& heights) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Terrain);
 
         const AZ::Vector2 gridResolution = GetHeightfieldGridSpacing();
 
@@ -314,7 +316,7 @@ namespace Terrain
     void TerrainPhysicsColliderComponent::UpdateHeightsAndMaterials(
         const Physics::UpdateHeightfieldSampleFunction& updateHeightsMaterialsCallback, const AZ::Aabb& regionIn) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Terrain);
 
         AZ::Aabb region = regionIn;
 

--- a/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.cpp
@@ -15,6 +15,8 @@
 #include <GradientSignal/Ebuses/GradientRequestBus.h>
 #include <TerrainSystem/TerrainSystemBus.h>
 
+AZ_DECLARE_BUDGET(Terrain);
+
 namespace Terrain
 {
     void TerrainSurfaceGradientMapping::Reflect(AZ::ReflectContext* context)
@@ -112,13 +114,18 @@ namespace Terrain
 
     void TerrainSurfaceGradientListComponent::Deactivate()
     {
+        // Ensure that we only deactivate when no queries are actively running.
+        AZStd::unique_lock lock(m_queryMutex);
+
         m_dependencyMonitor.Reset();
 
         Terrain::TerrainAreaSurfaceRequestBus::Handler::BusDisconnect();
         LmbrCentral::DependencyNotificationBus::Handler::BusDisconnect();
 
         // Since this surface data will no longer exist, notify the terrain system to refresh the area.
-        OnCompositionChanged();
+        TerrainSystemServiceRequestBus::Broadcast(
+            &TerrainSystemServiceRequestBus::Events::RefreshArea, GetEntityId(),
+            AzFramework::Terrain::TerrainDataNotifications::SurfaceData);
     }
 
     bool TerrainSurfaceGradientListComponent::ReadInConfig(const AZ::ComponentConfig* baseConfig)
@@ -145,6 +152,9 @@ namespace Terrain
         const AZ::Vector3& inPosition,
         AzFramework::SurfaceData::SurfaceTagWeightList& outSurfaceWeights) const
     {
+        // Allow multiple queries to run simultaneously, but prevent them from running in parallel with activation / deactivation.
+        AZStd::shared_lock lock(m_queryMutex);
+
         outSurfaceWeights.clear();
 
         if (Terrain::TerrainAreaSurfaceRequestBus::HasReentrantEBusUseThisThread())
@@ -170,6 +180,11 @@ namespace Terrain
         AZStd::span<const AZ::Vector3> inPositionList,
         AZStd::span<AzFramework::SurfaceData::SurfaceTagWeightList> outSurfaceWeightsList) const
     {
+        AZ_PROFILE_FUNCTION(Terrain);
+
+        // Allow multiple queries to run simultaneously, but prevent them from running in parallel with activation / deactivation.
+        AZStd::shared_lock lock(m_queryMutex);
+
         AZ_Assert(
             inPositionList.size() == outSurfaceWeightsList.size(), "The position list size doesn't match the outSurfaceWeights list size.");
 
@@ -197,6 +212,9 @@ namespace Terrain
 
     void TerrainSurfaceGradientListComponent::OnCompositionChanged()
     {
+        // Ensure that we only change our terrain registration status when no queries are actively running.
+        AZStd::unique_lock lock(m_queryMutex);
+
         TerrainSystemServiceRequestBus::Broadcast(
             &TerrainSystemServiceRequestBus::Events::RefreshArea, GetEntityId(),
             AzFramework::Terrain::TerrainDataNotifications::SurfaceData);

--- a/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Component/Component.h>
+#include <AzCore/std/parallel/shared_mutex.h>
 #include <AzFramework/Terrain/TerrainDataRequestBus.h>
 #include <LmbrCentral/Dependency/DependencyMonitor.h>
 #include <LmbrCentral/Dependency/DependencyNotificationBus.h>
@@ -99,5 +100,9 @@ namespace Terrain
 
         TerrainSurfaceGradientListConfig m_configuration;
         LmbrCentral::DependencyMonitor m_dependencyMonitor;
+
+        // The TerrainAreaSurfaceRequestBus has lockless dispatch, so make sure that queries don't happen at the same
+        // time as bus connects / disconnects.
+        mutable AZStd::shared_mutex m_queryMutex;
     };
 } // namespace Terrain

--- a/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.cpp
@@ -21,6 +21,8 @@
 #include <Atom/RPI.Public/ViewportContext.h>
 #include <Atom/RPI.Public/ViewportContextBus.h>
 
+AZ_DECLARE_BUDGET(Terrain);
+
 namespace Terrain
 {
     void TerrainWorldDebuggerConfig::Reflect(AZ::ReflectContext* context)
@@ -196,7 +198,7 @@ namespace Terrain
     void TerrainWorldDebuggerComponent::DrawWireframe(
         const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Terrain);
 
         if (!m_configuration.m_drawWireframe)
         {

--- a/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainPhysicsColliderComponent.cpp
+++ b/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainPhysicsColliderComponent.cpp
@@ -93,7 +93,6 @@ namespace Terrain
 
     AZStd::vector<AZStd::pair<AZ::u32, AZStd::string>> TerrainPhysicsSurfaceMaterialMapping::BuildSelectableTagList() const
     {
-        AZ_PROFILE_FUNCTION(Entity);
         return AZStd::move(Terrain::BuildSelectableTagList(m_tagListProvider, m_surfaceTag));
     }
 

--- a/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainSurfaceGradientListComponent.cpp
+++ b/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainSurfaceGradientListComponent.cpp
@@ -90,7 +90,6 @@ namespace Terrain
 
     AZStd::vector<AZStd::pair<AZ::u32, AZStd::string>> TerrainSurfaceGradientMapping::BuildSelectableTagList() const
     {
-        AZ_PROFILE_FUNCTION(Entity);
         return AZStd::move(Terrain::BuildSelectableTagList(m_tagListProvider, m_surfaceTag));
     }
 

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -22,6 +22,8 @@
 
 using namespace Terrain;
 
+AZ_DEFINE_BUDGET(Terrain);
+
 bool TerrainLayerPriorityComparator::operator()(const AZ::EntityId& layer1id, const AZ::EntityId& layer2id) const
 {
     // Comparator for insertion/keylookup.
@@ -197,6 +199,8 @@ void TerrainSystem::GenerateQueryPositions(const AZStd::span<const AZ::Vector3>&
     AZStd::vector<AZ::Vector3>& outPositions,
     Sampler sampler) const
 {
+    AZ_PROFILE_FUNCTION(Terrain);
+
     const float minHeight = m_currentSettings.m_worldBounds.GetMin().GetZ();
     for (auto& position : inPositions)
     {
@@ -249,6 +253,8 @@ AZStd::vector<AZ::Vector3> TerrainSystem::GenerateInputPositionsFromRegion(
     const AZ::Aabb& inRegion,
     const AZ::Vector2& stepSize) const
 {
+    AZ_PROFILE_FUNCTION(Terrain);
+
     AZStd::vector<AZ::Vector3> inPositions;
     const auto [numSamplesX, numSamplesY] = GetNumSamplesFromRegion(inRegion, stepSize);
     inPositions.reserve(numSamplesX * numSamplesY);
@@ -269,6 +275,8 @@ AZStd::vector<AZ::Vector3> TerrainSystem::GenerateInputPositionsFromRegion(
 AZStd::vector<AZ::Vector3> TerrainSystem::GenerateInputPositionsFromListOfVector2(
     const AZStd::span<const AZ::Vector2> inPositionsVec2) const
 {
+    AZ_PROFILE_FUNCTION(Terrain);
+
     AZStd::vector<AZ::Vector3> inPositions;
     inPositions.reserve(inPositionsVec2.size());
 
@@ -287,6 +295,8 @@ void TerrainSystem::MakeBulkQueries(
     AZStd::span<AzFramework::SurfaceData::SurfaceTagWeightList> outSurfaceWeights,
     BulkQueriesCallback queryCallback) const
 {
+    AZ_PROFILE_FUNCTION(Terrain);
+
     AZStd::shared_lock<AZStd::shared_mutex> lock(m_areaMutex);
 
     AZ::Aabb bounds;
@@ -344,6 +354,8 @@ void TerrainSystem::MakeBulkQueries(
 void TerrainSystem::GetHeightsSynchronous(const AZStd::span<const AZ::Vector3>& inPositions, Sampler sampler, 
     AZStd::span<float> heights, AZStd::span<bool> terrainExists) const
 {
+    AZ_PROFILE_FUNCTION(Terrain);
+
     AZStd::shared_lock<AZStd::shared_mutex> lock(m_areaMutex);
 
     AZStd::vector<AZ::Vector3> outPositions;
@@ -549,6 +561,8 @@ bool TerrainSystem::GetIsHoleFromFloats(float x, float y, Sampler sampler) const
 void TerrainSystem::GetNormalsSynchronous(const AZStd::span<const AZ::Vector3>& inPositions, Sampler sampler, 
     AZStd::span<AZ::Vector3> normals, AZStd::span<bool> terrainExists) const
 {
+    AZ_PROFILE_FUNCTION(Terrain);
+
     AZStd::vector<AZ::Vector3> directionVectors;
     directionVectors.reserve(inPositions.size() * 4);
     const AZ::Vector2 range(m_currentSettings.m_heightQueryResolution / 2.0f, m_currentSettings.m_heightQueryResolution / 2.0f);
@@ -869,6 +883,8 @@ void TerrainSystem::GetOrderedSurfaceWeightsFromList(
     AZStd::span<AzFramework::SurfaceData::SurfaceTagWeightList> outSurfaceWeightsList,
     AZStd::span<bool> terrainExists) const
 {
+    AZ_PROFILE_FUNCTION(Terrain);
+
     if (terrainExists.size() == outSurfaceWeightsList.size())
     {
         AZStd::vector<float> heights(inPositions.size());

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.h
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.h
@@ -27,6 +27,8 @@
 #include <TerrainRaycast/TerrainRaycastContext.h>
 #include <TerrainSystem/TerrainSystemBus.h>
 
+AZ_DECLARE_BUDGET(Terrain);
+
 namespace Terrain
 {
     struct TerrainLayerPriorityComparator
@@ -368,6 +370,8 @@ namespace Terrain
         Sampler sampleFilter,
         AZStd::shared_ptr<ProcessAsyncParams> params) const
     {
+        AZ_PROFILE_FUNCTION(Terrain);
+
         // Determine the number of jobs to split the work into based on:
         // 1. The number of available worker threads.
         // 2. The desired number of jobs as passed in.
@@ -445,6 +449,8 @@ namespace Terrain
         Sampler sampleFilter,
         AZStd::shared_ptr<ProcessAsyncParams> params) const
     {
+        AZ_PROFILE_FUNCTION(Terrain);
+
         // ToDo: Determine the number of jobs to split the work into based on:
         // 1. The number of available worker threads.
         // 2. The desired number of jobs as passed in.

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystemBus.h
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystemBus.h
@@ -23,7 +23,6 @@ namespace Terrain
 {
     /**
     * A bus to signal the life times of terrain areas
-    * Note: all the API are meant to be queued events
     */
     class TerrainSystemServiceRequests
         : public AZ::EBusTraits
@@ -53,7 +52,6 @@ namespace Terrain
 
     /**
     * A bus to signal the life times of terrain areas
-    * Note: all the API are meant to be queued events
     */
     class TerrainAreaHeightRequests
         : public AZ::ComponentBus
@@ -62,6 +60,11 @@ namespace Terrain
         ////////////////////////////////////////////////////////////////////////
         // EBusTraits
         using MutexType = AZStd::recursive_mutex;
+
+        // This bus will not lock during an EBus call. This lets us run multiple queries in parallel, but it also means
+        // that anything that implements this EBus will need to ensure that queries can't be in the middle of running at the
+        // same time as bus connects / disconnects.
+        static const bool LocklessDispatch = true;
         ////////////////////////////////////////////////////////////////////////
 
         virtual ~TerrainAreaHeightRequests() = default;

--- a/Gems/Terrain/Code/Tests/TerrainSystemBenchmarks.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainSystemBenchmarks.cpp
@@ -49,7 +49,7 @@ namespace UnitTest
                 const AZ::Aabb& worldBounds,
                 AzFramework::Terrain::TerrainDataRequests::Sampler sampler)> ApiCaller)
         {
-            AZ_PROFILE_FUNCTION(Entity);
+            AZ_PROFILE_FUNCTION(Terrain);
 
             // Get the ranges for querying from our benchmark parameters
             float boundsRange = aznumeric_cast<float>(state.range(0));
@@ -103,7 +103,7 @@ namespace UnitTest
             AZStd::function<void(
                 float queryResolution, const AZ::Aabb& worldBounds, AzFramework::Terrain::TerrainDataRequests::Sampler sampler)> ApiCaller)
         {
-            AZ_PROFILE_FUNCTION(Entity);
+            AZ_PROFILE_FUNCTION(Terrain);
 
             // Get the ranges for querying from our benchmark parameters.
             // state.range(1) contains the number of requested surfaces, for consistency with other benchmarks.


### PR DESCRIPTION
Reworked the mutex locking on the terrain components and their ebus definitions so that it is now possible to run simultaneous parallel queries against the components, but they will exclusively lock when being modified or deactivated.

The terrain queries will still immediately block inside of these components on the calls to the GradientRequestBus, but that will be addressed in a future PR.

This also adds a new "Terrain" profile tag so that it's easier to see the Terrain calls in the profiles.

Example PIX captures showing calls inside the components successfully running in parallel, but then getting blocked for most of the call *inside* the functions.

Before:
![image](https://user-images.githubusercontent.com/82224783/159056718-948a1da8-e2ef-4a85-8a95-44ca4243c5d4.png)
![image](https://user-images.githubusercontent.com/82224783/159056912-1ad9979e-7a94-4f4e-911d-d31f42ec417e.png)

After:
![image](https://user-images.githubusercontent.com/82224783/159055977-f49d0494-53da-4529-9456-ff4a1068f33a.png)
![image](https://user-images.githubusercontent.com/82224783/159056156-6846672e-d81a-4e78-b936-7fc4b5057f0a.png)
