### PR TITLE
Fixed physx material ids being set to null when used in a prefab

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Material.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Material.cpp
@@ -47,7 +47,26 @@ namespace Physics
             {
                 materialSelection->SetMaterialSlots(Physics::MaterialSelection::SlotsArray());
             }
-            materialSelection->SyncSelectionToMaterialLibrary();
+
+            // Not validating the material selection against the library at asset builder time
+            // because the library is not available. This happens when a MaterialSelection
+            // is part of a prefab. This will avoid writing null material ids into prefabs.
+            if (!IsAssetBuilder())
+            {
+                materialSelection->SyncSelectionToMaterialLibrary();
+            }
+        }
+
+        bool IsAssetBuilder() const
+        {
+            AZ::SerializeContext* serializeContext = nullptr;
+            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
+
+            // TypeId of AssetBuilderComponent
+            const char* typeIDAssetBuilderComponent = "{04332899-5d73-4d41-86b7-b1017d349673}";
+
+            return serializeContext
+                && serializeContext->FindClassData(AZ::TypeId::CreateString(typeIDAssetBuilderComponent));
         }
     };
 


### PR DESCRIPTION
The `OnReadEnd` function of the serialization of `MaterialSelection` class tries to validate the material ids after serialization by looking into the material library. The problem was when executed in the context of Asset Builder (due to a prefab), the material library is never loaded by the physics system because it's expecting the event "CriticalAssetsCompiled", which is not fired at asset processor time.

Fixed by adding a protection in `OnReadEnd` to only validate the material ids if it's not an asset builder. That way when prefabs are processing the data it will only write the ids out, and during editor/launcher it will validate it against the library.

Fixes #7550 

Signed-off-by: moraaar <moraaar@amazon.com>