### PR TITLE
EMotion FX: Unified inspector window framework

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportWidget.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportWidget.cpp
@@ -262,11 +262,16 @@ namespace EMStudio
 
     void AnimViewportWidget::RenderCustomPluginData()
     {
-        const size_t numPlugins = GetPluginManager()->GetNumActivePlugins();
-        for (size_t i = 0; i < numPlugins; ++i)
+        const EMotionFX::ActorRenderFlagsNamespace::ActorRenderFlags renderFlags = m_plugin->GetRenderOptions()->GetRenderFlags();
+
+        for (EMStudioPlugin* plugin : GetPluginManager()->GetActivePlugins())
         {
-            EMStudioPlugin* plugin = GetPluginManager()->GetActivePlugin(i);
-            plugin->Render(m_plugin->GetRenderOptions()->GetRenderFlags());
+            plugin->Render(renderFlags);
+        }
+
+        for (const AZStd::unique_ptr<PersistentPlugin>& plugin : GetPluginManager()->GetPersistentPlugins())
+        {
+            plugin->Render(renderFlags);
         }
     }
 

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.cpp
@@ -60,16 +60,6 @@ namespace EMStudio
         return static_cast<uint32>(AtomRenderPlugin::CLASS_ID);
     }
 
-    const char* AtomRenderPlugin::GetCreatorName() const
-    {
-        return "O3DE";
-    }
-
-    float AtomRenderPlugin::GetVersion() const
-    {
-        return 1.0f;
-    }
-
     bool AtomRenderPlugin::GetIsClosable() const
     {
         return true;
@@ -83,11 +73,6 @@ namespace EMStudio
     bool AtomRenderPlugin::GetIsVertical() const
     {
         return false;
-    }
-
-    EMStudioPlugin* AtomRenderPlugin::Clone()
-    {
-        return new AtomRenderPlugin();
     }
 
     EMStudioPlugin::EPluginType AtomRenderPlugin::GetPluginType() const

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.h
@@ -47,13 +47,11 @@ namespace EMStudio
         // Plugin information
         const char* GetName() const override;
         uint32 GetClassID() const override;
-        const char* GetCreatorName() const override;
-        float GetVersion() const override;
         bool GetIsClosable() const override;
         bool GetIsFloatable() const override;
         bool GetIsVertical() const override;
         bool Init() override;
-        EMStudioPlugin* Clone();
+        EMStudioPlugin* Clone() const { return new AtomRenderPlugin(); }
         EMStudioPlugin::EPluginType GetPluginType() const override;
         QWidget* GetInnerWidget();
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/DockWidgetPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/DockWidgetPlugin.h
@@ -29,7 +29,7 @@ namespace EMStudio
         DockWidgetPlugin();
          ~DockWidgetPlugin() override;
 
-        EMStudioPlugin::EPluginType GetPluginType() const override              { return EMStudioPlugin::PLUGINTYPE_DOCKWIDGET; }
+        EMStudioPlugin::EPluginType GetPluginType() const override              { return EMStudioPlugin::PLUGINTYPE_WINDOW; }
 
         void OnMainWindowClosed() override;
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/EMStudioManager.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/EMStudioManager.cpp
@@ -183,14 +183,16 @@ namespace EMStudio
         if (serializeContext)
         {
             // Reflect plugin related data.
-            const size_t numPlugins = m_pluginManager->GetNumPlugins();
-            if (numPlugins)
+            const PluginManager::PluginVector& registeredPlugins = m_pluginManager->GetRegisteredPlugins();
+            for (EMStudioPlugin* plugin : registeredPlugins)
             {
-                for (size_t i = 0; i < numPlugins; ++i)
-                {
-                    EMStudioPlugin* plugin = m_pluginManager->GetPlugin(i);
-                    plugin->Reflect(serializeContext);
-                }
+                plugin->Reflect(serializeContext);
+            }
+
+            const PluginManager::PersistentPluginVector& persistentPlugins = m_pluginManager->GetPersistentPlugins();
+            for (const AZStd::unique_ptr<PersistentPlugin>& plugin : persistentPlugins)
+            {
+                plugin->Reflect(serializeContext);
             }
 
             // Reflect shared data that might be used by multiple plugins.

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/EMStudioPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/EMStudioPlugin.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-// include MCore
 #if !defined(Q_MOC_RUN)
 #include <MCore/Source/StandardHeaders.h>
 #include <MCore/Source/MemoryFile.h>
@@ -35,36 +34,29 @@ namespace EMStudio
     class PreferencesWindow;
     class RenderPlugin;
 
-    /**
-     *
-     *
-     */
     class EMSTUDIO_API EMStudioPlugin
         : public QObject
     {
+        Q_OBJECT
         MCORE_MEMORYOBJECTCATEGORY(EMStudioPlugin, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_EMSTUDIOSDK)
 
     public:
         enum EPluginType
         {
-            PLUGINTYPE_DOCKWIDGET   = 0,
-            PLUGINTYPE_TOOLBAR      = 1,
-            PLUGINTYPE_RENDERING    = 2,
-            PLUGINTYPE_INVISIBLE    = 3
+            PLUGINTYPE_WINDOW = 0,
+            PLUGINTYPE_TOOLBAR = 1,
+            PLUGINTYPE_RENDERING = 2
         };
 
         EMStudioPlugin()
             : QObject() {}
-        virtual ~EMStudioPlugin() {}
+        virtual ~EMStudioPlugin() = default;
 
-        virtual const char* GetCompileDate() const { return MCORE_DATE; }
         virtual const char* GetName() const = 0;
         virtual uint32 GetClassID() const = 0;
-        virtual const char* GetCreatorName() const { return "Amazon.com, Inc."; }
-        virtual float GetVersion() const { return 1.0f; }
         virtual void Reflect(AZ::ReflectContext*) {}
         virtual bool Init() = 0;
-        virtual EMStudioPlugin* Clone() = 0;
+        virtual EMStudioPlugin* Clone() const = 0;
         virtual EMStudioPlugin::EPluginType GetPluginType() const = 0;
 
         virtual void OnAfterLoadLayout() {}
@@ -124,4 +116,4 @@ namespace EMStudio
 
         virtual void AddWindowMenuEntries([[maybe_unused]] QMenu* parent) { }
     };
-}   // namespace EMStudio
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/LayoutManager.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/LayoutManager.cpp
@@ -128,6 +128,7 @@ namespace EMStudio
         header.m_layoutVersionHigh = 0;
         header.m_layoutVersionLow = 1;
         header.m_numPlugins = aznumeric_caster(GetPluginManager()->GetNumActivePlugins());
+
         if (file.write((char*)&header, sizeof(LayoutHeader)) == -1)
         {
             MCore::LogWarning("Failed to write layout header to layout file '%s'", filename);
@@ -255,7 +256,7 @@ namespace EMStudio
                     {
                         plugin = *itActivePlugin;
                         plugin->SetObjectName(pluginHeader.m_objectName);
-                        if (plugin->GetPluginType() == EMStudioPlugin::PLUGINTYPE_DOCKWIDGET)
+                        if (plugin->GetPluginType() == EMStudioPlugin::PLUGINTYPE_WINDOW)
                         {
                             DockWidgetPlugin* dockPlugin = static_cast<DockWidgetPlugin*>(plugin);
                             // Dock widgets, when maximized, sometimes fail to
@@ -326,10 +327,10 @@ namespace EMStudio
         GetMainWindow()->UpdateCreateWindowMenu(); // update Window->Create menu
 
         // Trigger the OnAfterLoadLayout callbacks.
-        const size_t numActivePlugins = pluginManager->GetNumActivePlugins();
-        for (size_t p = 0; p < numActivePlugins; ++p)
+        const PluginManager::PluginVector& newActivePlugins = pluginManager->GetActivePlugins();
+        for (EMStudioPlugin* plugin : newActivePlugins)
         {
-            GetPluginManager()->GetActivePlugin(p)->OnAfterLoadLayout();
+            plugin->OnAfterLoadLayout();
         }
 
         m_isSwitching = false;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
@@ -44,10 +44,11 @@
 #include <QStatusBar>
 #include <QTextEdit>
 
-// include MCore related
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/IO/Path/Path.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/sort.h>
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
@@ -1088,37 +1089,27 @@ namespace EMStudio
     // update the items inside the Window->Create menu item
     void MainWindow::UpdateCreateWindowMenu()
     {
-        // get the plugin manager
         PluginManager* pluginManager = GetPluginManager();
 
-        // get the number of plugins
-        const size_t numPlugins = pluginManager->GetNumPlugins();
+        const size_t numRegisteredPlugins = pluginManager->GetNumRegisteredPlugins();
+        const PluginManager::PluginVector& registeredPlugins = pluginManager->GetRegisteredPlugins();
 
-        // add each plugin name in an array to sort them
-        AZStd::vector<AZStd::string> sortedPlugins;
-        sortedPlugins.reserve(numPlugins);
-        for (size_t p = 0; p < numPlugins; ++p)
+        AZStd::vector<AZStd::string> sortedPluginNames;
+        sortedPluginNames.reserve(numRegisteredPlugins);
+        for (EMStudioPlugin* plugin : registeredPlugins)
         {
-            EMStudioPlugin* plugin = pluginManager->GetPlugin(p);
-            sortedPlugins.emplace_back(plugin->GetName());
+            sortedPluginNames.push_back(plugin->GetName());
         }
-        AZStd::sort(begin(sortedPlugins), end(sortedPlugins));
+        AZStd::sort(sortedPluginNames.begin(), sortedPluginNames.end());
 
         // clear the window menu
         m_createWindowMenu->clear();
 
         // for all registered plugins, create a menu items
-        for (size_t p = 0; p < numPlugins; ++p)
+        for (const AZStd::string& pluginTypeString : sortedPluginNames)
         {
-            // get the plugin
-            const size_t pluginIndex = pluginManager->FindPluginByTypeString(sortedPlugins[p].c_str());
-            EMStudioPlugin* plugin = pluginManager->GetPlugin(pluginIndex);
-
-            // don't add invisible plugins to the list
-            if (plugin->GetPluginType() == EMStudioPlugin::PLUGINTYPE_INVISIBLE)
-            {
-                continue;
-            }
+            const size_t pluginIndex = pluginManager->FindRegisteredPluginIndex(pluginTypeString.c_str());
+            EMStudioPlugin* plugin = registeredPlugins[pluginIndex];
 
             // check if multiple instances allowed
             // on this case the plugin is not one action but one submenu
@@ -1177,7 +1168,7 @@ namespace EMStudio
             }
 
             // if we have a dock widget plugin here, making floatable and change its window size
-            if (newPlugin->GetPluginType() == EMStudioPlugin::PLUGINTYPE_DOCKWIDGET)
+            if (newPlugin->GetPluginType() == EMStudioPlugin::PLUGINTYPE_WINDOW)
             {
                 DockWidgetPlugin* dockPlugin = static_cast<DockWidgetPlugin*>(newPlugin);
                 QRect dockRect;
@@ -1188,7 +1179,7 @@ namespace EMStudio
         }
         else // (checked == false)
         {
-            EMStudioPlugin* plugin = EMStudio::GetPluginManager()->GetActivePluginByTypeString(FromQtString(pluginName).c_str());
+            EMStudioPlugin* plugin = EMStudio::GetPluginManager()->FindActivePluginByTypeString(FromQtString(pluginName).c_str());
             AZ_Assert(plugin, "Failed to get plugin, since it was checked it should be active");
             EMStudio::GetPluginManager()->RemoveActivePlugin(plugin);
         }
@@ -1226,17 +1217,24 @@ namespace EMStudio
 
             generalPropertyWidget->AddInstance(&m_options, azrtti_typeid(m_options));
 
-            PluginManager* pluginManager = GetPluginManager();
-            const size_t numPlugins = pluginManager->GetNumActivePlugins();
-            for (size_t i = 0; i < numPlugins; ++i)
+            const PluginManager::PluginVector& activePlugins = GetPluginManager()->GetActivePlugins();
+            for (EMStudioPlugin* plugin : activePlugins)
             {
-                EMStudioPlugin* currentPlugin = pluginManager->GetActivePlugin(i);
-                PluginOptions* pluginOptions = currentPlugin->GetOptions();
-                if (pluginOptions)
+                if (PluginOptions* pluginOptions = plugin->GetOptions())
                 {
                     generalPropertyWidget->AddInstance(pluginOptions, azrtti_typeid(pluginOptions));
                 }
             }
+
+            const PluginManager::PersistentPluginVector& persistentPlugins = GetPluginManager()->GetPersistentPlugins();
+            for (const AZStd::unique_ptr<PersistentPlugin>& plugin : persistentPlugins)
+            {
+                if (PluginOptions* pluginOptions = plugin->GetOptions())
+                {
+                    generalPropertyWidget->AddInstance(pluginOptions, azrtti_typeid(pluginOptions));
+                }
+            }
+
 
             AZ::SerializeContext* serializeContext = nullptr;
             AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
@@ -2283,16 +2281,12 @@ namespace EMStudio
                         // set the workspace not dirty
                         workspace->SetDirtyFlag(false);
 
-                        // for all registered plugins, call the after load workspace callback
-                        PluginManager* pluginManager = GetPluginManager();
-                        const size_t numPlugins = pluginManager->GetNumActivePlugins();
-                        for (size_t p = 0; p < numPlugins; ++p)
+                        const PluginManager::PluginVector& activePlugins = GetPluginManager()->GetActivePlugins();
+                        for (EMStudioPlugin* plugin : activePlugins)
                         {
-                            EMStudioPlugin* plugin = pluginManager->GetActivePlugin(p);
                             plugin->OnAfterLoadProject();
                         }
 
-                        // clear the history
                         GetCommandManager()->ClearHistory();
 
                         // set the window title using the workspace filename
@@ -2469,12 +2463,9 @@ namespace EMStudio
             LoadFiles(m_characterFiles, 0, 0, false, true);
             m_characterFiles.clear();
 
-            // for all registered plugins, call the after load actors callback
-            PluginManager* pluginManager = GetPluginManager();
-            const size_t numPlugins = pluginManager->GetNumActivePlugins();
-            for (size_t p = 0; p < numPlugins; ++p)
+            const PluginManager::PluginVector& activePlugins = GetPluginManager()->GetActivePlugins();
+            for (EMStudioPlugin* plugin : activePlugins)
             {
-                EMStudioPlugin* plugin = pluginManager->GetActivePlugin(p);
                 plugin->OnAfterLoadActors();
             }
         }
@@ -2805,14 +2796,9 @@ namespace EMStudio
 
     void MainWindow::OnUpdateRenderPlugins()
     {
-        // sort the active plugins based on their priority
-        PluginManager* pluginManager = GetPluginManager();
-
-        // get the number of active plugins, iterate through them and call the process frame method
-        const size_t numPlugins = pluginManager->GetNumActivePlugins();
-        for (size_t p = 0; p < numPlugins; ++p)
+        const PluginManager::PluginVector& activePlugins = GetPluginManager()->GetActivePlugins();
+        for (EMStudioPlugin* plugin : activePlugins)
         {
-            EMStudioPlugin* plugin = pluginManager->GetActivePlugin(p);
             if (plugin->GetPluginType() == EMStudioPlugin::PLUGINTYPE_RENDERING)
             {
                 plugin->ProcessFrame(0.0f);
@@ -2828,11 +2814,16 @@ namespace EMStudio
             return;
         }
 
-        const size_t numPlugins = pluginManager->GetNumActivePlugins();
-        for (size_t i = 0; i < numPlugins; ++i)
+        const PluginManager::PluginVector& activePlugins = pluginManager->GetActivePlugins();
+        for (EMStudioPlugin* plugin : activePlugins)
         {
-            EMStudio::EMStudioPlugin* plugin = pluginManager->GetActivePlugin(i);
             plugin->ProcessFrame(timeDelta);
+        }
+
+        const PluginManager::PersistentPluginVector& persistentPlugins = pluginManager->GetPersistentPlugins();
+        for (const AZStd::unique_ptr<PersistentPlugin>& plugin : persistentPlugins)
+        {
+            plugin->Update(timeDelta);
         }
     }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
@@ -1096,7 +1096,7 @@ namespace EMStudio
 
         AZStd::vector<AZStd::string> sortedPluginNames;
         sortedPluginNames.reserve(numRegisteredPlugins);
-        for (EMStudioPlugin* plugin : registeredPlugins)
+        for (const EMStudioPlugin* plugin : registeredPlugins)
         {
             sortedPluginNames.push_back(plugin->GetName());
         }

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.h
@@ -72,7 +72,6 @@ namespace EMStudio
 {
     // forward declaration
     class DirtyFileManager;
-    class EMStudioPlugin;
     class FileManager;
     class MainWindow;
     class NativeEventFilter;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.h
@@ -164,6 +164,8 @@ namespace EMStudio
 
         void LoadKeyboardShortcuts();
 
+        void UpdatePlugins(float timeDelta);
+
     public slots:
         void OnAutosaveTimeOut();
         void LoadLayoutAfterShow();
@@ -309,8 +311,6 @@ namespace EMStudio
         // AZ::TickBus::Handler overrides
         void OnTick(float delta, AZ::ScriptTimePoint timePoint) override;
         int GetTickOrder() override;
-
-        void UpdatePlugins(float timeDelta);
 
         void EnableUpdatingPlugins();
         void DisableUpdatingPlugins();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PersistentPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PersistentPlugin.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/RTTI/RTTI.h>
+#include <EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/EMStudioPlugin.h>
+
+namespace EMStudio
+{
+    class PersistentPlugin
+    {
+    public:
+        AZ_RTTI(PersistentPlugin, "{5A1715B1-4AAC-4DBE-B05F-F59D19EBF128}")
+
+        virtual const char* GetName() const = 0;
+
+        virtual void Reflect([[maybe_unused]] AZ::ReflectContext* reflectContext) {}
+        virtual PluginOptions* GetOptions() { return nullptr; }
+
+        virtual void Update([[maybe_unused]] float timeDeltaInSeconds) {}
+        virtual void Render([[maybe_unused]] EMotionFX::ActorRenderFlags renderFlags) {}
+    };
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PersistentPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PersistentPlugin.h
@@ -17,6 +17,7 @@ namespace EMStudio
     {
     public:
         AZ_RTTI(PersistentPlugin, "{5A1715B1-4AAC-4DBE-B05F-F59D19EBF128}")
+        virtual ~PersistentPlugin() = default;
 
         virtual const char* GetName() const = 0;
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PersistentPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PersistentPlugin.h
@@ -13,6 +13,8 @@
 
 namespace EMStudio
 {
+    //! Plugin that will be constructed along with the Animation Editor and survive its full life-cycle.
+    //! Persistent plugins will not be destructed and re-created along with changing layouts.
     class PersistentPlugin
     {
     public:

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PluginManager.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PluginManager.cpp
@@ -94,7 +94,7 @@ namespace EMStudio
                 pluginToNotify->OnBeforeRemovePlugin((*plugin)->GetClassID());
             }
 
-            delete* plugin;
+            delete *plugin;
             m_activePlugins.pop_back();
         }
 
@@ -189,7 +189,7 @@ namespace EMStudio
 
     void PluginManager::RemovePersistentPlugin(PersistentPlugin* plugin)
     {
-        const auto iterator = AZStd::find_if(m_persistentPlugins.begin(), m_persistentPlugins.end(), [=](const AZStd::unique_ptr<PersistentPlugin>& currentPlugin)
+        const auto iterator = AZStd::find_if(m_persistentPlugins.begin(), m_persistentPlugins.end(), [plugin](const AZStd::unique_ptr<PersistentPlugin>& currentPlugin)
             {
                 return (currentPlugin.get() == plugin);
             });

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PluginManager.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PluginManager.cpp
@@ -16,44 +16,52 @@
 #include "DockWidgetPlugin.h"
 
 // include Qt related
-#include <QApplication>
-#include <QDir>
 #include <QMainWindow>
-#include <QRandomGenerator>
+#include <QDir>
 #include <QTime>
 #include <QVariant>
-
+#include <QApplication>
 #include <AzQtComponents/Utilities/RandomNumberGenerator.h>
 
 // include MCore related
 #include <MCore/Source/StringConversions.h>
 #include <MCore/Source/LogManager.h>
 
+// plugins
+#include <EMotionStudio/Plugins/StandardPlugins/Source/LogWindow/LogWindowPlugin.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/CommandBar/CommandBarPlugin.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/ActionHistory/ActionHistoryPlugin.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/Inspector/InspectorWindow.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/MotionWindow/MotionWindowPlugin.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/MorphTargetsWindowPlugin.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/Attachments/AttachmentsPlugin.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/SceneManagerPlugin.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/NodeWindow/NodeWindowPlugin.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventsPlugin.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/NodeGroups/NodeGroupsPlugin.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.h>
+#include <EMotionStudio/Plugins/RenderPlugins/Source/OpenGLRender/OpenGLRenderPlugin.h>
+#include <Editor/Plugins/HitDetection/HitDetectionJointInspectorPlugin.h>
+#include <Editor/Plugins/SkeletonOutliner/SkeletonOutlinerPlugin.h>
+#include <Editor/Plugins/Ragdoll/RagdollNodeInspectorPlugin.h>
+#include <Editor/Plugins/Cloth/ClothJointInspectorPlugin.h>
+#include <Editor/Plugins/SimulatedObject/SimulatedObjectWidget.h>
+
 namespace EMStudio
 {
-    // constructor
-    PluginManager::PluginManager()
-    {
-        m_activePlugins.reserve(50);
-        m_plugins.reserve(50);
-    }
-
-
-    // destructor
     PluginManager::~PluginManager()
     {
-        MCore::LogInfo("Unloading plugins");
         UnloadPlugins();
     }
 
-
-    // remove a given active plugin
     void PluginManager::RemoveActivePlugin(EMStudioPlugin* plugin)
     {
-        PluginVector::const_iterator itPlugin = AZStd::find(m_activePlugins.begin(), m_activePlugins.end(), plugin);
-        if (itPlugin == m_activePlugins.end())
+        auto iterator = AZStd::find(m_activePlugins.begin(), m_activePlugins.end(), plugin);
+        if (iterator == m_activePlugins.end())
         {
-            MCore::LogWarning("Failed to remove plugin '%s'", plugin->GetName());
+            AZ_Warning("EMotionFX", false, "Failed to remove plugin '%s'", plugin->GetName());
             return;
         }
 
@@ -62,10 +70,9 @@ namespace EMStudio
             activePlugin->OnBeforeRemovePlugin(plugin->GetClassID());
         }
 
-        m_activePlugins.erase(itPlugin);
+        m_activePlugins.erase(iterator);
         delete plugin;
     }
-
 
     // unload the plugin libraries
     void PluginManager::UnloadPlugins()
@@ -73,14 +80,13 @@ namespace EMStudio
         // process any remaining events
         QApplication::processEvents();
 
-        // delete all plugins
-        for (EMStudioPlugin* plugin : m_plugins)
+        for (EMStudioPlugin* plugin : m_registeredPlugins)
         {
             delete plugin;
         }
-        m_plugins.clear();
+        m_registeredPlugins.clear();
 
-        // delete all active plugins
+        // delete all active plugins back to front
         for (auto plugin = m_activePlugins.rbegin(); plugin != m_activePlugins.rend(); ++plugin)
         {
             for (EMStudioPlugin* pluginToNotify : m_activePlugins)
@@ -88,31 +94,25 @@ namespace EMStudio
                 pluginToNotify->OnBeforeRemovePlugin((*plugin)->GetClassID());
             }
 
-            delete *plugin;
+            delete* plugin;
             m_activePlugins.pop_back();
         }
+
+        m_persistentPlugins.clear();
     }
-
-
-    // register the plugin
-    void PluginManager::RegisterPlugin(EMStudioPlugin* plugin)
-    {
-        m_plugins.push_back(plugin);
-    }
-
 
     // create a new active plugin from a given type
     EMStudioPlugin* PluginManager::CreateWindowOfType(const char* pluginType, const char* objectName)
     {
         // try to locate the plugin type
-        const size_t pluginIndex = FindPluginByTypeString(pluginType);
+        const size_t pluginIndex = FindRegisteredPluginIndex(pluginType);
         if (pluginIndex == InvalidIndex)
         {
             return nullptr;
         }
 
         // create the new plugin of this type
-        EMStudioPlugin* newPlugin = m_plugins[ pluginIndex ]->Clone();
+        EMStudioPlugin* newPlugin = m_registeredPlugins[pluginIndex]->Clone();
 
         // init the plugin
         newPlugin->CreateBaseInterface(objectName);
@@ -127,18 +127,18 @@ namespace EMStudio
         return newPlugin;
     }
 
-
     // find a given plugin by its name (type string)
-    size_t PluginManager::FindPluginByTypeString(const char* pluginType) const
+    size_t PluginManager::FindRegisteredPluginIndex(const char* pluginType) const
     {
-        const auto foundPlugin = AZStd::find_if(begin(m_plugins), end(m_plugins), [pluginType](const EMStudioPlugin* plugin)
+        const auto foundPlugin = AZStd::find_if(begin(m_registeredPlugins), end(m_registeredPlugins), [pluginType](const EMStudioPlugin* plugin)
         {
             return AzFramework::StringFunc::Equal(pluginType, plugin->GetName());
         });
-        return foundPlugin != end(m_plugins) ? AZStd::distance(begin(m_plugins), foundPlugin) : InvalidIndex;
+        return foundPlugin != end(m_registeredPlugins) ? AZStd::distance(begin(m_registeredPlugins), foundPlugin) : InvalidIndex;
+
     }
 
-    EMStudioPlugin* PluginManager::GetActivePluginByTypeString(const char* pluginType) const
+    EMStudioPlugin* PluginManager::FindActivePluginByTypeString(const char* pluginType) const
     {
         const auto foundPlugin = AZStd::find_if(begin(m_activePlugins), end(m_activePlugins), [pluginType](const EMStudioPlugin* plugin)
         {
@@ -179,7 +179,7 @@ namespace EMStudio
     }
 
     // find the number of active plugins of a given type
-    size_t PluginManager::GetNumActivePluginsOfType(const char* pluginType) const
+    size_t PluginManager::CalcNumActivePluginsOfType(const char* pluginType) const
     {
         return AZStd::accumulate(m_activePlugins.begin(), m_activePlugins.end(), size_t{0}, [pluginType](size_t total, const EMStudioPlugin* plugin)
         {
@@ -187,6 +187,19 @@ namespace EMStudio
         });
     }
 
+    void PluginManager::RemovePersistentPlugin(PersistentPlugin* plugin)
+    {
+        const auto iterator = AZStd::find_if(m_persistentPlugins.begin(), m_persistentPlugins.end(), [=](const AZStd::unique_ptr<PersistentPlugin>& currentPlugin)
+            {
+                return (currentPlugin.get() == plugin);
+            });
+
+        if (iterator != m_persistentPlugins.end())
+        {
+            m_persistentPlugins.erase(iterator);
+
+        }
+    }
 
     // find the first active plugin of a given type
     EMStudioPlugin* PluginManager::FindActivePlugin(uint32 classID) const
@@ -198,15 +211,39 @@ namespace EMStudio
         return foundPlugin != end(m_activePlugins) ? *foundPlugin : nullptr;
     }
 
-
-
-    // find the number of active plugins of a given type
-    size_t PluginManager::GetNumActivePluginsOfType(uint32 classID) const
+    size_t PluginManager::CalcNumActivePluginsOfType(uint32 classID) const
     {
         return AZStd::accumulate(m_activePlugins.begin(), m_activePlugins.end(), size_t{0}, [classID](size_t total, const EMStudioPlugin* plugin)
         {
             return total + (plugin->GetClassID() == classID);
         });
     }
-}   // namespace EMStudio
 
+    void PluginManager::RegisterDefaultPlugins()
+    {
+        m_registeredPlugins.reserve(32);
+
+        RegisterPlugin(new LogWindowPlugin());
+        RegisterPlugin(new CommandBarPlugin());
+        RegisterPlugin(new ActionHistoryPlugin());
+        RegisterPlugin(new MotionWindowPlugin());
+        RegisterPlugin(new MorphTargetsWindowPlugin());
+        RegisterPlugin(new TimeViewPlugin());
+        RegisterPlugin(new AttachmentsPlugin());
+        RegisterPlugin(new SceneManagerPlugin());
+        RegisterPlugin(new NodeWindowPlugin());
+        RegisterPlugin(new MotionEventsPlugin());
+        RegisterPlugin(new MotionSetsWindowPlugin());
+        RegisterPlugin(new NodeGroupsPlugin());
+        RegisterPlugin(new AnimGraphPlugin());
+        RegisterPlugin(new OpenGLRenderPlugin());
+        RegisterPlugin(new EMotionFX::HitDetectionJointInspectorPlugin());
+        RegisterPlugin(new EMotionFX::SkeletonOutlinerPlugin());
+        RegisterPlugin(new EMotionFX::RagdollNodeInspectorPlugin());
+        RegisterPlugin(new EMotionFX::ClothJointInspectorPlugin());
+        RegisterPlugin(new EMotionFX::SimulatedObjectWidget());
+        RegisterPlugin(new InspectorWindow());
+
+        m_activePlugins.reserve(m_registeredPlugins.size());
+    }
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PreferencesWindow.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PreferencesWindow.h
@@ -26,9 +26,6 @@ namespace AzToolsFramework
 
 namespace EMStudio
 {
-    // forward declaration
-    class EMStudioPlugin;
-
     class EMSTUDIO_API PreferencesWindow
         : public QDialog
     {

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderWidget.cpp
@@ -1047,13 +1047,11 @@ namespace EMStudio
             return;
         }
 
-        // render all custom plugin visuals
-        const size_t numPlugins = GetPluginManager()->GetNumActivePlugins();
-        for (size_t i = 0; i < numPlugins; ++i)
-        {
-            EMStudioPlugin* plugin = GetPluginManager()->GetActivePlugin(i);
-            EMStudioPlugin::RenderInfo renderInfo(renderUtil, m_camera, m_width, m_height);
+        EMStudioPlugin::RenderInfo renderInfo(renderUtil, m_camera, m_width, m_height);
 
+        const PluginManager::PluginVector& activePlugins = GetPluginManager()->GetActivePlugins();
+        for (EMStudioPlugin* plugin : activePlugins)
+        {
             plugin->LegacyRender(m_plugin, &renderInfo);
         }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/emstudiosdk_files.cmake
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/emstudiosdk_files.cmake
@@ -30,6 +30,7 @@ set(FILES
     Source/MainWindow.h
     Source/MotionEventPresetManager.cpp
     Source/MotionEventPresetManager.h
+    Source/PersistentPlugin.h
     Source/PluginManager.cpp
     Source/PluginManager.h
     Source/PluginOptions.h

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/RenderPlugins/Source/OpenGLRender/OpenGLRenderPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/RenderPlugins/Source/OpenGLRender/OpenGLRenderPlugin.h
@@ -34,18 +34,15 @@ namespace EMStudio
         ~OpenGLRenderPlugin();
 
         // plugin information
-        const char* GetCompileDate() const override         { return MCORE_DATE; }
         const char* GetName() const override                { return "OpenGL Render Window (Deprecated)"; }
         uint32 GetClassID() const override                  { return static_cast<uint32>(RenderPlugin::CLASS_ID); }
-        const char* GetCreatorName() const override         { return "O3DE"; }
-        float GetVersion() const override                   { return 1.0f;  }
         bool GetIsClosable() const override                 { return true;  }
         bool GetIsFloatable() const override                { return true;  }
         bool GetIsVertical() const override                 { return false; }
 
         // overloaded main init function
         bool Init() override;
-        EMStudioPlugin* Clone() override                    { return new OpenGLRenderPlugin(); }
+        EMStudioPlugin* Clone() const override              { return new OpenGLRenderPlugin(); }
 
         // overloaded functions
         void CreateRenderWidget(RenderViewWidget* renderViewWidget, RenderWidget** outRenderWidget, QWidget** outWidget) override;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/ActionHistory/ActionHistoryPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/ActionHistory/ActionHistoryPlugin.cpp
@@ -35,12 +35,6 @@ namespace EMStudio
     }
 
 
-    const char* ActionHistoryPlugin::GetCompileDate() const
-    {
-        return MCORE_DATE;
-    }
-
-
     const char* ActionHistoryPlugin::GetName() const
     {
         return "Action History";
@@ -50,25 +44,6 @@ namespace EMStudio
     uint32 ActionHistoryPlugin::GetClassID() const
     {
         return ActionHistoryPlugin::CLASS_ID;
-    }
-
-
-    const char* ActionHistoryPlugin::GetCreatorName() const
-    {
-        return "O3DE";
-    }
-
-
-    float ActionHistoryPlugin::GetVersion() const
-    {
-        return 1.0f;
-    }
-
-
-    EMStudioPlugin* ActionHistoryPlugin::Clone()
-    {
-        ActionHistoryPlugin* newPlugin = new ActionHistoryPlugin();
-        return newPlugin;
     }
 
 
@@ -135,5 +110,3 @@ namespace EMStudio
         m_callback->OnSetCurrentCommand(index);
     }
 } // namespace EMStudio
-
-#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/ActionHistory/moc_ActionHistoryPlugin.cpp>

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/ActionHistory/ActionHistoryPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/ActionHistory/ActionHistoryPlugin.h
@@ -19,7 +19,7 @@ namespace EMStudio
     class ActionHistoryPlugin
         : public EMStudio::DockWidgetPlugin
     {
-        Q_OBJECT
+        Q_OBJECT // AUTOMOC
         MCORE_MEMORYOBJECTCATEGORY(ActionHistoryPlugin, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_STANDARDPLUGINS);
 
     public:
@@ -32,18 +32,15 @@ namespace EMStudio
         ~ActionHistoryPlugin();
 
         // overloaded
-        const char* GetCompileDate() const override;
         const char* GetName() const override;
         uint32 GetClassID() const override;
-        const char* GetCreatorName() const override;
-        float GetVersion() const override;
         bool GetIsClosable() const override             { return true; }
         bool GetIsFloatable() const override            { return true; }
         bool GetIsVertical() const override             { return false; }
 
         // overloaded main init function
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override { return new ActionHistoryPlugin(); }
 
         void ReInit();
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.cpp
@@ -279,39 +279,16 @@ namespace EMStudio
         }
     }
 
-
-    // get the compile date
-    const char* AnimGraphPlugin::GetCompileDate() const
-    {
-        return MCORE_DATE;
-    }
-
-
     // get the name
     const char* AnimGraphPlugin::GetName() const
     {
         return "Anim Graph";
     }
 
-
     // get the plugin type id
     uint32 AnimGraphPlugin::GetClassID() const
     {
         return AnimGraphPlugin::CLASS_ID;
-    }
-
-
-    // get the creator name
-    const char* AnimGraphPlugin::GetCreatorName() const
-    {
-        return "O3DE";
-    }
-
-
-    // get the version
-    float AnimGraphPlugin::GetVersion() const
-    {
-        return 1.0f;
     }
 
     void AnimGraphPlugin::AddWindowMenuEntries(QMenu* parent)
@@ -437,14 +414,6 @@ namespace EMStudio
         {
             m_dockWindowActions[option]->setEnabled(isEnabled);
         }
-    }
-
-
-    // clone the log window
-    EMStudioPlugin* AnimGraphPlugin::Clone()
-    {
-        AnimGraphPlugin* newPlugin = new AnimGraphPlugin();
-        return newPlugin;
     }
 
     void AnimGraphPlugin::SetActionFilter(const AnimGraphActionFilter& actionFilter)

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.h
@@ -120,11 +120,8 @@ namespace EMStudio
         ~AnimGraphPlugin();
 
         // overloaded
-        const char* GetCompileDate() const override;
         const char* GetName() const override;
         uint32 GetClassID() const override;
-        const char* GetCreatorName() const override;
-        float GetVersion() const override;
         bool GetIsClosable() const override             { return true; }
         bool GetIsFloatable() const override            { return true; }
         bool GetIsVertical() const override             { return false; }
@@ -232,7 +229,7 @@ namespace EMStudio
         void Reflect(AZ::ReflectContext* serializeContext) override;
         bool Init() override;
         void OnAfterLoadLayout() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override { return new AnimGraphPlugin(); }
 
         const AnimGraphOptions& GetAnimGraphOptions() const                                { return m_options; }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Attachments/AttachmentsPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Attachments/AttachmentsPlugin.cpp
@@ -56,14 +56,6 @@ namespace EMStudio
         delete m_adjustActorCallback;
     }
 
-
-    // clone the log window
-    EMStudioPlugin* AttachmentsPlugin::Clone()
-    {
-        return new AttachmentsPlugin();
-    }
-
-
     // init after the parent dock window has been created
     bool AttachmentsPlugin::Init()
     {
@@ -285,5 +277,3 @@ namespace EMStudio
         return ReInitAttachmentsPlugin();
     }
 } // namespace EMStudio
-
-#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Attachments/moc_AttachmentsPlugin.cpp>

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Attachments/AttachmentsPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Attachments/AttachmentsPlugin.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-// include MCore
 #if !defined(Q_MOC_RUN)
 #include "../StandardPluginsConfig.h"
 #include "../../../../EMStudioSDK/Source/DockWidgetPlugin.h"
@@ -24,15 +23,11 @@ QT_FORWARD_DECLARE_CLASS(QLabel)
 
 namespace EMStudio
 {
-    /**
-     *
-     *
-     */
     class AttachmentsPlugin
         : public EMStudio::DockWidgetPlugin
     {
-        Q_OBJECT
-                           MCORE_MEMORYOBJECTCATEGORY(AttachmentsPlugin, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_STANDARDPLUGINS);
+        Q_OBJECT // AUTOMOC
+        MCORE_MEMORYOBJECTCATEGORY(AttachmentsPlugin, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_STANDARDPLUGINS);
 
     public:
         enum
@@ -44,18 +39,16 @@ namespace EMStudio
         ~AttachmentsPlugin();
 
         // overloaded
-        const char* GetCompileDate() const override         { return MCORE_DATE; }
         const char* GetName() const override                { return "Attachments"; }
         uint32 GetClassID() const override                  { return AttachmentsPlugin::CLASS_ID; }
-        const char* GetCreatorName() const override         { return "O3DE"; }
-        float GetVersion() const override                   { return 1.0f;  }
         bool GetIsClosable() const override                 { return true;  }
         bool GetIsFloatable() const override                { return true;  }
         bool GetIsVertical() const override                 { return false; }
 
         // overloaded main init function
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override { return new AttachmentsPlugin(); }
+
         void ReInit();
         AttachmentsWindow* GetAttachmentsWindow() const     { return m_attachmentsWindow; }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/CommandBar/CommandBarPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/CommandBar/CommandBarPlugin.cpp
@@ -47,11 +47,6 @@ namespace EMStudio
         }
     }
 
-    const char* CommandBarPlugin::GetCompileDate() const
-    {
-        return MCORE_DATE;
-    }
-
     const char* CommandBarPlugin::GetName() const
     {
         return "Command Bar";
@@ -60,22 +55,6 @@ namespace EMStudio
     uint32 CommandBarPlugin::GetClassID() const
     {
         return CommandBarPlugin::CLASS_ID;
-    }
-
-    const char* CommandBarPlugin::GetCreatorName() const
-    {
-        return "O3DE";
-    }
-
-    float CommandBarPlugin::GetVersion() const
-    {
-        return 1.0f;
-    }
-
-    EMStudioPlugin* CommandBarPlugin::Clone()
-    {
-        CommandBarPlugin* newPlugin = new CommandBarPlugin();
-        return newPlugin;
     }
 
     // init after the parent dock window has been created

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/CommandBar/CommandBarPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/CommandBar/CommandBarPlugin.h
@@ -45,11 +45,8 @@ namespace EMStudio
         ~CommandBarPlugin();
 
         // overloaded
-        const char* GetCompileDate() const override;
         const char* GetName() const override;
         uint32 GetClassID() const override;
-        const char* GetCreatorName() const override;
-        float GetVersion() const override;
 
         bool GetIsFloatable() const override                            { return false; }
         bool GetIsVertical() const override                             { return false; }
@@ -59,7 +56,7 @@ namespace EMStudio
 
         // overloaded main init function
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override { return new CommandBarPlugin(); }
 
         void UpdateLockSelectionIcon();
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentHeaderWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentHeaderWidget.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentHeaderWidget.h>
+#include <QHBoxLayout>
+#include <QLabel>
+
+namespace EMStudio
+{
+    ContentHeaderWidget::ContentHeaderWidget(QWidget* parent)
+        : QWidget(parent)
+    {
+        m_iconLabel = new QLabel();
+
+        m_titleLabel = new QLabel();
+        m_titleLabel->setStyleSheet("font-weight: bold;");
+
+        QHBoxLayout* filenameLayout = new QHBoxLayout();
+        filenameLayout->setMargin(2);
+        filenameLayout->addWidget(m_titleLabel, 0, Qt::AlignTop);
+
+        QVBoxLayout* vLayout = new QVBoxLayout();
+        vLayout->addLayout(filenameLayout);
+
+        QHBoxLayout* mainLayout = new QHBoxLayout(this);
+        mainLayout->addWidget(m_iconLabel, 0, Qt::AlignLeft | Qt::AlignTop);
+        mainLayout->addLayout(vLayout);
+        mainLayout->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Fixed));
+    }
+
+    void ContentHeaderWidget::Update(const QString& title, const QString& iconFilename)
+    {
+        m_titleLabel->setText(title);
+        m_iconLabel->setPixmap(FindOrCreateIcon((iconFilename)));
+    }
+
+    const QPixmap& ContentHeaderWidget::FindOrCreateIcon(const QString& iconFilename)
+    {
+        // Check if we have already loaded the icon.
+        const auto iterator = m_cachedIcons.find(iconFilename);
+        if (iterator != m_cachedIcons.end())
+        {
+            return iterator.value();
+        }
+
+        // Load it in case the icon is not in the cache.
+        m_cachedIcons[iconFilename] = QPixmap(iconFilename).scaled(QSize(s_iconSize, s_iconSize), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+        return m_cachedIcons[iconFilename];
+    }
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentHeaderWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentHeaderWidget.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <QHash>
+#include <QWidget>
+
+QT_FORWARD_DECLARE_CLASS(QLabel)
+
+namespace EMStudio
+{
+    //! Header widget used to identify the shown object in the content widget.
+    //! The header widget will be shown in case one or multiple objects are selected.
+    class ContentHeaderWidget
+        : public QWidget
+    {
+        Q_OBJECT //AUTOMOC
+
+    public:
+        explicit ContentHeaderWidget(QWidget* parent = nullptr);
+        ~ContentHeaderWidget() override = default;
+
+        void Update(const QString& title, const QString& iconFilename);
+
+    private:
+        const QPixmap& FindOrCreateIcon(const QString& iconFilename);
+
+        QHash<QString, QPixmap> m_cachedIcons;
+        QLabel* m_iconLabel = nullptr;
+        static constexpr int s_iconSize = 32;
+
+        QLabel* m_titleLabel = nullptr;
+    };
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentWidget.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Component/ComponentApplicationBus.h>
+#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentHeaderWidget.h>
+#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentWidget.h>
+#include <QHBoxLayout>
+
+namespace EMStudio
+{
+    ContentWidget::ContentWidget(QWidget* parent)
+        : QWidget(parent)
+    {
+        m_headerWidget = new ContentHeaderWidget(this);
+
+        m_layout = new QVBoxLayout();
+        m_layout->setAlignment(Qt::AlignTop);
+        m_layout->addWidget(m_headerWidget);
+        setLayout(m_layout);
+    }
+
+    void ContentWidget::Update(const QString& headerTitle, const QString& iconFilename, QWidget* widget)
+    {
+        if (m_widget)
+        {
+            m_widget->hide();
+            m_widget->deleteLater();
+        }
+        m_widget = widget;
+
+        if (widget)
+        {
+            m_layout->addWidget(widget);
+            m_headerWidget->Update(headerTitle, iconFilename);
+        }
+    }
+
+    void ContentWidget::Clear()
+    {
+        Update(/*headerTitle=*/{}, /*iconFilename=*/{}, /*widget=*/nullptr);
+    }
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentWidget.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <QWidget>
+
+QT_FORWARD_DECLARE_CLASS(QVBoxLayout)
+
+namespace EMStudio
+{
+    class ContentHeaderWidget;
+
+    //! The content widget presents the object data to the user.
+    //! It owns a header widget which will always be displayed above the actual data content widget.
+    class ContentWidget
+        : public QWidget
+    {
+        Q_OBJECT //AUTOMOC
+
+    public:
+        explicit ContentWidget(QWidget* parent = nullptr);
+        ~ContentWidget() override = default;
+
+        void Update(const QString& headerTitle, const QString& iconFilename, QWidget* widget);
+        void Clear();
+
+    private:
+        ContentHeaderWidget* m_headerWidget = nullptr;
+        QWidget* m_widget = nullptr;
+        QVBoxLayout* m_layout = nullptr;
+    };
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/InspectorWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/InspectorWindow.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/InspectorWindow.h>
+#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/NoSelectionWidget.h>
+#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentWidget.h>
+#include <QDockWidget>
+#include <QScrollArea>
+#include <QVBoxLayout>
+
+namespace EMStudio
+{
+    InspectorWindow::~InspectorWindow()
+    {
+        InspectorRequestBus::Handler::BusDisconnect();
+    }
+
+    bool InspectorWindow::Init()
+    {
+        m_scrollArea = new QScrollArea();
+        m_scrollArea->setWidgetResizable(true);
+
+        m_dock->setWidget(m_scrollArea);
+
+        m_contentWidget = new ContentWidget(m_dock);
+        m_contentWidget->hide();
+
+        m_noSelectionWidget = new NoSelectionWidget(m_dock);
+        InternalShow(m_noSelectionWidget);
+
+        InspectorRequestBus::Handler::BusConnect();
+        return true;
+    }
+
+    void InspectorWindow::Update(const QString& headerTitle, const QString& iconFilename, QWidget* widget)
+    {
+        if (!widget)
+        {
+            Clear();
+            return;
+        }
+
+        m_objectEditorCardPool.ReturnAllCards();
+        m_contentWidget->Update(headerTitle, iconFilename, widget);
+        InternalShow(m_contentWidget);
+    }
+
+    void InspectorWindow::UpdateWithRpe(const QString& headerTitle, const QString& iconFilename, const AZStd::vector<CardElement>& cardElements)
+    {
+        m_objectEditorCardPool.ReturnAllCards();
+
+        QWidget* containerWidget = new QWidget();
+        QVBoxLayout* vLayout = new QVBoxLayout();
+        vLayout->setMargin(0);
+        containerWidget->setLayout(vLayout);
+
+        for (const CardElement& cardElement : cardElements)
+        {
+            if (cardElement.m_object && !cardElement.m_objectTypeId.IsNull())
+            {
+                ObjectEditorCard* objectEditorCard = m_objectEditorCardPool.GetFree(GetSerializeContext(), containerWidget);
+                objectEditorCard->Update(cardElement.m_cardName, cardElement.m_objectTypeId, cardElement.m_object);
+                vLayout->addWidget(objectEditorCard);
+            }
+            else if (cardElement.m_customWidget)
+            {
+                vLayout->addWidget(cardElement.m_customWidget);
+            }
+        }
+
+        m_contentWidget->Update(headerTitle, iconFilename, containerWidget);
+        InternalShow(m_contentWidget);
+        containerWidget->show();
+    }
+
+    void InspectorWindow::InternalShow(QWidget* widget)
+    {
+        if (m_scrollArea->widget() != widget)
+        {
+            // Get back ownership of the cached widgets to avoid recreating it each time.
+            if (m_scrollArea->widget())
+            {
+                m_scrollArea->widget()->hide();
+            }
+            m_scrollArea->takeWidget();
+
+            // Set the no selection widget and destroy the previous one.
+            m_scrollArea->setWidget(widget);
+        }
+    }
+
+    void InspectorWindow::Clear()
+    {
+        m_objectEditorCardPool.ReturnAllCards();
+
+        m_contentWidget->Clear();
+        InternalShow(m_noSelectionWidget);
+    }
+
+    AZ::SerializeContext* InspectorWindow::GetSerializeContext()
+    {
+        if (!m_serializeContext)
+        {
+            AZ::ComponentApplicationBus::BroadcastResult(m_serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
+            AZ_Error("EMotionFX", m_serializeContext, "Can't get serialize context from component application.");
+        }
+
+        return m_serializeContext;
+    }
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/InspectorWindow.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/InspectorWindow.h
@@ -23,6 +23,9 @@ namespace EMStudio
     class ContentWidget;
     class NoSelectionWidget;
 
+    //! Unified inspector window
+    //! This plugin handles requests from the inspector bus and is used to show properties of
+    //! selected objects in the Animation Editor.
     class InspectorWindow
         : public DockWidgetPlugin
         , public InspectorRequestBus::Handler
@@ -38,13 +41,13 @@ namespace EMStudio
         InspectorWindow() = default;
         ~InspectorWindow() override;
 
-        // DockWidgetPlugin overrides
+        // DockWidgetPlugin overrides...
         bool Init() override;
         EMStudioPlugin* Clone() const override { return new InspectorWindow(); }
         const char* GetName() const override { return "Inspector"; }
         uint32 GetClassID() const override { return CLASS_ID; }
 
-        // InspectorRequestBus overrides
+        // InspectorRequestBus overrides...
         void Update(const QString& headerTitle, const QString& iconFilename, QWidget* widget) override;
         void UpdateWithRpe(const QString& headerTitle, const QString& iconFilename, const AZStd::vector<CardElement>& cardElements) override;
         void Clear() override;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/InspectorWindow.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/InspectorWindow.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/DockWidgetPlugin.h>
+#endif
+#include <Editor/ObjectEditorCardPool.h>
+#include <Editor/InspectorBus.h>
+#include <QVector>
+
+QT_FORWARD_DECLARE_CLASS(QWidget)
+QT_FORWARD_DECLARE_CLASS(QScrollArea)
+
+namespace EMStudio
+{
+    class ContentWidget;
+    class NoSelectionWidget;
+
+    class InspectorWindow
+        : public DockWidgetPlugin
+        , public InspectorRequestBus::Handler
+    {
+        Q_OBJECT //AUTOMOC
+
+    public:
+        enum
+        {
+            CLASS_ID = 0x20201006
+        };
+
+        InspectorWindow() = default;
+        ~InspectorWindow() override;
+
+        // DockWidgetPlugin overrides
+        bool Init() override;
+        EMStudioPlugin* Clone() const override { return new InspectorWindow(); }
+        const char* GetName() const override { return "Inspector"; }
+        uint32 GetClassID() const override { return CLASS_ID; }
+
+        // InspectorRequestBus overrides
+        void Update(const QString& headerTitle, const QString& iconFilename, QWidget* widget) override;
+        void UpdateWithRpe(const QString& headerTitle, const QString& iconFilename, const AZStd::vector<CardElement>& cardElements) override;
+        void Clear() override;
+
+    private:
+        void InternalShow(QWidget* widget);
+
+        AZ::SerializeContext* GetSerializeContext();
+        AZ::SerializeContext* m_serializeContext = nullptr;
+
+        QScrollArea* m_scrollArea = nullptr;
+
+        ContentWidget* m_contentWidget = nullptr;
+        NoSelectionWidget* m_noSelectionWidget = nullptr;
+
+        ObjectEditorCardPool m_objectEditorCardPool;
+    };
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/NoSelectionWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/NoSelectionWidget.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/NoSelectionWidget.h>
+#include <QLabel>
+#include <QFrame>
+#include <QVBoxLayout>
+
+namespace EMStudio
+{
+    NoSelectionWidget::NoSelectionWidget(QWidget* parent)
+        : QWidget(parent)
+    {
+        m_label = new QLabel("Select an object to show its properties in the inspector.", this);
+
+        QFrame* line = new QFrame(this);
+        line->setObjectName(QString::fromUtf8("line"));
+        line->setFrameShape(QFrame::HLine);
+        line->setFrameShadow(QFrame::Sunken);
+
+        QVBoxLayout* layout = new QVBoxLayout(this);
+        layout->setAlignment(Qt::AlignTop);
+        layout->addWidget(m_label);
+        layout->addWidget(line);
+    }
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/NoSelectionWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/NoSelectionWidget.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <QWidget>
+QT_FORWARD_DECLARE_CLASS(QLabel)
+
+namespace EMStudio
+{
+    class NoSelectionWidget
+        : public QWidget
+    {
+        Q_OBJECT //AUTOMOC
+
+    public:
+        explicit NoSelectionWidget(QWidget* parent = nullptr);
+        ~NoSelectionWidget() override = default;
+
+    private:
+        QLabel* m_label = nullptr;
+    };
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/NoSelectionWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/NoSelectionWidget.h
@@ -13,6 +13,7 @@ QT_FORWARD_DECLARE_CLASS(QLabel)
 
 namespace EMStudio
 {
+    //! Widget is shown in the inspector window in case no object is selected.
     class NoSelectionWidget
         : public QWidget
     {

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/LogWindow/LogWindowPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/LogWindow/LogWindowPlugin.cpp
@@ -35,49 +35,17 @@ namespace EMStudio
         }
     }
 
-
-    // get the compile date
-    const char* LogWindowPlugin::GetCompileDate() const
-    {
-        return MCORE_DATE;
-    }
-
-
     // get the name
     const char* LogWindowPlugin::GetName() const
     {
         return "Log Window";
     }
 
-
     // get the plugin type id
     uint32 LogWindowPlugin::GetClassID() const
     {
         return LogWindowPlugin::CLASS_ID;
     }
-
-
-    // get the creator name
-    const char* LogWindowPlugin::GetCreatorName() const
-    {
-        return "O3DE";
-    }
-
-
-    // get the version
-    float LogWindowPlugin::GetVersion() const
-    {
-        return 1.0f;
-    }
-
-
-    // clone the log window
-    EMStudioPlugin* LogWindowPlugin::Clone()
-    {
-        LogWindowPlugin* newPlugin = new LogWindowPlugin();
-        return newPlugin;
-    }
-
 
     // init after the parent dock window has been created
     bool LogWindowPlugin::Init()

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/LogWindow/LogWindowPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/LogWindow/LogWindowPlugin.h
@@ -30,7 +30,7 @@ namespace EMStudio
         : public EMStudio::DockWidgetPlugin
     {
         Q_OBJECT // AUTOMOC
-                           MCORE_MEMORYOBJECTCATEGORY(LogWindowPlugin, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_STANDARDPLUGINS);
+        MCORE_MEMORYOBJECTCATEGORY(LogWindowPlugin, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_STANDARDPLUGINS);
 
     public:
         enum
@@ -42,16 +42,13 @@ namespace EMStudio
         ~LogWindowPlugin();
 
         // overloaded
-        const char* GetCompileDate() const override;
         const char* GetName() const override;
         uint32 GetClassID() const override;
-        const char* GetCreatorName() const override;
-        float GetVersion() const override;
         bool GetIsClosable() const override             { return true; }
         bool GetIsFloatable() const override            { return true; }
         bool GetIsVertical() const override             { return false; }
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override { return new LogWindowPlugin(); }
 
     private slots:
         void OnTextFilterChanged(const QString& text);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/MorphTargetsWindowPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/MorphTargetsWindowPlugin.cpp
@@ -45,15 +45,6 @@ namespace EMStudio
         delete m_dialogStack;
     }
 
-
-    // clone the log window
-    EMStudioPlugin* MorphTargetsWindowPlugin::Clone()
-    {
-        MorphTargetsWindowPlugin* newPlugin = new MorphTargetsWindowPlugin();
-        return newPlugin;
-    }
-
-
     // init after the parent dock window has been created
     bool MorphTargetsWindowPlugin::Init()
     {

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/MorphTargetsWindowPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/MorphTargetsWindowPlugin.h
@@ -38,18 +38,15 @@ namespace EMStudio
         ~MorphTargetsWindowPlugin();
 
         // overloaded
-        const char* GetCompileDate() const override         { return MCORE_DATE; }
         const char* GetName() const override                { return "Morph Targets"; }
         uint32 GetClassID() const override                  { return MorphTargetsWindowPlugin::CLASS_ID; }
-        const char* GetCreatorName() const override         { return "O3DE"; }
-        float GetVersion() const override                   { return 1.0f;  }
         bool GetIsClosable() const override                 { return true;  }
         bool GetIsFloatable() const override                { return true;  }
         bool GetIsVertical() const override                 { return false; }
 
         // overloaded main init function
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override { return new MorphTargetsWindowPlugin(); }
 
         // update the morph targets window based on the current selection
         void ReInit(EMotionFX::ActorInstance* actorInstance, bool forceReInit = false);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventsPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventsPlugin.cpp
@@ -61,13 +61,6 @@ namespace EMStudio
         MotionEventPresetManager::Reflect(context);
     }
 
-    // clone the log window
-    EMStudioPlugin* MotionEventsPlugin::Clone()
-    {
-        return new MotionEventsPlugin();
-    }
-
-
     // on before remove plugin
     void MotionEventsPlugin::OnBeforeRemovePlugin(uint32 classID)
     {

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventsPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventsPlugin.h
@@ -41,18 +41,15 @@ namespace EMStudio
         void Reflect(AZ::ReflectContext* context) override;
 
         // overloaded
-        const char* GetCompileDate() const override     { return MCORE_DATE; }
         const char* GetName() const override            { return "Motion Events"; }
         uint32 GetClassID() const override              { return MotionEventsPlugin::CLASS_ID; }
-        const char* GetCreatorName() const override     { return "O3DE"; }
-        float GetVersion() const override               { return 1.0f;  }
         bool GetIsClosable() const override             { return true;  }
         bool GetIsFloatable() const override            { return true;  }
         bool GetIsVertical() const override             { return false; }
 
         // overloaded main init function
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override { return new MotionEventsPlugin(); }
 
         void OnBeforeRemovePlugin(uint32 classID) override;
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.cpp
@@ -141,12 +141,6 @@ namespace EMStudio
         delete m_dirtyFilesCallback;
     }
 
-    EMStudioPlugin* MotionSetsWindowPlugin::Clone()
-    {
-        MotionSetsWindowPlugin* newPlugin = new MotionSetsWindowPlugin();
-        return newPlugin;
-    }
-
     // init after the parent dock window has been created
     bool MotionSetsWindowPlugin::Init()
     {

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.h
@@ -51,18 +51,15 @@ namespace EMStudio
         ~MotionSetsWindowPlugin();
 
         // overloaded
-        const char* GetCompileDate() const override     { return MCORE_DATE; }
         const char* GetName() const override            { return "Motion Sets"; }
         uint32 GetClassID() const override              { return MotionSetsWindowPlugin::CLASS_ID; }
-        const char* GetCreatorName() const override     { return "O3DE"; }
-        float GetVersion() const override               { return 1.0f;  }
         bool GetIsClosable() const override             { return true;  }
         bool GetIsFloatable() const override            { return true;  }
         bool GetIsVertical() const override             { return false; }
 
         // overloaded main init function
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override { return new MotionSetsWindowPlugin(); }
         void OnAfterLoadProject() override;
 
         void ReInit();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionWindow/MotionWindowPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionWindow/MotionWindowPlugin.cpp
@@ -159,13 +159,6 @@ namespace EMStudio
         m_motionEntries.clear();
     }
 
-
-    EMStudioPlugin* MotionWindowPlugin::Clone()
-    {
-        return new MotionWindowPlugin();
-    }
-
-
     bool MotionWindowPlugin::Init()
     {
         //LogInfo("Initializing motion window.");

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionWindow/MotionWindowPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionWindow/MotionWindowPlugin.h
@@ -48,18 +48,15 @@ namespace EMStudio
         ~MotionWindowPlugin();
 
         // overloaded
-        const char* GetCompileDate() const override     { return MCORE_DATE; }
         const char* GetName() const override            { return "Motions"; }
         uint32 GetClassID() const override              { return MotionWindowPlugin::CLASS_ID; }
-        const char* GetCreatorName() const override     { return "O3DE"; }
-        float GetVersion() const override               { return 1.0f;  }
         bool GetIsClosable() const override             { return true;  }
         bool GetIsFloatable() const override            { return true;  }
         bool GetIsVertical() const override             { return false; }
 
         // overloaded main init function
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override { return new MotionWindowPlugin(); }
 
         void LegacyRender(RenderPlugin* renderPlugin, EMStudioPlugin::RenderInfo* renderInfo) override;
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/NodeGroups/NodeGroupsPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/NodeGroups/NodeGroupsPlugin.cpp
@@ -61,15 +61,6 @@ namespace EMStudio
         delete m_dialogStack;
     }
 
-
-    // clone the log window
-    EMStudioPlugin* NodeGroupsPlugin::Clone()
-    {
-        NodeGroupsPlugin* newPlugin = new NodeGroupsPlugin();
-        return newPlugin;
-    }
-
-
     // init after the parent dock window has been created
     bool NodeGroupsPlugin::Init()
     {

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/NodeGroups/NodeGroupsPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/NodeGroups/NodeGroupsPlugin.h
@@ -42,18 +42,15 @@ namespace EMStudio
         ~NodeGroupsPlugin();
 
         // overloaded
-        const char* GetCompileDate() const override         { return MCORE_DATE; }
         const char* GetName() const override                { return "Node Groups"; }
         uint32 GetClassID() const override                  { return NodeGroupsPlugin::CLASS_ID; }
-        const char* GetCreatorName() const override         { return "O3DE"; }
-        float GetVersion() const override                   { return 1.0f;  }
         bool GetIsClosable() const override                 { return true;  }
         bool GetIsFloatable() const override                { return true;  }
         bool GetIsVertical() const override                 { return false; }
 
         // overloaded main init function
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override { return new NodeGroupsPlugin(); }
 
         // update the node groups window based on the current selection
         void ReInit();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/NodeWindow/NodeWindowPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/NodeWindow/NodeWindowPlugin.cpp
@@ -47,12 +47,6 @@ namespace EMStudio
         m_callbacks.clear();
     }
 
-
-    EMStudioPlugin* NodeWindowPlugin::Clone()
-    {
-        return new NodeWindowPlugin();
-    }
-
     void NodeWindowPlugin::Reflect(AZ::ReflectContext* context)
     {
         NamedPropertyStringValue::Reflect(context);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/NodeWindow/NodeWindowPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/NodeWindow/NodeWindowPlugin.h
@@ -45,11 +45,8 @@ namespace EMStudio
         ~NodeWindowPlugin();
 
         // overloaded
-        const char* GetCompileDate() const override         { return MCORE_DATE; }
         const char* GetName() const override                { return "Joint outliner"; }
         uint32 GetClassID() const override                  { return CLASS_ID; }
-        const char* GetCreatorName() const override         { return "O3DE"; }
-        float GetVersion() const override                   { return 1.0f;  }
         bool GetIsClosable() const override                 { return true;  }
         bool GetIsFloatable() const override                { return true;  }
         bool GetIsVertical() const override                 { return false; }
@@ -57,7 +54,7 @@ namespace EMStudio
         // overloaded main init function
         void Reflect(AZ::ReflectContext* context) override;
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override { return new NodeWindowPlugin(); }
         void ReInit();
 
         void ProcessFrame(float timePassedInSeconds) override;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/SceneManagerPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/SceneManagerPlugin.cpp
@@ -206,14 +206,6 @@ namespace EMStudio
         delete m_dirtyFilesCallback;
     }
 
-
-    // clone the log window
-    EMStudioPlugin* SceneManagerPlugin::Clone()
-    {
-        return new SceneManagerPlugin();
-    }
-
-
     // init after the parent dock window has been created
     bool SceneManagerPlugin::Init()
     {

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/SceneManagerPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/SceneManagerPlugin.h
@@ -73,18 +73,15 @@ namespace EMStudio
         ~SceneManagerPlugin();
 
         // overloaded
-        const char* GetCompileDate() const override         { return MCORE_DATE; }
         const char* GetName() const override                { return "Actor Manager"; }
         uint32 GetClassID() const override                  { return CLASS_ID; }
-        const char* GetCreatorName() const override         { return "O3DE"; }
-        float GetVersion() const override                   { return 1.0f;  }
         bool GetIsClosable() const override                 { return true;  }
         bool GetIsFloatable() const override                { return true;  }
         bool GetIsVertical() const override                 { return false; }
 
         // overloaded main init function
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override { return new SceneManagerPlugin(); }
         void UpdateInterface();
         void ReInit();
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.cpp
@@ -113,14 +113,6 @@ namespace EMStudio
         }
     }
 
-
-    // get the compile date
-    const char* TimeViewPlugin::GetCompileDate() const
-    {
-        return MCORE_DATE;
-    }
-
-
     // get the name
     const char* TimeViewPlugin::GetName() const
     {
@@ -133,29 +125,6 @@ namespace EMStudio
     {
         return TimeViewPlugin::CLASS_ID;
     }
-
-
-    // get the creator name
-    const char* TimeViewPlugin::GetCreatorName() const
-    {
-        return "O3DE";
-    }
-
-
-    // get the version
-    float TimeViewPlugin::GetVersion() const
-    {
-        return 1.0f;
-    }
-
-
-    // clone the log window
-    EMStudioPlugin* TimeViewPlugin::Clone()
-    {
-        TimeViewPlugin* newPlugin = new TimeViewPlugin();
-        return newPlugin;
-    }
-
 
     // on before remove plugin
     void TimeViewPlugin::OnBeforeRemovePlugin(uint32 classID)

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.h
@@ -68,18 +68,15 @@ namespace EMStudio
         ~TimeViewPlugin();
 
         // overloaded
-        const char* GetCompileDate() const override;
         const char* GetName() const override;
         uint32 GetClassID() const override;
-        const char* GetCreatorName() const override;
-        float GetVersion() const override;
         bool GetIsClosable() const override             { return true; }
         bool GetIsFloatable() const override            { return true; }
         bool GetIsVertical() const override             { return false; }
 
         // overloaded main init function
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override { return new TimeViewPlugin(); }
 
         void OnBeforeRemovePlugin(uint32 classID) override;
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/standardplugins_files.cmake
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/standardplugins_files.cmake
@@ -130,6 +130,14 @@ set(FILES
     Source/AnimGraph/ParameterEditor/Vector4ParameterEditor.h
     Source/CommandBar/CommandBarPlugin.cpp
     Source/CommandBar/CommandBarPlugin.h
+    Source/Inspector/ContentWidget.cpp
+    Source/Inspector/ContentWidget.h
+    Source/Inspector/ContentHeaderWidget.cpp
+    Source/Inspector/ContentHeaderWidget.h
+    Source/Inspector/InspectorWindow.cpp
+    Source/Inspector/InspectorWindow.h
+    Source/Inspector/NoSelectionWidget.cpp
+    Source/Inspector/NoSelectionWidget.h
     Source/LogWindow/LogWindowCallback.cpp
     Source/LogWindow/LogWindowCallback.h
     Source/LogWindow/LogWindowPlugin.cpp

--- a/Gems/EMotionFX/Code/Source/Editor/InspectorBus.h
+++ b/Gems/EMotionFX/Code/Source/Editor/InspectorBus.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <QtGlobal>
+#include <QString>
+QT_FORWARD_DECLARE_CLASS(QWidget)
+
+namespace EMStudio
+{
+    class InspectorRequests
+        : public AZ::EBusTraits
+    {
+    public:
+        // Call in case a fully customized widget shall be shown in the inspector. The header widget will be shown above the given widget.
+        virtual void Update([[maybe_unused]] const QString& headerTitle, [[maybe_unused]] const QString& iconFilename, [[maybe_unused]] QWidget* widget) {}
+
+        // Call in case the objects to be inspected are reflected. This creates a card with a reflected property editor inside in the standard way for each object along with a header widget above.
+        // Use this method whenever a single, reflected object shall be visible in the inspector.
+        struct CardElement
+        {
+            void* m_object = nullptr;
+            AZ::TypeId m_objectTypeId;
+            QString m_cardName;
+            QWidget* m_customWidget = nullptr;
+        };
+        virtual void UpdateWithRpe([[maybe_unused]] const QString& headerTitle, [[maybe_unused]] const QString& iconFilename, [[maybe_unused]] const AZStd::vector<CardElement>& cardElements) {}
+
+        // Call in case the inspected object got removed or unselected. This will show the no selection widget in the inspector.
+        virtual void Clear() {}
+    };
+
+    using InspectorRequestBus = AZ::EBus<InspectorRequests>;
+
+
+    class InspectorNotifications
+        : public AZ::EBusTraits
+    {
+    public:
+    };
+
+    using InspectorNotificationBus = AZ::EBus<InspectorNotifications>;
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/Source/Editor/InspectorBus.h
+++ b/Gems/EMotionFX/Code/Source/Editor/InspectorBus.h
@@ -20,7 +20,7 @@ namespace EMStudio
     {
     public:
         // Call in case a fully customized widget shall be shown in the inspector. The header widget will be shown above the given widget.
-        virtual void Update([[maybe_unused]] const QString& headerTitle, [[maybe_unused]] const QString& iconFilename, [[maybe_unused]] QWidget* widget) {}
+        virtual void Update([[maybe_unused]] const QString& headerTitle, [[maybe_unused]] const QString& iconFilename, [[maybe_unused]] QWidget* widget) = 0;
 
         // Call in case the objects to be inspected are reflected. This creates a card with a reflected property editor inside in the standard way for each object along with a header widget above.
         // Use this method whenever a single, reflected object shall be visible in the inspector.
@@ -31,10 +31,10 @@ namespace EMStudio
             QString m_cardName;
             QWidget* m_customWidget = nullptr;
         };
-        virtual void UpdateWithRpe([[maybe_unused]] const QString& headerTitle, [[maybe_unused]] const QString& iconFilename, [[maybe_unused]] const AZStd::vector<CardElement>& cardElements) {}
+        virtual void UpdateWithRpe([[maybe_unused]] const QString& headerTitle, [[maybe_unused]] const QString& iconFilename, [[maybe_unused]] const AZStd::vector<CardElement>& cardElements) = 0;
 
         // Call in case the inspected object got removed or unselected. This will show the no selection widget in the inspector.
-        virtual void Clear() {}
+        virtual void Clear() = 0;
     };
 
     using InspectorRequestBus = AZ::EBus<InspectorRequests>;

--- a/Gems/EMotionFX/Code/Source/Editor/ObjectEditorCard.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/ObjectEditorCard.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzQtComponents/Components/Widgets/CardHeader.h>
+#include <Editor/ObjectEditorCard.h>
+#include <QWidget>
+
+namespace EMStudio
+{
+    ObjectEditorCard::ObjectEditorCard(AZ::SerializeContext* serializeContext, QWidget* parent)
+        : AzQtComponents::Card(parent)
+    {
+        m_objectEditor = new EMotionFX::ObjectEditor(serializeContext, this);
+        m_objectEditor->setObjectName("EMFX.AttributesWindow.ObjectEditor");
+        setContentWidget(m_objectEditor);
+    }
+
+    void ObjectEditorCard::Update(const QString& cardName, const AZ::TypeId& objectTypeId, void* object)
+    {
+        setTitle(cardName);
+        setExpanded(true);
+
+        AzQtComponents::CardHeader* cardHeader = header();
+        cardHeader->setHasContextMenu(false);
+        cardHeader->setHelpURL("");
+
+        m_objectEditor->ClearInstances(true);
+        m_objectEditor->AddInstance(object, objectTypeId);
+    }
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/Source/Editor/ObjectEditorCard.h
+++ b/Gems/EMotionFX/Code/Source/Editor/ObjectEditorCard.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzQtComponents/Components/Widgets/Card.h>
+#include <Source/Editor/ObjectEditor.h>
+
+QT_FORWARD_DECLARE_CLASS(QWidget)
+
+namespace AZ
+{
+    class SerializeContext;
+}
+
+namespace EMStudio
+{
+    class ObjectEditorCard
+        : public AzQtComponents::Card
+    {
+        Q_OBJECT //AUTOMOC
+
+    public:
+        ObjectEditorCard(AZ::SerializeContext* serializeContext, QWidget* parent = nullptr);
+        ~ObjectEditorCard() override = default;
+
+        void Update(const QString& cardName, const AZ::TypeId& objectTypeId, void* object);
+
+        EMotionFX::ObjectEditor* GetObjectEditor() const { return m_objectEditor; }
+
+    private:
+        EMotionFX::ObjectEditor* m_objectEditor = nullptr;
+    };
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/Source/Editor/ObjectEditorCardPool.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/ObjectEditorCardPool.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Editor/ObjectEditorCardPool.h>
+#include <Editor/ObjectEditorCard.h>
+#include <QLabel>
+#include <QFrame>
+#include <QVBoxLayout>
+
+namespace EMStudio
+{
+    ObjectEditorCard* ObjectEditorCardPool::GetFree(AZ::SerializeContext* serializeContext, QWidget* parent)
+    {
+        ObjectEditorCard* rpeCard = nullptr;
+        if (m_availableRpeCards.empty())
+        {
+            rpeCard = new ObjectEditorCard(serializeContext, parent);
+        }
+        else
+        {
+            rpeCard = m_availableRpeCards.top().release();
+            m_availableRpeCards.pop();
+            rpeCard->setParent(parent);
+            rpeCard->show();
+        }
+
+        m_usedRpeCards.push_back(rpeCard);
+        return rpeCard;
+    }
+
+    void ObjectEditorCardPool::ReturnAllCards()
+    {
+        for (ObjectEditorCard* rpeCard : m_usedRpeCards)
+        {
+            rpeCard->hide();
+            rpeCard->setParent(nullptr);
+            m_availableRpeCards.push(AZStd::unique_ptr<ObjectEditorCard>(rpeCard));
+        }
+        m_usedRpeCards.clear();
+    }
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/Source/Editor/ObjectEditorCardPool.h
+++ b/Gems/EMotionFX/Code/Source/Editor/ObjectEditorCardPool.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/std/containers/stack.h>
+#include <QVector>
+#include <Editor/ObjectEditorCard.h>
+
+QT_FORWARD_DECLARE_CLASS(QWidget);
+
+namespace EMStudio
+{
+    class ObjectEditorCardPool
+    {
+    public:
+        ObjectEditorCard* GetFree(AZ::SerializeContext* serializeContext, QWidget* parent);
+        void ReturnAllCards();
+
+    private:
+        AZStd::stack<AZStd::unique_ptr<ObjectEditorCard>> m_availableRpeCards;
+        QVector<ObjectEditorCard*> m_usedRpeCards;
+    };
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/Cloth/ClothJointInspectorPlugin.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/Cloth/ClothJointInspectorPlugin.cpp
@@ -35,12 +35,6 @@ namespace EMotionFX
         EMotionFX::SkeletonOutlinerNotificationBus::Handler::BusDisconnect();
     }
 
-    EMStudio::EMStudioPlugin* ClothJointInspectorPlugin::Clone()
-    {
-        ClothJointInspectorPlugin* newPlugin = new ClothJointInspectorPlugin();
-        return newPlugin;
-    }
-
     bool ClothJointInspectorPlugin::IsNvClothGemAvailable() const
     {
         AZ::SerializeContext* serializeContext = nullptr;

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/Cloth/ClothJointInspectorPlugin.h
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/Cloth/ClothJointInspectorPlugin.h
@@ -42,7 +42,7 @@ namespace EMotionFX
         bool GetIsFloatable() const override                { return true;  }
         bool GetIsVertical() const override                 { return false; }
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override              { return new ClothJointInspectorPlugin(); }
 
         // SkeletonOutlinerNotificationBus overrides
         void OnContextMenu(QMenu* menu, const QModelIndexList& selectedRowIndices) override;

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/HitDetection/HitDetectionJointInspectorPlugin.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/HitDetection/HitDetectionJointInspectorPlugin.cpp
@@ -33,12 +33,6 @@ namespace EMotionFX
         EMotionFX::SkeletonOutlinerNotificationBus::Handler::BusDisconnect();
     }
 
-    EMStudio::EMStudioPlugin* HitDetectionJointInspectorPlugin::Clone()
-    {
-        HitDetectionJointInspectorPlugin* newPlugin = new HitDetectionJointInspectorPlugin();
-        return newPlugin;
-    }
-
     bool HitDetectionJointInspectorPlugin::Init()
     {
         if (ColliderHelpers::AreCollidersReflected())

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/HitDetection/HitDetectionJointInspectorPlugin.h
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/HitDetection/HitDetectionJointInspectorPlugin.h
@@ -38,7 +38,7 @@ namespace EMotionFX
         bool GetIsFloatable() const override                { return true;  }
         bool GetIsVertical() const override                 { return false; }
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override              { return new HitDetectionJointInspectorPlugin(); }
 
         // SkeletonOutlinerNotificationBus overrides
         void OnContextMenu(QMenu* menu, const QModelIndexList& selectedRowIndices) override;

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeInspectorPlugin.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeInspectorPlugin.cpp
@@ -43,12 +43,6 @@ namespace EMotionFX
         EMotionFX::SkeletonOutlinerNotificationBus::Handler::BusDisconnect();
     }
 
-    EMStudio::EMStudioPlugin* RagdollNodeInspectorPlugin::Clone()
-    {
-        RagdollNodeInspectorPlugin* newPlugin = new RagdollNodeInspectorPlugin();
-        return newPlugin;
-    }
-
     bool RagdollNodeInspectorPlugin::IsPhysXGemAvailable() const
     {
         AZ::SerializeContext* serializeContext = nullptr;

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeInspectorPlugin.h
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeInspectorPlugin.h
@@ -43,7 +43,7 @@ namespace EMotionFX
         bool GetIsFloatable() const override                { return true;  }
         bool GetIsVertical() const override                 { return false; }
         bool Init() override;
-        EMStudioPlugin* Clone() override;
+        EMStudioPlugin* Clone() const override              { return new RagdollNodeInspectorPlugin(); }
 
         // SkeletonOutlinerNotificationBus overrides
         void OnContextMenu(QMenu* menu, const QModelIndexList& selectedRowIndices) override;

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/SimulatedObject/SimulatedObjectWidget.h
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/SimulatedObject/SimulatedObjectWidget.h
@@ -55,7 +55,7 @@ namespace EMotionFX
         bool GetIsClosable() const override { return true; }
         bool GetIsFloatable() const override { return true; }
         bool GetIsVertical() const override { return false; }
-        EMStudioPlugin* Clone() override { return new SimulatedObjectWidget(); }
+        EMStudioPlugin* Clone() const override { return new SimulatedObjectWidget(); }
         bool Init() override;
         void Reinit();
 

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/SkeletonOutliner/SkeletonOutlinerPlugin.h
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/SkeletonOutliner/SkeletonOutlinerPlugin.h
@@ -43,7 +43,7 @@ namespace EMotionFX
         bool GetIsClosable() const override                 { return true;  }
         bool GetIsFloatable() const override                { return true;  }
         bool GetIsVertical() const override                 { return false; }
-        EMStudioPlugin* Clone() override                    { return new SkeletonOutlinerPlugin(); }
+        EMStudioPlugin* Clone() const override              { return new SkeletonOutlinerPlugin(); }
         bool Init() override;
 
         // SkeletalOutlinerRequestBus overrides

--- a/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
@@ -74,26 +74,6 @@
 #include <QApplication>
 #include <EMotionStudio/EMStudioSDK/Source/MainWindow.h>
 #include <EMotionStudio/EMStudioSDK/Source/PluginManager.h>
-// EMStudio plugins
-#include <EMotionStudio/Plugins/StandardPlugins/Source/LogWindow/LogWindowPlugin.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/CommandBar/CommandBarPlugin.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/ActionHistory/ActionHistoryPlugin.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/MotionWindow/MotionWindowPlugin.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/MorphTargetsWindowPlugin.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/Attachments/AttachmentsPlugin.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/SceneManagerPlugin.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/NodeWindow/NodeWindowPlugin.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventsPlugin.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/NodeGroups/NodeGroupsPlugin.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.h>
-#include <EMotionStudio/Plugins/RenderPlugins/Source/OpenGLRender/OpenGLRenderPlugin.h>
-#include <Editor/Plugins/HitDetection/HitDetectionJointInspectorPlugin.h>
-#include <Editor/Plugins/SkeletonOutliner/SkeletonOutlinerPlugin.h>
-#include <Editor/Plugins/Ragdoll/RagdollNodeInspectorPlugin.h>
-#include <Editor/Plugins/Cloth/ClothJointInspectorPlugin.h>
-#include <Editor/Plugins/SimulatedObject/SimulatedObjectWidget.h>
 #include <Source/Editor/PropertyWidgets/PropertyTypes.h>
 #include <EMotionFX_Traits_Platform.h>
 
@@ -795,34 +775,6 @@ namespace EMotionFX
 #if defined (EMOTIONFXANIMATION_EDITOR)
 
         //////////////////////////////////////////////////////////////////////////
-        void InitializeEMStudioPlugins()
-        {
-            // Register EMFX plugins.
-            EMStudio::PluginManager* pluginManager = EMStudio::GetPluginManager();
-            pluginManager->RegisterPlugin(new EMStudio::LogWindowPlugin());
-            pluginManager->RegisterPlugin(new EMStudio::CommandBarPlugin());
-            pluginManager->RegisterPlugin(new EMStudio::ActionHistoryPlugin());
-            pluginManager->RegisterPlugin(new EMStudio::MotionWindowPlugin());
-            pluginManager->RegisterPlugin(new EMStudio::MorphTargetsWindowPlugin());
-            pluginManager->RegisterPlugin(new EMStudio::TimeViewPlugin());
-            pluginManager->RegisterPlugin(new EMStudio::AttachmentsPlugin());
-            pluginManager->RegisterPlugin(new EMStudio::SceneManagerPlugin());
-            pluginManager->RegisterPlugin(new EMStudio::NodeWindowPlugin());
-            pluginManager->RegisterPlugin(new EMStudio::MotionEventsPlugin());
-            pluginManager->RegisterPlugin(new EMStudio::MotionSetsWindowPlugin());
-            pluginManager->RegisterPlugin(new EMStudio::NodeGroupsPlugin());
-            pluginManager->RegisterPlugin(new EMStudio::AnimGraphPlugin());
-            pluginManager->RegisterPlugin(new EMStudio::OpenGLRenderPlugin());
-            pluginManager->RegisterPlugin(new EMotionFX::HitDetectionJointInspectorPlugin());
-            pluginManager->RegisterPlugin(new EMotionFX::SkeletonOutlinerPlugin());
-            pluginManager->RegisterPlugin(new EMotionFX::RagdollNodeInspectorPlugin());
-            pluginManager->RegisterPlugin(new EMotionFX::ClothJointInspectorPlugin());
-            pluginManager->RegisterPlugin(new EMotionFX::SimulatedObjectWidget());
-
-            SystemNotificationBus::Broadcast(&SystemNotificationBus::Events::OnRegisterPlugin);
-        }
-
-        //////////////////////////////////////////////////////////////////////////
         void SystemComponent::NotifyRegisterViews()
         {
             using namespace AzToolsFramework;
@@ -845,7 +797,13 @@ namespace EMotionFX
             MysticQt::Initializer::Init("", editorAssetsPath.c_str());
             m_emstudioManager = AZStd::make_unique<EMStudio::EMStudioManager>(qApp, argc, argv);
 
-            InitializeEMStudioPlugins();
+            // Register default plugins
+            EMStudio::PluginManager* pluginManager = EMStudio::GetManager()->GetPluginManager();
+            AZ_Assert(pluginManager, "The plugin manager should be initialized at the time the plugins get registered.");
+            pluginManager->RegisterDefaultPlugins();
+
+            // Let external gems register their plugins
+            SystemNotificationBus::Broadcast(&SystemNotificationBus::Events::OnRegisterPlugin);
 
             // Get the MainWindow the first time so it is constructed
             EMStudio::GetManager()->GetMainWindow();

--- a/Gems/EMotionFX/Code/Tests/Mocks/AtomRenderPlugin.h
+++ b/Gems/EMotionFX/Code/Tests/Mocks/AtomRenderPlugin.h
@@ -38,7 +38,7 @@ namespace EMStudio
             return true;
         };
 
-        EMStudioPlugin* Clone()
+        EMStudioPlugin* Clone() const
         {
             return new MockAtomRenderPlugin();
         };

--- a/Gems/EMotionFX/Code/Tests/UI/CanUseViewMenu.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanUseViewMenu.cpp
@@ -106,18 +106,11 @@ namespace EMotionFX
         QList<QAction*> actions = viewMenu->findChildren<QAction*>();
         int numActions = actions.size() - 1;// -1 as we don't want to include the view menu action itself.
 
-        const size_t numPlugins = pluginManager->GetNumPlugins();
-
         int visiblePlugins = 0;
 
-        for (AZ::u32 pluginIndex = 0; pluginIndex < numPlugins; pluginIndex++)
+        const EMStudio::PluginManager::PluginVector& registeredPlugins = pluginManager->GetRegisteredPlugins();
+        for (EMStudio::EMStudioPlugin* plugin : registeredPlugins)
         {
-            EMStudio::EMStudioPlugin* plugin = pluginManager->GetPlugin(pluginIndex);
-
-            if (plugin->GetPluginType() == EMStudio::EMStudioPlugin::PLUGINTYPE_INVISIBLE)
-            {
-                continue;
-            }
 
             TestViewMenuItem(viewMenu, plugin->GetName());
             visiblePlugins++;

--- a/Gems/EMotionFX/Code/Tests/UI/PersistentPluginTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/PersistentPluginTests.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <gtest/gtest.h>
+#include <Tests/UI/UIFixture.h>
+#include <EMotionStudio/EMStudioSDK/Source/EMStudioManager.h>
+#include <EMotionStudio/EMStudioSDK/Source/PersistentPlugin.h>
+#include <EMotionStudio/Plugins/RenderPlugins/Source/OpenGLRender/OpenGLRenderPlugin.h>
+
+namespace EMotionFX
+{
+    class PersistentTestPlugin
+        : public EMStudio::PersistentPlugin
+    {
+    public:
+        AZ_RTTI(PersistentTestPlugin, "{88360562-1A6D-4BA4-82E3-F9DE0D69732E}", EMStudio::PersistentPlugin)
+
+        const char* GetName() const override { return "PersistentTestPlugin"; }
+
+        MOCK_METHOD1(Reflect, void(AZ::ReflectContext*));
+        MOCK_METHOD0(GetOptions, EMStudio::PluginOptions*());
+        MOCK_METHOD1(Update, void(float));
+        MOCK_METHOD2(Render, void(EMStudio::RenderPlugin*, EMStudio::EMStudioPlugin::RenderInfo*));
+    };
+
+    TEST_F(UIFixture, CreatePersistentPluginTest)
+    {
+        EMStudio::PluginManager* pluginManager = EMStudio::GetPluginManager();
+        const size_t numPreviousPlugins = pluginManager->GetNumPersistentPlugins();
+
+        PersistentTestPlugin* plugin = new PersistentTestPlugin();
+        pluginManager->AddPersistentPlugin(plugin);
+        EXPECT_EQ(pluginManager->GetNumPersistentPlugins(), numPreviousPlugins + 1)
+            << "Failed to add persistent plugin to plugin manager.";
+        EXPECT_EQ(pluginManager->GetPersistentPlugins().size(), pluginManager->GetNumPersistentPlugins())
+            << "Mismatch between the actual container size and the returned number of plugins.";
+
+        EXPECT_CALL(*plugin, Reflect(testing::_)).Times(1);
+        EXPECT_CALL(*plugin, GetOptions()).Times(1);
+    }
+
+    TEST_F(UIFixture, RemovePersistentPluginTest)
+    {
+        EMStudio::PluginManager* pluginManager = EMStudio::GetPluginManager();
+        const size_t numPreviousPlugins = pluginManager->GetNumPersistentPlugins();
+
+        PersistentTestPlugin* plugin = new PersistentTestPlugin();
+        pluginManager->AddPersistentPlugin(plugin);
+        EXPECT_EQ(pluginManager->GetNumPersistentPlugins(), numPreviousPlugins + 1)
+            << "Failed to add persistent plugin to plugin manager.";
+
+        pluginManager->RemovePersistentPlugin(plugin);
+        EXPECT_EQ(pluginManager->GetNumPersistentPlugins(), numPreviousPlugins)
+            << "Failed to remove persistent plugin to plugin manager.";
+    }
+
+    TEST_F(UIFixture, UpdatePersistentPluginsTest)
+    {
+        PersistentTestPlugin* plugin = new PersistentTestPlugin();
+        EMStudio::GetPluginManager()->AddPersistentPlugin(plugin);
+
+        EXPECT_CALL(*plugin, Update(testing::_)).Times(1);
+        EMStudio::GetManager()->UpdatePlugins(1.0f / 60.0f);
+    }
+
+    TEST_F(UIFixture, RenderPersistentPluginsTest)
+    {
+        PersistentTestPlugin* plugin = new PersistentTestPlugin();
+        EMStudio::GetPluginManager()->AddPersistentPlugin(plugin);
+
+        EMStudio::PluginManager* pluginManager = EMStudio::GetPluginManager();
+        EMStudio::OpenGLRenderPlugin* renderPlugin = static_cast<EMStudio::OpenGLRenderPlugin*>(pluginManager->FindActivePlugin(EMStudio::OpenGLRenderPlugin::CLASS_ID));
+        ASSERT_TRUE(renderPlugin) << "Render plugin not found.";
+
+        ASSERT_TRUE(renderPlugin->GetNumViewWidgets() > 0) << "No render view widget available.";
+        EMStudio::RenderViewWidget* viewWidget = renderPlugin->GetViewWidget(0);
+        ASSERT_TRUE(viewWidget) << "Cannot get render view widget.";
+
+        EMStudio::RenderWidget* renderWidget = viewWidget->GetRenderWidget();
+        ASSERT_TRUE(renderWidget) << "No active render widget.";
+
+        EXPECT_CALL(*plugin, Render(testing::_, testing::_)).Times(1);
+        renderWidget->RenderCustomPluginData();
+    }
+} // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/UI/PersistentPluginTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/PersistentPluginTests.cpp
@@ -25,7 +25,7 @@ namespace EMotionFX
         MOCK_METHOD1(Reflect, void(AZ::ReflectContext*));
         MOCK_METHOD0(GetOptions, EMStudio::PluginOptions*());
         MOCK_METHOD1(Update, void(float));
-        MOCK_METHOD2(Render, void(EMStudio::RenderPlugin*, EMStudio::EMStudioPlugin::RenderInfo*));
+        MOCK_METHOD1(Render, void(EMotionFX::ActorRenderFlags));
     };
 
     TEST_F(UIFixture, CreatePersistentPluginTest)
@@ -39,9 +39,6 @@ namespace EMotionFX
             << "Failed to add persistent plugin to plugin manager.";
         EXPECT_EQ(pluginManager->GetPersistentPlugins().size(), pluginManager->GetNumPersistentPlugins())
             << "Mismatch between the actual container size and the returned number of plugins.";
-
-        EXPECT_CALL(*plugin, Reflect(testing::_)).Times(1);
-        EXPECT_CALL(*plugin, GetOptions()).Times(1);
     }
 
     TEST_F(UIFixture, RemovePersistentPluginTest)
@@ -65,26 +62,6 @@ namespace EMotionFX
         EMStudio::GetPluginManager()->AddPersistentPlugin(plugin);
 
         EXPECT_CALL(*plugin, Update(testing::_)).Times(1);
-        EMStudio::GetManager()->UpdatePlugins(1.0f / 60.0f);
-    }
-
-    TEST_F(UIFixture, RenderPersistentPluginsTest)
-    {
-        PersistentTestPlugin* plugin = new PersistentTestPlugin();
-        EMStudio::GetPluginManager()->AddPersistentPlugin(plugin);
-
-        EMStudio::PluginManager* pluginManager = EMStudio::GetPluginManager();
-        EMStudio::OpenGLRenderPlugin* renderPlugin = static_cast<EMStudio::OpenGLRenderPlugin*>(pluginManager->FindActivePlugin(EMStudio::OpenGLRenderPlugin::CLASS_ID));
-        ASSERT_TRUE(renderPlugin) << "Render plugin not found.";
-
-        ASSERT_TRUE(renderPlugin->GetNumViewWidgets() > 0) << "No render view widget available.";
-        EMStudio::RenderViewWidget* viewWidget = renderPlugin->GetViewWidget(0);
-        ASSERT_TRUE(viewWidget) << "Cannot get render view widget.";
-
-        EMStudio::RenderWidget* renderWidget = viewWidget->GetRenderWidget();
-        ASSERT_TRUE(renderWidget) << "No active render widget.";
-
-        EXPECT_CALL(*plugin, Render(testing::_, testing::_)).Times(1);
-        renderWidget->RenderCustomPluginData();
+        EMStudio::GetMainWindow()->UpdatePlugins(1.0f / 60.0f);
     }
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/UI/UIFixture.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/UIFixture.cpp
@@ -75,12 +75,10 @@ namespace EMotionFX
 
     void UIFixture::SetupPluginWindows()
     {
-        // Plugins have to be created after both the QApplication object and
-        // after the SystemComponent
-        const size_t numPlugins = EMStudio::GetPluginManager()->GetNumPlugins();
-        for (size_t i = 0; i < numPlugins; ++i)
+        // Plugins have to be created after both the QApplication object and after the SystemComponent
+        const EMStudio::PluginManager::PluginVector& registeredPlugins = EMStudio::GetPluginManager()->GetRegisteredPlugins();
+        for (EMStudio::EMStudioPlugin* plugin : registeredPlugins)
         {
-            EMStudio::EMStudioPlugin* plugin = EMStudio::GetPluginManager()->GetPlugin(i);
             EMStudio::GetPluginManager()->CreateWindowOfType(plugin->GetName());
         }
     }

--- a/Gems/EMotionFX/Code/emotionfx_editor_files.cmake
+++ b/Gems/EMotionFX/Code/emotionfx_editor_files.cmake
@@ -33,6 +33,7 @@ set(FILES
     Source/Editor/ColliderHelpers.cpp
     Source/Editor/InputDialogValidatable.h
     Source/Editor/InputDialogValidatable.cpp
+    Source/Editor/InspectorBus.h
     Source/Editor/JointSelectionWidget.h
     Source/Editor/JointSelectionWidget.cpp
     Source/Editor/JointSelectionDialog.h
@@ -43,6 +44,10 @@ set(FILES
     Source/Editor/NotificationWidget.cpp
     Source/Editor/ObjectEditor.h
     Source/Editor/ObjectEditor.cpp
+    Source/Editor/ObjectEditorCard.h
+    Source/Editor/ObjectEditorCard.cpp
+    Source/Editor/ObjectEditorCardPool.h
+    Source/Editor/ObjectEditorCardPool.cpp
     Source/Editor/QtMetaTypes.h
     Source/Editor/ReselectingTreeView.cpp
     Source/Editor/ReselectingTreeView.h

--- a/Gems/EMotionFX/Code/emotionfx_editor_tests_files.cmake
+++ b/Gems/EMotionFX/Code/emotionfx_editor_tests_files.cmake
@@ -47,6 +47,7 @@ set(FILES
     Tests/UI/UIFixture.h
     Tests/UI/ModalPopupHandler.cpp
     Tests/UI/ModalPopupHandler.h
+    Tests/UI/PersistentPluginTests.cpp
     Tests/UI/AnimGraphUIFixture.cpp
     Tests/UI/AnimGraphUIFixture.h
     Tests/UI/MenuUIFixture.cpp


### PR DESCRIPTION
* Added inspector plugin containing the content header widget, the content widget, the inspector plugin, no selection widget and the inspector bus.
* Added object editor card and pool
* Added persistent plugin
* Adapted plugin manager to also support the persistent plugins
* Moved registration of default plugins from system component to the plugin manager
* Added automated tests for the new persistent plugins.
* Removed the compile date, creator name and version functions from the plugin base
* Made the clone function const.
* Changed the plugintype enum.
* Adapted all plugins to the changes.

Addressed PR feedback from https://github.com/o3de/o3de/pull/8531