### PR TITLE
[Terrain] Made surface system async-friendly

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SurfaceData/SurfaceDataMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SurfaceData/SurfaceDataMeshComponent.cpp
@@ -103,7 +103,7 @@ namespace SurfaceData
     {
         if (m_providerHandle != InvalidSurfaceDataRegistryHandle)
         {
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataProvider, m_providerHandle);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataProvider(m_providerHandle);
             m_providerHandle = InvalidSurfaceDataRegistryHandle;
         }
 
@@ -268,7 +268,7 @@ namespace SurfaceData
             // Our mesh has become valid, so register as a provider and save off the provider handle
             AZ_Assert((m_providerHandle == InvalidSurfaceDataRegistryHandle), "Surface data handle is initialized before our mesh became active");
             AZ_Assert(m_meshBounds.IsValid(), "Mesh Geometry isn't correctly initialized.");
-            SurfaceDataSystemRequestBus::BroadcastResult(m_providerHandle, &SurfaceDataSystemRequestBus::Events::RegisterSurfaceDataProvider, registryEntry);
+            m_providerHandle = AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->RegisterSurfaceDataProvider(registryEntry);
 
             // Start listening for surface data events
             AZ_Assert((m_providerHandle != InvalidSurfaceDataRegistryHandle), "Invalid surface data handle");
@@ -278,7 +278,7 @@ namespace SurfaceData
         {
             // Our mesh has stopped being valid, so unregister and stop listening for surface data events
             AZ_Assert((m_providerHandle != InvalidSurfaceDataRegistryHandle), "Invalid surface data handle");
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataProvider, m_providerHandle);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataProvider(m_providerHandle);
             m_providerHandle = InvalidSurfaceDataRegistryHandle;
 
             SurfaceDataProviderRequestBus::Handler::BusDisconnect();
@@ -287,7 +287,7 @@ namespace SurfaceData
         {
             // Our mesh was valid before and after, it just changed in some way, so update our registry entry.
             AZ_Assert((m_providerHandle != InvalidSurfaceDataRegistryHandle), "Invalid surface data handle");
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UpdateSurfaceDataProvider, m_providerHandle, registryEntry);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UpdateSurfaceDataProvider(m_providerHandle, registryEntry);
         }
     }
 }

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Editor/EditorGradientComponentBase.inl
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Editor/EditorGradientComponentBase.inl
@@ -135,9 +135,6 @@ namespace GradientSignal
         // Cancel any pending preview refreshes before locking, to help ensure the preview itself isn't holding the lock
         auto entityIds = CancelPreviewRendering();
 
-         // block anyone from accessing the buses while the editor deactivates and re-activates the contained component.
-        auto& surfaceDataSystemRequestBusContext = SurfaceData::SurfaceDataSystemRequestBus::GetOrCreateContext(false);
-        AZStd::scoped_lock scopeLock(surfaceDataSystemRequestBusContext.m_contextMutex);
         auto refreshResult = BaseClassType::ConfigurationChanged();
 
         // Refresh any of the previews that we cancelled that were still in progress so they can be completed

