### PR TITLE
Vulkan Swapchain related fixes.

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
@@ -99,9 +99,11 @@ namespace AZ
             void InvalidateSurface();
             //! Destroy the old swapchain.
             void InvalidateNativeSwapChain();
+            void InvalidateNativeSwapChainImmediately();
 
             RHI::Ptr<WSISurface> m_surface;
             VkSwapchainKHR m_nativeSwapChain = VK_NULL_HANDLE;
+            VkSwapchainKHR m_oldNativeSwapChain = VK_NULL_HANDLE;
             CommandQueue* m_presentationQueue = nullptr;
             FrameContext m_currentFrameContext;
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -136,6 +136,7 @@ namespace AtomToolsFramework
 
     private:
         void SendWindowResizeEvent();
+        void SendWindowCloseEvent();
 
         // The underlying ViewportContext, our entry-point to the Atom RPI.
         AZ::RPI::ViewportContextPtr m_viewportContext;


### PR DESCRIPTION
- Add support to properly transition from an old swapchain to a new swapchain. This involved deleting the old swapchain properly
- Add support to handle surface destruction by Qt.
- Add support to handle missed resize event after changes to surface dimensions

Signed-off-by: moudgils <47460854+moudgils@users.noreply.github.com>