### PR TITLE
Fix a couple crashes in MacOS Editor / builders

### DIFF
--- a/Gems/PhysX/Code/Source/Module.cpp
+++ b/Gems/PhysX/Code/Source/Module.cpp
@@ -32,6 +32,7 @@ namespace PhysX
     {
     public:
         AZ_RTTI(PhysX::Module, "{160C59B1-FA68-4CDC-8562-D1204AB78FC1}", AZ::Module);
+        AZ_CLASS_ALLOCATOR(PhysX::Module, AZ::SystemAllocator, 0)
 
         Module()
             : AZ::Module()
@@ -41,6 +42,10 @@ namespace PhysX
             , m_physXSystem(new PhysXSettingsRegistryManager(), PxCooking::GetRealTimeCookingParams())
 #endif
         {
+            static_assert(alignof(PhysX::PhysXSystemConfiguration) == 16);
+            static_assert(alignof(PhysX::PhysXSystem) == 16);
+            static_assert(alignof(PhysX::Module) == 16);
+            
             LoadModules();
 
             AZStd::list<AZ::ComponentDescriptor*> descriptorsToAdd = GetDescriptors();

--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderDataSystem.cpp
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderDataSystem.cpp
@@ -36,6 +36,12 @@ namespace ScriptCanvasBuilder
         DataSystemRequestsBus::Handler::BusConnect();
     }
 
+    DataSystem::~DataSystem()
+    {
+        DataSystemRequestsBus::Handler::BusDisconnect();
+        AzToolsFramework::AssetSystemBus::Handler::BusDisconnect();
+    }
+
     void DataSystem::AddResult(const ScriptCanvasEditor::SourceHandle& handle, BuildResult&& result)
     {
         MutexLock lock(m_mutex);

--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderDataSystem.h
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderDataSystem.h
@@ -31,6 +31,7 @@ namespace ScriptCanvasBuilder
         AZ_CLASS_ALLOCATOR(DataSystem, AZ::SystemAllocator, 0);
 
         DataSystem();
+        virtual ~DataSystem();
 
         BuildResult CompileBuilderData(ScriptCanvasEditor::SourceHandle sourceHandle) override;
 


### PR DESCRIPTION
The Script Canvas Builder didn't disconnect from busses leading
to a lock-up on builder shut down.

The PhysX module didn't declare its allocator type, resulting in a
random crash occuring during initialization, becuase at random it would
be allocated on an 8 byte instead of 16 byte boundary, resulting in
SIMD-alignment failures.

fixes #8614 
fixes #8613 

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>