### PR TITLE
Update version indicators in the Editor

### DIFF
--- a/Code/Editor/AboutDialog.ui
+++ b/Code/Editor/AboutDialog.ui
@@ -117,41 +117,6 @@
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="m_transparentDevelopedBy">
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>18</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>development</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::AutoText</enum>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-           <widget class="QLabel" name="m_transparentCopyright">
-            <property name="geometry">
-             <rect>
-              <x>0</x>
-              <y>0</y>
-              <width>180</width>
-              <height>0</height>
-             </rect>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
-            </property>
-           </widget>
-          </widget>
-         </item>
-         <item>
           <widget class="QLabel" name="m_transparentTrademarks">
            <property name="maximumSize">
             <size>

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -852,6 +852,11 @@ namespace
 
 QString FormatVersion([[maybe_unused]] const SFileVersion& v)
 {
+    if (QObject::tr("%1").arg(LY_VERSION_BUILD_NUMBER) == "0")
+    {
+        return QObject::tr("Development Build");
+    }
+
     return QObject::tr("Version %1").arg(LY_VERSION_BUILD_NUMBER);
 }
 
@@ -3669,7 +3674,7 @@ void CCryEditApp::SetEditorWindowTitle(QString sTitleStr, QString sPreTitleStr, 
     {
         if (sTitleStr.isEmpty())
         {
-            sTitleStr = QObject::tr("O3DE Editor [Developer Preview]");
+            sTitleStr = QObject::tr("O3DE Editor [%1]").arg(FormatVersion(m_pEditor->GetFileVersion()));
         }
 
         if (!sPreTitleStr.isEmpty())

--- a/Code/Editor/StartupLogoDialog.ui
+++ b/Code/Editor/StartupLogoDialog.ui
@@ -101,13 +101,6 @@
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>development</string>
-           </property>
-          </widget>
-         </item>
-         <item>
           <widget class="QLabel" name="m_TransparentVersion">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">


### PR DESCRIPTION
Removes friendly version name labels in the Editor (since we now refer to releases just by their version number).
![version01](https://user-images.githubusercontent.com/82231674/163291017-07574b8a-b4ac-4137-b411-22cf078e3cfe.png)
![version02](https://user-images.githubusercontent.com/82231674/163291020-8cb1e9c7-9951-4aaa-951e-736a381d4f14.png)

Changes the Editor titlebar to display the version number
![version03](https://user-images.githubusercontent.com/82231674/163291039-818efe5c-3802-4608-8f73-f6e220c4bc74.png)

Note that this works when the version number is supplied **as a string** in the CMake configuration:
![versionStrings](https://user-images.githubusercontent.com/82231674/163291075-e3ef86e8-6c2f-4216-a6e9-ed519890e2c7.png)
The Jenkins instances that generate the installer set this value correctly, so the version will be displayed.

In local builds, that value defaults to 0. When no version number string is supplied, the Editor will display the text "Development Build" instead:
![default01](https://user-images.githubusercontent.com/82231674/163291181-6cd43e7d-99f1-4deb-a26e-b07b18ff88c6.png)
![default02](https://user-images.githubusercontent.com/82231674/163291182-2469d933-c162-48a4-94cf-60b3e4c36eed.png)
![default03](https://user-images.githubusercontent.com/82231674/163291184-cbc2d736-191d-486a-9f62-81a447628cdc.png)

