### PR TITLE
Graph Model: Added more numeric and math types to json serializer

### DIFF
--- a/Gems/GraphModel/Code/Source/Model/Slot.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Slot.cpp
@@ -316,9 +316,11 @@ namespace GraphModel
         {
             AZStd::any slotValue;
             if (LoadAny<bool>(slotValue, serializedSlotValue->value, context, result) ||
+                LoadAny<int16_t>(slotValue, serializedSlotValue->value, context, result) ||
+                LoadAny<uint16_t>(slotValue, serializedSlotValue->value, context, result) ||
                 LoadAny<int32_t>(slotValue, serializedSlotValue->value, context, result) ||
-                LoadAny<int64_t>(slotValue, serializedSlotValue->value, context, result) ||
                 LoadAny<uint32_t>(slotValue, serializedSlotValue->value, context, result) ||
+                LoadAny<int64_t>(slotValue, serializedSlotValue->value, context, result) ||
                 LoadAny<uint64_t>(slotValue, serializedSlotValue->value, context, result) ||
                 LoadAny<float>(slotValue, serializedSlotValue->value, context, result) ||
                 LoadAny<double>(slotValue, serializedSlotValue->value, context, result) ||
@@ -372,9 +374,11 @@ namespace GraphModel
             {
                 rapidjson::Value outputPropertyValue;
                 if (StoreAny<bool>(slot->m_value, outputPropertyValue, context, result) ||
+                    StoreAny<int16_t>(slot->m_value, outputPropertyValue, context, result) ||
+                    StoreAny<uint16_t>(slot->m_value, outputPropertyValue, context, result) ||
                     StoreAny<int32_t>(slot->m_value, outputPropertyValue, context, result) ||
-                    StoreAny<int64_t>(slot->m_value, outputPropertyValue, context, result) ||
                     StoreAny<uint32_t>(slot->m_value, outputPropertyValue, context, result) ||
+                    StoreAny<int64_t>(slot->m_value, outputPropertyValue, context, result) ||
                     StoreAny<uint64_t>(slot->m_value, outputPropertyValue, context, result) ||
                     StoreAny<float>(slot->m_value, outputPropertyValue, context, result) ||
                     StoreAny<double>(slot->m_value, outputPropertyValue, context, result) ||

--- a/Gems/GraphModel/Code/Source/Model/Slot.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Slot.cpp
@@ -316,12 +316,17 @@ namespace GraphModel
         {
             AZStd::any slotValue;
             if (LoadAny<bool>(slotValue, serializedSlotValue->value, context, result) ||
-                LoadAny<int>(slotValue, serializedSlotValue->value, context, result) ||
+                LoadAny<int32_t>(slotValue, serializedSlotValue->value, context, result) ||
+                LoadAny<int64_t>(slotValue, serializedSlotValue->value, context, result) ||
+                LoadAny<uint32_t>(slotValue, serializedSlotValue->value, context, result) ||
+                LoadAny<uint64_t>(slotValue, serializedSlotValue->value, context, result) ||
                 LoadAny<float>(slotValue, serializedSlotValue->value, context, result) ||
+                LoadAny<double>(slotValue, serializedSlotValue->value, context, result) ||
                 LoadAny<AZStd::string>(slotValue, serializedSlotValue->value, context, result) ||
                 LoadAny<AZ::Vector2>(slotValue, serializedSlotValue->value, context, result) ||
                 LoadAny<AZ::Vector3>(slotValue, serializedSlotValue->value, context, result) ||
                 LoadAny<AZ::Vector4>(slotValue, serializedSlotValue->value, context, result) ||
+                LoadAny<AZ::Color>(slotValue, serializedSlotValue->value, context, result) ||
                 LoadAny<AZ::EntityId>(slotValue, serializedSlotValue->value, context, result))
             {
                 slot->m_value = slotValue;
@@ -367,12 +372,17 @@ namespace GraphModel
             {
                 rapidjson::Value outputPropertyValue;
                 if (StoreAny<bool>(slot->m_value, outputPropertyValue, context, result) ||
-                    StoreAny<int>(slot->m_value, outputPropertyValue, context, result) ||
+                    StoreAny<int32_t>(slot->m_value, outputPropertyValue, context, result) ||
+                    StoreAny<int64_t>(slot->m_value, outputPropertyValue, context, result) ||
+                    StoreAny<uint32_t>(slot->m_value, outputPropertyValue, context, result) ||
+                    StoreAny<uint64_t>(slot->m_value, outputPropertyValue, context, result) ||
                     StoreAny<float>(slot->m_value, outputPropertyValue, context, result) ||
+                    StoreAny<double>(slot->m_value, outputPropertyValue, context, result) ||
                     StoreAny<AZStd::string>(slot->m_value, outputPropertyValue, context, result) ||
                     StoreAny<AZ::Vector2>(slot->m_value, outputPropertyValue, context, result) ||
                     StoreAny<AZ::Vector3>(slot->m_value, outputPropertyValue, context, result) ||
                     StoreAny<AZ::Vector4>(slot->m_value, outputPropertyValue, context, result) ||
+                    StoreAny<AZ::Color>(slot->m_value, outputPropertyValue, context, result) ||
                     StoreAny<AZ::EntityId>(slot->m_value, outputPropertyValue, context, result))
                 {
                     outputValue.AddMember("m_value", outputPropertyValue, context.GetJsonAllocator());


### PR DESCRIPTION
Adding basic math and numeric types, needed by material canvas, to graph model slot serializer.
This does not include advanced types like assets and other things that will be needed in the near future.
Eventually this should be pluggable so that new types can be added or natively supported by the serializer.

Only modifies Gems/GraphModel/Code/Source/Model/Slot.cpp
The rest is from https://github.com/o3de/o3de/pull/8998

Signed-off-by: Guthrie Adams <guthadam@amazon.com>