### PR TITLE
Fixed bug transitioning from simulation mode to game mode in editor.

### DIFF
--- a/Code/Editor/IEditorImpl.cpp
+++ b/Code/Editor/IEditorImpl.cpp
@@ -866,18 +866,14 @@ bool CEditorImpl::SelectColor(QColor& color, QWidget* parent)
 
 void CEditorImpl::SetInGameMode(bool inGame)
 {
-    static bool bWasInSimulationMode(false);
-
-    if (inGame)
+    if (IsInSimulationMode())
     {
-        bWasInSimulationMode = GetIEditor()->GetGameEngine()->GetSimulationMode();
-        GetIEditor()->GetGameEngine()->SetSimulationMode(false);
-        GetIEditor()->GetGameEngine()->RequestSetGameMode(true);
+        return;
     }
-    else
+
+    if (m_pGameEngine)
     {
-        GetIEditor()->GetGameEngine()->RequestSetGameMode(false);
-        GetIEditor()->GetGameEngine()->SetSimulationMode(bWasInSimulationMode);
+        m_pGameEngine->RequestSetGameMode(inGame);
     }
 }
 


### PR DESCRIPTION
Code to enter/exit simulation mode or game mode is not instantaneous, they cannot be called one after another at the same time without causing out of order events for creation and destruction of game entities.

To solve the problem, the code that makes the transition at the top level (`CryEdit.cpp`), it will exit simulation mode first and schedule the activation of game mode for the next frame.

Transitions tested:
- Editor mode to Game mode. Works.
- Editor mode to Simulation model. Works.
- Game mode to Simulation model. Not possible.
- Simulation mode to Game mode. Fixed by this PR.

Fixes #8714 

Signed-off-by: moraaar <moraaar@amazon.com>