### PR TITLE
Updated the o3de engine template and print registration test.

### DIFF
--- a/scripts/o3de/o3de/manifest.py
+++ b/scripts/o3de/o3de/manifest.py
@@ -156,25 +156,28 @@ def get_default_o3de_manifest_json_data() -> dict:
     return json_data
 
 def get_o3de_manifest() -> pathlib.Path:
-    manifest_path = get_o3de_folder() / 'o3de_manifest.json'
-    if not manifest_path.is_file():
-        json_data = get_default_o3de_manifest_json_data()
-
-        with manifest_path.open('w') as s:
-            s.write(json.dumps(json_data, indent=4) + '\n')
-
-    return manifest_path
+    return get_o3de_folder() / 'o3de_manifest.json'
 
 
 def load_o3de_manifest(manifest_path: pathlib.Path = None) -> dict:
     """
     Loads supplied manifest file or ~/.o3de/o3de_manifest.json if None
+    If the supplied manifest_path is None and  ~/.o3de/o3de_manifest.json doesn't exist default manifest data
+    is instead returned.
+    Note: There is a difference between supplying a manifest_path parameter of None and '~/.o3de/o3de_manifest.json'
+    In the former if the o3de_manifest.json doesn't exist, default o3de manifest data is returned.
+    In the later that the o3de_manifest.json must exist as the caller explicitly specified the manifest path
 
     raises Json.JSONDecodeError if manifest data could not be decoded to JSON
     :param manifest_path: optional path to manifest file to load
     """
     if not manifest_path:
         manifest_path = get_o3de_manifest()
+        # If the default o3de manifest file doesn't exist and the manifest_path parameter was not supplied
+        # return the default o3de manifest data
+        if not manifest_path.is_file():
+            return get_default_o3de_manifest_json_data()
+
     with manifest_path.open('r') as f:
         try:
             json_data = json.load(f)
