### PR TITLE
Remove invalid slash from AWS python test project names

### DIFF
--- a/scripts/build/Platform/Linux/deploy_cdk_applications.sh
+++ b/scripts/build/Platform/Linux/deploy_cdk_applications.sh
@@ -75,6 +75,7 @@ export AWS_ACCESS_KEY_ID=$(echo $credentials | cut -d' ' -f3)
 export O3DE_AWS_DEPLOY_ACCOUNT=$(echo "$ASSUME_ROLE_ARN" | cut -d':' -f5)
 if [[ -z "$O3DE_AWS_PROJECT_NAME" ]]; then
    export O3DE_AWS_PROJECT_NAME=$BRANCH_NAME-$PIPELINE_NAME-Linux
+   export O3DE_AWS_PROJECT_NAME=${O3DE_AWS_PROJECT_NAME///} # remove occurances of "/" b/c not allowed in AWS CFN stack names
 fi
 
 # Bootstrap and deploy the CDK applications

--- a/scripts/build/Platform/Linux/destroy_cdk_applications.sh
+++ b/scripts/build/Platform/Linux/destroy_cdk_applications.sh
@@ -77,6 +77,7 @@ export AWS_ACCESS_KEY_ID=$(echo $credentials | cut -d' ' -f3)
 
 if [[ -z "$O3DE_AWS_PROJECT_NAME" ]]; then
    export O3DE_AWS_PROJECT_NAME=$BRANCH_NAME-$PIPELINE_NAME-Linux
+   export O3DE_AWS_PROJECT_NAME=${O3DE_AWS_PROJECT_NAME///} # remove occurances of "/" b/c not allowed in AWS CFN stack names
 fi
 
 ERROR_EXISTS=0

--- a/scripts/build/Platform/Windows/deploy_cdk_applications.cmd
+++ b/scripts/build/Platform/Windows/deploy_cdk_applications.cmd
@@ -39,6 +39,8 @@ FOR /F "tokens=4 delims=:" %%a IN ("%ASSUME_ROLE_ARN%") DO SET O3DE_AWS_DEPLOY_A
 
 IF "%O3DE_AWS_PROJECT_NAME%"=="" (
     SET O3DE_AWS_PROJECT_NAME=%BRANCH_NAME%-%PIPELINE_NAME%-Windows
+    SET slashreplace=
+    call SET O3DE_AWS_PROJECT_NAME=%%O3DE_AWS_PROJECT_NAME:/=%slashreplace%%%
 )
 
 REM Bootstrap and deploy the CDK applications

--- a/scripts/build/Platform/Windows/destroy_cdk_applications.cmd
+++ b/scripts/build/Platform/Windows/destroy_cdk_applications.cmd
@@ -38,6 +38,8 @@ FOR /f "tokens=1,2,3" %%a IN ('CALL aws sts assume-role --query Credentials.[Sec
 FOR /F "tokens=4 delims=:" %%a IN ("%ASSUME_ROLE_ARN%") DO SET O3DE_AWS_DEPLOY_ACCOUNT=%%a
 IF "%O3DE_AWS_PROJECT_NAME%"=="" (
     SET O3DE_AWS_PROJECT_NAME=%BRANCH_NAME%-%PIPELINE_NAME%-Windows
+    SET slashreplace=
+    call SET O3DE_AWS_PROJECT_NAME=%%O3DE_AWS_PROJECT_NAME:/=%slashreplace%%%
 )
 
 SET ERROR_EXISTS=0


### PR DESCRIPTION
When running [`deploy_cdk_applications`](https://github.com/o3de/o3de/blob/stabilization/2205/scripts/build/Platform/Windows/deploy_cdk_applications.cmd) with the `$BRANCH_NAME` and `$PIPELINE_NAME` env vars (such as on Jenkins),  `cdk deploy` would fail with errors like:

```
STABILIZATION--2205-NIGHTLY-CLEAN-WINDOWS-AWSCore failed: Error [ValidationError]: Template format error: Output STABILIZATION2205NIGHTLYCLEANWINDOWSResourceGroupOutput is malformed. The Name field of every Export member must be specified and consist only of alphanumeric characters, colons, or hyphens.
```

...if the `$BRANCH_NAME` included a slash (e.g.,: "stabilization/2205")

This change replaces any occurrences of `/` with empty string to avoid similar failures when the branch under test includes it.

### Testing

* successfully deployed + destroyed on **Windows**
```bash
✅  STABILIZATION2205-NIGHTLYTEST-WINDOWS-AWSCore-Example-eu-west-1: destroyed
STABILIZATION2205-NIGHTLYTEST-WINDOWS-AWSCore: destroying...

 ✅  STABILIZATION2205-NIGHTLYTEST-WINDOWS-AWSCore: destroyed
```

* successfully deployed + destroyed on **Linux** (WSL)
```
STABILIZATION2205-NIGHTLYTEST-LINUX-AWSCore-Example-eu-west-1: destroying...

 ✅  STABILIZATION2205-NIGHTLYTEST-LINUX-AWSCore-Example-eu-west-1: destroyed
STABILIZATION2205-NIGHTLYTEST-LINUX-AWSCore: destroying...

 ✅  STABILIZATION2205-NIGHTLYTEST-LINUX-AWSCore: destroyed
```