--- a/Gems/GradientSignal/Code/Include/GradientSignal/GradientSampler.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/GradientSampler.h
@@ -107,11 +107,6 @@ namespace GradientSignal
         float output = 0.0f;
 
         {
-            // Block other threads from accessing the surface data bus while we are in GetValue (which may call into the SurfaceData bus).
-            // This prevents lock inversion deadlocks between this calling Gradient->Surface and something else calling Surface->Gradient.
-            auto& surfaceDataContext = SurfaceData::SurfaceDataSystemRequestBus::GetOrCreateContext(false);
-            typename SurfaceData::SurfaceDataSystemRequestBus::Context::DispatchLockGuard scopeLock(surfaceDataContext.m_contextMutex);
-
             if (GradientRequestBus::HasReentrantEBusUseThisThread())
             {
                 AZ_ErrorOnce("GradientSignal", false, "Detected cyclic dependencies with gradient entity references on entity id %s",
@@ -172,11 +167,6 @@ namespace GradientSignal
         }
 
         {
-            // Block other threads from accessing the surface data bus while we are in GetValue (which may call into the SurfaceData bus).
-            // This prevents lock inversion deadlocks between this calling Gradient->Surface and something else calling Surface->Gradient.
-            auto& surfaceDataContext = SurfaceData::SurfaceDataSystemRequestBus::GetOrCreateContext(false);
-            typename SurfaceData::SurfaceDataSystemRequestBus::Context::DispatchLockGuard scopeLock(surfaceDataContext.m_contextMutex);
-
             if (GradientRequestBus::HasReentrantEBusUseThisThread())
             {
                 AZ_ErrorOnce(

--- a/Gems/GradientSignal/Code/Source/Components/SurfaceAltitudeGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/SurfaceAltitudeGradientComponent.cpp
@@ -231,9 +231,8 @@ namespace GradientSignal
         AZStd::shared_lock lock(m_queryMutex);
 
         SurfaceData::SurfacePointList points;
-        SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-            &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromList, positions, m_configuration.m_surfaceTagsToSample,
-            points);
+        AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromList(
+            positions, m_configuration.m_surfaceTagsToSample, points);
 
         // For each position, turn the height into a 0-1 value based on our min/max altitudes.
         for (size_t index = 0; index < positions.size(); index++)

--- a/Gems/GradientSignal/Code/Source/Components/SurfaceMaskGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/SurfaceMaskGradientComponent.cpp
@@ -193,9 +193,8 @@ namespace GradientSignal
         if (!m_configuration.m_surfaceTagList.empty())
         {
             SurfaceData::SurfacePointList points;
-            SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-                &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromList, positions, m_configuration.m_surfaceTagList,
-                points);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromList(
+                positions, m_configuration.m_surfaceTagList, points);
 
             // For each position, get the max surface weight that matches our filter and that appears at that position.
             points.EnumeratePoints(

--- a/Gems/GradientSignal/Code/Source/Components/SurfaceSlopeGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/SurfaceSlopeGradientComponent.cpp
@@ -232,9 +232,8 @@ namespace GradientSignal
         AZStd::shared_lock lock(m_queryMutex);
 
         SurfaceData::SurfacePointList points;
-        SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-            &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromList, positions, m_configuration.m_surfaceTagsToSample,
-            points);
+        AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromList(
+            positions, m_configuration.m_surfaceTagsToSample, points);
 
         const float angleMin = AZ::DegToRad(AZ::GetClamp(m_configuration.m_slopeMin, 0.0f, 90.0f));
         const float angleMax = AZ::DegToRad(AZ::GetClamp(m_configuration.m_slopeMax, 0.0f, 90.0f));

--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientSurfaceDataComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientSurfaceDataComponent.cpp
@@ -111,24 +111,14 @@ namespace GradientSignal
             point.m_normal = AZ::Vector3::CreateAxisZ();
             SurfaceData::SurfacePointList pointList;
 
-            // Lock the SurfaceDataSystemRequestBus during the point list construction so that we always follow a pattern of locking the
-            // system bus *before* modifying surface weights, which locks the SurfaceDataModifierBus. Otherwise, it's possible to get
-            // these to lock in the reverse order which can cause deadlocks.
-            {
-                auto& surfaceDataContext = SurfaceData::SurfaceDataSystemRequestBus::GetOrCreateContext(false);
-                typename SurfaceData::SurfaceDataSystemRequestBus::Context::DispatchLockGuard scopeLock(surfaceDataContext.m_contextMutex);
+            // Get the Surface Modifier handle for this component.
+            SurfaceData::SurfaceDataRegistryHandle modifierHandle = SurfaceData::InvalidSurfaceDataRegistryHandle;
+            modifierHandle = AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfaceDataModifierHandle(m_component.GetEntityId());
 
-                // Get the Surface Modifier handle for this component.
-                SurfaceData::SurfaceDataRegistryHandle modifierHandle = SurfaceData::InvalidSurfaceDataRegistryHandle;
-                SurfaceData::SurfaceDataSystemRequestBus::BroadcastResult(
-                    modifierHandle, &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfaceDataModifierHandle,
-                    m_component.GetEntityId());
-
-                // Send the fake surface point into the component, see what emerges
-                pointList.StartListConstruction(AZStd::span<const AzFramework::SurfaceData::SurfacePoint>(&point, 1));
-                pointList.ModifySurfaceWeights(modifierHandle);
-                pointList.EndListConstruction();
-            }
+            // Send the fake surface point into the component, see what emerges
+            pointList.StartListConstruction(AZStd::span<const AzFramework::SurfaceData::SurfacePoint>(&point, 1));
+            pointList.ModifySurfaceWeights(modifierHandle);
+            pointList.EndListConstruction();
 
             // If the point was successfully modified, we should have one or more masks with a non-zero value.
             // Technically, they should all have the same value, but we'll grab the max from all of them in case

--- a/Gems/GradientSignal/Code/Tests/GradientSignalBenchmarks.cpp
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalBenchmarks.cpp
@@ -277,8 +277,7 @@ namespace UnitTest
                     AZ::Vector3 queryPosition(x, y, 0.0f);
                     points.Clear();
 
-                    SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-                        &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePoints, queryPosition, filterTags, points);
+                    AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePoints(queryPosition, filterTags, points);
                     benchmark::DoNotOptimize(points);
                 }
             }
@@ -301,8 +300,7 @@ namespace UnitTest
 
             AZ::Aabb inRegion = AZ::Aabb::CreateFromMinMax(AZ::Vector3(0.0f), AZ::Vector3(worldSize));
             AZ::Vector2 stepSize(1.0f);
-            SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-                &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromRegion, inRegion, stepSize, filterTags, points);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromRegion(inRegion, stepSize, filterTags, points);
             benchmark::DoNotOptimize(points);
         }
     }
@@ -333,8 +331,7 @@ namespace UnitTest
 
             SurfaceData::SurfacePointList points;
 
-            SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-                &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromList, queryPositions, filterTags, points);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromList(queryPositions, filterTags, points);
             benchmark::DoNotOptimize(points);
         }
     }

--- a/Gems/GradientSignal/Code/Tests/GradientSignalSurfaceTests.cpp
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalSurfaceTests.cpp
@@ -103,8 +103,7 @@ namespace UnitTest
 
             // Get our registered modifier handle (and verify that it's valid)
             SurfaceData::SurfaceDataRegistryHandle modifierHandle = SurfaceData::InvalidSurfaceDataRegistryHandle;
-            SurfaceData::SurfaceDataSystemRequestBus::BroadcastResult(
-                modifierHandle, &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfaceDataModifierHandle, entity->GetId());
+            modifierHandle = AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfaceDataModifierHandle(entity->GetId());
             EXPECT_TRUE(modifierHandle != SurfaceData::InvalidSurfaceDataRegistryHandle);
 
             // Call ModifySurfacePoints and verify the results

--- a/Gems/GradientSignal/Code/Tests/GradientSignalTestMocks.h
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalTestMocks.h
@@ -143,15 +143,13 @@ namespace UnitTest
                 }
             }
 
