### PR TITLE
Adding sections of code which SIG-Core group owns

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,27 +13,42 @@
 /Tools/RemoteConsole/ @o3de/sig-testing-reviewers
 
 # SIG-Core areas of ownership
-/Code/LauncherUnified/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/Code/Tools/AssetProcessor/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/AutomatedTesting/Gem/PythonTests/Prefab/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Code/CrashHandler/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Code/Framework/AzCore/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Code/Framework/AzFramework/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Code/Framework/AzGameFramework/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Code/Framework/AzToolsFramework/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Code/LauncherUnified/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/engine.json @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Gems/CrashReporting/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/Gems/LmbrCentral/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/Gems/Profiler/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/Gems/Prefab/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Gems/ImGui/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Gems/LmbrCentral/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Gems/Prefab/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Gems/Profiler/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Registry/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/Templates/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/Tools/EventLogTool/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/cmake/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /scripts/o3de/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /scripts/o3de.* @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/engine.json @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Templates/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Tools/EventLogTool/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+
 # SIG-Core deprecated areas of ownership
+/cmake/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Code/Legacy/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/Tools/SerializeContextAnalyzer/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/SerializeContextAnalysis.bat @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Code/Tools/SerializeContextTools/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/SerializeContextAnalysis.bat @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Tools/SerializeContextAnalyzer/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+
+# SIG-Core temporary areas of ownership. Will be moved to SIG-Simulation when that group is created
+/AutomatedTesting/Gem/PythonTests/Blast @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/AutomatedTesting/Gem/PythonTests/NvCloth @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/AutomatedTesting/Gem/PythonTests/Physics @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Gems/Blast/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Gems/NvCloth/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Gems/PhysX/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Gems/PhysXDebug/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+
+# SIG-Core Asset Pipeline test ownership area
+/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Code/Tools/AssetProcessor/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,28 @@
 # This is being deprecated.
 /Tools/RemoteConsole/ @o3de/sig-testing-reviewers
 
+# SIG-Core areas of ownership
+/Code/LauncherUnified/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Code/Tools/AssetProcessor/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Code/CrashHandler/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Code/Framework/AzCore/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Code/Framework/AzFramework/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Code/Framework/AzGameFramework/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Code/Framework/AzToolsFramework/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Gems/CrashReporting/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Gems/LmbrCentral/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Gems/Profiler/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Gems/Prefab/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Gems/ImGui/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Registry/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Templates/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Tools/EventLogTool/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/cmake/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/scripts/o3de/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/scripts/o3de.* @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/engine.json @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+# SIG-Core deprecated areas of ownership
+/Code/Legacy/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Tools/SerializeContextAnalyzer/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/SerializeContextAnalysis.bat @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Code/Tools/SerializeContextTools/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,6 @@
 /Tools/RemoteConsole/ @o3de/sig-testing-reviewers
 
 # SIG-Core areas of ownership
-/AutomatedTesting/Gem/PythonTests/Prefab/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Code/CrashHandler/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Code/Framework/AzCore/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Code/Framework/AzFramework/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
@@ -24,13 +23,17 @@
 /Gems/CrashReporting/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Gems/ImGui/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Gems/LmbrCentral/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/Gems/Prefab/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Gems/Profiler/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Registry/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /scripts/o3de/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /scripts/o3de.* @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Templates/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Tools/EventLogTool/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+
+# SIG-Core Asset Pipeline ownership area
+/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Code/Tools/AssetProcessor/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 
 # SIG-Core deprecated areas of ownership
 /cmake/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
@@ -47,8 +50,3 @@
 /Gems/NvCloth/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Gems/PhysX/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Gems/PhysXDebug/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-
-# SIG-Core Asset Pipeline test ownership area
-/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/Code/Tools/AssetProcessor/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers


### PR DESCRIPTION
Any changes to those areas of code will add the o3de/sig-core-maintainers and
o3de/sig-core-reviewers groups to any PRs being merge to the o3de protected branches
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>