### PR TITLE
Atom Tools: Fix crash opening/saving documents outside of asset safe/scan folders

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocument.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocument.h
@@ -45,6 +45,7 @@ namespace AtomToolsFramework
         bool SaveAsCopy(const AZStd::string& savePath) override;
         bool SaveAsChild(const AZStd::string& savePath) override;
         bool Close() override;
+        void Clear() override;
         bool IsOpen() const override;
         bool IsModified() const override;
         bool CanSave() const override;
@@ -56,8 +57,6 @@ namespace AtomToolsFramework
         bool EndEdit() override;
 
     protected:
-        virtual void Clear();
-
         virtual bool OpenSucceeded();
         virtual bool OpenFailed();
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
@@ -94,6 +94,8 @@ namespace AtomToolsFramework
         // AtomToolsDocumentNotificationBus::Handler overrides...
         void OnDocumentOpened(const AZ::Uuid& documentId) override;
         void OnDocumentClosed(const AZ::Uuid& documentId) override;
+        void OnDocumentCleared(const AZ::Uuid& documentId) override;
+        void OnDocumentError(const AZ::Uuid& documentId) override;
         void OnDocumentDestroyed(const AZ::Uuid& documentId) override;
         void OnDocumentModified(const AZ::Uuid& documentId) override;
         void OnDocumentUndoStateChanged(const AZ::Uuid& documentId) override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h
@@ -23,39 +23,39 @@ namespace AtomToolsFramework
 
         //! Signal that a document was created
         //! @param documentId unique id of document for which the notification is sent
-        virtual void OnDocumentCreated([[maybe_unused]] const AZ::Uuid& documentId) {}
+        virtual void OnDocumentCreated([[maybe_unused]] const AZ::Uuid& documentId){};
 
         //! Signal that a document was destroyed
         //! @param documentId unique id of document for which the notification is sent
-        virtual void OnDocumentDestroyed([[maybe_unused]] const AZ::Uuid& documentId) {}
+        virtual void OnDocumentDestroyed([[maybe_unused]] const AZ::Uuid& documentId){};
 
         //! Signal that a document was opened
         //! @param documentId unique id of document for which the notification is sent
-        virtual void OnDocumentOpened([[maybe_unused]] const AZ::Uuid& documentId) {}
+        virtual void OnDocumentOpened([[maybe_unused]] const AZ::Uuid& documentId){};
 
         //! Signal that a document was closed
         //! @param documentId unique id of document for which the notification is sent
-        virtual void OnDocumentClosed([[maybe_unused]] const AZ::Uuid& documentId) {}
+        virtual void OnDocumentClosed([[maybe_unused]] const AZ::Uuid& documentId){};
 
         //! Signal that a document was saved
         //! @param documentId unique id of document for which the notification is sent
-        virtual void OnDocumentSaved([[maybe_unused]] const AZ::Uuid& documentId) {}
+        virtual void OnDocumentSaved([[maybe_unused]] const AZ::Uuid& documentId){};
 
         //! Signal that a document was modified
         //! @param documentId unique id of document for which the notification is sent
-        virtual void OnDocumentModified([[maybe_unused]] const AZ::Uuid& documentId) {}
+        virtual void OnDocumentModified([[maybe_unused]] const AZ::Uuid& documentId){};
 
         //! Signal that a document dependency was modified
         //! @param documentId unique id of document for which the notification is sent
-        virtual void OnDocumentDependencyModified([[maybe_unused]] const AZ::Uuid& documentId) {}
+        virtual void OnDocumentDependencyModified([[maybe_unused]] const AZ::Uuid& documentId){};
 
         //! Signal that a document was modified externally
         //! @param documentId unique id of document for which the notification is sent
-        virtual void OnDocumentExternallyModified([[maybe_unused]] const AZ::Uuid& documentId) {}
+        virtual void OnDocumentExternallyModified([[maybe_unused]] const AZ::Uuid& documentId){};
 
         //! Signal that a document undo state was updated
         //! @param documentId unique id of document for which the notification is sent
