### PR TITLE
Add EBus support for shared_mutex

### DIFF
--- a/Code/Framework/AzCore/AzCore/EBus/BusImpl.h
+++ b/Code/Framework/AzCore/AzCore/EBus/BusImpl.h
@@ -190,12 +190,35 @@ namespace AZ
             static constexpr bool HasId = Traits::AddressPolicy != EBusAddressPolicy::Single;
 
             /**
+             * The following Lock Guard classes are exposed so that it's possible to override them with custom lock/unlock functionality
+             * when using custom types for the EBus MutexType.
+             */
+
+            /**
             * Template Lock Guard class that wraps around the Mutex
             * The EBus uses for Dispatching Events.
             * This is not the EBus Context Mutex if LocklessDispatch is true
             */
             template <typename DispatchMutex>
             using DispatchLockGuard = typename Traits::template DispatchLockGuard<DispatchMutex, Traits::LocklessDispatch>;
+
+            /**
+             * Template Lock Guard class that protects connection / disconnection. 
+             */
+            template<typename ContextMutex>
+            using ConnectLockGuard = typename Traits::template ConnectLockGuard<ContextMutex>;
+
+            /**
+             * Template Lock Guard class that protects bind calls. 
+             */
+            template<typename ContextMutex>
+            using BindLockGuard = typename Traits::template BindLockGuard<ContextMutex>;
+
+            /**
+             * Template Lock Guard class that protects callstack tracking.
+             */
+            template<typename ContextMutex>
+            using CallstackTrackerLockGuard = typename Traits::template CallstackTrackerLockGuard<ContextMutex>;
         };
 
         /**
@@ -615,7 +638,7 @@ namespace AZ
         inline void EBusEventer<Bus, Traits>::Bind(BusPtr& ptr, const BusIdType& id)
         {
             auto& context = Bus::GetOrCreateContext();
-            AZStd::scoped_lock<decltype(context.m_contextMutex)> lock(context.m_contextMutex);
+            typename Traits::template BindLockGuard<decltype(context.m_contextMutex)> lock(context.m_contextMutex);
             context.m_buses.Bind(ptr, id);
         }
 

--- a/Code/Framework/AzCore/AzCore/EBus/EBus.h
+++ b/Code/Framework/AzCore/AzCore/EBus/EBus.h
@@ -146,6 +146,9 @@ namespace AZ
          * - For simple multithreaded cases, use AZStd::mutex.
          * - For multithreaded cases where an event handler sends a new event on the same bus
          *   or connects/disconnects while handling an event on the same bus, use AZStd::recursive_mutex.
+         * - For specialized multithreading cases, such as allowing events to execute in parallel with each other but not with
+         *   connects / disconnects, use custom mutex types along with custom LockGuard policies to control the specific locking
+         *   requirements for each mutex use case (connection, dispatch, binding, callstack tracking).
          */
         using MutexType = NullMutex;
 
@@ -245,15 +248,53 @@ namespace AZ
         using EventProcessingPolicy = EBusEventProcessingPolicy;
 
         /**
-        * Template Lock Guard class that wraps around the Mutex
-        * The EBus Context uses the LockGuard when dispatching
-        * (either AZStd::scoped_lock<MutexType> or NullLockGuard<MutexType>)
+         * The following Lock Guard classes are exposed so that it's possible to redefine them with custom lock/unlock functionality
+         * when using custom types for the EBus MutexType.
+         */
+
+       /**
+        * Template Lock Guard class to use during event dispatches.
+        * By default it will use a scoped_lock, but IsLocklessDispatch=true will cause it to use a NullLockGuard.
         * The IsLocklessDispatch bool is there to defer evaluation of the LocklessDispatch constant
         * Otherwise the value above in EBusTraits.h is always used and not the value
         * that the derived trait class sets.
         */
         template <typename DispatchMutex, bool IsLocklessDispatch>
         using DispatchLockGuard = AZStd::conditional_t<IsLocklessDispatch, AZ::Internal::NullLockGuard<DispatchMutex>, AZStd::scoped_lock<DispatchMutex>>;
