### PR TITLE
Blast improvements

### DIFF
--- a/Gems/Blast/Code/Include/Blast/BlastActor.h
+++ b/Gems/Blast/Code/Include/Blast/BlastActor.h
@@ -46,7 +46,7 @@ namespace Blast
 
         virtual AZ::Transform GetTransform() const = 0;
         virtual const BlastFamily& GetFamily() const = 0;
-        virtual Nv::Blast::TkActor& GetTkActor() const = 0;
+        virtual const Nv::Blast::TkActor& GetTkActor() const = 0;
         virtual AzPhysics::SimulatedBody* GetSimulatedBody() = 0;
         virtual const AzPhysics::SimulatedBody* GetSimulatedBody() const = 0;
         virtual const AZ::Entity* GetEntity() const = 0;

--- a/Gems/Blast/Code/Include/Blast/BlastSystemBus.h
+++ b/Gems/Blast/Code/Include/Blast/BlastSystemBus.h
@@ -56,7 +56,7 @@ namespace Blast
         //! Getters for the NvBlast singletons
         virtual Nv::Blast::TkFramework* GetTkFramework() const = 0;
         virtual Nv::Blast::ExtSerialization* GetExtSerialization() const = 0;
-        virtual Nv::Blast::TkGroup* GetTkGroup() = 0;
+        virtual Nv::Blast::TkGroup* CreateTkGroup() = 0;
 
         //! Configuration
         virtual const BlastGlobalConfiguration& GetGlobalConfiguration() const = 0;

--- a/Gems/Blast/Code/Source/Actor/BlastActorImpl.cpp
+++ b/Gems/Blast/Code/Source/Actor/BlastActorImpl.cpp
@@ -31,7 +31,6 @@ namespace Blast
 {
     BlastActorImpl::BlastActorImpl(const BlastActorDesc& desc)
         : m_family(*desc.m_family)
-        , m_tkActor(*desc.m_tkActor)
         , m_entity(desc.m_entity)
         , m_chunkIndices(desc.m_chunkIndices)
         , m_isLeafChunk(desc.m_isLeafChunk)
@@ -42,15 +41,16 @@ namespace Blast
         , m_bodyConfiguration(desc.m_bodyConfiguration)
         , m_scale(desc.m_scale)
     {
+        m_tkActor.reset(desc.m_tkActor);
+
         // Store pointer to ourselves in the blast toolkit actor's userData
-        m_tkActor.userData = this;
+        m_tkActor->userData = this;
 
         m_shapesProvider = AZStd::make_unique<ShapesProvider>(m_entity->GetId(), desc.m_bodyConfiguration);
     }
 
     BlastActorImpl::~BlastActorImpl()
     {
-        m_tkActor.userData = nullptr;
     }
 
     void BlastActorImpl::Spawn()
@@ -166,9 +166,9 @@ namespace Blast
         return m_family;
     }
 
-    Nv::Blast::TkActor& BlastActorImpl::GetTkActor() const
+    const Nv::Blast::TkActor& BlastActorImpl::GetTkActor() const
     {
-        return m_tkActor;
+        return *m_tkActor.get();
     }
 
     AzPhysics::SimulatedBody* BlastActorImpl::GetSimulatedBody()
@@ -204,6 +204,6 @@ namespace Blast
 
     void BlastActorImpl::Damage(const NvBlastDamageProgram& program, NvBlastExtProgramParams* programParams)
     {
-        m_tkActor.damage(program, programParams);
+        m_tkActor->damage(program, programParams);
     }
 } // namespace Blast

--- a/Gems/Blast/Code/Source/Actor/BlastActorImpl.cpp
+++ b/Gems/Blast/Code/Source/Actor/BlastActorImpl.cpp
@@ -31,6 +31,7 @@ namespace Blast
 {
     BlastActorImpl::BlastActorImpl(const BlastActorDesc& desc)
         : m_family(*desc.m_family)
+        , m_tkActor(*desc.m_tkActor)
         , m_entity(desc.m_entity)
         , m_chunkIndices(desc.m_chunkIndices)
         , m_isLeafChunk(desc.m_isLeafChunk)
@@ -41,16 +42,15 @@ namespace Blast
         , m_bodyConfiguration(desc.m_bodyConfiguration)
         , m_scale(desc.m_scale)
     {
-        m_tkActor.reset(desc.m_tkActor);
-
         // Store pointer to ourselves in the blast toolkit actor's userData
-        m_tkActor->userData = this;
+        m_tkActor.userData = this;
 
         m_shapesProvider = AZStd::make_unique<ShapesProvider>(m_entity->GetId(), desc.m_bodyConfiguration);
     }
 
     BlastActorImpl::~BlastActorImpl()
     {
+        m_tkActor.userData = nullptr;
     }
 
     void BlastActorImpl::Spawn()
@@ -168,7 +168,7 @@ namespace Blast
 
     const Nv::Blast::TkActor& BlastActorImpl::GetTkActor() const
     {
-        return *m_tkActor.get();
+        return m_tkActor;
     }
 
     AzPhysics::SimulatedBody* BlastActorImpl::GetSimulatedBody()
@@ -204,6 +204,6 @@ namespace Blast
 
     void BlastActorImpl::Damage(const NvBlastDamageProgram& program, NvBlastExtProgramParams* programParams)
     {
-        m_tkActor->damage(program, programParams);
+        m_tkActor.damage(program, programParams);
     }
 } // namespace Blast

--- a/Gems/Blast/Code/Source/Actor/BlastActorImpl.h
+++ b/Gems/Blast/Code/Source/Actor/BlastActorImpl.h
@@ -11,7 +11,6 @@
 #include <Blast/BlastActor.h>
 #include <Actor/BlastActorDesc.h>
 #include <PhysX/ColliderComponentBus.h>
