### PR TITLE
Do not load the asset catalog in EMotionFX tests

### DIFF
--- a/Gems/EMotionFX/Code/Tests/SystemComponentFixture.h
+++ b/Gems/EMotionFX/Code/Tests/SystemComponentFixture.h
@@ -116,6 +116,7 @@ namespace EMotionFX
 
             AZ::ComponentApplication::StartupParameters startupParameters;
             startupParameters.m_createEditContext = true;
+            startupParameters.m_loadAssetCatalog = false;
 
             // Add EMotionFX as an active gem within the Settings Registry for unit test
             if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)


### PR DESCRIPTION
This was first fixed in commit 7a9520bd0264f68ba50466ac3bf8586405615701,
but the change in behavior to load the asset catalog in
AzFramework::Application instead of LmbrCentral in commit
3b9384f1e63fcef2605ad904976f413b11a6ed20 reintroduced loading the
AssetCatalog in the EMotionFX tests.

Signed-off-by: Chris Burel <burelc@amazon.com>