### PR TITLE
Remove Multiplayer Gem from DefaultProject Template

### DIFF
--- a/Templates/DefaultProject/Template/Gem/enabled_gems.cmake
+++ b/Templates/DefaultProject/Template/Gem/enabled_gems.cmake
@@ -19,7 +19,6 @@ set(ENABLED_GEMS
     ImGui
     LandscapeCanvas
     LyShine
-    Multiplayer
     PhysX
     PrimitiveAssets
     PrefabBuilder


### PR DESCRIPTION
Fixes #7478

After this change, the Multiplayer gem is no longer enabled in the DefaultProject template.

![image](https://user-images.githubusercontent.com/26804013/159372807-5868fea2-4c6b-48de-8bfb-18a4b6ab4498.png)
 

### Testing
- Re-installed Windows in undersea laboratory clean room under the watchful eye of the Kraken.
- Hot-swapped cryo-frozen RAM modules during solar flare event while generating new DefaultProject at precisely 2/22/2022 22:22:22 and verified generation completed successfully in double-blind presidential run-off
- Made a coffee