### PR TITLE
Add AWS cdk dirs to install output

### DIFF
--- a/Gems/AWSClientAuth/CMakeLists.txt
+++ b/Gems/AWSClientAuth/CMakeLists.txt
@@ -11,3 +11,5 @@ set(gem_json ${gem_path}/gem.json)
 o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
 
 add_subdirectory(Code)
+
+ly_install_directory(DIRECTORIES cdk)

--- a/Gems/AWSCore/CMakeLists.txt
+++ b/Gems/AWSCore/CMakeLists.txt
@@ -11,3 +11,5 @@ set(gem_json ${gem_path}/gem.json)
 o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
 
 add_subdirectory(Code)
+
+ly_install_directory(DIRECTORIES cdk)

--- a/Gems/AWSGameLift/CMakeLists.txt
+++ b/Gems/AWSGameLift/CMakeLists.txt
@@ -7,3 +7,5 @@
 #
 
 add_subdirectory(Code)
+
+ly_install_directory(DIRECTORIES cdk)

--- a/Gems/AWSMetrics/CMakeLists.txt
+++ b/Gems/AWSMetrics/CMakeLists.txt
@@ -7,3 +7,5 @@
 #
 
 add_subdirectory(Code)
+
+ly_install_directory(DIRECTORIES cdk)


### PR DESCRIPTION
Previously, CDK projects associated with the AWS gems were not being included in the `INSTALL` target, making it much harder to get started with these gems if working from an installer version of the engine (vs. source). This change updates CMAKE to include them as part of `INSTALL`.

### Testing

Example: AWSCore built by `INSTALL` _before_:
![image](https://user-images.githubusercontent.com/34254888/161315313-01db0b25-50c1-4138-baea-1c8c2e32763c.png)

...and AWSCore built by `INSTALL` _after_:
![image](https://user-images.githubusercontent.com/34254888/161315635-b9126ffc-ae6a-4cdb-9075-6c46078507a2.png)


 