### PR TITLE
Fixed AZSLc command line arguments on metal.

### DIFF
--- a/Gems/Atom/Asset/Shader/Config/Platform/Mac/shader_build_options.json
+++ b/Gems/Atom/Asset/Shader/Config/Platform/Mac/shader_build_options.json
@@ -4,7 +4,8 @@
         "preprocessor": [],
         "azslc": ["--min-descriptors=128,16,-1,-1,-1" //Sets,Spaces,Samplers,Textures,Buffers
                 , "--unique-idx"
-                , "--namespace=mt,vk"
+                , "--namespace=mt"
+                , "--namespace=vk"
                 , "--pad-root-const"
         ],
         "dxc": ["-spirv"


### PR DESCRIPTION
It was passing arguments incorrectly, activating a namespace called "mt,vk" instead of namespaces "mt" and "vk".

Fixes https://github.com/o3de/o3de/issues/8162

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>