### PR TITLE
Fixed bug about reparenting prefab

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/reparent_prefab/ReparentPrefab_UnderAnotherPrefab.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/reparent_prefab/ReparentPrefab_UnderAnotherPrefab.py
@@ -39,6 +39,8 @@ def ReparentPrefab_UnderAnotherPrefab():
         _, wheel = Prefab.create_prefab(
             wheel_prefab_entities, WHEEL_PREFAB_FILE_NAME)
 
+        # Ensure focus gets set on the prefab you want to parent under. This mirrors how users would do
+        # reparenting in the editor.
         car.container_entity.focus_on_owning_prefab()
 
         # Reparents the wheel prefab instance to the container entity of the car prefab instance

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/reparent_prefab/ReparentPrefab_UnderAnotherPrefab.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/reparent_prefab/ReparentPrefab_UnderAnotherPrefab.py
@@ -39,6 +39,8 @@ def ReparentPrefab_UnderAnotherPrefab():
         _, wheel = Prefab.create_prefab(
             wheel_prefab_entities, WHEEL_PREFAB_FILE_NAME)
 
+        car.container_entity.focus_on_owning_prefab()
+
         # Reparents the wheel prefab instance to the container entity of the car prefab instance
         await wheel.ui_reparent_prefab_instance(car.container_entity.id)
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.cpp
@@ -172,7 +172,7 @@ namespace AzToolsFramework
             }
             else
             {
-                AZ_Error(
+                AZ_Warning(
                     "Prefab",
                     (result.GetOutcome() != AZ::JsonSerializationResult::Outcomes::Skipped) &&
                     (result.GetOutcome() != AZ::JsonSerializationResult::Outcomes::PartialSkip),

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -734,9 +734,6 @@ namespace AzToolsFramework
                 bool isInstanceContainerEntity = IsInstanceContainerEntity(entityId) && !IsLevelInstanceContainerEntity(entityId);
                 bool isNewParentOwnedByDifferentInstance = false;
 
-                bool isInFocusTree = m_prefabFocusPublicInterface->IsOwningPrefabInFocusHierarchy(entityId);
-                bool isOwnedByFocusedPrefabInstance = m_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityId);
-
                 if (beforeParentId != afterParentId)
                 {
                     // If the entity parent changed, verify if the owning instance changed too
@@ -790,7 +787,7 @@ namespace AzToolsFramework
                     }
                 }
 
-                if (isInFocusTree && !isOwnedByFocusedPrefabInstance)
+                if (isInstanceContainerEntity)
                 {
                     if (isNewParentOwnedByDifferentInstance)
                     {


### PR DESCRIPTION
Changes in this PR: 

- Fixes [8957](https://github.com/o3de/o3de/issues/8957)
   I'm reverting code that's added as part of[ this PR](https://github.com/o3de/o3de/pull/5747/files#diff-308bb40f413fd91e92bc448b7e35af07ddb3529cce9e2d21fb83872fa4847fb4R768), which added it in anticipation of upcoming override work. I'm reverting it to get base workflows stable. Will add any required code for overrides later.
- Changed an error to warning regarding partial patch application failures. This is consistent with other warnings sent by json serialization and EntityIdMapper for missing fields.

Testing:
Tested manually and also modified existing automated test to take focus mode into consideration. The test didn't catch the bug because it was trying to reparent prefabs without focusing on any prefab. That is prevented for manual interactions in the editor but the test goes around it by calling the transform ebus.