### PR TITLE
Fix State Transition After Building Again After A Failed Build

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectBuilderWorker.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectBuilderWorker.cpp
@@ -28,7 +28,6 @@ namespace O3DE::ProjectManager
 
     void ProjectBuilderWorker::BuildProject()
     {
-
         auto result = BuildProjectForPlatform();
 
         if (result.IsSuccess())

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -329,14 +329,19 @@ namespace O3DE::ProjectManager
                 auto projectIter = m_projectButtons.find(QDir::toNativeSeparators(project.m_path));
                 if (projectIter != m_projectButtons.end())
                 {
-                    if (project.m_buildFailed)
+                    // If project is not currently or about to build
+                    if (!m_currentBuilder || m_currentBuilder->GetProjectInfo() != project)
                     {
-                        projectIter.value()->SetBuildLogsLink(project.m_logUrl);
-                        projectIter.value()->SetState(ProjectButtonState::BuildFailed);
-                    }
-                    else
-                    {
-                        projectIter.value()->SetState(ProjectButtonState::NeedsToBuild);
+
+                        if (project.m_buildFailed)
+                        {
+                            projectIter.value()->SetBuildLogsLink(project.m_logUrl);
+                            projectIter.value()->SetState(ProjectButtonState::BuildFailed);
+                        }
+                        else
+                        {
+                            projectIter.value()->SetState(ProjectButtonState::NeedsToBuild);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Previously the project button would get into an invalid state and the UI would be unreadable.

![o3de_zrxzdTtwEx](https://user-images.githubusercontent.com/52797929/162869141-1df8f4f6-4c3a-41ef-9901-3aa1ffa9c33c.gif)


Signed-off-by: nggieber <52797929+AMZN-nggieber@users.noreply.github.com>