### PR TITLE
Material Component: fix prefab serialization for model UV overrides

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
@@ -34,9 +34,10 @@ namespace AZ
                 serializeContext->RegisterGenericType<MaterialPropertyOverrideMap>();
 
                 serializeContext->Class<MaterialAssignment>()
-                    ->Version(1)
+                    ->Version(2)
                     ->Field("MaterialAsset", &MaterialAssignment::m_materialAsset)
                     ->Field("PropertyOverrides", &MaterialAssignment::m_propertyOverrides)
+                    ->Field("ModelUvOverrides", &MaterialAssignment::m_matModUvOverrides)
                     ;
 
                 if (auto editContext = serializeContext->GetEditContext())


### PR DESCRIPTION
Updating the material assignment serializer to include model UV overrides
JSON serializer does a basic conversion to and from a map of strings

Signed-off-by: Guthrie Adams <guthadam@amazon.com>