### PR TITLE
Limit task graph concurrency on certain processes

### DIFF
--- a/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
@@ -60,7 +60,7 @@ namespace AZ
         #if (AZ_TRAIT_THREAD_NUM_JOB_MANAGER_WORKER_THREADS)
             numberOfWorkerThreads = AZ_TRAIT_THREAD_NUM_JOB_MANAGER_WORKER_THREADS;
         #else
-            uint32_t scaledHardwareThreads = Threading::CalcNumWorkerThreads(cl_jobThreadsConcurrencyRatio, cl_jobThreadsMinNumber, cl_jobThreadsNumReserved);
+            uint32_t scaledHardwareThreads = Threading::CalcNumWorkerThreads(cl_jobThreadsConcurrencyRatio, cl_jobThreadsMinNumber, 0, cl_jobThreadsNumReserved);
             numberOfWorkerThreads = AZ::GetMin(static_cast<unsigned int>(desc.m_workerThreads.capacity()), scaledHardwareThreads);
         #endif // (AZ_TRAIT_THREAD_NUM_JOB_MANAGER_WORKER_THREADS)
         }

--- a/Code/Framework/AzCore/AzCore/Threading/ThreadUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Threading/ThreadUtils.cpp
@@ -12,11 +12,11 @@
 
 namespace AZ::Threading
 {
-    uint32_t CalcNumWorkerThreads(float workerThreadsRatio, uint32_t minNumWorkerThreads, uint32_t reservedNumThreads)
+    uint32_t CalcNumWorkerThreads(float workerThreadsRatio, uint32_t minNumWorkerThreads, uint32_t maxNumWorkerThreads, uint32_t reservedNumThreads)
     {
         const uint32_t maxHardwareThreads = AZStd::thread::hardware_concurrency();
         const uint32_t numReservedThreads = AZ::GetMin<uint32_t>(reservedNumThreads, maxHardwareThreads); // protect against num reserved being bigger than the number of hw threads
-        const uint32_t maxWorkerThreads = maxHardwareThreads - numReservedThreads;
+        const uint32_t maxWorkerThreads = maxNumWorkerThreads > 0 ? maxNumWorkerThreads : maxHardwareThreads - numReservedThreads;
         const float requestedWorkerThreads = AZ::GetClamp<float>(workerThreadsRatio, 0.0f, 1.0f) * static_cast<float>(maxWorkerThreads);
         const uint32_t requestedWorkerThreadsRounded = AZStd::lround(requestedWorkerThreads);
         const uint32_t numWorkerThreads = AZ::GetMax<uint32_t>(minNumWorkerThreads, requestedWorkerThreadsRounded);

--- a/Code/Framework/AzCore/AzCore/Threading/ThreadUtils.h
+++ b/Code/Framework/AzCore/AzCore/Threading/ThreadUtils.h
@@ -16,7 +16,8 @@ namespace AZ::Threading
     //!         result = max (minNumWorkerThreads, workerThreadsRatio * (num_hardware_threads - reservedNumThreads))
     //! @param workerThreadsRatio scale applied to the calculated maximum number of threads available after reserved threads have been accounted for. Clamped between 0 and 1.
     //! @param minNumWorkerThreads minimum value that will be returned. Value is unclamped and can be more than num_hardware_threads.
+    //! @param maxNumWorkerThreads maximum value that will be returned. Ignored if 0 and overrides maximum derived from other parameters.
     //! @param reservedNumThreads number of hardware threads to reserve for O3DE system threads. Value clamped to num_hardware_threads.
     //! @return number of worker threads for the calling system to allocate
-    uint32_t CalcNumWorkerThreads(float workerThreadsRatio, uint32_t minNumWorkerThreads, uint32_t reservedNumThreads);
+    uint32_t CalcNumWorkerThreads(float workerThreadsRatio, uint32_t minNumWorkerThreads, uint32_t maxNumWorkerThreads, uint32_t reservedNumThreads);
 };


### PR DESCRIPTION
Processes not marked as the main runtime or editor will have limited
thread slots allocated in the task graph to conserve memory and threads
spawned.