### PR TITLE
Remove the cached access token and id token to address security concerns

### DIFF
--- a/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationProviderBus.h
+++ b/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationProviderBus.h
@@ -29,8 +29,10 @@ namespace AWSClientAuth
         //! @return bool True if valid access token available, else False
         virtual bool IsSignedIn(const ProviderNameEnum& providerName) = 0;
 
-        //! [Deprecated] Get cached tokens from last last successful sign-in for the provider.
-        //! The returned access tokens will only include the refresh token.
+        //! [Deprecated] Get cached tokens from last successful sign-in for the provider.
+        //! Note that the returned authentication tokens object will only include the refresh token.
+        //! Your can get all the authentication tokens (access token, ID token and refresh token) by
+        //! implementing custom handlers to the AuthenticationProviderNotifications in your project code.
         //! @param providerName Provider to get authentication tokens.
         //! @return AuthenticationTokens tokens from successful authentication.
         virtual AuthenticationTokens GetAuthenticationTokens(const ProviderNameEnum& providerName) = 0;

--- a/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationProviderBus.h
+++ b/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationProviderBus.h
@@ -30,10 +30,9 @@ namespace AWSClientAuth
         virtual bool IsSignedIn(const ProviderNameEnum& providerName) = 0;
 
         //! [Deprecated] Get cached tokens from last successful sign-in for the provider.
-        //! Note that the access token and ID token are not cached by the authentication provider any more
-        //! to address the security concern and the returned authentication tokens object will only include the refresh token.
-        //! Your can get all the authentication tokens (access token, ID token and refresh token) by
-        //! implementing custom handlers to the AuthenticationProviderNotifications in your project code.
+        //! To enhance security, only the refresh token is cached and will be returned by this function.
+        //! If you need the access or ID tokens, all authentication tokens (access token, ID token and refresh token)
+        //! can be retrieved by implementing custom handlers for AuthenticationProviderNotifications in your project code.
         //! @param providerName Provider to get authentication tokens.
         //! @return AuthenticationTokens tokens from successful authentication.
         virtual AuthenticationTokens GetAuthenticationTokens(const ProviderNameEnum& providerName) = 0;

--- a/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationProviderBus.h
+++ b/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationProviderBus.h
@@ -29,7 +29,8 @@ namespace AWSClientAuth
         //! @return bool True if valid access token available, else False
         virtual bool IsSignedIn(const ProviderNameEnum& providerName) = 0;
 
-        //! Get cached tokens from last last successful sign-in for the provider.
+        //! [Deprecated] Get cached tokens from last last successful sign-in for the provider.
+        //! The returned access tokens will only include the refresh token.
         //! @param providerName Provider to get authentication tokens.
         //! @return AuthenticationTokens tokens from successful authentication.
         virtual AuthenticationTokens GetAuthenticationTokens(const ProviderNameEnum& providerName) = 0;

--- a/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationProviderBus.h
+++ b/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationProviderBus.h
@@ -30,7 +30,8 @@ namespace AWSClientAuth
         virtual bool IsSignedIn(const ProviderNameEnum& providerName) = 0;
 
         //! [Deprecated] Get cached tokens from last successful sign-in for the provider.
-        //! Note that the returned authentication tokens object will only include the refresh token.
+        //! Note that the access token and ID token are not cached by the authentication provider any more
+        //! to address the security concern and the returned authentication tokens object will only include the refresh token.
         //! Your can get all the authentication tokens (access token, ID token and refresh token) by
         //! implementing custom handlers to the AuthenticationProviderNotifications in your project code.
         //! @param providerName Provider to get authentication tokens.

--- a/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationTokens.h
+++ b/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationTokens.h
@@ -24,7 +24,7 @@ namespace AWSClientAuth
         AZ_TYPE_INFO(AuthenticationTokens, "{F965D1B2-9DE3-4900-B44B-E58D9F083ACB}");
         AuthenticationTokens();
         AuthenticationTokens(const AuthenticationTokens& other);
