### PR TITLE
Adjust manipulator scale using scale manipulator

### DIFF
--- a/Code/Editor/EditorPreferencesPageViewportManipulator.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportManipulator.cpp
@@ -92,8 +92,8 @@ void CEditorPreferencesPage_ViewportManipulator::Reflect(AZ::SerializeContext& s
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_manipulatorViewBaseScale, "Manipulator View Base Scale",
                 "The base scale to apply to all Manipulator Views (default is 1.0)")
-            ->Attribute(AZ::Edit::Attributes::Min, 0.5f)
-            ->Attribute(AZ::Edit::Attributes::Max, 2.0f)
+            ->Attribute(AZ::Edit::Attributes::Min, AzToolsFramework::MinManipulatorViewBaseScale)
+            ->Attribute(AZ::Edit::Attributes::Max, AzToolsFramework::MaxManipulatorViewBaseScale)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox, &Manipulators::m_flipManipulatorAxesTowardsView, "Flip Manipulator Axes Towards View",
                 "Determines whether Planar and Linear Manipulators should switch to face the view (camera) in the Editor");

--- a/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
+++ b/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
@@ -102,7 +102,6 @@ namespace UnitTest
 
         void TearDown() override
         {
-
             AZ::SettingsRegistry::Unregister(m_settingsRegistry.get());
             m_settingsRegistry.reset();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/LinearManipulator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/LinearManipulator.cpp
@@ -52,7 +52,6 @@ namespace AzToolsFramework
         start.m_screenPosition = interaction.m_mousePick.m_screenCoordinates;
         start.m_localPosition = localTransform.GetTranslation();
         start.m_localScale = AZ::Vector3(localTransform.GetUniformScale());
-        ;
         start.m_localAxis = axis;
         // sign to determine which side of the linear axis we pressed
         // (useful to know when the visual axis flips to face the camera)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportSettings.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportSettings.cpp
@@ -10,14 +10,16 @@
 
 namespace AzToolsFramework
 {
-    constexpr AZStd::string_view FlipManipulatorAxesTowardsViewSetting = "/Amazon/Preferences/Editor/Manipulator/FlipManipulatorAxesTowardsView";
+    constexpr AZStd::string_view FlipManipulatorAxesTowardsViewSetting =
+        "/Amazon/Preferences/Editor/Manipulator/FlipManipulatorAxesTowardsView";
     constexpr AZStd::string_view LinearManipulatorAxisLengthSetting = "/Amazon/Preferences/Editor/Manipulator/LinearManipulatorAxisLength";
     constexpr AZStd::string_view PlanarManipulatorAxisLengthSetting = "/Amazon/Preferences/Editor/Manipulator/PlanarManipulatorAxisLength";
     constexpr AZStd::string_view SurfaceManipulatorRadiusSetting = "/Amazon/Preferences/Editor/Manipulator/SurfaceManipulatorRadius";
     constexpr AZStd::string_view SurfaceManipulatorOpacitySetting = "/Amazon/Preferences/Editor/Manipulator/SurfaceManipulatorOpacity";
     constexpr AZStd::string_view LinearManipulatorConeLengthSetting = "/Amazon/Preferences/Editor/Manipulator/LinearManipulatorConeLength";
     constexpr AZStd::string_view LinearManipulatorConeRadiusSetting = "/Amazon/Preferences/Editor/Manipulator/LinearManipulatorConeRadius";
-    constexpr AZStd::string_view ScaleManipulatorBoxHalfExtentSetting = "/Amazon/Preferences/Editor/Manipulator/ScaleManipulatorBoxHalfExtent";
+    constexpr AZStd::string_view ScaleManipulatorBoxHalfExtentSetting =
+        "/Amazon/Preferences/Editor/Manipulator/ScaleManipulatorBoxHalfExtent";
     constexpr AZStd::string_view RotationManipulatorRadiusSetting = "/Amazon/Preferences/Editor/Manipulator/RotationManipulatorRadius";
     constexpr AZStd::string_view ManipulatorViewBaseScaleSetting = "/Amazon/Preferences/Editor/Manipulator/ViewBaseScale";
     constexpr AZStd::string_view IconsVisibleSetting = "/Amazon/Preferences/Editor/IconsVisible";
@@ -115,7 +117,7 @@ namespace AzToolsFramework
 
     float ManipulatorViewBaseScale()
     {
-        return aznumeric_cast<float>(GetRegistry(ManipulatorViewBaseScaleSetting, 1.0));
+        return aznumeric_cast<float>(GetRegistry(ManipulatorViewBaseScaleSetting, aznumeric_cast<double>(DefaultManipulatorViewBaseScale)));
     }
 
     void SetManipulatorViewBaseScale(const float scale)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportSettings.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportSettings.h
@@ -37,6 +37,10 @@ namespace AzToolsFramework
         return value;
     }
 
+    inline constexpr float DefaultManipulatorViewBaseScale = 1.0f;
+    inline constexpr float MinManipulatorViewBaseScale = 0.25f;
+    inline constexpr float MaxManipulatorViewBaseScale = 2.0f;
+
     bool FlipManipulatorAxesTowardsView();
     void SetFlipManipulatorAxesTowardsView(bool enabled);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1546,7 +1546,7 @@ namespace AzToolsFramework
 
         struct SharedScaleState
         {
-            AZ::Vector3 m_savedScale = AZ::Vector3::CreateZero();
+            AZ::Vector3 m_savedScaleOffset = AZ::Vector3::CreateZero();
             float m_initialViewScale = 0.0f;
             EntityIdList m_entityIds;
         };
@@ -1556,7 +1556,7 @@ namespace AzToolsFramework
 
         auto uniformLeftMouseDownCallback = [this, sharedScaleState]([[maybe_unused]] const LinearManipulator::Action& action)
         {
-            sharedScaleState->m_savedScale = AZ::Vector3::CreateZero();
+            sharedScaleState->m_savedScaleOffset = AZ::Vector3::CreateZero();
             sharedScaleState->m_initialViewScale = ManipulatorViewBaseScale();
             // important to sort entityIds based on hierarchy order when updating transforms
             BuildSortedEntityIdVectorFromEntityIdMap(m_entityIdManipulators.m_lookups, sharedScaleState->m_entityIds);
@@ -1582,7 +1582,7 @@ namespace AzToolsFramework
             if (prevModifiers != action.m_modifiers)
             {
                 UpdateInitialTransform(m_entityIdManipulators);
-                sharedScaleState->m_savedScale = action.LocalScaleOffset();
+                sharedScaleState->m_savedScaleOffset = action.LocalScaleOffset();
                 sharedScaleState->m_initialViewScale = ManipulatorViewBaseScale();
             }
 
@@ -1592,7 +1592,7 @@ namespace AzToolsFramework
             };
 
             const float uniformScale =
-                action.m_start.m_sign * sumVectorElements(action.LocalScaleOffset() - sharedScaleState->m_savedScale);
+                action.m_start.m_sign * sumVectorElements(action.LocalScaleOffset() - sharedScaleState->m_savedScaleOffset);
 
             if (action.m_modifiers.Ctrl())
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -449,8 +449,6 @@ namespace AzToolsFramework
 
     static void InitializeTranslationLookup(EntityIdManipulators& entityIdManipulators)
     {
-        AZ_PROFILE_FUNCTION(AzToolsFramework);
-
         for (auto& entityIdLookup : entityIdManipulators.m_lookups)
         {
             entityIdLookup.second.m_initial = AZ::Transform::CreateTranslation(GetWorldTranslation(entityIdLookup.first));
@@ -783,10 +781,7 @@ namespace AzToolsFramework
         // or switching type of rotation (modifier keys change))
         for (auto& entityIdLookup : entityManipulators.m_lookups)
         {
-            AZ::Transform worldFromLocal = AZ::Transform::CreateIdentity();
-            AZ::TransformBus::EventResult(worldFromLocal, entityIdLookup.first, &AZ::TransformBus::Events::GetWorldTM);
-
-            entityIdLookup.second.m_initial = worldFromLocal;
+            entityIdLookup.second.m_initial = GetWorldTransform(entityIdLookup.first);
         }
     }
 
@@ -1414,13 +1409,7 @@ namespace AzToolsFramework
                 // important to sort entityIds based on hierarchy order when updating transforms
                 BuildSortedEntityIdVectorFromEntityIdMap(m_entityIdManipulators.m_lookups, sharedRotationState->m_entityIds);
 
-                for (auto& entityIdLookup : m_entityIdManipulators.m_lookups)
-                {
-                    AZ::Transform worldFromLocal = AZ::Transform::CreateIdentity();
-                    AZ::TransformBus::EventResult(worldFromLocal, entityIdLookup.first, &AZ::TransformBus::Events::GetWorldTM);
-
-                    entityIdLookup.second.m_initial = worldFromLocal;
-                }
+                UpdateInitialTransform(m_entityIdManipulators);
 
                 m_axisPreview.m_translation = m_entityIdManipulators.m_manipulators->GetLocalTransform().GetTranslation();
                 m_axisPreview.m_orientation = QuaternionFromTransformNoScaling(m_entityIdManipulators.m_manipulators->GetLocalTransform());
@@ -1557,7 +1546,8 @@ namespace AzToolsFramework
 
         struct SharedScaleState
         {
-            AZ::Vector3 m_savedScaleOffset = AZ::Vector3::CreateZero();
+            AZ::Vector3 m_savedScale = AZ::Vector3::CreateZero();
+            float m_initialViewScale = 0.0f;
             EntityIdList m_entityIds;
         };
 
@@ -1566,17 +1556,12 @@ namespace AzToolsFramework
 
         auto uniformLeftMouseDownCallback = [this, sharedScaleState]([[maybe_unused]] const LinearManipulator::Action& action)
         {
-            sharedScaleState->m_savedScaleOffset = AZ::Vector3::CreateZero();
+            sharedScaleState->m_savedScale = AZ::Vector3::CreateZero();
+            sharedScaleState->m_initialViewScale = ManipulatorViewBaseScale();
             // important to sort entityIds based on hierarchy order when updating transforms
             BuildSortedEntityIdVectorFromEntityIdMap(m_entityIdManipulators.m_lookups, sharedScaleState->m_entityIds);
 
-            for (auto& entityIdLookup : m_entityIdManipulators.m_lookups)
-            {
-                AZ::Transform worldFromLocal = AZ::Transform::CreateIdentity();
-                AZ::TransformBus::EventResult(worldFromLocal, entityIdLookup.first, &AZ::TransformBus::Events::GetWorldTM);
-
-                entityIdLookup.second.m_initial = worldFromLocal;
-            }
+            UpdateInitialTransform(m_entityIdManipulators);
 
             m_axisPreview.m_translation = m_entityIdManipulators.m_manipulators->GetLocalTransform().GetTranslation();
             m_axisPreview.m_orientation = QuaternionFromTransformNoScaling(m_entityIdManipulators.m_manipulators->GetLocalTransform());
@@ -1594,57 +1579,62 @@ namespace AzToolsFramework
         auto uniformLeftMouseMoveCallback = [this, sharedScaleState, prevModifiers = ViewportInteraction::KeyboardModifiers()](
                                                 const LinearManipulator::Action& action) mutable
         {
-            // do nothing to modify the manipulator
-            if (action.m_modifiers.Ctrl())
-            {
-                return;
-            }
-
             if (prevModifiers != action.m_modifiers)
             {
                 UpdateInitialTransform(m_entityIdManipulators);
-                sharedScaleState->m_savedScaleOffset = action.LocalScaleOffset();
+                sharedScaleState->m_savedScale = action.LocalScaleOffset();
+                sharedScaleState->m_initialViewScale = ManipulatorViewBaseScale();
             }
 
-            // note: must use sorted entityIds based on hierarchy order when updating transforms
-            for (AZ::EntityId entityId : sharedScaleState->m_entityIds)
+            const auto sumVectorElements = [](const AZ::Vector3& vec)
             {
-                auto entityIdLookupIt = m_entityIdManipulators.m_lookups.find(entityId);
-                if (entityIdLookupIt == m_entityIdManipulators.m_lookups.end())
+                return vec.GetX() + vec.GetY() + vec.GetZ();
+            };
+
+            const float uniformScale =
+                action.m_start.m_sign * sumVectorElements(action.LocalScaleOffset() - sharedScaleState->m_savedScale);
+
+            if (action.m_modifiers.Ctrl())
+            {
+                // adjust the manipulator scale when ctrl is held
+                SetManipulatorViewBaseScale(AZ::GetClamp(
+                    sharedScaleState->m_initialViewScale + uniformScale, MinManipulatorViewBaseScale, MaxManipulatorViewBaseScale));
+            }
+            else
+            {
+                // note: must use sorted entityIds based on hierarchy order when updating transforms
+                for (AZ::EntityId entityId : sharedScaleState->m_entityIds)
                 {
-                    continue;
-                }
-
-                const AZ::Transform initial = entityIdLookupIt->second.m_initial;
-                const float initialScale = initial.GetUniformScale();
-
-                const auto sumVectorElements = [](const AZ::Vector3& vec)
-                {
-                    return vec.GetX() + vec.GetY() + vec.GetZ();
-                };
-
-                const float uniformScale =
-                    action.m_start.m_sign * sumVectorElements(action.LocalScaleOffset() - sharedScaleState->m_savedScaleOffset);
-                const float scale = AZ::GetClamp(1.0f + uniformScale / initialScale, AZ::MinTransformScale, AZ::MaxTransformScale);
-                const AZ::Transform scaleTransform = AZ::Transform::CreateUniformScale(scale);
-
-                switch (InfluenceFromModifiers(action.m_modifiers))
-                {
-                case Influence::Individual:
+                    auto entityIdLookupIt = m_entityIdManipulators.m_lookups.find(entityId);
+                    if (entityIdLookupIt == m_entityIdManipulators.m_lookups.end())
                     {
-                        const AZ::Transform pivotTransform = TransformNormalizedScale(entityIdLookupIt->second.m_initial);
-                        const AZ::Transform transformInPivotSpace = pivotTransform.GetInverse() * initial;
-
-                        SetEntityWorldTransform(entityId, pivotTransform * scaleTransform * transformInPivotSpace);
+                        continue;
                     }
-                    break;
-                case Influence::Group:
-                    {
-                        const AZ::Transform pivotTransform =
-                            TransformNormalizedScale(m_entityIdManipulators.m_manipulators->GetLocalTransform());
-                        const AZ::Transform transformInPivotSpace = pivotTransform.GetInverse() * initial;
 
-                        SetEntityWorldTransform(entityId, pivotTransform * scaleTransform * transformInPivotSpace);
+                    const AZ::Transform initial = entityIdLookupIt->second.m_initial;
+                    const float initialScale = initial.GetUniformScale();
+
+                    const float scale = AZ::GetClamp(1.0f + uniformScale / initialScale, AZ::MinTransformScale, AZ::MaxTransformScale);
+                    const AZ::Transform scaleTransform = AZ::Transform::CreateUniformScale(scale);
+
+                    switch (InfluenceFromModifiers(action.m_modifiers))
+                    {
+                    case Influence::Individual:
+                        {
+                            const AZ::Transform pivotTransform = TransformNormalizedScale(entityIdLookupIt->second.m_initial);
+                            const AZ::Transform transformInPivotSpace = pivotTransform.GetInverse() * initial;
+
+                            SetEntityWorldTransform(entityId, pivotTransform * scaleTransform * transformInPivotSpace);
+                        }
+                        break;
+                    case Influence::Group:
+                        {
+                            const AZ::Transform pivotTransform =
+                                TransformNormalizedScale(m_entityIdManipulators.m_manipulators->GetLocalTransform());
+                            const AZ::Transform transformInPivotSpace = pivotTransform.GetInverse() * initial;
+
+                            SetEntityWorldTransform(entityId, pivotTransform * scaleTransform * transformInPivotSpace);
+                        }
                     }
                 }
             }
@@ -2159,6 +2149,7 @@ namespace AzToolsFramework
             ClearManipulatorOrientationOverride();
             break;
         case Mode::Scale:
+            SetManipulatorViewBaseScale(DefaultManipulatorViewBaseScale);
             m_pivotOverrideFrame.m_pickedEntityIdOverride.SetInvalid();
             break;
         case Mode::Translation:

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -1755,10 +1755,8 @@ namespace UnitTest
                 AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity2WorldTranslation),
                 AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity3WorldTranslation) }));
 