-        virtual void OnDocumentUndoStateChanged([[maybe_unused]] const AZ::Uuid& documentId) {}
+        virtual void OnDocumentUndoStateChanged([[maybe_unused]] const AZ::Uuid& documentId){};
 
         //! Signal that the group has been changed.
         //! @param documentId unique id of document for which the notification is sent
@@ -64,7 +64,15 @@ namespace AtomToolsFramework
         virtual void OnDocumentObjectInfoChanged(
             [[maybe_unused]] const AZ::Uuid& documentId,
             [[maybe_unused]] const DocumentObjectInfo& objectInfo,
-            [[maybe_unused]] bool rebuilt) {}
+            [[maybe_unused]] bool rebuilt){};
+
+        //! Signal the document content has been cleared
+        //! @param documentId unique id of document for which the notification is sent
+        virtual void OnDocumentCleared([[maybe_unused]] const AZ::Uuid& documentId){};
+
+        //! Signal the document has experienced an error
+        //! @param documentId unique id of document for which the notification is sent
+        virtual void OnDocumentError([[maybe_unused]] const AZ::Uuid& documentId){};
     };
 
     using AtomToolsDocumentNotificationBus = AZ::EBus<AtomToolsDocumentNotifications>;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentRequestBus.h
@@ -58,6 +58,9 @@ namespace AtomToolsFramework
         //! Close document and reset its data
         virtual bool Close() = 0;
 
+        //! Clear document of all content
+        virtual void Clear() = 0;
+
         //! Document is loaded
         virtual bool IsOpen() const = 0;
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -29,16 +29,61 @@ class QWidget;
 namespace AtomToolsFramework
 {
     using LoadImageAsyncCallback = AZStd::function<void(const QImage&)>;
+
+    //! Loads an image file asynchronously and invokes the callback with the resulting image after load is complete
+    //! @path Absolute path of image file to be loaded
+    //! @param callback callback that will be triggered once the file is loaded
     void LoadImageAsync(const AZStd::string& path, LoadImageAsyncCallback callback);
 
+    //! Get a pointer to the application main window
+    //! @returns a pointer to the application main window 
     QWidget* GetToolMainWindow();
+
+    //! Returns a sanitized display name by removing the path, extension, and replacing special characters in a filename
+    //! @param path File path that will be converted into a display name
+    //! @returns the display name generated from the file path
     AZStd::string GetDisplayNameFromPath(const AZStd::string& path);
+
+    //! Opens a dialog to prompt the user to select a save file path
+    //! @param initialPath File path initially selected in the dialog
+    //! @param title Description of the filetype being opened that's displayed at the top of the dialog
+    //! @returns Absolute path of the selected file, or an empty string if nothing was selected
     AZStd::string GetSaveFilePath(const AZStd::string& initialPath, const AZStd::string& title = "Document");
+
+    //! Opens a dialog to prompt the user to select one or more files to open 
+    //! @param filter A regular expression filter to determine which files are selectable and displayed in the dialog 
+    //! @param title Description of the filetype being opened that's displayed at the top of the dialog
+    //! @returns Container of selected files matching the filter 
     AZStd::vector<AZStd::string> GetOpenFilePaths(const QRegExp& filter, const AZStd::string& title = "Document");
+
+    //! Converts an input file path to a unique file path by appending a unique number
+    //! @param initialPath The starting path that will be compared to other existing files and modified until it is unique
+    //! @returns A unique file path based on the initial file path
     AZStd::string GetUniqueFilePath(const AZStd::string& initialPath);
+
+    //! Generates a unique, untitled file path in the project asset folder
+    //! @param Extension Extension of the file path to be generated
+    //! @returns Absolute file path with a unique filename
     AZStd::string GetUniqueDefaultSaveFilePath(const AZStd::string& extension);
+
+    //! Opens a dialog to prompt the user to select a file path where the initial file will be duplicated 
+    //! @param initialPath File path to be duplicated, will be used to generate a unique filename for the new file 
+    //! @returns Absolute path of the selected file, or an empty string if nothing was selected
     AZStd::string GetUniqueDuplicateFilePath(const AZStd::string& initialPath);
+
+    //! Verifies that an input file path is not empty, is not relative, can be normalized, and is a valid source file path accessible by the project
+    //! @param path File path to be validated and normalized
+    //! @returns True if the path is valid, otherwise false
     bool ValidateDocumentPath(AZStd::string& path);
+
+    //! Determines if a file path exists in a valid asset folder for the project or one of its gems
+    //! @param path File path to be validated
+    //! @returns True if the path is valid, otherwise false
+    bool IsValidSourceDocumentPath(const AZStd::string& path);
+
+    //! Launches an O3DE application in a detached process
+    //! @param baseName Base filename of the application executable that must be in the bin folder
+    //! @returns True if the process was launched, otherwise false
     bool LaunchTool(const QString& baseName, const QStringList& arguments);
 
     //! Generate a file path that is relative to either the source asset root or the export path

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocument.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocument.cpp
@@ -97,7 +97,8 @@ namespace AtomToolsFramework
             return OpenFailed();
         }
 
