### PR TITLE
Remove enable_prefab_system option from all automated test frameworks

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main.py
@@ -58,8 +58,7 @@ class EditorSingleTest_WithFileOverrides(EditorSingleTest):
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 class TestAutomation(EditorTestSuite):
 
-    global_extra_cmdline_args = ['-BatchMode', '-autotest_mode',
-                                 '--regset=/Amazon/Preferences/EnablePrefabSystem=true']
+    global_extra_cmdline_args = ['-BatchMode', '-autotest_mode']
 
     @staticmethod
     def get_number_parallel_editors():

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/force_region/ForceRegion_PrefabFileInstantiates.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/force_region/ForceRegion_PrefabFileInstantiates.py
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 
 # Test case ID : C6090546
-# Test Case Title : Check that a force region slice can be saved and instantiated
+# Test Case Title : Check that a force region prefab can be saved and instantiated
 
 
 
@@ -22,15 +22,15 @@ class Tests():
 # fmt: on
 
 
-def ForceRegion_SliceFileInstantiates():
+def ForceRegion_PrefabFileInstantiates():
 
     """
     Summary:
-    Check that a force region slice can be saved and instantiated
+    Check that a force region prefab can be saved and instantiated
 
     Level Description:
     The SphereRigidBody entity is placed above the ForceRegionBox entity
-    ForceRegionSliceEntity (entity) - Slice Asset which is imported from .slice file of another level which has
+    ForceRegionPrefabEntity (entity) - Prefab Asset which is imported from .prefab file of another level which has
                                       an entity with force region component.
     SphereRigidBody (entity) - Entity with PhysX Rigid body, Mesh and collider components.
     The SphereRigidBody is placed above the ForceRegionEntity.
@@ -134,4 +134,4 @@ def ForceRegion_SliceFileInstantiates():
 
 if __name__ == "__main__":
     from editor_python_test_tools.utils import Report
-    Report.start_test(ForceRegion_SliceFileInstantiates)
+    Report.start_test(ForceRegion_PrefabFileInstantiates)

--- a/AutomatedTesting/Gem/PythonTests/automatedtesting_shared/base.py
+++ b/AutomatedTesting/Gem/PythonTests/automatedtesting_shared/base.py
@@ -56,7 +56,7 @@ class TestAutomationBase:
         cls._kill_ly_processes(include_asset_processor=True)
 
     def _run_test(self, request, workspace, editor, testcase_module, extra_cmdline_args=[], batch_mode=True,
-                  autotest_mode=True, use_null_renderer=True, enable_prefab_system=True):
+                  autotest_mode=True, use_null_renderer=True):
         test_starttime = time.time()
         self.logger = logging.getLogger(__name__)
         errors = []
@@ -96,19 +96,16 @@ class TestAutomationBase:
         editor_starttime = time.time()
         self.logger.debug("Running automated test")
         testcase_module_filepath = self._get_testcase_module_filepath(testcase_module)
-        pycmd = ["--runpythontest", testcase_module_filepath, f"-pythontestcase={request.node.name}"]
+        pycmd = ["--runpythontest", testcase_module_filepath, f"-pythontestcase={request.node.name}",
+                 "--regset=/Amazon/Preferences/EnablePrefabSystem=true",
+                 f"--regset-file={path.join(workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}"]
+
         if use_null_renderer:
             pycmd += ["-rhi=null"]
         if batch_mode:
             pycmd += ["-BatchMode"]
         if autotest_mode:
             pycmd += ["-autotest_mode"]
-        if enable_prefab_system:
-            pycmd += [
-                "--regset=/Amazon/Preferences/EnablePrefabSystem=true",
-                f"--regset-file={path.join(workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}"]
-        else:
-            pycmd += ["--regset=/Amazon/Preferences/EnablePrefabSystem=false"]
 
         pycmd += extra_cmdline_args
         editor.args.extend(pycmd) # args are added to the WinLauncher start command

--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -319,8 +319,6 @@ class EditorTestSuite:
     use_null_renderer = True
     # Maximum time for a single editor to stay open on a shared test
     timeout_editor_shared_test = 300
-    # Flag to determine whether to use new prefab system or use deprecated slice system for this test suite
-    enable_prefab_system = True
 
     # Function to calculate number of editors to run in parallel, this can be overridden by the user
     @staticmethod
@@ -767,6 +765,10 @@ class EditorTestSuite:
         if cmdline_args is None:
             cmdline_args = []
         test_cmdline_args = self.global_extra_cmdline_args + cmdline_args
+        test_cmdline_args += [
+            "--regset=/Amazon/Preferences/EnablePrefabSystem=true",
+            f"--regset-file={os.path.join(workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}"]
+
         test_spec_uses_null_renderer = getattr(test_spec, "use_null_renderer", None)
         if test_spec_uses_null_renderer or (test_spec_uses_null_renderer is None and self.use_null_renderer):
             test_cmdline_args += ["-rhi=null"]
@@ -774,12 +776,6 @@ class EditorTestSuite:
             test_cmdline_args += ["--attach-debugger"]
         if test_spec.wait_for_debugger:
             test_cmdline_args += ["--wait-for-debugger"]
-        if self.enable_prefab_system:
-            test_cmdline_args += [
-                "--regset=/Amazon/Preferences/EnablePrefabSystem=true",
-                f"--regset-file={os.path.join(workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}"]
-        else:
-            test_cmdline_args += ["--regset=/Amazon/Preferences/EnablePrefabSystem=false"]
 
         # Cycle any old crash report in case it wasn't cycled properly
         editor_utils.cycle_crash_report(run_id, workspace)
@@ -851,18 +847,16 @@ class EditorTestSuite:
         if cmdline_args is None:
             cmdline_args = []
         test_cmdline_args = self.global_extra_cmdline_args + cmdline_args
+        test_cmdline_args += [
+            "--regset=/Amazon/Preferences/EnablePrefabSystem=true",
+            f"--regset-file={os.path.join(workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}"]
+
         if self.use_null_renderer:
             test_cmdline_args += ["-rhi=null"]
         if any([t.attach_debugger for t in test_spec_list]):
             test_cmdline_args += ["--attach-debugger"]
         if any([t.wait_for_debugger for t in test_spec_list]):
             test_cmdline_args += ["--wait-for-debugger"]
-        if self.enable_prefab_system:
-            test_cmdline_args += [
-                "--regset=/Amazon/Preferences/EnablePrefabSystem=true",
-                f"--regset-file={os.path.join(workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}"]
-        else:
-            test_cmdline_args += ["--regset=/Amazon/Preferences/EnablePrefabSystem=false"]
 
         # Cycle any old crash report in case it wasn't cycled properly
         editor_utils.cycle_crash_report(run_id, workspace)


### PR DESCRIPTION
Remove enable_prefab_system option from the following automated test helper classes/functions:

- EditorTestSuite::_exec_editor_test
- EditorTestSuite::_exec_editor_multitest
- TestAutomationBase::_run_test

Also remove slice related terms in ForceRegion_SliceFileInstantiates.