### PR TITLE
New terrain benchmark that tests parallel terrain queries.

### DIFF
--- a/Gems/Terrain/Code/Tests/TerrainSystemBenchmarks.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainSystemBenchmarks.cpp
@@ -1117,6 +1117,68 @@ namespace UnitTest
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR), 4 })
         ->Unit(::benchmark::kMillisecond);
 
+    // Get timings for how long it takes to run N of the same query at the same time.
+    BENCHMARK_DEFINE_F(TerrainSurfaceGradientBenchmarkFixture, BM_ParallelProcessSurfacePointsList_SurfaceGradients)
+    (benchmark::State& state)
+    {
+        // Run the benchmark
+        RunTerrainApiSurfaceBenchmark(
+            state,
+            [this, state](float queryResolution, const AZ::Aabb& worldBounds, AzFramework::Terrain::TerrainDataRequests::Sampler sampler)
+            {
+                AZStd::vector<AZ::Vector3> inPositions;
+                GenerateInputPositionsList(queryResolution, worldBounds, inPositions);
+
+                auto perPositionCallback =
+                    [](const AzFramework::SurfaceData::SurfacePoint& surfacePoint, [[maybe_unused]] bool terrainExists)
+                {
+                    benchmark::DoNotOptimize(surfacePoint);
+                };
+
+                constexpr uint32_t MaxParallelQueries = 16;
+                AZStd::thread threads[MaxParallelQueries];
+                AZStd::semaphore syncThreads;
+
+                uint32_t numParallelQueries = AZStd::min(aznumeric_cast<uint32_t>(state.range(3)), MaxParallelQueries);
+
+                // Create N threads, each one running a "ProcessSurfacePointsFromList" synchronous terrain query.
+                for (uint32_t thread = 0; thread < numParallelQueries; thread++)
+                {
+                    threads[thread] = AZStd::thread(
+                        [&inPositions, &syncThreads, sampler]()
+                        {
+                            auto perPositionCallback =
+                                [](const AzFramework::SurfaceData::SurfacePoint& surfacePoint, [[maybe_unused]] bool terrainExists)
+                            {
+                                benchmark::DoNotOptimize(surfacePoint);
+                            };
+
+                            syncThreads.acquire();
+
+                            AzFramework::Terrain::TerrainDataRequestBus::Broadcast(
+                                &AzFramework::Terrain::TerrainDataRequests::ProcessSurfacePointsFromList, inPositions, perPositionCallback,
+                                sampler);
+                        });
+                }
+
+                // Now that all threads are created, signal everything to start running in parallel.
+                syncThreads.release(numParallelQueries);
+
+                // Wait for the threads to finish.
+                for (uint32_t thread = 0; thread < numParallelQueries; thread++)
+                {
+                    threads[thread].join();
+                }
+            });
+    }
+
+    BENCHMARK_REGISTER_F(TerrainSurfaceGradientBenchmarkFixture, BM_ParallelProcessSurfacePointsList_SurfaceGradients)
+        ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR), 1 })
+        ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR), 2 })
+        ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR), 3 })
+        ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR), 4 })
+        ->Unit(::benchmark::kMillisecond);
+
 #endif
 
 }

--- a/Gems/Terrain/Code/Tests/TerrainSystemBenchmarks.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainSystemBenchmarks.cpp
@@ -1129,12 +1129,6 @@ namespace UnitTest
                 AZStd::vector<AZ::Vector3> inPositions;
                 GenerateInputPositionsList(queryResolution, worldBounds, inPositions);
 
-                auto perPositionCallback =
-                    [](const AzFramework::SurfaceData::SurfacePoint& surfacePoint, [[maybe_unused]] bool terrainExists)
-                {
-                    benchmark::DoNotOptimize(surfacePoint);
-                };
-
                 constexpr uint32_t MaxParallelQueries = 16;
                 AZStd::thread threads[MaxParallelQueries];
                 AZStd::semaphore syncThreads;


### PR DESCRIPTION
This currently demonstrates that attempting to run multiple synchronous terrain queries in parallel results in locks that force them to run serially. It will be used to demonstrate the improvement once they're able to run in parallel.

![image](https://user-images.githubusercontent.com/82224783/164251142-2e5b45fc-2642-45fe-9fcf-431c0d1d7135.png)

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>