### PR TITLE
reduce setup of emfx fuzz tests

### DIFF
--- a/Gems/EMotionFX/Code/Tests/AnimGraphFuzzTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphFuzzTests.cpp
@@ -20,7 +20,7 @@
 namespace EMotionFX
 {
     // Control the load for the AnimGraphFuzzTest
-    static constexpr int s_AnimGraphFuzzTestLoad = 100;
+    static constexpr int s_AnimGraphFuzzTestLoad = 1;
     
     // Make it clear that the AnimGraphFuzzTest fixture is parameterized on a
     // seed value for a Random object
@@ -101,7 +101,7 @@ namespace EMotionFX
 
         const size_t bufSize = charBuffer.size();
 
-        for (int i = 0; i < 10; ++i)
+        for (int i = 0; i < 1000; ++i)
         {
             const unsigned int positionToEdit = random.GetRandom() % bufSize;
             const char newValue = random.GetRandom() % 256;


### PR DESCRIPTION
Sets up a single test that fuzzes 1000 times instead of setting up 100 tests that fuzz 10 times.

Profiling these tests showed this area was quite slow, particularly the cost to start each test. This reduces overall test duration of module Gem::EMotionFX.Tests by 13% from 118594ms to 103176ms. Notably, the majority of time in this test module remains spent repeatedly launching an AzFramework::Application.

Verified these changes locally in both profile and debug.

Signed-off-by: Sean Sweeney <sweeneys@amazon.com>