### PR TITLE
Controller for Normal Shadow Bias parameter of the

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
@@ -535,7 +535,7 @@ class AtomComponentProperties:
             'Attenuation radius Radius': 'Controller|Configuration|Attenuation radius|Radius',
             'Enable shadow': 'Controller|Configuration|Shadows|Enable shadow',
             'Shadows Bias': 'Controller|Configuration|Shadows|Bias',
-            'Normal shadow bias': 'Controller|Configuration|Shadows|Normal Shadow Bias\n',
+            'Normal shadow bias': 'Controller|Configuration|Shadows|Normal Shadow Bias',
             'Shadowmap size': 'Controller|Configuration|Shadows|Shadowmap size',
             'Shadow filter method': 'Controller|Configuration|Shadows|Shadow filter method',
             'Filtering sample count': 'Controller|Configuration|Shadows|Filtering sample count',

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/PhotometricValue.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/PhotometricValue.h
@@ -19,7 +19,7 @@ namespace AZ
 
     namespace Render
     {
-        enum class PhotometricUnit : char
+        enum class PhotometricUnit : AZ::u8
         {
             Lumen,              // Total amount of luminous power emitted. Since a unit sphere is 4 pi steradians, 1 candela emitting uniformly in all directions is 4 pi lumens.
             Candela,            // Base unit of luminous intensity; luminous power per unit solid angle.

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
@@ -172,7 +172,7 @@ namespace AZ
                             ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::SupportsShadows)
                             ->Attribute(Edit::Attributes::ReadOnly, &AreaLightComponentConfig::IsEsmDisabled)
                         ->DataElement(
-                            Edit::UIHandlers::Slider, &AreaLightComponentConfig::m_normalShadowBias, "Normal Shadow Bias\n",
+                            Edit::UIHandlers::Slider, &AreaLightComponentConfig::m_normalShadowBias, "Normal Shadow Bias",
                             "Reduces acne by biasing the shadowmap lookup along the geometric normal.\n"
                             "If this is 0, no biasing is applied.")
                             ->Attribute(Edit::Attributes::Min, 0.f)


### PR DESCRIPTION
Light component has an errant "\n."

1. Remove the trailing "\n"
2. Changed PhotometricUnit enum type to AZ::u8 instead of char because
   python was interpreting as a string instead of a numeric value.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>