### PR TITLE
Don't render grid component if size <= 0

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Grid/GridComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Grid/GridComponentController.cpp
@@ -174,11 +174,17 @@ namespace AZ
 
         void GridComponentController::OnBeginPrepareRender()
         {
+            if (m_configuration.m_gridSize <= 0.0f)
+            {
+                return;
+            }
+
             auto* auxGeomFP = AZ::RPI::Scene::GetFeatureProcessorForEntity<AZ::RPI::AuxGeomFeatureProcessorInterface>(m_entityId);
             if (!auxGeomFP)
             {
                 return;
             }
+
             if (auto auxGeom = auxGeomFP->GetDrawQueue())
             {
                 BuildGrid();


### PR DESCRIPTION
This prevents warnings or errors when the grid size is less than or equal to 0

Signed-off-by: Guthrie Adams <guthadam@amazon.com>