### PR TITLE
Adding CMakePresets support for O3DE

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,18 @@
+{
+    "version": 4,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 23,
+        "patch": 0
+    },
+    "include": [
+        "cmake/Platform/Android/CMakePresets.json",
+        "cmake/Platform/iOS/CMakePresets.json",
+        "cmake/Platform/Linux/CMakePresets.json",
+        "cmake/Platform/Mac/CMakePresets.json",
+        "cmake/Platform/Windows/CMakePresets.json"
+    ],
+    "configurePresets": [],
+    "buildPresets": [],
+    "testPresets": []
+}

--- a/Templates/DefaultProject/Template/.gitignore
+++ b/Templates/DefaultProject/Template/.gitignore
@@ -3,3 +3,4 @@
 [Uu]ser/
 [Uu]ser_test*/
 _savebackup/
+CMakeUserPresets.json

--- a/Templates/DefaultProject/Template/CMakePresets.json
+++ b/Templates/DefaultProject/Template/CMakePresets.json
@@ -1,0 +1,8 @@
+{
+    "version": 4,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 23,
+        "patch": 0
+    }
+}

--- a/Templates/MinimalProject/Template/.gitignore
+++ b/Templates/MinimalProject/Template/.gitignore
@@ -2,3 +2,4 @@
 [Cc]ache/
 [Uu]ser/
 _savebackup/
+CMakeUserPresets.json

--- a/Templates/MinimalProject/Template/CMakePresets.json
+++ b/Templates/MinimalProject/Template/CMakePresets.json
@@ -1,0 +1,8 @@
+{
+    "version": 4,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 23,
+        "patch": 0
+    }
+}

--- a/cmake/Platform/Android/CMakePresets.json
+++ b/cmake/Platform/Android/CMakePresets.json
@@ -1,0 +1,256 @@
+{
+  "version": 4,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 23,
+    "patch": 0
+  },
+  "include": [
+    "../Common/CMakePresets.json"
+  ],
+  "configurePresets": [
+    {
+      "name": "android-default",
+      "displayName": "Android",
+      "description": "Android default configuration",
+      "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
+      "inherits": [
+        "android-ninja",
+        "android-unity",
+        "android-non-monolithic"
+      ],
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Darwin",
+          "Linux",
+          "Windows"
+        ]
+      }
+    },
+    {
+      "name": "android-mono-default",
+      "displayName": "Android Monolithic with Unity and Ninja",
+      "description": "Configures Android to build the Monolithic permutation using Ninja with Unity builds",
+      "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
+      "inherits": [
+        "android-ninja",
+        "android-unity",
+        "android-monolithic"
+      ],
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Darwin",
+          "Linux",
+          "Windows"
+        ]
+      }
+    },
+    {
+      "name": "android-unity",
+      "displayName": "Android Unity",
+      "description": "Android build which uses unity files",
+      "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
+      "binaryDir": "${sourceDir}/build/android",
+      "inherits": [
+        "unity"
+      ],
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Darwin",
+          "Linux",
+          "Windows"
+        ]
+      }
+    },
+    {
+      "name": "android-no-unity",
+      "displayName": "Android without Unity",
+      "description": "Android build which uses unity files",
+      "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
+      "binaryDir": "${sourceDir}/build/android_no_unity",
+      "inherits": [
+        "no-unity"
+      ],
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Darwin",
+          "Linux",
+          "Windows"
+        ]
+      }
+    },
+    {
+      "name": "android-non-monolithic",
+      "displayName": "Android Non-Monolithic",
+      "description": "Default configuration for non-monolithic builds",
+      "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
+      "inherits": [
+        "non-monolithic"
+      ],
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Darwin",
+          "Linux",
+          "Windows"
+        ]
+      }
+    },
+    {
+      "name": "android-monolithic",
+      "displayName": "Android Monolithic",
+      "description": "Default configuration for monolithic builds",
+      "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
+      "binaryDir": "${sourceDir}/build/android_mono",
+      "inherits": [
+        "monolithic"
+      ],
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Darwin",
+          "Linux",
+          "Windows"
+        ]
+      }
+    },
+    {
+      "name": "android-ninja",
+      "displayName": "Android Ninja",
+      "description": "Configure Android using with the Ninja generator",
+      "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
+      "binaryDir": "${sourceDir}/build/android_ninja",
+      "inherits": [
+        "android-ninja-unity"
+      ],
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Darwin",
+          "Linux",
+          "Windows"
+        ]
+      }
+    },
+    {
+      "name": "android-ninja-unity",
+      "displayName": "Android Ninja Unity",
+      "description": "Configure Android with the Ninja generator + Unity Builds",
+      "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
+      "binaryDir": "${sourceDir}/build/android_ninja_unity",
+      "inherits": [
+        "ninja-multi-config",
+        "android-unity"
+      ],
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Darwin",
+          "Linux",
+          "Windows"
+        ]
+      }
+    },
+    {
+      "name": "android-ninja-no-unity",
+      "displayName": "Android Ninja without Unity",
+      "description": "Configure Android with the Ninja Generator without unity builds",
+      "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
+      "binaryDir": "${sourceDir}/build/android_ninja_no_unity",
+      "inherits": [
+        "ninja-multi-config",
+        "android-no-unity"
+      ],
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Darwin",
+          "Linux",
+          "Windows"
+        ]
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "android-default",
+      "displayName": "Android",
+      "description": "Builds all targets for Android",
+      "configurePreset": "android-default",
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Darwin",
+          "Linux",
+          "Windows"
+        ]
+      }
+    },
+    {
+      "name": "android-install",
+      "displayName": "Android install",
+      "description": "Builds the \"install\" target for Android, which builds all target and runs the CMake --install step",
+      "configurePreset": "android-default",
+      "inherits": [
+        "install"
+      ],
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Darwin",
+          "Linux",
+          "Windows"
+        ]
+      }
+    },
+    {
+      "name": "android-mono-default",
+      "displayName": "Android Monolithic",
+      "description": "Builds all targets for Android in the monolithic permutation",
+      "configurePreset": "android-mono-default",
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Darwin",
+          "Linux",
+          "Windows"
+        ]
+      }
+    },
+    {
+      "name": "android-mono-install",
+      "displayName": "Android Monolithic install",
+      "description": "Builds the \"install\" target for android monolithic permutation, which builds all target and runs the CMake --install step",
+      "configurePreset": "android-mono-default",
+      "inherits": [
+        "install"
+      ],
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Darwin",
+          "Linux",
+          "Windows"
+        ]
+      }
+    }
+  ],
+  "testPresets": []
+}

