### PR TITLE
- removed old bug workaround that hurts GraphCanvas performance

### DIFF
--- a/Gems/GraphCanvas/Code/Source/Components/SceneComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/SceneComponent.cpp
@@ -4698,9 +4698,6 @@ namespace GraphCanvas
         : m_scene(scene)
         , m_suppressContextMenu(false)
     {
-        // Workaround for QTBUG-18021
-        setItemIndexMethod(QGraphicsScene::NoIndex);
-
         setMinimumRenderSize(2.0f);
         connect(this, &QGraphicsScene::selectionChanged, this, [this]() { m_scene.OnSelectionChanged(); });
         setSceneRect(-20000, -20000, 40000, 40000);


### PR DESCRIPTION
The Qt bug for this workaround has been fixed, so restoring the BSP tree default behavior is safe and provides a boost in performance, saving about 30 seconds for a large graph load in local testing:
https://bugreports.qt.io/browse/QTBUG-18021
Signed-off-by: Alex Montgomery <alexmont@amazon.com>