-        AuthenticationTokens(const AZStd::string& accessToken, const AZStd::string& refreshToken, const AZStd::string& openidToken
+        AuthenticationTokens(const AZStd::string& accessToken, const AZStd::string& refreshToken, const AZStd::string& openIdToken
             , const ProviderNameEnum& providerName, int tokensExpireTimeSeconds);
 
         //! Compares current time stamp to expired time stamp.

--- a/Gems/AWSClientAuth/Code/Include/Authorization/ClientAuthAWSCredentials.h
+++ b/Gems/AWSClientAuth/Code/Include/Authorization/ClientAuthAWSCredentials.h
@@ -34,10 +34,10 @@ namespace AWSClientAuth
         }
 
         ClientAuthAWSCredentials(const AZStd::string& accessKeyId, const AZStd::string& secretKey, const AZStd::string& sessionToken)
+            : m_accessKeyId(accessKeyId)
+            , m_secretKey(secretKey)
+            , m_sessionToken(sessionToken)
         {
-            m_accessKeyId = accessKeyId;
-            m_secretKey = secretKey;
-            m_sessionToken = sessionToken;
         }
 
         //! Gets the access key

--- a/Gems/AWSClientAuth/Code/Source/Authentication/AWSCognitoAuthenticationProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authentication/AWSCognitoAuthenticationProvider.cpp
@@ -51,8 +51,11 @@ namespace AWSClientAuth
                 {
                     Aws::CognitoIdentityProvider::Model::AuthenticationResultType authenticationResult = initiateAuthResult.GetAuthenticationResult();
                     UpdateTokens(authenticationResult);
-                    AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnPasswordGrantSingleFactorSignInSuccess
-                        , m_authenticationTokens);
+
+                    AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnPasswordGrantSingleFactorSignInSuccess,
+                        AuthenticationTokens(authenticationResult.GetAccessToken().c_str(),
+                            authenticationResult.GetRefreshToken().c_str(), authenticationResult.GetIdToken().c_str(),
+                            ProviderNameEnum::AWSCognitoIDP, authenticationResult.GetExpiresIn()));
                 }
                 else
                 {
@@ -126,8 +129,11 @@ namespace AWSClientAuth
                 {
                     Aws::CognitoIdentityProvider::Model::AuthenticationResultType authenticationResult = respondToAuthChallengeResult.GetAuthenticationResult();
                     UpdateTokens(authenticationResult);
-                    AuthenticationProviderNotificationBus::Broadcast(
-                        &AuthenticationProviderNotifications::OnPasswordGrantMultiFactorConfirmSignInSuccess, m_authenticationTokens);
+
+                    AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnPasswordGrantMultiFactorConfirmSignInSuccess,
+                        AuthenticationTokens(authenticationResult.GetAccessToken().c_str(),
+                            authenticationResult.GetRefreshToken().c_str(), authenticationResult.GetIdToken().c_str(),
+                            ProviderNameEnum::AWSCognitoIDP, authenticationResult.GetExpiresIn()));
                 }
             }
             else
