### PR TITLE
Improved gradient preview popout UX

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Images/Application/popout-overlay-hover.svg
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Images/Application/popout-overlay-hover.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" rx="4" fill="#4285F4"/>
+<path d="M19.022 5.99296H12.9085L14.9117 7.98131L11.8995 10.949L14.0214 13.1006L17.0039 10.0884L19.022 12.1064V5.99296Z" fill="black"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M22.0015 3H9V16H22.0015V3ZM20 5H11V14H20V5Z" fill="black"/>
+<path d="M7 12H5V20H13.0031V18H15V22H3V10H7V12Z" fill="black"/>
+</svg>

--- a/Code/Framework/AzQtComponents/AzQtComponents/Images/Application/popout-overlay.svg
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Images/Application/popout-overlay.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" rx="4" fill="black"/>
+<path d="M19.022 5.99296H12.9085L14.9117 7.98131L11.8995 10.949L14.0214 13.1006L17.0039 10.0884L19.022 12.1064V5.99296Z" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M22.0015 3H9V16H22.0015V3ZM20 5H11V14H20V5Z" fill="white"/>
+<path d="M7 12H5V20H13.0031V18H15V22H3V10H7V12Z" fill="white"/>
+</svg>

--- a/Code/Framework/AzQtComponents/AzQtComponents/Images/resources.qrc
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Images/resources.qrc
@@ -1,5 +1,7 @@
 <!DOCTYPE RCC><RCC version="1.0">
     <qresource prefix="/Application">
+        <file alias="popout-overlay.svg">Application/popout-overlay.svg</file>
+        <file alias="popout-overlay-hover.svg">Application/popout-overlay-hover.svg</file>
         <file alias="titlebar-close.svg">Application/titlebar-close.svg</file>
         <file alias="titlebar-maximize.svg">Application/titlebar-maximize.svg</file>
         <file alias="titlebar-minimize.svg">Application/titlebar-minimize.svg</file>

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Editor/EditorGradientPreviewRenderer.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Editor/EditorGradientPreviewRenderer.h
@@ -17,7 +17,6 @@
 
 // Qt
 #include <QImage>
-#include <QObject>
 #include <QSize>
 #include <QTimer>
 
@@ -424,14 +423,12 @@ namespace GradientSignal
     };
 
     class EditorGradientPreviewRenderer
