### PR TITLE
Graph Model: Removing overloaded template function to get data types from graph model contexts

### DIFF
--- a/Gems/GraphModel/Code/Include/GraphModel/Model/IGraphContext.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/IGraphContext.h
@@ -52,11 +52,8 @@ namespace GraphModel
         virtual DataTypePtr GetDataType(DataType::Enum typeEnum) const = 0;
 
         //! Utility function to returns a DataType object representing the given template type T, or Invalid if it doesn't exist.
-        //! Subclasses may need to implement this function too, and just call IGraphContext::GetDataType<T>()
-        //! in order to avoid "error C2275: 'Type': illegal use of this type as an expression"
         template<typename T>
         DataTypePtr GetDataType() const { return GetDataType(azrtti_typeid<T>()); }
-
     };
     
 } // namespace GraphModel

--- a/Gems/GraphModel/Code/Tests/TestEnvironment.h
+++ b/Gems/GraphModel/Code/Tests/TestEnvironment.h
@@ -58,13 +58,6 @@ namespace GraphModelIntegrationTest
         const GraphModel::DataTypeList& GetAllDataTypes() const override;
         GraphModel::DataTypePtr GetDataType(AZ::Uuid typeId) const override;
         GraphModel::DataTypePtr GetDataType(GraphModel::DataType::Enum typeEnum) const override;
-
-        template<typename T>
-        GraphModel::DataTypePtr GetDataType() const
-        {
-            return IGraphContext::GetDataType<T>();
-        }
-
         GraphModel::ModuleGraphManagerPtr GetModuleGraphManager() const override;
 
     private:

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Core/GraphContext.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Core/GraphContext.h
@@ -34,10 +34,6 @@ namespace LandscapeCanvas
         GraphModel::DataTypePtr GetDataType(AZ::Uuid typeId) const override;
         GraphModel::DataTypePtr GetDataTypeForValue(const AZStd::any& value) const override;
         GraphModel::DataTypePtr GetDataType(GraphModel::DataType::Enum typeEnum) const override;
-
-        template<typename T>
-        GraphModel::DataTypePtr GetDataType() const { return IGraphContext::GetDataType<T>(); }
-
         GraphModel::ModuleGraphManagerPtr GetModuleGraphManager() const override;
 
     private:

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/AltitudeFilterNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/AltitudeFilterNode.cpp
@@ -43,8 +43,8 @@ namespace LandscapeCanvas
 
     void AltitudeFilterNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr boundsDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             PIN_TO_SHAPE_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/DistributionFilterNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/DistributionFilterNode.cpp
@@ -43,8 +43,8 @@ namespace LandscapeCanvas
 
     void DistributionFilterNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr gradientDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_GRADIENT_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/ShapeIntersectionFilterNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/ShapeIntersectionFilterNode.cpp
@@ -43,8 +43,8 @@ namespace LandscapeCanvas
 
     void ShapeIntersectionFilterNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr boundsDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_SHAPE_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/PositionModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/PositionModifierNode.cpp
@@ -43,8 +43,8 @@ namespace LandscapeCanvas
 
     void PositionModifierNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr gradientDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             BaseAreaModifierNode::INBOUND_GRADIENT_X_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/RotationModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/RotationModifierNode.cpp
@@ -43,8 +43,8 @@ namespace LandscapeCanvas
 
     void RotationModifierNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr gradientDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             BaseAreaModifierNode::INBOUND_GRADIENT_X_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/ScaleModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/ScaleModifierNode.cpp
@@ -43,8 +43,8 @@ namespace LandscapeCanvas
 
     void ScaleModifierNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr gradientDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_GRADIENT_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/SlopeAlignmentModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/SlopeAlignmentModifierNode.cpp
@@ -43,8 +43,8 @@ namespace LandscapeCanvas
 
     void SlopeAlignmentModifierNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr gradientDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_GRADIENT_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaSelectors/AssetWeightSelectorNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaSelectors/AssetWeightSelectorNode.cpp
