### PR TITLE
Fix Multiplayer Editor Invalid Connection

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
@@ -173,7 +173,7 @@ class TestHelper:
             # make sure the server launcher is running
             waiter.wait_for(lambda: process_utils.process_exists("AutomatedTesting.ServerLauncher", ignore_extensions=True), timeout=5.0, exc=AssertionError("AutomatedTesting.ServerLauncher has NOT launched!"), interval=1.0)
 
-            TestHelper.succeed_if_log_line_found("EditorServer", "MultiplayerEditorConnection: Editor-server activation has found and connected to the editor.", section_tracer.prints, 15.0)
+            TestHelper.succeed_if_log_line_found("EditorServer", "MultiplayerEditorConnection: Editor-server has connected to the editor.", section_tracer.prints, 120.0)
 
             TestHelper.succeed_if_log_line_found("MultiplayerEditor", "Editor is sending the editor-server the level data packet.", section_tracer.prints, 5.0)
 

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
@@ -173,7 +173,7 @@ class TestHelper:
             # make sure the server launcher is running
             waiter.wait_for(lambda: process_utils.process_exists("AutomatedTesting.ServerLauncher", ignore_extensions=True), timeout=5.0, exc=AssertionError("AutomatedTesting.ServerLauncher has NOT launched!"), interval=1.0)
 
-            TestHelper.succeed_if_log_line_found("EditorServer", "MultiplayerEditorConnection: Editor-server has connected to the editor.", section_tracer.prints, 120.0)
+            TestHelper.succeed_if_log_line_found("MultiplayerEditor", "Editor has connected to the editor-server.", section_tracer.prints, 120.0)
 
             TestHelper.succeed_if_log_line_found("MultiplayerEditor", "Editor is sending the editor-server the level data packet.", section_tracer.prints, 5.0)
 

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
@@ -22,14 +22,12 @@
 #include <AzNetworking/Framework/INetworking.h>
 #include <AzCore/Console/IConsole.h>
 #include <AzCore/Component/ComponentApplicationLifecycle.h>
-#include <AzCore/EBus/IEventScheduler.h>
 
 namespace Multiplayer
 {
     using namespace AzNetworking;
 
     AZ_CVAR(bool, editorsv_isDedicated, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Whether to init as a server expecting data from an Editor. Do not modify unless you're sure of what you're doing.");
-    AZ_CVAR(bool, editorsv_editorIsListening, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Whether the editor is already listening; connect to the editor as soon as possible. Do not modify unless you're sure of what you're doing.");
     AZ_CVAR(uint16_t, editorsv_port, DefaultServerEditorPort, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "The port that the multiplayer editor gem will bind to for traffic.");
 
     MultiplayerEditorConnection::MultiplayerEditorConnection()
@@ -64,33 +62,6 @@ namespace Multiplayer
             }
         }
     }
-    
-    void MultiplayerEditorConnection::Connect()
-    {
-        ++m_connectionAttempts;
-        AZ_Printf("MultiplayerEditorConnection", "Editor-server tcp connection attempt #%i.\n", m_connectionAttempts)
-
-        const ConnectionId editorServerToEditorConnectionId = m_networkEditorInterface->Connect(IpAddress(LocalHost.data(), editorsv_port, ProtocolType::Tcp));
-
-        if (editorServerToEditorConnectionId != AzNetworking::InvalidConnectionId)
-        {
-            m_networkEditorInterface->SendReliablePacket(editorServerToEditorConnectionId, MultiplayerEditorPackets::EditorServerReadyForLevelData());
-            AZ_Printf("MultiplayerEditorConnection", "Editor-server has connected to the editor.\n")
-        }
-        else
-        {
-            // Keep trying to connect every 30 seconds until the port is finally available.
-            constexpr float timeoutSeconds = 30.0f;
-            AZ_Printf("MultiplayerEditorConnection", "Editor-server couldn't connect to editor, will attempt in %f seconds...\n", timeoutSeconds)
-            AZ::Interface<AZ::IEventScheduler>::Get()->AddCallback([this]
-                {
-                    this->Connect();
-                }, 
-                AZ::Name("MultiplayerEditorConnection attempt connection"),
-                AZ::SecondsToTimeMs(timeoutSeconds)
-            );
-        }
-    }
 
     void MultiplayerEditorConnection::ActivateDedicatedEditorServer() const
     {
@@ -102,18 +73,7 @@ namespace Multiplayer
         
         AZ_Assert(m_networkEditorInterface, "MP Editor Network Interface was unregistered before Editor Server could start listening.")
 
-        if (editorsv_editorIsListening)
-        {
-            // An editor is out there waiting to connect
-            m_connectionAttempts = 0;
-            Connect();
-        }
-        else
-        {
-            // If there wasn't an editor waiting for this server to start, then assume this is an editor-server launched by hand... listen
-            // and wait for the editor to request a connection
-            m_networkEditorInterface->Listen(editorsv_port);
-         }
+        m_networkEditorInterface->Listen(editorsv_port);
     }
 
     bool MultiplayerEditorConnection::HandleRequest

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.h
@@ -44,11 +44,13 @@ namespace Multiplayer
 
     private:
         void ActivateDedicatedEditorServer() const;