-        : public QObject
-        , private AZ::TickBus::Handler
+        : private AZ::TickBus::Handler
     {
     public:
         using SampleFilterFunc = AZStd::function<float(float, const GradientSampleParams&)>;
 
         EditorGradientPreviewRenderer()
-            : QObject()
         {
             m_updateJob = aznew EditorGradientPreviewUpdateJob();
             AZ::TickBus::Handler::BusConnect();

--- a/Gems/GradientSignal/Code/Source/UI/GradientPreviewDataWidget.cpp
+++ b/Gems/GradientSignal/Code/Source/UI/GradientPreviewDataWidget.cpp
@@ -11,7 +11,6 @@
 
 #include <AzCore/Component/EntityId.h>
 
-#include <QPushButton>
 #include <QVBoxLayout>
 
 namespace GradientSignal
@@ -110,13 +109,11 @@ namespace GradientSignal
         layout->setContentsMargins(QMargins());
         layout->setAlignment(Qt::AlignHCenter);
 
-        m_preview = new GradientPreviewWidget(this);
+        m_preview = new GradientPreviewWidget(true, this);
         m_preview->setFixedSize(256, 256);
         layout->addWidget(m_preview);
 
-        QPushButton* popout = new QPushButton("Show Larger Preview");
-        layout->addWidget(popout);
-        connect(popout, &QPushButton::clicked, this, [this]()
+        QObject::connect(m_preview, &GradientPreviewWidget::popoutClicked, this, [this]()
         {
             delete m_previewWindow;
             m_previewWindow = new GradientPreviewWidget;

--- a/Gems/GradientSignal/Code/Source/UI/GradientPreviewWidget.cpp
+++ b/Gems/GradientSignal/Code/Source/UI/GradientPreviewWidget.cpp
@@ -8,15 +8,46 @@
 
 #include <UI/GradientPreviewWidget.h>
 
+#include <QIcon>
 #include <QPainter>
+#include <QToolButton>
+#include <QVBoxLayout>
 
 namespace GradientSignal
 {
-    GradientPreviewWidget::GradientPreviewWidget(QWidget* parent)
+    GradientPreviewWidget::GradientPreviewWidget(bool enablePopout, QWidget* parent)
         : QWidget(parent)
     {
         setMinimumSize(256, 256);
         setAttribute(Qt::WA_OpaquePaintEvent); // We're responsible for painting everything, don't bother erasing before paint
+
+        // For the preview with popout icon, configure an icon in the top-right
+        // corner of our preview that only appears when the user hovers over
+        // the preview
+        if (enablePopout)
+        {
+            QVBoxLayout* layout = new QVBoxLayout(this);
+            layout->setContentsMargins(QMargins(2, 2, 2, 2));
+            layout->setAlignment(Qt::AlignTop | Qt::AlignRight);
+
+            QIcon icon;
+            icon.addPixmap(QPixmap(":/Application/popout-overlay.svg"), QIcon::Normal);
+            icon.addPixmap(QPixmap(":/Application/popout-overlay-hover.svg"), QIcon::Active);
+
+            m_popoutButton = new QToolButton(this);
+            m_popoutButton->setIcon(icon);
+            m_popoutButton->setAutoRaise(true);
+            m_popoutButton->setIconSize(QSize(24, 24));
+            m_popoutButton->setCursor(Qt::PointingHandCursor);
+            m_popoutButton->hide();
+            layout->addWidget(m_popoutButton);
+            QObject::connect(m_popoutButton, &QToolButton::clicked, this, &GradientPreviewWidget::popoutClicked);
+        }
+        // For the popped out preview, make sure its window always stays on top
+        else
+        {
+            setWindowFlag(Qt::WindowStaysOnTopHint, true);
+        }
     }
 
     GradientPreviewWidget::~GradientPreviewWidget()
@@ -31,6 +62,26 @@ namespace GradientSignal
     QSize GradientPreviewWidget::GetPreviewSize() const
     {
         return size();
+    }
+
+    void GradientPreviewWidget::enterEvent(QEvent* event)
+    {
+        QWidget::enterEvent(event);
+
+        if (m_popoutButton)
+        {
+            m_popoutButton->show();
+        }
+    }
+
+    void GradientPreviewWidget::leaveEvent(QEvent* event)
+    {
+        QWidget::leaveEvent(event);
+
+        if (m_popoutButton)
+        {
+            m_popoutButton->hide();
+        }
     }
 
     void GradientPreviewWidget::paintEvent([[maybe_unused]] QPaintEvent* paintEvent)
@@ -49,3 +100,5 @@ namespace GradientSignal
         QueueUpdate();
     }
 } //namespace GradientSignal
+
+#include "UI/moc_GradientPreviewWidget.cpp"

--- a/Gems/GradientSignal/Code/Source/UI/GradientPreviewWidget.h
+++ b/Gems/GradientSignal/Code/Source/UI/GradientPreviewWidget.h
@@ -8,9 +8,13 @@
 
 #pragma once
 
+#if !defined(Q_MOC_RUN)
 #include <QWidget>
 
 #include <GradientSignal/Editor/EditorGradientPreviewRenderer.h>
+#endif
+
+class QToolButton;
 
 namespace GradientSignal
 {
@@ -18,16 +22,26 @@ namespace GradientSignal
         : public QWidget
         , public EditorGradientPreviewRenderer
     {
+        Q_OBJECT
+
     public:
-        GradientPreviewWidget(QWidget* parent = nullptr);
+        GradientPreviewWidget(bool enablePopout = false, QWidget* parent = nullptr);
         ~GradientPreviewWidget() override;
 
+    Q_SIGNALS:
+        void popoutClicked();
+
     protected:
+        void enterEvent(QEvent* event) override;
+        void leaveEvent(QEvent* event) override;
         void paintEvent(QPaintEvent* paintEvent) override;
         void resizeEvent(QResizeEvent* resizeEvent) override;
 
         void OnUpdate() override;
         QSize GetPreviewSize() const override;
+
+    private:
+        QToolButton* m_popoutButton = nullptr;
     };
 
 } //namespace GradientSignal


### PR DESCRIPTION
Improved the image gradient preview UX. Previously, the "Show Larger Preview" button causes the preview group to take up a lot of extra real-estate. In addition, the larger preview does not stay on top of the Editor, so if you click away from it, it gets hidden.

Before:

![ImageGradientComponentPrevious](https://user-images.githubusercontent.com/7519264/159366297-ea49099b-ede6-4b58-baad-dc7a01165553.png)

Improvements:
* Removed the "Show Larger Preview" button
* Popout icon appears in the upper right hand corner of the preview widget when the mouse hovers over the preview image
* Cursor changes to pointer when hovered over popout icon
* Clicking on the popout icon displays the larger preview
* The larger preview window stays on top of the Editor even when clicking off it

After:

![GradientPreviewPopout](https://user-images.githubusercontent.com/7519264/159366408-5485c239-f0e4-4dd8-90a3-40fad353024b.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>