### PR TITLE
Make Lua functor paths be relative to the asset system root path

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedPBR.materialtype
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedPBR.materialtype
@@ -165,7 +165,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_ShaderEnable.lua"
+                "file": "Materials/Types/StandardPBR_ShaderEnable.lua"
             }
         }
     ],

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/ClearCoatPropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/ClearCoatPropertyGroup.json
@@ -141,13 +141,13 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_ClearCoatState.lua"
+                "file": "Materials/Types/StandardPBR_ClearCoatState.lua"
             }
         },
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_ClearCoatEnableFeature.lua"
+                "file": "Materials/Types/StandardPBR_ClearCoatEnableFeature.lua"
             }
         }
     ]

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/DetailMapsPropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/DetailMapsPropertyGroup.json
@@ -180,7 +180,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "MaterialInputs/DetailMapsCommonFunctor.lua"
+                "file": "Materials/Types/MaterialInputs/DetailMapsCommonFunctor.lua"
             }
         }
     ]

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/EmissivePropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/EmissivePropertyGroup.json
@@ -87,7 +87,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_EmissiveState.lua"
+                "file": "Materials/Types/StandardPBR_EmissiveState.lua"
             }
         }
     ]

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/OpacityPropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/OpacityPropertyGroup.json
@@ -80,7 +80,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_HandleOpacityMode.lua"
+                "file": "Materials/Types/StandardPBR_HandleOpacityMode.lua"
             }
         }
     ]

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/SubsurfaceAndTransmissionPropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/SubsurfaceAndTransmissionPropertyGroup.json
@@ -232,7 +232,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "EnhancedPBR_SubsurfaceState.lua"
+                "file": "Materials/Types/EnhancedPBR_SubsurfaceState.lua"
             }
         }
     ]

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Skin.materialtype
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Skin.materialtype
@@ -1121,27 +1121,27 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_Roughness.lua",
+                "file": "Materials/Types/StandardPBR_Roughness.lua",
                 "propertyNamePrefix": "roughness."
             }
         },
         {
             "type": "Lua",
             "args": {
-                "file": "EnhancedPBR_SubsurfaceState.lua",
+                "file": "Materials/Types/EnhancedPBR_SubsurfaceState.lua",
                 "propertyNamePrefix": "subsurfaceScattering."
             }
         },
         {
             "type": "Lua",
             "args": {
-                "file": "Skin_WrinkleMaps.lua"
+                "file": "Materials/Types/Skin_WrinkleMaps.lua"
             }
         },
         {
             "type": "Lua",
             "args": {
-                "file": "Skin_SpecularF0.lua"
+                "file": "Materials/Types/Skin_SpecularF0.lua"
             }
         }
     ],

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.materialtype
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.materialtype
@@ -2660,25 +2660,25 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardMultilayerPBR_ShaderEnable.lua"
+                "file": "Materials/Types/StandardMultilayerPBR_ShaderEnable.lua"
             }
         },
         {
             "type": "Lua",
             "args": {
-                "file": "StandardMultilayerPBR_LayerEnable.lua"
+                "file": "Materials/Types/StandardMultilayerPBR_LayerEnable.lua"
             }
         },
         {
             "type": "Lua",
             "args": {
-                "file": "StandardMultilayerPBR_ClearCoatEnableFeature.lua"
+                "file": "Materials/Types/StandardMultilayerPBR_ClearCoatEnableFeature.lua"
             }
         },
         {
             "type": "Lua",
             "args": {
-                "file": "StandardMultilayerPBR_Displacement.lua"
+                "file": "Materials/Types/StandardMultilayerPBR_Displacement.lua"
             }
         },
         //##############################################################################################
@@ -2700,7 +2700,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_Metallic.lua",
+                "file": "Materials/Types/StandardPBR_Metallic.lua",
                 "propertyNamePrefix": "layer1_metallic.",
                 "srgNamePrefix": "m_layer1_",
                 "optionsNamePrefix": "o_layer1_"