@@ -179,7 +185,11 @@ namespace AWSClientAuth
                 {
                     Aws::CognitoIdentityProvider::Model::AuthenticationResultType authenticationResult = initiateAuthResult.GetAuthenticationResult();
                     UpdateTokens(authenticationResult);
-                    AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnRefreshTokensSuccess, m_authenticationTokens);
+
+                    AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnRefreshTokensSuccess,
+                        AuthenticationTokens(authenticationResult.GetAccessToken().c_str(),
+                            authenticationResult.GetRefreshToken().c_str(), authenticationResult.GetIdToken().c_str(),
+                            ProviderNameEnum::AWSCognitoIDP, authenticationResult.GetExpiresIn()));
                 }
                 else
                 {
@@ -231,8 +241,8 @@ namespace AWSClientAuth
 
     void AWSCognitoAuthenticationProvider::UpdateTokens(const Aws::CognitoIdentityProvider::Model::AuthenticationResultType& authenticationResult)
     {
-        m_authenticationTokens = AuthenticationTokens(authenticationResult.GetAccessToken().c_str(), authenticationResult.GetRefreshToken().c_str(),
-            authenticationResult.GetIdToken().c_str(), ProviderNameEnum::AWSCognitoIDP,
+        m_authenticationTokens = AuthenticationTokens("", authenticationResult.GetRefreshToken().c_str(),
+            "", ProviderNameEnum::AWSCognitoIDP,
             authenticationResult.GetExpiresIn());
     }
 } // namespace AWSClientAuth

--- a/Gems/AWSClientAuth/Code/Source/Authentication/AWSCognitoAuthenticationProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authentication/AWSCognitoAuthenticationProvider.cpp
@@ -241,6 +241,8 @@ namespace AWSClientAuth
 
     void AWSCognitoAuthenticationProvider::UpdateTokens(const Aws::CognitoIdentityProvider::Model::AuthenticationResultType& authenticationResult)
     {
+        // Storing authentication tokens in memory can be a security concern. The access token and id token are not actually in use by
+        // the authentication provider and shouldn't be stored in the member variable.
         m_authenticationTokens = AuthenticationTokens("", authenticationResult.GetRefreshToken().c_str(),
             "", ProviderNameEnum::AWSCognitoIDP,
             authenticationResult.GetExpiresIn());

--- a/Gems/AWSClientAuth/Code/Source/Authentication/AuthenticationTokens.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authentication/AuthenticationTokens.cpp
@@ -19,24 +19,24 @@ namespace AWSClientAuth
     }
 
     AuthenticationTokens::AuthenticationTokens(const AuthenticationTokens& other)
+        : m_accessToken(other.m_accessToken)
+        , m_refreshToken(other.m_refreshToken)
+        , m_openIdToken(other.m_openIdToken)
+        , m_providerName(other.m_providerName)
+        , m_tokensExpireTimeSeconds(other.m_tokensExpireTimeSeconds)
+        , m_tokensExpireTimeStamp(other.m_tokensExpireTimeStamp)
     {
-        m_accessToken = other.m_accessToken;
-        m_refreshToken = other.m_refreshToken;
-        m_openIdToken = other.m_openIdToken;
-        m_providerName = other.m_providerName;
-        m_tokensExpireTimeSeconds = other.m_tokensExpireTimeSeconds;
-        m_tokensExpireTimeStamp = other.m_tokensExpireTimeStamp;
     }
 
     AuthenticationTokens::AuthenticationTokens(
-        const AZStd::string& accessToken, const AZStd::string& refreshToken, const AZStd::string& openidToken, const ProviderNameEnum& providerName, int tokensExpireTimeSeconds)
+        const AZStd::string& accessToken, const AZStd::string& refreshToken, const AZStd::string& openIdToken, const ProviderNameEnum& providerName, int tokensExpireTimeSeconds)
+        : m_accessToken(accessToken)
+        , m_refreshToken(refreshToken)
+        , m_openIdToken(openIdToken)
+        , m_providerName(providerName)
+        , m_tokensExpireTimeSeconds(tokensExpireTimeSeconds)
+        , m_tokensExpireTimeStamp(AZStd::chrono::system_clock::now() + AZStd::chrono::seconds(tokensExpireTimeSeconds))
     {
-        m_accessToken = accessToken;
-        m_refreshToken = refreshToken;
-        m_openIdToken = openidToken;
-        m_providerName = providerName;
-        m_tokensExpireTimeSeconds = tokensExpireTimeSeconds;
-        m_tokensExpireTimeStamp =  AZStd::chrono::system_clock::now() + AZStd::chrono::seconds(tokensExpireTimeSeconds);
     }
 
     //! Compares current time stamp to expired time stamp.