-    class EditorTransformComponentSelectionScaleManipulatorInteractionTestFixture
-        : public EditorTransformComponentSelectionManipulatorInteractionTestFixture
-    {
-    };
+    using EditorTransformComponentSelectionScaleManipulatorInteractionTestFixture =
+        EditorTransformComponentSelectionManipulatorInteractionTestFixture;
 
     TEST_F(
         EditorTransformComponentSelectionScaleManipulatorInteractionTestFixture,

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -157,6 +157,9 @@ namespace UnitTest
             m_entityId1 = CreateEntityWithBounds("Entity1");
             m_entityId2 = CreateEntityWithBounds("Entity2");
             m_entityId3 = CreateEntityWithBounds("Entity3");
+
+            // ensure manipulator view base scale has a sensible default value
+            AzToolsFramework::SetManipulatorViewBaseScale(1.0f);
         }
 
         void PositionEntities()
@@ -1762,9 +1765,6 @@ namespace UnitTest
         UsingScaleManipulatorWithCtrlHeldAdjustsManipulatorBaseViewScale)
     {
         using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
-
-        // ensure manipulator view base scale has a sensible default value
-        AzToolsFramework::SetManipulatorViewBaseScale(1.0f);
 
         PositionEntities();
 

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -29,6 +29,7 @@
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
 #include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 #include <AzToolsFramework/Viewport/ActionBus.h>
+#include <AzToolsFramework/Viewport/ViewportSettings.h>
 #include <AzToolsFramework/ViewportSelection/EditorDefaultSelection.h>
 #include <AzToolsFramework/ViewportSelection/EditorInteractionSystemViewportSelectionRequestBus.h>
 #include <AzToolsFramework/ViewportSelection/EditorPickEntitySelection.h>
@@ -1750,6 +1751,61 @@ namespace UnitTest
                 AZ::Transform::CreateTranslation(AggregateManipulatorPositionWithEntity2and3Selected),
                 AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity2WorldTranslation),
                 AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity3WorldTranslation) }));
