### PR TITLE
Minor improvement to setreg usage for ViewBookmark vector

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/LocalViewBookmarkComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/LocalViewBookmarkComponent.cpp
@@ -8,6 +8,7 @@
 
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/std/containers/vector.h>
 #include <AzToolsFramework/Viewport/LocalViewBookmarkComponent.h>
 #include <Viewport/ViewBookmarkLoaderInterface.h>
 
@@ -19,6 +20,8 @@ namespace AzToolsFramework
 
         if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
+            serializeContext->RegisterGenericType<AZStd::vector<ViewBookmark>>();
+
             serializeContext->Class<LocalViewBookmarkComponent, EditorComponentBase>()->Version(1)->Field(
                 "LocalBookmarkFileName", &LocalViewBookmarkComponent::m_localBookmarksFileName);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/LocalViewBookmarkLoader.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/LocalViewBookmarkLoader.cpp
@@ -45,9 +45,14 @@ namespace AzToolsFramework
         return outputFile.Length() > 0;
     }
 
-    static AZStd::string BookmarkSetRegPath(const AZStd::string& bookmarkFileName, const int index)
+    static AZStd::string BookmarkSetRegPath(const AZStd::string& bookmarkFileName)
     {
-        return "/" + bookmarkFileName + "/LocalBookmarks/" + AZStd::to_string(index);
+        return "/" + bookmarkFileName + "/LocalBookmarks";
+    }
+
+    static AZStd::string BookmarkSetRegPathAtIndex(const AZStd::string& bookmarkFileName, const int index)
+    {
+        return BookmarkSetRegPath(bookmarkFileName) + "/" + AZStd::to_string(index);
     }
 
     void LocalViewBookmarkLoader::RegisterViewBookmarkLoaderInterface()
@@ -130,7 +135,7 @@ namespace AzToolsFramework
         if (auto registry = AZ::SettingsRegistry::Get())
         {
             // write to the settings registry
-            success = registry->SetObject(BookmarkSetRegPath(m_bookmarkFileName, index), bookmark);
+            success = registry->SetObject(BookmarkSetRegPathAtIndex(m_bookmarkFileName, index), bookmark);
         }
 
         if (!success)
@@ -306,16 +311,6 @@ namespace AzToolsFramework
                         {
                             m_localBookmarks = viewBookmarkVisitor.m_bookmarkMap.at(localBookmarkFileName);
                             m_lastKnownLocation = viewBookmarkVisitor.m_lastKnownLocation;
-
-                            for (int i = 0; i < m_localBookmarks.size(); ++i)
-                            {
-                                // write to the settings registry
-                                if (const auto setRegPath = BookmarkSetRegPath(localBookmarkFileName, i);
-                                    !registry->SetObject(setRegPath, m_localBookmarks[i]))
-                                {
-                                    AZ_Warning("LocalViewBookmarkLoader", false, "SetObject for \"%s\" failed", setRegPath.c_str());
-                                }
-                            }
                         }
 
                         return visitedViewBookmarks;
@@ -325,14 +320,10 @@ namespace AzToolsFramework
                 {
                     // initialize default locations to 0. This is a temporary solution to match the 12 locations of the legacy system
                     // once there is a UI for the view bookmarks these lines should be removed
-                    for (int i = 0; i < DefaultViewBookmarkCount; i++)
+                    if (const auto setRegPath = BookmarkSetRegPath(m_bookmarkFileName);
+                        !registry->SetObject(setRegPath, AZStd::vector<ViewBookmark>(12, ViewBookmark())))
                     {
-                        // write to the settings registry
-                        if (const auto setRegPath = BookmarkSetRegPath(m_bookmarkFileName, i);
-                            !registry->SetObject(setRegPath, ViewBookmark()))
-                        {
-                            AZ_Warning("LocalViewBookmarkLoader", false, "SetObject for \"%s\" failed", setRegPath.c_str());
-                        }
+                        AZ_Warning("LocalViewBookmarkLoader", false, "SetObject for \"%s\" failed", setRegPath.c_str());
                     }
                 }
             }
@@ -367,7 +358,7 @@ namespace AzToolsFramework
         bool success = false;
         if (auto registry = AZ::SettingsRegistry::Get())
         {
-            success = registry->Remove(BookmarkSetRegPath(m_bookmarkFileName, index));
+            success = registry->Remove(BookmarkSetRegPathAtIndex(m_bookmarkFileName, index));
         }
 
         if (!success)
@@ -468,21 +459,24 @@ namespace AzToolsFramework
         m_bookmarkFileName = bookmarkComponent->GetLocalBookmarksFileName();
     }
 
-    bool LocalViewBookmarkLoader::SaveLocalBookmark(const ViewBookmark& bookmark, ViewBookmarkType bookmarkType)
+    bool LocalViewBookmarkLoader::SaveLocalBookmark(const ViewBookmark& bookmark, const ViewBookmarkType bookmarkType)
     {
         SetupLocalViewBookmarkComponent();
 
-        AZStd::string setRegPath;
-        switch (bookmarkType)
+        const AZStd::string setRegPath = [this, bookmarkType]
         {
-        case ViewBookmarkType::Standard:
-            // note: this function is not used currently and will need to be updated when DefaultViewBookmarkCount is removed
-            setRegPath = BookmarkSetRegPath(m_bookmarkFileName, aznumeric_cast<int>(m_localBookmarks.size()) + 1);
-            break;
-        case ViewBookmarkType::LastKnownLocation:
-            setRegPath = "/" + m_bookmarkFileName + "/LastKnownLocation";
-            break;
-        }
+            switch (bookmarkType)
+            {
+            case ViewBookmarkType::Standard:
+                // note: this function is not currently used and will need to be updated when DefaultViewBookmarkCount is removed
+                return BookmarkSetRegPathAtIndex(m_bookmarkFileName, aznumeric_cast<int>(m_localBookmarks.size()) + 1);
+            case ViewBookmarkType::LastKnownLocation:
+                return "/" + m_bookmarkFileName + "/LastKnownLocation";
+            default:
+                AZ_Assert(false, "Invalid ViewBookmarkType found: %d", bookmarkType);
+                return AZStd::string{};
+            }
+        }();
 
         bool success = false;
         if (auto registry = AZ::SettingsRegistry::Get())


### PR DESCRIPTION
After discussing briefly with @lumberyard-employee-dm we decided on adding a small simplification so the set reg usage for the `vector` of `ViewBookmarks` (this is something that will likely change in future once UX support is added). We also removed some redundant code that turned out not to be needed.

Signed-off-by: Tom Hulton-Harrop <82228511+hultonha@users.noreply.github.com>