### PR TITLE
Graph Model: Move graph context implementation into base class

### DIFF
--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/EditorMainWindow.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/EditorMainWindow.h
@@ -34,7 +34,7 @@ namespace GraphModelIntegration
     protected:
         /// Subclasses must implement this method so that this class can
         /// create graphs on their behalf.
-        virtual GraphModel::IGraphContextPtr GetGraphContext() const = 0;
+        virtual GraphModel::GraphContextPtr GetGraphContext() const = 0;
 
         /// Helper method for retrieving the graph associated with a graphId.
         GraphModel::GraphPtr GetGraphById(GraphCanvas::GraphId graphId) const;

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/Common.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/Common.h
@@ -33,9 +33,9 @@ namespace GraphModel
     using DataTypePtr = AZStd::shared_ptr<const DataType>; //!< All pointers are const since this data is immutable anyway
     using DataTypeList = AZStd::vector<DataTypePtr>;
 
-    class IGraphContext;
-    using IGraphContextPtr = AZStd::shared_ptr<IGraphContext>;
-    using ConstIGraphContextPtr = AZStd::shared_ptr<const IGraphContext>;
+    class GraphContext;
+    using GraphContextPtr = AZStd::shared_ptr<GraphContext>;
+    using ConstGraphContextPtr = AZStd::shared_ptr<const GraphContext>;
 
     class Graph;
     using GraphPtr = AZStd::shared_ptr<Graph>;

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/DataType.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/DataType.h
@@ -42,7 +42,7 @@ namespace GraphModel
         DataType();
 
         //! Constructs a new DataType object.
-        //! @param typeEnum - The main unique ID used by the GraphModel framework for this DataType object.Every DataType in the IGraphContext must have a unique enum value.
+        //! @param typeEnum - The main unique ID used by the GraphModel framework for this DataType object.Every DataType in the GraphContext must have a unique enum value.
         //! @param typeUuid - An alternate unique ID that is used by the node graph UI system. (This is not necessarily the same thing as an RTTI TypeId.The only requirement is that it maps 1:1 with the typeEnum).
         //! @param defaultValue - The default value assigned to any slot that uses this data type upon creation.
         //! @param typeDisplayName - Used for tooltips or other UI elements as well as debug messages.This should be unique, and similar to typeEnum.

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/Graph.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/Graph.h
@@ -76,7 +76,7 @@ namespace GraphModel
 
         //! Constructor
         //! \param  graphContext  interface to client system specific data and functionality
-        explicit Graph(IGraphContextPtr graphContext);
+        explicit Graph(GraphContextPtr graphContext);
 
         virtual ~Graph() = default;
 
@@ -86,7 +86,7 @@ namespace GraphModel
         //! and perform any other precedural setup that isn't stored in the 
         //! serialized data.
         //! \param  graphContext  interface to client system specific data and functionality
-        void PostLoadSetup(IGraphContextPtr graphContext);
+        void PostLoadSetup(GraphContextPtr graphContext);
 
         //! Add a node that has been deserialized to the graph
         //! This should only be necessary for cases like copy/paste where we
@@ -94,7 +94,7 @@ namespace GraphModel
         NodeId PostLoadSetup(NodePtr node);
 
         //! Returns the interface to client system specific data and functionality
-        IGraphContextPtr GetContext() const;
+        GraphContextPtr GetContext() const;
 
         //! This name is used for debug messages in GraphModel classes, to provide appropriate context for the user.
         //! It's a convenience function for GetContext()->GetSystemName()
@@ -158,7 +158,7 @@ namespace GraphModel
         //! Used to store all of our node <-> wrapper node mappings
         NodeWrappingMap m_nodeWrappings;
 
