### PR TITLE
Add an AZ component template

### DIFF
--- a/Templates/DefaultComponent/Template/Include/${Name}Interface.h
+++ b/Templates/DefaultComponent/Template/Include/${Name}Interface.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Component/EntityId.h>
+
+namespace ${SanitizedCppName}
+{
+    class ${SanitizedCppName}Requests
+    {
+    public:
+        AZ_RTTI(${SanitizedCppName}Requests, "{${Random_Uuid}}");
+        virtual ~${SanitizedCppName}Requests() = default;
+        // Put your public methods here
+
+        // Put notification events here
+        // void RegisterEvent(AZ::EventHandler<...> notifyHandler);
+        // AZ::Event<...> m_notifyEvent1;
+    };
+
+    class ${SanitizedCppName}BusTraits
+        : public AZ::EBusTraits
+    {
+    public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        using BusIdType = AZ::EntityId;
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+        //////////////////////////////////////////////////////////////////////////
+    };
+
+    using ${SanitizedCppName}RequestBus = AZ::EBus<${SanitizedCppName}Requests, ${SanitizedCppName}BusTraits>;
+    inline namespace ${SanitizedCppName}Interface
+    {
+        inline constexpr auto Get = [](${SanitizedCppName}BusTraits::BusIdType busId) {return ${SanitizedCppName}RequestBus::FindFirstHandler(busId); };
+    }
+
+} // namespace ${SanitizedCppName}

--- a/Templates/DefaultComponent/Template/Include/${Name}Interface.h
+++ b/Templates/DefaultComponent/Template/Include/${Name}Interface.h
@@ -1,3 +1,13 @@
+// {BEGIN_LICENSE}
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+// {END_LICENSE}
+
 #pragma once
 
 #include <AzCore/EBus/EBus.h>

--- a/Templates/DefaultComponent/Template/Source/${Name}Component.cpp
+++ b/Templates/DefaultComponent/Template/Source/${Name}Component.cpp
@@ -1,0 +1,62 @@
+#include <${SanitizedCppName}Component.h>
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+
+namespace ${SanitizedCppName}
+{
+    void ${SanitizedCppName}Component::Activate()
+    {
+        ${SanitizedCppName}RequestBus::Handler::BusConnect(GetEntityId());
+    }
+
+    void ${SanitizedCppName}Component::Deactivate()
+    {
+        ${SanitizedCppName}RequestBus::Handler::BusDisconnect(GetEntityId());
+    }
+
+    void ${SanitizedCppName}Component::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<${SanitizedCppName}Component, AZ::Component>()
+                ->Version(1)
+                ;
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<${SanitizedCppName}Component>("${SanitizedCppName}Component", "[Description of functionality provided by this component]")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "ComponentCategory")
+                    ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/ComponentPlaceholder.svg")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                    ;
+            }
+        }
+
+        if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<${SanitizedCppName}Component>("${SanitizedCppName} Component Group")
+                ->Attribute(AZ::Script::Attributes::Category, "${SanitizedCppName} Gem Group")
+                ;
+        }
+    }
+
+    void ${SanitizedCppName}Component::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("${SanitizedCppName}ComponentService"));
+    }
+
+    void ${SanitizedCppName}Component::GetIncompatibleServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+    }
+
+    void ${SanitizedCppName}Component::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+    }
+
+    void ${SanitizedCppName}Component::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+    }
+} // namespace ${SanitizedCppName}

--- a/Templates/DefaultComponent/Template/Source/${Name}Component.cpp
+++ b/Templates/DefaultComponent/Template/Source/${Name}Component.cpp
@@ -1,3 +1,13 @@
+// {BEGIN_LICENSE}
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+// {END_LICENSE}
+
 #include <${SanitizedCppName}Component.h>
 
 #include <AzCore/Serialization/SerializeContext.h>

