### PR TITLE
Motion Matching: Multi-threaded feature extraction

### DIFF
--- a/Gems/MotionMatching/Code/Source/Feature.h
+++ b/Gems/MotionMatching/Code/Source/Feature.h
@@ -13,6 +13,7 @@
 #include <AzCore/RTTI/RTTI.h>
 
 #include <EMotionFX/Source/EMotionFXConfig.h>
+#include <EMotionFX/Source/AnimGraphPosePool.h>
 #include <EMotionFX/Source/Node.h>
 #include <EMotionFX/Source/Skeleton.h>
 
@@ -66,8 +67,9 @@ namespace EMotionFX::MotionMatching
         // Feature extraction
         struct EMFX_API ExtractFeatureContext
         {
-            ExtractFeatureContext(FeatureMatrix& featureMatrix)
+            ExtractFeatureContext(FeatureMatrix& featureMatrix, AnimGraphPosePool& posePool)
                 : m_featureMatrix(featureMatrix)
+                , m_posePool(posePool)
             {
             }
 
@@ -76,6 +78,7 @@ namespace EMotionFX::MotionMatching
 
             size_t m_frameIndex = InvalidIndex;
             const Pose* m_framePose = nullptr; //! Pre-sampled pose for the given frame.
+            AnimGraphPosePool& m_posePool;
 
             ActorInstance* m_actorInstance = nullptr;
         };

--- a/Gems/MotionMatching/Code/Source/FeatureTrajectory.cpp
+++ b/Gems/MotionMatching/Code/Source/FeatureTrajectory.cpp
@@ -103,9 +103,8 @@ namespace EMotionFX::MotionMatching
     void FeatureTrajectory::ExtractFeatureValues(const ExtractFeatureContext& context)
     {
         const ActorInstance* actorInstance = context.m_actorInstance;
-        AnimGraphPosePool& posePool = GetEMotionFX().GetThreadData(actorInstance->GetThreadIndex())->GetPosePool();
-        AnimGraphPose* samplePose = posePool.RequestPose(actorInstance);
-        AnimGraphPose* nextSamplePose = posePool.RequestPose(actorInstance);
+        AnimGraphPose* samplePose = context.m_posePool.RequestPose(actorInstance);
+        AnimGraphPose* nextSamplePose = context.m_posePool.RequestPose(actorInstance);
 
         const size_t frameIndex = context.m_frameIndex;
         const Frame& currentFrame = context.m_frameDatabase->GetFrame(context.m_frameIndex);
@@ -149,8 +148,8 @@ namespace EMotionFX::MotionMatching
             *samplePose = *nextSamplePose;
         }
 
-        posePool.FreePose(samplePose);
-        posePool.FreePose(nextSamplePose);
+        context.m_posePool.FreePose(samplePose);
+        context.m_posePool.FreePose(nextSamplePose);
     }
 
     void FeatureTrajectory::SetPastTimeRange(float timeInSeconds)

--- a/Gems/MotionMatching/Code/Source/FeatureVelocity.cpp
+++ b/Gems/MotionMatching/Code/Source/FeatureVelocity.cpp
@@ -43,12 +43,12 @@ namespace EMotionFX::MotionMatching
         const ActorInstance* actorInstance = context.m_actorInstance;
         const Frame& frame = context.m_frameDatabase->GetFrame(context.m_frameIndex);
 
-        AnimGraphPosePool& posePool = GetEMotionFX().GetThreadData(actorInstance->GetThreadIndex())->GetPosePool();
-        AnimGraphPose* tempPose = posePool.RequestPose(actorInstance);
+        AnimGraphPose* tempPose = context.m_posePool.RequestPose(actorInstance);
         {
             // Calculate the joint velocities for the sampled pose using the same method as we do for the frame database.
             PoseDataJointVelocities* velocityPoseData = tempPose->GetPose().GetAndPreparePoseData<PoseDataJointVelocities>(actorInstance);
             velocityPoseData->CalculateVelocity(actorInstance,
+                context.m_posePool,
                 frame.GetSourceMotion(),
                 frame.GetSampleTime(),
                 m_relativeToNodeIndex);
@@ -56,7 +56,7 @@ namespace EMotionFX::MotionMatching
             const AZ::Vector3& velocity = velocityPoseData->GetVelocities()[m_jointIndex];
             SetFeatureData(context.m_featureMatrix, context.m_frameIndex, velocity);
         }