--- a/Gems/AWSClientAuth/Code/Source/Authentication/GoogleAuthenticationProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authentication/GoogleAuthenticationProvider.cpp
@@ -174,6 +174,8 @@ namespace AWSClientAuth
 
     void GoogleAuthenticationProvider::UpdateTokens(const Aws::Utils::Json::JsonView& jsonView)
     {
+        // Storing authentication tokens in memory can be a security concern. The access token and id token are not actually in use by
+        // the authentication provider and shouldn't be stored in the member variable.
         m_authenticationTokens = AuthenticationTokens("",
             jsonView.GetString(OAuthRefreshTokenResponseKey).c_str() ,"", ProviderNameEnum::Google
             , jsonView.GetInteger(OAuthExpiresInResponseKey));

--- a/Gems/AWSClientAuth/Code/Source/Authentication/GoogleAuthenticationProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authentication/GoogleAuthenticationProvider.cpp
@@ -122,8 +122,12 @@ namespace AWSClientAuth
                 if (responseCode == Aws::Http::HttpResponseCode::OK)
                 {
                     UpdateTokens(jsonView);
+
                     AuthenticationProviderNotificationBus::Broadcast(
-                        &AuthenticationProviderNotifications::OnDeviceCodeGrantConfirmSignInSuccess, m_authenticationTokens);
+                        &AuthenticationProviderNotifications::OnDeviceCodeGrantConfirmSignInSuccess,
+                        AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
+                            jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(), jsonView.GetString(OAuthIdTokenResponseKey).c_str(),
+                            ProviderNameEnum::Google, jsonView.GetInteger(OAuthExpiresInResponseKey)));
                 }
                 else
                 {
@@ -153,8 +157,11 @@ namespace AWSClientAuth
             if (responseCode == Aws::Http::HttpResponseCode::OK)
             {
                 UpdateTokens(jsonView);
-                AuthenticationProviderNotificationBus::Broadcast(
-                    &AuthenticationProviderNotifications::OnRefreshTokensSuccess, m_authenticationTokens);
+
+                AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnRefreshTokensSuccess,
+                    AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
+                        jsonView.GetString(OAuthRefreshTokenResponseKey).c_str() ,jsonView.GetString(OAuthIdTokenResponseKey).c_str(),
+                        ProviderNameEnum::Google, jsonView.GetInteger(OAuthExpiresInResponseKey)));
             }
             else
             {
@@ -167,8 +174,8 @@ namespace AWSClientAuth
 
     void GoogleAuthenticationProvider::UpdateTokens(const Aws::Utils::Json::JsonView& jsonView)
     {
-        m_authenticationTokens = AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
-            jsonView.GetString(OAuthRefreshTokenResponseKey).c_str() ,jsonView.GetString(OAuthIdTokenResponseKey).c_str(), ProviderNameEnum::Google
+        m_authenticationTokens = AuthenticationTokens("",
+            jsonView.GetString(OAuthRefreshTokenResponseKey).c_str() ,"", ProviderNameEnum::Google
             , jsonView.GetInteger(OAuthExpiresInResponseKey));
     }
 

--- a/Gems/AWSClientAuth/Code/Source/Authentication/LWAAuthenticationProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authentication/LWAAuthenticationProvider.cpp
@@ -174,7 +174,8 @@ namespace AWSClientAuth
 
     void LWAAuthenticationProvider::UpdateTokens(const Aws::Utils::Json::JsonView& jsonView)
     {
-        // For Login with Amazon openId and access tokens are the same.
+        // Storing authentication tokens in memory can be a security concern. The access token and id token are not actually in use by
+        // the authentication provider and shouldn't be stored in the member variable.
         m_authenticationTokens = AuthenticationTokens("", jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(),
             "", ProviderNameEnum::LoginWithAmazon
             , jsonView.GetInteger(OAuthExpiresInResponseKey));

--- a/Gems/AWSClientAuth/Code/Source/Authentication/LWAAuthenticationProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authentication/LWAAuthenticationProvider.cpp
@@ -125,7 +125,7 @@ namespace AWSClientAuth
 
                     AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnDeviceCodeGrantConfirmSignInSuccess,
                         AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
-                            jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(), jsonView.GetString(OAuthIdTokenResponseKey).c_str(),
+                            jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(), jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
                             ProviderNameEnum::LoginWithAmazon, jsonView.GetInteger(OAuthExpiresInResponseKey)));
                     m_cachedUserCode = "";
                     m_cachedDeviceCode = "";
@@ -160,7 +160,7 @@ namespace AWSClientAuth
 
                 AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnRefreshTokensSuccess,
                     AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
-                        jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(), jsonView.GetString(OAuthIdTokenResponseKey).c_str(),
+                        jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(), jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
                         ProviderNameEnum::LoginWithAmazon, jsonView.GetInteger(OAuthExpiresInResponseKey)));
             }
             else

