### PR TITLE
Add Python executable path to the Path environment variable

### DIFF
--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -351,7 +351,8 @@
     },
     "COMMAND": "deploy_cdk_applications.sh",
     "PARAMETERS": {
-      "NVM_VERSION": "v0.39.1"
+      "NVM_VERSION": "v0.39.1",
+      "PYTHON_RUNTIME": "python-3.7.12-rev2-linux"
     }
   },
   "awsi_destruction": {
@@ -361,7 +362,8 @@
     },
     "COMMAND": "destroy_cdk_applications.sh",
     "PARAMETERS": {
-      "NVM_VERSION": "v0.39.1"
+      "NVM_VERSION": "v0.39.1",
+      "PYTHON_RUNTIME": "python-3.7.12-rev2-linux"
     }
   }
 }

--- a/scripts/build/Platform/Linux/deploy_cdk_applications.sh
+++ b/scripts/build/Platform/Linux/deploy_cdk_applications.sh
@@ -9,7 +9,7 @@
 # Deploy the CDK applications for AWS gems (Linux only)
 
 SOURCE_DIRECTORY=$PWD
-PATH=$SOURCE_DIRECTORY/python:$PATH
+PATH=$SOURCE_DIRECTORY/python/runtime/$PYTHON_RUNTIME/python/bin:$PATH
 GEM_DIRECTORY=$SOURCE_DIRECTORY/Gems
 
 DeployCDKApplication()

--- a/scripts/build/Platform/Linux/destroy_cdk_applications.sh
+++ b/scripts/build/Platform/Linux/destroy_cdk_applications.sh
@@ -12,7 +12,7 @@
 # 2) Node.js version >= 10.13.0, except for versions 13.0.0 - 13.6.0. A version in active long-term support is recommended.
 
 SOURCE_DIRECTORY=$PWD
-PATH=$SOURCE_DIRECTORY/python:$PATH
+PATH=$SOURCE_DIRECTORY/python/runtime/$PYTHON_RUNTIME/python/bin:$PATH
 GEM_DIRECTORY=$SOURCE_DIRECTORY/Gems
 
 DestroyCDKApplication()


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

This is a follow up fix related to https://github.com/o3de/o3de/pull/8827

We have to add the Python executable path to the PATH environment variable so that CDK can pick up the O3DE Python instead of the Linux system Python during the deployment since it is not running under a Python virtual environment any more. This is a temporary fix as https://github.com/o3de/o3de/pull/8827 and we will revert both of these two PRs once O3DE Python is fixed (https://github.com/o3de/o3de/issues/8794).

Verified the scripts on a local Linux machine.