--- a/cmake/Platform/Common/CMakePresets.json
+++ b/cmake/Platform/Common/CMakePresets.json
@@ -1,0 +1,199 @@
+{
+    "version": 4,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 23,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "default",
+            "description": "Placeholder configuration that buildPresets and testPresets can inherit from",
+            "hidden": true
+        },
+        {
+            "name": "debug",
+            "description": "Specifies build type for single-configuration generators: debug",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": {
+                    "type": "STRING",
+                    "value": "debug"
+                }
+            }
+        },
+        {
+            "name": "release",
+            "description": "Specifies build type for single-configuration generators: release",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": {
+                    "type": "STRING",
+                    "value": "release"
+                }
+            }
+        },
+        {
+            "name": "profile",
+            "description": "Specifies build type for single-configuration generators: profile",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": {
+                    "type": "STRING",
+                    "value": "profile"
+                }
+            }
+        },
+        {
+            "name": "no-unity",
+            "description": "unity: off",
+            "hidden": true,
+            "cacheVariables": {
+                "LY_UNITY_BUILD": {
+                    "type": "BOOL",
+                    "value": "OFF"
+                }
+            }
+        },
+        {
+            "name": "unity",
+            "description": "unity: on",
+            "hidden": true,
+            "cacheVariables": {
+                "LY_UNITY_BUILD": {
+                    "type": "BOOL",
+                    "value": "ON"
+                }
+            }
+        },
+        {
+            "name": "non-monolithic",
+            "description": "non-monolithic permutation(Default)",
+            "hidden": true,
+            "cacheVariables": {
+                "LY_MONOLITHIC_GAME": {
+                    "type": "BOOL",
+                    "value": "OFF"
+                }
+            }
+        },
+        {
+            "name": "monolithic",
+            "description": "monolithic permutation(Monolithic)",
+            "hidden": true,
+            "cacheVariables": {
+                "LY_MONOLITHIC_GAME": {
+                    "type": "BOOL",
+                    "value": "ON"
+                }
+            }
+        },
+        {
+            "name": "ninja-multi-config",
+            "displayName": "Ninja Multi-Config",
+            "description": "Default build using Ninja Multi-Config generator",
+            "hidden": true,
+            "generator": "Ninja Multi-Config"
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "debug",
+            "description": "configuration: debug",
+            "hidden": true,
+            "configurePreset": "default",
+            "configuration": "debug"
+        },
+        {
+            "name": "release",
+            "description": "configuration: release",
+            "hidden": true,
+            "configurePreset": "default",
+            "configuration": "release"
+        },
+        {
+            "name": "profile",
+            "description": "configuration: profile",
+            "hidden": true,
+            "configurePreset": "default",
+            "configuration": "profile"
+        },
+        {
+            "name": "editor",
+            "description": "target: editor",
+            "hidden": true,
+            "configurePreset": "default",
+            "inherits": [ "profile"],
+            "targets": "Editor"
+        },
+        {
+            "name": "assetprocessor",
+            "description": "target: asset processor",
+            "hidden": true,
+            "configurePreset": "default",
+            "inherits": [ "profile"],
+            "targets": "AssetProcessor"
+        },
+        {
+            "name": "install",
+            "description": "Builds the dependencies install(Ninja, Make, etc...) or INSTALL(Visual Studio, Xcode) target. Afterwards run the CMake install step to install the build dependencies",
+            "hidden": true,
+            "configurePreset": "default",
+            "inherits": [ "profile"],
+            "targets": "install"
+        },
+        {
+            "name": "test-default",
+            "description": "Builds the smoke and main test suite dependencies",
+            "hidden": true,
+            "configurePreset": "default",
+            "inherits": [ "profile"],
+            "targets": ["TEST_SUITE_main", "TEST_SUITE_smoke"]
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "test-default",
+            "description": "CTest preset which runs the smoke and main test suites",
+            "hidden": true,
+            "configurePreset": "default",
+            "output": {
+                "outputOnFailure": true,
+                "outputLogFile": "Ctest-${presetName}.log"
+            },
+            "execution": {
+                "noTestsAction": "error"
+            },
+            "filter": {
+                "include": {
+                    "label": "(SUITE_smoke|SUITE_main)"
+                },
+                "exclude": {
+                    "label": "(REQUIRES_gpu)"
+                }
+            }
+        },
+        {
+            "name": "test-default-debug",
+            "description": "Runs the smoke and main test suites using the debug configuration",
+            "hidden": true,
+            "configurePreset": "default",
+            "inherits": ["test-default"],
+            "configuration": "debug",
+            "output": {
+                "outputLogFile": "Ctest-${presetName}-debug.log"
+            }
+        },
+        {
+            "name": "test-default-profile",
+            "description": "Runs the smoke and main test suites using the profile configuration",
+            "hidden": true,
+            "configurePreset": "default",
+            "inherits": ["test-default"],
+            "configuration": "profile",
+            "output": {
+                "outputLogFile": "Ctest-${presetName}-profile.log"
+            }
+        }
+    ]
+}

