### PR TITLE
Gave Entity Inspector window an object name

### DIFF
--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/QComponentEntityEditorMainWindow.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/QComponentEntityEditorMainWindow.cpp
@@ -21,7 +21,7 @@ QComponentEntityEditorInspectorWindow::QComponentEntityEditorInspectorWindow(QWi
     : QMainWindow(parent)
     , m_propertyEditor(nullptr)
 {
-    setObjectName("ComponentEntityInspector");
+    setObjectName("InspectorMainWindow");
     gEnv->pSystem->GetISystemEventDispatcher()->RegisterListener(this);
 
     Init();

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/QComponentEntityEditorMainWindow.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/QComponentEntityEditorMainWindow.cpp
@@ -21,6 +21,7 @@ QComponentEntityEditorInspectorWindow::QComponentEntityEditorInspectorWindow(QWi
     : QMainWindow(parent)
     , m_propertyEditor(nullptr)
 {
+    setObjectName("ComponentEntityInspector");
     gEnv->pSystem->GetISystemEventDispatcher()->RegisterListener(this);
 
     Init();


### PR DESCRIPTION
Gave the Entity Inspector window an object name so it can be found easier in automated testing.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>