-        if (!GetDocumentTypeInfo().IsSupportedExtensionToOpen(m_absolutePath))
+        if (!GetDocumentTypeInfo().IsSupportedExtensionToOpen(m_absolutePath) &&
+            !GetDocumentTypeInfo().IsSupportedExtensionToCreate(m_absolutePath))
         {
             AZ_Error("AtomToolsDocument", false, "Document path extension is not supported: '%s'.", m_absolutePath.c_str());
             return OpenFailed();
@@ -124,10 +125,8 @@ namespace AtomToolsFramework
             return false;
         }
 
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
-            m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentModified, m_id);
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
-            m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentUndoStateChanged, m_id);
+        AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentModified, m_id);
+        AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentUndoStateChanged, m_id);
         return true;
     }
 
@@ -231,12 +230,24 @@ namespace AtomToolsFramework
 
         AZ_TracePrintf("AtomToolsDocument", "Document closed: '%s'.\n", m_absolutePath.c_str());
 
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
-            m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentClosed, m_id);
+        AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentClosed, m_id);
 
         // Clearing after notification so paths are still available
         Clear();
         return true;
+    }
+
+    void AtomToolsDocument::Clear()
+    {
+        AzToolsFramework::AssetSystemBus::Handler::BusDisconnect();
+
+        m_absolutePath.clear();
+        m_sourceDependencies.clear();
+        m_ignoreSourceFileChangeToSelf = {};
+        m_undoHistory.clear();
+        m_undoHistoryIndex = {};
+
+        AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentCleared, m_id);
     }
 
     bool AtomToolsDocument::IsOpen() const
@@ -273,8 +284,7 @@ namespace AtomToolsFramework
             // The history index is one beyond the last executed command. Decrement the index then execute undo.
             m_undoHistory[--m_undoHistoryIndex].first();
             AZ_TracePrintf("AtomToolsDocument", "Document undo: '%s'.\n", m_absolutePath.c_str());
-            AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
-                m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentUndoStateChanged, m_id);
+            AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentUndoStateChanged, m_id);
             return true;
         }
         return false;
@@ -287,8 +297,7 @@ namespace AtomToolsFramework
             // Execute the current redo command then move the history index to the next position.
             m_undoHistory[m_undoHistoryIndex++].second();
             AZ_TracePrintf("AtomToolsDocument", "Document redo: '%s'.\n", m_absolutePath.c_str());
-            AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
-                m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentUndoStateChanged, m_id);
+            AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentUndoStateChanged, m_id);
             return true;
         }
         return false;
@@ -306,29 +315,18 @@ namespace AtomToolsFramework
         return false;
     }
 
