### PR TITLE
fix the issue where client can not connect to Server after disconnect

### DIFF
--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -188,8 +188,6 @@ namespace Multiplayer
                 console->PerformCommand("disconnect");
             }
 
-            AZ::Interface<INetworkEntityManager>::Get()->ClearAllEntities();
-
             // Rebuild the library to clear temporary in-memory spawnable assets
             AZ::Interface<INetworkSpawnableLibrary>::Get()->BuildSpawnablesList();
 

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -248,6 +248,10 @@ namespace Multiplayer
             m_networkInterface->StopListening();
             m_shutdownEvent.Signal(m_networkInterface);
         }
+
+        // Clear out all the registered network entities
+        GetNetworkEntityManager()->ClearAllEntities();
+
         InitializeMultiplayer(MultiplayerAgentType::Uninitialized);
 
         // Signal session management, do this after uninitializing state


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

Fix for https://github.com/o3de/o3de/issues/8870

Network entities are not cleared when a client disconnect from the server and when it tries to reconnect, an assert is triggered at https://github.com/o3de/o3de/blob/development/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityTracker.cpp#L20 since the same entity is added to the map again.

Test Done:
- All multiplayer unit tests passed
- Connected two clients to the server. Disconnected and reconnected one of them successfully