-#include <PxSmartPtr.h>
 
 namespace Nv::Blast
 {
@@ -61,7 +60,7 @@ namespace Blast
             const Physics::MaterialId& material);
 
         const BlastFamily& m_family;
-        physx::unique_ptr<Nv::Blast::TkActor> m_tkActor;
+        Nv::Blast::TkActor& m_tkActor;
         AZStd::unique_ptr<ShapesProvider> m_shapesProvider;
 
         AZStd::shared_ptr<AZ::Entity> m_entity;

--- a/Gems/Blast/Code/Source/Actor/BlastActorImpl.h
+++ b/Gems/Blast/Code/Source/Actor/BlastActorImpl.h
@@ -11,6 +11,7 @@
 #include <Blast/BlastActor.h>
 #include <Actor/BlastActorDesc.h>
 #include <PhysX/ColliderComponentBus.h>
+#include <PxSmartPtr.h>
 
 namespace Nv::Blast
 {
@@ -33,7 +34,7 @@ namespace Blast
         void Damage(const NvBlastDamageProgram& program, NvBlastExtProgramParams* programParams) override;
 
         const BlastFamily& GetFamily() const override;
-        Nv::Blast::TkActor& GetTkActor() const override;
+        const Nv::Blast::TkActor& GetTkActor() const override;
         AZ::Transform GetTransform() const override;
 
         const AZ::Entity* GetEntity() const override;
@@ -60,7 +61,7 @@ namespace Blast
             const Physics::MaterialId& material);
 
         const BlastFamily& m_family;
-        Nv::Blast::TkActor& m_tkActor;
+        physx::unique_ptr<Nv::Blast::TkActor> m_tkActor;
         AZStd::unique_ptr<ShapesProvider> m_shapesProvider;
 
         AZStd::shared_ptr<AZ::Entity> m_entity;

--- a/Gems/Blast/Code/Source/Components/BlastFamilyComponent.cpp
+++ b/Gems/Blast/Code/Source/Components/BlastFamilyComponent.cpp
@@ -139,23 +139,23 @@ namespace Blast
 
     void BlastFamilyComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
     {
-        provided.push_back(AZ_CRC("BlastFamilyService"));
+        provided.push_back(AZ_CRC_CE("BlastFamilyService"));
     }
 
     void BlastFamilyComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
     {
-        incompatible.push_back(AZ_CRC("BlastFamilyService"));
+        incompatible.push_back(AZ_CRC_CE("BlastFamilyService"));
         incompatible.push_back(AZ_CRC_CE("NonUniformScaleService"));
     }
 
     void BlastFamilyComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
-        required.push_back(AZ_CRC("TransformService", 0x8ee22c50));
+        required.push_back(AZ_CRC_CE("TransformService"));
     }
 
     void BlastFamilyComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
     {
-        dependent.push_back(AZ_CRC("BlastMeshDataService"));
+        dependent.push_back(AZ_CRC_CE("BlastMeshDataService"));
     }
 
     AZStd::vector<const BlastActor*> BlastFamilyComponent::GetActors()
@@ -167,14 +167,11 @@ namespace Blast
 
     AZStd::vector<BlastActorData> BlastFamilyComponent::GetActorsData()
     {
-        if (!m_family)
-        {
-            AZ_Warning("Blast", false, "The family is not active.");
-            return {};
-        }
+        const AZStd::unordered_set<BlastActor*>& familyActors = m_family->GetActorTracker().GetActors();
 
         AZStd::vector<BlastActorData> actors;
-        for (auto actor : m_family->GetActorTracker().GetActors())
+        actors.reserve(familyActors.size());
+        for (const auto* actor : familyActors)
         {
             actors.emplace_back(*actor);
         }
@@ -194,24 +191,11 @@ namespace Blast
         AZ_Assert(m_blastAsset.GetId().IsValid(), "BlastFamilyComponent created with invalid blast asset.");
 
         Spawn();
-
-        BlastFamilyDamageRequestBus::MultiHandler::BusConnect(GetEntityId());
-        BlastFamilyComponentRequestBus::Handler::BusConnect(GetEntityId());
     }
 
     void BlastFamilyComponent::Deactivate()
     {
         AZ_PROFILE_FUNCTION(Physics);
-
-        // cleanup collision handlers
-        for (auto& itr : m_collisionHandlers)
-        {
-            itr.second.Disconnect();
-        }
-        m_collisionHandlers.clear();
-
-        BlastFamilyDamageRequestBus::MultiHandler::BusDisconnect();
-        BlastFamilyComponentRequestBus::Handler::BusDisconnect();
 
         Despawn();
     }
@@ -219,6 +203,11 @@ namespace Blast
     void BlastFamilyComponent::Spawn()
     {
         AZ_PROFILE_FUNCTION(Physics);
+
+        if (m_isSpawned)
+        {
+            return;
+        }
 
         if (!m_blastAsset.IsReady())
         {
@@ -241,17 +230,15 @@ namespace Blast
         }
         auto blastMaterial = BlastMaterial(blastMaterialConfiguration.m_configuration);
 
-        AZStd::shared_ptr<EntityProvider> entityProvider = EntityProvider::Create();
-
         // Create family
         const BlastFamilyDesc familyDesc
             {*m_blastAsset.Get(),
              this,
-             blastSystem->GetTkGroup(),
+             blastSystem->CreateTkGroup(), // Blast system takes care of destroying this group when it's empty.
              m_physicsMaterialId,
              blastMaterial,
              AZStd::make_shared<BlastActorFactoryImpl>(),
-             entityProvider,
+             EntityProvider::Create(),
              m_actorConfiguration};
 
         m_family = BlastFamily::Create(familyDesc);
@@ -294,6 +281,9 @@ namespace Blast
         // Spawn the family
         m_family->Spawn(transform);
 
+        BlastFamilyDamageRequestBus::MultiHandler::BusConnect(GetEntityId());
+        BlastFamilyComponentRequestBus::Handler::BusConnect(GetEntityId());
+
         m_isSpawned = true;
     }
 