-        IGraphContextPtr m_graphContext; //!< interface to client system specific data and functionality
+        GraphContextPtr m_graphContext; //!< interface to client system specific data and functionality
     };
 
 } // namespace GraphModel

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/GraphContext.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/GraphContext.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+// AZ
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/smart_ptr/enable_shared_from_this.h>
+#include <AzCore/std/string/string.h>
+
+// GraphModel
+#include <GraphModel/Model/DataType.h>
+
+namespace GraphModel
+{
+
+    //!!! Start in Graph.h for high level GraphModel documentation !!!
+
+    //! GraphContext provides access to client specific information and systems required by the graphmodel framework.
+    //! All supported data types used by graphs in the client system must be registered with the GraphContext.
+    //! All systems that use GraphModel must provide an instance of this, or a derived, class, passed to the main Graph object.
+    class GraphContext : public AZStd::enable_shared_from_this<GraphContext>
+    {
+    public:
+        using DataTypeList = AZStd::vector<DataTypePtr>;
+
+        GraphContext(const AZStd::string& systemName, const AZStd::string& moduleExtension, const DataTypeList& dataTypes);
+        virtual ~GraphContext() = default;
+
+        //! Returns the name of the system that is using the GraphModel framework, mostly for debug messages.
+        const char* GetSystemName() const;
+
+        //! Returns the file extension used for module files
+        const char* GetModuleFileExtension() const;
+
+        //! Returns a ModuleGraphManager to support creating ModuleNodes. Subclasses can just return nullptr if this isn't needed.
+        ModuleGraphManagerPtr GetModuleGraphManager() const;
+
+        //! Returns all available data types.
+        const DataTypeList& GetAllDataTypes() const;
+
+        //! Returns a DataType object representing the given TypeId, or Invalid if it doesn't exist.
+        DataTypePtr GetDataType(DataType::Enum typeEnum) const;
+
+        //! Returns a DataType object representing the given cpp or display name, or Invalid if it doesn't exist.
+        DataTypePtr GetDataType(const AZStd::string& name) const;
+
+        //! Returns a DataType object representing the given TypeId, or Invalid if it doesn't exist.
+        DataTypePtr GetDataType(AZ::Uuid typeId) const;
+
+        //! Utility function to returns a DataType object representing the given template type T, or Invalid if it doesn't exist.
+        template<typename T>
+        DataTypePtr GetDataType() const { return GetDataType(azrtti_typeid<T>()); }
+
+        //! Returns a DataType object representing the given AZStd::any value, or Invalid if it doesn't exist.
+        //! This data type method has a different name because if the GraphContext implementation doesn't override
+        //! this, there will be a compile error for a hidden function because of subclasses implementing
+        //! the templated version below
+        virtual DataTypePtr GetDataTypeForValue(const AZStd::any& value) const;
+
+    protected:
+        AZStd::string m_systemName;
+        AZStd::string m_moduleExtension;
+        DataTypeList m_dataTypes;
+        GraphModel::ModuleGraphManagerPtr m_moduleGraphManager;
+    };
+    
+} // namespace GraphModel
+
+
+
+

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/GraphContext.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/GraphContext.h
@@ -37,6 +37,10 @@ namespace GraphModel
         //! Returns the file extension used for module files
         const char* GetModuleFileExtension() const;
 
+        //! Creates the module graph manager used by all module nodes in this context.
+        //! This is done after construction because it is optional and the module graph manager needs a reference to the graph context
+        virtual void CreateModuleGraphManager();
+
         //! Returns a ModuleGraphManager to support creating ModuleNodes. Subclasses can just return nullptr if this isn't needed.
         ModuleGraphManagerPtr GetModuleGraphManager() const;
 

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/GraphElement.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/GraphElement.h
@@ -34,8 +34,8 @@ namespace GraphModel
         //! Returns the Graph that owns this GraphElement
         GraphPtr GetGraph() const;
 
-        //! Returns the IGraphContext for this GraphElement
-        IGraphContextPtr GetGraphContext() const;
+        //! Returns the GraphContext for this GraphElement
+        GraphContextPtr GetGraphContext() const;
 
     protected:
 

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/Module/ModuleGraphManager.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/Module/ModuleGraphManager.h
@@ -40,7 +40,7 @@ namespace GraphModel
         AZ_CLASS_ALLOCATOR(ModuleGraphManager, AZ::SystemAllocator, 0);
         AZ_RTTI(Graph, "{68476353-C672-4408-9B34-A409CC63858E}");
 
-        explicit ModuleGraphManager(IGraphContextPtr graphContext, AZ::SerializeContext* serializeContext = nullptr);
+        explicit ModuleGraphManager(GraphContextPtr graphContext, AZ::SerializeContext* serializeContext = nullptr);
         virtual ~ModuleGraphManager();
 
         //! Returns the Graph loaded from a module source file. If the file has already been loaded,