-        posePool.FreePose(tempPose);
+        context.m_posePool.FreePose(tempPose);
     }
 
     void FeatureVelocity::DebugDraw(AzFramework::DebugDisplayRequests& debugDisplay,

--- a/Gems/MotionMatching/Code/Source/MotionMatchingData.h
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingData.h
@@ -61,7 +61,13 @@ namespace EMotionFX::MotionMatching
         const AZStd::vector<Feature*>& GetFeaturesInKdTree() const { return m_featuresInKdTree; }
 
     protected:
+        //! Extract features from the motion database (multi-threaded).
         bool ExtractFeatures(ActorInstance* actorInstance, FrameDatabase* frameDatabase, size_t maxKdTreeDepth=20, size_t minFramesPerKdTreeNode=2000);
+
+        //! Extract features for a given range of frames and store the values in the feature matrix.
+        static void ExtractFeatureValuesRange(ActorInstance* actorInstance, FrameDatabase& frameDatabase, const FeatureSchema& featureSchema, FeatureMatrix& featureMatrix, size_t startFrame, size_t endFrame);
+
+        const size_t s_numFramesPerBatch = 1000; //!< Number of frames per task in the multi-threaded feature extraction routine.
 
         FrameDatabase m_frameDatabase; //< The animation database with all the keyframes and joint transform data.
 

--- a/Gems/MotionMatching/Code/Source/MotionMatchingInstance.cpp
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingInstance.cpp
@@ -407,7 +407,8 @@ namespace EMotionFX::MotionMatching
 
                 // Calculate the joint velocities for the sampled pose using the same method as we do for the frame database.
                 PoseDataJointVelocities* velocityPoseData = m_queryPose.GetAndPreparePoseData<PoseDataJointVelocities>(m_actorInstance);
-                velocityPoseData->CalculateVelocity(m_actorInstance, m_motionInstance->GetMotion(), newMotionTime, m_cachedTrajectoryFeature->GetRelativeToNodeIndex());
+                AnimGraphPosePool& posePool = GetEMotionFX().GetThreadData(m_actorInstance->GetThreadIndex())->GetPosePool();
+                velocityPoseData->CalculateVelocity(m_actorInstance, posePool, m_motionInstance->GetMotion(), newMotionTime, m_cachedTrajectoryFeature->GetRelativeToNodeIndex());
             }
 
             const FeatureMatrix& featureMatrix = m_data->GetFeatureMatrix();

--- a/Gems/MotionMatching/Code/Source/MotionMatchingSystemComponent.cpp
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingSystemComponent.cpp
@@ -46,6 +46,9 @@ namespace EMotionFX::MotionMatching
         "Use Kd-Tree to accelerate the motion matching search for the best next matching frame. "
         "Disabling it will heavily slow down performance and should only be done for debugging purposes");
 
+    AZ_CVAR(bool, mm_multiThreadedInitialization, true, nullptr, AZ::ConsoleFunctorFlags::Null,
+        "Use multi-threading to initialize motion matching.");
+
     void MotionMatchingSystemComponent::Reflect(AZ::ReflectContext* context)
     {
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))

--- a/Gems/MotionMatching/Code/Source/PoseDataJointVelocities.cpp
+++ b/Gems/MotionMatching/Code/Source/PoseDataJointVelocities.cpp
@@ -137,7 +137,7 @@ namespace EMotionFX::MotionMatching
         }
     }
 
-    void PoseDataJointVelocities::CalculateVelocity(const ActorInstance* actorInstance, Motion* motion, float requestedSampleTime, size_t relativeToJointIndex)
+    void PoseDataJointVelocities::CalculateVelocity(const ActorInstance* actorInstance, AnimGraphPosePool& posePool, Motion* motion, float requestedSampleTime, size_t relativeToJointIndex)
     {
         MotionDataSampleSettings sampleSettings;
         sampleSettings.m_actorInstance = actorInstance;
@@ -152,7 +152,6 @@ namespace EMotionFX::MotionMatching
         m_angularVelocities.resize(numJoints);
 
         // Prepare for sampling.
-        AnimGraphPosePool& posePool = GetEMotionFX().GetThreadData(actorInstance->GetThreadIndex())->GetPosePool();
         AnimGraphPose* prevPose = posePool.RequestPose(actorInstance);
         AnimGraphPose* currentPose = posePool.RequestPose(actorInstance);
 

--- a/Gems/MotionMatching/Code/Source/PoseDataJointVelocities.h
+++ b/Gems/MotionMatching/Code/Source/PoseDataJointVelocities.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Quaternion.h>
+#include <EMotionFX/Source/AnimGraphPosePool.h>
 #include <EMotionFX/Source/PoseData.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 
@@ -37,7 +38,15 @@ namespace EMotionFX::MotionMatching
         void CopyFrom(const PoseData* from) override;
         void Blend(const Pose* destPose, float weight) override;
 
-        void CalculateVelocity(const ActorInstance* actorInstance, Motion* motion, float requestedSampleTime, size_t relativeToJointIndex);
+        //! Calculate velocities for all joints in the pose.
+        //! @param[in] actorInstance The actor instance to use the skeleton and bind pose from.
+        //! @param[in] posePool Calculating velocities will require to sample the motion across a small window of time. The pose pool is used for storing temporary poses.
+        //!                     Note that the pose pool is not thread-safe.
+        //! @param[in] motion The source motion to use to calculate the velocities.
+        //! @param[in] requestedSampleTime The point in time in the motion to calculate the velocities for.
+        //! @param[in] relativeToJointIndex Calculate velocities relative to a given joint transform.
+        void CalculateVelocity(const ActorInstance* actorInstance, AnimGraphPosePool& posePool, Motion* motion, float requestedSampleTime, size_t relativeToJointIndex);
+
         void DebugDraw(AzFramework::DebugDisplayRequests& debugDisplay, const AZ::Color& color) const override;
 
         AZStd::vector<AZ::Vector3>& GetVelocities()                         { return m_velocities; }


### PR DESCRIPTION
* Multi-threaded feature extraction using the job system as well as the task graph.
* The pose pool is not multi-thread safe. We added a pose pool parameter to the extraction context to control the pool usage manually.
* Rather than using the default pose pool for the given actor instance, we now use the given pose pool from the context when calculating the features.
* Features are now separated into batches and then extracted simultaneously, each job/task having its own pose pool.
* Added CVAR to enable/disable multi-threaded feature extraction.

Extracting features for 36k frames / 20mins motion database previously took ~6425ms and now takes around ~280ms using a 32-core Threadripper, 23x speedup.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>