### PR TITLE
Add support for the Enable IBL material option (New Branch)

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/ForwardPassOutput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/ForwardPassOutput.azsli
@@ -27,7 +27,7 @@ struct ForwardPassOutput
     float4 m_specularColor : SV_Target1;     //!< RGB = Specular Lighting, A = Unused
     float4 m_albedo : SV_Target2;            //!< RGB = Surface albedo pre-multiplied by other factors that will be multiplied later by diffuse GI, A = specularOcclusion
     float4 m_specularF0 : SV_Target3;        //!< RGB = Specular F0, A = roughness
-    float4 m_normal : SV_Target4;            //!< RGB10 = EncodeNormalSignedOctahedron(worldNormal), A2 = multiScatterCompensationEnabled
+    float4 m_normal : SV_Target4;            //!< RGB10 = EncodeNormalSignedOctahedron(worldNormal), A2 = Flags (IBL/Multiscatter enabled)
 };
 
 struct ForwardPassOutputWithDepth

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/BaseLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/BaseLighting.azsli
@@ -65,7 +65,7 @@ PbrLightingOutput GetPbrLightingOutput(Surface surface, LightingData lightingDat
     lightingOutput.m_albedo.rgb = surface.albedo * lightingData.diffuseResponse * lightingData.diffuseAmbientOcclusion;
     lightingOutput.m_albedo.a = lightingData.specularOcclusion;
     lightingOutput.m_normal.rgb = EncodeNormalSignedOctahedron(surface.normal);
-    lightingOutput.m_normal.a = o_specularF0_enableMultiScatterCompensation ? 1.0f : 0.0f;
+    lightingOutput.m_normal.a = EncodeUnorm2BitFlags(o_enableIBL, o_specularF0_enableMultiScatterCompensation);
     
     return lightingOutput;
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/EnhancedLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/EnhancedLighting.azsli
@@ -105,7 +105,7 @@ PbrLightingOutput GetPbrLightingOutput(Surface surface, LightingData lightingDat
     lightingOutput.m_albedo.rgb = surface.albedo * lightingData.diffuseResponse * lightingData.diffuseAmbientOcclusion;
     lightingOutput.m_albedo.a = lightingData.specularOcclusion;
     lightingOutput.m_normal.rgb = EncodeNormalSignedOctahedron(surface.normal);
-    lightingOutput.m_normal.a = o_specularF0_enableMultiScatterCompensation ? 1.0f : 0.0f;
+    lightingOutput.m_normal.a = EncodeUnorm2BitFlags(o_enableIBL, o_specularF0_enableMultiScatterCompensation);
     
     return lightingOutput;
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/SkinLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/SkinLighting.azsli
@@ -96,7 +96,7 @@ PbrLightingOutput GetPbrLightingOutput(Surface surface, LightingData lightingDat
     lightingOutput.m_albedo.rgb = surface.albedo * lightingData.diffuseResponse * lightingData.diffuseAmbientOcclusion;
     lightingOutput.m_albedo.a = lightingData.specularOcclusion;
     lightingOutput.m_normal.rgb = EncodeNormalSignedOctahedron(surface.normal);
-    lightingOutput.m_normal.a = o_specularF0_enableMultiScatterCompensation ? 1.0f : 0.0f;
+    lightingOutput.m_normal.a = EncodeUnorm2BitFlags(o_enableIBL, o_specularF0_enableMultiScatterCompensation);
     
     return lightingOutput;
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/StandardLighting.azsli
@@ -88,7 +88,7 @@ PbrLightingOutput GetPbrLightingOutput(Surface surface, LightingData lightingDat
     lightingOutput.m_albedo.rgb = surface.albedo * lightingData.diffuseResponse * lightingData.diffuseAmbientOcclusion;
     lightingOutput.m_albedo.a = lightingData.specularOcclusion;
     lightingOutput.m_normal.rgb = EncodeNormalSignedOctahedron(surface.normal);
-    lightingOutput.m_normal.a = o_specularF0_enableMultiScatterCompensation ? 1.0f : 0.0f;
+    lightingOutput.m_normal.a = EncodeUnorm2BitFlags(o_enableIBL, o_specularF0_enableMultiScatterCompensation);
     
     return lightingOutput;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseComposite.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseComposite.azsl
@@ -158,6 +158,7 @@ PSOutput MainPS(VSOutput IN, in uint sampleIndex : SV_SampleIndex)
     float depth = PassSrg::m_depth.Load(screenCoords, sampleIndex).r;
     float4 encodedNormal = PassSrg::m_normal.Load(screenCoords, sampleIndex);
     float3 normal = DecodeNormalSignedOctahedron(encodedNormal.rgb);
+    bool enableIBL = DecodeUnorm2BitFlag1(encodedNormal.a);
     float4 albedo = PassSrg::m_albedo.Load(screenCoords, sampleIndex);
     float probeIrradianceBlendWeight = saturate(PassSrg::m_downsampledProbeIrradiance.Load(probeIrradianceCoords, sampleIndex).a);
   
@@ -168,7 +169,7 @@ PSOutput MainPS(VSOutput IN, in uint sampleIndex : SV_SampleIndex)
         diffuse = (albedo.rgb / PI) * probeIrradiance * probeIrradianceBlendWeight;
     }
 
-    if (probeIrradianceBlendWeight < 1.0f)
+    if (probeIrradianceBlendWeight < 1.0f && enableIBL)
     {
         float3 globalIrradiance = SampleGlobalIBL(sampleIndex, screenCoords, depth, normal);
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionGlobalFullscreen.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionGlobalFullscreen.azsl
@@ -75,8 +75,15 @@ PSOutput MainPS(VSOutput IN, in uint sampleIndex : SV_SampleIndex)
 {
     float4 encodedNormal = PassSrg::m_normal.Load(IN.m_position.xy, sampleIndex);
     float3 normal = DecodeNormalSignedOctahedron(encodedNormal.rgb);
-    bool multiScatterCompensationEnabled = (encodedNormal.a > 0.0f);
-    
+    bool enableIBL = DecodeUnorm2BitFlag1(encodedNormal.a);
+    if (!enableIBL)
+    {
+        PSOutput OUT;
+        OUT.m_color = float4(0.0f, 0.0f, 0.0f, 1.0f);
+        return OUT;
+    }
+
+    bool multiScatterCompensationEnabled = DecodeUnorm2BitFlag2(encodedNormal.a);
     float4 albedo = PassSrg::m_albedo.Load(IN.m_position.xy, sampleIndex);
     float specularOcclusion = albedo.a;
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeRenderCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeRenderCommon.azsli
@@ -25,8 +25,13 @@ bool ComputeProbeSpecular(float2 screenCoords, float3 positionWS, float4x4 obbTr
     // retrieve normal from the encoded buffer written by the forward pass
     float4 encodedNormal = PassSrg::m_normal.Load(screenCoords, sampleIndex);
     float3 normal = DecodeNormalSignedOctahedron(encodedNormal.rgb);
-    bool multiScatterCompensationEnabled = (encodedNormal.a > 0.0f);
+    bool enableIBL = DecodeUnorm2BitFlag1(encodedNormal.a);
+    if (!enableIBL)
+    {
+        return false;
+    }
 
+    bool multiScatterCompensationEnabled = DecodeUnorm2BitFlag2(encodedNormal.a);
     float3 dirToCamera = normalize(ViewSrg::m_worldPosition.xyz - positionWS);
     float NdotV = dot(normal, dirToCamera);
     NdotV = max(NdotV, 0.01f);    // [GFX TODO][ATOM-4466] This is a current band-aid for specular noise at grazing angles.

--- a/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/Math.azsli
+++ b/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/Math.azsli
@@ -237,6 +237,32 @@ float3 DecodedNormalSphereMap(float2 encodedNormal)
     return (encodedNormal.x + encodedNormal.y) > EPSILON ? normal : float3(0.0, 0.0, -1.0);
 }
 
+// ---------- Unorm 2-bit Encoding -----------
+
+// The four possible values in a UNORM 2-bit channel are encoded as: 0/3, 1/3, 2/3, 3/3
+static const float UNORM_2BIT_FLAG1ONLY = 1.0f / 3.0f;
+static const float UNORM_2BIT_FLAG2ONLY = 2.0f / 3.0f;
+static const float UNORM_2BIT_BOTHFLAGS = 3.0f / 3.0f;
+static const float UNORM_2BIT_EPSILON = 10e-3f;
+
+// Encode two flags into a UNORM 2-bit channel
+float EncodeUnorm2BitFlags(bool flag1, bool flag2)
+{
+    return (flag1 + (flag2 * 2)) / 3.0f;
+}
+
+// Decode flag1 from a UNORM 2-bit channel
+bool DecodeUnorm2BitFlag1(float value)
+{
+    return (abs(value - UNORM_2BIT_FLAG1ONLY) < UNORM_2BIT_EPSILON) || (value == UNORM_2BIT_BOTHFLAGS);
+}
+
+// Decode flag2 from a UNORM 2-bit channel
+bool DecodeUnorm2BitFlag2(float value)
+{
+    return (abs(value - UNORM_2BIT_FLAG2ONLY) < UNORM_2BIT_EPSILON) || (value == UNORM_2BIT_BOTHFLAGS);
+}
+
 // ---------- Quaternion -----------
 
 float3 MultiplyVectorQuaternion(float3 v, float4 q)


### PR DESCRIPTION
Encoded the EnableIBL material option into the alpha channel of the Normal RGB10A2 texture

Tested AtomSampleViewer DX12/Vulkan
Tested Editor DX12/Vulkan
Tested MaterialEditor DX12/Vulkan

Signed-off-by: dmcdiarmid-ly <63674186+dmcdiarmid-ly@users.noreply.github.com>