-            SurfaceData::SurfaceDataSystemRequestBus::BroadcastResult(
-                m_providerHandle, &SurfaceData::SurfaceDataSystemRequestBus::Events::RegisterSurfaceDataProvider, providerRegistryEntry);
+            m_providerHandle = AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->RegisterSurfaceDataProvider(providerRegistryEntry);
             SurfaceData::SurfaceDataProviderRequestBus::Handler::BusConnect(m_providerHandle);
         }
 
         void Deactivate() override
         {
-            SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-                &SurfaceData::SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataProvider, m_providerHandle);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataProvider(m_providerHandle);
             m_providerHandle = SurfaceData::InvalidSurfaceDataRegistryHandle;
             SurfaceData::SurfaceDataProviderRequestBus::Handler::BusDisconnect();
         }

--- a/Gems/SurfaceData/Code/Include/SurfaceData/SurfaceDataModifierRequestBus.h
+++ b/Gems/SurfaceData/Code/Include/SurfaceData/SurfaceDataModifierRequestBus.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/EBus/EBus.h>
+#include <AzCore/EBus/EBusSharedDispatchTraits.h>
 #include <AzCore/Math/Aabb.h>
 #include <SurfaceData/SurfaceDataTypes.h>
 #include <SurfaceData/SurfacePointList.h>
