### PR TITLE
Misc terrain bugfixes

### DIFF
--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
@@ -263,6 +263,13 @@ namespace Terrain
             const uint32_t updateWidth = aznumeric_cast<uint32_t>(numSamples.first);
             const uint32_t updateHeight = aznumeric_cast<uint32_t>(numSamples.second);
 
+            // If there aren't any samples in the region, there's nothing to update, so just return.
+            if ((updateWidth == 0) || (updateHeight == 0))
+            {
+                m_dirtyRegion = AZ::Aabb::CreateNull();
+                return;
+            }
+
             AZStd::vector<uint16_t> pixels;
             pixels.reserve(updateWidth * updateHeight);
 

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -1220,6 +1220,11 @@ void TerrainSystem::ProcessHeightsFromRegion(
 
     AZStd::vector<AZ::Vector3> inPositions = GenerateInputPositionsFromRegion(inRegion, stepSize, sampler);
 
+    if (inPositions.empty())
+    {
+        return;
+    }
+
     AZStd::vector<bool> terrainExists(inPositions.size());
     AZStd::vector<float> heights(inPositions.size());
 
@@ -1252,6 +1257,11 @@ void TerrainSystem::ProcessNormalsFromRegion(
     const auto [numSamplesX, numSamplesY] = GetNumSamplesFromRegion(inRegion, stepSize, sampler);
 
     AZStd::vector<AZ::Vector3> inPositions = GenerateInputPositionsFromRegion(inRegion, stepSize, sampler);
+
+    if (inPositions.empty())
+    {
+        return;
+    }
 
     AZStd::vector<bool> terrainExists(inPositions.size());
     AZStd::vector<AZ::Vector3> normals(inPositions.size());
@@ -1287,6 +1297,11 @@ void TerrainSystem::ProcessSurfaceWeightsFromRegion(
 
     AZStd::vector<AZ::Vector3> inPositions = GenerateInputPositionsFromRegion(inRegion, stepSize, sampler);
 
+    if (inPositions.empty())
+    {
+        return;
+    }
+
     AZStd::vector<AzFramework::SurfaceData::SurfaceTagWeightList> outSurfaceWeightsList(inPositions.size());
     AZStd::vector<bool> terrainExists(inPositions.size());
 
@@ -1320,6 +1335,11 @@ void TerrainSystem::ProcessSurfacePointsFromRegion(
     const auto [numSamplesX, numSamplesY] = GetNumSamplesFromRegion(inRegion, stepSize, sampler);
 
     AZStd::vector<AZ::Vector3> inPositions = GenerateInputPositionsFromRegion(inRegion, stepSize, sampler);
+
+    if (inPositions.empty())
+    {
+        return;
+    }
 
     AZStd::vector<float> heights(inPositions.size());
     AZStd::vector<AZ::Vector3> normals(inPositions.size());


### PR DESCRIPTION
This fixes a few bugs I ran into while testing out some custom terrain components:
* Fixed multiple out-of-bounds data accesses that occur if bounding box regions are small enough that they cause 0 points to be queried.
* Fixed order-of-initialization bugs with the macro material manager where asserts would trigger if macro material entities started up in certain specific orders relative to the macro material manager.