### PR TITLE
Renaming parameters to avoid name collision

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/DespawnNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/DespawnNodeable.ScriptCanvasNodeable.xml
@@ -17,7 +17,7 @@
     </Input>
 
     <Output Name="On Despawn" Description="Called when despawning entities has completed.">
-        <Parameter Name="SpawnTicket" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance of the despawn result."/>
+        <Parameter Name="SpawnTicketOut" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance of the despawn result."/>
     </Output>/>
   </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/SpawnNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/SpawnNodeable.ScriptCanvasNodeable.xml
@@ -21,7 +21,7 @@
     </Input>
 
     <Output Name="On Spawn Completed" Description="Called when spawning entities is completed.">
-        <Parameter Name="SpawnTicket" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance of the spawn result."/>
+        <Parameter Name="SpawnTicketOut" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance of the spawn result."/>
         <Parameter Name="SpawnedEntitiesList" Type="AZStd::vector&lt;Data::EntityIDType&gt;" Description="List of spawned entities sorted by hierarchy with the root being first"/>
     </Output>/>
   </Class>


### PR DESCRIPTION
Fixes an issue when performing undo/redo operations on Spawn/Despawn nodes in ScriptCanvas is causing them to get corrupted. This seems to be related to parameter name collision of SpawnTicket.

Signed-off-by: Mikhail Naumov <mnaumov@amazon.com>