@@ -69,7 +69,7 @@ namespace GraphModel
         // We use a weak_ptr to allow the graphs to go out of scope and be deleted when not used
         using ModuleGraphMap = AZStd::unordered_map<AZ::Uuid /*Source File ID*/, AZStd::weak_ptr<const Graph>>;
 
-        AZStd::weak_ptr<IGraphContext> m_graphContext; //!< interface to client system specific data and functionality. Uses a weak_ptr so the IGraphContext can hold this ModuleGraphManager.
+        AZStd::weak_ptr<GraphContext> m_graphContext; //!< interface to client system specific data and functionality. Uses a weak_ptr so the GraphContext can hold this ModuleGraphManager.
         AZStd::string m_moduleFileExtension;
         AZ::SerializeContext* m_serializeContext;
         ModuleGraphMap m_graphs;

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/Slot.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/Slot.h
@@ -17,8 +17,8 @@
 
 // Graph Model
 #include <GraphModel/Model/Common.h>
+#include <GraphModel/Model/GraphContext.h>
 #include <GraphModel/Model/GraphElement.h>
-#include <GraphModel/Model/IGraphContext.h>
 
 namespace GraphModel
 {

--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -35,7 +35,7 @@
 #include <GraphModel/Model/Node.h>
 #include <GraphModel/Model/Connection.h>
 #include <GraphModel/Model/Graph.h>
-#include <GraphModel/Model/IGraphContext.h>
+#include <GraphModel/Model/GraphContext.h>
 #include <GraphModel/Model/DataType.h>
 #include <GraphModel/Integration/BooleanDataInterface.h>
 #include <GraphModel/Integration/IntegerDataInterface.h>

--- a/Gems/GraphModel/Code/Source/Model/Graph.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Graph.cpp
@@ -14,7 +14,7 @@
 
 // Graph Model
 #include <GraphModel/Model/Graph.h>
-#include <GraphModel/Model/IGraphContext.h>
+#include <GraphModel/Model/GraphContext.h>
 #include <GraphModel/Model/Node.h>
 #include <GraphModel/Model/Slot.h>
 #include <GraphModel/Model/Connection.h>
@@ -42,13 +42,13 @@ namespace GraphModel
         }
     }
 
-    Graph::Graph(IGraphContextPtr graphContext)
+    Graph::Graph(GraphContextPtr graphContext)
         : m_graphContext(graphContext)
     {
 
     }
 
-    void Graph::PostLoadSetup(IGraphContextPtr graphContext)
+    void Graph::PostLoadSetup(GraphContextPtr graphContext)
     {
         AZ_Assert(m_nextNodeId == 1, "This graph has been set up before");
 
@@ -94,7 +94,7 @@ namespace GraphModel
         return nodeId;
     }
 