-    void AtomToolsDocument::Clear()
-    {
-        AzToolsFramework::AssetSystemBus::Handler::BusDisconnect();
-
-        m_absolutePath.clear();
-        m_sourceDependencies.clear();
-        m_ignoreSourceFileChangeToSelf = {};
-        m_undoHistory.clear();
-        m_undoHistoryIndex = {};
-    }
-
     bool AtomToolsDocument::OpenSucceeded()
     {
         AZ_TracePrintf("AtomToolsDocument", "Document opened: '%s'.\n", m_absolutePath.c_str());
         AzToolsFramework::AssetSystemBus::Handler::BusConnect();
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
-            m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, m_id);
+        AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, m_id);
         return true;
     }
 
     bool AtomToolsDocument::OpenFailed()
     {
         AZ_TracePrintf("AtomToolsDocument", "Document could not opened: '%s'.\n", m_absolutePath.c_str());
+        AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentError, m_id);
         Clear();
         return false;
     }
@@ -344,14 +342,14 @@ namespace AtomToolsFramework
             &AzToolsFramework::SourceControlCommandBus::Events::RequestEdit, m_savePathNormalized.c_str(), true,
             [](bool, const AzToolsFramework::SourceControlFileInfo&) {});
 
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
-            m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentSaved, m_id);
+        AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentSaved, m_id);
         return true;
     }
 
     bool AtomToolsDocument::SaveFailed()
     {
         AZ_TracePrintf("AtomToolsDocument", "Document not saved: '%s'.\n", m_savePathNormalized.c_str());
+        AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentError, m_id);
         return false;
     }
 
@@ -381,8 +379,7 @@ namespace AtomToolsFramework
 
         // Assign the index to the end of history
         m_undoHistoryIndex = aznumeric_cast<int>(m_undoHistory.size());
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
-            m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentUndoStateChanged, m_id);
+        AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentUndoStateChanged, m_id);
     }
 
     void AtomToolsDocument::SourceFileChanged(AZStd::string relativePath, AZStd::string scanFolder, [[maybe_unused]] AZ::Uuid sourceUUID)
@@ -395,16 +392,16 @@ namespace AtomToolsFramework
             if (!m_ignoreSourceFileChangeToSelf)
             {
                 AZ_TracePrintf("AtomToolsDocument", "Document changed externally: '%s'.\n", m_absolutePath.c_str());
-                AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
-                    m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentExternallyModified, m_id);
+                AtomToolsDocumentNotificationBus::Event(
+                    m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentExternallyModified, m_id);
             }
             m_ignoreSourceFileChangeToSelf = false;
         }
         else if (m_sourceDependencies.find(sourcePath) != m_sourceDependencies.end())
         {
             AZ_TracePrintf("AtomToolsDocument", "Document dependency changed: '%s'.\n", m_absolutePath.c_str());
-            AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
-                m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentDependencyModified, m_id);
+            AtomToolsDocumentNotificationBus::Event(
+                m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentDependencyModified, m_id);
         }
     }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -575,6 +575,20 @@ namespace AtomToolsFramework
         SetStatusMessage(tr("Document closed: %1").arg(GetDocumentPath(documentId)));
     }
 
