### PR TITLE
Implemented bilinear filtering sample type for image gradients

### DIFF
--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
@@ -145,7 +145,7 @@ namespace GradientSignal
         void SetupDefaultMultiplierAndOffset();
         void SetupAutoScaleMultiplierAndOffset();
         void SetupManualScaleMultiplierAndOffset();
-        float GetValueForSamplingType(AZ::u32 x, AZ::u32 y, float pixelX, float pixelY) const;
+        float GetValueForSamplingType(AZ::u32 x0, AZ::u32 y0, float pixelX, float pixelY) const;
 
         // ImageGradientRequestBus overrides...
         AZStd::string GetImageAssetPath() const override;

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
@@ -62,6 +62,13 @@ namespace GradientSignal
         Manual                  //! Scale according to m_scaleRangeMin and m_scaleRangeMax
     };
 
+    //! Sampling type to use for the image data
+    enum class SamplingType : AZ::u8
+    {
+        Point,                  //! Point sampling just queries the X,Y point as specified (Default)
+        Bilinear                //! Apply a bilinear filter to the image data
+    };
+
     class ImageGradientConfig
         : public AZ::ComponentConfig
     {
@@ -82,6 +89,7 @@ namespace GradientSignal
         float m_scaleRangeMin = 0.0f;
         float m_scaleRangeMax = 1.0f;
         AZ::u32 m_mipIndex = 0;
+        SamplingType m_samplingType = SamplingType::Point;
     };
 
     static const AZ::Uuid ImageGradientComponentTypeId = "{4741F079-157F-457E-93E0-D6BA4EAF76FE}";
@@ -131,11 +139,13 @@ namespace GradientSignal
 
         void GetSubImageData();
         float GetValueFromImageData(const AZ::Vector3& uvw, float defaultValue) const;
+        float GetPixelValue(AZ::u32 x, AZ::u32 y) const;
         float GetTerrariumPixelValue(AZ::u32 x, AZ::u32 y) const;
         void SetupMultiplierAndOffset(float min, float max);
         void SetupDefaultMultiplierAndOffset();
         void SetupAutoScaleMultiplierAndOffset();
         void SetupManualScaleMultiplierAndOffset();
+        void HandleSamplingType(float& value, AZ::u32 x, AZ::u32 y, float pixelX, float pixelY) const;
 
         // ImageGradientRequestBus overrides...
         AZStd::string GetImageAssetPath() const override;
@@ -159,5 +169,6 @@ namespace GradientSignal
         float m_offset = 0.0f;
         AZ::u32 m_currentMipIndex = 0;
         AZ::RHI::ImageDescriptor m_imageDescriptor;
+        SamplingType m_currentSamplingType = SamplingType::Point;
     };
 }

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
@@ -145,7 +145,7 @@ namespace GradientSignal
         void SetupDefaultMultiplierAndOffset();
         void SetupAutoScaleMultiplierAndOffset();
         void SetupManualScaleMultiplierAndOffset();
-        void HandleSamplingType(float& value, AZ::u32 x, AZ::u32 y, float pixelX, float pixelY) const;
+        float GetValueForSamplingType(AZ::u32 x, AZ::u32 y, float pixelX, float pixelY) const;
 
         // ImageGradientRequestBus overrides...
         AZStd::string GetImageAssetPath() const override;

--- a/Gems/GradientSignal/Code/Include/GradientSignal/GradientTransform.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/GradientTransform.h
@@ -108,6 +108,9 @@ namespace GradientSignal
         */
         static constexpr float UvEpsilon = 0.001f;
 
