### PR TITLE
Fixes PyTest Warning: Cannot Collect Test Class 'TestData'

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -331,6 +331,8 @@ class EditorTestSuite:
     _TEST_FAIL_RETCODE = 0xF  # Return code for test failure
 
     class TestData:
+        __test__ = False  # Required to tell PyTest to skip collecting this class even though it has "Test" in the name; avoids PyTest warnings.
+
         def __init__(self):
             self.results = {}  # Dict of str(test_spec.__name__) -> Result
             self.asset_processor = None


### PR DESCRIPTION
Fixes a PyTest warning due to PyTest trying to collect 'TestData' because it has 'Test' in the name, but it doesn't need to collect it. Because TestData has an _ init _ method, PyTest cannot collect the test anyways.

In response to #8452.
Tested by running PyTest and seeing the warning no longer appears.

Signed-off-by: Gene Walters <genewalt@amazon.com>