--- a/Gems/AWSClientAuth/Code/Source/Authentication/LWAAuthenticationProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authentication/LWAAuthenticationProvider.cpp
@@ -122,8 +122,11 @@ namespace AWSClientAuth
                 {
                     // Id and access token are the same.
                     UpdateTokens(jsonView);
-                    AuthenticationProviderNotificationBus::Broadcast(
-                        &AuthenticationProviderNotifications::OnDeviceCodeGrantConfirmSignInSuccess, m_authenticationTokens);
+
+                    AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnDeviceCodeGrantConfirmSignInSuccess,
+                        AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
+                            jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(), jsonView.GetString(OAuthIdTokenResponseKey).c_str(),
+                            ProviderNameEnum::LoginWithAmazon, jsonView.GetInteger(OAuthExpiresInResponseKey)));
                     m_cachedUserCode = "";
                     m_cachedDeviceCode = "";
                 }
@@ -154,7 +157,11 @@ namespace AWSClientAuth
             {
                 // Id and access token are the same.
                 UpdateTokens(jsonView);
-                AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnRefreshTokensSuccess, m_authenticationTokens);
+
+                AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnRefreshTokensSuccess,
+                    AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
+                        jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(), jsonView.GetString(OAuthIdTokenResponseKey).c_str(),
+                        ProviderNameEnum::LoginWithAmazon, jsonView.GetInteger(OAuthExpiresInResponseKey)));
             }
             else
             {
@@ -168,8 +175,8 @@ namespace AWSClientAuth
     void LWAAuthenticationProvider::UpdateTokens(const Aws::Utils::Json::JsonView& jsonView)
     {
         // For Login with Amazon openId and access tokens are the same.
-        m_authenticationTokens = AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(), jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(),
-            jsonView.GetString(OAuthAccessTokenResponseKey).c_str(), ProviderNameEnum::LoginWithAmazon
+        m_authenticationTokens = AuthenticationTokens("", jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(),
+            "", ProviderNameEnum::LoginWithAmazon
             , jsonView.GetInteger(OAuthExpiresInResponseKey));
     }
 

--- a/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
+++ b/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
@@ -191,10 +191,10 @@ namespace AWSClientAuthUnitTest
             jsonValue.WithString("user_code", "TestCode");
             jsonValue.WithString("device_code", "TestDeviceCode");
             jsonValue.WithString("verification_uri", "TestVerificationURI");
-            jsonValue.WithString("access_token", "TestAccessToken");
-            jsonValue.WithString("refresh_token", "TestRefreshToken");
-            jsonValue.WithString("id_token", "TestIdToken");
-            jsonValue.WithString("expires_in", "600");
+            jsonValue.WithString("access_token", TEST_ACCESS_TOKEN);
+            jsonValue.WithString("refresh_token", TEST_REFRESH_TOKEN);
+            jsonValue.WithString("id_token", TEST_ID_TOKEN);
+            jsonValue.WithInteger("expires_in", 600);
             Aws::Utils::Json::JsonView jsonView(jsonValue);
             Aws::Http::HttpResponseCode code = Aws::Http::HttpResponseCode::OK;
             callback(jsonView, code);
@@ -395,6 +395,11 @@ namespace AWSClientAuthUnitTest
     public:
         AuthenticationProviderNotificationsBusMock()
         {
+            ON_CALL(*this, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).WillByDefault(testing::Invoke(this, &AuthenticationProviderNotificationsBusMock::AssertAuthenticationTokensPopulated));
+            ON_CALL(*this, OnPasswordGrantMultiFactorConfirmSignInSuccess(testing::_)).WillByDefault(testing::Invoke(this, &AuthenticationProviderNotificationsBusMock::AssertAuthenticationTokensPopulated));
+            ON_CALL(*this, OnDeviceCodeGrantConfirmSignInSuccess(testing::_)).WillByDefault(testing::Invoke(this, &AuthenticationProviderNotificationsBusMock::AssertAuthenticationTokensPopulated));
+            ON_CALL(*this, OnRefreshTokensSuccess(testing::_)).WillByDefault(testing::Invoke(this, &AuthenticationProviderNotificationsBusMock::AssertAuthenticationTokensPopulated));
+
             AWSClientAuth::AuthenticationProviderNotificationBus::Handler::BusConnect();
         }
 
@@ -416,6 +421,24 @@ namespace AWSClientAuthUnitTest
         MOCK_METHOD1(OnRefreshTokensSuccess, void(const AWSClientAuth::AuthenticationTokens& authenticationToken));
         MOCK_METHOD1(OnRefreshTokensFail, void(const AZStd::string& error));
         MOCK_METHOD1(OnSignOut, void(const AWSClientAuth::ProviderNameEnum& providerName));
+
+    private:
+        void AssertAuthenticationTokensPopulated(const AWSClientAuth::AuthenticationTokens& authenticationToken)
+        {
+            AZ_Assert(
+                authenticationToken.GetAccessToken() == TEST_ACCESS_TOKEN,
+                "Access token expected to match");
+            AZ_Assert(
+                authenticationToken.GetOpenIdToken() == TEST_ID_TOKEN,
+                "Id token expected to match");
+            AZ_Assert(
+                authenticationToken.GetRefreshToken() == TEST_REFRESH_TOKEN,
+                "Refresh token expected match");
+            AZ_Assert(
+                authenticationToken.GetTokensExpireTimeSeconds() != 0,
+                "Access token expiry expected to be set");
+            AZ_Assert(authenticationToken.AreTokensValid(), "Tokens expected to be valid");
+        }
     };
 
     class AWSCognitoAuthorizationNotificationsBusMock

