### PR TITLE
reduce sleeps in azcore tests

### DIFF
--- a/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
@@ -206,7 +206,7 @@ namespace UnitTest
             catalog->AddAsset<AssetWithSerializedData>(MyAsset5Id, "TestAsset5.txt");
             catalog->AddAsset<AssetWithSerializedData>(MyAsset6Id, "TestAsset6.txt");
 
-            catalog->AddAsset<AssetWithAssetReference>(DelayLoadAssetId, "DelayLoadAsset.txt", 2000);
+            catalog->AddAsset<AssetWithAssetReference>(DelayLoadAssetId, "DelayLoadAsset.txt", 10);
             catalog->AddAsset<AssetWithAssetReference>(NoLoadAssetId, "NoLoadAsset.txt")->AddNoLoad(MyAsset2Id);
 
             catalog->AddAsset<AssetWithQueueAndPreLoadReferences>(PreloadAssetRootId, "PreLoadRoot.txt")->AddPreload(PreloadAssetAId)->AddQueueLoad(QueueLoadAssetAId);
@@ -543,7 +543,6 @@ namespace UnitTest
         // Make sure we didn't time out.
         ASSERT_FALSE(timedOut);
 
-
         // This should mark the first for an additional reload
         m_testAssetManager->ReloadAsset(DelayLoadAssetId, AZ::Data::AssetLoadBehavior::Default);
         // This should do nothing
@@ -727,7 +726,7 @@ namespace UnitTest
 
         AZStd::thread thread([streamer, &completeSignal]()
             {
-                AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(30));
+                AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
                 streamer->ResumeProcessing();
 
                 if (!completeSignal.try_acquire_for(AZStd::chrono::seconds(5)))
@@ -872,7 +871,7 @@ namespace UnitTest
 
         while (m_loadDataSynchronizer.m_numBlocking < 2)
         {
-            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(5));
+            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
         }
 
         m_loadDataSynchronizer.m_readyToLoad = true;
@@ -2769,7 +2768,7 @@ namespace UnitTest
             EXPECT_TRUE(asset1.IsReady());
             EXPECT_TRUE(asset2.IsReady());
 
-            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(100));
+            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
             AssetManager::Instance().DispatchEvents();
 
             EXPECT_EQ(m_assetHandlerAndCatalog->m_numLoads, 2);
@@ -2808,7 +2807,7 @@ namespace UnitTest
             EXPECT_TRUE(asset1.IsReady());
             EXPECT_TRUE(asset2.IsReady());
 
-            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(100));
+            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
             AssetManager::Instance().DispatchEvents();
 
             EXPECT_EQ(m_assetHandlerAndCatalog->m_numLoads, 2);
@@ -2845,10 +2844,10 @@ namespace UnitTest
 
                 ASSERT_TRUE(asset1);
 
-                AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(50));
+                AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
             }
 
-            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(80));
+            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
             AssetManager::Instance().DispatchEvents();
 
             EXPECT_EQ(m_assetHandlerAndCatalog->m_numLoads, 1);
@@ -3060,7 +3059,7 @@ namespace UnitTest
         auto rootAsset = AssetManager::Instance().GetAsset<AssetWithAssetReference>(RootAssetId, AssetLoadBehavior::Default);
         while (m_loadDataSynchronizer.m_numBlocking < 1)
         {
-            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(5));
+            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
         }
 
         // Verify that the loading state on the nested dependent asset has been reached.
@@ -3121,7 +3120,7 @@ namespace UnitTest
         auto rootAsset = AssetManager::Instance().GetAsset<AssetWithAssetReference>(RootAssetId, AssetLoadBehavior::Default);
         while (m_loadDataSynchronizer.m_numBlocking < 1)
         {
-            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(5));
+            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
         }
 
         // Get references to the dependent and nested dependent assets

--- a/Code/Framework/AzCore/Tests/EBus/ScheduledEventTests.cpp
+++ b/Code/Framework/AzCore/Tests/EBus/ScheduledEventTests.cpp
@@ -75,7 +75,7 @@ namespace UnitTest
         const AZ::TimeMs startTimeMs = AZ::GetElapsedTimeMs();
         for (;;)
         {
-            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(25));
+            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
             m_eventSchedulerComponent->OnTick(0.0f, AZ::ScriptTimePoint());
             if (AZ::GetElapsedTimeMs() - startTimeMs > TotalIterationTimeMs)
             {
@@ -92,7 +92,7 @@ namespace UnitTest
         const AZ::TimeMs startTimeMs = AZ::GetElapsedTimeMs();
         for (;;)
         {
-            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(25));
+            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
             m_eventSchedulerComponent->OnTick(0.0f, AZ::ScriptTimePoint());
             if (AZ::GetElapsedTimeMs() - startTimeMs > TotalIterationTimeMs)
             {

--- a/Code/Framework/AzCore/Tests/Streamer/FullDecompressorTests.cpp
+++ b/Code/Framework/AzCore/Tests/Streamer/FullDecompressorTests.cpp
@@ -175,7 +175,7 @@ namespace AZ::IO
             AZ_Assert(compressedSize == uncompressedBufferSize, "Fake decompression algorithm only supports copying data.");
             if (sleep)
             {
-                AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(80));
+                AZStd::this_thread::sleep_for(AZStd::chrono::microseconds(1));
             }
             memcpy(uncompressed, compressed, compressedSize);
             return true;

--- a/Code/Framework/AzCore/Tests/Streamer/SchedulerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Streamer/SchedulerTests.cpp
@@ -364,7 +364,7 @@ namespace AZ::IO
                 }
                 else
                 {
-                    AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(32));
+                    AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
                     return true;
                 }
             }));

--- a/Code/Framework/AzCore/Tests/StreamerTests.cpp
+++ b/Code/Framework/AzCore/Tests/StreamerTests.cpp
@@ -299,7 +299,7 @@ namespace AZ::IO
         //! then call WaitForScheduler to give Steamers scheduler some time to update it's internal status.
         void WaitForScheduler()
         {
-            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(250));
+            AZStd::this_thread::sleep_for(AZStd::chrono::microseconds(1));
         }
 
     protected:


### PR DESCRIPTION
Reduces the duration and frequency of tests calling sleep in AZ::AzCore.Tests.main.  This reduces the total time to execute all tests in this module by 60% from 124767ms to 50879ms.

These inefficiencies were found while profiling the test module. While it's best to avoid sleeps, I couldn't see a simple way to verify the same multi-thread conditions without sleeping.

Verified this remains consistently passing locally in both profile and debug.

Signed-off-by: Sean Sweeney <sweeneys@amazon.com>