### PR TITLE
{lyn11886} adding logging for building events CreateJobs and Process

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
@@ -296,7 +296,7 @@ namespace AssetProcessor
         }
         else if (jobCancelListener && jobCancelListener->IsCancelled())
         {
-            AZ_Error("Builder", false, "Job request was cancelled");
+            AZ_Error("Builder", false, "Job request was canceled");
             TerminateProcess(AZ::u32(-1)); // Terminate the builder. Even if it isn't deadlocked, we can't put it back in the pool while it's busy.
             return BuilderRunJobOutcome::JobCancelled;
         }

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
@@ -19,6 +19,29 @@ namespace AssetProcessor
         TNetResponse netResponse;
         netRequest.m_request = request;
 
+        struct BuildTracker final
+        {
+            BuildTracker(const Builder& builder, const AZStd::string& sourceFile, const AZStd::string& task)
+                : m_builder(builder)
+                , m_sourceFile(sourceFile)
+                , m_task(task)
+            {
+                AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Request started builder [%s] task (%s) %s \n",
+                    m_builder.UuidString().c_str(), m_task.c_str(), m_sourceFile.c_str());
+            }
+
+            ~BuildTracker()
+            {
+                AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Request stopped builder [%s] task (%s) %s \n",
+                    m_builder.UuidString().c_str(), m_task.c_str(), m_sourceFile.c_str());
+            }
+
+            const Builder& m_builder;
+            const AZStd::string& m_sourceFile;
+            const AZStd::string& m_task;
+        };
+        BuildTracker tracker(*this, request.m_sourceFile, task);
+
         [[maybe_unused]] AZ::u32 type;
         QByteArray data;
         AZStd::binary_semaphore wait;


### PR DESCRIPTION
This will allow log readers to determine how long the events have taken
so that very long CreateJobs events and their builders can be matched

Signed-off-by: Allen Jackson <23512001+jackalbe@users.noreply.github.com>