### PR TITLE
reduce atom test duration, fix comments

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
 class TestAutomation(EditorTestSuite):
-    # Remove -autotest_mode from global_extra_cmdline_args since we need rendering for these tests.
+    # Remove -BatchMode from global_extra_cmdline_args since we need rendering for these tests.
     global_extra_cmdline_args = ["-autotest_mode"]  # Default is ["-BatchMode", "-autotest_mode"]
     use_null_renderer = False  # Default is True
 

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
@@ -31,8 +31,6 @@ class TestHelper:
     @staticmethod
     def init_idle():
         general.idle_enable(True)
-        # JIRA: SPEC-2880
-        # general.idle_wait_frames(1)
 
     @staticmethod
     def create_level(level_name: str) -> bool:


### PR DESCRIPTION
Changed AtomCore C++ tests to run for iterations instead of a duration, reducing total test module runtime from 109446ms to 723ms (99.3% reduction). Left in a change to test helper functions passing const&'s, which was a negligible improvement. Commented out test debugging statements.

Found this bottleneck while profiling the test suites.

Also fixes some inaccurate comments used by Atom Python-based tests.

Signed-off-by: Sean Sweeney <sweeneys@amazon.com>