### PR TITLE
Save crash artifacts in LyTestTools

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -815,13 +815,18 @@ class EditorTestSuite:
                     crash_output = editor_utils.retrieve_crash_output(run_id, workspace, self._TIMEOUT_CRASH_LOG)
                     test_result = Result.Crash(test_spec, output, return_code, crash_output, None)
                     # Save the crash log
-                    crash_file_name = os.path.basename(workspace.paths.crash_log())
+                    crash_file_name = os.path.join(editor_utils.retrieve_log_path(run_id, workspace),
+                                                   os.path.basename(workspace.paths.crash_log()))
                     if os.path.exists(crash_file_name):
-                        workspace.artifact_manager.save_artifact(
-                            os.path.join(editor_utils.retrieve_log_path(run_id, workspace), crash_file_name))
+                        workspace.artifact_manager.save_artifact(crash_file_name)
                         editor_utils.cycle_crash_report(run_id, workspace)
                     else:
                         logger.warning(f"Crash occurred, but could not find log {crash_file_name}")
+                    # .dmp file is generated on Windows only
+                    dmp_file_name = os.path.join(editor_utils.retrieve_log_path(run_id, workspace),
+                                                 'error.dmp')
+                    if os.path.exists(dmp_file_name):
+                        workspace.artifact_manager.save_artifact(dmp_file_name)
                 else:
                     test_result = Result.Fail(test_spec, output, editor_log_content)
         except WaitTimeoutError:
@@ -915,13 +920,18 @@ class EditorTestSuite:
                                 crash_error = editor_utils.retrieve_crash_output(run_id, workspace,
                                                                                  self._TIMEOUT_CRASH_LOG)
                                 # Save the crash log
-                                crash_file_name = os.path.basename(workspace.paths.crash_log())
+                                crash_file_name = os.path.join(editor_utils.retrieve_log_path(run_id, workspace),
+                                                               os.path.basename(workspace.paths.crash_log()))
                                 if os.path.exists(crash_file_name):
-                                    workspace.artifact_manager.save_artifact(
-                                        os.path.join(editor_utils.retrieve_log_path(run_id, workspace), crash_file_name))
+                                    workspace.artifact_manager.save_artifact(crash_file_name)
                                     editor_utils.cycle_crash_report(run_id, workspace)
                                 else:
                                     logger.warning(f"Crash occurred, but could not find log {crash_file_name}")
+                                # .dmp file is generated on Windows only
+                                dmp_file_name = os.path.join(editor_utils.retrieve_log_path(run_id, workspace),
+                                                             'error.dmp')
+                                if os.path.exists(dmp_file_name):
+                                    workspace.artifact_manager.save_artifact(dmp_file_name)
                                 results[test_spec_name] = Result.Crash(result.test_spec, output, return_code,
                                                                        crash_error, result.editor_log)
                                 crashed_result = result

--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -814,6 +814,11 @@ class EditorTestSuite:
                 if has_crashed:
                     crash_output = editor_utils.retrieve_crash_output(run_id, workspace, self._TIMEOUT_CRASH_LOG)
                     test_result = Result.Crash(test_spec, output, return_code, crash_output, None)
+                    # Save the .dmp file which is generated on Windows only
+                    dmp_file_name = os.path.join(editor_utils.retrieve_log_path(run_id, workspace),
+                                                 'error.dmp')
+                    if os.path.exists(dmp_file_name):
+                        workspace.artifact_manager.save_artifact(dmp_file_name)
                     # Save the crash log
                     crash_file_name = os.path.join(editor_utils.retrieve_log_path(run_id, workspace),
                                                    os.path.basename(workspace.paths.crash_log()))
@@ -822,11 +827,6 @@ class EditorTestSuite:
                         editor_utils.cycle_crash_report(run_id, workspace)
                     else:
                         logger.warning(f"Crash occurred, but could not find log {crash_file_name}")
-                    # .dmp file is generated on Windows only
-                    dmp_file_name = os.path.join(editor_utils.retrieve_log_path(run_id, workspace),
-                                                 'error.dmp')
-                    if os.path.exists(dmp_file_name):
-                        workspace.artifact_manager.save_artifact(dmp_file_name)
                 else:
                     test_result = Result.Fail(test_spec, output, editor_log_content)
         except WaitTimeoutError:
@@ -919,6 +919,11 @@ class EditorTestSuite:
                                 # The first test with "Unknown" result (no data in output) is likely the one that crashed
                                 crash_error = editor_utils.retrieve_crash_output(run_id, workspace,
                                                                                  self._TIMEOUT_CRASH_LOG)
+                                # Save the .dmp file which is generated on Windows only
+                                dmp_file_name = os.path.join(editor_utils.retrieve_log_path(run_id, workspace),
+                                                             'error.dmp')
+                                if os.path.exists(dmp_file_name):
+                                    workspace.artifact_manager.save_artifact(dmp_file_name)
                                 # Save the crash log
                                 crash_file_name = os.path.join(editor_utils.retrieve_log_path(run_id, workspace),
                                                                os.path.basename(workspace.paths.crash_log()))
@@ -927,11 +932,6 @@ class EditorTestSuite:
                                     editor_utils.cycle_crash_report(run_id, workspace)
                                 else:
                                     logger.warning(f"Crash occurred, but could not find log {crash_file_name}")
-                                # .dmp file is generated on Windows only
-                                dmp_file_name = os.path.join(editor_utils.retrieve_log_path(run_id, workspace),
-                                                             'error.dmp')
-                                if os.path.exists(dmp_file_name):
-                                    workspace.artifact_manager.save_artifact(dmp_file_name)
                                 results[test_spec_name] = Result.Crash(result.test_spec, output, return_code,
                                                                        crash_error, result.editor_log)
                                 crashed_result = result

--- a/Tools/LyTestTools/tests/unit/test_o3de_editor_test.py
+++ b/Tools/LyTestTools/tests/unit/test_o3de_editor_test.py
@@ -648,6 +648,8 @@ class TestRunningTests(unittest.TestCase):
         assert isinstance(results[mock_test_spec.__name__], editor_test.Result.Crash)
         assert mock_editor.start.called
         assert mock_retrieve_crash.called
+        # Save editor log, crash log, and crash dmp
+        assert mock_workspace.artifact_manager.save_artifact.call_count == 3
 
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
@@ -760,6 +762,8 @@ class TestRunningTests(unittest.TestCase):
         assert mock_cycle_crash.call_count == 2
         assert mock_get_results.called
         assert isinstance(results[mock_test_spec.__name__], editor_test.Result.Crash)
+        # Save editor log, crash log, and crash dmp
+        assert mock_workspace.artifact_manager.save_artifact.call_count == 3
 
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_crash_output')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')


### PR DESCRIPTION
Tested by collecting a crash artifact locally and ran unit tests.