@@ -16,10 +17,11 @@
 namespace SurfaceData
 {
     /**
-    * the EBus is used to request information about a surface
-    */
-    class SurfaceDataModifierRequests
-        : public AZ::EBusTraits
+     * The EBus is used to request information about a surface.
+     * This bus uses shared dispatches, which means that all requests on the bus can run in parallel, but will NOT run in parallel
+     * with bus connections / disconnections.
+     */
+    class SurfaceDataModifierRequests : public AZ::EBusSharedDispatchTraits<SurfaceDataModifierRequests>
     {
     public:
         ////////////////////////////////////////////////////////////////////////
@@ -28,9 +30,6 @@ namespace SurfaceData
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
         typedef AZ::u32 BusIdType;
         ////////////////////////////////////////////////////////////////////////
-
-        //! allows multiple threads to call
-        using MutexType = AZStd::recursive_mutex;
 
         virtual void ModifySurfacePoints(
             AZStd::span<const AZ::Vector3> positions,

--- a/Gems/SurfaceData/Code/Include/SurfaceData/SurfaceDataProviderRequestBus.h
+++ b/Gems/SurfaceData/Code/Include/SurfaceData/SurfaceDataProviderRequestBus.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/EBus/EBus.h>
+#include <AzCore/EBus/EBusSharedDispatchTraits.h>
 #include <AzCore/std/containers/span.h>
 #include <SurfaceData/SurfaceDataTypes.h>
 #include <SurfaceData/SurfacePointList.h>
@@ -16,10 +17,11 @@
 namespace SurfaceData
 {
     /**
-    * the EBus is used to request information about a surface
+    * The EBus is used to request information about a surface.
+    * This bus uses shared dispatches, which means that all requests on the bus can run in parallel, but will NOT run in parallel
+    * with bus connections / disconnections.
     */
-    class SurfaceDataProviderRequests
-        : public AZ::EBusTraits
+    class SurfaceDataProviderRequests : public AZ::EBusSharedDispatchTraits<SurfaceDataProviderRequests>
     {
     public:
         ////////////////////////////////////////////////////////////////////////
@@ -28,9 +30,6 @@ namespace SurfaceData
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
         typedef AZ::u32 BusIdType;
         ////////////////////////////////////////////////////////////////////////
-
-        //! allows multiple threads to call
-        using MutexType = AZStd::recursive_mutex;
 
         //! Get all of the surface points that this provider has at the given input position.
         //! @param inPosition - The input position to query. Only XY are guaranteed to be valid, Z should be ignored.

--- a/Gems/SurfaceData/Code/Include/SurfaceData/SurfaceDataSystemRequestBus.h
+++ b/Gems/SurfaceData/Code/Include/SurfaceData/SurfaceDataSystemRequestBus.h
@@ -18,36 +18,29 @@
 
 namespace SurfaceData
 {
-    /**
-    * the EBus is used to request information about a surface
-    */
-    class SurfaceDataSystemRequests
-        : public AZ::EBusTraits
+    class SurfaceDataSystem
     {
     public:
-        ////////////////////////////////////////////////////////////////////////
-        // EBusTraits
-        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
-        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
-        ////////////////////////////////////////////////////////////////////////
+        AZ_RTTI(SurfaceDataSystem, "{381E1C98-F942-434D-B0C7-22F1AFB679A9}");
 
-        //! allows multiple threads to call
-        using MutexType = AZStd::recursive_mutex;
-
-        // Get all surface points located at the inPosition that matches one or more of the desiredTags.  Only the XY components of inPosition are used.
-        virtual void GetSurfacePoints(const AZ::Vector3& inPosition, const SurfaceTagVector& desiredTags, SurfacePointList& surfacePointList) const = 0;
+        // Get all surface points located at the inPosition that matches one or more of the desiredTags.  Only the XY components of
+        // inPosition are used.
+        virtual void GetSurfacePoints(
+            const AZ::Vector3& inPosition, const SurfaceTagVector& desiredTags, SurfacePointList& surfacePointList) const = 0;
 
         // Get all surface points for every input position within an AABB region.  Only the XY dimensions of the AABB region are used.
         // The input positions are chosen by starting at the min sides of inRegion and incrementing by stepSize.  This method is inclusive
-        // on the min sides of the AABB, and exclusive on the max sides (i.e. for a box of (0,0) - (4,4), the point (0,0) is included but (4,4) isn't).
-        virtual void GetSurfacePointsFromRegion(const AZ::Aabb& inRegion, const AZ::Vector2 stepSize, const SurfaceTagVector& desiredTags,
-                                                SurfacePointList& surfacePointLists) const = 0;
+        // on the min sides of the AABB, and exclusive on the max sides (i.e. for a box of (0,0) - (4,4), the point (0,0) is included but
+        // (4,4) isn't).
+        virtual void GetSurfacePointsFromRegion(
+            const AZ::Aabb& inRegion,
+            const AZ::Vector2 stepSize,
+            const SurfaceTagVector& desiredTags,
+            SurfacePointList& surfacePointLists) const = 0;
 
         // Get all surface points for every passed-in input position.  Only the XY dimensions of each position are used.
         virtual void GetSurfacePointsFromList(
-            AZStd::span<const AZ::Vector3> inPositions,
-            const SurfaceTagVector& desiredTags,
-            SurfacePointList& surfacePointLists) const = 0;
+            AZStd::span<const AZ::Vector3> inPositions, const SurfaceTagVector& desiredTags, SurfacePointList& surfacePointLists) const = 0;
 
         virtual SurfaceDataRegistryHandle RegisterSurfaceDataProvider(const SurfaceDataRegistryEntry& entry) = 0;
         virtual void UnregisterSurfaceDataProvider(const SurfaceDataRegistryHandle& handle) = 0;
@@ -65,5 +58,19 @@ namespace SurfaceData
         virtual SurfaceDataRegistryHandle GetSurfaceDataModifierHandle(const AZ::EntityId& modifierEntityId) = 0;
     };
 
-    typedef AZ::EBus<SurfaceDataSystemRequests> SurfaceDataSystemRequestBus;
+    /**
+    * the EBus is used to request information about a surface
+    */
+    class SurfaceDataSystemRequestTraits
+        : public AZ::EBusTraits
+    {
+    public:
+        ////////////////////////////////////////////////////////////////////////
+        // EBusTraits
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        ////////////////////////////////////////////////////////////////////////
+    };
+
+    using SurfaceDataSystemRequestBus = AZ::EBus<SurfaceDataSystem, SurfaceDataSystemRequestTraits>;
 }

--- a/Gems/SurfaceData/Code/Include/SurfaceData/Tests/SurfaceDataTestMocks.h
+++ b/Gems/SurfaceData/Code/Include/SurfaceData/Tests/SurfaceDataTestMocks.h
@@ -185,12 +185,14 @@ namespace UnitTest
     {
         MockSurfaceDataSystem()
         {
+            AZ::Interface<SurfaceDataSystem>::Register(this);
             BusConnect();
         }
 
         ~MockSurfaceDataSystem()
         {
             BusDisconnect();
+            AZ::Interface<SurfaceDataSystem>::Unregister(this);
         }
 
         AZStd::unordered_map<AZStd::pair<float, float>, SurfaceData::SurfacePointList> m_surfacePoints;

--- a/Gems/SurfaceData/Code/Source/Components/SurfaceDataColliderComponent.cpp
+++ b/Gems/SurfaceData/Code/Source/Components/SurfaceDataColliderComponent.cpp
@@ -140,12 +140,12 @@ namespace SurfaceData
     {
         if (m_providerHandle != InvalidSurfaceDataRegistryHandle)
         {
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataProvider, m_providerHandle);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataProvider(m_providerHandle);
             m_providerHandle = InvalidSurfaceDataRegistryHandle;
         }
         if (m_modifierHandle != InvalidSurfaceDataRegistryHandle)
         {
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataModifier, m_modifierHandle);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataModifier(m_modifierHandle);
             m_modifierHandle = InvalidSurfaceDataRegistryHandle;
         }
 
@@ -341,8 +341,8 @@ namespace SurfaceData
             AZ_Assert((m_providerHandle == InvalidSurfaceDataRegistryHandle), "Surface data handle is initialized before our collider became valid");
             AZ_Assert((m_modifierHandle == InvalidSurfaceDataRegistryHandle), "Surface Modifier data handle is initialized before our collider became valid");
             AZ_Assert(m_colliderBounds.IsValid(), "Collider Geometry isn't correctly initialized.");
-            SurfaceDataSystemRequestBus::BroadcastResult(m_providerHandle, &SurfaceDataSystemRequestBus::Events::RegisterSurfaceDataProvider, providerRegistryEntry);
-            SurfaceDataSystemRequestBus::BroadcastResult(m_modifierHandle, &SurfaceDataSystemRequestBus::Events::RegisterSurfaceDataModifier, modifierRegistryEntry);
+            m_providerHandle = AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->RegisterSurfaceDataProvider(providerRegistryEntry);
+            m_modifierHandle = AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->RegisterSurfaceDataModifier(modifierRegistryEntry);
 
             // Start listening for surface data events
             AZ_Assert((m_providerHandle != InvalidSurfaceDataRegistryHandle), "Invalid surface data handle");
@@ -355,8 +355,8 @@ namespace SurfaceData
             // Our collider has stopped being valid, so unregister and stop listening for surface data events
             AZ_Assert((m_providerHandle != InvalidSurfaceDataRegistryHandle), "Invalid surface data handle");
             AZ_Assert((m_modifierHandle != InvalidSurfaceDataRegistryHandle), "Invalid surface data handle");
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataProvider, m_providerHandle);
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataModifier, m_modifierHandle);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataProvider(m_providerHandle);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataModifier(m_modifierHandle);
             m_providerHandle = InvalidSurfaceDataRegistryHandle;
             m_modifierHandle = InvalidSurfaceDataRegistryHandle;
 
@@ -368,8 +368,8 @@ namespace SurfaceData
             // Our collider was valid before and after, it just changed in some way, so update our registry entry.
             AZ_Assert((m_providerHandle != InvalidSurfaceDataRegistryHandle), "Invalid surface data handle");
             AZ_Assert((m_modifierHandle != InvalidSurfaceDataRegistryHandle), "Invalid modifier data handle");
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UpdateSurfaceDataProvider, m_providerHandle, providerRegistryEntry);
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UpdateSurfaceDataModifier, m_modifierHandle, modifierRegistryEntry);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UpdateSurfaceDataProvider(m_providerHandle, providerRegistryEntry);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UpdateSurfaceDataModifier(m_modifierHandle, modifierRegistryEntry);
         }
     }
 }

