### PR TITLE
Atom gem release build fix

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuildArgumentsManager.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuildArgumentsManager.cpp
@@ -50,7 +50,7 @@ namespace AZ
                         scopeName.c_str());
                     continue;
                 }
-                const auto addedDefinitionCount = shaderBuildOptions.m_addBuildArguments.AppendDefinitions(shaderBuildOptions.m_definitions);
+                [[maybe_unused]]const auto addedDefinitionCount = shaderBuildOptions.m_addBuildArguments.AppendDefinitions(shaderBuildOptions.m_definitions);
                 AZ_Assert(addedDefinitionCount >= 0, "Failed to add definitions");
 
                 removeBuildArgumentsMap.emplace(scopeName, AZStd::move(shaderBuildOptions.m_removeBuildArguments));
@@ -112,7 +112,7 @@ namespace AZ
             auto newTopName = currentTopName.empty() ? anyName : AZStd::string::format("%s.%s", currentTopName.c_str(), anyName.c_str());
 
             auto newArguments = GetCurrentArguments() - removeArguments;
-            const auto addedDefinitionCount = newArguments.AppendDefinitions(definitions);
+            [[maybe_unused]] const auto addedDefinitionCount = newArguments.AppendDefinitions(definitions);
             AZ_Assert(addedDefinitionCount >= 0, "Failed to add definitions");
 
             return PushArgumentsInternal(newTopName, newArguments + addArguments);


### PR DESCRIPTION
`addedDefinitionCount` variables in `ShaderBuildArgumentsManager.cpp` (Atom gem) are unused for `release` build config. This PR suppress warnings (and errors) during build.

Very similar to #8859, which mentions `clang 13` as the used compiler. However, in this case, the errors were on `clang 12`. 

Signed-off-by: Piotr Jaroszek <piotr.jaroszek@robotec.ai>