### PR TITLE
Add metadata to mark AMD Radeon driver 22.2.3 has issues.

### DIFF
--- a/Gems/Atom/RHI/Registry/Platform/Windows/PhysicalDeviceDriverInfo.setreg
+++ b/Gems/Atom/RHI/Registry/Platform/Windows/PhysicalDeviceDriverInfo.setreg
@@ -44,7 +44,7 @@
                                 "$type": "AZ::RHI::PhysicalDeviceDriverInfo",
                                 "vendor": "AMD",
                                 "minVersion": "0.0.0",
-                                "versionWithIssues": []
+                                "versionWithIssues": [22.2.3]
                             }
                     }
                 }

--- a/Gems/Atom/RHI/Registry/Platform/Windows/PhysicalDeviceDriverInfo.setreg
+++ b/Gems/Atom/RHI/Registry/Platform/Windows/PhysicalDeviceDriverInfo.setreg
@@ -44,7 +44,7 @@
                                 "$type": "AZ::RHI::PhysicalDeviceDriverInfo",
                                 "vendor": "AMD",
                                 "minVersion": "0.0.0",
-                                "versionWithIssues": [22.2.3]
+                                "versionWithIssues": ["22.2.3"]
                             }
                     }
                 }


### PR DESCRIPTION
22.2.3 has issues creating the vulkan device.

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>