--- a/Gems/SurfaceData/Code/Source/Components/SurfaceDataShapeComponent.cpp
+++ b/Gems/SurfaceData/Code/Source/Components/SurfaceDataShapeComponent.cpp
@@ -97,12 +97,12 @@ namespace SurfaceData
     {
         if (m_providerHandle != InvalidSurfaceDataRegistryHandle)
         {
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataProvider, m_providerHandle);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataProvider(m_providerHandle);
             m_providerHandle = InvalidSurfaceDataRegistryHandle;
         }
         if (m_modifierHandle != InvalidSurfaceDataRegistryHandle)
         {
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataModifier, m_modifierHandle);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataModifier(m_modifierHandle);
             m_modifierHandle = InvalidSurfaceDataRegistryHandle;
 
         }
@@ -288,16 +288,16 @@ namespace SurfaceData
             // Our shape was valid before and after, it just changed in some way, so update our registry entries
             AZ_Assert((m_providerHandle != InvalidSurfaceDataRegistryHandle), "Invalid surface data handle");
             AZ_Assert((m_modifierHandle != InvalidSurfaceDataRegistryHandle), "Invalid modifier data handle");
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UpdateSurfaceDataProvider, m_providerHandle, providerRegistryEntry);
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UpdateSurfaceDataModifier, m_modifierHandle, modifierRegistryEntry);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UpdateSurfaceDataProvider(m_providerHandle, providerRegistryEntry);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UpdateSurfaceDataModifier(m_modifierHandle, modifierRegistryEntry);
         }
         else if (!shapeValidBeforeUpdate && shapeValidAfterUpdate)
         {
             // Our shape has become valid, so register as a provider and save off the registry handles
             AZ_Assert((m_providerHandle == InvalidSurfaceDataRegistryHandle), "Surface Provider data handle is initialized before our shape became valid");
             AZ_Assert((m_modifierHandle == InvalidSurfaceDataRegistryHandle), "Surface Modifier data handle is initialized before our shape became valid");
-            SurfaceDataSystemRequestBus::BroadcastResult(m_providerHandle, &SurfaceDataSystemRequestBus::Events::RegisterSurfaceDataProvider, providerRegistryEntry);
-            SurfaceDataSystemRequestBus::BroadcastResult(m_modifierHandle, &SurfaceDataSystemRequestBus::Events::RegisterSurfaceDataModifier, modifierRegistryEntry);
+            m_providerHandle = AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->RegisterSurfaceDataProvider(providerRegistryEntry);
+            m_modifierHandle = AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->RegisterSurfaceDataModifier(modifierRegistryEntry);
 
             // Start listening for surface data events
             AZ_Assert((m_providerHandle != InvalidSurfaceDataRegistryHandle), "Invalid surface data handle");
@@ -310,8 +310,8 @@ namespace SurfaceData
             // Our shape has stopped being valid, so unregister and stop listening for surface data events
             AZ_Assert((m_providerHandle != InvalidSurfaceDataRegistryHandle), "Invalid surface data handle");
             AZ_Assert((m_modifierHandle != InvalidSurfaceDataRegistryHandle), "Invalid surface data handle");
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataProvider, m_providerHandle);
-            SurfaceDataSystemRequestBus::Broadcast(&SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataModifier, m_modifierHandle);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataProvider(m_providerHandle);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataModifier(m_modifierHandle);
             m_providerHandle = InvalidSurfaceDataRegistryHandle;
             m_modifierHandle = InvalidSurfaceDataRegistryHandle;
 

--- a/Gems/SurfaceData/Code/Source/SurfaceDataSystemComponent.cpp
+++ b/Gems/SurfaceData/Code/Source/SurfaceDataSystemComponent.cpp
@@ -95,12 +95,14 @@ namespace SurfaceData
 
     void SurfaceDataSystemComponent::Activate()
     {
+        AZ::Interface<SurfaceDataSystem>::Register(this);
         SurfaceDataSystemRequestBus::Handler::BusConnect();
     }
 
     void SurfaceDataSystemComponent::Deactivate()
     {
         SurfaceDataSystemRequestBus::Handler::BusDisconnect();
+        AZ::Interface<SurfaceDataSystem>::Unregister(this);
     }
 
     SurfaceDataRegistryHandle SurfaceDataSystemComponent::RegisterSurfaceDataProvider(const SurfaceDataRegistryEntry& entry)

--- a/Gems/SurfaceData/Code/Tests/SurfaceDataBenchmarks.cpp
+++ b/Gems/SurfaceData/Code/Tests/SurfaceDataBenchmarks.cpp
@@ -191,9 +191,7 @@ namespace UnitTest
                 {
                     AZ::Vector3 queryPosition(x, y, 0.0f);
                     points.Clear();
-
-                    SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-                        &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePoints, queryPosition, filterTags, points);
+                    AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePoints(queryPosition, filterTags, points);
                     benchmark::DoNotOptimize(points);
                 }
             }
@@ -216,9 +214,7 @@ namespace UnitTest
 
             AZ::Aabb inRegion = AZ::Aabb::CreateFromMinMax(AZ::Vector3(0.0f), AZ::Vector3(worldSize));
             AZ::Vector2 stepSize(1.0f);
-            SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-                &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromRegion, inRegion, stepSize, filterTags,
-                points);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromRegion(inRegion, stepSize, filterTags, points);
             benchmark::DoNotOptimize(points);
         }
     }