+        //! Return the WrappingType for this GradientTransform
+        WrappingType GetWrappingType() const;
+
     private:
 
         //! These are the various transformations that will be performed, based on wrapping type.

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -581,14 +581,12 @@ namespace GradientSignal
 
     float ImageGradientComponent::GetValueForSamplingType(AZ::u32 x, AZ::u32 y, float pixelX, float pixelY) const
     {
-        float value = 0.0f;
-
         switch (m_currentSamplingType)
         {
         case SamplingType::Point:
+        default:
             // Retrieve the pixel value for the single point
-            value = GetPixelValue(x, y);
-            break;
+            return GetPixelValue(x, y);
 
         case SamplingType::Bilinear:
             // Bilinear interpolation
@@ -660,11 +658,8 @@ namespace GradientSignal
             const float valueX1Y1 = (x1IsValid && y1IsValid) ? GetPixelValue(x1, y1) : 0.0f;
             const float valueXY0 = AZ::Lerp(valueX0Y0, valueX1Y0, deltaX);
             const float valueXY1 = AZ::Lerp(valueX0Y1, valueX1Y1, deltaX);
-            value = AZ::Lerp(valueXY0, valueXY1, deltaY);
-            break;
+            return AZ::Lerp(valueXY0, valueXY1, deltaY);
         }
-
-        return value;
     }
 
     void ImageGradientComponent::Activate()

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -616,10 +616,6 @@ namespace GradientSignal
             bool y1IsValid = true;
             switch (m_gradientTransform.GetWrappingType())
             {
-            case WrappingType::ClampToEdge:
-                x1 = AZStd::min(x0 + 1, width - 1);
-                y1 = AZStd::min(y0 + 1, height - 1);
-                break;
             case WrappingType::ClampToZero:
                 // For ClampToZero, the value will always be 0 outside of the shape
                 // So go ahead and do the calculation here, but if it ends
@@ -636,6 +632,7 @@ namespace GradientSignal
                     y1IsValid = false;
                 }
                 break;
+            case WrappingType::ClampToEdge:
             case WrappingType::Mirror:
                 // On the mirror edge case we are only ever
                 // looking at x+1 or y+1 just out of the image

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -635,6 +635,7 @@ namespace GradientSignal
                 {
                     y1IsValid = false;
                 }
+                break;
             case WrappingType::Mirror:
                 // On the mirror edge case we are only ever
                 // looking at x+1 or y+1 just out of the image

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -579,14 +579,14 @@ namespace GradientSignal
         SetupMultiplierAndOffset(m_configuration.m_scaleRangeMin, m_configuration.m_scaleRangeMax);
     }
 