-    IGraphContextPtr Graph::GetContext() const
+    GraphContextPtr Graph::GetContext() const
     {
         AZ_Assert(m_graphContext, "Graph::m_graphContext is not set");
         return m_graphContext;

--- a/Gems/GraphModel/Code/Source/Model/GraphContext.cpp
+++ b/Gems/GraphModel/Code/Source/Model/GraphContext.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// AZ
+#include <AzCore/StringFunc/StringFunc.h>
+
+// Graph Model
+#include <GraphModel/Model/Graph.h>
+#include <GraphModel/Model/GraphContext.h>
+
+namespace GraphModel
+{
+    GraphContext::GraphContext(const AZStd::string& systemName, const AZStd::string& moduleExtension, const DataTypeList& dataTypes)
+        : m_systemName(systemName)
+        , m_moduleExtension(moduleExtension)
+        , m_dataTypes(dataTypes)
+    {
+    }
+
+    const char* GraphContext::GetSystemName() const
+    {
+        return m_systemName.c_str();
+    }
+
+    const char* GraphContext::GetModuleFileExtension() const
+    {
+        return m_moduleExtension.c_str();
+    }
+
+    ModuleGraphManagerPtr GraphContext::GetModuleGraphManager() const
+    {
+        return m_moduleGraphManager;
+    }
+
+    const AZStd::vector<DataTypePtr>& GraphContext::GetAllDataTypes() const
+    {
+        return m_dataTypes;
+    }
+
+    DataTypePtr GraphContext::GetDataType(DataType::Enum typeEnum) const
+    {
+        for (DataTypePtr dataType : m_dataTypes)
+        {
+            if (dataType->GetTypeEnum() == typeEnum)
+            {
+                return dataType;
+            }
+        }
+
+        return {};
+    }
+
+    DataTypePtr GraphContext::GetDataType(const AZStd::string& name) const
+    {
+        for (DataTypePtr dataType : m_dataTypes)
+        {
+            if (AZ::StringFunc::Equal(dataType->GetCppName(), name) || AZ::StringFunc::Equal(dataType->GetDisplayName(), name))
+            {
+                return dataType;
+            }
+        }
+
+        return {};
+    }
+
+    DataTypePtr GraphContext::GetDataType(AZ::Uuid typeId) const
+    {
+        for (DataTypePtr dataType : m_dataTypes)
+        {
+            if (dataType->GetTypeUuid() == typeId)
+            {
+                return dataType;
+            }
+        }
+
+        return {};
+    }
+
+    DataTypePtr GraphContext::GetDataTypeForValue(const AZStd::any& value) const
+    {
+        return GetDataType(value.type());
+    }
+} // namespace GraphModel

--- a/Gems/GraphModel/Code/Source/Model/GraphContext.cpp
+++ b/Gems/GraphModel/Code/Source/Model/GraphContext.cpp
@@ -8,10 +8,12 @@
 
 // AZ
 #include <AzCore/StringFunc/StringFunc.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
 
 // Graph Model
 #include <GraphModel/Model/Graph.h>
 #include <GraphModel/Model/GraphContext.h>
+#include <GraphModel/Model/Module/ModuleGraphManager.h>
 
 namespace GraphModel
 {
@@ -30,6 +32,14 @@ namespace GraphModel
     const char* GraphContext::GetModuleFileExtension() const
     {
         return m_moduleExtension.c_str();
+    }
+
+    void GraphContext::CreateModuleGraphManager()
+    {
+        if (!m_moduleGraphManager)
+        {
+            m_moduleGraphManager = AZStd::make_shared<ModuleGraphManager>(shared_from_this());
+        }
     }
 
     ModuleGraphManagerPtr GraphContext::GetModuleGraphManager() const

--- a/Gems/GraphModel/Code/Source/Model/GraphElement.cpp
+++ b/Gems/GraphModel/Code/Source/Model/GraphElement.cpp
@@ -22,7 +22,7 @@ namespace GraphModel
         return m_graph.lock();
     }
 
-    IGraphContextPtr GraphElement::GetGraphContext() const
+    GraphContextPtr GraphElement::GetGraphContext() const
     {
         GraphPtr graph = m_graph.lock();
         return graph ? graph->GetContext() : nullptr;

--- a/Gems/GraphModel/Code/Source/Model/Module/ModuleGraphManager.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Module/ModuleGraphManager.cpp
@@ -16,12 +16,12 @@
 
 // Graph Model
 #include <GraphModel/Model/Graph.h>
-#include <GraphModel/Model/IGraphContext.h>
+#include <GraphModel/Model/GraphContext.h>
 #include <GraphModel/Model/Module/ModuleGraphManager.h>
 
 namespace GraphModel
 {
-    ModuleGraphManager::ModuleGraphManager(IGraphContextPtr graphContext, AZ::SerializeContext* serializeContext)
+    ModuleGraphManager::ModuleGraphManager(GraphContextPtr graphContext, AZ::SerializeContext* serializeContext)
         : m_graphContext(graphContext)
         , m_moduleFileExtension(graphContext->GetModuleFileExtension())
         , m_serializeContext(serializeContext)

--- a/Gems/GraphModel/Code/Source/Model/Module/ModuleNode.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Module/ModuleNode.cpp
@@ -15,7 +15,7 @@
 #include <GraphModel/Model/Module/ModuleNode.h>
 #include <GraphModel/Model/Module/ModuleGraphManager.h>
 #include <GraphModel/Model/Module/InputOutputNodes.h>
-#include <GraphModel/Model/IGraphContext.h>
+#include <GraphModel/Model/GraphContext.h>
 
 namespace GraphModel
 {

--- a/Gems/GraphModel/Code/Source/Model/Slot.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Slot.cpp
@@ -21,7 +21,7 @@
 #include <GraphModel/Model/Slot.h>
 #include <GraphModel/Model/Node.h>
 #include <GraphModel/Model/Graph.h>
-#include <GraphModel/Model/IGraphContext.h>
+#include <GraphModel/Model/GraphContext.h>
 
 namespace GraphModel
 {

--- a/Gems/GraphModel/Code/Tests/TestEnvironment.cpp
+++ b/Gems/GraphModel/Code/Tests/TestEnvironment.cpp
@@ -13,57 +13,13 @@ namespace GraphModelIntegrationTest
 {
     // TestGraphContext
     TestGraphContext::TestGraphContext()
+        : GraphModel::GraphContext("GraphModelIntegrationTest", ".nodeTest", {})
     {
         // Construct basic data types
         const AZ::Uuid stringTypeUuid = azrtti_typeid<AZStd::string>();
         const AZ::Uuid entityIdTypeUuid = azrtti_typeid<AZ::EntityId>();
         m_dataTypes.push_back(AZStd::make_shared<GraphModel::DataType>(TestDataTypeEnum::TestDataTypeEnum_String, stringTypeUuid, AZStd::any(AZStd::string("")), "String", "AZStd::string"));
         m_dataTypes.push_back(AZStd::make_shared<GraphModel::DataType>(TestDataTypeEnum::TestDataTypeEnum_EntityId, entityIdTypeUuid, AZStd::any(AZ::EntityId()), "EntityId", "AZ::EntityId"));
-    }
-
-    const char* TestGraphContext::GetSystemName() const
-    {
-        return "GraphModelIntegrationTest";
-    }
-
-    const char* TestGraphContext::GetModuleFileExtension() const
-    {
-        return ".nodeTest";
-    }
-
-    const GraphModel::DataTypeList& TestGraphContext::GetAllDataTypes() const
-    {
-        return m_dataTypes;
-    }
-
-    GraphModel::DataTypePtr TestGraphContext::GetDataType(AZ::Uuid typeId) const
-    {
-        for (GraphModel::DataTypePtr dataType : m_dataTypes)
-        {
-            if (dataType->GetTypeUuid() == typeId)
-            {
-                return dataType;
-            }
-        }
-
-        return AZStd::make_shared<GraphModel::DataType>();
-    }
-
-    GraphModel::DataTypePtr TestGraphContext::GetDataType(GraphModel::DataType::Enum typeEnum) const
-    {
-        if (typeEnum < m_dataTypes.size())
-        {
-            return m_dataTypes[typeEnum];
-        }
-        else
-        {
-            return AZStd::make_shared<GraphModel::DataType>();
-        }
-    }
-
-    GraphModel::ModuleGraphManagerPtr TestGraphContext::GetModuleGraphManager() const
-    {
-        return nullptr;
     }
 
     // TestNode

--- a/Gems/GraphModel/Code/Tests/TestEnvironment.h
+++ b/Gems/GraphModel/Code/Tests/TestEnvironment.h
@@ -22,7 +22,7 @@
 
 // GraphModel ...
 #include <GraphModel/Model/DataType.h>
-#include <GraphModel/Model/IGraphContext.h>
+#include <GraphModel/Model/GraphContext.h>
 #include <GraphModel/Model/Graph.h>
 #include <GraphModel/Model/Node.h>
 #include <GraphModel/Model/Slot.h>
@@ -45,23 +45,11 @@ namespace GraphModelIntegrationTest
         TestDataTypeEnum_Count
     };
 
-    class TestGraphContext
-        : public GraphModel::IGraphContext
-        , public AZStd::enable_shared_from_this<TestGraphContext>
+    class TestGraphContext : public GraphModel::GraphContext
     {
     public:
         TestGraphContext();
         virtual ~TestGraphContext() = default;
-
-        const char* GetSystemName() const override;
-        const char* GetModuleFileExtension() const override;
-        const GraphModel::DataTypeList& GetAllDataTypes() const override;
-        GraphModel::DataTypePtr GetDataType(AZ::Uuid typeId) const override;
-        GraphModel::DataTypePtr GetDataType(GraphModel::DataType::Enum typeEnum) const override;
-        GraphModel::ModuleGraphManagerPtr GetModuleGraphManager() const override;
-
-    private:
-        GraphModel::DataTypeList m_dataTypes;
     };
 
     class TestNode

--- a/Gems/GraphModel/Code/graphmodel_editor_static_files.cmake
+++ b/Gems/GraphModel/Code/graphmodel_editor_static_files.cmake
@@ -13,7 +13,7 @@ set(FILES
     Include/GraphModel/Model/DataType.h
     Include/GraphModel/Model/Graph.h
     Include/GraphModel/Model/GraphElement.h
-    Include/GraphModel/Model/IGraphContext.h
+    Include/GraphModel/Model/GraphContext.h
     Include/GraphModel/Model/Node.h
     Include/GraphModel/Model/Slot.h
     Include/GraphModel/Model/Module/InputOutputNodes.h
@@ -42,6 +42,7 @@ set(FILES
     Source/Model/Connection.cpp
     Source/Model/DataType.cpp
     Source/Model/Graph.cpp
+    Source/Model/GraphContext.cpp
     Source/Model/GraphElement.cpp
     Source/Model/Node.cpp
     Source/Model/Slot.cpp

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Core/GraphContext.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Core/GraphContext.cpp
@@ -27,7 +27,7 @@ namespace LandscapeCanvas
 
         if (s_instance)
         {
-            s_instance->Init();
+            s_instance->CreateModuleGraphManager();
         }
     }
 
@@ -51,14 +51,6 @@ namespace LandscapeCanvas
         // Construct basic data types
         const AZ::Uuid stringTypeUuid = azrtti_typeid<AZStd::string>();
         m_dataTypes.push_back(AZStd::make_shared<LandscapeCanvasDataType>(LandscapeCanvasDataTypeEnum::String, stringTypeUuid, AZStd::any(AZStd::string("")), "String", "AZStd::string"));
-    }
-
-    void GraphContext::Init()
-    {
-        if (!m_moduleGraphManager)
-        {
-            m_moduleGraphManager = AZStd::make_shared<GraphModel::ModuleGraphManager>(shared_from_this());
-        }
     }
 
     GraphModel::DataTypePtr GraphContext::GetDataTypeForValue(const AZStd::any& value) const

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Core/GraphContext.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Core/GraphContext.cpp
@@ -37,6 +37,7 @@ namespace LandscapeCanvas
     }
 
     GraphContext::GraphContext()
+        : GraphModel::GraphContext(SYSTEM_NAME, MODULE_FILE_EXTENSION, {})
     {
         // Construct our custom data types
         const AZ::EntityId invalidEntity;
@@ -60,29 +61,6 @@ namespace LandscapeCanvas
         }
     }
 
-    const char* GraphContext::GetSystemName() const
-    {
-        return SYSTEM_NAME;
-    }
-
-    const char* GraphContext::GetModuleFileExtension() const
-    {
-        return MODULE_FILE_EXTENSION;
-    }
-
-    GraphModel::DataTypePtr GraphContext::GetDataType(AZ::Uuid typeId) const
-    {
-        for (GraphModel::DataTypePtr dataType : m_dataTypes)
-        {
-            if (dataType->GetTypeUuid() == typeId)
-            {
-                return dataType;
-            }
-        }
-
-        return AZStd::make_shared<LandscapeCanvasDataType>(); // LandscapeCanvasDataType is Invalid
-    }
-
     GraphModel::DataTypePtr GraphContext::GetDataTypeForValue(const AZStd::any& value) const
     {
         // If the value is an AZ::EntityId::InvalidEntityId return our special
@@ -97,28 +75,6 @@ namespace LandscapeCanvas
             }
         }
 
-        return GraphModel::IGraphContext::GetDataTypeForValue(value);
-    }
-
-    GraphModel::DataTypePtr GraphContext::GetDataType(GraphModel::DataType::Enum typeEnum) const
-    {
-        if (typeEnum < m_dataTypes.size())
-        {
-            return m_dataTypes[typeEnum];
-        }
-        else
-        {
-            return AZStd::make_shared<LandscapeCanvasDataType>(); // LandscapeCanvasDataType is Invalid
-        }
-    }
-
-    const AZStd::vector<GraphModel::DataTypePtr>& GraphContext::GetAllDataTypes() const
-    {
-        return m_dataTypes;
-    }
-
-    GraphModel::ModuleGraphManagerPtr GraphContext::GetModuleGraphManager() const
-    {
-        return m_moduleGraphManager;
+        return GraphModel::GraphContext::GetDataTypeForValue(value);
     }
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Core/GraphContext.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Core/GraphContext.h
@@ -29,9 +29,6 @@ namespace LandscapeCanvas
         GraphModel::DataTypePtr GetDataTypeForValue(const AZStd::any& value) const override;
 
     private:
-        //! Performs initialization that can't be done in the constructor
-        void Init();
-
         static AZStd::shared_ptr<GraphContext> s_instance;
     };
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Core/GraphContext.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Core/GraphContext.h
@@ -8,18 +8,15 @@
 
 #pragma once
 