+
+        /**
+         * Template Lock Guard class to use during connection / disconnection.
+         * By default it will use a unique_lock if the ContextMutex is anything but a NullMutex.
+         * This can be overridden to provide a different locking policy with custom EBus MutexType settings.
+         * Also, some specialized policies execute handler methods which can cause unnecessary delays holding
+         * the context mutex, such as performing blocking waits. These methods must unlock the context mutex before
+         * doing so to prevent deadlocks, especially when the wait is for an event in another thread which is trying
+         * to connect to the same bus before it can complete.
+         */
+        template<typename ContextMutex>
+        using ConnectLockGuard = AZStd::conditional_t<
+            AZStd::is_same_v<ContextMutex, AZ::NullMutex>,
+            AZ::Internal::NullLockGuard<ContextMutex>,
+            AZStd::unique_lock<ContextMutex>>;
+
+        /**
+         * Template Lock Guard class to use for EBus bind calls.
+         * By default it will use a scoped_lock.
+         * This can be overridden to provide a different locking policy with custom EBus MutexType settings.
+         */
+        template<typename ContextMutex>
+        using BindLockGuard = AZStd::scoped_lock<ContextMutex>;
+
+        /**
+         * Template Lock Guard class to use for EBus callstack tracking.
+         * By default it will use a unique_lock if the ContextMutex is anything but a NullMutex.
+         * This can be overridden to provide a different locking policy with custom EBus MutexType settings.
+         */
+        template<typename ContextMutex>
+        using CallstackTrackerLockGuard = AZStd::conditional_t<
+            AZStd::is_same_v<ContextMutex, AZ::NullMutex>,
+            AZ::Internal::NullLockGuard<ContextMutex>,
+            AZStd::unique_lock<ContextMutex>>;
     };
 
     namespace Internal
@@ -522,6 +563,24 @@ namespace AZ
         template <typename DispatchMutex>
         using DispatchLockGuardTemplate = typename ImplTraits::template DispatchLockGuard<DispatchMutex>;
 
+        /**
+         * Template Lock Guard class that wraps around the Mutex the EBus uses for Bus Connects / Disconnects.
+         */
+        template<typename ContextMutexType>
+        using ConnectLockGuardTemplate = typename ImplTraits::template ConnectLockGuard<ContextMutexType>;
+
+        /**
+         * Template Lock Guard class that wraps around the Mutex the EBus uses for Bus Bind calls.
+         */
+        template<typename ContextMutexType>
+        using BindLockGuardTemplate = typename ImplTraits::template BindLockGuard<ContextMutexType>;
+
+        /**
+         * Template Lock Guard class that wraps around the Mutex the EBus uses for Bus callstack tracking.
+         */
+        template<typename ContextMutexType>
+        using CallstackTrackerLockGuardTemplate = typename ImplTraits::template CallstackTrackerLockGuard<ContextMutexType>;
+
         //////////////////////////////////////////////////////////////////////////
         // Check to help identify common mistakes
         /// @cond EXCLUDE_DOCS
@@ -663,12 +722,22 @@ namespace AZ
             using DispatchLockGuard = DispatchLockGuardTemplate<ContextMutexType>;
 
             /**
-            * The scoped lock guard to use during connection.  Some specialized policies execute handler methods which
+            * The scoped lock guard to use during connection / disconnection.  Some specialized policies execute handler methods which
             * can cause unnecessary delays holding the context mutex or in some cases perform blocking waits and
             * must unlock the context mutex before doing so to prevent deadlock when the wait is for
             * an event in another thread which is trying to connect to the same bus before it can complete
             */
-            using ConnectLockGuard = AZStd::conditional_t<AZStd::is_same_v<ContextMutexType, AZ::NullMutex>, AZ::Internal::NullLockGuard<ContextMutexType>, AZStd::unique_lock<ContextMutexType>>;
+            using ConnectLockGuard = ConnectLockGuardTemplate<ContextMutexType>;
+
+            /**
+             * The scoped lock guard to use for bind calls.
+             */
+            using BindLockGuard = BindLockGuardTemplate<ContextMutexType>;
+
+            /**
+             * The scoped lock guard to use for callstack tracking.
+             */
+            using CallstackTrackerLockGuard = CallstackTrackerLockGuardTemplate<ContextMutexType>;
 
             BusesContainer          m_buses;         ///< The actual bus container, which is a static map for each bus type.
             ContextMutexType        m_contextMutex;  ///< Mutex to control access when modifying the context
@@ -1051,7 +1120,7 @@ AZ_PUSH_DISABLE_WARNING(4127, "-Wunknown-warning-option")
         if (Context* context = GetContext())
         {
             // scoped lock guard in case of exception / other odd situation
-            AZStd::scoped_lock<decltype(context->m_contextMutex)> lock(context->m_contextMutex);
+            ConnectLockGuard lock(context->m_contextMutex);
             DisconnectInternal(*context, handler);
         }
     }
