### PR TITLE
Make TaskGraph return immediately if an empty TaskGraph is submitted

### DIFF
--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
@@ -99,7 +99,16 @@ namespace AZ
 
     void TaskGraph::Submit(TaskGraphEvent* waitEvent)
     {
-        AZ_Assert(!IsEmpty(), "Empty task graph submitted");
+        // If this is a new empty task graph (and not a retained taskgraph that was previously run),
+        // return immediately
+        if (IsEmpty() && !m_compiledTaskGraph)
+        {
+            if (waitEvent)
+            {
+                waitEvent->Signal();
+            }
+            return;
+        }
         SubmitOnExecutor(TaskExecutor::Instance(), waitEvent);
     }
 


### PR DESCRIPTION
Signal the wait event if one was supplied

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>