### PR TITLE
Remove use of malloc_trim on mac, mac doesn't have this function

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/Apple/AzCore/Memory/OSAllocator_Apple.h
+++ b/Code/Framework/AzCore/Platform/Common/Apple/AzCore/Memory/OSAllocator_Apple.h
@@ -18,4 +18,4 @@ inline void* memalign(size_t blocksize, size_t bytes)
 
 # define AZ_OS_MALLOC(byteSize, alignment) memalign(alignment, byteSize)
 # define AZ_OS_FREE(pointer) ::free(pointer)
-# define AZ_MALLOC_TRIM(pad) ::malloc_trim(pad)
+# define AZ_MALLOC_TRIM(pad) AZ_UNUSED(pad)


### PR DESCRIPTION
Signed-off-by: Chris Burel <burelc@amazon.com>