### PR TITLE
Update Project Manager to Build ServerLauncher

### DIFF
--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectBuilderWorker_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectBuilderWorker_linux.cpp
@@ -40,9 +40,8 @@ namespace O3DE::ProjectManager
     {
         auto    whichNinjaResult = ProjectUtils::ExecuteCommandResult("which", QStringList{"ninja"});
         bool    compileProfileOnBuild = (whichNinjaResult.IsSuccess());
-        QString targetBuildPath = QDir(m_projectInfo.m_path).filePath(ProjectBuildPathPostfix);
-        QString gameLauncherTargetName = m_projectInfo.m_projectName + ".GameLauncher";
-        QString serverLauncherTargetName = m_projectInfo.m_projectName + ".ServerLauncher";
+        const QString gameLauncherTargetName = m_projectInfo.m_projectName + ".GameLauncher";
+        const QString serverLauncherTargetName = m_projectInfo.m_projectName + ".ServerLauncher";
 
         QStringList buildProjectArgs = QStringList{ProjectCMakeCommand,
                                                    "--build", ProjectBuildPathPostfix,

--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectBuilderWorker_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectBuilderWorker_linux.cpp
@@ -41,11 +41,12 @@ namespace O3DE::ProjectManager
         auto    whichNinjaResult = ProjectUtils::ExecuteCommandResult("which", QStringList{"ninja"});
         bool    compileProfileOnBuild = (whichNinjaResult.IsSuccess());
         QString targetBuildPath = QDir(m_projectInfo.m_path).filePath(ProjectBuildPathPostfix);
-        QString launcherTargetName = m_projectInfo.m_projectName + ".GameLauncher";
+        QString gameLauncherTargetName = m_projectInfo.m_projectName + ".GameLauncher";
+        QString serverLauncherTargetName = m_projectInfo.m_projectName + ".ServerLauncher";
 
         QStringList buildProjectArgs = QStringList{ProjectCMakeCommand,
                                                    "--build", ProjectBuildPathPostfix,
-                                                   "--target", launcherTargetName, ProjectCMakeBuildTargetEditor};
+                                                   "--target", gameLauncherTargetName, serverLauncherTargetName, ProjectCMakeBuildTargetEditor};
         if (compileProfileOnBuild)
         {
             buildProjectArgs.append(QStringList{"--config","profile"});

--- a/Code/Tools/ProjectManager/Platform/Mac/ProjectBuilderWorker_mac.cpp
+++ b/Code/Tools/ProjectManager/Platform/Mac/ProjectBuilderWorker_mac.cpp
@@ -70,13 +70,12 @@ namespace O3DE::ProjectManager
 
         QString cmakeInstalledPath = cmakeInstalledPathQuery.GetValue();
         QString targetBuildPath = QDir(m_projectInfo.m_path).filePath(ProjectBuildPathPostfix);
-        QString gameLauncherTargetName = m_projectInfo.m_projectName + ".GameLauncher";
-        QString serverLauncherTargetName = m_projectInfo.m_projectName + ".ServerLauncher";
+        QString launcherTargetName = m_projectInfo.m_projectName + ".GameLauncher";
 
         return AZ::Success(QStringList{cmakeInstalledPath,
                                         "--build", targetBuildPath,
                                         "--config", "profile",
-                                        "--target", gameLauncherTargetName, serverLauncherTargetName, ProjectCMakeBuildTargetEditor});
+                                        "--target", launcherTargetName, ProjectCMakeBuildTargetEditor});
     }
 
     AZ::Outcome<QStringList, QString> ProjectBuilderWorker::ConstructKillProcessCommandArguments(const QString& pidToKill) const

--- a/Code/Tools/ProjectManager/Platform/Mac/ProjectBuilderWorker_mac.cpp
+++ b/Code/Tools/ProjectManager/Platform/Mac/ProjectBuilderWorker_mac.cpp
@@ -70,12 +70,13 @@ namespace O3DE::ProjectManager
 
         QString cmakeInstalledPath = cmakeInstalledPathQuery.GetValue();
         QString targetBuildPath = QDir(m_projectInfo.m_path).filePath(ProjectBuildPathPostfix);
