### PR TITLE
Updated code ownership file to point asset pipeline systems to sig content, not sig core

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,16 +30,6 @@
 /Templates/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Tools/EventLogTool/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 
-# SIG-Content Asset Pipeline ownership area
-/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ @o3de/sig-content-maintainers
-/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ @o3de/sig-content-maintainers
-/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/ @o3de/sig-content-maintainers
-/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/ @o3de/sig-content-maintainers
-/Code/Tools/AssetBundler/ @o3de/sig-content-maintainers
-/Code/Tools/AssetProcessor/ @o3de/sig-content-maintainers
-/Code/Tools/SceneAPI/ @o3de/sig-content-maintainers
-/Gems/SceneProcessing/ @o3de/sig-content-maintainers
-
 # SIG-Core deprecated areas of ownership
 /cmake/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Code/Legacy/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
@@ -55,3 +45,13 @@
 /Gems/NvCloth/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Gems/PhysX/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Gems/PhysXDebug/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+
+# SIG-Content Asset Pipeline ownership area
+/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/ @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/ @o3de/sig-content-maintainers
+/Code/Tools/AssetBundler/ @o3de/sig-content-maintainers
+/Code/Tools/AssetProcessor/ @o3de/sig-content-maintainers
+/Code/Tools/SceneAPI/ @o3de/sig-content-maintainers
+/Gems/SceneProcessing/ @o3de/sig-content-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,10 +30,15 @@
 /Templates/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Tools/EventLogTool/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 
-# SIG-Core Asset Pipeline ownership area
-/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
-/Code/Tools/AssetProcessor/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+# SIG-Content Asset Pipeline ownership area
+/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
+/Code/Tools/AssetBundler/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
+/Code/Tools/AssetProcessor/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
+/Code/Tools/SceneAPI/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
+/Gems/SceneProcessing/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
 
 # SIG-Core deprecated areas of ownership
 /cmake/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,14 +31,14 @@
 /Tools/EventLogTool/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 
 # SIG-Content Asset Pipeline ownership area
-/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ @o3de/sig-content @o3de/sig-content-maintainers
-/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ @o3de/sig-content @o3de/sig-content-maintainers
-/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/ @o3de/sig-content @o3de/sig-content-maintainers
-/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/ @o3de/sig-content @o3de/sig-content-maintainers
-/Code/Tools/AssetBundler/ @o3de/sig-content @o3de/sig-content-maintainers
-/Code/Tools/AssetProcessor/ @o3de/sig-content @o3de/sig-content-maintainers
-/Code/Tools/SceneAPI/ @o3de/sig-content @o3de/sig-content-maintainers
-/Gems/SceneProcessing/ @o3de/sig-content @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/ @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/ @o3de/sig-content-maintainers
+/Code/Tools/AssetBundler/ @o3de/sig-content-maintainers
+/Code/Tools/AssetProcessor/ @o3de/sig-content-maintainers
+/Code/Tools/SceneAPI/ @o3de/sig-content-maintainers
+/Gems/SceneProcessing/ @o3de/sig-content-maintainers
 
 # SIG-Core deprecated areas of ownership
 /cmake/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,14 +31,14 @@
 /Tools/EventLogTool/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 
 # SIG-Content Asset Pipeline ownership area
-/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
-/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
-/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
-/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
-/Code/Tools/AssetBundler/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
-/Code/Tools/AssetProcessor/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
-/Code/Tools/SceneAPI/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
-/Gems/SceneProcessing/ @o3de/sig-content-reviewers @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ @o3de/sig-content @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ @o3de/sig-content @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/ @o3de/sig-content @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/ @o3de/sig-content @o3de/sig-content-maintainers
+/Code/Tools/AssetBundler/ @o3de/sig-content @o3de/sig-content-maintainers
+/Code/Tools/AssetProcessor/ @o3de/sig-content @o3de/sig-content-maintainers
+/Code/Tools/SceneAPI/ @o3de/sig-content @o3de/sig-content-maintainers
+/Gems/SceneProcessing/ @o3de/sig-content @o3de/sig-content-maintainers
 
 # SIG-Core deprecated areas of ownership
 /cmake/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers


### PR DESCRIPTION
Updated code ownership file to point asset pipeline systems to sig content, not sig core

Signed-off-by: AMZN-stankowi <4838196+AMZN-stankowi@users.noreply.github.com>