### PR TITLE
Fix/Convert physics automated tests from TestSuite_Utils

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Utils.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Utils.py
@@ -32,6 +32,10 @@ class TestUtils(TestAutomationBase):
         unexpected_lines = ["Assert"]
         self._run_test(request, workspace, editor, physmaterial_editor_test_module, expected_lines, unexpected_lines)
 
+    def test_UtilTest_Tracer_PicksErrorsAndWarnings(self, request, workspace, launcher_platform, editor):
+        from .utils import UtilTest_Tracer_PicksErrorsAndWarnings as testcase_module
+        self._run_test(request, workspace, editor, testcase_module, [], [])
+
     def test_FileManagement_FindingFiles(self, workspace, launcher_platform):
         """
         Tests the functionality of "searching for files" with FileManagement._find_files()

--- a/AutomatedTesting/Levels/Physics/Physmaterial_Editor_Test/Physmaterial_Editor_Test.prefab
+++ b/AutomatedTesting/Levels/Physics/Physmaterial_Editor_Test/Physmaterial_Editor_Test.prefab
@@ -1,0 +1,118 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Physmaterial_Editor_Test",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[272593270528]": {
+            "Id": "Entity_[272593270528]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                },
+                "Component_[988635461778470350]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 988635461778470350
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Utils/Tracer_ErrorEntity/Tracer_ErrorEntity.prefab
+++ b/AutomatedTesting/Levels/Utils/Tracer_ErrorEntity/Tracer_ErrorEntity.prefab
@@ -1,0 +1,202 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Tracer_ErrorEntity",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[265225761592]": {
+            "Id": "Entity_[265225761592]",
+            "Name": "Entity2",
+            "Components": {
+                "Component_[12562971457884359004]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 12562971457884359004
+                },
+                "Component_[1373734234768443887]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1373734234768443887
+                },
+                "Component_[15285589305898993309]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15285589305898993309
+                },
+                "Component_[1619635290299047744]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1619635290299047744
+                },
+                "Component_[17966844772936319085]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17966844772936319085,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 884904950851484416
+                        },
+                        {
+                            "ComponentId": 7666850511170058566,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17982257912988768282]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17982257912988768282
+                },
+                "Component_[5540118842216992104]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5540118842216992104
+                },
+                "Component_[6131282612213913817]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6131282612213913817
+                },
+                "Component_[7666850511170058566]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 7666850511170058566,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                0.0,
+                                1.0,
+                                1.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[884904950851484416]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 884904950851484416,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            532.0,
+                            34.0
+                        ]
+                    }
+                },
+                "Component_[9055996217752214834]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9055996217752214834
+                }
+            }
+        },
+        "Entity_[273322370241]": {
+            "Id": "Entity_[273322370241]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[7505662882395796332]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7505662882395796332
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Utils/Tracer_WarningEntity/Tracer_WarningEntity.prefab
+++ b/AutomatedTesting/Levels/Utils/Tracer_WarningEntity/Tracer_WarningEntity.prefab
@@ -1,0 +1,132 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Tracer_WarningEntity",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[1645906536243]": {
+            "Id": "Entity_[1645906536243]",
+            "Name": "Entity1",
+            "Components": {
+                "Component_[11165581923831972219]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11165581923831972219
+                },
+                "Component_[11477254106071328893]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11477254106071328893
+                },
+                "Component_[13149469815849867525]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 13149469815849867525,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            545.5,
+                            34.0
+                        ]
+                    }
+                },
+                "Component_[13819484726390584651]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13819484726390584651
+                },
+                "Component_[15783310040117081788]": {
+                    "$type": "EditorScriptCanvasComponent",
+                    "Id": 15783310040117081788,
+                    "m_name": "warning",
+                    "runtimeDataOverrides": {
+                        "source": {
+                            "id": "{644C4886-57E2-5302-B415-B54EDA15894E}"
+                        }
+                    },
+                    "sourceHandle": {
+                        "id": "{644C4886-57E2-5302-B415-B54EDA15894E}",
+                        "path": "levels/utils/tracer_warningentity/scripts/warning.scriptcanvas"
+                    }
+                },
+                "Component_[16454211254045200068]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16454211254045200068
+                },
+                "Component_[17103619063337887770]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17103619063337887770
+                },
+                "Component_[2876676844700944614]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2876676844700944614
+                },
+                "Component_[349477231014193432]": {
+                    "$type": "SelectionComponent",
+                    "Id": 349477231014193432
+                },
+                "Component_[5984633249487220232]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5984633249487220232,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 13149469815849867525
+                        },
+                        {
+                            "ComponentId": 15783310040117081788,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[7243008244758440760]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7243008244758440760
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add physics automated test **test_UtilTest_Tracer_PicksErrorsAndWarnings** back into **TestSuite_Utils.py**, and convert the test levels **Tracer_WarningEntity** and **Tracer_ErrorEntity** into prefab format. This test passed after the conversion.

Also convert test level **Physmaterial_Editor_Test** but the test **UtilTest_Physmaterial_Editor** is still failing.

Using the following command for testing:
```
python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Physics\TestSuite_Utils.py --build-directory windows_vs2019\bin\profile
```

Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>