-    float ImageGradientComponent::GetValueForSamplingType(AZ::u32 x, AZ::u32 y, float pixelX, float pixelY) const
+    float ImageGradientComponent::GetValueForSamplingType(AZ::u32 x0, AZ::u32 y0, float pixelX, float pixelY) const
     {
         switch (m_currentSamplingType)
         {
         case SamplingType::Point:
         default:
             // Retrieve the pixel value for the single point
-            return GetPixelValue(x, y);
+            return GetPixelValue(x0, y0);
 
         case SamplingType::Bilinear:
             // Bilinear interpolation
@@ -617,20 +617,20 @@ namespace GradientSignal
             switch (m_gradientTransform.GetWrappingType())
             {
             case WrappingType::ClampToEdge:
-                x1 = AZStd::min(x + 1, width - 1);
-                y1 = AZStd::min(y + 1, height - 1);
+                x1 = AZStd::min(x0 + 1, width - 1);
+                y1 = AZStd::min(y0 + 1, height - 1);
                 break;
             case WrappingType::ClampToZero:
                 // For ClampToZero, the value will always be 0 outside of the shape
                 // So go ahead and do the calculation here, but if it ends
                 // up being outside of the shape, then it will be considered
                 // invalid and we will use 0 for the value below
-                x1 = x + 1;
+                x1 = x0 + 1;
                 if (x1 >= width)
                 {
                     x1IsValid = false;
                 }
-                y1 = y + 1;
+                y1 = y0 + 1;
                 if (y1 >= height)
                 {
                     y1IsValid = false;
@@ -640,21 +640,21 @@ namespace GradientSignal
                 // looking at x+1 or y+1 just out of the image
                 // bounds, so the edge value will be the
                 // mirrored value
-                x1 = AZStd::min(x + 1, width - 1);
-                y1 = AZStd::min(y + 1, height - 1);
+                x1 = AZStd::min(x0 + 1, width - 1);
+                y1 = AZStd::min(y0 + 1, height - 1);
                 break;
             case WrappingType::None:
             case WrappingType::Repeat:
             default:
-                x1 = (x + 1) % width;
-                y1 = (y + 1) % width;
+                x1 = (x0 + 1) % width;
+                y1 = (y0 + 1) % width;
                 break;
             }
 
             // Retrieve all the points in the grid and then perform the interpolation
-            const float valueX0Y0 = GetPixelValue(x, y);
-            const float valueX1Y0 = (x1IsValid) ? GetPixelValue(x1, y) : 0.0f;
-            const float valueX0Y1 = (y1IsValid) ? GetPixelValue(x, y1) : 0.0f;
+            const float valueX0Y0 = GetPixelValue(x0, y0);
+            const float valueX1Y0 = (x1IsValid) ? GetPixelValue(x1, y0) : 0.0f;
+            const float valueX0Y1 = (y1IsValid) ? GetPixelValue(x0, y1) : 0.0f;
             const float valueX1Y1 = (x1IsValid && y1IsValid) ? GetPixelValue(x1, y1) : 0.0f;
             const float valueXY0 = AZ::Lerp(valueX0Y0, valueX1Y0, deltaX);
             const float valueXY1 = AZ::Lerp(valueX0Y1, valueX1Y1, deltaX);

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -140,6 +140,16 @@ namespace GradientSignal
         return options;
     }
 
+    AZStd::vector<AZ::Edit::EnumConstant<SamplingType>> SupportedSamplingTypeOptions()
+    {
+        AZStd::vector<AZ::Edit::EnumConstant<SamplingType>> options;
+
+        options.push_back(AZ::Edit::EnumConstant<SamplingType>(SamplingType::Point, "Point"));
+        options.push_back(AZ::Edit::EnumConstant<SamplingType>(SamplingType::Bilinear, "Bilinear"));
+
+        return options;
+    }
+
     bool DoesFormatSupportTerrarium(AZ::RHI::Format format)
     {
         // The terrarium type is only supported by 8-bit formats that have
@@ -174,6 +184,7 @@ namespace GradientSignal
                 ->Field("ScaleRangeMin", &ImageGradientConfig::m_scaleRangeMin)
                 ->Field("ScaleRangeMax", &ImageGradientConfig::m_scaleRangeMax)
                 ->Field("MipIndex", &ImageGradientConfig::m_mipIndex)
+                ->Field("SamplingType", &ImageGradientConfig::m_samplingType)
                 ;
 
             AZ::EditContext* edit = serialize->GetEditContext();
@@ -215,6 +226,11 @@ namespace GradientSignal
                     ->Attribute(AZ::Edit::Attributes::ReadOnly, &ImageGradientConfig::IsAdvancedModeReadOnly)
                     ->Attribute(AZ::Edit::Attributes::Min, 0)
                     ->Attribute(AZ::Edit::Attributes::Max, AZ::RHI::Limits::Image::MipCountMax)
+
+                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &ImageGradientConfig::m_samplingType, "Sampling Type", "Sampling type to use for the image data.")
+                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &ImageGradientConfig::IsAdvancedModeReadOnly)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                    ->Attribute(AZ::Edit::Attributes::EnumValues, &SupportedSamplingTypeOptions)
                     ;
             }
         }
@@ -346,6 +362,7 @@ namespace GradientSignal
 
             m_currentChannel = m_configuration.m_channelToUse;
             m_currentScaleType = m_configuration.m_customScaleType;
+            m_currentSamplingType = m_configuration.m_samplingType;
 
             // Make sure the custom mip level doesn't exceed the available mip levels in this
             // image asset. If so, then just use the lowest available mip level.
@@ -364,6 +381,7 @@ namespace GradientSignal
             m_currentChannel = ChannelToUse::Red;
             m_currentScaleType = CustomScaleType::None;
             m_currentMipIndex = 0;
+            m_currentSamplingType = SamplingType::Point;
         }
 
         // Update our cached image data
@@ -431,17 +449,16 @@ namespace GradientSignal
                 // UVs outside the 0-1 range are treated as infinitely tiling, so that we behave the same as the 
                 // other gradient generators.  As mentioned above, if clamping is desired, we expect it to be applied
                 // outside of this function.
-                auto x = aznumeric_cast<AZ::u32>(pixelLookup.GetX()) % width;
-                auto y = aznumeric_cast<AZ::u32>(pixelLookup.GetY()) % height;
+                float pixelX = pixelLookup.GetX();
+                float pixelY = pixelLookup.GetY();
+                auto x = aznumeric_cast<AZ::u32>(pixelX) % width;
+                auto y = aznumeric_cast<AZ::u32>(pixelY) % height;
 
-                // Flip the y because images are stored in reverse of our world axes
-                y = (height - 1) - y;
+                // Retrieve the pixel value from the image data
+                float value = GetPixelValue(x, y);
 
