### PR TITLE
Surface materials weren't checking regions correctly.

### DIFF
--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
@@ -18,6 +18,7 @@
 #include <Atom/Utils/MaterialUtils.h>
 
 #include <SurfaceData/SurfaceDataSystemRequestBus.h>
+#include <SurfaceData/Utility/SurfaceDataUtility.h>
 
 namespace Terrain
 {
@@ -999,7 +1000,7 @@ namespace Terrain
     {
         for (const auto& materialRegion : m_detailMaterialRegions.GetDataVector())
         {
-            if (materialRegion.m_region.Contains(AZ::Vector3(position.GetX(), position.GetY(), 0.0f)))
+            if (SurfaceData::AabbContains2D(materialRegion.m_region, position))
             {
                 return &materialRegion;
             }


### PR DESCRIPTION
This was causing the materials to intermittently not show up. The region comparisons needed to use a 2D AABB check instead of a 3D one with height set to 0, because the camera height could cause the checks to fail.

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>