### PR TITLE
Clarifying unknown results in LyTestTools parallel editor tests

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -136,8 +136,11 @@ class EditorBatchedTest(EditorSharedTest):
     is_batchable = True
     is_parallelizable = False
 
-
 class Result:
+
+    class EditorTestResultException(Exception):
+        """ Indicates that an unknown result was found during the tests  """
+
     class Base:
         def get_output_str(self):
             # type () -> str
@@ -467,9 +470,11 @@ class EditorTestSuite:
                         def result(self, request, workspace, editor, editor_test_data, launcher_platform):
                             # The runner must have filled the editor_test_data.results dict fixture for this test.
                             # Hitting this assert could mean if there was an error executing the runner
-                            assert test_spec.__name__ in editor_test_data.results, \
-                                f"No results found for {test_spec.__name__}. Test may not have ran due to the Editor " \
-                                f"shutting down. Check for issues in previous tests."
+                            if test_spec.__name__ not in editor_test_data.results:
+                                raise Result.EditorTestResultException(f"No results found for {test_spec.__name__}. "
+                                                                       f"Test may not have ran due to the Editor "
+                                                                       f"shutting down. Check for issues in previous "
+                                                                       f"tests.")
                             cls._report_result(test_spec.__name__, editor_test_data.results[test_spec.__name__])
                         return result
                     

--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -467,7 +467,9 @@ class EditorTestSuite:
                         def result(self, request, workspace, editor, editor_test_data, launcher_platform):
                             # The runner must have filled the editor_test_data.results dict fixture for this test.
                             # Hitting this assert could mean if there was an error executing the runner
-                            assert test_spec.__name__ in editor_test_data.results, f"No run data for test: {test_spec.__name__}."
+                            assert test_spec.__name__ in editor_test_data.results, \
+                                f"No results found for {test_spec.__name__}. Test may not have ran due to the Editor " \
+                                f"shutting down. Check for issues in previous tests."
                             cls._report_result(test_spec.__name__, editor_test_data.results[test_spec.__name__])
                         return result
                     

--- a/Tools/LyTestTools/tests/unit/test_o3de_editor_test.py
+++ b/Tools/LyTestTools/tests/unit/test_o3de_editor_test.py
@@ -20,18 +20,18 @@ class TestEditorTestBase(unittest.TestCase):
 
     def test_EditorSharedTest_Init_CorrectAttributes(self):
         mock_editorsharedtest = editor_test.EditorSharedTest()
-        assert mock_editorsharedtest.is_batchable == True
-        assert mock_editorsharedtest.is_parallelizable == True
+        assert mock_editorsharedtest.is_batchable
+        assert mock_editorsharedtest.is_parallelizable
 
     def test_EditorParallelTest_Init_CorrectAttributes(self):
         mock_editorsharedtest = editor_test.EditorParallelTest()
-        assert mock_editorsharedtest.is_batchable == False
-        assert mock_editorsharedtest.is_parallelizable == True
+        assert not mock_editorsharedtest.is_batchable
+        assert mock_editorsharedtest.is_parallelizable
 
     def test_EditorBatchedTest_Init_CorrectAttributes(self):
         mock_editorsharedtest = editor_test.EditorBatchedTest()
-        assert mock_editorsharedtest.is_batchable == True
-        assert mock_editorsharedtest.is_parallelizable == False
+        assert mock_editorsharedtest.is_batchable
+        assert not mock_editorsharedtest.is_parallelizable
 
 
 class TestResultBase(unittest.TestCase):


### PR DESCRIPTION
Clarified wording of assert message to direct the user to issues in previous tests. Also cleaned up some minor test formatting. Tested by running unit tests.

Signed-off-by: evanchia-ly-sdets <evanchia@amazon.com>