+
+    class EditorTransformComponentSelectionScaleManipulatorInteractionTestFixture
+        : public EditorTransformComponentSelectionManipulatorInteractionTestFixture
+    {
+    };
+
+    TEST_F(
+        EditorTransformComponentSelectionScaleManipulatorInteractionTestFixture,
+        UsingScaleManipulatorWithCtrlHeldAdjustsManipulatorBaseViewScale)
+    {
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
+
+        // ensure manipulator view base scale has a sensible default value
+        AzToolsFramework::SetManipulatorViewBaseScale(1.0f);
+
+        PositionEntities();
+
+        // move camera up and to the left so it's just above the normal row of entities
+        AzFramework::SetCameraTransform(
+            m_cameraState,
+            AZ::Transform::CreateFromQuaternionAndTranslation(
+                AZ::Quaternion::CreateFromEulerAnglesDegrees(AZ::Vector3(0.0f, 0.0f, 90.0f)), AZ::Vector3(10.0f, 15.0f, 10.1f)));
+
+        SetTransformMode(EditorTransformComponentSelectionRequestBus::Events::Mode::Scale);
+
+        AzToolsFramework::SelectEntities({ m_entityId1 });
+
+        // manipulator should be centered between the two entities
+        const auto initialManipulatorTransform = GetManipulatorTransform();
+
+        const float screenToWorldMultiplier =
+            AzToolsFramework::CalculateScreenToWorldMultiplier(initialManipulatorTransform->GetTranslation(), m_cameraState);
+
+        const auto translationManipulatorStartHoldWorldPosition1 = AzToolsFramework::GetWorldTransform(m_entityId1).GetTranslation() +
+            initialManipulatorTransform->GetBasisZ() * screenToWorldMultiplier;
+        const auto translationManipulatorEndHoldWorldPosition1 =
+            translationManipulatorStartHoldWorldPosition1 + AZ::Vector3::CreateAxisZ(LinearManipulatorZAxisMovementScale);
+
+        // calculate screen space positions
+        const auto scaleManipulatorHoldScreenPosition =
+            AzFramework::WorldToScreen(translationManipulatorStartHoldWorldPosition1, m_cameraState);
+        const auto scaleManipulatorEndHoldScreenPosition =
+            AzFramework::WorldToScreen(translationManipulatorEndHoldWorldPosition1, m_cameraState);
+
+        m_actionDispatcher->CameraState(m_cameraState)
+            ->MousePosition(scaleManipulatorHoldScreenPosition)
+            ->KeyboardModifierDown(AzToolsFramework::ViewportInteraction::KeyboardModifier::Control)
+            ->MouseLButtonDown()
+            ->MousePosition(scaleManipulatorEndHoldScreenPosition)
+            ->MouseLButtonUp();
+
+        // verify the view base scale as changed the expected amount based on the adjustment made to the manipulator
+        const auto expectedManipulatorViewBaseScale = AzToolsFramework::ManipulatorViewBaseScale();
+        EXPECT_NEAR(expectedManipulatorViewBaseScale, 2.0f, 0.01f);
+    }
 
     using EditorTransformComponentSelectionManipulatorTestFixture =
         IndirectCallManipulatorViewportInteractionFixtureMixin<EditorTransformComponentSelectionFixture>;


### PR DESCRIPTION
This PR adds the ability to hold Ctrl and drag the `ScaleManipulator` to change the size of it (much as you can hold Ctrl and move the `TranslationManipulator` and `ScaleManipulator` without moving the Entity.

https://user-images.githubusercontent.com/82228511/161104601-63f10a7f-ce5f-43b1-ac4d-357130a22301.mp4

## Tests

```
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from EditorTransformComponentSelectionScaleManipulatorInteractionTestFixture
[ RUN      ] EditorTransformComponentSelectionScaleManipulatorInteractionTestFixture.UsingScaleManipulatorWithCtrlHeldAdjustsManipulatorBaseViewScale
[       OK ] EditorTransformComponentSelectionScaleManipulatorInteractionTestFixture.UsingScaleManipulatorWithCtrlHeldAdjustsManipulatorBaseViewScale (237 ms)
[----------] 1 test from EditorTransformComponentSelectionScaleManipulatorInteractionTestFixture (238 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (255 ms total)
[  PASSED  ] 1 test.

# all EditorTransformComponentSelection tests

[----------] Global test environment tear-down
[==========] 87 tests from 20 test cases ran. (17700 ms total)
[  PASSED  ] 87 tests.
```