### PR TITLE
HDR Color Grading component's "Generate LUT" and

### DIFF
--- a/Gems/Atom/Feature/Common/Editor/Scripts/ColorGrading/activate_lut_asset.py
+++ b/Gems/Atom/Feature/Common/Editor/Scripts/ColorGrading/activate_lut_asset.py
@@ -92,3 +92,5 @@ if __name__ == "__main__":
 
     for entityId in entityIdList:
         activate_lut_asset(entityId, args.assetRelativePath)
+        azlmbr.render.EditorHDRColorGradingNotificationBus(azlmbr.bus.Event, 'OnActivateLutCompleted', entityId)
+    

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/PostProcess/ColorGrading/EditorHDRColorGradingBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/PostProcess/ColorGrading/EditorHDRColorGradingBus.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        //! The main interface, usable in Editor mode, to request an "HDR Color Grading" component to generate & activate
+        //! the LUT. The operations are asynchronous, so it is important to register for completion events
+        //! on the EditorHDRColorGradingNotificationBus. 
+        class EditorHDRColorGradingRequests
+            : public ComponentBus
+        {
+        public:
+            AZ_RTTI(AZ::Render::EditorHDRColorGradingRequests, "{13C81A89-587D-4AA6-B66D-903F8F947EF0}");
+
+            static const EBusHandlerPolicy HandlerPolicy = EBusHandlerPolicy::Single;
+
+            virtual ~EditorHDRColorGradingRequests() {}
+
+            // Starts generating/baking an LUT asset. When the asset is generated a notification
+            // will be sent with EditorHDRColorGradingNotificationBus::OnGenerateLutCompleted.
+            virtual void GenerateLutAsync() = 0;
+
+            // Adds and activates a "Look Modification" component using the LUT asset
+            // genrated when GenerateLutAsync() was called. Also, the "HDR Color Grading" component
+            // will be deactivated.
+            // When the whole operation is finished, a notification
+            // will be sent with EditorHDRColorGradingNotificationBus::OnActivateLutCompleted.
+            virtual void ActivateLutAsync() = 0;
+
+        };
+
+        typedef AZ::EBus<EditorHDRColorGradingRequests> EditorHDRColorGradingRequestBus;
+
+
+        //! This EBus is useful to get notified whenever operations invoked on EditorHDRColorGradingRequestBus
+        //! are completed. This notification EBus is only useful in Editor mode.
+        class EditorHDRColorGradingNotification
+            : public ComponentBus
+        {
+        public:
+
+            //! Destroys the instance of the class.
+            virtual ~EditorHDRColorGradingNotification() {}
+
+            //! This event is sent on response to EditorHDRColorGradingRequestBus::GenerateLutAsync()
+            //! when the LUT asset is ready.
+            virtual void OnGenerateLutCompleted(const AZStd::string& lutAssetAbsolutePath) = 0;
+
+            //! This event is sent on response to EditorHDRColorGradingRequestBus::ActivateLutAsync()
+            //! when the "Look Modification" component is activated.
+            virtual void OnActivateLutCompleted() = 0;
+
+        };
+
+        using EditorHDRColorGradingNotificationBus = AZ::EBus<EditorHDRColorGradingNotification>;
+
+    } // namespace Render
+} // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ColorGrading/EditorHDRColorGradingComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ColorGrading/EditorHDRColorGradingComponent.h
@@ -12,6 +12,7 @@
 #include <AzToolsFramework/ToolsComponents/EditorComponentAdapter.h>
 #include <Atom/Feature/Utils/FrameCaptureBus.h>
 #include <PostProcess/ColorGrading/HDRColorGradingComponent.h>
+#include <AtomLyIntegration/CommonFeatures/PostProcess/ColorGrading/EditorHDRColorGradingBus.h>
 
 namespace AZ
 {
@@ -27,6 +28,7 @@ namespace AZ
                   EditorComponentAdapter<HDRColorGradingComponentController, HDRColorGradingComponent, HDRColorGradingComponentConfig>
             , private TickBus::Handler
             , private FrameCaptureNotificationBus::Handler
+            , private EditorHDRColorGradingRequestBus::Handler
         {
         public:
             using BaseClass = AzToolsFramework::Components::EditorComponentAdapter<HDRColorGradingComponentController, HDRColorGradingComponent, HDRColorGradingComponentConfig>;
@@ -36,6 +38,9 @@ namespace AZ
 
             EditorHDRColorGradingComponent() = default;
             EditorHDRColorGradingComponent(const HDRColorGradingComponentConfig& config);
+
+            void Activate() override;
+            void Deactivate() override;
 
             //! EditorRenderComponentAdapter overrides...
             AZ::u32 OnConfigurationChanged() override;
@@ -47,8 +52,13 @@ namespace AZ
             // FrameCaptureNotificationBus overrides ...
             void OnCaptureFinished(AZ::Render::FrameCaptureResult result, const AZStd::string& info) override;
 
+            //! EditorHDRColorGradingRequestBus overrides...
+            void GenerateLutAsync() override;
+            void ActivateLutAsync() override;
+
             void GenerateLut();
             AZ::u32 ActivateLut();
+
             bool GetGeneratedLutVisibilitySettings();
 
             bool m_waitOneFrame = false;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_public_files.cmake
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_public_files.cmake
@@ -43,6 +43,7 @@ set(FILES
     Include/AtomLyIntegration/CommonFeatures/PostProcess/ExposureControl/ExposureControlBus.h
     Include/AtomLyIntegration/CommonFeatures/PostProcess/ExposureControl/ExposureControlComponentConfig.h
     Include/AtomLyIntegration/CommonFeatures/PostProcess/ExposureControl/ExposureControlComponentConstants.h
+    Include/AtomLyIntegration/CommonFeatures/PostProcess/ColorGrading/EditorHDRColorGradingBus.h
     Include/AtomLyIntegration/CommonFeatures/PostProcess/ColorGrading/HDRColorGradingBus.h
     Include/AtomLyIntegration/CommonFeatures/PostProcess/ColorGrading/HDRColorGradingComponentConfig.h
     Include/AtomLyIntegration/CommonFeatures/PostProcess/Ssao/SsaoBus.h


### PR DESCRIPTION
"Activate LUT" are not exposed to Python.

This PR exposes in the behavior context, and for automation purposes only,
 the functionality provided to the
user by the  "Generate LUT" and "Activate LUT" buttons
available in the "HDR Color Grading" component.

The equivalent to "Generate LUT" button can be done
by calling EditorHDRColorGradingRequestBus::GenerateLutAsync
and the completion event is signaled on
EditorHDRColorGradingNotificationBus::OnGenerateLutCompleted

The equivalent to "Activate LUT" button can be done
by calling EditorHDRColorGradingRequestBus::ActivateLutAsync
and the completion event is signaled on
EditorHDRColorGradingNotificationBus::OnActivateLutCompleted

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>