-                // For terrarium, there is a separate algorithm for retrieving the value
-                const float value = (m_currentChannel == ChannelToUse::Terrarium)
-                    ? GetTerrariumPixelValue(x, y)
-                    : AZ::RPI::GetImageDataPixelValue<float>(
-                        m_imageData, m_imageDescriptor, x, y, aznumeric_cast<AZ::u8>(m_currentChannel));
+                // Handle any additional processing based on our sampling type
+                HandleSamplingType(value, x, y, pixelX, pixelY);
 
                 // Scale (inverse lerp) the value into a 0 - 1 range. We also clamp it because manual scale values could cause
                 // the result to fall outside of the expected output range.
@@ -450,6 +467,21 @@ namespace GradientSignal
         }
 
         return defaultValue;
+    }
+
+    float ImageGradientComponent::GetPixelValue(AZ::u32 x, AZ::u32 y) const
+    {
+        // Flip the y because images are stored in reverse of our world axes
+        const auto& height = m_imageDescriptor.m_size.m_height;
+        y = (height - 1) - y;
+
+        // For terrarium, there is a separate algorithm for retrieving the value
+        float value = (m_currentChannel == ChannelToUse::Terrarium)
+            ? GetTerrariumPixelValue(x, y)
+            : AZ::RPI::GetImageDataPixelValue<float>(
+                m_imageData, m_imageDescriptor, x, y, aznumeric_cast<AZ::u8>(m_currentChannel));
+
+        return value;
     }
 
     float ImageGradientComponent::GetTerrariumPixelValue(AZ::u32 x, AZ::u32 y) const
@@ -548,6 +580,46 @@ namespace GradientSignal
         // Set our multiplier and offset based on the manual scale range. Note that the manual scale range might be less than the
         // input range and possibly even inverted.
         SetupMultiplierAndOffset(m_configuration.m_scaleRangeMin, m_configuration.m_scaleRangeMax);
+    }
+
+    void ImageGradientComponent::HandleSamplingType(float& value, AZ::u32 x, AZ::u32 y, float pixelX, float pixelY) const
+    {
+        switch (m_currentSamplingType)
+        {
+        case SamplingType::Bilinear:
+            // Bilinear interpolation
+            //
+            //   |
+            //   |
+            //   |  (x0,y1) *             * (x1,y1)
+            //   |
+            //   |                o (x,y)
+            //   |
+            //   |  (x0,y0) *             * (x1,y0)
+            //   |___________________________________
+            //
+            // The bilinear filtering samples from a grid around a desired pixel (x,y)
+            // x0,y0 contains one corner of our grid square, x1,y1 contains the opposite corner, and deltaX/Y is the fractional
+            // amount the position exists between those corners.
+            // Ex: (3.3, 4.4) would have a x0,y0 of (3, 4), a x1,y1 of (4, 5), and a deltaX/Y of (0.3, 0.4).
+            const auto& width = m_imageDescriptor.m_size.m_width;
+            const auto& height = m_imageDescriptor.m_size.m_height;
+            float deltaX = pixelX - floor(pixelX);
+            float deltaY = pixelY - floor(pixelY);
+
+            // Don't let the x1,y1 point extend beyond the bounds of our width/height
+            AZ::u32 x1 = AZStd::min(x + 1, width - 1);
+            AZ::u32 y1 = AZStd::min(y + 1, height - 1);
+
+            // The `value` variable already has the x0,y0 value for us
+            const float valueX1Y0 = GetPixelValue(x1, y);
+            const float valueX0Y1 = GetPixelValue(x, y1);
+            const float valueX1Y1 = GetPixelValue(x1, y1);
+            const float valueXY0 = AZ::Lerp(value, valueX1Y0, deltaX);
+            const float valueXY1 = AZ::Lerp(valueX0Y1, valueX1Y1, deltaX);
+            value = AZ::Lerp(valueXY0, valueXY1, deltaY);
+            break;
+        }
     }
 
     void ImageGradientComponent::Activate()

--- a/Gems/GradientSignal/Code/Source/GradientTransform.cpp
+++ b/Gems/GradientSignal/Code/Source/GradientTransform.cpp
@@ -93,6 +93,11 @@ namespace GradientSignal
         outUVW = m_normalizeExtentsReciprocal * (outUVW - m_shapeBounds.GetMin());
     }
 
