### PR TITLE
Allow EditorTestSuite to Accept PyTest execution_number

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -425,7 +425,7 @@ class EditorTestSuite:
 
                 def make_test_func(name, test_spec):
                     @set_marks({"run_type": "run_single"})
-                    def single_run(self, request, workspace, editor, editor_test_data, launcher_platform):
+                    def single_run(self, request, workspace, editor, editor_test_data, launcher_platform, execution_number):
                         # only single tests are allowed to have setup/teardown, however we can have shared tests that
                         # were explicitly set as single, for example via cmdline argument override
                         is_single_test = issubclass(test_spec, EditorSingleTest)
@@ -458,7 +458,7 @@ class EditorTestSuite:
 
                 def make_func():
                     @set_marks({"runner": runner, "run_type": "run_shared"})
-                    def shared_run(self, request, workspace, editor, editor_test_data, launcher_platform):
+                    def shared_run(self, request, workspace, editor, editor_test_data, launcher_platform, execution_number):
                         getattr(self, function.__name__)(request, workspace, editor, editor_test_data, runner.tests)
                     return shared_run
                 setattr(self.obj, name, make_func())


### PR DESCRIPTION
EditorTestSuites can now use pytest execution_number (allowing users to run the same test many times)

Tested by running Multiplayer test suite 100 times
Add @pytest.mark.parametrize('execution_number', range(10)) to Multiplayer MainSuite TestAutomation class
![image](https://user-images.githubusercontent.com/32776221/162649734-32ae3d79-f45c-4050-aabb-4e44c451868b.png)

Resolves #8818
Signed-off-by: Gene Walters <genewalt@amazon.com>