+        void Connect();
 
         AzNetworking::INetworkInterface* m_networkEditorInterface = nullptr;
         AZStd::vector<uint8_t> m_buffer;
         AZ::IO::ByteContainerStream<AZStd::vector<uint8_t>> m_byteStream;
         mutable bool m_isActivated = false;
         AZ::SettingsRegistryInterface::NotifyEventHandler m_componentApplicationLifecycleHandler;
+        int m_connectionAttempts = 0;
     };
 }

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.h
@@ -44,13 +44,11 @@ namespace Multiplayer
 
     private:
         void ActivateDedicatedEditorServer() const;
-        void Connect();
 
         AzNetworking::INetworkInterface* m_networkEditorInterface = nullptr;
         AZStd::vector<uint8_t> m_buffer;
         AZ::IO::ByteContainerStream<AZStd::vector<uint8_t>> m_byteStream;
         mutable bool m_isActivated = false;
         AZ::SettingsRegistryInterface::NotifyEventHandler m_componentApplicationLifecycleHandler;
-        int m_connectionAttempts = 0;
     };
 }

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -24,7 +24,6 @@
 #include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipInterface.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
-#include <AzCore/EBus/IEventScheduler.h>
 
 
 namespace Multiplayer

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -272,7 +272,7 @@ namespace Multiplayer
         }
 
         processLaunchInfo.m_commandlineParameters = AZStd::string::format(
-            R"("%s" --project-path "%s" --editorsv_isDedicated true --bg_ConnectToAssetProcessor false --rhi "%s" --editorsv_port %i --editorsv_editorIsListening true)",
+            R"("%s" --project-path "%s" --editorsv_isDedicated true --bg_ConnectToAssetProcessor false --rhi "%s" --editorsv_port %i)",
             serverPath.c_str(),
             AZ::Utils::GetProjectPath().c_str(),
             server_rhi.GetCStr(),

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
@@ -116,6 +116,6 @@ namespace Multiplayer
 
         ServerAcceptanceReceivedEvent::Handler m_serverAcceptanceReceivedHandler;
         AZ::ScheduledEvent m_connectionEvent = AZ::ScheduledEvent([this]{this->Connect();}, AZ::Name("MultiplayerEditorConnect"));
-        int m_connectionAttempts = 0;
+        uint16_t m_connectionAttempts = 0;
     };
 }

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
@@ -86,6 +86,7 @@ namespace Multiplayer
     private:
         void LaunchEditorServer();
         bool FindServerLauncher(AZ::IO::FixedMaxPath& serverPath);
+        void Connect();
         
         //! EditorEvents::Handler overrides
         //! @{
@@ -114,5 +115,7 @@ namespace Multiplayer
         AzNetworking::ConnectionId m_editorConnId;
 
         ServerAcceptanceReceivedEvent::Handler m_serverAcceptanceReceivedHandler;
+        AZ::ScheduledEvent m_connectionEvent = AZ::ScheduledEvent([this]{this->Connect();}, AZ::Name("MultiplayerEditorConnect"));
+        int m_connectionAttempts = 0;
     };
 }

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -548,7 +548,7 @@ namespace Multiplayer
             }
             else
             {
-                AZLOG_ERROR("No IMultiplyaerSpawner was available. Ensure that one is registered for usage on PlayerJoin.");
+                AZLOG_ERROR("No IMultiplayerSpawner was available. Ensure that one is registered for usage on PlayerJoin.");
             }
 
             if (controlledEntity.Exists())


### PR DESCRIPTION
Simplify multiplayer editor. Going back to original setup where editor connects and server listens, except this time the editor will keep trying to reconnect if it fails (for example if the server isn't finished launching, or the port isn't available yet)

Tested by:
1) Seeing successful AR python/python.sh -m pytest --build-directory ./AutomatedTesting/build/linux/bin/profile/ ./AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Sandbox.py::TestAutomation
2) Running editor CTRL+G mode
3) Running editor CTRL+G mode and exiting before the server is done loading
4) Running a server by hand and then entering CTLR+G mode
  
Resolves #8605