@@ -249,8 +245,7 @@ namespace UnitTest
 
             SurfaceData::SurfacePointList points;
 
-            SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-                &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromList, queryPositions, filterTags, points);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromList(queryPositions, filterTags, points);
             benchmark::DoNotOptimize(points);
         }
     }

--- a/Gems/SurfaceData/Code/Tests/SurfaceDataTest.cpp
+++ b/Gems/SurfaceData/Code/Tests/SurfaceDataTest.cpp
@@ -122,12 +122,12 @@ class MockSurfaceProvider
                     registryEntry.m_maxPointsCreatedPerInput = AZ::GetMax(registryEntry.m_maxPointsCreatedPerInput, entry.second.size());
                 }
 
-                SurfaceData::SurfaceDataSystemRequestBus::BroadcastResult(m_providerHandle, &SurfaceData::SurfaceDataSystemRequestBus::Events::RegisterSurfaceDataProvider, registryEntry);
+                m_providerHandle = AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->RegisterSurfaceDataProvider(registryEntry);
                 SurfaceData::SurfaceDataProviderRequestBus::Handler::BusConnect(m_providerHandle);
             }
             else
             {
-                SurfaceData::SurfaceDataSystemRequestBus::BroadcastResult(m_providerHandle, &SurfaceData::SurfaceDataSystemRequestBus::Events::RegisterSurfaceDataModifier, registryEntry);
+                m_providerHandle = AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->RegisterSurfaceDataModifier(registryEntry);
                 SurfaceData::SurfaceDataModifierRequestBus::Handler::BusConnect(m_providerHandle);
             }
         }
@@ -137,12 +137,12 @@ class MockSurfaceProvider
             if (m_providerType == ProviderType::SURFACE_PROVIDER)
             {
                 SurfaceData::SurfaceDataProviderRequestBus::Handler::BusDisconnect();
-                SurfaceData::SurfaceDataSystemRequestBus::Broadcast(&SurfaceData::SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataProvider, m_providerHandle);
+                AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataProvider(m_providerHandle);
             }
             else
             {
                 SurfaceData::SurfaceDataModifierRequestBus::Handler::BusDisconnect();
-                SurfaceData::SurfaceDataSystemRequestBus::Broadcast(&SurfaceData::SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataModifier, m_providerHandle);
+                AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataModifier(m_providerHandle);
             }
 
             m_providerHandle = SurfaceData::InvalidSurfaceDataRegistryHandle;
@@ -228,8 +228,8 @@ public:
             tempSingleQueryPointList.Clear();
             singleQueryResults.clear();
 
