### PR TITLE
Use O3DE Python to run cdk deploy

### DIFF
--- a/scripts/build/Platform/Windows/deploy_cdk_applications.cmd
+++ b/scripts/build/Platform/Windows/deploy_cdk_applications.cmd
@@ -17,18 +17,6 @@ SET SOURCE_DIRECTORY=%CD%
 SET PATH=%SOURCE_DIRECTORY%\python;%PATH%
 SET GEM_DIRECTORY=%SOURCE_DIRECTORY%\Gems
 
-REM Create and activate a virtualenv for the CDK deployment
-CALL python -m venv .env
-IF ERRORLEVEL 1 (
-    ECHO [cdk_bootstrap] Failed to create a virtualenv for the CDK deployment
-    exit /b 1
-)
-CALL .env\Scripts\activate.bat
-IF ERRORLEVEL 1 (
-    ECHO [cdk_bootstrap] Failed to activate the virtualenv for the CDK deployment
-    exit /b 1
-)
-
 ECHO [cdk_installation] Install the latest version of CDK
 CALL npm uninstall -g aws-cdk
 IF ERRORLEVEL 1 (

--- a/scripts/build/Platform/Windows/destroy_cdk_applications.cmd
+++ b/scripts/build/Platform/Windows/destroy_cdk_applications.cmd
@@ -17,18 +17,6 @@ SET SOURCE_DIRECTORY=%CD%
 SET PATH=%SOURCE_DIRECTORY%\python;%PATH%
 SET GEM_DIRECTORY=%SOURCE_DIRECTORY%\Gems
 
-REM Create and activate a virtualenv for the CDK destruction
-CALL python -m venv .env
-IF ERRORLEVEL 1 (
-    ECHO [cdk_bootstrap] Failed to create a virtualenv for the CDK destruction
-    exit /b 1
-)
-CALL .env\Scripts\activate.bat
-IF ERRORLEVEL 1 (
-    ECHO [cdk_bootstrap] Failed to activate the virtualenv for the CDK destruction
-    exit /b 1
-)
-
 ECHO [cdk_installation] Install the latest version of CDK
 CALL npm uninstall -g aws-cdk
 IF ERRORLEVEL 1 (


### PR DESCRIPTION
There is an issue that Python from O3DE cannot create virtual environment.

Use O3DE Python to run cdk deploy, each Jenkins job has its own EBS volume, installing Python dependencies in one job won't affect other jobs.

Signed-off-by: Shirang Jia <shiranj@amazon.com>