### PR TITLE
[Terrain] Switch the terrain system to allow concurrent queries.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AzCore/EBus/EBus.h>
+#include <AzCore/EBus/EBusSharedDispatchTraits.h>
 #include <AzCore/Jobs/JobContext.h>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
@@ -27,7 +28,7 @@ namespace AzFramework
 
         //! Shared interface for terrain system implementations
         class TerrainDataRequests
-            : public AZ::EBusTraits
+            : public AZ::EBusSharedDispatchTraits<TerrainDataRequests>
         {
         public:
             static void Reflect(AZ::ReflectContext* context);
@@ -36,7 +37,6 @@ namespace AzFramework
             // EBusTraits overrides
             static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
             static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
-            using MutexType = AZStd::recursive_mutex;
             //////////////////////////////////////////////////////////////////////////
 
             enum class Sampler

--- a/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.h
@@ -95,8 +95,8 @@ namespace Terrain
 
         LmbrCentral::DependencyMonitor m_dependencyMonitor;
 
-        // The TerrainAreaHeightRequestBus has lockless dispatch, so make sure that queries don't happen at the same
-        // time as bus connects / disconnects.
+        // The TerrainAreaHeightRequestBus allows parallel dispatches, so make sure that queries don't happen at the same
+        // time as cached data updates.
         AZStd::shared_mutex m_queryMutex;
     };
 }

--- a/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.cpp
@@ -151,9 +151,6 @@ namespace Terrain
         const AZ::Vector3& inPosition,
         AzFramework::SurfaceData::SurfaceTagWeightList& outSurfaceWeights) const
     {
-        // Make sure we don't run queries simultaneously with changing any of the cached data.
-        AZStd::shared_lock lock(m_queryMutex);
-
         outSurfaceWeights.clear();
 
         if (Terrain::TerrainAreaSurfaceRequestBus::HasReentrantEBusUseThisThread())
@@ -180,9 +177,6 @@ namespace Terrain
         AZStd::span<AzFramework::SurfaceData::SurfaceTagWeightList> outSurfaceWeightsList) const
     {
         AZ_PROFILE_FUNCTION(Terrain);
-
-        // Make sure we don't run queries simultaneously with changing any of the cached data.
-        AZStd::shared_lock lock(m_queryMutex);
 
         AZ_Assert(
             inPositionList.size() == outSurfaceWeightsList.size(), "The position list size doesn't match the outSurfaceWeights list size.");
@@ -211,9 +205,6 @@ namespace Terrain
 
     void TerrainSurfaceGradientListComponent::OnCompositionChanged()
     {
-        // Ensure that we only change our terrain registration status when no queries are actively running.
-        AZStd::unique_lock lock(m_queryMutex);
-
         TerrainSystemServiceRequestBus::Broadcast(
             &TerrainSystemServiceRequestBus::Events::RefreshArea, GetEntityId(),
             AzFramework::Terrain::TerrainDataNotifications::SurfaceData);

--- a/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.h
@@ -100,9 +100,5 @@ namespace Terrain
 
         TerrainSurfaceGradientListConfig m_configuration;
         LmbrCentral::DependencyMonitor m_dependencyMonitor;
-
-        // The TerrainAreaSurfaceRequestBus has lockless dispatch, so make sure that queries don't happen at the same
-        // time as bus connects / disconnects.
-        mutable AZStd::shared_mutex m_queryMutex;
     };
 } // namespace Terrain


### PR DESCRIPTION
This also required fixes to the Terrain components to avoid lock inversion deadlocks.

Demonstration of parallel terrain query benchmark running the queries in parallel without locking:
![image](https://user-images.githubusercontent.com/82224783/164312323-84e5dea4-0cf9-4efd-bfd1-98e6219cdfcf.png)


Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>