### PR TITLE
Fix memory leak when storing the generic class info for Assets

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
@@ -3239,12 +3239,6 @@ namespace AZ
         }
     }
 
-    AZ::GenericClassInfo* SerializeContext::PerModuleGenericClassInfo::FindGenericClassInfo(const AZ::TypeId& genericTypeId) const
-    {
-        auto genericClassInfoFoundIt = m_moduleLocalGenericClassInfos.find(genericTypeId);
-        return genericClassInfoFoundIt != m_moduleLocalGenericClassInfos.end() ? genericClassInfoFoundIt->second : nullptr;
-    }
-
     AZ::IAllocator& SerializeContext::PerModuleGenericClassInfo::GetAllocator()
     {
         return m_moduleOSAllocator;

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
@@ -2496,10 +2496,6 @@ namespace AZ
         template <typename T>
         typename SerializeGenericTypeInfo<T>::ClassInfoType* CreateGenericClassInfo();
 
-        /// Returns GenericClassInfo registered with the current module.
-        template <typename T>
-        AZ::GenericClassInfo* FindGenericClassInfo() const;
-        AZ::GenericClassInfo* FindGenericClassInfo(const AZ::TypeId& genericTypeId) const;
     private:
         void Cleanup();
 
@@ -2516,7 +2512,7 @@ namespace AZ
         using GenericClassInfoType = typename SerializeGenericTypeInfo<T>::ClassInfoType;
         static_assert(AZStd::is_base_of<AZ::GenericClassInfo, GenericClassInfoType>::value, "GenericClassInfoType must be be derived from AZ::GenericClassInfo");
 
-        const AZ::TypeId& canonicalTypeId = AzTypeInfo<T>::Uuid();
+        const AZ::TypeId& canonicalTypeId = GenericClassInfoType().GetSpecializedTypeId();
         auto findIt = m_moduleLocalGenericClassInfos.find(canonicalTypeId);
         if (findIt != m_moduleLocalGenericClassInfos.end())
         {
@@ -2531,12 +2527,6 @@ namespace AZ
             AddGenericClassInfo(genericClassInfo);
         }
         return genericClassInfo;
-    }
-
-    template<typename T>
-    AZ::GenericClassInfo* SerializeContext::PerModuleGenericClassInfo::FindGenericClassInfo() const
-    {
-        return FindGenericClassInfo(azrtti_typeid<T>());
     }
 
     /// Creates AZ::Attribute that is allocated using the the SerializeContext PerModule allocator


### PR DESCRIPTION
Asset types are serialized with a custom serializer that uses the generic
serialization API. This allows for the serializer to be templated on the
asset type. Normally, the serialize context tries to create those generic
serializers only once, by keeping a map of `AZ::TypeId`->`Serializer*`. It
would look in the map to see if a serializer was already present, and only
if it wasn't found, it would create the serializer for that type.

However, the `GenericClassInfo` is allowed to override the typeid that
should be used to identify the types it handles. The map lookup was done
with the "canonical" typeid (ie, the result of `AzTypeInfo<T>::Uuid()`),
but then stored based on the generic's _specialized_ typeid, (ie, the
result of `SerializeGenericTypeInfo<T>::ClassInfoType::GetSpecializedTypeId()`).
Consequently the lookup for a serializer of any asset type would never find
a previously made serializer. To make matters worse, the code that inserts
into the map does not check for pre-existing values, so it would overwrite
the existing `Serializer*`, resulting in a memory leak.

This fixes both issues by making the key used to look up values in the map
the same as the key used to store the value.

Signed-off-by: Chris Burel <burelc@amazon.com>