-        QString launcherTargetName = m_projectInfo.m_projectName + ".GameLauncher";
+        QString gameLauncherTargetName = m_projectInfo.m_projectName + ".GameLauncher";
+        QString serverLauncherTargetName = m_projectInfo.m_projectName + ".ServerLauncher";
 
         return AZ::Success(QStringList{cmakeInstalledPath,
                                         "--build", targetBuildPath,
                                         "--config", "profile",
-                                        "--target", launcherTargetName, ProjectCMakeBuildTargetEditor});
+                                        "--target", gameLauncherTargetName, serverLauncherTargetName, ProjectCMakeBuildTargetEditor});
     }
 
     AZ::Outcome<QStringList, QString> ProjectBuilderWorker::ConstructKillProcessCommandArguments(const QString& pidToKill) const

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectBuilderWorker_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectBuilderWorker_windows.cpp
@@ -28,12 +28,13 @@ namespace O3DE::ProjectManager
     AZ::Outcome<QStringList, QString> ProjectBuilderWorker::ConstructCmakeBuildCommandArguments() const
     {
         QString targetBuildPath = QDir(m_projectInfo.m_path).filePath(ProjectBuildPathPostfix);
-        QString launcherTargetName = m_projectInfo.m_projectName + ".GameLauncher";
+        QString gameLauncherTargetName = m_projectInfo.m_projectName + ".GameLauncher";
+        QString serverLauncherTargetName = m_projectInfo.m_projectName + ".ServerLauncher";
 
         return AZ::Success(QStringList{ ProjectCMakeCommand,
                                         "--build", targetBuildPath,
                                         "--config", "profile",
-                                        "--target", launcherTargetName, ProjectCMakeBuildTargetEditor });
+                                        "--target", gameLauncherTargetName, serverLauncherTargetName, ProjectCMakeBuildTargetEditor });
     }
 
     AZ::Outcome<QStringList, QString> ProjectBuilderWorker::ConstructKillProcessCommandArguments(const QString& pidToKill) const

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectBuilderWorker_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectBuilderWorker_windows.cpp
@@ -27,9 +27,9 @@ namespace O3DE::ProjectManager
 
     AZ::Outcome<QStringList, QString> ProjectBuilderWorker::ConstructCmakeBuildCommandArguments() const
     {
-        QString targetBuildPath = QDir(m_projectInfo.m_path).filePath(ProjectBuildPathPostfix);
-        QString gameLauncherTargetName = m_projectInfo.m_projectName + ".GameLauncher";
-        QString serverLauncherTargetName = m_projectInfo.m_projectName + ".ServerLauncher";
+        const QString targetBuildPath = QDir(m_projectInfo.m_path).filePath(ProjectBuildPathPostfix);
+        const QString gameLauncherTargetName = m_projectInfo.m_projectName + ".GameLauncher";
+        const QString serverLauncherTargetName = m_projectInfo.m_projectName + ".ServerLauncher";
 
         return AZ::Success(QStringList{ ProjectCMakeCommand,
                                         "--build", targetBuildPath,


### PR DESCRIPTION
Update project manager so that building builds Editor, GameLauncher, and now **ServerLauncher** (on Windows and Linux, not Mac)

Tested by building a project and seeing ServerLauncher get created. Also works with projects that don't enable MultiplayerGem, I was worried that ServerLaunchers are only defined when MP gem is enabled, but apparently not.

Building ServerLauncher does not add much time to build either. Since the ServerLauncher is basically the GameLauncher, if the GameLauncher is already built it looks like ServerLauncher just compiles 1/1 cxx. This might change once the client/server split is implemented (see https://github.com/o3de/sig-network/blob/main/rfcs/rfc-net-20220118-1-clientserver.md)

Resolves #8407
Signed-off-by: Gene Walters <genewalt@amazon.com>