### PR TITLE
Lua script that can trigger recording frametimes in the GameLauncher.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.cpp
@@ -66,8 +66,6 @@ namespace AZ
                 if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
                 {
                     behaviorContext->EBus<ProfilingCaptureNotificationBus>("ProfilingCaptureNotificationBus")
-                        ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
-                        ->Attribute(AZ::Script::Attributes::Module, "atom")
                         ->Handler<ProfilingCaptureNotificationBusHandler>()
                         ;
                 }
@@ -346,8 +344,6 @@ namespace AZ
             if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
             {
                 behaviorContext->EBus<ProfilingCaptureRequestBus>("ProfilingCaptureRequestBus")
-                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
-                    ->Attribute(AZ::Script::Attributes::Module, "atom")
                     ->Event("CapturePassTimestamp", &ProfilingCaptureRequestBus::Events::CapturePassTimestamp)
                     ->Event("CaptureCpuFrameTime", &ProfilingCaptureRequestBus::Events::CaptureCpuFrameTime)
                     ->Event("CapturePassPipelineStatistics", &ProfilingCaptureRequestBus::Events::CapturePassPipelineStatistics)

--- a/Gems/AtomLyIntegration/CommonFeatures/Assets/Scripts/Profiling/OutputProfileData.lua
+++ b/Gems/AtomLyIntegration/CommonFeatures/Assets/Scripts/Profiling/OutputProfileData.lua
@@ -1,0 +1,134 @@
+----------------------------------------------------------------------------------------------------
+--
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
+--
+-- SPDX-License-Identifier: Apache-2.0 OR MIT
+--
+--
+--
+----------------------------------------------------------------------------------------------------
+
+local OutputProfileData = 
+{
+    Properties = 
+    {
+        FrameDelayCount = 100,
+        FrameCaptureCount = 100,
+        ProfileName = "LevelFrameTiming",
+        QuitOnComplete = true,
+    },
+    frameCount = 0,
+    frameDelayCount = 0,
+    frameCaptureCount = 0,
+    captureCount = 0,
+    quitOnComplete = false,
+    profileName = "UninitializedName",
+    outputFolder = "UninitializedPath",
+    cpuTimingsOutputPath = "UninitializedPath",
+    captureInProgress = false,
+    active = false,
+};
+
+local FrameTimeRecordingActiveRegistryKey <const> = "/O3DE/Performance/FrameTimeRecording/Activate"
+local FrameDelayCountRegistryKey <const> = "/O3DE/Performance/FrameTimeRecording/DelayCount"
+local FrameCaptureCountRegistryKey <const> = "/O3DE/Performance/FrameTimeRecording/CaptureCount"
+local ProfileNameRegistryKey <const> = "/O3DE/Performance/FrameTimeRecording/ProfileName"
+local QuitOnCompleteRegistryKey <const> = "/O3DE/Performance/FrameTimeRecording/QuitOnComplete"
+local SourceProjectUserPathRegistryKey <const> = "/O3DE/Runtime/FilePaths/SourceProjectUserPath"
+local ConsoleCommandQuitRegistryKey <const> = "/Amazon/AzCore/Runtime/ConsoleCommands/quit"
+
+function OutputProfileData:TryDisconnect()
+    if (self.active) then
+        self.active = false
+        self.profileCaptureNotificationHandler:Disconnect()
+        self.tickHandler:Disconnect()
+    end
+end
+
+function OutputProfileData:TryQuitOnComplete()
+    if (self.quitOnComplete) then
+        g_SettingsRegistry:SetString(ConsoleCommandQuitRegistryKey, "")
+    end
+end
+
+function OutputProfileData:TryCapture()
+    self.captureInProgress = true
+    self.cpuTimingsOutputPath = tostring(self.outputFolder) .. '/cpu_frame' .. tostring(self.captureCount) .. '_time.json'
+    ProfilingCaptureRequestBus.Broadcast.CaptureCpuFrameTime(self.cpuTimingsOutputPath)
+end
+
+function OutputProfileData:CaptureFinished()
+    self.captureInProgress = false
+end
+
+
+function OutputProfileData:OnActivate()
+    if (g_SettingsRegistry:IsValid()) then
+        local quitOnCompleteValue = g_SettingsRegistry:GetBool(QuitOnCompleteRegistryKey)
+        self.quitOnComplete = quitOnCompleteValue:value_or(self.Properties.QuitOnComplete)
+
+        local frameTimeRecordingActivateValue = g_SettingsRegistry:GetBool(FrameTimeRecordingActiveRegistryKey)
+        if (not frameTimeRecordingActivateValue:has_value() or not frameTimeRecordingActivateValue:value()) then
+            Debug:Log("OutputProfileData:OnActivate - Missing registry setting to activate frame time recording, aborting data collection")
+            self:TryQuitOnComplete()
+            return
+        end
+
+        -- get path to user folder
+        local pathToUserFolder = "InvalidPath/"
+        local settingsRegistryResult =  g_SettingsRegistry:GetString(SourceProjectUserPathRegistryKey)
+        if (settingsRegistryResult:has_value()) then
+            pathToUserFolder = settingsRegistryResult:value()
+        else
+            Debug:Log("OutputProfileData:OnActivate - Unable to resolve the SourceProjectUserPath, aborting data collection")
+            self:TryQuitOnComplete()
+            return
+        end
+
+        -- get any registry property overrides
+        local frameDelayCountValue = g_SettingsRegistry:GetUInt(FrameDelayCountRegistryKey)
+        self.frameDelayCount = frameDelayCountValue:value_or(self.Properties.FrameDelayCount)
+        local frameCaptureCountValue = g_SettingsRegistry:GetUInt(FrameCaptureCountRegistryKey)
+        self.frameCaptureCount = frameCaptureCountValue:value_or(self.Properties.FrameCaptureCount)
+        local profileNameValue = g_SettingsRegistry:GetString(ProfileNameRegistryKey)
+        self.profileName = profileNameValue:value_or(self.Properties.ProfileName)
+
+        -- generate final output path string
+        self.outputFolder = tostring(pathToUserFolder) .. "/Scripts/PerformanceBenchmarks/" .. tostring(self.profileName)
+
+        -- register for ebus callbacks
+        self.tickHandler = TickBus.Connect(self)
+        self.profileCaptureNotificationHandler = ProfilingCaptureNotificationBus.Connect(self)
+        self.active = true
+    end
+end
+
+function OutputProfileData:OnTick()
+    self.frameCount = self.frameCount + 1
+    if (self.frameCount <= self.frameDelayCount) then
+        return
+    end
+
+    if (self.captureCount < self.frameCaptureCount and not self.captureInProgress) then
+        self.captureCount = self.captureCount + 1
+        self:TryCapture()
+    elseif (self.captureCount >= self.frameCaptureCount and not self.captureInProgress) then
+        Debug:Log("OutputProfileData complete")
+        self:TryDisconnect()
+        self:TryQuitOnComplete()
+    end
+end
+
+function OutputProfileData:OnCaptureCpuFrameTimeFinished(successful, capture_output_path)
+    if (self.captureInProgress and self.cpuTimingsOutputPath == capture_output_path) then
+        self:CaptureFinished()
+    end
+end
+
+
+function OutputProfileData:OnDeactivate()
+    self:TryDisconnect()
+end
+
+return OutputProfileData


### PR DESCRIPTION
Plus a small c++ change to expose the necessary ebus's to lua.

Script is expected to be active in the level to be profiled. A registry key needs to be active to trigger the profiling, plus several values can be overridden with other registry values.

Supported values: Number of frames to wait before beginning profiling, number of frames to record time for, Profile name, Whether to quit after all frames have been timed.

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>