@@ -70,8 +70,8 @@ namespace LandscapeCanvas
 
     void AssetWeightSelectorNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr gradientDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_GRADIENT_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/AreaBlenderNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/AreaBlenderNode.cpp
@@ -45,8 +45,8 @@ namespace LandscapeCanvas
     {
         CreateEntityNameSlot();
 
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr areaDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Area);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr areaDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Area);
 
         GraphModel::ExtendableSlotConfiguration slotConfig;
         slotConfig.m_addButtonLabel = QObject::tr("Add Area").toUtf8().constData();

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/BaseAreaNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/BaseAreaNode.cpp
@@ -76,9 +76,9 @@ namespace LandscapeCanvas
     {
         CreateEntityNameSlot();
 
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr boundsDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
-        GraphModel::DataTypePtr areaDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Area);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
+        GraphModel::DataTypePtr areaDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Area);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             PLACEMENT_BOUNDS_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/BaseNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/BaseNode.cpp
@@ -45,7 +45,7 @@ namespace LandscapeCanvas
     void BaseNode::CreateEntityNameSlot()
     {
         // Property field to show the name of the corresponding Vegetation Entity
-        GraphModel::DataTypePtr stringDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::String);
+        GraphModel::DataTypePtr stringDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::String);
         RegisterSlot(GraphModel::SlotDefinition::CreateProperty(
             ENTITY_NAME_SLOT_ID,
             ENTITY_NAME_SLOT_LABEL.toUtf8().constData(),

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/BaseGradientModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/BaseGradientModifierNode.cpp
@@ -53,9 +53,9 @@ namespace LandscapeCanvas
     {
         CreateEntityNameSlot();
 
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr boundsDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
-        GraphModel::DataTypePtr gradientDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
+        GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             PREVIEW_BOUNDS_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/GradientMixerNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/GradientMixerNode.cpp
@@ -70,9 +70,9 @@ namespace LandscapeCanvas
     {
         CreateEntityNameSlot();
 
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr boundsDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
-        GraphModel::DataTypePtr gradientDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
+        GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             PREVIEW_BOUNDS_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/AltitudeGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/AltitudeGradientNode.cpp
@@ -46,8 +46,8 @@ namespace LandscapeCanvas
         BaseGradientNode::RegisterSlots();
 
         // Altitude Gradient has an additional input slot for an inbound shape
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr boundsDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             PIN_TO_SHAPE_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/BaseGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/BaseGradientNode.cpp
@@ -51,9 +51,9 @@ namespace LandscapeCanvas
     {
         CreateEntityNameSlot();
 
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr boundsDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
-        GraphModel::DataTypePtr gradientDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
+        GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             PREVIEW_BOUNDS_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ShapeAreaFalloffGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ShapeAreaFalloffGradientNode.cpp
@@ -46,8 +46,8 @@ namespace LandscapeCanvas
         BaseGradientNode::RegisterSlots();
 
         // Shape Falloff Gradient has an additional input slot for an inbound shape
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
-        GraphModel::DataTypePtr boundsDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
+        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
+        GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_SHAPE_SLOT_ID,

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/BaseShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/BaseShapeNode.cpp
@@ -58,7 +58,7 @@ namespace LandscapeCanvas
     {
         CreateEntityNameSlot();
 
-        GraphModel::DataTypePtr dataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
+        GraphModel::DataTypePtr dataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
         RegisterSlot(GraphModel::SlotDefinition::CreateOutputData(
             BOUNDS_SLOT_ID,
             BOUNDS_SLOT_LABEL.toUtf8().constData(),


### PR DESCRIPTION
This overload was added to compensate for a compile error that does not seem to be happening anymore.
Using the overloaded function would also require a reference to an instance of the derived context class instead of working with the interface ptr contained in every graph element.