--- a/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
+++ b/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
@@ -430,7 +430,7 @@ namespace AWSClientAuthUnitTest
                 "Access token expected to match");
             AZ_Assert(
                 authenticationToken.GetProviderName() == AWSClientAuth::ProviderNameEnum::LoginWithAmazon ?
-                authenticationToken.GetOpenIdToken() == TEST_ACCESS_TOKEN : authenticationToken.GetOpenIdToken() == TEST_ID_TOKEN,
+                    authenticationToken.GetOpenIdToken() == TEST_ACCESS_TOKEN : authenticationToken.GetOpenIdToken() == TEST_ID_TOKEN,
                 "Id token expected to match");
             AZ_Assert(
                 authenticationToken.GetRefreshToken() == TEST_REFRESH_TOKEN,

--- a/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
+++ b/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
@@ -423,13 +423,14 @@ namespace AWSClientAuthUnitTest
         MOCK_METHOD1(OnSignOut, void(const AWSClientAuth::ProviderNameEnum& providerName));
 
     private:
-        void AssertAuthenticationTokensPopulated(const AWSClientAuth::AuthenticationTokens& authenticationToken)
+        void AssertAuthenticationTokensPopulated([[maybe_unused]] const AWSClientAuth::AuthenticationTokens& authenticationToken)
         {
             AZ_Assert(
                 authenticationToken.GetAccessToken() == TEST_ACCESS_TOKEN,
                 "Access token expected to match");
             AZ_Assert(
-                authenticationToken.GetOpenIdToken() == TEST_ID_TOKEN,
+                authenticationToken.GetProviderName() == AWSClientAuth::ProviderNameEnum::LoginWithAmazon ?
+                authenticationToken.GetOpenIdToken() == TEST_ACCESS_TOKEN : authenticationToken.GetOpenIdToken() == TEST_ID_TOKEN,
                 "Id token expected to match");
             AZ_Assert(
                 authenticationToken.GetRefreshToken() == TEST_REFRESH_TOKEN,

--- a/Gems/AWSClientAuth/Code/Tests/Authentication/AWSCognitoAuthenticationProviderTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/Authentication/AWSCognitoAuthenticationProviderTest.cpp
@@ -64,12 +64,12 @@ public:
     {
         AZ_Assert(
         m_cognitoAuthenticationProviderMock.GetAuthenticationTokens().GetAccessToken() ==
-            AWSClientAuthUnitTest::TEST_ACCESS_TOKEN,
-        "Access token expected to match");
+                "",
+            "Access token expected to be empty");
         AZ_Assert(
             m_cognitoAuthenticationProviderMock.GetAuthenticationTokens().GetOpenIdToken() ==
-                AWSClientAuthUnitTest::TEST_ID_TOKEN,
-            "Id token expected to match");
+                "",
+            "Id token expected to be empty");
         AZ_Assert(
             m_cognitoAuthenticationProviderMock.GetAuthenticationTokens().GetRefreshToken() ==
                 AWSClientAuthUnitTest::TEST_REFRESH_TOKEN,

--- a/Gems/AWSClientAuth/Code/Tests/Authentication/AuthenticationProviderManagerScriptCanvasBusTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/Authentication/AuthenticationProviderManagerScriptCanvasBusTest.cpp
@@ -178,7 +178,7 @@ TEST_F(AuthenticationProviderManagerScriptCanvasTest, GetTokensWithRefreshAsync_
     testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>* cognitoProviderMock = (testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>*)m_mockController->m_authenticationProvidersMap[AWSClientAuth::ProviderNameEnum::AWSCognitoIDP].get();
 
      AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 600);
     EXPECT_CALL(*cognitoProviderMock, GetAuthenticationTokens()).Times(1).WillOnce(testing::Return(tokens));
     EXPECT_CALL(*cognitoProviderMock, RefreshTokensAsync()).Times(0);
@@ -215,7 +215,7 @@ TEST_F(AuthenticationProviderManagerScriptCanvasTest, GetTokens_Success)
     testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>* cognitoProviderMock = (testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>*)m_mockController->m_authenticationProvidersMap[AWSClientAuth::ProviderNameEnum::AWSCognitoIDP].get();
 
      AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
     EXPECT_CALL(*cognitoProviderMock, GetAuthenticationTokens()).Times(1).WillOnce(testing::Return(tokens));
@@ -230,7 +230,7 @@ TEST_F(AuthenticationProviderManagerScriptCanvasTest, IsSignedIn_Success)
     testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>* cognitoProviderMock = (testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>*)m_mockController->m_authenticationProvidersMap[AWSClientAuth::ProviderNameEnum::AWSCognitoIDP].get();
 
      AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
     EXPECT_CALL(*cognitoProviderMock, GetAuthenticationTokens()).Times(1).WillOnce(testing::Return(tokens));
     m_mockController->IsSignedIn(AWSClientAuth::ProvideNameEnumStringAWSCognitoIDP);

--- a/Gems/AWSClientAuth/Code/Tests/Authentication/AuthenticationProviderManagerTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/Authentication/AuthenticationProviderManagerTest.cpp
@@ -177,7 +177,7 @@ TEST_F(AuthenticationProviderManagerTest, GetTokensWithRefreshAsync_ValidToken_S
     testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>* cognitoProviderMock = (testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>*)m_mockController->m_authenticationProvidersMap[AWSClientAuth::ProviderNameEnum::AWSCognitoIDP].get();
 
      AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 600);
     EXPECT_CALL(*cognitoProviderMock, GetAuthenticationTokens()).Times(1).WillOnce(testing::Return(tokens));
     EXPECT_CALL(*cognitoProviderMock, RefreshTokensAsync()).Times(0);
@@ -214,7 +214,7 @@ TEST_F(AuthenticationProviderManagerTest, GetTokens_Success)
     testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>* cognitoProviderMock = (testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>*)m_mockController->m_authenticationProvidersMap[AWSClientAuth::ProviderNameEnum::AWSCognitoIDP].get();
 
      AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
     EXPECT_CALL(*cognitoProviderMock, GetAuthenticationTokens()).Times(1).WillOnce(testing::Return(tokens));
@@ -229,7 +229,7 @@ TEST_F(AuthenticationProviderManagerTest, IsSignedIn_Success)
     testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>* cognitoProviderMock = (testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>*)m_mockController->m_authenticationProvidersMap[AWSClientAuth::ProviderNameEnum::AWSCognitoIDP].get();
 
      AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
     EXPECT_CALL(*cognitoProviderMock, GetAuthenticationTokens()).Times(1).WillOnce(testing::Return(tokens));
     m_mockController->IsSignedIn(AWSClientAuth::ProviderNameEnum::AWSCognitoIDP);

--- a/Gems/AWSClientAuth/Code/Tests/Authorization/AWSCognitoAuthorizationControllerTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/Authorization/AWSCognitoAuthorizationControllerTest.cpp
@@ -73,7 +73,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, Initialize_Success_GetAWSAccountEm
 TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_WithLogins_Success)
 {
     AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);
@@ -81,7 +81,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_WithLogins_S
         &AWSClientAuth::AuthenticationProviderNotifications::OnPasswordGrantSingleFactorSignInSuccess, tokens);
 
     AWSClientAuth::AuthenticationTokens tokens1(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::Google, 60);
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnDeviceCodeGrantConfirmSignInSuccess(testing::_)).Times(1);
     AWSClientAuth::AuthenticationProviderNotificationBus::Broadcast(
@@ -132,7 +132,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, MultipleCalls_UsesCacheCredentials
 TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_Fail_GetIdError) // fail
 {
     AWSClientAuth::AuthenticationTokens cognitoTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
     
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);
@@ -156,14 +156,14 @@ TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_Fail_GetIdEr
 TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_Fail_GetCredentialsForIdentityError)
 {
     AWSClientAuth::AuthenticationTokens cognitoTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);
     AWSClientAuth::AuthenticationProviderNotificationBus::Broadcast(
         &AWSClientAuth::AuthenticationProviderNotifications::OnPasswordGrantSingleFactorSignInSuccess, cognitoTokens);
 
     AWSClientAuth::AuthenticationTokens googleTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::Google, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnDeviceCodeGrantConfirmSignInSuccess(testing::_)).Times(1);
