### PR TITLE
Optimize AzToolsFramework.Tests by disabling long poll connection polling

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/ToolsTestApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/ToolsTestApplication.cpp
@@ -8,17 +8,23 @@
 
 #include <AzToolsFramework/UnitTest/ToolsTestApplication.h>
 
+#include <AzCore/Console/IConsole.h>
+
 namespace UnitTest
 {
     ToolsTestApplication::ToolsTestApplication(AZStd::string applicationName)
         :ToolsTestApplication(AZStd::move(applicationName), 0, nullptr)
     {
+        ;
     }
 
     ToolsTestApplication::ToolsTestApplication(AZStd::string applicationName, int argc, char** argv)
         : AzToolsFramework::ToolsApplication(&argc, &argv)
         , m_applicationName(AZStd::move(applicationName))
     {
+        // Connection polling can be slow, disable for Tools Tests
+        const auto console = AZ::Interface<AZ::IConsole>::Get();
+        console->PerformCommand("target_autoconnect false");
     }
 
     void ToolsTestApplication::SetSettingsRegistrySpecializations(AZ::SettingsRegistryInterface::Specializations& specializations)


### PR DESCRIPTION
TargetManagement's polling for a connection in a side thread can take time to resolve on failure. It seems tests can't tear down until the thread is done with this. Disabling this behavior in TestToolsApplication vis IConsole to remove the slowdown. This speeds up hundreds of tests by over a second each.

This relates to https://github.com/o3de/o3de/issues/9022. 

Signed-off-by: puvvadar <puvvadar@amazon.com>