### PR TITLE
Fix for deadlock loading Sponza level

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetCommon.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetCommon.cpp
@@ -459,5 +459,20 @@ namespace AZ::Data
             }
             return returnFlags;
         }
+
+        void SetAssetLoadBehavior(ProductDependencyFlags& dependencyFlags, AZ::Data::AssetLoadBehavior autoLoadBehavior)
+        {
+            // Create flags that can clear any load behaviors
+            Data::ProductDependencyInfo::ProductDependencyFlags clearLoadBehaviorBits;
+            for (AZ::u8 thisFlag = aznumeric_cast<AZ::u8>(Data::ProductDependencyInfo::ProductDependencyFlagBits::LoadBehaviorLow);
+                 thisFlag <= aznumeric_cast<AZ::u8>(Data::ProductDependencyInfo::ProductDependencyFlagBits::LoadBehaviorHigh); ++thisFlag)
+            {
+                clearLoadBehaviorBits.set(thisFlag);
+            }
+            clearLoadBehaviorBits.flip();
+
+            dependencyFlags &= clearLoadBehaviorBits;
+            dependencyFlags |= Data::ProductDependencyInfo::CreateFlags(autoLoadBehavior);
+        }
     }
 } // namespace AZ::Data

--- a/Code/Framework/AzCore/AzCore/Asset/AssetCommon.h
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetCommon.h
@@ -1235,6 +1235,8 @@ namespace AZ
             using ProductDependencyFlags = AZStd::bitset<64>;
             AZ::Data::AssetLoadBehavior LoadBehaviorFromFlags(const ProductDependencyFlags& dependencyFlags);
             AZ::Data::ProductDependencyInfo::ProductDependencyFlags CreateFlags(AZ::Data::AssetLoadBehavior autoLoadBehavior);
+            //! Clears any existing AssetLoadBehavior flags and sets a new AssetLoadBehavior without overwriting any other flags
+            void SetAssetLoadBehavior(ProductDependencyFlags& dependencyFlags, AZ::Data::AssetLoadBehavior autoLoadBehavior);
         } // namespace ProductDependencyInfo
     }  // namespace Data
 

--- a/Code/Framework/AzCore/Tests/Asset/AssetCommon.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/AssetCommon.cpp
@@ -253,5 +253,40 @@ namespace UnitTest
         }
         AZ_TEST_STOP_TRACE_SUPPRESSION(1);
     }
+
+    TEST(ProductDependencyFlags, CreateFlags_LoadBehaviorFromFlags_LoadBehaviorMatchesCreateBehavior)
+    {
+        // Test that creating product dependency flags with asset load behaviors
+        ProductDependencyInfo::ProductDependencyFlags flags = ProductDependencyInfo::CreateFlags(Data::AssetLoadBehavior::PreLoad);
+        EXPECT_EQ(ProductDependencyInfo::LoadBehaviorFromFlags(flags), Data::AssetLoadBehavior::PreLoad);
+
+        flags = ProductDependencyInfo::CreateFlags(Data::AssetLoadBehavior::QueueLoad);
+        EXPECT_EQ(ProductDependencyInfo::LoadBehaviorFromFlags(flags), Data::AssetLoadBehavior::QueueLoad);
+
+        flags = ProductDependencyInfo::CreateFlags(Data::AssetLoadBehavior::NoLoad);
+        EXPECT_EQ(ProductDependencyInfo::LoadBehaviorFromFlags(flags), Data::AssetLoadBehavior::NoLoad);
+
+    }
+
+    TEST(ProductDependencyFlags, SetAssetLoadBehavior_TestBitIsSet_AssetLoadBehaviorIsSetAndTestBitIsSet)
+    {
+        // Create flags with NoLoad behavior and an arbitrary bit set
+        ProductDependencyInfo::ProductDependencyFlags flags = ProductDependencyInfo::CreateFlags(Data::AssetLoadBehavior::NoLoad);
+        constexpr uint8_t testBit = 7;
+        flags.set(testBit);
+
+        // Test that SetFlags will change the asset load behavior
+        ProductDependencyInfo::SetAssetLoadBehavior(flags, Data::AssetLoadBehavior::PreLoad);
+        EXPECT_EQ(ProductDependencyInfo::LoadBehaviorFromFlags(flags), Data::AssetLoadBehavior::PreLoad);
+
+        ProductDependencyInfo::SetAssetLoadBehavior(flags, Data::AssetLoadBehavior::QueueLoad);
+        EXPECT_EQ(ProductDependencyInfo::LoadBehaviorFromFlags(flags), Data::AssetLoadBehavior::QueueLoad);
+
+        ProductDependencyInfo::SetAssetLoadBehavior(flags, Data::AssetLoadBehavior::NoLoad);
+        EXPECT_EQ(ProductDependencyInfo::LoadBehaviorFromFlags(flags), Data::AssetLoadBehavior::NoLoad);
+        
+        // Test that SetAssetLoadBehavior does not clear the test bit
+        EXPECT_TRUE(flags.test(testBit));
+    }
 }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -54,7 +54,7 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = JobKey;