@@ -192,7 +192,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_Fail_GetCred
 TEST_F(AWSCognitoAuthorizationControllerTest, AddRemoveLogins_Succuess)
 {
     AWSClientAuth::AuthenticationTokens cognitoTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);
@@ -210,7 +210,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, AddRemoveLogins_Succuess)
     ASSERT_TRUE(m_mockController->m_persistentCognitoIdentityProvider->GetLogins().size() == 1);
 
     AWSClientAuth::AuthenticationTokens googleTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::Google, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnDeviceCodeGrantConfirmSignInSuccess(testing::_)).Times(1);
@@ -236,7 +236,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, AddRemoveLogins_Succuess)
     ASSERT_TRUE(m_mockController->m_persistentCognitoIdentityProvider->GetLogins().size() == 0);
 
     AWSClientAuth::AuthenticationTokens lwaTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::LoginWithAmazon, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantMultiFactorConfirmSignInSuccess(testing::_)).Times(1);
@@ -254,7 +254,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, AddRemoveLogins_Succuess)
 TEST_F(AWSCognitoAuthorizationControllerTest, ResetAuthenticated_ClearsCachedLoginsAndIdentityId_Success)
 {
     AWSClientAuth::AuthenticationTokens cognitoTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);
@@ -308,7 +308,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, ResetAnonymous_ClearsCachedLoginsA
 TEST_F(AWSCognitoAuthorizationControllerTest, GetCredentialsProvider_ForPersistedLogins_ResultIsAuthenticatedCredentials)
 {
     AWSClientAuth::AuthenticationTokens cognitoTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);
@@ -361,7 +361,7 @@ TEST_F(
 
     testThreads.emplace_back(AZStd::thread([&]() {
         AWSClientAuth::AuthenticationTokens cognitoTokens(
-            AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+            AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
             AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
         EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);

--- a/Gems/AWSClientAuth/Code/Tests/Authorization/AWSCognitoAuthorizationControllerTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/Authorization/AWSCognitoAuthorizationControllerTest.cpp
@@ -236,7 +236,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, AddRemoveLogins_Succuess)
     ASSERT_TRUE(m_mockController->m_persistentCognitoIdentityProvider->GetLogins().size() == 0);
 
     AWSClientAuth::AuthenticationTokens lwaTokens(
-        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ACCESS_TOKEN,
         AWSClientAuth::ProviderNameEnum::LoginWithAmazon, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantMultiFactorConfirmSignInSuccess(testing::_)).Times(1);


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

Removed the cached access token and ID token in the authentication providers to address security concerns around credentials in memory. Tokens will be sent out via the notification bus and the Client Auth gem won't store the access token and ID token for retrieval any more (The GetAuthenticationTokens API should be deprecated).  

Passed Client Auth gem unit tests and end-to-end tests (Python). Also verified the Google Signin and Login with Amazon (LWA) workflow.