### PR TITLE
Enable incremental linking for ImageProcessingAtom debug builds.

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Platform/Common/msvc/imageprocessingatom_editor_static_msvc.cmake
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Platform/Common/msvc/imageprocessingatom_editor_static_msvc.cmake
@@ -10,3 +10,9 @@ set(LY_COMPILE_OPTIONS
     PRIVATE
         /EHsc
 )
+
+# Temporary fix for the linker issue caused by OpenEXR libs on debug builds
+set(LY_LINK_OPTIONS 
+	INTERFACE 
+		"$<$<CONFIG:debug>:/INCREMENTAL>"
+)

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Platform/Windows/platform_windows.cmake
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Platform/Windows/platform_windows.cmake
@@ -5,6 +5,3 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #
-
-# Temporary fix for the linker issue caused by OpenEXR libs on debug builds
-set(LY_LINK_OPTIONS INTERFACE "$<$<CONFIG:debug>:/INCREMENTAL>")

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Platform/Windows/platform_windows.cmake
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Platform/Windows/platform_windows.cmake
@@ -6,3 +6,4 @@
 #
 #
 
+set(LY_LINK_OPTIONS INTERFACE "$<$<CONFIG:debug>:/INCREMENTAL>")

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Platform/Windows/platform_windows.cmake
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Platform/Windows/platform_windows.cmake
@@ -6,4 +6,5 @@
 #
 #
 
+# Temporary fix for the linker issue caused by OpenEXR libs on debug builds
 set(LY_LINK_OPTIONS INTERFACE "$<$<CONFIG:debug>:/INCREMENTAL>")


### PR DESCRIPTION
Tested by running cmake for Windows vs2019 and verifying that the "Enable Incremental Linking" option in the ImageProcessingAtom.Editor project is enabled. 

Signed-off-by: hershey5045 <43485729+hershey5045@users.noreply.github.com>