### PR TITLE
Relax PRIu64 format specifier to zu

### DIFF
--- a/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
+++ b/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
@@ -1682,7 +1682,7 @@ namespace AZ
         static constexpr const char* MemoryCSVHeader =
             "Pool Name, Memory Type (0 == Host : 1 == Device), Allocation Name, Allocation Type (0 == Buffer : "
             "1 == Texture), Byte Size, Flags\n";
-        static constexpr const char* MemoryCSVRowFormat = "%s, %i, %s, %i, %" PRIu64 ", %" PRIu32 "\n";
+        static constexpr const char* MemoryCSVRowFormat = "%s, %i, %s, %i, %zu, %" PRIu32 "\n";
         static constexpr size_t MemoryCSVFieldCount = 6;
 
         void ImGuiGpuMemoryView::SaveToCSV()


### PR DESCRIPTION
Despite compiling on a 64-bit system, clang on Mac warns (which then
errors) when passing a `size_t` value to a `%PRIu64` format specifier.
This PR uses the architecture-variable `%zu` specifier instead.