@@ -1248,8 +1317,9 @@ AZ_POP_DISABLE_WARNING
         Context* context = StoragePolicy::Get();
         if (trackCallstack && context && !context->s_callstack)
         {
-            // cache the callstack into this thread/dll
-            AZStd::scoped_lock<decltype(context->m_contextMutex)> lock(context->m_contextMutex);
+            // Cache the callstack root into this thread/dll. Even though s_callstack is thread-local, we need a mutex lock
+            // for the modifications to m_callstackRoots, which is NOT thread-local.
+            typename Context::CallstackTrackerLockGuard lock(context->m_contextMutex);
             context->s_callstack = &context->m_callstackRoots[AZStd::this_thread::get_id().m_id];
         }
         return context;
@@ -1264,8 +1334,9 @@ AZ_POP_DISABLE_WARNING
         Context& context = StoragePolicy::GetOrCreate();
         if (trackCallstack && !context.s_callstack)
         {
-            // cache the callstack into this thread/dll
-            AZStd::scoped_lock<decltype(context.m_contextMutex)> lock(context.m_contextMutex);
+            // Cache the callstack root into this thread/dll. Even though s_callstack is thread-local, we need a mutex lock
+            // for the modifications to m_callstackRoots, which is NOT thread-local.
+            typename Context::CallstackTrackerLockGuard lock(context.m_contextMutex);
             context.s_callstack = &context.m_callstackRoots[AZStd::this_thread::get_id().m_id];
         }
         return context;
