### PR TITLE
[Linux] Fix No Minimum Size For Project Manager

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/WindowDecorationWrapper.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/WindowDecorationWrapper.cpp
@@ -125,7 +125,11 @@ namespace AzQtComponents
 
         // Create a QWindow -- windowHandle()
         setAttribute(Qt::WA_NativeWindow, true);
-        TitleBarOverdrawHandler::getInstance()->addTitleBarOverdrawWidget(this);
+
+        if (auto handler = TitleBarOverdrawHandler::getInstance())
+        {
+            handler->addTitleBarOverdrawWidget(this);
+        }
     }
 
     WindowDecorationWrapper::~WindowDecorationWrapper()
@@ -422,6 +426,9 @@ namespace AzQtComponents
 
         if (m_guestWidget && !m_guestWidget->testAttribute(Qt::WA_PendingResizeEvent))
         {
+            // When using X11 Window System (Unix) the resize event can only be sent to the wrapper instead of the guest widget
+            // Update constraints to ensure the guest widget stays above its minimum size
+            updateConstraints();
             adjustWidgetGeometry();
         }
     }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Tests/WindowDecoratorWrapperTests.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Tests/WindowDecoratorWrapperTests.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzTest/AzTest.h>
+#include <AzQtComponents/Components/WindowDecorationWrapper.h>
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+
+#include <QApplication>
+
+namespace AzQtComponents
+{
+    class WindowDecorationWrapperTests
+        : public ::UnitTest::ScopedAllocatorSetupFixture
+    {
+    public:
+        WindowDecorationWrapperTests()
+        {
+            // Used to initiaize QApplication
+            char programName[] = "test";
+            char* argv[] = { &programName[0], nullptr };
+            int argc = 1;
+
+            // Must be created for widgets to work
+            m_application = AZStd::make_unique<QApplication>(argc, argv);
+            m_wrapper = AZStd::make_unique<WindowDecorationWrapper>(WindowDecorationWrapper::Option::OptionDisabled);
+            m_guest = AZStd::make_unique<QWidget>();
+        }
+
+        ~WindowDecorationWrapperTests()
+        {
+            m_guest.reset();
+            m_wrapper.reset();
+            m_application.reset();
+        }
+
+        AZStd::unique_ptr<QApplication> m_application;
+        AZStd::unique_ptr<WindowDecorationWrapper> m_wrapper;
+        AZStd::unique_ptr<QWidget> m_guest;
+    };
+
+    TEST_F(WindowDecorationWrapperTests, WindowDecorationWrapper_ShrinkWindow_KeepsGuestMinimumSize)
+    {
+        QWidget* guest = new QWidget();
+        QSize minimumSize(100, 100);
+        guest->setMinimumSize(minimumSize);
+        m_wrapper->setGuest(guest);
+
+        m_wrapper->resize(50, 50);
+
+        QSize guestSize = guest->size();
+        EXPECT_TRUE(guestSize.width() >= minimumSize.width());
+        EXPECT_TRUE(guestSize.height() >= minimumSize.height());
+    }
+
+} // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Tests/WindowDecoratorWrapperTests.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Tests/WindowDecoratorWrapperTests.cpp
@@ -47,14 +47,13 @@ namespace AzQtComponents
 
     TEST_F(WindowDecorationWrapperTests, WindowDecorationWrapper_ShrinkWindow_KeepsGuestMinimumSize)
     {
-        QWidget* guest = new QWidget();
         QSize minimumSize(100, 100);
-        guest->setMinimumSize(minimumSize);
-        m_wrapper->setGuest(guest);
+        m_guest->setMinimumSize(minimumSize);
+        m_wrapper->setGuest(m_guest.get());
 
         m_wrapper->resize(50, 50);
 
-        QSize guestSize = guest->size();
+        QSize guestSize = m_guest->size();
         EXPECT_TRUE(guestSize.width() >= minimumSize.width());
         EXPECT_TRUE(guestSize.height() >= minimumSize.height());
     }

--- a/Code/Framework/AzQtComponents/AzQtComponents/azqtcomponents_testing_files.cmake
+++ b/Code/Framework/AzQtComponents/AzQtComponents/azqtcomponents_testing_files.cmake
@@ -13,6 +13,7 @@ set(FILES
     Tests/FloatToStringConversionTests.cpp
     Tests/HexParsingTests.cpp
     Tests/StyleSheetCacheTests.cpp
+    Tests/WindowDecoratorWrapperTests.cpp
     Tests/qrc1.qrc
     Tests/qrc2.qrc
     Tests/qrc1/sheet1.qss


### PR DESCRIPTION
![Peek 2022-03-22 10-04](https://user-images.githubusercontent.com/52797929/159535762-e0ff8966-bb08-46d9-b1c6-d7304578d867.gif)


Fixes a bug in WindowDecorationWrapper on X11 Window server based systems where guest widget constrains are not checked when resizing the window.

Also adds a test to check for this.

Closes #5369