### PR TITLE
[Terrain] Fix shape area falloff to calculate either 2D or 3D falloff.

### DIFF
--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ShapeAreaFalloffGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ShapeAreaFalloffGradientComponent.h
@@ -14,6 +14,7 @@
 #include <GradientSignal/Ebuses/ShapeAreaFalloffGradientRequestBus.h>
 #include <GradientSignal/GradientSampler.h>
 #include <LmbrCentral/Dependency/DependencyMonitor.h>
+#include <LmbrCentral/Shape/ShapeComponentBus.h>
 
 namespace LmbrCentral
 {
@@ -46,6 +47,7 @@ namespace GradientSignal
         : public AZ::Component
         , private GradientRequestBus::Handler
         , private ShapeAreaFalloffGradientRequestBus::Handler
+        , private LmbrCentral::ShapeComponentNotificationsBus::Handler
     {
     public:
         template<typename, typename> friend class LmbrCentral::EditorWrappedComponentBase;
@@ -72,6 +74,10 @@ namespace GradientSignal
         void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
 
     protected:
+        ////////////////////////////////////////////////////////////////////////
+        // LmbrCentral::ShapeComponentNotificationsBus
+        void OnShapeChanged(LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons reasons) override;
+
         //////////////////////////////////////////////////////////////////////////
         // ShapeAreaFalloffGradientRequestBus
         AZ::EntityId GetShapeEntityId() const override;
@@ -83,9 +89,12 @@ namespace GradientSignal
         FalloffType GetFalloffType() const override;
         void SetFalloffType(FalloffType type) override;
 
+        void CacheShapeBounds();
+
     private:
         ShapeAreaFalloffGradientConfig m_configuration;
         LmbrCentral::DependencyMonitor m_dependencyMonitor;
         mutable AZStd::shared_mutex m_queryMutex;
+        AZ::Vector3 m_cachedShapeCenter;
     };
 }

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ShapeAreaFalloffGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ShapeAreaFalloffGradientComponent.h
@@ -34,8 +34,8 @@ namespace GradientSignal
 
         AZ::EntityId m_shapeEntityId;
         float m_falloffWidth = 1.0f;
-
         FalloffType m_falloffType = FalloffType::Outer;
+        bool m_is3dFalloff = false;
     };
 
     static const AZ::Uuid ShapeAreaFalloffGradientComponentTypeId = "{F32A108B-7612-4AC2-B436-96DDDCE9E70B}";
@@ -89,8 +89,10 @@ namespace GradientSignal
         FalloffType GetFalloffType() const override;
         void SetFalloffType(FalloffType type) override;
 
-        void CacheShapeBounds();
+        bool Get3dFalloff() const override;
+        void Set3dFalloff(bool is3dFalloff) override;
 
+        void CacheShapeBounds();
     private:
         ShapeAreaFalloffGradientConfig m_configuration;
         LmbrCentral::DependencyMonitor m_dependencyMonitor;

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/ShapeAreaFalloffGradientRequestBus.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/ShapeAreaFalloffGradientRequestBus.h
@@ -38,6 +38,9 @@ namespace GradientSignal
 
         virtual FalloffType GetFalloffType() const = 0;
         virtual void SetFalloffType(FalloffType type) = 0;
+
+        virtual bool Get3dFalloff() const = 0;
+        virtual void Set3dFalloff(bool is3dFalloff) = 0;
     };
 
     using ShapeAreaFalloffGradientRequestBus = AZ::EBus<ShapeAreaFalloffGradientRequests>;

--- a/Gems/GradientSignal/Code/Tests/GradientSignalServicesTests.cpp
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalServicesTests.cpp
@@ -15,6 +15,7 @@
 #include <GradientSignal/Components/ConstantGradientComponent.h>
 #include <GradientSignal/Components/DitherGradientComponent.h>
 #include <GradientSignal/Components/InvertGradientComponent.h>
