### PR TITLE
Fix lyn12116 test chunks crash

### DIFF
--- a/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
@@ -18,9 +18,6 @@
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <AzToolsFramework/API/EditorPythonConsoleBus.h>
 #include <AzToolsFramework/API/EditorPythonRunnerRequestsBus.h>
-#include <Entity/EntityUtilityComponent.h>
-#include <Prefab/PrefabSystemComponentInterface.h>
-#include <Prefab/PrefabSystemScriptingBus.h>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
 #include <SceneAPI/SceneCore/Containers/SceneGraph.h>
 #include <SceneAPI/SceneCore/Containers/SceneManifest.h>
@@ -360,9 +357,6 @@ namespace AZ::SceneAPI::Behaviors
             {
                 return Events::ProcessingResult::Ignored;
             }
-
-            EntityUtilityBus::Broadcast(&EntityUtilityBus::Events::ResetEntityContext);
-            AZ::Interface<Prefab::PrefabSystemComponentInterface>::Get()->RemoveAllTemplates();
 
             // attempt to load the manifest string back to a JSON-scene-manifest
             auto sceneManifestLoader = AZStd::make_unique<AZ::SceneAPI::Containers::SceneManifest>();

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
@@ -47,21 +47,6 @@
 #include <SceneAPI/SceneData/Rules/CoordinateSystemRule.h>
 #include <SceneAPI/SceneData/Rules/LodRule.h>
 
-//#include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
-//#include <AzCore/IO/Path/Path.h>
-//#include <AzCore/RTTI/BehaviorContext.h>
-//#include <AzCore/Serialization/SerializeContext.h>
-//#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
-//#include <AzCore/std/smart_ptr/make_shared.h>
-//#include <AzFramework/API/ApplicationAPI.h>
-//#include <AzFramework/Asset/AssetSystemComponent.h>
-//#include <AzFramework/StringFunc/StringFunc.h>
-//#include <AzToolsFramework/API/EditorPythonConsoleBus.h>
-//#include <AzToolsFramework/API/EditorPythonRunnerRequestsBus.h>
-//#include <Entity/EntityUtilityComponent.h>
-//#include <Prefab/PrefabSystemComponentInterface.h>
-//#include <Prefab/PrefabSystemScriptingBus.h>
-
 namespace AZStd
 {
     template<> struct hash<AZ::SceneAPI::Containers::SceneGraph::NodeIndex>


### PR DESCRIPTION
{lyn12116} fix for an Editor crash for test_chunks.fbx

* moved AZ::Interface<Prefab::PrefabSystemComponentInterface>::Get()->RemoveAllTemplates(); logic into PrefabBuilder
* mesh group names shrunk by hashing node path
* only run the RemoveAllTemplates() before an Asset Processor request, not an Editor request
* all platforms will be affected
* the automated tests already cover these cases

Signed-off-by: Allen Jackson <23512001+jackalbe@users.noreply.github.com>