### PR TITLE
Fix corrupted default name

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/MethodConfiguration.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/MethodConfiguration.cpp
@@ -31,7 +31,7 @@ namespace ScriptCanvas
                 }
                 else
                 {
-                    AZStd::string_view argumentTypeName = replaceTypeName;
+                    AZStd::string argumentTypeName = replaceTypeName;
                     if (argumentTypeName.empty())
                     {
                         if (AZ::BehaviorContextHelper::IsStringParameter(*argument))
@@ -52,7 +52,7 @@ namespace ScriptCanvas
                     }
                     else
                     {
-                        return AZStd::string::format("%s:%2zu", argumentTypeName.data(), argIndex);
+                        return AZStd::string::format("%s:%2zu", argumentTypeName.c_str(), argIndex);
                     }
                 }
             }


### PR DESCRIPTION
## Details
as string_view doesn't have conversion to char*, and we can't guarantee there is always terminated string previous step
using string instead

Signed-off-by: onecent1101 <liug@amazon.com>