@@ -1340,7 +1411,7 @@ AZ_POP_DISABLE_WARNING
         {
             if (typename BusType::Context* context = BusType::GetContext())
             {
-                AZStd::scoped_lock<decltype(context->m_contextMutex)> contextLock(context->m_contextMutex);
+                typename BusType::Context::ConnectLockGuard contextLock(context->m_contextMutex);
                 if (BusIsConnected())
                 {
                     BusType::DisconnectInternal(*context, m_node);
@@ -1374,7 +1445,7 @@ AZ_POP_DISABLE_WARNING
         {
             if (typename BusType::Context* context = BusType::GetContext())
             {
-                AZStd::scoped_lock<decltype(context->m_contextMutex)> contextLock(context->m_contextMutex);
+                typename BusType::Context::ConnectLockGuard contextLock(context->m_contextMutex);
                 if (BusIsConnectedId(id))
                 {
                     BusType::DisconnectInternal(*context, m_node);
@@ -1386,7 +1457,7 @@ AZ_POP_DISABLE_WARNING
         {
             if (typename BusType::Context* context = BusType::GetContext())
             {
-                AZStd::scoped_lock<decltype(context->m_contextMutex)> contextLock(context->m_contextMutex);
+                typename BusType::Context::ConnectLockGuard contextLock(context->m_contextMutex);
                 if (BusIsConnected())
                 {
                     BusType::DisconnectInternal(*context, m_node);
@@ -1414,7 +1485,7 @@ AZ_POP_DISABLE_WARNING
         {
             if (typename BusType::Context* context = BusType::GetContext())
             {
-                AZStd::scoped_lock<decltype(context->m_contextMutex)> contextLock(context->m_contextMutex);
+                typename BusType::Context::ConnectLockGuard contextLock(context->m_contextMutex);
                 auto nodeIt = m_handlerNodes.find(id);
                 if (nodeIt != m_handlerNodes.end())
                 {
@@ -1432,7 +1503,7 @@ AZ_POP_DISABLE_WARNING
             decltype(m_handlerNodes) handlerNodesToDisconnect;
             if (typename BusType::Context* context = BusType::GetContext())
             {
-                AZStd::scoped_lock<decltype(context->m_contextMutex)> contextLock(context->m_contextMutex);
+                typename BusType::Context::ConnectLockGuard contextLock(context->m_contextMutex);
                 handlerNodesToDisconnect = AZStd::move(m_handlerNodes);
 
                 for (const auto& nodePair : handlerNodesToDisconnect)

--- a/Code/Framework/AzCore/AzCore/EBus/EBusSharedDispatchMutex.h
+++ b/Code/Framework/AzCore/AzCore/EBus/EBusSharedDispatchMutex.h
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/std/parallel/mutex.h>
+#include <AzCore/std/parallel/shared_mutex.h>
+
+namespace AZ
+{
+    /**
+     * %EBusSharedDispatchMutex is a custom mutex type that can be used with an EBus to allow for parallel dispatch calls, but still
+     * prevents connects / disconnects during a dispatch.
+     *
+     * Features:
+     *   - Event dispatches can execute in parallel when called on separate threads
+     *   - Bus connects / disconnects will only execute when no event dispatches are executing
+     *   - Event dispatches can call other event dispatches on the same bus recursively
+     *
+     * Limitations:
+     *   - If the bus contains custom connect / disconnect logic, it must not call any event dispatches on the same bus.
+     *   - Bus connects / disconnects cannot happen within event dispatches on the same bus.
+     *
+     * Usage:
+     *   Add code like the following to the definition of a specific EBus:
+     *      using MutexType = AZ::EBusSharedDispatchMutex;
+     *
+     *      template <typename MutexType, bool IsLocklessDispatch>
+     *      using DispatchLockGuard = AZ::EBusSharedDispatchMutexDispatchLockGuard<AZ::EBus<MyBus>>;
+     *
+     *      template<typename MutexType>
+     *      using ConnectLockGuard = AZ::EBusSharedDispatchMutexConnectLockGuard<AZ::EBus<MyBus>>;
+     *
+     *      template<typename MutexType>
+     *      using CallstackTrackerLockGuard = AZ::EBusSharedDispatchMutexCallstackLockGuard<AZ::EBus<MyBus>>;
+     */
+
+    // Simple custom mutex class that contains a shared_mutex for use with connects / disconnects / event dispatches
+    // and a separate mutex for callstack tracking thread protection.
+    class EBusSharedDispatchMutex
+    {
+    public:
+        EBusSharedDispatchMutex() = default;
+        ~EBusSharedDispatchMutex() = default;
+
+        void CallstackMutexLock()
+        {
+            m_callstackMutex.lock();
+        }
+
+        void CallstackMutexUnlock()
+        {
+            m_callstackMutex.unlock();
+        }
+
+        void EventMutexLockExclusive()
+        {
+            m_eventMutex.lock();
+        }
+
+        void EventMutexUnlockExclusive()
+        {
+            m_eventMutex.unlock();
+        }
+
+        void EventMutexLockShared()
+        {
+            m_eventMutex.lock_shared();
+        }
+
+        void EventMutexUnlockShared()
+        {
+            m_eventMutex.unlock_shared();
+        }
+
+    private:
+        AZStd::shared_mutex m_eventMutex;
+        AZStd::mutex m_callstackMutex;
+
+        // This custom mutex type should only be used with the lock guards below since it needs additional context to know which
+        // mutex to lock and what type of lock to request. If you get a compile error due to these methods being private, the EBus
+        // declaration is likely missing one or more of the lock guards below.
+        void lock(){}
+        void unlock(){}
+    };
+
+    // Custom lock guard to handle Connection lock management.
+    // This will lock/unlock the event mutex with an exclusive lock. It will assert and disallow
+    // exclusive locks if currently inside of a shared lock.
+    template<class EBusType>
+    class EBusSharedDispatchMutexConnectLockGuard
+    {
+    public:
+        AZ_FORCE_INLINE EBusSharedDispatchMutexConnectLockGuard(EBusSharedDispatchMutex& mutex, AZStd::adopt_lock_t)
+            : m_mutex(mutex)
+        {
+        }
+
+        AZ_FORCE_INLINE explicit EBusSharedDispatchMutexConnectLockGuard(EBusSharedDispatchMutex& mutex)
+            : m_mutex(mutex)
+        {
+            AZ_Assert(!EBusType::IsInDispatchThisThread(), "Can't connect/disconnect while inside an event dispatch.");
+            m_mutex.EventMutexLockExclusive();
+        }
+        AZ_FORCE_INLINE ~EBusSharedDispatchMutexConnectLockGuard()
+        {
+            m_mutex.EventMutexUnlockExclusive();
+        }
+
+    private:
+        AZ_FORCE_INLINE EBusSharedDispatchMutexConnectLockGuard(EBusSharedDispatchMutexConnectLockGuard const&) = delete;
+        AZ_FORCE_INLINE EBusSharedDispatchMutexConnectLockGuard& operator=(EBusSharedDispatchMutexConnectLockGuard const&) = delete;
+        EBusSharedDispatchMutex& m_mutex;
+    };
+
+    // Custom lock guard to handle Dispatch lock management.
+    // This will lock/unlock the event mutex with a shared lock. It also allows for recursive shared locks by only holding the
+    // shared lock at the top level of the recursion.
+    template<class EBusType>
+    class EBusSharedDispatchMutexDispatchLockGuard
+    {
+    public:
+        AZ_FORCE_INLINE EBusSharedDispatchMutexDispatchLockGuard(EBusSharedDispatchMutex& mutex, AZStd::adopt_lock_t)
+            : m_mutex(mutex)
+        {
+        }
+
+        AZ_FORCE_INLINE explicit EBusSharedDispatchMutexDispatchLockGuard(EBusSharedDispatchMutex& mutex)
+            : m_mutex(mutex)
+        {
+            if (!EBusType::IsInDispatchThisThread())
+            {
+                m_ownSharedLockOnThread = true;
+                m_mutex.EventMutexLockShared();
+            }
+        }
+        AZ_FORCE_INLINE ~EBusSharedDispatchMutexDispatchLockGuard()
+        {
+            if (m_ownSharedLockOnThread)
+            {
+                m_mutex.EventMutexUnlockShared();
+            }
+        }
+
+    private:
+        AZ_FORCE_INLINE EBusSharedDispatchMutexDispatchLockGuard(EBusSharedDispatchMutexDispatchLockGuard const&) = delete;
+        AZ_FORCE_INLINE EBusSharedDispatchMutexDispatchLockGuard& operator=(EBusSharedDispatchMutexDispatchLockGuard const&) = delete;
+        EBusSharedDispatchMutex& m_mutex;
+        bool m_ownSharedLockOnThread = false;
+    };
+
+    // Custom lock guard to handle callstack tracking lock management.
+    // This uses a separate always-exclusive lock for the callstack tracking, regardless of whether or not we're in a shared lock
+    // for event dispatches.
+    template<class EBusType>
+    class EBusSharedDispatchMutexCallstackLockGuard
+    {
+    public:
+        AZ_FORCE_INLINE EBusSharedDispatchMutexCallstackLockGuard(EBusSharedDispatchMutex& mutex, AZStd::adopt_lock_t)
+            : m_mutex(mutex)
+        {
+        }
+
+        AZ_FORCE_INLINE explicit EBusSharedDispatchMutexCallstackLockGuard(EBusSharedDispatchMutex& mutex)
+            : m_mutex(mutex)
+        {
+            m_mutex.CallstackMutexLock();
+        }
+        AZ_FORCE_INLINE ~EBusSharedDispatchMutexCallstackLockGuard()
+        {
+            m_mutex.CallstackMutexUnlock();
+        }
+
+    private:
+        AZ_FORCE_INLINE EBusSharedDispatchMutexCallstackLockGuard(EBusSharedDispatchMutexCallstackLockGuard const&) = delete;
+        AZ_FORCE_INLINE EBusSharedDispatchMutexCallstackLockGuard& operator=(EBusSharedDispatchMutexCallstackLockGuard const&) = delete;
+        EBusSharedDispatchMutex& m_mutex;
+        bool m_ownSharedLockOnThread = false;
+    };
+
+} // namespace AZ
+

--- a/Code/Framework/AzCore/AzCore/EBus/Policies.h
+++ b/Code/Framework/AzCore/AzCore/EBus/Policies.h
@@ -132,7 +132,7 @@ namespace AZ
         typedef typename Bus::MutexType MutexType;
 
         /**
-        * Lock type used for connecting to the bus.  When NullMutex isn't used as the
+        * Lock type used for connecting / disconnecting to the bus.  When NullMutex isn't used as the
         * default mutex this will be a unique lock to allow for unlocking before connection
         * dispatches which some specialized policies perform
         *

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -138,6 +138,7 @@ set(FILES
     EBus/BusImpl.h
     EBus/EBus.h
     EBus/EBusEnvironment.cpp
+    EBus/EBusSharedDispatchMutex.h
     EBus/Environment.h
     EBus/Event.h
     EBus/Event.inl

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -138,7 +138,7 @@ set(FILES
     EBus/BusImpl.h
     EBus/EBus.h
     EBus/EBusEnvironment.cpp
-    EBus/EBusSharedDispatchMutex.h
+    EBus/EBusSharedDispatchTraits.h
     EBus/Environment.h
     EBus/Event.h
     EBus/Event.inl

--- a/Code/Framework/AzCore/Tests/EBus/EBusSharedDispatchMutexTests.cpp
+++ b/Code/Framework/AzCore/Tests/EBus/EBusSharedDispatchMutexTests.cpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/EBus/EBusSharedDispatchMutex.h>
+#include <AzCore/std/parallel/mutex.h>
+#include <AzCore/std/parallel/semaphore.h>
+#include <AzCore/std/parallel/thread.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <Tests/AZTestShared/Utils/Utils.h>
+
+#include <gtest/gtest.h>
+
+using namespace AZ;
+
+namespace UnitTest
+{
+    // Test EBus that uses the EBusSharedDispatchMutex.
+    class SharedDispatchRequests : public AZ::EBusTraits
+    {
+    public:
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+
+        // Make the EBus use the EBusSharedDispatchMutex
+        using MutexType = AZ::EBusSharedDispatchMutex;
+
+        // The EBusSharedDispatchMutex requires the LockGuard definitions to be customized.
+        template<typename MutexType, bool IsLocklessDispatch>
+        using DispatchLockGuard = AZ::EBusSharedDispatchMutexDispatchLockGuard<AZ::EBus<SharedDispatchRequests>>;
+
+        template<typename MutexType>
+        using ConnectLockGuard = AZ::EBusSharedDispatchMutexConnectLockGuard<AZ::EBus<SharedDispatchRequests>>;
+
+        template<typename MutexType>
+        using CallstackTrackerLockGuard = AZ::EBusSharedDispatchMutexCallstackLockGuard<AZ::EBus<SharedDispatchRequests>>;
+
+        // Connection policy that auto-calls OnTerrainDataCreateBegin & OnTerrainDataCreateEnd on connection.
+        template<class Bus>
+        struct ConnectionPolicy : public AZ::EBusConnectionPolicy<Bus>
+        {
+            static void Connect(
+                typename Bus::BusPtr& busPtr,
+                typename Bus::Context& context,
+                typename Bus::HandlerNode& handler,
+                typename Bus::Context::ConnectLockGuard& connectLock,
+                const typename Bus::BusIdType& id = 0)
+            {
+                AZ::EBusConnectionPolicy<Bus>::Connect(busPtr, context, handler, connectLock, id);
+            }
+
+            static void Disconnect(
+                typename Bus::Context& context,
+                typename Bus::HandlerNode& handler,
+                typename Bus::BusPtr& busPtr)
+            {
+                EXPECT_EQ(m_totalRecursiveQueriesInProgress, 0);
+                AZ::EBusConnectionPolicy<Bus>::Disconnect(context, handler, busPtr);
+            }
+        };
+
+        // Provide a test EBus call that can be run in parallel.
+        virtual void RecursiveQuery(int32_t numRecursions = 5) = 0;
+
+        // These are static and defined on the EBus so that we can check the values from Disconnect.
+        static AZStd::atomic_int m_totalRecursiveQueriesInProgress;
+        static AZStd::atomic_int m_totalRecursiveQueriesCompleted;
+    };
+    using SharedDispatchRequestBus = AZ::EBus<SharedDispatchRequests>;
+
+    AZStd::atomic_int SharedDispatchRequests::m_totalRecursiveQueriesInProgress = 0;
+    AZStd::atomic_int SharedDispatchRequests::m_totalRecursiveQueriesCompleted = 0;
+
+    // Test EBus handler that provides recursion and synchronization to test out the features of the EBusSharedDispatchMutex.
+    class SharedDispatchRequestHandler : public SharedDispatchRequestBus::Handler
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(SharedDispatchRequestHandler, AZ::SystemAllocator, 0);
+
+        AZStd::semaphore m_querySemaphore; 
+        AZStd::semaphore m_syncSemaphore;
+        AZStd::semaphore m_disconnectSemaphore;
+
+        AZStd::atomic_int m_numDisconnects = 0;
+
+        SharedDispatchRequestHandler()
+        {
+            // Reinitialize these for every test.
+            m_totalRecursiveQueriesInProgress = 0;
+            m_totalRecursiveQueriesCompleted = 0;
+        }
+
+        ~SharedDispatchRequestHandler() override
+        {
+            SharedDispatchRequestBus::Handler::BusDisconnect();
+        }
+
+        void Connect()
+        {
+            SharedDispatchRequestBus::Handler::BusConnect();
+        }
+
+        void Disconnect()
+        {
+            // Signal that the thread is running and has at least made it this far.
+            m_disconnectSemaphore.release();
+
+            SharedDispatchRequestBus::Handler::BusDisconnect();
+            m_numDisconnects++;
+        }
+
+        void RecursiveQuery(int32_t numRecursions = 5) override
+        {
+            if (numRecursions <= 0)
+            {
+                // At the end of the recursion, signal the syncSemaphore that we've reached the end of the recursion.
+                // We'll use this as a way to guarantee that all our threads have reached this point at the same time.
+                m_syncSemaphore.release();
+
+                // Block on the querySemaphore. This won't get released until every thread has released the syncSemaphore.
+                m_querySemaphore.acquire();
+
+                // Track that we've completed the query successfully.
+                m_totalRecursiveQueriesCompleted++;
+                return;
+            }
+
+            // Recursively call the EBus a fixed number of times, and keep track of how many times we've successfully recursed.
+            m_totalRecursiveQueriesInProgress++;
+            SharedDispatchRequestBus::Broadcast(&SharedDispatchRequestBus::Events::RecursiveQuery, numRecursions - 1);
+            m_totalRecursiveQueriesInProgress--;
+        }
+    };
+
+    class EBusSharedDispatchMutexTestFixture
+        : public AllocatorsFixture
+    {
+    public:
+
+        EBusSharedDispatchMutexTestFixture()
+        {
+            SharedDispatchRequestBus::GetOrCreateContext();
+        }
+    };
+
+    TEST_F(EBusSharedDispatchMutexTestFixture, RecursiveBusCallsOnSingleThreadWorks)
+    {
+        // Verify that multiple nested bus calls to the same bus on the same thread works without deadlocks.
+
+        constexpr int32_t TotalRecursiveQueries = 10;
+        SharedDispatchRequestHandler handler;
+        handler.Connect();
+
+        // This is a single-threaded test, so we don't need the recursive query to block before returning.
+        handler.m_querySemaphore.release();
+
+        SharedDispatchRequestBus::Broadcast(&SharedDispatchRequestBus::Events::RecursiveQuery, TotalRecursiveQueries);
+        EXPECT_EQ(handler.m_totalRecursiveQueriesInProgress, 0);
+        EXPECT_EQ(handler.m_totalRecursiveQueriesCompleted, 1);
+        handler.Disconnect();
+    }
+
+    TEST_F(EBusSharedDispatchMutexTestFixture, RecursiveBusCallsOnMultipleThreadsWork)
+    {
+        // Verify that multiple dispatched events run in parallel without deadlocks, even if each thread has recursively called
+        // events on the same bus.
+
+        constexpr int32_t TotalRecursiveQueries = 10;
+        SharedDispatchRequestHandler handler;
+        handler.Connect();
+
+        constexpr size_t ThreadCount = 4;
+        AZStd::thread threads[ThreadCount];
+
+        // Each thread will trigger the RecursiveQuery call. This call has semaphores in it so that we can guarantee that
+        // every thread has reached the same state at the same time.
+        for (AZStd::thread& thread : threads)
+        {
+            thread = AZStd::thread(
+                [TotalRecursiveQueries]()
+                {
+                    SharedDispatchRequestBus::Broadcast(&SharedDispatchRequestBus::Events::RecursiveQuery, TotalRecursiveQueries);
+                });
+        }
+
+        // Wait for all the threads to reach the point where they're blocking. This will occur once they've each successfully called
+        // down through the RecursiveQuery multiple times and are ready to finish.
+        for (size_t threadNum = 0; threadNum < ThreadCount; threadNum++)
+        {
+            handler.m_syncSemaphore.acquire();
+        }
+
+        // Before unblocking the threads, verify that we've got the total number of expected recursions in progress
+        // and that none of the calls have completed.
+        EXPECT_EQ(handler.m_totalRecursiveQueriesInProgress, TotalRecursiveQueries * ThreadCount);
+        EXPECT_EQ(handler.m_totalRecursiveQueriesCompleted, 0);
+
+        // Unblock all the threads.
+        for (size_t threadNum = 0; threadNum < ThreadCount; threadNum++)
+        {
+            handler.m_querySemaphore.release();
+        }
+
+        // Wait for the threads to finish.
+        for (AZStd::thread& thread : threads)
+        {
+            thread.join();
+        }
+
+        // Verify that we ended up with the correct number of completed recursive calls and that none are still in progress.
+        EXPECT_EQ(handler.m_totalRecursiveQueriesInProgress, 0);
+        EXPECT_EQ(handler.m_totalRecursiveQueriesCompleted, ThreadCount);
+
+        handler.Disconnect();
+    }
+
+    TEST_F(EBusSharedDispatchMutexTestFixture, DispatchCallsBlockDisconnectFromRunning)
+    {
+        // Verify that BusConnect / BusDisconnect cannot run in parallel with event dispatches.
+        // We can't easily test BusConnect running in parallel, because by definition no dispatches can successfully occur before
+        // the handler is connected. However, we can test Disconnect by doing the following:
+        // - Run multiple dispatches in parallel and block them mid-dispatch
+        // - Run Disconnect() on a thread
+        // - Unblock the dispatches
+        // - Wait for the dispatches and disconnect to complete.
+        // The Disconnect() logic will verify that the number of running dispatches is 0. If the dispatches successfully blocked the
+        // disconnect, the Disconnect() won't be able to execute until all the dispatches have completed. If they don't block the
+        // disconnect, then there will be dispatches running at the same time and the verification will fail.
+
+        constexpr int32_t TotalRecursiveQueries = 5;
+        SharedDispatchRequestHandler handler;
+        handler.Connect();
+
+        constexpr size_t ThreadCount = 4;
+        AZStd::thread threads[ThreadCount];
+        AZStd::thread disconnectThread;
+
+        // Each thread will trigger the RecursiveQuery call. This call has semaphores in it so that we can guarantee that
+        // every thread has reached the same state at the same time.
+        for (AZStd::thread& thread : threads)
+        {
+            thread = AZStd::thread(
+                [TotalRecursiveQueries]()
+                {
+                    SharedDispatchRequestBus::Broadcast(&SharedDispatchRequestBus::Events::RecursiveQuery, TotalRecursiveQueries);
+                });
+        }
+
+        // Wait for all the threads to reach the point where they're blocking. This will occur once they've each successfully called
+        // down through the RecursiveQuery multiple times and are ready to finish.
+        for (size_t threadNum = 0; threadNum < ThreadCount; threadNum++)
+        {
+            handler.m_syncSemaphore.acquire();
+        }
+
+        disconnectThread = AZStd::thread(
+            [&handler]()
+            {
+                handler.Disconnect();
+            }
+        );
+
+        // Wait for the disconnect thread to start running. At this point, no disconnects should have occurred, because it's blocked
+        // waiting on the dispatches to finish.
+        handler.m_disconnectSemaphore.acquire();
+        EXPECT_EQ(handler.m_numDisconnects, 0);
+
+        // Unblock all the dispatch threads.
+        for (size_t threadNum = 0; threadNum < ThreadCount; threadNum++)
+        {
+            handler.m_querySemaphore.release();
+        }
+
+        // Wait for the dispatch threads to finish.
+        for (AZStd::thread& thread : threads)
+        {
+            thread.join();
+        }
+
+        // Wait for the disconnect thread to finish.
+        disconnectThread.join();
+
+        // Verify that the disconnect finished. Our disconnect logic will verify that no dispatches were running during the disconnect.
+        EXPECT_EQ(handler.m_numDisconnects, 1);
+    }
+
+} // namespace UnitTest
+

--- a/Code/Framework/AzCore/Tests/EBus/EBusSharedDispatchMutexTests.cpp
+++ b/Code/Framework/AzCore/Tests/EBus/EBusSharedDispatchMutexTests.cpp
@@ -137,6 +137,11 @@ namespace UnitTest
         SharedDispatchRequestBus::Broadcast(&SharedDispatchRequestBus::Events::RecursiveQuery, TotalRecursiveQueries);
         EXPECT_EQ(handler.m_totalRecursiveQueriesInProgress, 0);
         EXPECT_EQ(handler.m_totalRecursiveQueriesCompleted, 1);
+
+        // Not strictly needed, but since we're doing a release() in RecursiveQuery, this keeps the semaphore acquire/release calls
+        // balanced for the test.
+        handler.m_syncSemaphore.acquire();
+
         handler.Disconnect();
     }
 

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -17,6 +17,7 @@ set(FILES
     Asset/MockLoadAssetCatalogAndHandler.h
     Asset/TestAssetTypes.h
     AssetJsonSerializerTests.cpp
+    EBus/EBusSharedDispatchMutexTests.cpp
     EBus/ScheduledEventTests.cpp
     AssetManager.cpp
     TestCatalog.h


### PR DESCRIPTION
EBus currently supports LocklessDispatch, which enables the dispatch to run without any locks, while still keeping locks on BusConnect and BusDisconnect. This ensures that Connect/Disconnect are safe from each other, but it does not provide safety for a BusConnect / BusDisconnect call that occurs while a dispatch is in progress (or vice versa). It will assert in this scenario, but doesn't prevent it.

The goal here is to provide a means of using an EBus that still allows for parallel dispatches but also blocks the dispatches vs BusConnect / BusDisconnect. The theoretical solution is to use an EBus MutexType of shared_mutex, but this doesn't quite work in practice since there are some nuances required to handle the different types of locking and nested locking, and there's no one single solution that necessarily meets all needs.

The solution in this PR is to introduce EBusSharedDispatchMutex as a new optional custom MutexType that implements a type of shared_mutex support, where multiple (and optionally nested) dispatches can occur in parallel, but they will exclusively block with BusConnect / BusDisconnect. The EBus code needed to be modified minimally to expose more custom LockGuard types that can be overridden, so that it's possible to get different locking semantics based on the type of locking that the EBus is trying to do.

Locally I have the GradientRequestBus modified to use the new mutex type, but I'm saving that change for a separate PR so that the implementation itself can be examined and reviewed in isolation, separate from the concrete usage.

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>