### PR TITLE
Add autogen jinja template and registry for function use case

### DIFF
--- a/Gems/ScriptCanvas/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvas/Code/CMakeLists.txt
@@ -81,7 +81,9 @@ ly_add_target(
             AZ::AzCore
             AZ::AzFramework
             Gem::ScriptCanvasDebugger
+            Gem::ScriptCanvas.AutoGen
     AUTOGEN_RULES
+        *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Source.jinja,$path/$fileprefix.generated.cpp
         *.ScriptCanvasGrammar.xml,ScriptCanvasGrammar_Header.jinja,$path/$fileprefix.generated.h
         *.ScriptCanvasGrammar.xml,ScriptCanvasGrammar_Source.jinja,$path/$fileprefix.generated.cpp
         *.ScriptCanvasNodeable.xml,ScriptCanvasNodeable_Header.jinja,$path/$fileprefix.generated.h
@@ -104,6 +106,20 @@ ly_add_target(
             .
             Include
             ${SCRIPT_CANVAS_AUTOGEN_BUILD_DIR}
+)
+
+ly_add_target(
+    NAME ScriptCanvas.AutoGen STATIC
+    NAMESPACE Gem
+    FILES_CMAKE
+        scriptcanvasgem_autogen_files.cmake
+    INCLUDE_DIRECTORIES
+        PUBLIC
+            Include/ScriptCanvas/AutoGen
+    BUILD_DEPENDENCIES
+        PUBLIC
+            AZ::AzCore
+            AZ::AzFramework
 )
 
 ly_add_target(

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <algorithm>
+
+#include "ScriptCanvasAutoGenRegistry.h"
+
+namespace ScriptCanvas
+{
+    AutoGenRegistry::~AutoGenRegistry()
+    {
+        m_functions.clear();
+    }
+
+    AutoGenRegistry* AutoGenRegistry::GetInstance()
+    {
+        // Use static object so each module will keep its own registry collection
+        static AutoGenRegistry s_autogenRegistry;
+
+        return &s_autogenRegistry;
+    }
+
+    void AutoGenRegistry::ReflectFunctions(AZ::ReflectContext* context)
+    {
+        if (auto registry = GetInstance())
+        {
+            for (auto& iter : registry->m_functions)
+            {
+                if (iter.second)
+                {
+                    iter.second->Reflect(context);
+                }
+            }
+        }
+    }
+
+    void AutoGenRegistry::RegisterFunction(const char* className, IScriptCanvasFunctionRegistry* registry)
+    {
+        if (m_functions.find(className) == m_functions.end() && registry != nullptr)
+        {
+            m_functions.emplace(className, registry);
+        }
+    }
+} // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace ScriptCanvas
+{
+    class IScriptCanvasFunctionRegistry
+    {
+    public:
+        virtual void Reflect(AZ::ReflectContext* context) = 0;
+    };
+
+    class AutoGenRegistry
+    {
+    public:
+        AutoGenRegistry() = default;
+        ~AutoGenRegistry();
+
+        static AutoGenRegistry* GetInstance();
+        static void ReflectFunctions(AZ::ReflectContext* context);
+
+        void RegisterFunction(const char* className, IScriptCanvasFunctionRegistry* registry);
+
+        std::unordered_map<std::string, IScriptCanvasFunctionRegistry*> m_functions;
+    };
+} // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
@@ -1,0 +1,72 @@
+{#
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+#}
+
+{% import 'ScriptCanvas_Macros.jinja' as macros %}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// This code was produced with AzAutoGen, any modifications made will not be preserved.
+// If you need to modify this code see:
+//
+// Gems\ScriptCanvas\Code\Include\ScriptCanvas\AutoGen\ScriptCanvasFunction_Source.jinja
+//
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <ScriptCanvasAutoGenRegistry.h>
+
+{% for xml in dataFiles %}
+{% for Library in xml.iter('ScriptCanvasFunction') %}
+
+#include "{{ Library.attrib['Include'] }}"
+
+{% set className = macros.CleanName('ScriptCanvasFunction' + Library.attrib['Name']) %}
+{% set namespaceList = macros.CleanName(Library.attrib['Namespace']).split('::') %}
+{% set prettyNamespaceName = macros.CleanName(Library.attrib['Namespace'].replace('::', '_')) %}
+{% set categoryName = Library.attrib['Category']%}
+
+{% for namespace in namespaceList %}
+namespace {{namespace}}
+{
+{% endfor %}
+
+    class {{className}}
+        : public ScriptCanvas::IScriptCanvasFunctionRegistry
+    {
+    public:
+        {{className}}()
+        {
+            ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction("{{className}}", this);
+        }
+
+        ~{{className}}() = default;
+ 
+        void Reflect(AZ::ReflectContext* context) override
+        {
+            if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+{% for function in Library.findall('Function') %}
+{% set functionName = macros.CleanName(function.attrib['Name'])%}
+                behaviorContext->Method("{{prettyNamespaceName}}_{{functionName}}", &{{functionName}}, 
+{{macros.GenerateFunctionMetaData(function)}})
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                    ->Attribute(AZ::Script::Attributes::Category, "{{categoryName}}")
+                ;
+
+{% endfor %}
+            }
+        }
+    };
+
+    static {{className}} s_{{className}};
+
+{% for namespace in namespaceList %}
+}
+{% endfor %}
+
+{% endfor %}
+{% endfor %}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Macros.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Macros.jinja
@@ -44,6 +44,27 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 {# ------- #}
 
+{%- macro GenerateFunctionMetaData(function) -%}
+{% set parameters = function.findall('Parameter') %}
+{% if not parameters %}
+{ { } }
+{%- else -%}
+{ {
+{% for index in range(0, parameters|length()) %}
+{% set parameterName = parameters[index].attrib['Name'] %}
+{% set parameterDefaultValue = parameters[index].attrib['DefaultValue'] %}
+{% set parameterDescription = parameters[index].attrib['Description'] %}
+    { {%- if parameterName is defined %}"{{parameterName}}"{% else %}""{% endif %},
+      {%- if parameterDescription is defined %} "{{parameterDescription}}"{% else %} ""{% endif %},
+      {%- if parameterDefaultValue is defined %} behaviorContext->MakeDefaultValue({{parameterDefaultValue}}){% else %} nullptr{% endif %} }{% if index != parameters|length() - 1 %},{% endif %}
+
+{% endfor %}
+} }
+{%- endif -%}
+{%- endmacro -%}
+
+{# ------- #}
+
 {%- macro SlotName(slotName) -%}
 {{slotName|replace("\\", '')|replace("\"", '')}}
 {%- endmacro -%}

--- a/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/Serialization/Utils.h>
 #include <Libraries/Libraries.h>
 #include <ScriptCanvas/Asset/RuntimeAsset.h>
+#include <ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h>
 #include <ScriptCanvas/Core/Contract.h>
 #include <ScriptCanvas/Core/Graph.h>
 #include <ScriptCanvas/Core/Node.h>
@@ -59,6 +60,7 @@ namespace ScriptCanvas
 {
     void SystemComponent::Reflect(AZ::ReflectContext* context)
     {
+        AutoGenRegistry::ReflectFunctions(context);
         VersionData::Reflect(context);
         Nodeable::Reflect(context);
         ReflectLibraries(context);

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_autogen_files.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_autogen_files.cmake
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
+    Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+)

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
@@ -67,6 +67,8 @@ set(FILES
     Include/ScriptCanvas/PerformanceTracker.h
     Include/ScriptCanvas/AutoGen/ScriptCanvas_Macros.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
+    Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
+    Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Header.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Source.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Header.jinja


### PR DESCRIPTION
## Details
The initial version of autogen jinja template and registry to support function use case

## For example:
The function header looks like following
```
#include <AzCore/std/string/string.h>

namespace ScriptCanvas
{
    namespace StringFunctions
    {
        AZStd::string ToLower(AZStd::string sourceString);

        AZStd::string ToUpper(AZStd::string sourceString);

        AZStd::string Substring(AZStd::string sourceString, AZ::u32 index, AZ::u32 length);
    } // namespace StringFunctions
} // namespace ScriptCanvas
```
### AutoGen Input
As users, all they need to provide is following data input .xml file which will be used by scriptcanvas to register function into system. Following is the minimum content of .xml
```
<?xml version="1.0" encoding="utf-8"?>

<ScriptCanvasFunction
    Include="Include/ScriptCanvas/Libraries/String/StringFunctions.h"    <!-- This field is used to locate function definition -->
    Name="StringFunctions"    <!-- This field is used to create function registry wrapper class -->
    Namespace="ScriptCanvas::StringFunctions"    <!-- This field is used to make sure reflected function with unique name, e.g. ScriptCanvas_StringFunctions_ToLower -->
    Category="String/Utils"    <!-- This field is used to define scriptcanvas node category -->
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

    <Function Name="ToLower"/>    <!-- This field is required to match with function name in header file  -->

    <Function Name="ToUpper"/>

    <Function Name="Substring"/>

</ScriptCanvasFunction>
```
User is also able to provide a verbose version for each function to provide more detailed information, like parameter name, tooltip and defaultvalue
```
<Function Name="ToUpper">
    <Parameter Name=''Source" Description="The source string to convert to upper case" DefaultValue="AZStd::string()">
</Function>
```

### AutoGen Output
```
/*
 * Copyright (c) Contributors to the Open 3D Engine Project.
 * For complete copyright and license terms please see the LICENSE at the root of this distribution.
 *
 * SPDX-License-Identifier: Apache-2.0 OR MIT
 *
 * This file is generated automatically at compile time, DO NOT EDIT BY HAND
 * Template Source E:\Lumberyard\o3de\Gems\ScriptCanvas\Code\Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja; Data Sources E:\Lumberyard\o3de\Gems\ScriptCanvas\Code\Include\ScriptCanvas\Libraries\String\StringFunctions.ScriptCanvasFunction.xml
 */



//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
//
// This code was produced with AzAutoGen, any modifications made will not be preserved.
// If you need to modify this code see:
//
// Gems\ScriptCanvas\Code\Include\ScriptCanvas\AutoGen\ScriptCanvasFunction_Source.jinja
//
//////////////////////////////////////////////////////////////////////////////////////////////////////////////////

#include <AzCore/RTTI/BehaviorContext.h>
#include <ScriptCanvasAutoGenRegistry.h>


#include "Include/ScriptCanvas/Libraries/String/StringFunctions.h"


namespace ScriptCanvas
{
namespace StringFunctions
{

    class ScriptCanvasFunctionStringFunctions
        : public ScriptCanvas::IScriptCanvasFunctionRegistry
    {
    public:
        ScriptCanvasFunctionStringFunctions()
        {
            ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction("ScriptCanvasFunctionStringFunctions", this);
        }

        ~ScriptCanvasFunctionStringFunctions() = default;
 
        void Reflect(AZ::ReflectContext* context) override
        {
            if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
            {
                behaviorContext->Method("ScriptCanvas_StringFunctions_ToLower", &ToLower, 
{ { } })
                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                    ->Attribute(AZ::Script::Attributes::Category, "String/Utils")
                ;

                behaviorContext->Method("ScriptCanvas_StringFunctions_ToUpper", &ToUpper, 
{ { } })
                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                    ->Attribute(AZ::Script::Attributes::Category, "String/Utils")
                ;

                behaviorContext->Method("ScriptCanvas_StringFunctions_Substring", &Substring, 
{ { } })
                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                    ->Attribute(AZ::Script::Attributes::Category, "String/Utils")
                ;

            }
        }
    };

    static ScriptCanvasFunctionStringFunctions s_ScriptCanvasFunctionStringFunctions;

}
}
```

Signed-off-by: onecent1101 <liug@amazon.com>