-// AZ
-#include <AzCore/std/smart_ptr/enable_shared_from_this.h>
-
 // GraphModel
-#include <GraphModel/Model/IGraphContext.h>
+#include <GraphModel/Model/GraphContext.h>
 
 // Landscape Canvas
 #include <Editor/Core/DataTypes.h>
 
 namespace LandscapeCanvas
 {
-    class GraphContext : public GraphModel::IGraphContext, public AZStd::enable_shared_from_this<GraphContext>
+    class GraphContext : public GraphModel::GraphContext
     {
     public:
         static void SetInstance(AZStd::shared_ptr<GraphContext> graphContext);
@@ -28,21 +25,13 @@ namespace LandscapeCanvas
         GraphContext();
         virtual ~GraphContext() = default;
 
-        const char* GetSystemName() const override;
-        const char* GetModuleFileExtension() const override;
-        const DataTypeList& GetAllDataTypes() const override;
-        GraphModel::DataTypePtr GetDataType(AZ::Uuid typeId) const override;
+        //! Overridden for custom handling of invalid entity IDs
         GraphModel::DataTypePtr GetDataTypeForValue(const AZStd::any& value) const override;
-        GraphModel::DataTypePtr GetDataType(GraphModel::DataType::Enum typeEnum) const override;
-        GraphModel::ModuleGraphManagerPtr GetModuleGraphManager() const override;
 
     private:
         //! Performs initialization that can't be done in the constructor
         void Init();
 
         static AZStd::shared_ptr<GraphContext> s_instance;
-
-        DataTypeList m_dataTypes;
-        GraphModel::ModuleGraphManagerPtr m_moduleGraphManager;
     };
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -531,7 +531,7 @@ namespace LandscapeCanvasEditor
         LandscapeCanvas::LandscapeCanvasRequestBus::Handler::BusDisconnect();
     }
 