+    void AtomToolsDocumentMainWindow::OnDocumentCleared(const AZ::Uuid& documentId)
+    {
+        UpdateDocumentTab(documentId);
+        QueueUpdateMenus(true);
+        SetStatusMessage(tr("Document cleared: %1").arg(GetDocumentPath(documentId)));
+    }
+
+    void AtomToolsDocumentMainWindow::OnDocumentError(const AZ::Uuid& documentId)
+    {
+        UpdateDocumentTab(documentId);
+        QueueUpdateMenus(true);
+        SetStatusError(tr("Document error: %1").arg(GetDocumentPath(documentId)));
+    }
+
     void AtomToolsDocumentMainWindow::OnDocumentDestroyed(const AZ::Uuid& documentId)
     {
         RemoveDocumentTab(documentId);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -156,7 +156,28 @@ namespace AtomToolsFramework
 
     bool ValidateDocumentPath(AZStd::string& path)
     {
-        return !path.empty() && AzFramework::StringFunc::Path::Normalize(path) && !AzFramework::StringFunc::Path::IsRelative(path.c_str());
+        return !path.empty() && AzFramework::StringFunc::Path::Normalize(path) &&
+            !AzFramework::StringFunc::Path::IsRelative(path.c_str()) && IsValidSourceDocumentPath(path);
+    }
+
+    bool IsValidSourceDocumentPath(const AZStd::string& path)
+    {
+        bool assetFoldersRetrieved = false;
+        AZStd::vector<AZStd::string> assetFolders;
+        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+            assetFoldersRetrieved, &AzToolsFramework::AssetSystemRequestBus::Events::GetAssetSafeFolders, assetFolders);
+
+        AZ::IO::FixedMaxPath assetPath = AZ::IO::PathView(path).LexicallyNormal();
+        for (const auto& assetFolder : assetFolders)
+        {
+            // Check if the path is relative to the asset folder
+            if (assetPath.IsRelativeTo(AZ::IO::PathView(assetFolder)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     bool LaunchTool(const QString& baseName, const QStringList& arguments)

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
@@ -101,6 +101,18 @@ namespace MaterialCanvas
         m_materialInspector->SetDocumentId(documentId);
     }
 
+    void MaterialCanvasMainWindow::OnDocumentCleared(const AZ::Uuid& documentId)
+    {
+        Base::OnDocumentCleared(documentId);
+        m_materialInspector->SetDocumentId(documentId);
+    }
+
+    void MaterialCanvasMainWindow::OnDocumentError(const AZ::Uuid& documentId)
+    {
+        Base::OnDocumentError(documentId);
+        m_materialInspector->SetDocumentId(documentId);
+    }
+
     void MaterialCanvasMainWindow::ResizeViewportRenderTarget(uint32_t width, uint32_t height)
     {
         QSize requestedViewportSize = QSize(width, height) / devicePixelRatioF();

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.h
@@ -47,6 +47,8 @@ namespace MaterialCanvas
 
         // AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler overrides...
         void OnDocumentOpened(const AZ::Uuid& documentId) override;
+        void OnDocumentCleared(const AZ::Uuid& documentId) override;
+        void OnDocumentError(const AZ::Uuid& documentId) override;
 
         // AtomToolsFramework::AtomToolsDocumentMainWindow overrides...
         void OpenSettings() override;

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.cpp
@@ -63,6 +63,18 @@ namespace MaterialEditor
         m_materialInspector->SetDocumentId(documentId);
     }
 
+    void MaterialEditorMainWindow::OnDocumentCleared(const AZ::Uuid& documentId)
+    {
+        Base::OnDocumentCleared(documentId);
+        m_materialInspector->SetDocumentId(documentId);
+    }
+
+    void MaterialEditorMainWindow::OnDocumentError(const AZ::Uuid& documentId)
+    {
+        Base::OnDocumentError(documentId);
+        m_materialInspector->SetDocumentId(documentId);
+    }
+
     void MaterialEditorMainWindow::ResizeViewportRenderTarget(uint32_t width, uint32_t height)
     {
         QSize requestedViewportSize = QSize(width, height) / devicePixelRatioF();

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.h
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.h
@@ -41,6 +41,8 @@ namespace MaterialEditor
 
         // AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler overrides...
         void OnDocumentOpened(const AZ::Uuid& documentId) override;
+        void OnDocumentCleared(const AZ::Uuid& documentId) override;
+        void OnDocumentError(const AZ::Uuid& documentId) override;
 
         // AtomToolsFramework::AtomToolsDocumentMainWindow overrides...
         void OpenSettings() override;


### PR DESCRIPTION
• This change fixes a crash that was caused by opening a material document that was saved outside of project or gem asset scan folder.
• The direct crash occurred because the material inspector was refreshing itself after the document objects were destroyed. Notifications were added so the application can respond and invalidate the inspector.
• More validation was added to make sure that the requested path is in an asset scan folder before saving or loading documents.
• Also added more comments to utility functions

Signed-off-by: Guthrie Adams <guthadam@amazon.com>