+    WrappingType GradientTransform::GetWrappingType() const
+    {
+        return m_wrappingType;
+    }
+
     AZ::Vector3 GradientTransform::NoTransform(const AZ::Vector3& point, const AZ::Aabb& /*bounds*/)
     {
         return point;

--- a/Gems/GradientSignal/Code/Tests/GradientSignalImageTests.cpp
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalImageTests.cpp
@@ -474,14 +474,14 @@ namespace UnitTest
         RunPixelTest(test);
     }
 
-    TEST_F(GradientSignalImageTestsFixture, ImageGradientComponentAdvancedBilinearSampling)
+    TEST_F(GradientSignalImageTestsFixture, ImageGradientComponentAdvancedBilinearSamplingClampToZero)
     {
         // Set one pixel, map Gradient 1:1 to lookup space, get same pixel back
         PixelTestSetup test =
         {
             4, AZ::Vector2(0.25f, 0.25f), {200, 150, 100, 50},          // Source image:  4 x 4 with (0, 0) set to different values in each channel
             4, 1.0f,                                                    // Mapped Shape:  4 x 4 with tiling (1.0, 1.0), unbounded
-            GradientSignal::WrappingType::None,
+            GradientSignal::WrappingType::ClampToZero,
             4, 0.25f, 1.0f,                                             // Validate that in 4 x 4 range, only 0, 0 is set
             { AZ::Vector2(0.25f, 0.25f), PixelTestSetup::EndOfList },
             true,                                                       // Enabled the advanced mode
@@ -534,6 +534,207 @@ namespace UnitTest
 
                     EXPECT_TRUE(AZ::IsClose(value, expectedValue));
                 }
+            }
+        }
+    }
+
+    TEST_F(GradientSignalImageTestsFixture, ImageGradientComponentAdvancedBilinearSamplingClampToEdge)
+    {
+        // Set one pixel, map Gradient 1:1 to lookup space, get same pixel back
+        PixelTestSetup test =
+        {
+            4, AZ::Vector2(0.25f, 0.25f), {200, 150, 100, 50},          // Source image:  4 x 4 with (0, 0) set to different values in each channel
+            4, 1.0f,                                                    // Mapped Shape:  4 x 4 with tiling (1.0, 1.0), unbounded
+            GradientSignal::WrappingType::ClampToEdge,
+            4, 0.25f, 1.0f,                                             // Validate that in 4 x 4 range, only 0, 0 is set
+            { AZ::Vector2(0.25f, 0.25f), PixelTestSetup::EndOfList },
+            true,                                                       // Enabled the advanced mode
+            GradientSignal::ChannelToUse::Red,                          // Use Red channel (default)
+            GradientSignal::CustomScaleType::None,                      // No custom scale (default)
+            0.0f,                                                       // Min scale (won't be used since None scale type is set)
+            1.0f,                                                       // Max scale (won't be used since None scale type is set)
+            GradientSignal::SamplingType::Bilinear                      // Enable the bilinear sampling type
+        };
+
+        // Create the gradient entity with the proper configuration
+        auto entity = CreateGradientConfigEntity(test);
+
+        // Create a gradient sampler and run through a series of points to see if they match expectations.
+        GradientSignal::GradientSampler gradientSampler;
+        gradientSampler.m_gradientId = entity->GetId();
+
+        // Iterate over the points with a 0.25 step size so that we can test
+        // fractional values to verify the interpolation is working
+        for (float y = 0.0f; y < static_cast<float>(test.m_validationSize); y += test.m_stepSize)
+        {
+            for (float x = 0.0f; x < static_cast<float>(test.m_validationSize); x += test.m_stepSize)
+            {
+                GradientSignal::GradientSampleParams params;
+                params.m_position = AZ::Vector3(x, y, 0.0f);
+                float value = gradientSampler.GetValue(params);
+
+                // Only the 0,0 point has a non-zero value, so anything out of that bounds
+                // will be 0
+                if (floor(x) > 0 || floor(y) > 0)
+                {
+                    EXPECT_TRUE(value == 0.0f);
+                }
+                // Otherwise, figure out the expected interpolated value
+                else
+                {
+                    // Compute the delta X/Y for sampling pixel
+                    float deltaX = x - floor(x);
+                    float deltaY = y - floor(y);
+
+                    // Only the 0,0 pixel is set to a specific value, so the other
+                    // points in the grid we will lookup will all be 0
+                    const float valueX0Y0 = test.m_setPixelValues[0] / 255.0f;
+                    const float valueX1Y0 = 0.0f;
+                    const float valueX0Y1 = 0.0f;
+                    const float valueX1Y1 = 0.0f;
+                    const float valueXY0 = AZ::Lerp(valueX0Y0, valueX1Y0, deltaX);
+                    const float valueXY1 = AZ::Lerp(valueX0Y1, valueX1Y1, deltaX);
+                    const float expectedValue = AZ::Lerp(valueXY0, valueXY1, deltaY);
+
+                    EXPECT_TRUE(AZ::IsClose(value, expectedValue));
+                }
+            }
+        }
+    }
+
+    TEST_F(GradientSignalImageTestsFixture, ImageGradientComponentAdvancedBilinearSamplingMirror)
+    {
+        // Set one pixel, map Gradient 1:1 to lookup space, get same pixel back
+        PixelTestSetup test =
+        {
+            4, AZ::Vector2(0.25f, 0.25f), {200, 150, 100, 50},          // Source image:  4 x 4 with (0, 0) set to different values in each channel
+            4, 1.0f,                                                    // Mapped Shape:  4 x 4 with tiling (1.0, 1.0), unbounded
+            GradientSignal::WrappingType::Mirror,
+            4, 0.25f, 1.0f,                                             // Validate that in 4 x 4 range, only 0, 0 is set
+            { AZ::Vector2(0.25f, 0.25f), PixelTestSetup::EndOfList },
+            true,                                                       // Enabled the advanced mode
+            GradientSignal::ChannelToUse::Red,                          // Use Red channel (default)
+            GradientSignal::CustomScaleType::None,                      // No custom scale (default)
+            0.0f,                                                       // Min scale (won't be used since None scale type is set)
+            1.0f,                                                       // Max scale (won't be used since None scale type is set)
+            GradientSignal::SamplingType::Bilinear                      // Enable the bilinear sampling type
+        };
+
+        // Create the gradient entity with the proper configuration
+        auto entity = CreateGradientConfigEntity(test);
+
+        // Create a gradient sampler and run through a series of points to see if they match expectations.
+        GradientSignal::GradientSampler gradientSampler;
+        gradientSampler.m_gradientId = entity->GetId();
+
+        // Iterate over the points with a 0.25 step size so that we can test
+        // fractional values to verify the interpolation is working
+        for (float y = 0.0f; y < static_cast<float>(test.m_validationSize); y += test.m_stepSize)
+        {
+            for (float x = 0.0f; x < static_cast<float>(test.m_validationSize); x += test.m_stepSize)
+            {
+                GradientSignal::GradientSampleParams params;
+                params.m_position = AZ::Vector3(x, y, 0.0f);
+                float value = gradientSampler.GetValue(params);
+
+                // Only the 0,0 point has a non-zero value, so anything out of that bounds
+                // will be 0
+                if (floor(x) > 0 || floor(y) > 0)
+                {
+                    EXPECT_TRUE(value == 0.0f);
+                }
+                // Otherwise, figure out the expected interpolated value
+                else
+                {
+                    // Compute the delta X/Y for sampling pixel
+                    float deltaX = x - floor(x);
+                    float deltaY = y - floor(y);
+
+                    // Only the 0,0 pixel is set to a specific value, so the other
+                    // points in the grid we will lookup will all be 0
+                    const float valueX0Y0 = test.m_setPixelValues[0] / 255.0f;
+                    const float valueX1Y0 = 0.0f;
+                    const float valueX0Y1 = 0.0f;
+                    const float valueX1Y1 = 0.0f;
+                    const float valueXY0 = AZ::Lerp(valueX0Y0, valueX1Y0, deltaX);
+                    const float valueXY1 = AZ::Lerp(valueX0Y1, valueX1Y1, deltaX);
+                    const float expectedValue = AZ::Lerp(valueXY0, valueXY1, deltaY);
+
+                    EXPECT_TRUE(AZ::IsClose(value, expectedValue));
+                }
+            }
+        }
+    }
+
+    TEST_F(GradientSignalImageTestsFixture, ImageGradientComponentAdvancedBilinearSamplingRepeat)
+    {
+        // Set one pixel, map Gradient 1:1 to lookup space, get same pixel back
+        PixelTestSetup test =
+        {
+            4, AZ::Vector2(0.25f, 0.25f), {200, 150, 100, 50},          // Source image:  4 x 4 with (0, 0) set to different values in each channel
+            4, 1.0f,                                                    // Mapped Shape:  4 x 4 with tiling (1.0, 1.0), unbounded
+            GradientSignal::WrappingType::Repeat,
+            4, 0.25f, 1.0f,                                             // Validate that in 4 x 4 range, only 0, 0 is set
+            { AZ::Vector2(0.25f, 0.25f), PixelTestSetup::EndOfList },
+            true,                                                       // Enabled the advanced mode
+            GradientSignal::ChannelToUse::Red,                          // Use Red channel (default)
+            GradientSignal::CustomScaleType::None,                      // No custom scale (default)
+            0.0f,                                                       // Min scale (won't be used since None scale type is set)
+            1.0f,                                                       // Max scale (won't be used since None scale type is set)
+            GradientSignal::SamplingType::Bilinear                      // Enable the bilinear sampling type
+        };
+
+        // Create the gradient entity with the proper configuration
+        auto entity = CreateGradientConfigEntity(test);
+
+        // Create a gradient sampler and run through a series of points to see if they match expectations.
+        GradientSignal::GradientSampler gradientSampler;
+        gradientSampler.m_gradientId = entity->GetId();
+
+        // Helper method to return the pixel value given x/y coordinate
+        // This helper method will handle the repeating logic for us
+        auto getPixelValue = [test](AZ::u32 pixelX, AZ::u32 pixelY) {
+            pixelX = pixelX % test.m_validationSize;
+            pixelY = pixelY % test.m_validationSize;
+            if (pixelX == 0 && pixelY == 0)
+            {
+                return test.m_setPixelValues[0] / 255.0f;
+            }
+            else
+            {
+                return 0.0f;
+            }
+        };
+
+        // Iterate over the points with a 0.25 step size so that we can test
+        // fractional values to verify the interpolation is working
+        for (float y = 0.0f; y < static_cast<float>(test.m_validationSize); y += test.m_stepSize)
+        {
+            for (float x = 0.0f; x < static_cast<float>(test.m_validationSize); x += test.m_stepSize)
+            {
+                GradientSignal::GradientSampleParams params;
+                params.m_position = AZ::Vector3(x, y, 0.0f);
+                float value = gradientSampler.GetValue(params);
+
+                // Compute the delta X/Y for sampling pixel
+                float deltaX = x - floor(x);
+                float deltaY = y - floor(y);
+
+                // Any x/y pixel value that ends up being 0,0 based on the
+                // Repeat wrapping type has a specific pixel value.
+                // All other pixel values are 0.0f, so we use the getPixelValue
+                // helper method to handle getting the proper pixel value for us.
+                AZ::u32 pixelX = aznumeric_cast<AZ::u32>(floor(x));
+                AZ::u32 pixelY = aznumeric_cast<AZ::u32>(floor(y));
+                const float valueX0Y0 = getPixelValue(pixelX, pixelY);
+                const float valueX1Y0 = getPixelValue(pixelX + 1, pixelY);;
+                const float valueX0Y1 = getPixelValue(pixelX, pixelY + 1);
+                const float valueX1Y1 = getPixelValue(pixelX + 1, pixelY + 1);
+                const float valueXY0 = AZ::Lerp(valueX0Y0, valueX1Y0, deltaX);
+                const float valueXY1 = AZ::Lerp(valueX0Y1, valueX1Y1, deltaX);
+                const float expectedValue = AZ::Lerp(valueXY0, valueXY1, deltaY);
+
+                EXPECT_TRUE(AZ::IsClose(value, expectedValue));
             }
         }
     }


### PR DESCRIPTION
Added a bilinear filtering sample type to the Image Gradient component.
- Image Gradient now has a sampling type field with `Point` and `Bilinear` options
- `Point` sampling is the default and current implementation
- `Bilinear` type performs bilinear interpolation

![BilinearFiltering](https://user-images.githubusercontent.com/7519264/162475146-8b178e0f-c028-4473-abb6-6570f580a151.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>