### PR TITLE
reduce test setup in azframework tests

### DIFF
--- a/Code/Framework/AzFramework/Tests/ArchiveCompressionTests.cpp
+++ b/Code/Framework/AzFramework/Tests/ArchiveCompressionTests.cpp
@@ -35,29 +35,6 @@ namespace UnitTest
             : m_application { AZStd::make_unique<AzFramework::Application>() }
         {}
 
-        void SetUp() override
-        {
-            AZ::SettingsRegistryInterface* registry = AZ::SettingsRegistry::Get();
-
-            auto projectPathKey =
-                AZ::SettingsRegistryInterface::FixedValueString(AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) + "/project_path";
-            AZ::IO::FixedMaxPath enginePath;
-            registry->Get(enginePath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
-            registry->Set(projectPathKey, (enginePath / "AutomatedTesting").Native());
-            AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_AddRuntimeFilePaths(*registry);
-
-            m_application->Start({});
-            // Without this, the user settings component would attempt to save on finalize/shutdown. Since the file is
-            // shared across the whole engine, if multiple tests are run in parallel, the saving could cause a crash 
-            // in the unit tests.
-            AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
-        }
-
-        void TearDown() override
-        {
-            m_application->Stop();
-        }
-
     private:
         AZStd::unique_ptr<AzFramework::Application> m_application;
     };

--- a/Code/Framework/AzFramework/Tests/FileIO.cpp
+++ b/Code/Framework/AzFramework/Tests/FileIO.cpp
@@ -436,10 +436,9 @@ namespace UnitTest
                     fclose(tempFile);
                 }
 
-                // make sure attributes are copied (such as modtime) even if they're copied:
-                AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1500));
+                // make sure attributes are copied, such as original modtime:
+                AZStd::this_thread::sleep_for(AZStd::chrono::seconds(1));
                 AZ_TEST_ASSERT(local.Copy(m_file01Name.c_str(), m_file02Name.c_str()));
-                AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1500));
                 AZ_TEST_ASSERT(local.Copy(m_file01Name.c_str(), m_file03Name.c_str()));
 
                 AZ_TEST_ASSERT(local.Exists(m_file01Name.c_str()));
@@ -467,9 +466,6 @@ namespace UnitTest
                 EXPECT_TRUE(file.Open(m_file01Name.c_str(), SystemFile::SF_OPEN_WRITE_ONLY));
                 file.Write("this is just a test that is longer", 34);
                 file.Close();
-
-                // make sure attributes are copied (such as modtime) even if they're copied:
-                AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1500));
 
                 EXPECT_TRUE(local.Copy(m_file01Name.c_str(), m_file02Name.c_str()));
 
@@ -514,7 +510,6 @@ namespace UnitTest
                 AZ_TEST_ASSERT(local.Write(fileHandle, "more", 4));
                 AZ_TEST_ASSERT(local.Close(fileHandle));
 
-                AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1500));
                 // No-append-mode
                 AZ_TEST_ASSERT(local.Open(m_file03Name.c_str(), AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeBinary, fileHandle));
                 AZ_TEST_ASSERT(fileHandle != AZ::IO::InvalidHandle);
@@ -524,7 +519,7 @@ namespace UnitTest
                 modTimeC = local.ModificationTime(m_file02Name.c_str());
                 modTimeD = local.ModificationTime(m_file03Name.c_str());
 
-                AZ_TEST_ASSERT(modTimeD > modTimeC);
+                AZ_TEST_ASSERT(modTimeD >= modTimeC); // should never be descending
 
                 AZ::u64 f1s = 0;
                 AZ::u64 f2s = 0;


### PR DESCRIPTION
Proposed changes were found while profiling tests, and reduce running AZ::AzFramework.Tests.main by 57% from 92752ms to 39867ms. Other tests in this module appear more tightly integrated with creating an actual application context.

Reduces sleeps when testing FileIO, though a more invasive fix would be to mock the system time responses that FileIO is depending on from the OS, or to mock more of the actual I/O. This would also prevent a rare edge case failure where actual system time is modified during test execution (could be user-initiated, though more likely automated in the case of DST, leap seconds, and internal clock drift)

Application start/stop was not required to test compression.

Verified these changes locally in both profile and debug.

Signed-off-by: Sweeney <sweeneys@amazon.com>