### PR TITLE
Sort search result by relevance to filter text

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.h
@@ -62,6 +62,7 @@ namespace GraphCanvas
         NodePaletteSortFilterProxyModel(QObject* parent);
 
         bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
+        bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const override;
 
         void PopulateUnfilteredModel();
 
@@ -78,7 +79,7 @@ namespace GraphCanvas
         void OnModelElementAboutToBeRemoved(const GraphCanvasTreeItem* treeItem);
 
     private:
-
+        int CalculateSortingScore(const QModelIndex& source) const;
         void ProcessItemForUnfilteredModel(const GraphCanvasTreeItem* currentItem, bool signalAdd = false);
 
         QCompleter m_unfilteredCompleter;

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/NodePaletteTreeView.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/NodePaletteTreeView.cpp
@@ -30,6 +30,8 @@ namespace GraphCanvas
         setSelectionMode(QAbstractItemView::SelectionMode::ExtendedSelection);
         setDragDropMode(QAbstractItemView::DragDropMode::DragOnly);
         setMouseTracking(true);
+        setSortingEnabled(true);
+        sortByColumn(0, Qt::SortOrder::AscendingOrder);
 
         QObject::connect(this, &AzToolsFramework::QTreeViewWithStateSaving::clicked, this, &NodePaletteTreeView::OnClicked);
         QObject::connect(this, &AzToolsFramework::QTreeViewWithStateSaving::doubleClicked, this, &NodePaletteTreeView::OnDoubleClicked);


### PR DESCRIPTION
## Details
Sort the search result to help find target node easier
Logic:
if item has children, we check against the minimum sorting score from its children including itself
if item has no children, we just check against with its own sorting score

Sorting score logic:
1. item string match with filter, return -1
2. item string contains filter or filter regex, return item string length (assume shorter name has stronger relevance)
3. if none, return max int

https://user-images.githubusercontent.com/5900509/161163442-1ccb374f-cad9-4123-ba7c-b81bd047f808.mp4


Signed-off-by: onecent1101 <liug@amazon.com>