@@ -2709,7 +2709,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_Roughness.lua",
+                "file": "Materials/Types/StandardPBR_Roughness.lua",
                 "propertyNamePrefix": "layer1_roughness.",
                 "srgNamePrefix": "m_layer1_",
                 "optionsNamePrefix": "o_layer1_"
@@ -2744,7 +2744,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_ClearCoatState.lua",
+                "file": "Materials/Types/StandardPBR_ClearCoatState.lua",
                 "propertyNamePrefix": "layer1_clearCoat.",
                 "srgNamePrefix": "m_layer1_",
                 "optionsNamePrefix": "o_layer1_"
@@ -2771,7 +2771,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_EmissiveState.lua",
+                "file": "Materials/Types/StandardPBR_EmissiveState.lua",
                 "propertyNamePrefix": "layer1_emissive.",
                 "srgNamePrefix": "m_layer1_",
                 "optionsNamePrefix": "o_layer1_"
@@ -2833,7 +2833,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_Metallic.lua",
+                "file": "Materials/Types/StandardPBR_Metallic.lua",
                 "propertyNamePrefix": "layer2_metallic.",
                 "srgNamePrefix": "m_layer2_",
                 "optionsNamePrefix": "o_layer2_"
@@ -2842,7 +2842,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_Roughness.lua",
+                "file": "Materials/Types/StandardPBR_Roughness.lua",
                 "propertyNamePrefix": "layer2_roughness.",
                 "srgNamePrefix": "m_layer2_",
                 "optionsNamePrefix": "o_layer2_"
@@ -2877,7 +2877,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_ClearCoatState.lua",
+                "file": "Materials/Types/StandardPBR_ClearCoatState.lua",
                 "propertyNamePrefix": "layer2_clearCoat.",
                 "srgNamePrefix": "m_layer2_",
                 "optionsNamePrefix": "o_layer2_"
@@ -2904,7 +2904,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_EmissiveState.lua",
+                "file": "Materials/Types/StandardPBR_EmissiveState.lua",
                 "propertyNamePrefix": "layer2_emissive.",
                 "srgNamePrefix": "m_layer2_",
                 "optionsNamePrefix": "o_layer2_"
@@ -2966,7 +2966,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_Metallic.lua",
+                "file": "Materials/Types/StandardPBR_Metallic.lua",
                 "propertyNamePrefix": "layer3_metallic.",
                 "srgNamePrefix": "m_layer3_",
                 "optionsNamePrefix": "o_layer3_"
@@ -2975,7 +2975,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_Roughness.lua",
+                "file": "Materials/Types/StandardPBR_Roughness.lua",
                 "propertyNamePrefix": "layer3_roughness.",
                 "srgNamePrefix": "m_layer3_",
                 "optionsNamePrefix": "o_layer3_"
@@ -3010,7 +3010,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_ClearCoatState.lua",
+                "file": "Materials/Types/StandardPBR_ClearCoatState.lua",
                 "propertyNamePrefix": "layer3_clearCoat.",
                 "srgNamePrefix": "m_layer3_",
                 "optionsNamePrefix": "o_layer3_"
@@ -3037,7 +3037,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_EmissiveState.lua",
+                "file": "Materials/Types/StandardPBR_EmissiveState.lua",
                 "propertyNamePrefix": "layer3_emissive.",
                 "srgNamePrefix": "m_layer3_",
                 "optionsNamePrefix": "o_layer3_"

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR.materialtype
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR.materialtype
@@ -103,7 +103,7 @@
         {
             "type": "Lua",
             "args": {
-                "file": "StandardPBR_ShaderEnable.lua"
+                "file": "Materials/Types/StandardPBR_ShaderEnable.lua"
             }
         }
     ],


### PR DESCRIPTION
Fixed the path to Lua functors to make them relative to the root of the assets system. This allows games and gems to `$import` property groups from Atom in their material types without triggering errors in the Asset Processor telling a Lua functor cannot be found.