+#include <GradientSignal/Ebuses/ShapeAreaFalloffGradientRequestBus.h>
 
 namespace UnitTest
 {
@@ -347,18 +348,25 @@ namespace UnitTest
 
     TEST_F(GradientSignalServicesTestsFixture, ShapeAreaFalloffGradientComponent_ValidateKnownPoints)
     {
-        // Create a shape area falloff gradient centered at (10,10,10) with a box of size 20 and falloff of 16.
+        // Create a shape area falloff gradient centered at (10,10,10) with a box of size 20 and falloff of 10.
         // This will give us the following:
         //   |_______________|------------------|_______________|
-        // (-16)  falloff   (0)       box      (20)  falloff   (36)
+        // (-10)  falloff   (0)       box      (20)  falloff   (30)
 
         const float HalfBounds = 10.0f;
         auto entity = BuildTestShapeAreaFalloffGradient(HalfBounds);
 
+        const float FalloffWidth = 10.0f;
+        GradientSignal::ShapeAreaFalloffGradientRequestBus::Event(
+            entity->GetId(), &GradientSignal::ShapeAreaFalloffGradientRequestBus::Events::SetFalloffWidth, FalloffWidth);
+
+        GradientSignal::ShapeAreaFalloffGradientRequestBus::Event(
+            entity->GetId(), &GradientSignal::ShapeAreaFalloffGradientRequestBus::Events::Set3dFalloff, false);
+
         GradientSignal::GradientSampler gradientSampler;
         gradientSampler.m_gradientId = entity->GetId();
 
-        AZStd::vector<AZStd::pair<AZ::Vector3, float>> positionsAndOutputs =
+        const AZStd::vector<AZStd::pair<AZ::Vector3, float>> positionsAndOutputs =
         {
             // Verify that points that occur within the box get a gradient value of 1.
             { {   0.0f,  0.0f, 0.0f }, 1.0f },
@@ -367,24 +375,86 @@ namespace UnitTest
             { {   0.0f, 10.0f, 0.0f }, 1.0f },
             { {   0.0f, 20.0f, 0.0f }, 1.0f },
 
-            // Verify that points far away from the box get a gradient value of 0. (i.e. outside of -16 to 36)
-            { { -20.0f,   0.0f, 0.0f }, 0.0f },
-            { {  40.0f,   0.0f, 0.0f }, 0.0f },
-            { {   0.0f, -20.0f, 0.0f }, 0.0f },
-            { {   0.0f,  40.0f, 0.0f }, 0.0f },
+            // Verify that points far away from the box get a gradient value of 0. (i.e. outside of -10 to 30)
+            { { -11.0f,   0.0f, 0.0f }, 0.0f },
+            { {  31.0f,   0.0f, 0.0f }, 0.0f },
+            { {   0.0f, -11.0f, 0.0f }, 0.0f },
+            { {   0.0f,  31.0f, 0.0f }, 0.0f },
 
             // Verify that points halfway into the falloff get a value of 0.5.
-            // The box goes from 0 to 20, and the falloff is 16, so -8 and 28 should be halfway into the falloff in each direction.
-            { {  -8.0f,   0.0f, 0.0f }, 0.5f },
-            { {  28.0f,   0.0f, 0.0f }, 0.5f },
-            { {   0.0f,  -8.0f, 0.0f }, 0.5f },
-            { {   0.0f,  28.0f, 0.0f }, 0.5f },
+            // The box goes from 0 to 20, and the falloff is 10, so -5 and 25 should be halfway into the falloff in each direction.
+            { {  -5.0f,   0.0f, 0.0f }, 0.5f },
+            { {  25.0f,   0.0f, 0.0f }, 0.5f },
+            { {   0.0f,  -5.0f, 0.0f }, 0.5f },
+            { {   0.0f,  25.0f, 0.0f }, 0.5f },
 
             // Verify that the Z height of the query has no bearing on the falloff value.
-            { { -8.0f, 0.0f, 1000.0f }, 0.5f },
-            { { 28.0f, 0.0f, 1000.0f }, 0.5f },
-            { { 0.0f, -8.0f, 1000.0f }, 0.5f },
-            { { 0.0f, 28.0f, 1000.0f }, 0.5f },
+            { { -5.0f, 0.0f, 1000.0f }, 0.5f },
+            { { 25.0f, 0.0f, 1000.0f }, 0.5f },
+            { { 0.0f, -5.0f, 1000.0f }, 0.5f },
+            { { 0.0f, 25.0f, 1000.0f }, 0.5f },
+        };
+
+        for (auto& [queryPosition, expectedOutput] : positionsAndOutputs)
+        {
+            GradientSignal::GradientSampleParams params;
+            params.m_position = queryPosition;
+
+            float actualValue = gradientSampler.GetValue(params);
+            EXPECT_NEAR(actualValue, expectedOutput, 0.01f);
+        }
+    }
+
+    TEST_F(GradientSignalServicesTestsFixture, ShapeAreaFalloffGradientComponent_Validate3dFalloff)
+    {
+        // Create a shape area falloff gradient centered at (10,10,10) with a box of size 20 and falloff of 10.
+        // This will give us the following:
+        //   |_______________|------------------|_______________|
+        // (-10)  falloff   (0)       box      (20)  falloff   (30)
+
+        const float HalfBounds = 10.0f;
+        auto entity = BuildTestShapeAreaFalloffGradient(HalfBounds);
+
+        const float FalloffWidth = 10.0f;
+        GradientSignal::ShapeAreaFalloffGradientRequestBus::Event(
+            entity->GetId(), &GradientSignal::ShapeAreaFalloffGradientRequestBus::Events::SetFalloffWidth, FalloffWidth);
+
+        // Enable 3d falloff 
+        GradientSignal::ShapeAreaFalloffGradientRequestBus::Event(
+            entity->GetId(), &GradientSignal::ShapeAreaFalloffGradientRequestBus::Events::Set3dFalloff, true);
+
+        GradientSignal::GradientSampler gradientSampler;
+        gradientSampler.m_gradientId = entity->GetId();
+
+        const AZStd::vector<AZStd::pair<AZ::Vector3, float>> positionsAndOutputs = {
+            // Verify that points halfway into the falloff in the X direction get a value of 0.5.
+            // The box goes from 0 to 20, and the falloff is 10, so -5 and 25 should be halfway into the falloff in each direction.
+            { { -5.0f, 0.0f, 0.0f }, 0.5f },
+            { { -5.0f, 0.0f, 10.0f }, 0.5f },
+            { { -5.0f, 0.0f, 20.0f }, 0.5f },
+            { { 25.0f, 0.0f, 0.0f }, 0.5f },
+            { { 25.0f, 0.0f, 10.0f }, 0.5f },
+            { { 25.0f, 0.0f, 20.0f }, 0.5f },
+
+            // Verify that points halfway into the falloff in the Y direction get a value of 0.5.
+            { { 0.0f, -5.0f, 0.0f }, 0.5f },
+            { { 0.0f, -5.0f, 10.0f }, 0.5f },
+            { { 0.0f, -5.0f, 20.0f }, 0.5f },
+            { { 0.0f, 25.0f, 0.0f }, 0.5f },
+            { { 0.0f, 25.0f, 10.0f }, 0.5f },
+            { { 0.0f, 25.0f, 20.0f }, 0.5f },
+
+            // Verify that points halfway into the falloff in the Z direction get a value of 0.5.
+            { { 0.0f, 0.0f, -5.0f }, 0.5f },
+            { { 10.0f, 10.0f, -5.0f }, 0.5f },
+            { { 20.0f, 20.0f, -5.0f }, 0.5f },
+            { { 0.0f, 0.0f, 25.0f }, 0.5f },
+            { { 10.0f, 10.0f, 25.0f }, 0.5f },
+            { { 20.0f, 20.0f, 25.0f }, 0.5f },
+
+            // Verify that faraway Z points have 0 falloff, even though the XY points are within the box.
+            { { 10.0f, 10.0f, -1000.0f }, 0.0f },
+            { { 10.0f, 10.0f, 1000.0f }, 0.0f },
         };
 
         for (auto& [queryPosition, expectedOutput] : positionsAndOutputs)


### PR DESCRIPTION
The previous approach was using the height of the query point as a part of the distance calculating, which gave us full 3D falloff. This really wasn't desirable behavior for either vegetation or terrain, so the gradient has been switched to use 2D falloff instead by default. Added a toggle to allow for either 2D or 3D falloff.

Added unit tests to validate and enforce the new behavior.

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>