-            SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-                &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePoints, queryPositions[inputIndex], testTags, tempSingleQueryPointList);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePoints(
+                queryPositions[inputIndex], testTags, tempSingleQueryPointList);
             tempSingleQueryPointList.EnumeratePoints([&singleQueryResults](
                     [[maybe_unused]] size_t inPositionIndex, const AZ::Vector3& position,
                     const AZ::Vector3& normal, const SurfaceData::SurfaceTagWeights& masks) -> bool
@@ -496,8 +496,7 @@ TEST_F(SurfaceDataTestApp, SurfaceData_TestSurfacePointsFromRegion)
     AZ::Aabb regionBounds = AZ::Aabb::CreateFromMinMax(AZ::Vector3(0.0f, 0.0f, 16.0f), AZ::Vector3(4.0f, 4.0f, 16.0f));
     SurfaceData::SurfaceTagVector testTags = providerTags;
 
-    SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-        &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromRegion,
+    AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromRegion(
         regionBounds, stepSize, testTags, availablePointsPerPosition);
 
     // We expect every entry in the output list to have two surface points, at heights 0 and 4, sorted in
@@ -533,8 +532,7 @@ TEST_F(SurfaceDataTestApp, SurfaceData_TestSurfacePointsFromRegion_NoMatchingMas
     AZ::Aabb regionBounds = AZ::Aabb::CreateFromMinMax(AZ::Vector3(0.0f), AZ::Vector3(4.0f));
     SurfaceData::SurfaceTagVector testTags = { SurfaceData::SurfaceTag(m_testSurfaceNoMatchCrc) };
 
-    SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-        &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromRegion,
+    AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromRegion(
         regionBounds, stepSize, testTags, availablePointsPerPosition);
 
     // We expect every entry in the output list to have no surface points, since the requested mask doesn't match
@@ -558,8 +556,7 @@ TEST_F(SurfaceDataTestApp, SurfaceData_TestSurfacePointsFromRegion_NoMatchingReg
     AZ::Aabb regionBounds = AZ::Aabb::CreateFromMinMax(AZ::Vector3(16.0f), AZ::Vector3(20.0f));
     SurfaceData::SurfaceTagVector testTags = providerTags;
 
-    SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-        &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromRegion,
+    AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromRegion(
         regionBounds, stepSize, testTags, availablePointsPerPosition);
 
     // We expect every entry in the output list to have no surface points, since the input points don't overlap with
@@ -605,8 +602,7 @@ TEST_F(SurfaceDataTestApp, SurfaceData_TestSurfacePointsFromRegion_ProviderModif
         AZ::Aabb regionBounds = AZ::Aabb::CreateFromMinMax(AZ::Vector3(0.0f), AZ::Vector3(4.0f));
         SurfaceData::SurfaceTagVector testTags = tagTest;
 
-        SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-            &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromRegion,
+        AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromRegion(
             regionBounds, stepSize, testTags, availablePointsPerPosition);
 
         // We expect every entry in the output list to have two surface points (with heights 0 and 4),
@@ -652,8 +648,7 @@ TEST_F(SurfaceDataTestApp, SurfaceData_TestSurfacePointsFromRegion_SimilarPoints
     AZ::Aabb regionBounds = AZ::Aabb::CreateFromMinMax(AZ::Vector3(0.0f), AZ::Vector3(4.0f));
     SurfaceData::SurfaceTagVector testTags = { SurfaceData::SurfaceTag(m_testSurface1Crc), SurfaceData::SurfaceTag(m_testSurface2Crc) };
 
-    SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-        &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromRegion,
+    AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromRegion(
         regionBounds, stepSize, testTags, availablePointsPerPosition);
 
     // We expect every entry in the output list to have two surface points, not four.  The two points
@@ -701,8 +696,7 @@ TEST_F(SurfaceDataTestApp, SurfaceData_TestSurfacePointsFromRegion_DissimilarPoi
     AZ::Aabb regionBounds = AZ::Aabb::CreateFromMinMax(AZ::Vector3(0.0f), AZ::Vector3(4.0f));
     SurfaceData::SurfaceTagVector testTags = { SurfaceData::SurfaceTag(m_testSurface1Crc), SurfaceData::SurfaceTag(m_testSurface2Crc) };
 
-    SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-        &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromRegion,
+    AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromRegion(
         regionBounds, stepSize, testTags, availablePointsPerPosition);
 
     // We expect every entry in the output list to have four surface points with one tag each,
@@ -734,9 +728,8 @@ TEST_F(SurfaceDataTestApp, SurfaceData_VerifyGetSurfacePointsFromRegionAndGetSur
     AZ::Vector2 stepSize(1.0f, 1.0f);
     AZ::Aabb regionBounds = AZ::Aabb::CreateFromMinMax(AZ::Vector3(0.0f, 0.0f, 16.0f), AZ::Vector3(4.0f, 4.0f, 16.0f));
 
-    SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-        &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromRegion, regionBounds, stepSize, providerTags,
-        availablePointsPerPosition);
+    AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromRegion(
+        regionBounds, stepSize, providerTags, availablePointsPerPosition);
 
     // For each point entry returned from GetSurfacePointsFromRegion, call GetSurfacePoints and verify the results match.
     AZStd::vector<AZ::Vector3> queryPositions;
@@ -774,8 +767,7 @@ TEST_F(SurfaceDataTestApp, SurfaceData_VerifyGetSurfacePointsFromListAndGetSurfa
         }
     }
 
-    SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-        &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromList,
+    AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromList(
         queryPositions, providerTags, availablePointsPerPosition);
 
     // For each point entry returned from GetSurfacePointsFromList, call GetSurfacePoints and verify the results match.

--- a/Gems/Terrain/Code/Source/Components/TerrainSurfaceDataSystemComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainSurfaceDataSystemComponent.cpp
@@ -107,8 +107,7 @@ namespace Terrain
     {
         if (m_providerHandle != SurfaceData::InvalidSurfaceDataRegistryHandle)
         {
-            SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-                &SurfaceData::SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataProvider, m_providerHandle);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataProvider(m_providerHandle);
             m_providerHandle = SurfaceData::InvalidSurfaceDataRegistryHandle;
         }
 
@@ -221,13 +220,11 @@ namespace Terrain
             // that the entire terrain provider needs to be updated, since it either has new bounds or the entire set of data is dirty.
             if (dirtyRegion.IsValid() && m_terrainBounds.IsClose(terrainBoundsBeforeUpdate))
             {
-                SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-                    &SurfaceData::SurfaceDataSystemRequestBus::Events::RefreshSurfaceData, dirtyRegion);
+                AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->RefreshSurfaceData(dirtyRegion);
             }
             else
             {
-                SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-                    &SurfaceData::SurfaceDataSystemRequestBus::Events::UpdateSurfaceDataProvider, m_providerHandle, registryEntry);
+                AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UpdateSurfaceDataProvider(m_providerHandle, registryEntry);
             }
         }
         else if (!terrainValidBeforeUpdate && terrainValidAfterUpdate)
@@ -236,8 +233,7 @@ namespace Terrain
             AZ_Assert(
                 (m_providerHandle == SurfaceData::InvalidSurfaceDataRegistryHandle),
                 "Surface Provider data handle is initialized before our terrain became valid");
-            SurfaceData::SurfaceDataSystemRequestBus::BroadcastResult(
-                m_providerHandle, &SurfaceData::SurfaceDataSystemRequestBus::Events::RegisterSurfaceDataProvider, registryEntry);
+            m_providerHandle = AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->RegisterSurfaceDataProvider(registryEntry);
 
             // Start listening for surface data events
             AZ_Assert((m_providerHandle != SurfaceData::InvalidSurfaceDataRegistryHandle), "Invalid surface data handle");
@@ -247,8 +243,7 @@ namespace Terrain
         {
             // Our terrain has stopped being valid, so unregister and stop listening for surface data events
             AZ_Assert((m_providerHandle != SurfaceData::InvalidSurfaceDataRegistryHandle), "Invalid surface data handle");
-            SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-                &SurfaceData::SurfaceDataSystemRequestBus::Events::UnregisterSurfaceDataProvider, m_providerHandle);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->UnregisterSurfaceDataProvider(m_providerHandle);
             m_providerHandle = SurfaceData::InvalidSurfaceDataRegistryHandle;
             SurfaceData::SurfaceDataProviderRequestBus::Handler::BusDisconnect();
         }

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
@@ -955,16 +955,9 @@ namespace Terrain
         AZ::Vector2 stepSize(m_detailTextureScale);
         AZ::Aabb offsetWorldAabb = worldUpdateAabb.GetTranslated(AZ::Vector3(m_detailTextureScale * 0.5f)); // offset by half a pixel
 
-        {
-            // Block other threads from accessing the surface data bus while we are in GetValue (which may call into the SurfaceData bus).
-            // This prevents lock inversion deadlocks between this calling Gradient->Surface and something else calling Surface->Gradient.
-            auto& surfaceDataContext = SurfaceData::SurfaceDataSystemRequestBus::GetOrCreateContext(false);
-            typename SurfaceData::SurfaceDataSystemRequestBus::Context::DispatchLockGuard scopeLock(surfaceDataContext.m_contextMutex);
-
-            AzFramework::Terrain::TerrainDataRequestBus::Broadcast(
-                &AzFramework::Terrain::TerrainDataRequests::ProcessSurfaceWeightsFromRegion, offsetWorldAabb, stepSize, perPositionCallback,
-                AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT);
-        }
+        AzFramework::Terrain::TerrainDataRequestBus::Broadcast(
+            &AzFramework::Terrain::TerrainDataRequests::ProcessSurfaceWeightsFromRegion, offsetWorldAabb, stepSize, perPositionCallback,
+            AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT);
 
         const int32_t left = textureUpdateAabb.m_min.m_x;
         const int32_t top = textureUpdateAabb.m_min.m_y;

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -1495,11 +1495,6 @@ void TerrainSystem::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*time*/)
 
     if (terrainSettingsChanged || m_terrainHeightDirty || m_terrainSurfacesDirty)
     {
-        // Block other threads from accessing the surface data bus while we are in GetValue (which may call into the SurfaceData bus).
-        // This prevents lock inversion deadlocks between this calling Gradient->Surface and something else calling Surface->Gradient.
-        auto& surfaceDataContext = SurfaceData::SurfaceDataSystemRequestBus::GetOrCreateContext(false);
-        typename SurfaceData::SurfaceDataSystemRequestBus::Context::DispatchLockGuard scopeLock(surfaceDataContext.m_contextMutex);
-
         Terrain::TerrainDataChangedMask changeMask = Terrain::TerrainDataChangedMask::None;
 
         if (terrainSettingsChanged)

--- a/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
@@ -1113,8 +1113,7 @@ namespace Vegetation
         regionBounds.SetMax(regionBounds.GetMin() + AZ::Vector3(vegStep * (sectorDensity - 0.5f),
             vegStep * (sectorDensity - 0.5f), 0.0f));
 
-        SurfaceData::SurfaceDataSystemRequestBus::Broadcast(
-            &SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePointsFromRegion,
+        AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePointsFromRegion(
             regionBounds,
             stepSize,
             SurfaceData::SurfaceTagVector(),

--- a/Gems/Vegetation/Code/Source/Components/PositionModifierComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/PositionModifierComponent.cpp
@@ -320,7 +320,8 @@ namespace Vegetation
 
             //get the intersection data at the new position
             m_points.Clear();
-            SurfaceData::SurfaceDataSystemRequestBus::Broadcast(&SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePoints, instanceData.m_position, m_surfaceTagsToSnapToCombined, m_points);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePoints(
+                instanceData.m_position, m_surfaceTagsToSnapToCombined, m_points);
 
             // Get the point with the closest distance from the new position in case there are multiple intersections at different or
             // unrelated heights

--- a/Gems/Vegetation/Code/Source/Components/SurfaceMaskDepthFilterComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/SurfaceMaskDepthFilterComponent.cpp
@@ -215,7 +215,7 @@ namespace Vegetation
         if (!surfaceTagsToCompare.empty())
         {
             m_points.Clear();
-            SurfaceData::SurfaceDataSystemRequestBus::Broadcast(&SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePoints, instanceData.m_position, surfaceTagsToCompare, m_points);
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePoints(instanceData.m_position, surfaceTagsToCompare, m_points);
 
             float instanceZ = instanceData.m_position.GetZ();
             m_points.EnumeratePoints(

--- a/Gems/Vegetation/Code/Source/Debugger/DebugComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Debugger/DebugComponent.cpp
@@ -856,7 +856,7 @@ void DebugComponent::PrepareNextReport()
                                 0.0f);
 
         SurfaceData::SurfacePointList points;
-        SurfaceData::SurfaceDataSystemRequestBus::Broadcast(&SurfaceData::SurfaceDataSystemRequestBus::Events::GetSurfacePoints, pos, SurfaceData::SurfaceTagVector(), points);
+        AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfacePoints(pos, SurfaceData::SurfaceTagVector(), points);
         constexpr size_t inPositionIndex = 0;
         timing.m_worldPosition = points.IsEmpty(inPositionIndex) ? pos : points.GetHighestSurfacePoint(inPositionIndex).m_position;
         return timing;

--- a/Gems/Vegetation/Code/Tests/VegetationMocks.h
+++ b/Gems/Vegetation/Code/Tests/VegetationMocks.h
@@ -319,12 +319,12 @@ namespace UnitTest
 
         MockSurfaceHandler()
         {
-            SurfaceData::SurfaceDataSystemRequestBus::Handler::BusConnect();
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Register(this);
         }
 
         ~MockSurfaceHandler()
         {
-            SurfaceData::SurfaceDataSystemRequestBus::Handler::BusDisconnect();
+            AZ::Interface<SurfaceData::SurfaceDataSystem>::Unregister(this);
         }
 
         AZ::Vector3 m_outPosition = {};


### PR DESCRIPTION
* Added AZ::Interface support to SurfaceDataSystemComponent
* Changed all code-side usage of SurfaceDataSystemRequestBus to use the AZ::Interface instead so that it no longer has mutex-locked calls to the system component.
* Removed all extra locks of the SurfaceDataSystemRequestBus that were added to keep lock-inverted deadlocks from happening
* Made SurfaceDataProvider / SurfaceDataModifier busses use the EBusSharedDispatchTraits to allow for parallel queries

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>