### PR TITLE
Fixed deadlock due to asset.BlockUntilLoadComplete

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/AssetCollectionAsyncLoader.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/AssetCollectionAsyncLoader.h
@@ -99,6 +99,8 @@ namespace AZ
 
         //! The key is the asset path
         AZStd::unordered_map<AZStd::string, Data::Asset<Data::AssetData>> m_readyAssets;
+        //! Assets that are queued for loading, waiting for OnAssetReady event.
+        AZStd::unordered_map<AZStd::string, Data::Asset<Data::AssetData>> m_notReadyAssets;
 
         // Called by the m_assetDiscoveryJob as it discovers assets in the AP Cache.
         friend class AssetDiscoveryJob;

--- a/Gems/Atom/Utils/Code/Source/AssetCollectionAsyncLoader.cpp
+++ b/Gems/Atom/Utils/Code/Source/AssetCollectionAsyncLoader.cpp
@@ -215,16 +215,17 @@ namespace AZ
 
     void AssetCollectionAsyncLoader::OnAssetIsValid(AZStd::string_view assetPath, const Data::AssetId& assetId, const Data::AssetType& assetType)
     {
+        // Kick off asset loading.
+        auto asset = Data::AssetManager::Instance().GetAsset(assetId, assetType, AZ::Data::AssetLoadBehavior::QueueLoad);
+
         const auto assetIdStr = assetId.ToString<AZStd::string>();
 
         {
             AZStd::unique_lock<decltype(m_mutex)> lock(m_mutex);
             m_assetIdStrToAssetPath[assetIdStr] = assetPath;
+            m_notReadyAssets[assetPath] = asset;
         }
 
-        // Kick off asset loading.
-        auto asset = Data::AssetManager::Instance().GetAsset(assetId, assetType, AZ::Data::AssetLoadBehavior::QueueLoad);
-        m_notReadyAssets[assetPath] = asset;
         Data::AssetBus::MultiHandler::BusConnect(assetId);
     }
 

--- a/Gems/Atom/Utils/Code/Source/AssetCollectionAsyncLoader.cpp
+++ b/Gems/Atom/Utils/Code/Source/AssetCollectionAsyncLoader.cpp
@@ -170,6 +170,7 @@ namespace AZ
         m_assetsToNotify.clear();
         m_assetIdStrToAssetPath.clear();
         m_readyAssets.clear();
+        m_notReadyAssets.clear();
     }
 
     void AssetCollectionAsyncLoader::PostNotifyReadyAssetsCB(Data::Asset<Data::AssetData> asset, bool success)
@@ -187,6 +188,7 @@ namespace AZ
 
             AZ_Assert(m_assetsToLoad.count(assetPath), "Asset with path %s, hint %s was not scheduled to load\n", assetPath.c_str(), asset.GetHint().c_str());
 
+            m_notReadyAssets.erase(assetPath);
             m_assetsToLoad.erase(assetPath);
             m_readyAssets[assetPath] = asset;
             m_assetsToNotify[assetPath] = success;
@@ -222,8 +224,8 @@ namespace AZ
 
         Data::AssetBus::MultiHandler::BusConnect(assetId);
         // Kick off asset loading.
-        auto asset = Data::AssetManager::Instance().GetAsset(assetId, assetType, AZ::Data::AssetLoadBehavior::PreLoad);
-        asset.BlockUntilLoadComplete();
+        auto asset = Data::AssetManager::Instance().GetAsset(assetId, assetType, AZ::Data::AssetLoadBehavior::QueueLoad);
+        m_notReadyAssets[assetPath] = asset;
     }
 
     ///////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/Utils/Code/Source/AssetCollectionAsyncLoader.cpp
+++ b/Gems/Atom/Utils/Code/Source/AssetCollectionAsyncLoader.cpp
@@ -222,10 +222,10 @@ namespace AZ
             m_assetIdStrToAssetPath[assetIdStr] = assetPath;
         }
 
-        Data::AssetBus::MultiHandler::BusConnect(assetId);
         // Kick off asset loading.
         auto asset = Data::AssetManager::Instance().GetAsset(assetId, assetType, AZ::Data::AssetLoadBehavior::QueueLoad);
         m_notReadyAssets[assetPath] = asset;
+        Data::AssetBus::MultiHandler::BusConnect(assetId);
     }
 
     ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Even though asset.BlockUntilLoadComplete was being called on a worker
thread instead of the main thread, deadlocks were occurring under
stressful circumstances like setting Lattice values to 25^3
in ASV RPI/AssetLoadTest.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>