### PR TITLE
Update the iOS OpenSSL package used by O3DE

### DIFF
--- a/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
+++ b/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
@@ -28,6 +28,6 @@ ly_associate_package(PACKAGE_NAME googletest-1.8.1-rev4-ios      TARGETS googlet
 ly_associate_package(PACKAGE_NAME googlebenchmark-1.5.0-rev2-ios TARGETS GoogleBenchmark PACKAGE_HASH c2ffaed2b658892b1bcf81dee4b44cd1cb09fc78d55584ef5cb8ab87f2d8d1ae)
 ly_associate_package(PACKAGE_NAME png-1.6.37-rev2-ios            TARGETS PNG             PACKAGE_HASH f6a412a761cf3c3076b73a8115911328917b4b4ea6defc78b328a799b7bbed6d)
 ly_associate_package(PACKAGE_NAME libsamplerate-0.2.1-rev2-ios   TARGETS libsamplerate   PACKAGE_HASH 7656b961697f490d4f9c35d2e61559f6fc38c32102e542a33c212cd618fc2119)
-ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1b-rev1-ios        TARGETS OpenSSL         PACKAGE_HASH cd0dfce3086a7172777c63dadbaf0ac3695b676119ecb6d0614b5fb1da03462f)
+ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1m-rev1-ios        TARGETS OpenSSL         PACKAGE_HASH 3e6325f33db6a50ddc44051db1efe4cb0ccd2934eaa6d0d6ffc7ff338219f28c)
 ly_associate_package(PACKAGE_NAME zlib-1.2.11-rev5-ios           TARGETS ZLIB            PACKAGE_HASH c7f10b4d0fe63192054d926f53b08e852cdf472bc2b18e2f7be5aecac1869f7f)
 ly_associate_package(PACKAGE_NAME lz4-1.9.3-vcpkg-rev4-ios       TARGETS lz4             PACKAGE_HASH 588ea05739caa9231a9a17a1e8cf64c5b9a265e16528bc05420af7e2534e86c1)


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

Verified the iOS package using MultiplayerSample. Was able to connect iOS client and Windows server using self-signed cert.