--- a/cmake/Platform/Linux/CMakePresets.json
+++ b/cmake/Platform/Linux/CMakePresets.json
@@ -1,0 +1,478 @@
+{
+    "version": 4,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 23,
+        "patch": 0
+    },
+    "include": [
+        "../Common/CMakePresets.json"
+    ],
+    "configurePresets": [
+        {
+            "name": "linux-default",
+            "displayName": "Linux",
+            "description": "Linux default configuration",
+            "inherits": [
+                "linux-ninja",
+                "linux-unity",
+                "linux-non-monolithic"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-mono-default",
+            "displayName": "Linux Monolithic with Unity and Ninja",
+            "description": "Configures Mac to build the Monolithic permutation using Ninja with Unity builds",
+            "inherits": [
+                "linux-ninja",
+                "linux-unity",
+                "linux-monolithic"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-clang-default",
+            "displayName": "Linux Clang with Ninja and unity",
+            "description": "Configure Linux using the Ninja generator and clang compiler in non-monolithic",
+            "binaryDir": "${sourceDir}/build/linux_ninja_clang",
+            "inherits": [
+                "linux-ninja",
+                "linux-clang",
+                "linux-non-monolithic"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-gcc-default",
+            "displayName": "Linux GCC with Ninja and unity",
+            "description": "Configure Linux using the Ninja generator and gcc compiler in non-monolithic",
+            "binaryDir": "${sourceDir}/build/linux_ninja_gcc",
+            "inherits": [
+                "linux-ninja",
+                "linux-gcc",
+                "linux-non-monolithic"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-unity",
+            "displayName": "Linux Unity",
+            "description": "Linux build which uses unity files",
+            "binaryDir": "${sourceDir}/build/linux",
+            "inherits": [
+                "unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-no-unity",
+            "displayName": "Linux without Unity",
+            "description": "Linux build which uses unity files",
+            "binaryDir": "${sourceDir}/build/linux_no_unity",
+            "inherits": [
+                "no-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-non-monolithic",
+            "displayName": "Linux Non-monolithic",
+            "description": "Default configuration for non-monolithic builds",
+            "inherits": [
+                "non-monolithic"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-monolithic",
+            "displayName": "Linux Monolithic",
+            "description": "Default configuration for monolithic builds",
+            "binaryDir": "${sourceDir}/build/linux_mono",
+            "inherits": [
+                "monolithic"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-ninja",
+            "displayName": "Linux Ninja",
+            "description": "Configure Linux using with the Ninja generator",
+            "binaryDir": "${sourceDir}/build/linux_ninja",
+            "inherits": [
+                "ninja-multi-config"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-ninja-unity",
+            "displayName": "Linux Ninja Unity",
+            "description": "Configure Linux with the Ninja generator + Unity Builds",
+            "binaryDir": "${sourceDir}/build/linux_ninja_unity",
+            "inherits": [
+                "ninja-multi-config",
+                "linux-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-ninja-no-unity",
+            "displayName": "Linux Ninja without Unity",
+            "description": "Configure Linux with the Ninja Generator without unity builds",
+            "binaryDir": "${sourceDir}/build/linux_ninja_no_unity",
+            "inherits": [
+                "ninja-multi-config",
+                "linux-no-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-makefiles",
+            "displayName": "Linux Unix Makefiles",
+            "description": "Configure Linux using with the Unix Makefiles generator",
+            "binaryDir": "${sourceDir}/build/linux_makefiles",
+            "generator": "Unix Makefiles",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-makefiles-unity",
+            "displayName": "Linux Unix Makefiles Unity",
+            "description": "Configure Linux with the Unix Makefiles generator + Unity Builds",
+            "binaryDir": "${sourceDir}/build/linux_makefiles_unity",
+            "generator": "Unix Makefiles",
+            "inherits": [
+                "linux-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-makefiles-no-unity",
+            "displayName": "Linux Unix Makefiles without Unity",
+            "description": "Configure Linux with the Unix Makefiles Generator without unity builds",
+            "binaryDir": "${sourceDir}/build/linux_makefiles_no_unity",
+            "generator": "Unix Makefiles",
+            "inherits": [
+                "linux-no-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-clang",
+            "displayName": "Linux Clang",
+            "description": "Default Linux configuration using the clang compiler",
+            "binaryDir": "${sourceDir}/build/linux_clang",
+            "inherits":[
+                "linux-clang-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-clang-unity",
+            "displayName": "Linux Clang + Unity",
+            "description": "Configure Linux with the clang compiler + Unity Builds",
+            "binaryDir": "${sourceDir}/build/linux_clang_unity",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": {
+                    "type": "STRING",
+                    "value": "clang"
+                },
+                "CMAKE_CXX_COMPILER": {
+                    "type": "STRING",
+                    "value": "clang++"
+                }
+            },
+            "inherits": [
+                "linux-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-clang-no-unity",
+            "displayName": "Linux Clang without Unity",
+            "description": "Configure Linux with the clang compiler without unity builds",
+            "binaryDir": "${sourceDir}/build/linux_clang_no_unity",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": {
+                    "type": "STRING",
+                    "value": "clang"
+                },
+                "CMAKE_CXX_COMPILER": {
+                    "type": "STRING",
+                    "value": "clang++"
+                }
+            },
+            "inherits": [
+                "linux-no-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-gcc",
+            "displayName": "Linux GCC",
+            "description": "Default Linux configuration using the gcc compiler",
+            "binaryDir": "${sourceDir}/build/linux_gcc",
+            "inherits":[
+                "linux-gcc-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-gcc-unity",
+            "displayName": "Linux GCC + Unity",
+            "description": "Configure Linux with the GCC compiler + Unity Builds",
+            "binaryDir": "${sourceDir}/build/linux_gcc_unity",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": {
+                    "type": "STRING",
+                    "value": "gcc"
+                },
+                "CMAKE_CXX_COMPILER": {
+                    "type": "STRING",
+                    "value": "g++"
+                }
+            },
+            "inherits": [
+                "linux-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-gcc-no-unity",
+            "displayName": "Linux GCC without Unity",
+            "description": "Configure Linux with the GCC compiler without unity builds",
+            "binaryDir": "${sourceDir}/build/linux_gcc_no_unity",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": {
+                    "type": "STRING",
+                    "value": "gcc"
+                },
+                "CMAKE_CXX_COMPILER": {
+                    "type": "STRING",
+                    "value": "g++"
+                }
+            },
+            "inherits": [
+                "linux-no-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "linux-default",
+            "displayName": "Linux",
+            "description": "Builds all targets for Linux",
+            "configurePreset": "linux-default",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-install",
+            "displayName": "Linux install",
+            "description": "Builds the \"install\" target for Linux, which builds all target and runs the CMake --install step",
+            "configurePreset": "linux-default",
+            "inherits": [
+                "install"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-mono-default",
+            "displayName": "Linux Monolithic",
+            "description": "Builds all targets for Linux in the monolithic permutation",
+            "configurePreset": "linux-mono-default",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-mono-install",
+            "displayName": "Linux Monolithic install",
+            "description": "Builds the \"install\" target for linux monolithic permutation, which builds all target and runs the CMake --install step",
+            "configurePreset": "linux-mono-default",
+            "inherits": [
+                "install"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-editor",
+            "displayName": "Linux Editor",
+            "description": "Builds the Editor application for Linux",
+            "configurePreset": "linux-default",
+            "inherits": [
+                "editor"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-assetprocessor",
+            "displayName": "Linux AssetProcessor",
+            "description": "Builds the AssetProcessor application for Linux",
+            "configurePreset": "linux-default",
+            "inherits": [
+                "assetprocessor"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-test",
+            "displayName": "Linux CTest",
+            "description": "Builds the TEST_SUITE_smoke/TEST_SUITE_main custom targets for Linux",
+            "configurePreset": "linux-default",
+            "inherits": [
+                "test-default"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "linux-test-default",
+            "displayName": "Linux CTest",
+            "description": "Runs the Smoke + Main Test Suite. Requires the linux-test build preset to have completed successfully",
+            "configurePreset": "linux-default",
+            "inherits": [
+                "test-default"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-test-debug",
+            "displayName": "Linux CTest debug",
+            "description": "Runs the Smoke + Main Test Suite in debug configuration. Requires the linux-test build preset to have completed successfully",
+            "configurePreset": "linux-default",
+            "inherits": [
+                "test-default-debug"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-test-profile",
+            "displayName": "Linux CTest profile",
+            "description": "Runs the Smoke + Main Test Suite in profile configuration. Requires the linux-test build preset to have completed successfully",
+            "configurePreset": "linux-default",
+            "inherits": [
+                "test-default-profile"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        }
+    ]
+}

--- a/cmake/Platform/Mac/CMakePresets.json
+++ b/cmake/Platform/Mac/CMakePresets.json
@@ -1,0 +1,322 @@
+{
+  "version": 4,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 23,
+    "patch": 0
+  },
+  "include": [
+    "../Common/CMakePresets.json"
+  ],
+  "configurePresets": [
+    {
+      "name": "mac-default",
+      "displayName": "Mac",
+      "description": "Mac default configuratoin",
+      "inherits": [
+        "mac-xcode",
+        "mac-unity",
+        "mac-non-monolithic"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-mono-default",
+      "displayName": "Mac Monolithic with Unity and Xcode",
+      "description": "Configures Mac to build the Monolithic permutation using Xcode with Unity builds",
+      "inherits": [
+        "mac-ninja",
+        "mac-unity",
+        "mac-monolithic"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-unity",
+      "displayName": "Mac Unity",
+      "description": "Mac build which uses unity files",
+      "binaryDir": "${sourceDir}/build/mac",
+      "inherits": [
+        "unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-no-unity",
+      "displayName": "Mac without Unity",
+      "description": "Mac build which uses unity files",
+      "binaryDir": "${sourceDir}/build/mac_no_unity",
+      "inherits": [
+        "no-unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-non-monolithic",
+      "displayName": "Mac Non-Monolithic",
+      "description": "Default configuration for non-monolithic builds",
+      "inherits": [
+        "non-monolithic"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-monolithic",
+      "displayName": "Mac Monolithic",
+      "description": "Default configuration for monolithic builds",
+      "binaryDir": "${sourceDir}/build/mac_mono",
+      "inherits": [
+        "monolithic"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-xcode",
+      "displayName": "Mac Xcode",
+      "description": "Configure Mac using with the Xcode generator",
+      "binaryDir": "${sourceDir}/build/mac_xcode",
+      "generator": "Xcode",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-xcode-unity",
+      "displayName": "Mac Xcode Unity",
+      "description": "Configure Mac with the Xcode generator + Unity Builds",
+      "binaryDir": "${sourceDir}/build/mac_xcode_unity",
+      "generator": "Xcode",
+      "inherits": [
+        "mac-unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-xcode-no-unity",
+      "displayName": "Mac Xcode without Unity",
+      "description": "Configure Mac with the Xcode Generator without unity builds",
+      "binaryDir": "${sourceDir}/build/mac_xcode_no_unity",
+      "generator": "Xcode",
+      "inherits": [
+        "mac-no-unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-ninja",
+      "displayName": "Mac Ninja",
+      "description": "Configure Mac using with the Ninja generator",
+      "binaryDir": "${sourceDir}/build/mac_ninja",
+      "inherits": [
+        "mac-ninja-unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-ninja-unity",
+      "displayName": "Mac Ninja Unity",
+      "description": "Configure Mac with the Ninja generator + Unity Builds",
+      "binaryDir": "${sourceDir}/build/mac_ninja_unity",
+      "inherits": [
+        "ninja-multi-config",
+        "mac-unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-ninja-no-unity",
+      "displayName": "Mac Ninja without Unity",
+      "description": "Configure Mac with the Ninja Generator without unity builds",
+      "binaryDir": "${sourceDir}/build/mac_ninja_no_unity",
+      "inherits": [
+        "ninja-multi-config",
+        "mac-no-unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "mac-default",
+      "displayName": "Mac",
+      "description": "Builds all targets for Mac",
+      "configurePreset": "mac-default",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-install",
+      "displayName": "Mac install",
+      "description": "Builds the \"install\" target for Mac, which builds all target and runs the CMake --install step",
+      "configurePreset": "mac-default",
+      "inherits": [
+        "install"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-mono-default",
+      "displayName": "Mac Monolithic",
+      "description": "Builds all targets for Mac in the monolithic permutation",
+      "configurePreset": "mac-mono-default",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-mono-install",
+      "displayName": "Mac Monolithic install",
+      "description": "Builds the \"install\" target for mac monolithic permutation, which builds all target and runs the CMake --install step",
+      "configurePreset": "mac-mono-default",
+      "inherits": [
+        "install"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-editor",
+      "displayName": "Mac Editor",
+      "description": "Builds the Editor application for Mac",
+      "configurePreset": "mac-default",
+      "inherits": [
+        "editor"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-assetprocessor",
+      "displayName": "Mac AssetProcessor",
+      "description": "Builds the AssetProcessor application for Mac",
+      "configurePreset": "mac-default",
+      "inherits": [
+        "assetprocessor"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-test",
+      "displayName": "Mac CTest",
+      "description": "Builds the TEST_SUITE_smoke/TEST_SUITE_main custom targets for Mac",
+      "configurePreset": "mac-default",
+      "inherits": [
+        "test-default"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "mac-test-default",
+      "displayName": "Mac CTest",
+      "description": "Runs the Smoke + Main Test Suite. Requires the mac-test build preset to have completed successfully",
+      "configurePreset": "mac-default",
+      "inherits": [
+        "test-default"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-test-debug",
+      "displayName": "Mac CTest debug",
+      "description": "Runs the Smoke + Main Test Suite in debug configuration. Requires the mac-test build preset to have completed successfully",
+      "configurePreset": "mac-default",
+      "inherits": [
+        "test-default-debug"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "mac-test-profile",
+      "displayName": "Mac CTest profile",
+      "description": "Runs the Smoke + Main Test Suite in profile configuration. Requires the mac-test build preset to have completed successfully",
+      "configurePreset": "mac-default",
+      "inherits": [
+        "test-default-profile"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    }
+  ]
+}

--- a/cmake/Platform/Windows/CMakePresets.json
+++ b/cmake/Platform/Windows/CMakePresets.json
@@ -1,0 +1,312 @@
+{
+    "version": 4,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 23,
+        "patch": 0
+    },
+    "include": [
+        "../Common/CMakePresets.json"
+    ],
+    "configurePresets": [
+        {
+            "name": "windows-default",
+            "displayName": "Windows",
+            "description": "Default Windows",
+            "inherits": [
+                "windows-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-mono-default",
+            "displayName": "Windows Monolithic with Unity and Visual Studio",
+            "description": "Configures Windows to build the Monolithic permutation using Visual Studio with Unity builds",
+            "inherits": [
+                "windows-unity",
+                "windows-monolithic"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-unity",
+            "displayName": "Windows Unity",
+            "description": "Windows build which uses unity files",
+            "binaryDir": "${sourceDir}/build/windows",
+            "inherits": [
+                "unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-no-unity",
+            "displayName": "Windows without Unity",
+            "description": "Windows build which uses unity files",
+            "binaryDir": "${sourceDir}/build/windows",
+            "inherits": [
+                "no-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-non-monolithic",
+            "displayName": "Windows Non-Monolithic",
+            "description": "Default configuration for non-monolithic builds",
+            "inherits": [
+                "non-monolithic"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-monolithic",
+            "displayName": "Windows Monolithic",
+            "description": "Default configuration for monolithic builds",
+            "binaryDir": "${sourceDir}/build/windows_mono",
+            "inherits": [
+                "monolithic"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-vs",
+            "displayName": "Windows Visual Studio",
+            "description": "Configure Windows with the Visual Studio IDE",
+            "inherits": [
+                "windows-vs-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-vs-unity",
+            "displayName": "Windows Visual Studio Unity",
+            "description": "Configure Windows with the Visual Studio IDE + Unity Builds",
+            "inherits": [
+                "windows-vs2019",
+                "windows-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-vs-no-unity",
+            "displayName": "Windows Visual Studio without Unity",
+            "description": "Configure Windows with the Visual Studio IDE without unity builds",
+            "inherits": [
+                "windows-vs2019",
+                "windows-no-unity"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-vs2019",
+            "displayName": "Windows Visual Studio 2019",
+            "description": "Configure Windows to use the VS2019 generator",
+            "binaryDir": "${sourceDir}/build/windows_vs2019",
+            "generator": "Visual Studio 16",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-vs2022",
+            "displayName": "Windows Visual Studio 2022",
+            "description": "Configure Windows to use the VS2022 generator",
+            "binaryDir": "${sourceDir}/build/windows_vs2022",
+            "generator": "Visual Studio 17",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-ninja",
+            "displayName": "Windows Ninja",
+            "description": "Configure Windows using the Ninja Multi-Config genrator",
+            "binaryDir": "${sourceDir}/build/windows_ninja",
+            "inherits": [
+                "ninja-multi-config"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "windows-default",
+            "displayName": "Windows",
+            "description": "Builds all targets for Windows",
+            "configurePreset": "windows-default",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-install",
+            "displayName": "Windows install",
+            "description": "Builds the \"install\" target for windows, which builds all target and runs the CMake --install step",
+            "configurePreset": "windows-default",
+            "inherits": [
+                "install"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-mono-default",
+            "displayName": "Windows Monolithic",
+            "description": "Builds all targets for Windows in the monolithic permutation",
+            "configurePreset": "windows-mono-default",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-mono-install",
+            "displayName": "Windows Monolithic install",
+            "description": "Builds the \"install\" target for windows monolithic permutation, which builds all target and runs the CMake --install step",
+            "configurePreset": "windows-mono-default",
+            "inherits": [
+                "install"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-editor",
+            "displayName": "Windows Editor",
+            "description": "Builds the Editor application for Windows",
+            "configurePreset": "windows-default",
+            "inherits": [
+                "editor"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-assetprocessor",
+            "displayName": "Windows AssetProcessor",
+            "description": "Builds the AssetProcessor application for windows",
+            "configurePreset": "windows-default",
+            "inherits": [
+                "assetprocessor"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-test",
+            "displayName": "Windows CTest",
+            "description": "Builds the TEST_SUITE_smoke/TEST_SUITE_main custom targets for Windows",
+            "configurePreset": "windows-default",
+            "inherits": [
+                "test-default"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "windows-test-default",
+            "displayName": "Windows CTest",
+            "description": "Runs the Smoke + Main Test Suite. Requires the windows-test build preset to have completed successfully",
+            "configurePreset": "windows-default",
+            "inherits": [
+                "test-default"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-test-debug",
+            "displayName": "Windows CTest debug",
+            "description": "Runs the Smoke + Main Test Suite in debug configuration. Requires the windows-test build preset to have completed successfully",
+            "configurePreset": "windows-default",
+            "inherits": [
+                "test-default-debug"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "Windows-test-profile",
+            "displayName": "Windows CTest profile",
+            "description": "Runs the Smoke + Main Test Suite in profile configuration. Requires the windows test build preset to have completed successfully",
+            "configurePreset": "windows-default",
+            "inherits": [
+                "test-default-profile"
+            ],
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        }
+    ]
+}

--- a/cmake/Platform/iOS/CMakePresets.json
+++ b/cmake/Platform/iOS/CMakePresets.json
@@ -1,0 +1,249 @@
+{
+  "version": 4,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 23,
+    "patch": 0
+  },
+  "include": [
+    "../Common/CMakePresets.json"
+  ],
+  "configurePresets": [
+    {
+      "name": "ios-default",
+      "displayName": "iOS",
+      "description": "iOS default configuration",
+      "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
+      "inherits": [
+        "ios-xcode",
+        "ios-unity",
+        "ios-monolithic"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-mono-default",
+      "displayName": "iOS Monolithic with Unity and Xcode",
+      "description": "Configures iOS to build the Monolithic permutation using Xcode with Unity builds",
+      "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
+      "inherits": [
+        "ios-ninja",
+        "ios-unity",
+        "ios-monolithic"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-unity",
+      "displayName": "iOS Unity",
+      "description": "iOS build which uses unity files",
+      "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
+      "binaryDir": "${sourceDir}/build/ios",
+      "inherits": [
+        "unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-no-unity",
+      "displayName": "iOS without Unity",
+      "description": "iOS build which uses unity files",
+      "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
+      "binaryDir": "${sourceDir}/build/ios_no_unity",
+      "inherits": [
+        "no-unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-non-monolithic",
+      "displayName": "iOS Non-Monolithic",
+      "description": "Default configuration for non-monolithic builds",
+      "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
+      "inherits": [
+        "non-monolithic"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-monolithic",
+      "displayName": "iOS Monolithic",
+      "description": "Default configuration for monolithic builds",
+      "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
+      "binaryDir": "${sourceDir}/build/ios_mono",
+      "inherits": [
+        "monolithic"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-xcode",
+      "displayName": "iOS Xcode",
+      "description": "Configure iOS using with the Xcode generator",
+      "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
+      "binaryDir": "${sourceDir}/build/ios_xcode",
+      "generator": "Xcode",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-xcode-unity",
+      "displayName": "iOS Xcode Unity",
+      "description": "Configure iOS with the Xcode generator + Unity Builds",
+      "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
+      "binaryDir": "${sourceDir}/build/ios_xcode_unity",
+      "generator": "Xcode",
+      "inherits": [
+        "ios-unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-xcode-no-unity",
+      "displayName": "iOS Xcode without Unity",
+      "description": "Configure iOS with the Xcode Generator without unity builds",
+      "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
+      "binaryDir": "${sourceDir}/build/ios_xcode_no_unity",
+      "generator": "Xcode",
+      "inherits": [
+        "ios-no-unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-ninja",
+      "displayName": "iOS Ninja",
+      "description": "Configure iOS using with the Ninja generator",
+      "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
+      "binaryDir": "${sourceDir}/build/ios_ninja",
+      "inherits": [
+        "ios-ninja-unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-ninja-unity",
+      "displayName": "iOS Ninja Unity",
+      "description": "Configure iOS with the Ninja generator + Unity Builds",
+      "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
+      "binaryDir": "${sourceDir}/build/ios_ninja_unity",
+      "inherits": [
+        "ninja-multi-config",
+        "ios-unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-ninja-no-unity",
+      "displayName": "iOS Ninja without Unity",
+      "description": "Configure iOS with the Ninja Generator without unity builds",
+      "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
+      "binaryDir": "${sourceDir}/build/ios_ninja_no_unity",
+      "inherits": [
+        "ninja-multi-config",
+        "ios-no-unity"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "ios-default",
+      "displayName": "iOS",
+      "description": "Builds all targets for iOS",
+      "configurePreset": "ios-default",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-install",
+      "displayName": "iOS install",
+      "description": "Builds the \"install\" target for iOS, which builds all target and runs the CMake --install step",
+      "configurePreset": "ios-default",
+      "inherits": [
+        "install"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-mono-default",
+      "displayName": "iOS Mono",
+      "description": "Builds all targets for iOS in the monolithic permutation",
+      "configurePreset": "ios-mono-default",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-mono-install",
+      "displayName": "iOS Mono install",
+      "description": "Builds the \"install\" target for ios monolithic permutation, which builds all target and runs the CMake --install step",
+      "configurePreset": "ios-mono-default",
+      "inherits": [
+        "install"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    }
+  ],
+  "testPresets": []
+}


### PR DESCRIPTION
For host platforms of Windows, Linux and MacOS support for
configure, build and test presets has been added.
The non-host platforms of iOS and Android has supported for configure
and build presets.

Using the CMake presets with O3DE requires CMake 3.23.0 or above to be installed.
It is optional feature, so using the CMake without presets work as is in versions 3.22 and below.

How to use Presets can be seen from the [cmake(1)](https://cmake.org/cmake/help/latest/manual/cmake.1.html) page.

The list of presets can output for the configurationm build and test steps by running the following command
```
cmake --list-presets
cmake --build list-presets
ctest --list-presets
```
Below is an example of listing presets on Linux for the normal cmake command, cmake build wrapper command and ctest command.

cmake --list-presets
---
```
Available configure presets:

  "android-default"          - Android
  "android-mono-default"     - Android Monolithic with Unity and Xcode
  "android-unity"            - Android Unity
  "android-no-unity"         - Android without Unity
  "android-non-monolithic"   - Android Non-Monolithic
  "android-monolithic"       - Android Monolithic
  "android-ninja"            - Android Ninja
  "android-ninja-unity"      - Android Ninja Unity
  "android-ninja-no-unity"   - Android Ninja without Unity
  "linux-default"            - Linux
  "linux-mono-default"       - Linux Monolithic with Unity and Ninja
  "linux-clang-default"      - Linux Clang with Ninja and unity
  "linux-gcc-default"        - Linux GCC with Ninja and unity
  "linux-unity"              - Linux Unity
  "linux-no-unity"           - Linux without Unity
  "linux-non-monolithic"     - Linux
  "linux-monolithic"         - Linux
  "linux-ninja"              - Linux Ninja
  "linux-ninja-unity"        - Linux Ninja Unity
  "linux-ninja-no-unity"     - Linux Ninja without Unity
  "linux-makefiles"          - Linux Unix Makefiles
  "linux-makefiles-unity"    - Linux Unix Makefiles Unity
  "linux-makefiles-no-unity" - Linux Unix Makefiles without Unity
  "linux-clang"              - Linux Clang
  "linux-clang-unity"        - Linux Clang + Unity
  "linux-clang-no-unity"     - Linux Clang without Unity
  "linux-gcc"                - Linux GCC
  "linux-gcc-unity"          - Linux GCC + Unity
  "linux-gcc-no-unity"       - Linux GCC without Unity

```

cmake --build --list-presets
---
```
Available build presets:

  "android-default"      - Android
  "android-install"      - Android install
  "android-mono-default" - Android Mono
  "android-mono-install" - Android Mono install
  "linux-default"        - Linux
  "linux-install"        - Linux install
  "linux-mono-default"   - Linux Mono
  "linux-mono-install"   - Linux Mono install
  "linux-editor"         - Linux Editor
  "linux-assetprocessor" - Linux AssetProcessor
  "linux-test"           - Linux CTest
```

ctest --list-presets
---
```
Available test presets:

  "linux-test-default" - Linux CTest
  "linux-test-debug"   - Linux CTest debug
  "linux-test-profile" - Linux CTest profile
```

Presets can be run using the `--preset` option
So instead of running the following command to configure for linux without builds
`cmake -B build/linux -S. -G"Ninja Multi-Config" -DLY_UNITY_BUILD=ON`  
A preset can be used instead
`cmake --preset linux-default`

Presets can also be used with normal options to override to supplement values specified in the preset
For example to use an engine -centric workflow  the LY_PROJECTS parameter can be set as well
`cmake --preset linux-default -DLY_PROJECTS=<project-path>`

For build presets the build folder is picked up from the configure preset it is associated with, so it doesn't have to specified.
For example to build linux using the cmake build wrapper command will work.
```
# Build for linux using  the default 'CMAKE_BUILD_TYPE' configuration
cmake --build --preset linux-default

# Build for linux specifically for the 'profile' configuration
cmake --build --preset linux-default --config profile
```

Test presets also picks up the build folder from the configure preset(However the test presets does not perform a build)
```
# Run ctest for the default for the profile configuration
ctest --preset linux-test-profile

# Run ctest with the output log file parameter
ctest --preset linux-test-profile -O ctest.log
```

Finally users can create their own presets that inherits from the CMakePresets.json by creating a CMakeUserPresets.json in root directory of the engine. That file is gitignored, so it will not be added to source control.

The following is example of adding a configurePrest entry on Linux that configure o3de with the AutomatedTesting using an engine-centric workflow

CMakeUserPresets.json
---
```
{
    "version": 4,
    "cmakeMinimumRequired": {
        "major": 3,
        "minor": 23,
        "patch": 0
    },
    "configurePresets": [
        {
            "name": "linux-automated-testing",
            "displayName": "Linux AutomatedTesting project",
            "description": "Configure Linux with the LY_PROJECTS path set to the AutomatedTesting project directory",
            "inherits": [
                "linux-default"
            ],
            "cacheVariables": {
                "LY_PROJECTS": {
                    "type": "FILEPATH",
                    "value": "${sourceDir}/AutomatedTesting"
                }
            },
            "condition": {
                "type": "equals",
                "lhs": "${hostSystemName}",
                "rhs": "Linux"
            }
        }
    ],
    "buildPresets": [
        {
            "name": "linux-automated-testing-launchers",
            "displayName": "Linux Automated Testing",
            "description": "Builds launcher targets for the AutomatedTesting project on Linux",
            "configurePreset": "linux-default",
            "inherits": [
                "profile"
            ],
            "targets": [
                "AutomatedTesting.GameLauncher",
                "AutomatedTesting.ServerLauncher"
            ],
            "condition": {
                "type": "equals",
                "lhs": "${hostSystemName}",
                "rhs": "Linux"
            }
        }
    ]
}
```

#resolves https://github.com/o3de/sig-build/issues/22

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

Filled out the CMakePresets configuration, build and test presets for all platforms.

A monolithic and non-monolithic preset has been added to each platform along with a unity/no-unity build preset and presets for the de-facto build generators for each platform.

The host platforms in addition have build presets for the Editor, AssetProcessor and the test suites of smoke and main.
Furthermore a test preset has been addded to run those test.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>