### PR TITLE
Remove the step for creating Python virtual environment to unblock AWSI automation tests on Linux

### DIFF
--- a/scripts/build/Platform/Linux/deploy_cdk_applications.sh
+++ b/scripts/build/Platform/Linux/deploy_cdk_applications.sh
@@ -46,18 +46,6 @@ DeployCDKApplication()
     popd
 }
 
-# Create and activate a virtualenv for the CDK deployment
-if ! python/python.sh -m venv .env;
-then
-    echo [cdk_bootstrap] Failed to create a virtualenv for the CDK deployment
-    exit 1
-fi
-if ! source .env/bin/activate;
-then
-    echo [cdk_bootstrap] Failed to activate the virtualenv for the CDK deployment
-    exit 1
-fi
-
 echo [cdk_installation] Install nvm $NVM_VERSION
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh | bash
 export NVM_DIR="$HOME/.nvm"

--- a/scripts/build/Platform/Linux/destroy_cdk_applications.sh
+++ b/scripts/build/Platform/Linux/destroy_cdk_applications.sh
@@ -49,18 +49,6 @@ popd
 return 0
 }
 
-# Create and activate a virtualenv for the CDK deployment
-if ! python/python.sh -m venv .env;
-then
-    echo [cdk_bootstrap] Failed to create a virtualenv for the CDK deployment
-    return 1
-fi
-if ! source .env/bin/activate;
-then
-    echo [cdk_bootstrap] Failed to activate the virtualenv for the CDK deployment
-    exit 1
-fi
-
 echo [cdk_installation] Install nvm $NVM_VERSION
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh | bash
 export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

The AWSI Linux automation tests are blocked by an known issue (https://github.com/o3de/o3de/issues/8794) where O3DE Python fails to create virtual environment. Each Jenkins job has its own EBS volume, so installing Python dependencies in awsi_deployment job won't affect other jobs. As a temporary workaround for unblocking the tests, we can use system/O3DE Python directly. This change is related to https://github.com/o3de/o3de/pull/8784.

Verified the deployment and destruction script on Jenkins.