### PR TITLE
Remove enable_prefab_system option from hydra_test_utils.launch_and_validate_results

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/hydra_test_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/hydra_test_utils.py
@@ -29,7 +29,7 @@ def teardown_editor(editor):
 
 def launch_and_validate_results(request, test_directory, editor, editor_script, expected_lines, unexpected_lines=[],
                                 halt_on_unexpected=False, run_python="--runpythontest", auto_test_mode=True, null_renderer=True, cfg_args=[],
-                                timeout=300, log_file_name="Editor.log", enable_prefab_system=True):
+                                timeout=300, log_file_name="Editor.log"):
     """
     Runs the Editor with the specified script, and monitors for expected log lines.
     :param request: Special fixture providing information of the requesting test function.
@@ -45,25 +45,19 @@ def launch_and_validate_results(request, test_directory, editor, editor_script, 
     :param cfg_args: Additional arguments for CFG, such as LevelName.
     :param timeout: Length of time for test to run. Default is 60.
     :param log_file_name: Name of the log file created by the editor. Defaults to 'Editor.log'
-    :param enable_prefab_system: Flag to determine whether to use new prefab system or use deprecated slice system. Defaults to True.
     """
     test_case = os.path.join(test_directory, editor_script)
     request.addfinalizer(lambda: teardown_editor(editor))
     logger.debug("Running automated test: {}".format(editor_script))
     editor.args.extend(["--skipWelcomeScreenDialog", "--regset=/Amazon/Settings/EnableSourceControl=false", 
                         run_python, test_case,
+                        "--regset=/Amazon/Preferences/EnablePrefabSystem=true",
+                        f"--regset-file={os.path.join(editor.workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}",
                         f"--pythontestcase={request.node.name}", "--runpythonargs", " ".join(cfg_args)])
     if auto_test_mode:
         editor.args.extend(["--autotest_mode"])
     if null_renderer:
         editor.args.extend(["-rhi=Null"])
-    if enable_prefab_system:
-        from os import path
-        editor.args.extend([
-            "--regset=/Amazon/Preferences/EnablePrefabSystem=true",
-            f"--regset-file={os.path.join(editor.workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}"])
-    else:
-        editor.args.extend(["--regset=/Amazon/Preferences/EnablePrefabSystem=false"])
 
     with editor.start():
 


### PR DESCRIPTION
Tested tests using **launch_and_validate_results** with the following commands:
```
python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_GPU.py::TestMaterialEditor --build-directory windows_vs2019\bin\profile
```
```
python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main.py::TestMaterialEditorBasicTests --build-directory windows_vs2019\bin\profile
```
```
python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Benchmark_GPU.py::TestPerformanceBenchmarkSuite --build-directory windows_vs2019\bin\profile
```
```
python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\scripting\TestSuite_Periodic.py::TestAutomation --build-directory windows_vs2019\bin\profile
``` 

Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>