### PR TITLE
New label for node AMI, libssl-dev for OpenSSL, enable coredump

### DIFF
--- a/scripts/build/Platform/Linux/pipeline.json
+++ b/scripts/build/Platform/Linux/pipeline.json
@@ -1,6 +1,6 @@
 {
     "ENV": {
-        "NODE_LABEL": "linux-707531fc7",
+        "NODE_LABEL": "linux-7cb44cc9e",
         "LY_3RDPARTY_PATH": "/data/workspace/3rdParty",
         "TIMEOUT": 30,
         "WORKSPACE": "/data/workspace",

--- a/scripts/build/build_node/Platform/Linux/install-ubuntu.sh
+++ b/scripts/build/build_node/Platform/Linux/install-ubuntu.sh
@@ -13,6 +13,11 @@ then
     exit 1
 fi
 
+echo Configuring environment settings
+
+# Enable coredumps - Will be written to /var/lib/apport/coredump
+ulimit -c unlimited
+
 echo Installing packages and tools for O3DE development
 
 # Install awscli

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
@@ -13,6 +13,7 @@ libxcb-xinput0                          # For Qt plugins at runtime
 libfontconfig1-dev                      # For Qt plugins at runtime
 libcurl4-openssl-dev                    # For HttpRequestor
 # libsdl2-dev                             # For WWise/Audio
+libssl-dev                              # For system default OpenSSL
 libxcb-xkb-dev                          # For xcb keyboard input
 libxkbcommon-x11-dev                    # For xcb keyboard input
 libxkbcommon-dev                        # For xcb keyboard input

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-focal.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-focal.txt
@@ -13,6 +13,7 @@ libxcb-xinput0                          # For Qt plugins at runtime
 libfontconfig1-dev                      # For Qt plugins at runtime
 libcurl4-openssl-dev                    # For HttpRequestor
 # libsdl2-dev                             # for WWise/Audio
+libssl-dev                              # For system default OpenSSL
 libxcb-xkb-dev                          # For xcb keyboard input
 libxkbcommon-x11-dev                    # For xcb keyboard input
 libxkbcommon-dev                        # For xcb keyboard input


### PR DESCRIPTION
Installs libssl-dev on the Ubuntu AR build node for https://github.com/o3de/o3de/pull/8366, updates the AR label, and enables coredumps

Signed-off-by: Mike Chang <changml@amazon.com>