@@ -692,20 +695,40 @@ def get_registered(engine_name: str = None,
 
     elif isinstance(default_folder, str):
         if default_folder == 'engines':
-            default_engines_folder = pathlib.Path(json_data['default_engines_folder']).resolve()
-            return default_engines_folder
+            if 'default_engines_folder' in json_data:
+                default_engines_folder = pathlib.Path(json_data['default_engines_folder'])
+            else:
+                default_engines_folder = pathlib.Path(
+                    get_default_o3de_manifest_json_data().get('default_engines_folder', None))
+            return default_engines_folder.resolve() if default_engines_folder else None
         elif default_folder == 'projects':
-            default_projects_folder = pathlib.Path(json_data['default_projects_folder']).resolve()
-            return default_projects_folder
+            if 'default_projects_folder' in json_data:
+                default_projects_folder = pathlib.Path(json_data['default_projects_folder'])
+            else:
+                default_projects_folder = pathlib.Path(
+                    get_default_o3de_manifest_json_data().get('default_projects_folder', None))
+            return default_projects_folder.resolve() if default_projects_folder else None
         elif default_folder == 'gems':
-            default_gems_folder = pathlib.Path(json_data['default_gems_folder']).resolve()
-            return default_gems_folder
+            if 'default_gems_folder' in json_data:
+                default_gems_folder = pathlib.Path(json_data['default_gems_folder'])
+            else:
+                default_gems_folder = pathlib.Path(
+                    get_default_o3de_manifest_json_data().get('default_gems_folder', None))
+            return default_gems_folder.resolve() if default_gems_folder else None
         elif default_folder == 'templates':
-            default_templates_folder = pathlib.Path(json_data['default_templates_folder']).resolve()
-            return default_templates_folder
+            if 'default_templates_folder' in json_data:
+                default_templates_folder = pathlib.Path(json_data['default_templates_folder'])
+            else:
+                default_templates_folder = pathlib.Path(
+                    get_default_o3de_manifest_json_data().get('default_templates_folder', None))
+            return default_templates_folder.resolve() if default_templates_folder else None
         elif default_folder == 'restricted':
-            default_restricted_folder = pathlib.Path(json_data['default_restricted_folder']).resolve()
-            return default_restricted_folder
+            if 'default_restricted_folder' in json_data:
+                default_restricted_folder = pathlib.Path(json_data['default_restricted_folder'])
+            else:
+                default_restricted_folder = pathlib.Path(
+                    get_default_o3de_manifest_json_data().get('default_restricted_folder', None))
+            return default_restricted_folder.resolve() if default_restricted_folder else None
 
     elif isinstance(repo_name, str):
         cache_folder = get_o3de_cache_folder()

--- a/scripts/o3de/tests/test_engine_template.py
+++ b/scripts/o3de/tests/test_engine_template.py
@@ -175,8 +175,11 @@ def test_create_template(tmpdir,
     template_folder =  engine_root / 'Templates'
     template_folder.mkdir(parents=True, exist_ok=True)
 
-    result = engine_template.create_template(template_source_path, template_folder, source_name='TestTemplate',
-                                             keep_license_text=keep_license_text, force=force)
+    # Prevents writes to the o3de manifest files via these test
+    with patch('o3de.manifest.load_o3de_manifest', return_value={}) as load_o3de_manifest_patch, \
+            patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_o3de_manifest_patch:
+        result = engine_template.create_template(template_source_path, template_folder, source_name='TestTemplate',
+                                                 keep_license_text=keep_license_text, force=force)
 
     if expect_failure:
         assert result != 0
@@ -255,7 +258,10 @@ class TestCreateTemplate:
 
         template_dest_path = engine_root / instantiated_name
         # Skip registration in test
-        with patch('uuid.uuid4', return_value=uuid.uuid5(uuid.NAMESPACE_DNS, instantiated_name)) as uuid4_mock:
+
+        with patch('uuid.uuid4', return_value=uuid.uuid5(uuid.NAMESPACE_DNS, instantiated_name)) as uuid4_mock, \
+                patch('o3de.manifest.load_o3de_manifest', return_value={}) as load_o3de_manifest_patch, \
+                patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_o3de_manifest_patch:
             result = create_from_template_func(template_dest_path,
                                                template_path=template_default_folder,
                                                keep_license_text=keep_license_text,

--- a/scripts/o3de/tests/test_print_registration.py
+++ b/scripts/o3de/tests/test_print_registration.py
@@ -185,6 +185,7 @@ class TestPrintRegistration:
         test_args = parser.parse_args(arg_list)
 
         with patch('o3de.manifest.load_o3de_manifest', side_effect=self.load_manifest_json) as load_manifest_patch, \
+                patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_manifest_patch, \
                 patch('o3de.manifest.get_engine_json_data',
                       side_effect=self.get_engine_json_data) as get_engine_json_data_patch, \
                 patch('o3de.manifest.get_project_json_data',
@@ -214,6 +215,7 @@ class TestPrintRegistration:
 
 
         with patch('o3de.manifest.load_o3de_manifest', side_effect=self.load_manifest_json) as load_manifest_patch, \
+                patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_manifest_patch, \
                 patch('o3de.manifest.get_engine_json_data', side_effect=self.get_engine_json_data) as get_engine_json_data_patch:
             result = print_registration._run_register_show(test_args)
             assert result == 0
@@ -239,6 +241,7 @@ class TestPrintRegistration:
 
 
         with patch('o3de.manifest.load_o3de_manifest', side_effect=self.load_manifest_json) as load_manifest_patch, \
+                patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_manifest_patch, \
                 patch('o3de.manifest.get_project_json_data', side_effect=self.get_project_json_data) as get_json_data_patch:
             result = print_registration._run_register_show(test_args)
             assert result == 0
@@ -271,6 +274,7 @@ class TestPrintRegistration:
         # Patch the manifest.py function to locate gem.json files in external subdirectories
         # to just return a fake path to a single test gem
         with patch('o3de.manifest.load_o3de_manifest', side_effect=self.load_manifest_json) as load_manifest_patch, \
+                patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_manifest_patch, \
                 patch('o3de.manifest.get_gem_json_data', side_effect=self.get_gem_json_data) as get_json_patch, \
                 patch('o3de.manifest.get_project_json_data', side_effect=self.get_project_json_data) as get_project_json_patch, \
                 patch('o3de.print_registration.get_project_path', return_value=project_path) as get_project_path_patch:
@@ -302,8 +306,8 @@ class TestPrintRegistration:
             arg_list += ['-' + 'v' * verbose]
         test_args = parser.parse_args(arg_list)
 
-
         with patch('o3de.manifest.load_o3de_manifest', side_effect=self.load_manifest_json) as load_manifest_patch, \
+                patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_manifest_patch, \
                 patch('o3de.manifest.get_template_json_data', side_effect=self.get_template_json_data) as get_json_patch, \
                 patch('o3de.manifest.get_project_json_data', side_effect=self.get_project_json_data) as get_project_json_patch, \
                 patch('o3de.print_registration.get_project_path', return_value=project_path) as get_project_path_patch:
@@ -336,6 +340,7 @@ class TestPrintRegistration:
         test_args = parser.parse_args(arg_list)
 
         with patch('o3de.manifest.load_o3de_manifest', side_effect=self.load_manifest_json) as load_manifest_patch, \
+                patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_manifest_patch, \
                 patch('o3de.manifest.get_restricted_json_data', side_effect=self.get_restricted_json_data) as get_json_patch, \
                 patch('o3de.manifest.get_project_json_data', side_effect=self.get_project_json_data) as get_project_json_patch, \
                 patch('o3de.print_registration.get_project_path', return_value=project_path) as get_project_path_patch:
@@ -365,6 +370,7 @@ class TestPrintRegistration:
         test_args = parser.parse_args(arg_list)
 
         with patch('o3de.manifest.load_o3de_manifest', side_effect=self.load_manifest_json) as load_manifest_patch, \
+                patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_manifest_patch, \
                 patch('o3de.manifest.get_project_json_data',
                       side_effect=self.get_project_json_data) as get_project_json_patch, \
                 patch('o3de.print_registration.get_project_path', return_value=project_path) as get_project_path_patch:


### PR DESCRIPTION
Those test now mock their calls to manifest.save_o3de_manifest

Updated the `manifest.get_o3de_manifest` method to not write to disk an
o3de_manifest.json file.
It only returns the path to the o3de_manifest.json

The `manifest.load_o3de_manifest` will now use the default o3de manifest
data if a manifest_path paramter of None is supplied and the default
manifest location of `~/.o3de/o3de_manifest.json` does not exist.

The prevents the load_o3de_manifest method from creating a manifest.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>