-    GraphModel::IGraphContextPtr MainWindow::GetGraphContext() const
+    GraphModel::GraphContextPtr MainWindow::GetGraphContext() const
     {
         return LandscapeCanvas::GraphContext::GetInstance();
     }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
@@ -103,7 +103,7 @@ namespace LandscapeCanvasEditor
         ~MainWindow() override;
 
     private:
-        GraphModel::IGraphContextPtr GetGraphContext() const override;
+        GraphModel::GraphContextPtr GetGraphContext() const override;
 
         ////////////////////////////////////////////////////////////////////////
         // GraphModelIntegration::GraphControllerNotificationBus::Handler overrides


### PR DESCRIPTION
- Instead of reimplementing graph context for every tool and test, upgraded the graph context interface into a base class and moved the implementation into it.
- Preserve the virtual functions necessary for landscape canvas special entity ID logic.
- Added functions for looking up types by name.
- Changed function that looked up types by enum to search instead of direct index because nothing is enforcing that types are added in the same order as the enumeration. This might benefit from removing the enumeration and relying only on UUIDs or switching to an associative container.
- Added construction parameters to pass in the system name, module details, and data types so the class does not need to be overridden in most cases.
- ~~Still need to address the case where the module manager relies on the graph context which means it cannot be constructed in the constructor.~~

Building on top of the following PRs and file count will reduce once they have merged.
https://github.com/o3de/o3de/pull/8998
https://github.com/o3de/o3de/pull/9001

Signed-off-by: Guthrie Adams <guthadam@amazon.com>