### PR TITLE
Fix translation file path

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.cpp
@@ -851,41 +851,11 @@ namespace ScriptCanvasEditor
             CycleToNextNode();
         }
 
-        static AZStd::string GetGemPath(const AZStd::string& gemName)
-        {
-            if (auto settingsRegistry = AZ::Interface<AZ::SettingsRegistryInterface>::Get(); settingsRegistry != nullptr)
-            {
-                AZ::IO::Path gemSourceAssetDirectories;
-                AZStd::vector<AzFramework::GemInfo> gemInfos;
-                if (AzFramework::GetGemsInfo(gemInfos, *settingsRegistry))
-                {
-                    auto FindGemByName = [gemName](const AzFramework::GemInfo& gemInfo)
-                    {
-                        return gemInfo.m_gemName == gemName;
-                    };
-                    // Gather unique list of Gem Paths from the Settings Registry
-
-                    auto foundIt = AZStd::find_if(gemInfos.begin(), gemInfos.end(), FindGemByName);
-                    if (foundIt != gemInfos.end())
-                    {
-                        const AzFramework::GemInfo& gemInfo = *foundIt;
-                        for (const AZ::IO::Path& absoluteSourcePath : gemInfo.m_absoluteSourcePaths)
-                        {
-                            gemSourceAssetDirectories = (absoluteSourcePath / gemInfo.GetGemAssetFolder());
-                        }
-
-                        return gemSourceAssetDirectories.c_str();
-                    }
-                }
-            }
-            return "";
-        }
-
         void NodePaletteDockWidget::NavigateToTranslationFile(GraphCanvas::NodePaletteTreeItem* nodePaletteItem)
         {
             if (nodePaletteItem)
             {
-                AZ::IO::Path gemPath = GetGemPath("ScriptCanvas.Editor");
+                AZ::IO::Path gemPath = ScriptCanvasEditorTools::Helpers::GetGemPath("ScriptCanvas");
                 gemPath = gemPath / AZ::IO::Path("TranslationAssets");
                 gemPath = gemPath / nodePaletteItem->GetTranslationDataPath();
                 gemPath.ReplaceExtension(".names");

--- a/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
+++ b/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
@@ -1319,7 +1319,7 @@ namespace ScriptCanvasEditorTools
 
         document.AddMember("entries", entries, document.GetAllocator());
 
-        AZ::IO::Path gemPath = Helpers::GetGemPath("ScriptCanvas.Editor");
+        AZ::IO::Path gemPath = Helpers::GetGemPath("ScriptCanvas");
         gemPath = gemPath / AZ::IO::Path("TranslationAssets");
         gemPath = gemPath / filename;
         gemPath.ReplaceExtension(".names");


### PR DESCRIPTION
## Details
After Gem filesystem alias change, it is not required to check against cmake target name, instead we can look for gem name directly.

## Testing
Tested by generating and exploring translation file, both cases can route to correct translation asset directory.

Signed-off-by: onecent1101 <liug@amazon.com>