### PR TITLE
[Mac] Fix build errors reported by Xcode 13.3

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/Apple/AzCore/Debug/Trace_Apple.cpp
+++ b/Code/Framework/AzCore/Platform/Common/Apple/AzCore/Debug/Trace_Apple.cpp
@@ -27,7 +27,7 @@ namespace AZ
             // running under the debugger or has a debugger attached post facto).
             bool IsDebuggerPresent()
             {
-                int                 junk;
+                [[maybe_unused]] int                 junk;
                 int                 mib[4];
                 struct kinfo_proc   info;
                 size_t              size;

--- a/Gems/Microphone/Code/Source/Platform/Mac/MicrophoneSystemComponent_Mac.mm
+++ b/Gems/Microphone/Code/Source/Platform/Mac/MicrophoneSystemComponent_Mac.mm
@@ -328,9 +328,7 @@ private:
         
         // Obtain recorded samples
         
-        OSStatus status;
-        
-        status = AudioUnitRender(impl->m_audioUnit, 
+        AudioUnitRender(impl->m_audioUnit, 
             ioActionFlags, 
             inTimeStamp, 
             inBusNumber, 


### PR DESCRIPTION
Eg: `error: variable 'junk' set but not used [-Werror,-Wunused-but-set-variable]`

Signed-off-by: amzn-sj <srikkant@amazon.com>