### PR TITLE
Remove reorder from containers unless requested

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
@@ -124,6 +124,7 @@ namespace AZ
             //! Container attribute that is used to override labels for its elements given the index of the element
             const static AZ::Crc32 IndexedChildNameLabelOverride = AZ_CRC("IndexedChildNameLabelOverride", 0x5f313ac2);
             const static AZ::Crc32 DescriptionTextOverride = AZ_CRC("DescriptionTextOverride", 0x608b64a8);
+            const static AZ::Crc32 ContainerReorderAllow = AZ_CRC_CE("ContainerReorderAllow");
 
             const static AZ::Crc32 PrimaryAssetType = AZ_CRC("PrimaryAssetType", 0xa400a5ce);
             const static AZ::Crc32 DynamicElementType = AZ_CRC("DynamicElementType", 0x7c0b82f9);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
@@ -28,7 +28,7 @@ AZ_POP_DISABLE_WARNING
 
 static const int LabelColumnStretch = 2;
 static const int ValueColumnStretch = 3;
-
+#pragma optimize("", off)
 namespace AzToolsFramework
 {
     PropertyRowWidget::PropertyRowWidget(QWidget* pParent)
@@ -922,6 +922,13 @@ namespace AzToolsFramework
                 SetNameLabel(labelText.c_str());
             }
         }
+        else if (attributeName == AZ::Edit::Attributes::ContainerReorderAllow)
+        {
+            if (m_containerEditable)
+            {
+                reader.Read<bool>(m_reorderAllow);
+            }
+        }
         else if (attributeName == AZ::Edit::Attributes::DescriptionTextOverride)
         {
             AZStd::string labelText;
@@ -1744,11 +1751,14 @@ namespace AzToolsFramework
         {
             return false;
         }
-
-        return m_parentRow->CanChildrenBeReordered();
+        if (m_parentRow->m_reorderAllow)
+        {
+            return m_parentRow->CanChildrenBeReordered();
+        }
+        return false;
     }
 
-        int PropertyRowWidget::GetIndexInParent() const
+    int PropertyRowWidget::GetIndexInParent() const
     {
         if (!GetParentRow())
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.hxx
@@ -236,7 +236,6 @@ namespace AzToolsFramework
         bool m_isMultiSizeContainer = false;
         bool m_isFixedSizeOrSmartPtrContainer = false;
         bool m_custom = false;
-        bool m_canChildrenBeReordered = false;
 
         bool m_isSelected = false;
         bool m_selectionEnabled = false;
@@ -260,6 +259,8 @@ namespace AzToolsFramework
 
         QIcon m_iconOpen;
         QIcon m_iconClosed;
+
+        bool m_reorderAllow = false;
 
         /// Marks the field to be visualized as "overridden".
         void SetOverridden(bool overridden);

--- a/Gems/Vegetation/Code/Source/Components/DescriptorListComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/DescriptorListComponent.cpp
@@ -56,6 +56,7 @@ namespace Vegetation
                     ->Attribute(AZ::Edit::Attributes::Visibility, &DescriptorListConfig::IsEmbeddedSource)
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, true)
+                    ->Attribute(AZ::Edit::Attributes::ContainerReorderAllow, true)
                     ->ElementAttribute(AZ::Edit::Attributes::NameLabelOverride, &Descriptor::GetDescriptorName)
                     ->ElementAttribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;


### PR DESCRIPTION
Signed-off-by: John Jones-Steele <82226755+jjjoness@users.noreply.github.com>
Fixes #7516

Removed the allowing reordering containers in the RPE unless explicitly requested. This can be removed if it is decided that reordering should never be allowed.