### PR TITLE
Fix the Android release build failure caused by unused variables

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
@@ -17,10 +17,10 @@ namespace AZ::Debug
 {
 #if defined(AZ_ENABLE_DEBUG_TOOLS)
     void ExceptionHandler(int signal);
-#endif
 
     constexpr int MaxMessageLength = 4096;
     constexpr int MaxStackLines = 100;
+#endif
 
     namespace Platform
     {


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

I got a failure for Android release build since the MaxMessageLength and MaxStackLines variables are unused if AZ_ENABLE_DEBUG_TOOLS is not defined. This PR move the definition of these two variables into the #if defined(AZ_ENABLE_DEBUG_TOOLS) block.