### PR TITLE
Fixed Parallax test in ASV

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/ParallaxInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/ParallaxInput.azsli
@@ -32,7 +32,7 @@ void GetParallaxInput(float3 normal, float3 tangent, float3 bitangent, float hei
     if(o_parallax_feature_enabled)
     {
         float3 dirToCamera;
-        if(ViewSrg::m_projectionMatrix[0].w)
+        if(ViewSrg::m_projectionMatrix[3].w == 1)
         {
             // orthographic projection (directional light)
             // No view position, use light direction


### PR DESCRIPTION
Fixed Parallax test in ASV, check for orthogonal projection matrix was checking projectionMatrix[0].w which can be 0 under certain edge cases. Checking projectionMatrix[3].w is a much better check, and fixes the test failures for Parallax.

See https://github.com/o3de/o3de-atom-sampleviewer/issues/379 

Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>