@@ -301,12 +291,28 @@ namespace Blast
     {
         AZ_PROFILE_FUNCTION(Physics);
 
-        m_isSpawned = false;
+        if (!m_isSpawned)
+        {
+            return;
+        }
 
-        m_family = nullptr;
-        m_actorRenderManager = nullptr;
-        m_damageManager = nullptr;
-        m_solver = nullptr;
+        // Despawn family before reseting members so all the events are properly called
+        // and all data is available to be cleaned up accordingly.
+        m_family->Despawn();
+
+        // collision handlers should have been cleaned up when the family was despawn
+        AZ_Assert(m_collisionHandlers.empty(), "%d collision handlers were missing to be deactivated when its blast actors were destroyed", m_collisionHandlers.size());
+
+        // Disconnect from buses before destroying everything.
+        BlastFamilyDamageRequestBus::MultiHandler::BusDisconnect();
+        BlastFamilyComponentRequestBus::Handler::BusDisconnect();
+
+        m_actorRenderManager.reset();
+        m_damageManager.reset();
+        m_solver.reset();
+        m_family.reset();
+
+        m_isSpawned = false;
     }
 
     AZ::EntityId BlastFamilyComponent::GetFamilyId()
@@ -436,10 +442,7 @@ namespace Blast
     void BlastFamilyComponent::FillDebugRenderBuffer(
         DebugRenderBuffer& debugRenderBuffer, DebugRenderMode debugRenderMode)
     {
-        if (m_family)
-        {
-            m_family->FillDebugRender(debugRenderBuffer, debugRenderMode, 1.0);
-        }
+        m_family->FillDebugRender(debugRenderBuffer, debugRenderMode, 1.0f);
 
         if (!(DebugRenderStressGraph <= debugRenderMode && debugRenderMode <= DebugRenderStressGraphBondsImpulses))
         {
@@ -448,7 +451,7 @@ namespace Blast
 
         for (const BlastActor* blastActor : m_family->GetActorTracker().GetActors())
         {
-            Nv::Blast::TkActor& actor = blastActor->GetTkActor();
+            const Nv::Blast::TkActor& actor = blastActor->GetTkActor();
             auto lineStartIndex = aznumeric_cast<uint32_t>(debugRenderBuffer.m_lines.size());
 
             uint32_t nodeCount = actor.getGraphNodeCount();
@@ -497,44 +500,41 @@ namespace Blast
     {
         AZ_PROFILE_FUNCTION(Physics);
 
-        if (m_solver)
+        for (auto actor : m_family->GetActorTracker().GetActors())
         {
-            for (auto actor : m_family->GetActorTracker().GetActors())
+            auto worldBody = actor->GetSimulatedBody();
+            if (actor->IsStatic())
             {
-                auto worldBody = actor->GetSimulatedBody();
-                if (actor->IsStatic())
+                AZ::Vector3 gravity = AzPhysics::DefaultGravity;
+                if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
                 {
-                    AZ::Vector3 gravity = AzPhysics::DefaultGravity;
-                    if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
-                    {
-                        gravity = sceneInterface->GetGravity(worldBody->m_sceneOwner);
-                    }
-                    auto localGravity =
-                        worldBody->GetTransform().GetRotation().GetInverseFull().TransformVector(gravity);
-                    m_solver->addGravityForce(*actor->GetTkActor().getActorLL(), Convert(localGravity));
+                    gravity = sceneInterface->GetGravity(worldBody->m_sceneOwner);
                 }
-                else
-                {
-                    auto* rigidBody = static_cast<AzPhysics::RigidBody*>(worldBody);
-                    auto localCenterMass = rigidBody->GetCenterOfMassLocal();
-                    auto localAngularVelocity =
-                        worldBody->GetTransform().GetRotation().GetInverseFull().TransformVector(
-                            rigidBody->GetAngularVelocity());
-                    m_solver->addAngularVelocity(
-                        *actor->GetTkActor().getActorLL(), Convert(localCenterMass), Convert(localAngularVelocity));
-                }
+                auto localGravity =
+                    worldBody->GetTransform().GetRotation().GetInverseFull().TransformVector(gravity);
+                m_solver->addGravityForce(*actor->GetTkActor().getActorLL(), Convert(localGravity));
             }
-
-            m_solver->update();
-
-            if (m_solver->getOverstressedBondCount() > 0)
+            else
             {
-                NvBlastFractureBuffers commands;
-                m_solver->generateFractureCommands(commands);
-                if (commands.bondFractureCount > 0)
-                {
-                    m_family->GetTkFamily()->applyFracture(&commands);
-                }
+                auto* rigidBody = static_cast<AzPhysics::RigidBody*>(worldBody);
+                auto localCenterMass = rigidBody->GetCenterOfMassLocal();
+                auto localAngularVelocity =
+                    worldBody->GetTransform().GetRotation().GetInverseFull().TransformVector(
+                        rigidBody->GetAngularVelocity());
+                m_solver->addAngularVelocity(
+                    *actor->GetTkActor().getActorLL(), Convert(localCenterMass), Convert(localAngularVelocity));
+            }
+        }
+
+        m_solver->update();
+
+        if (m_solver->getOverstressedBondCount() > 0)
+        {
+            NvBlastFractureBuffers commands;
+            m_solver->generateFractureCommands(commands);
+            if (commands.bondFractureCount > 0)
+            {
+                m_family->GetTkFamily()->applyFracture(&commands);
             }
         }
     }

--- a/Gems/Blast/Code/Source/Components/BlastFamilyComponent.cpp
+++ b/Gems/Blast/Code/Source/Components/BlastFamilyComponent.cpp
@@ -306,13 +306,13 @@ namespace Blast
         }
 
         // Despawn family before reseting members so all the events are properly called
-        // and all data is available to be cleaned up accordingly.
+        // and all data is available to be cleaned up accordingly
         m_family->Despawn();
 
-        // collision handlers should have been cleaned up when the family was despawn
+        // collision handlers should have been cleaned up when the family was despawned
         AZ_Assert(m_collisionHandlers.empty(), "%d collision handlers were missing to be deactivated when its blast actors were destroyed", m_collisionHandlers.size());
 
-        // Disconnect from buses before destroying everything.
+        // Disconnect from buses before destroying everything
         BlastFamilyDamageRequestBus::MultiHandler::BusDisconnect();
         BlastFamilyComponentRequestBus::Handler::BusDisconnect();
 

--- a/Gems/Blast/Code/Source/Components/BlastFamilyComponent.cpp
+++ b/Gems/Blast/Code/Source/Components/BlastFamilyComponent.cpp
@@ -188,7 +188,11 @@ namespace Blast
     {
         AZ_PROFILE_FUNCTION(Physics);
 
-        AZ_Assert(m_blastAsset.GetId().IsValid(), "BlastFamilyComponent created with invalid blast asset.");
+        if (!m_blastAsset.GetId().IsValid())
+        {
+            AZ_Warning("BlastFamilyComponent", false, "Blast Family Component created with invalid blast asset.");
+            return;
+        }
 
         Spawn();
     }
@@ -211,8 +215,13 @@ namespace Blast
 
         if (!m_blastAsset.IsReady())
         {
-            m_shouldSpawnOnAssetLoad = true;
-            return;
+            m_blastAsset.QueueLoad();
+            m_blastAsset.BlockUntilLoadComplete();
+            if (!m_blastAsset.IsReady())
+            {
+                AZ_Error("BlastFamilyComponent", false, "Failed to load blast asset %s.", m_blastAsset.GetHint().c_str());
+                return;
+            }
         }
 
         auto blastSystem = AZ::Interface<BlastSystemRequests>::Get();

--- a/Gems/Blast/Code/Source/Components/BlastFamilyComponent.h
+++ b/Gems/Blast/Code/Source/Components/BlastFamilyComponent.h
@@ -113,7 +113,6 @@ namespace Blast
         const BlastActorConfiguration m_actorConfiguration{};
 
         bool m_isSpawned = false;
-        bool m_shouldSpawnOnAssetLoad = false;
         DebugRenderMode m_debugRenderMode;
 
         using CollisionHandlersMap = AZStd::unordered_map<AZ::EntityId, AzPhysics::SimulatedBodyEvents::OnCollisionBegin::Handler>;

--- a/Gems/Blast/Code/Source/Components/BlastFamilyComponent.h
+++ b/Gems/Blast/Code/Source/Components/BlastFamilyComponent.h
@@ -54,7 +54,7 @@ namespace Blast
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
         static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
 
-        // AZ::Component interface implementation
+        // AZ::Component overrides ...
         void Init() override;
         void Activate() override;
         void Deactivate() override;
@@ -64,7 +64,7 @@ namespace Blast
         void Spawn();
         void Despawn();
 
-        // BlastFamilyDamageRequestBus
+        // BlastFamilyDamageRequestBus overrides ...
         AZ::EntityId GetFamilyId() override;
         void RadialDamage(const AZ::Vector3& position, float minRadius, float maxRadius, float damage) override;
         void CapsuleDamage(
@@ -81,7 +81,7 @@ namespace Blast
         void StressDamage(const BlastActor& blastActor, const AZ::Vector3& position, const AZ::Vector3& force) override;
         void DestroyActor() override;
 
-        // BlastFamilyComponentRequestBus
+        // BlastFamilyComponentRequestBus overrides ...
         AZStd::vector<const BlastActor*> GetActors() override;
         AZStd::vector<BlastActorData> GetActorsData() override;
         void FillDebugRenderBuffer(DebugRenderBuffer& debugRenderBuffer, DebugRenderMode debugRenderMode) override;
@@ -89,8 +89,8 @@ namespace Blast
         void SyncMeshes() override;
 
     private:
-        // BlastListener interface implementation. These methods trigger notifications on
-        // BlastFamilyComponentNotificationBus.
+        // BlastListener overrides ...
+        // These methods trigger notifications on BlastFamilyComponentNotificationBus.
         void OnActorCreated(const BlastFamily& family, const BlastActor& actor) override;
         void OnActorDestroyed(const BlastFamily& family, const BlastActor& actor) override;
 

--- a/Gems/Blast/Code/Source/Components/BlastFamilyComponent.h
+++ b/Gems/Blast/Code/Source/Components/BlastFamilyComponent.h
@@ -34,8 +34,8 @@ namespace Blast
     //! Component that handles simulation of the Blast family.
     class BlastFamilyComponent
         : public AZ::Component
-        , public BlastFamilyDamageRequestBus::MultiHandler
-        , public BlastFamilyComponentRequestBus::Handler
+        , protected BlastFamilyDamageRequestBus::MultiHandler
+        , protected BlastFamilyComponentRequestBus::Handler
         , protected BlastListener
     {
     public:
@@ -59,6 +59,7 @@ namespace Blast
         void Activate() override;
         void Deactivate() override;
 
+    protected:
         // Lifecycle
         void Spawn();
         void Despawn();
@@ -83,7 +84,6 @@ namespace Blast
         // BlastFamilyComponentRequestBus
         AZStd::vector<const BlastActor*> GetActors() override;
         AZStd::vector<BlastActorData> GetActorsData() override;
-
         void FillDebugRenderBuffer(DebugRenderBuffer& debugRenderBuffer, DebugRenderMode debugRenderMode) override;
         void ApplyStressDamage() override;
         void SyncMeshes() override;

--- a/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
+++ b/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
@@ -219,13 +219,16 @@ namespace Blast
         jobCompletion.StartAndWaitForCompletion();
 
         // Remove empty groups
-        for (size_t i = 0; i < m_groups.size(); ++i)
+        for (size_t i = 0; i < m_groups.size();)
         {
             if (m_groups[i].m_tkGroup->getActorCount() == 0)
             {
                 AZStd::swap(m_groups[i], m_groups.back());
                 m_groups.pop_back();
-                --i; // Decrease index so in the next loop we consider the same position (as another group has been put in)
+            }
+            else
+            {
+                ++i;
             }
         }
 

--- a/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
+++ b/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
@@ -218,16 +218,18 @@ namespace Blast
 
         jobCompletion.StartAndWaitForCompletion();
 
-        // Run groups
-        for (auto i = 0; i < m_groups.size(); ++i)
+        // Remove empty groups
+        for (size_t i = 0; i < m_groups.size(); ++i)
         {
             if (m_groups[i].m_tkGroup->getActorCount() == 0)
             {
                 AZStd::swap(m_groups[i], m_groups.back());
                 m_groups.pop_back();
+                --i; // Decrease index so in the next loop we consider the same position (as another group has been put in)
             }
         }
 
+        // Run groups
         for (auto& group : m_groups)
         {
             AZ_PROFILE_SCOPE(Physics, "ExtGroupTaskManager::process");
@@ -354,7 +356,7 @@ namespace Blast
         return m_extSerialization.get();
     }
 
-    Nv::Blast::TkGroup* BlastSystemComponent::GetTkGroup()
+    Nv::Blast::TkGroup* BlastSystemComponent::CreateTkGroup()
     {
         m_groups.emplace_back();
         Nv::Blast::TkGroupDesc groupDesc;

--- a/Gems/Blast/Code/Source/Components/BlastSystemComponent.h
+++ b/Gems/Blast/Code/Source/Components/BlastSystemComponent.h
@@ -76,7 +76,7 @@ namespace Blast
         // Getters for physx/NvBlast structures
         Nv::Blast::TkFramework* GetTkFramework() const override;
         Nv::Blast::ExtSerialization* GetExtSerialization() const override;
-        Nv::Blast::TkGroup* GetTkGroup() override;
+        Nv::Blast::TkGroup* CreateTkGroup() override;
 
         void AddDamageDesc(AZStd::unique_ptr<NvBlastExtRadialDamageDesc> desc) override;
         void AddDamageDesc(AZStd::unique_ptr<NvBlastExtCapsuleRadialDamageDesc> desc) override;

--- a/Gems/Blast/Code/Source/Family/BlastFamilyImpl.cpp
+++ b/Gems/Blast/Code/Source/Family/BlastFamilyImpl.cpp
@@ -164,9 +164,7 @@ namespace Blast
         BlastActor* parentActor = reinterpret_cast<BlastActor*>(splitEvent->parentData.userData);
         AZ_Assert(parentActor, "TkActor had a null user data instead of a BlastActor.");
 
-        // TODO: Parent body might have or not simulated body??
         AzPhysics::SimulatedBody* parentBody = parentActor->GetSimulatedBody();
-        AZ_Assert(parentActor, "TkActor's BlastActor had a null simulated body.");
 
         const uint32_t newActorsCount = splitEvent->numChildren;
         const bool parentStatic = parentActor->IsStatic();

--- a/Gems/Blast/Code/Source/Family/BlastFamilyImpl.cpp
+++ b/Gems/Blast/Code/Source/Family/BlastFamilyImpl.cpp
@@ -121,9 +121,6 @@ namespace Blast
     {
         AZ_PROFILE_FUNCTION(Physics);
 
-        AZStd::vector<BlastActorDesc> newActorsDesc;
-        AZStd::unordered_set<BlastActor*> actorsToDelete;
-
         for (uint32_t i = 0; i < eventCount; ++i)
         {
             const Nv::Blast::TkEvent& event = events[i];
@@ -131,16 +128,19 @@ namespace Blast
             {
             case Nv::Blast::TkEvent::Split:
                 {
+                    AZStd::vector<BlastActorDesc> newActorsDesc;
+                    AZStd::unordered_set<BlastActor*> actorsToDelete;
+
                     HandleSplitEvent(event.getPayload<Nv::Blast::TkSplitEvent>(), newActorsDesc, actorsToDelete);
+
+                    DestroyActors(actorsToDelete);
+                    CreateActors(AZStd::move(newActorsDesc));
                     break;
                 }
             default:
                 break;
             }
         }
-
-        DestroyActors(actorsToDelete);
-        CreateActors(AZStd::move(newActorsDesc));
     }
 
     void BlastFamilyImpl::HandleSplitEvent(

--- a/Gems/Blast/Code/Source/Family/BlastFamilyImpl.cpp
+++ b/Gems/Blast/Code/Source/Family/BlastFamilyImpl.cpp
@@ -161,7 +161,7 @@ namespace Blast
             return;
         }
 
-        BlastActor* parentActor = reinterpret_cast<BlastActor*>(splitEvent->parentData.userData);
+        BlastActor* parentActor = static_cast<BlastActor*>(splitEvent->parentData.userData);
         AZ_Assert(parentActor, "TkActor had a null user data instead of a BlastActor.");
 
         AzPhysics::SimulatedBody* parentBody = parentActor->GetSimulatedBody();

--- a/Gems/Blast/Code/Source/Family/BlastFamilyImpl.cpp
+++ b/Gems/Blast/Code/Source/Family/BlastFamilyImpl.cpp
@@ -45,10 +45,6 @@ namespace Blast
     {
         Nv::Blast::TkFramework* tkFramework = AZ::Interface<BlastSystemRequests>::Get()->GetTkFramework();
         AZ_Assert(tkFramework, "TkFramework uninitialized when trying to create BlastFamily");
-        if (!tkFramework)
-        {
-            return;
-        }
 
         // Create the TkActor from our Blast asset
         Nv::Blast::TkActorDesc tkActorDesc;
@@ -69,12 +65,13 @@ namespace Blast
         Nv::Blast::TkActor* actor = tkFramework->createActor(tkActorDesc);
         AZ_Assert(actor, "TkActor creation failed when creating BlastFamily.");
 
-        if (!actor)
-        {
-            return;
-        }
-
+        // The new actor is the first member of a new TkFamily, which will be owned by BlastFamilyImpl.
+        // Family takes care of releasing whatever actor remaining.
         m_tkFamily.reset(&actor->getFamily());
+
+        // If a TkGroup was passed in the description, add the new TkActor to it.
+        // Actors will remove themselves from the group when they are released.
+        // BlastSystemComponet takes care of destroying empty groups.
         if (desc.m_group)
         {
             desc.m_group->addActor(*actor);
@@ -83,17 +80,15 @@ namespace Blast
 
     BlastFamilyImpl::~BlastFamilyImpl()
     {
-        if (m_isSpawned)
-        {
-            Despawn();
-        }
+        Despawn();
+
+        // TODO: Spawn and Despawn are not equals. Spawn assumes that family has 1 actor. Despawn destroys all actors, leaving family empy, so it cannot be called Spawn again.
     }
 
     bool BlastFamilyImpl::Spawn(const AZ::Transform& transform)
     {
-        AZ_Assert(!m_isSpawned, "BlastFamily was already spawned.");
         AZ_Assert(m_tkFamily, "No TkFamily created for this BlastFamily.");
-        if (m_isSpawned || !m_tkFamily)
+        if (m_isSpawned)
         {
             return false;
         }
@@ -102,7 +97,7 @@ namespace Blast
 
         m_tkFamily->addListener(*this);
 
-        CreateActors(CalculateInitialActors(transform));
+        CreateActors(CalculateActorsDescFromFamily(transform));
 
         m_isSpawned = true;
         return true;
@@ -110,14 +105,17 @@ namespace Blast
 
     void BlastFamilyImpl::Despawn()
     {
+        AZ_Assert(m_tkFamily, "No TkFamily created for this BlastFamily.");
+        if (!m_isSpawned)
+        {
+            return;
+        }
+
         // Intentional copy here as we will use this set to delete actors from ActorTracker itself
         AZStd::unordered_set<BlastActor*> toDelete = m_actorTracker.GetActors();
         DestroyActors(toDelete);
 
-        if (m_tkFamily)
-        {
-            m_tkFamily->removeListener(*this);
-        }
+        m_tkFamily->removeListener(*this);
         m_isSpawned = false;
     }
 
@@ -125,7 +123,7 @@ namespace Blast
     {
         AZ_PROFILE_FUNCTION(Physics);
 
-        AZStd::vector<BlastActorDesc> newActors;
+        AZStd::vector<BlastActorDesc> newActorsDesc;
         AZStd::unordered_set<BlastActor*> actorsToDelete;
 
         for (uint32_t i = 0; i < eventCount; ++i)
@@ -135,7 +133,7 @@ namespace Blast
             {
             case Nv::Blast::TkEvent::Split:
                 {
-                    HandleSplitEvent(event.getPayload<Nv::Blast::TkSplitEvent>(), newActors, actorsToDelete);
+                    HandleSplitEvent(event.getPayload<Nv::Blast::TkSplitEvent>(), newActorsDesc, actorsToDelete);
                     break;
                 }
             default:
@@ -144,53 +142,44 @@ namespace Blast
         }
 
         DestroyActors(actorsToDelete);
-        CreateActors(AZStd::move(newActors));
+        CreateActors(AZStd::move(newActorsDesc));
     }
 
     void BlastFamilyImpl::HandleSplitEvent(
-        const Nv::Blast::TkSplitEvent* splitEvent, AZStd::vector<BlastActorDesc>& newActors,
+        const Nv::Blast::TkSplitEvent* splitEvent, AZStd::vector<BlastActorDesc>& newActorsDesc,
         AZStd::unordered_set<BlastActor*>& actorsToDelete)
     {
         AZ_PROFILE_FUNCTION(Physics);
 
-        AZ_Assert(splitEvent, "Received null TkSplitEvent from the Blast library.");
         if (!splitEvent)
         {
+            AZ_Error("Blast", false, "Received null TkSplitEvent from the Blast library.");
             return;
         }
 
-        const uint32_t newActorsCount = splitEvent->numChildren;
-
-        BlastActor* parentActor = nullptr;
-        AzPhysics::SimulatedBody* parentBody = nullptr;
-        AZ_Assert(splitEvent->parentData.userData, "Parent actor in split event must have user data.");
         if (!splitEvent->parentData.userData)
         {
+            AZ_Error("Blast", false, "Parent actor in split event must have user data.");
             return;
         }
 
-        parentActor = reinterpret_cast<BlastActor*>(splitEvent->parentData.userData);
+        BlastActor* parentActor = reinterpret_cast<BlastActor*>(splitEvent->parentData.userData);
         AZ_Assert(parentActor, "TkActor had a null user data instead of a BlastActor.");
-        if (!parentActor)
-        {
-            return;
-        }
-        parentBody = parentActor->GetSimulatedBody();
 
+        // TODO: Parent body might have or not simulated body??
+        AzPhysics::SimulatedBody* parentBody = parentActor->GetSimulatedBody();
+        AZ_Assert(parentActor, "TkActor's BlastActor had a null simulated body.");
+
+        const uint32_t newActorsCount = splitEvent->numChildren;
         const bool parentStatic = parentActor->IsStatic();
 
         // Fill in actor create infos for newly created actors, based on the parent's velocity & center of mass
         for (uint32_t childIndex = 0; childIndex < newActorsCount; ++childIndex)
         {
-            if (childIndex >= splitEvent->numChildren)
+            Nv::Blast::TkActor* tkActorChild = splitEvent->children[childIndex];
+            if (!tkActorChild)
             {
-                AZ_Assert(false, "Out of bounds access to split event's children.");
-                continue;
-            }
-
-            if (!splitEvent->children[childIndex])
-            {
-                AZ_Assert(false, "Split event generated with null TkActor");
+                AZ_Error("Blast", false, "Split event generated with null TkActor");
                 continue;
             }
 
@@ -205,8 +194,8 @@ namespace Blast
                 parentTransform = m_initialTransform;
             }
 
-            newActors.push_back(
-                CalculateActorDesc(parentBody, parentStatic, parentTransform, splitEvent->children[childIndex]));
+            newActorsDesc.push_back(
+                CalculateActorDesc(parentBody, parentStatic, parentTransform, tkActorChild));
         }
 
         actorsToDelete.insert(parentActor);
@@ -217,13 +206,18 @@ namespace Blast
     {
         auto actorDesc = CalculateActorDesc(parentTransform, tkActor);
 
-        actorDesc.m_bodyConfiguration.m_initialAngularVelocity = !parentStatic
+        const bool isParentBodyDynamic = (parentBody && !parentStatic);
+
+        actorDesc.m_bodyConfiguration.m_initialAngularVelocity =
+            isParentBodyDynamic
             ? static_cast<AzPhysics::RigidBody*>(parentBody)->GetAngularVelocity()
             : AZ::Vector3::CreateZero();
         actorDesc.m_parentCenterOfMass = parentTransform.TransformPoint(
-            !parentStatic ? static_cast<AzPhysics::RigidBody*>(parentBody)->GetCenterOfMassLocal()
-                          : AZ::Vector3::CreateZero());
-        actorDesc.m_parentLinearVelocity = !parentStatic
+            isParentBodyDynamic
+            ? static_cast<AzPhysics::RigidBody*>(parentBody)->GetCenterOfMassLocal()
+            : AZ::Vector3::CreateZero());
+        actorDesc.m_parentLinearVelocity =
+            isParentBodyDynamic
             ? static_cast<AzPhysics::RigidBody*>(parentBody)->GetLinearVelocity()
             : AZ::Vector3::CreateZero();
 
@@ -259,7 +253,7 @@ namespace Blast
     {
         AZ_PROFILE_FUNCTION(Physics);
 
-        for (auto& actorDesc : actorDescs)
+        for (const auto& actorDesc : actorDescs)
         {
             BlastActor* actor = m_actorFactory->CreateActor(actorDesc);
             m_actorTracker.AddActor(actor);
@@ -271,7 +265,7 @@ namespace Blast
     {
         AZ_PROFILE_FUNCTION(Physics);
 
-        for (const auto actor : actors)
+        for (auto* actor : actors)
         {
             m_actorTracker.RemoveActor(actor);
             DispatchActorDestroyed(*actor);
@@ -281,6 +275,11 @@ namespace Blast
 
     void BlastFamilyImpl::DestroyActor(BlastActor* blastActor)
     {
+        if (!blastActor)
+        {
+            return;
+        }
+
         if (m_actorTracker.GetActors().find(blastActor) == m_actorTracker.GetActors().end())
         {
             AZ_Warning(
@@ -307,23 +306,22 @@ namespace Blast
         m_listener->OnActorDestroyed(*this, actor);
     }
 
-    AZStd::vector<BlastActorDesc> BlastFamilyImpl::CalculateInitialActors(const AZ::Transform& transform)
+    AZStd::vector<BlastActorDesc> BlastFamilyImpl::CalculateActorsDescFromFamily(const AZ::Transform& transform)
     {
         // Get current active TkActors
         // Normally only 1, but it can be already in split state
         const uint32_t actorCount = m_tkFamily->getActorCount();
-        AZStd::vector<Nv::Blast::TkActor*> initialTkActors;
-        initialTkActors.resize_no_construct(actorCount);
+        AZStd::vector<Nv::Blast::TkActor*> initialTkActors(actorCount, nullptr);
         m_tkFamily->getActors(initialTkActors.data(), actorCount);
 
         // Fill initial actor create infos
         AZStd::vector<BlastActorDesc> initialActors;
         initialActors.reserve(actorCount);
-        for (auto tkActor : initialTkActors)
+        for (auto* tkActor : initialTkActors)
         {
             initialActors.push_back(CalculateActorDesc(transform, tkActor));
         }
-        return AZStd::move(initialActors);
+        return initialActors;
     }
 
     static AZ::Color MixColors(const AZ::Color& color1, AZ::Color color2, float ratio)
@@ -381,7 +379,7 @@ namespace Blast
     }
 
     void BlastFamilyImpl::FillDebugRenderHealthGraph(
-        DebugRenderBuffer& debugRenderBuffer, DebugRenderMode mode, Nv::Blast::TkActor& actor)
+        DebugRenderBuffer& debugRenderBuffer, DebugRenderMode mode, const Nv::Blast::TkActor& actor)
     {
         const NvBlastChunk* chunks = actor.getFamily().getAsset()->getChunks();
         const NvBlastBond* bonds = actor.getFamily().getAsset()->getBonds();
@@ -468,7 +466,7 @@ namespace Blast
     {
         for (const BlastActor* blastActor : m_actorTracker.GetActors())
         {
-            Nv::Blast::TkActor& actor = blastActor->GetTkActor();
+            const Nv::Blast::TkActor& actor = blastActor->GetTkActor();
             auto lineStartIndex = aznumeric_cast<uint32_t>(debugRenderBuffer.m_lines.size());
 
             uint32_t nodeCount = actor.getGraphNodeCount();

--- a/Gems/Blast/Code/Source/Family/BlastFamilyImpl.cpp
+++ b/Gems/Blast/Code/Source/Family/BlastFamilyImpl.cpp
@@ -66,7 +66,7 @@ namespace Blast
         AZ_Assert(actor, "TkActor creation failed when creating BlastFamily.");
 
         // The new actor is the first member of a new TkFamily, which will be owned by BlastFamilyImpl.
-        // Family takes care of releasing whatever actor remaining.
+        // Family takes care of releasing whatever actor is remaining.
         m_tkFamily.reset(&actor->getFamily());
 
         // If a TkGroup was passed in the description, add the new TkActor to it.
@@ -81,8 +81,6 @@ namespace Blast
     BlastFamilyImpl::~BlastFamilyImpl()
     {
         Despawn();
-
-        // TODO: Spawn and Despawn are not equals. Spawn assumes that family has 1 actor. Despawn destroys all actors, leaving family empy, so it cannot be called Spawn again.
     }
 
     bool BlastFamilyImpl::Spawn(const AZ::Transform& transform)

--- a/Gems/Blast/Code/Source/Family/BlastFamilyImpl.h
+++ b/Gems/Blast/Code/Source/Family/BlastFamilyImpl.h
@@ -58,10 +58,10 @@ namespace Blast
         void DispatchActorCreated(const BlastActor& actor);
         void DispatchActorDestroyed(const BlastActor& actor);
 
-        AZStd::vector<BlastActorDesc> CalculateInitialActors(const AZ::Transform& transform);
+        AZStd::vector<BlastActorDesc> CalculateActorsDescFromFamily(const AZ::Transform& transform);
 
         void HandleSplitEvent(
-            const Nv::Blast::TkSplitEvent* splitEvent, AZStd::vector<BlastActorDesc>& newActors,
+            const Nv::Blast::TkSplitEvent* splitEvent, AZStd::vector<BlastActorDesc>& newActorsDesc,
             AZStd::unordered_set<BlastActor*>& actorsToDelete);
 
         // Calculates actor description for an actor that has a parent.
@@ -73,7 +73,7 @@ namespace Blast
         BlastActorDesc CalculateActorDesc(const AZ::Transform& transform, Nv::Blast::TkActor* tkActor);
 
         void FillDebugRenderHealthGraph(
-            DebugRenderBuffer& debugRenderBuffer, DebugRenderMode mode, Nv::Blast::TkActor& actor);
+            DebugRenderBuffer& debugRenderBuffer, DebugRenderMode mode, const Nv::Blast::TkActor& actor);
         void FillDebugRenderAccelerator(DebugRenderBuffer& debugRenderBuffer, DebugRenderMode mode);
 
 

--- a/Gems/Blast/Code/Tests/Mocks/BlastMocks.h
+++ b/Gems/Blast/Code/Tests/Mocks/BlastMocks.h
@@ -747,7 +747,7 @@ namespace Blast
     public:
         MOCK_CONST_METHOD0(GetTkFramework, Nv::Blast::TkFramework*());
         MOCK_CONST_METHOD0(GetExtSerialization, Nv::Blast::ExtSerialization*());
-        MOCK_METHOD0(GetTkGroup, Nv::Blast::TkGroup*());
+        MOCK_METHOD0(CreateTkGroup, Nv::Blast::TkGroup*());
         MOCK_CONST_METHOD0(GetGlobalConfiguration, const BlastGlobalConfiguration&());
         MOCK_METHOD1(SetGlobalConfiguration, void(const BlastGlobalConfiguration&));
         MOCK_METHOD0(InitPhysics, void());


### PR DESCRIPTION
- Renaming `GetTkGroup` to `CreateTkGroup` as it reflects better the operation it's doing.
- Replace old `AZ_CRC` with `AZ_CRC_CE`
- Protect Spawn/Despawn code in `BlastFamilyComponent`. Remove unnecessary checks to members from buses implementations (nobody can call them because it's only connected when it's spawned and data is valid).
- On BlastFamilyComponent spawn code, but the asset is not ready yet, load the asset. 
- Fixed bug when removing empty blast groups.
- Protect Spawn/Despawn code in `BlastFamilyImpl`.
- Added comments to clarify further who owns data.

Testing:
- Blast unit tests passed.
- Blast automated tests passed.
- Create level with blast assets from AutomatedTesting project and run it.

Signed-off-by: moraaar <moraaar@amazon.com>