### PR TITLE
Added missing lowend shader variant lists

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/BasePBR_LowEndForward.shadervariantlist
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/BasePBR_LowEndForward.shadervariantlist
@@ -1,0 +1,29 @@
+{
+    "Shader" : "BasePBR_LowEndForward.shader",
+    "Variants": [
+        {
+            "StableId": 1,
+            "Options": {
+                "o_directional_shadow_filtering_method": "ShadowFilterMethod::None"
+            }
+        },
+        {
+            "StableId": 2,
+            "Options": {
+                "o_directional_shadow_filtering_method": "ShadowFilterMethod::Pcf"
+            }
+        },
+        {
+            "StableId": 3,
+            "Options": {
+                "o_directional_shadow_filtering_method": "ShadowFilterMethod::Esm"
+            }
+        },
+        {
+            "StableId": 4,
+            "Options": {
+                "o_directional_shadow_filtering_method": "ShadowFilterMethod::EsmPcf"
+            }
+        }
+    ] 
+}

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_LowEndForward.shadervariantlist
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_LowEndForward.shadervariantlist
@@ -1,0 +1,29 @@
+{
+    "Shader" : "StandardPBR_LowEndForward.shader",
+    "Variants": [
+        {
+            "StableId": 1,
+            "Options": {
+                "o_directional_shadow_filtering_method": "ShadowFilterMethod::None"
+            }
+        },
+        {
+            "StableId": 2,
+            "Options": {
+                "o_directional_shadow_filtering_method": "ShadowFilterMethod::Pcf"
+            }
+        },
+        {
+            "StableId": 3,
+            "Options": {
+                "o_directional_shadow_filtering_method": "ShadowFilterMethod::Esm"
+            }
+        },
+        {
+            "StableId": 4,
+            "Options": {
+                "o_directional_shadow_filtering_method": "ShadowFilterMethod::EsmPcf"
+            }
+        }
+    ] 
+}

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_LowEndForward_EDS.shadervariantlist
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_LowEndForward_EDS.shadervariantlist
@@ -1,0 +1,29 @@
+{
+    "Shader" : "StandardPBR_LowEndForward_EDS.shader",
+    "Variants": [
+        {
+            "StableId": 1,
+            "Options": {
+                "o_directional_shadow_filtering_method": "ShadowFilterMethod::None"
+            }
+        },
+        {
+            "StableId": 2,
+            "Options": {
+                "o_directional_shadow_filtering_method": "ShadowFilterMethod::Pcf"
+            }
+        },
+        {
+            "StableId": 3,
+            "Options": {
+                "o_directional_shadow_filtering_method": "ShadowFilterMethod::Esm"
+            }
+        },
+        {
+            "StableId": 4,
+            "Options": {
+                "o_directional_shadow_filtering_method": "ShadowFilterMethod::EsmPcf"
+            }
+        }
+    ] 
+}


### PR DESCRIPTION
Added variant lists for BasePBR_LowEndForward, StandardPBR_LowEndForward and StandardPBR_LowEndForward_EDS. The varianlists are similar to all the other PBR ones creating variants for each shadow sampling method. A big performance gain could be seen in my tests for BasePBR_LowEndForward. Perhaps even more variants could be defined later on.