-            materialBuilderDescriptor.m_version = 132; // Job Dependency subIds
+            materialBuilderDescriptor.m_version = 133; // Preload material dependencies
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.material", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.materialtype", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialBuilder>();
@@ -545,6 +545,12 @@ namespace AZ
                 {
                     AZ_Error(MaterialBuilderName, false, "Failed to output product dependencies.");
                     return;
+                }
+
+                for (auto& dependency : jobProduct.m_dependencies)
+                {
+                    // Set the load behavior to PreLoad, without clearing any other product dependency flags
+                    Data::ProductDependencyInfo::SetAssetLoadBehavior(dependency.m_flags, Data::AssetLoadBehavior::PreLoad);
                 }
 
                 response.m_outputProducts.push_back(AZStd::move(jobProduct));


### PR DESCRIPTION
If anyone calls RPI::Material::FindOrCreate in response to the OnAssetReady event of a material, it can result in a deadlock. FindOrCreate will do a blocking asset load for any asset the material depends on if that asset is not already loaded. By pre-loading the asset, the asset system can stream the dependent assets in parallel and have them all ready by the time the material asset's OnAssetReady event is called, which should be more performant and avoids the deadlock.

-Add utility to set the AssetLoadBehavior on ProductDependencyFlags 
-Set material asset dependencies as pre-load

ASV output:
RHI API: dx12
Test Script Count: 23
Screenshot Count: 213
Manually Validated Screenshots: 22/211
Screenshot automatic checks failed: 2
	scripts/parallaxtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_11_problematicAngle.png 'Level I' 0.107137
	scripts/shadowtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//spot_filter_method.png 'Level H' 0.065215
Screenshot interactive check 'High Difference'
	scripts/shadowtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//spot_no_red_shadow.png 'Level H' 0.019649
	scripts/shadowtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_pcf_high.png 'Level H' 0.020760
	scripts/shadowtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_esm_pcf.png 'Level H' 0.010912
	scripts/parallaxtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_9_offsetClipping.png 'Level I' 0.028470
	scripts/shadowtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_esm.png 'Level H' 0.010744
	scripts/parallaxtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_10_offsetClippingSteep.png 'Level I' 0.032833
	scripts/shadowtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_pcf_low.png 'Level H' 0.019089
	scripts/materialscreenshottests.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/012_parallax_pom_cutout.png 'Level I' 0.047330
Screenshot interactive check 'Moderate Difference'
	scripts/shadowtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//spot_shadowmap_size.png 'Level H' 0.022756
	scripts/shadowtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//initial.png 'Level H' 0.013812
	scripts/materialscreenshottests.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/100_uvtiling_metallic.png 'Level H' 0.010563
	scripts/materialscreenshottests.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/013_specularaa_on.png 'Level J' 0.030430
	scripts/parallaxtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_5.png 'Level I' 0.013230
	scripts/parallaxtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_7.png 'Level I' 0.031991
	scripts/shadowtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//spot_initial.png 'Level H' 0.021197
	scripts/materialscreenshottests.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/010_ambientocclusion.png 'Level H' 0.014087
Screenshot interactive check 'Low Difference'
	scripts/parallaxtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_6.png 'Level I' 0.011327
	scripts/materialscreenshottests.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardMultilayerPBR/005_usedisplacement_layer2off.png 'Level I' 0.010631
	scripts/shadowtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_initial.png 'Level H' 0.016336
	scripts/shadowtest.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_cascade_correction.png 'Level H' 0.011582
Screenshot interactive check 'No Difference'
	scripts/materialscreenshottests.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/013_specularaa_off.png 'Level I' 0.023675
	scripts/materialscreenshottests.bv.luac D:/GitHub/tinyprbranch/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardMultilayerPBR/002_parallaxpdo.png 'Level J' 0.025094


Signed-off-by: Tommy Walton <waltont@amazon.com>