### PR TITLE
reduce ap test calls to sleep

### DIFF
--- a/Code/Tools/AssetProcessor/native/unittests/FileWatcherUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/FileWatcherUnitTests.cpp
@@ -36,7 +36,7 @@ void FileWatcherUnitTestRunner::StartTest()
         });
 
         // give the file watcher thread a moment to get started
-        QThread::sleep(1);
+        QThread::msleep(50);
 
         QFile testTif(tempPath + "/test.tif");
         bool open = testTif.open(QFile::WriteOnly);
@@ -46,10 +46,9 @@ void FileWatcherUnitTestRunner::StartTest()
         testTif.write("0");
         testTif.close();
 
-
         // Wait for file change to be found, timeout, and be delivered
         unsigned int tries = 0;
-        while (!foundFile && tries++ < 100)
+        while (!foundFile && tries++ < 10)
         {
             QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
             QThread::msleep(10);
@@ -61,7 +60,7 @@ void FileWatcherUnitTestRunner::StartTest()
 
     { // test a whole bunch of files created/written
       // send enough files such that main thread is likely to be blocked:
-        const unsigned long maxFiles = 10000;
+        const unsigned long maxFiles = 1000;
         QSet<QString> outstandingFiles;
 
         auto connection = QObject::connect(&fileWatcher, &FileWatcher::fileAdded, this, [&](QString filename)
@@ -71,11 +70,11 @@ void FileWatcherUnitTestRunner::StartTest()
         AZ_TracePrintf(AssetProcessor::DebugChannel, "Performing multi-file test...\n");
 
         // give the file watcher thread a moment to get started
-        QThread::sleep(1);
+        QThread::msleep(50);
 
         for (unsigned long fileIndex = 0; fileIndex < maxFiles; ++fileIndex)
         {
-            if (fileIndex % 1000 == 0)
+            if (fileIndex % 100 == 0)
             {
                 AZ_TracePrintf(AssetProcessor::DebugChannel, "Performing multi-file test... creating file  %d / %d\n", fileIndex, maxFiles);
             }
@@ -116,6 +115,7 @@ void FileWatcherUnitTestRunner::StartTest()
         QObject::disconnect(connection);
     }
 
+
     AZ_TracePrintf(AssetProcessor::DebugChannel, "Deletion test ... \n");
 
     { // test deletion
@@ -127,7 +127,7 @@ void FileWatcherUnitTestRunner::StartTest()
         });
 
         // give the file watcher thread a moment to get started
-        QThread::sleep(1);
+        QThread::msleep(50);
 
         QString filename(tempPath + "/test.tif");
         bool removed = QFile::remove(filename);
@@ -176,7 +176,7 @@ void FileWatcherUnitTestRunner::StartTest()
         });
 
         // give the file watcher thread a moment to get started
-        QThread::sleep(1);
+        QThread::msleep(50);
 
         QDir tempDirPath(tempPath);
         tempDirPath.mkpath("dir1");
@@ -192,7 +192,7 @@ void FileWatcherUnitTestRunner::StartTest()
         UNIT_TEST_EXPECT_TRUE(UnitTestUtils::CreateDummyFile(originalName));
 
         int tries = 0;
-        while (!(fileAddCalled && fileRemoveCalled && fileModifiedCalled) && tries++ < 100)
+        while (!(fileAddCalled && fileModifiedCalled) && tries++ < 100)
         {
             QThread::msleep(10);
             QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
@@ -286,7 +286,7 @@ void FileWatcherUnitTestRunner::StartTest()
         UNIT_TEST_EXPECT_TRUE(renamer.rename(tempDirPath.absoluteFilePath("dir3"), tempDirPath.absoluteFilePath("dir4")));
 
         tries = 0;
-        while (!(fileAddCalled && fileRemoveCalled && fileModifiedCalled) && tries++ < 100)
+        while (!(fileAddCalled && fileRemoveCalled) && tries++ < 100)
         {
             QThread::msleep(10);
             QCoreApplication::processEvents(QEventLoop::AllEvents, 100);

--- a/Code/Tools/AssetProcessor/native/unittests/RCcontrollerUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/RCcontrollerUnitTests.cpp
@@ -539,12 +539,11 @@ void RCcontrollerUnitTests::RunRCControllerTests()
     rcJob.SetCheckExclusiveLock(true);
     rcJob.Start();
 
-
 #if defined(AZ_PLATFORM_WINDOWS)
     // on windows, opening a file for reading locks it
     // but on other platforms, this is not the case.
     // we only expect work to begin when we can gain an exclusive lock on this file.
-    UNIT_TEST_EXPECT_FALSE(UnitTestUtils::BlockUntil(beginWork, 5000));
+    UNIT_TEST_EXPECT_FALSE(UnitTestUtils::BlockUntil(beginWork, 500));
 
     // Once we release the file, it should process normally
     lockFileTest.close();
@@ -553,7 +552,7 @@ void RCcontrollerUnitTests::RunRCControllerTests()
 #endif
 
     //Once we release the lock we should see jobStarted and jobFinished
-    UNIT_TEST_EXPECT_TRUE(UnitTestUtils::BlockUntil(jobFinished, 5000));
+    UNIT_TEST_EXPECT_TRUE(UnitTestUtils::BlockUntil(jobFinished, 500));
     UNIT_TEST_EXPECT_TRUE(beginWork);
     UNIT_TEST_EXPECT_TRUE(rcJob.m_DoWorkCalled);
 
@@ -691,7 +690,7 @@ void RCcontrollerUnitTests::RunRCControllerTests()
     m_rcController.SetDispatchPaused(false);
 
     m_rcController.DispatchJobs();
-    UNIT_TEST_EXPECT_TRUE(UnitTestUtils::BlockUntil(allJobsCompleted, 5000));
+    UNIT_TEST_EXPECT_TRUE(UnitTestUtils::BlockUntil(allJobsCompleted, 500));
     UNIT_TEST_EXPECT_TRUE(jobFinishedB);
 
     // Now test the use case where we have a cyclic dependency,
@@ -746,7 +745,7 @@ void RCcontrollerUnitTests::RunRCControllerTests()
 
     m_rcController.SetDispatchPaused(false);
     m_rcController.DispatchJobs();
-    UNIT_TEST_EXPECT_TRUE(UnitTestUtils::BlockUntil(allJobsCompleted, 5000));
+    UNIT_TEST_EXPECT_TRUE(UnitTestUtils::BlockUntil(allJobsCompleted, 500));
 
     // Test case when source file is deleted before it started processing
     {


### PR DESCRIPTION
Reduces blind waiting on other parts of the application to be ready, as well as busy waits on conditions which are not expected to change.

Profiling these tests showed these areas were quite slow, and it may be possible to minimize sleeps further than this experiment. This reduces the duration of AZ::AssetProcessor.Tests by 60% from 200199ms to 82891ms.

Verified these changes locally in both profile and debug.

Signed-off-by: Sean Sweeney <sweeneys@amazon.com>