--- a/Templates/DefaultComponent/Template/Source/${Name}Component.h
+++ b/Templates/DefaultComponent/Template/Source/${Name}Component.h
@@ -1,3 +1,13 @@
+// {BEGIN_LICENSE}
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+// {END_LICENSE}
+
 #pragma once
 
 #include <AzCore/Component/Component.h>

--- a/Templates/DefaultComponent/Template/Source/${Name}Component.h
+++ b/Templates/DefaultComponent/Template/Source/${Name}Component.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <${SanitizedCppName}Interface.h>
+
+namespace ${SanitizedCppName}
+{
+    class ${SanitizedCppName}Component
+        : public AZ::Component
+        , public ${SanitizedCppName}RequestBus::Handler
+    {
+    public:
+        AZ_COMPONENT(${SanitizedCppName}Component, "{${Random_Uuid}}");
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+    protected:
+        ////////////////////////////////////////////////////////////////////////
+        // AZ::Component interface implementation
+        void Activate() override;
+        void Deactivate() override;
+        ////////////////////////////////////////////////////////////////////////
+    };
+} // namespace ${SanitizedCppName}

--- a/Templates/DefaultComponent/preview.png
+++ b/Templates/DefaultComponent/preview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15f0306bf2c2710f892a791ba0813966677f85165a92ad718c52a3cb9573eb41
+size 3193

--- a/Templates/DefaultComponent/template.json
+++ b/Templates/DefaultComponent/template.json
@@ -1,0 +1,38 @@
+{
+    "template_name": "DefaultComponent",
+    "origin": "Open 3D Engine - o3de.org",
+    "origin_url": "https://github.com/o3de/o3de",
+    "license": "Apache-2.0 or MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
+    "display_name": "Default Component Template",
+    "summary": "A component template for a typical game component.",
+    "canonical_tags": [
+        "Template"
+    ],
+    "user_tags": [
+        "DefaultComponent"
+    ],
+    "icon_path": "preview.png",
+    "copyFiles": [
+        {
+            "file": "Source/${Name}Component.cpp",
+            "isTemplated": true
+        },
+        {
+            "file": "Source/${Name}Component.h",
+            "isTemplated": true
+        },
+        {
+            "file": "Include/${Name}Interface.h",
+            "isTemplated": true
+        }
+    ],
+    "createDirectories": [
+        {
+            "dir": "Include"
+        },
+        {
+            "dir": "Source"
+        }
+    ]
+}

--- a/engine.json
+++ b/engine.json
@@ -92,6 +92,7 @@
     "templates": [
         "Templates/GemRepo",
         "Templates/AssetGem",
+        "Templates/DefaultComponent",
         "Templates/DefaultGem",
         "Templates/DefaultProject",
         "Templates/CppToolGem",


### PR DESCRIPTION
Adds a "default" AZ component template to the collection of engine templates included with O3DE, as described in the linked issue. This template can streamline the creation of standard game components, and is intended to incorporate the latest best practices around component development.

Includes the following boilerplate code:

- AZ::Component class interface implementation.
- Standard component services methods.
- Starter code for serialization, edit, and behavior contexts in the Reflect method.
- Bus interface class for EBus support that can store AZ::Events.
- Bus connect and disconnect.

Not every component will need all of these features. The most common code that would be time-saving for most users was included.

To create a component, you would use the `o3de create-from-template` CLI command as follows:
`scripts\o3de.bat create-from-template -dp <destination-dir> -dn <component-name> -tn DefaultComponent`

To create the component in an existing directory, such as a Gem that's in progress, the `-f` option is needed to force the creation of the component files. Example:
`scripts\o3de create-from-template -dp D:\Gems\MyGem\Code -dn MyTest -tn DefaultComponent -f`

Being a good "default" component, we should consider adding an `o3de create-component` command if this template turns out to work well for users.

The public bus interface header is created in an `Include` subdirectory.
The component header and implementation are created in a `Source` subdirectory.

Two additional component templates would make sense for a future PR:

- editor + game component
- system component

Resolves #7225 