### PR TITLE
Fix RPE crash when displaying uninitialized optional properties in FBX Settings Inspect panel

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -1808,7 +1808,13 @@ namespace AZ
                     return false;
                 };
                 EnumElements(instance, captureValue);
-                typename T::value_type *valuePtr = *reinterpret_cast<typename T::value_type**>(ptrToRawPtr);
+
+                if (!ptrToRawPtr)
+                {
+                    return nullptr;
+                }
+
+                typename T::value_type* valuePtr = *reinterpret_cast<typename T::value_type**>(ptrToRawPtr);
                 return valuePtr;
             }
 

--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -1796,6 +1796,7 @@ namespace AZ
             }
 
             /// Get an element's address by its index (called before the element is loaded).
+            /// Caller should ensure CanAccessElementsByIndex returns true for this to be valid.
             void* GetElementByIndex(void* instance, const SerializeContext::ClassElement* classElement, size_t index) override
             {
                 (void)classElement;
@@ -1808,12 +1809,6 @@ namespace AZ
                     return false;
                 };
                 EnumElements(instance, captureValue);
-
-                if (!ptrToRawPtr)
-                {
-                    return nullptr;
-                }
-
                 typename T::value_type* valuePtr = *reinterpret_cast<typename T::value_type**>(ptrToRawPtr);
                 return valuePtr;
             }

--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -1783,7 +1783,7 @@ namespace AZ
             /// Returns true if the container is a smart pointer.
             bool IsSmartPointer() const override             { return true; }
 
-            /// Returns true if the container elements can be addressesd by index, otherwise false.
+            /// Returns true if the container elements can be addressed by index, otherwise false.
             bool CanAccessElementsByIndex() const override   { return false; }
 
             /// Reserve element

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
@@ -531,7 +531,12 @@ namespace AzToolsFramework
                         if (genericClassInfo->GetNumTemplatedArguments() == 1)
                         {
                             void* ptrAddress = dataNode->GetInstance(0);
-                            void* ptrValue = container->GetElementByIndex(ptrAddress, classElement, 0);
+                            void* ptrValue = nullptr;
+                            if (container->CanAccessElementsByIndex())
+                            {
+                                container->GetElementByIndex(ptrAddress, classElement, 0);
+                            }
+
                             AZ::Uuid pointeeType;
                             // If the pointer is non-null, find the polymorphic type info
                             if (ptrValue)


### PR DESCRIPTION
Closes #9065 

Fixes a crash in the Scene Inspector for fbx files with uninitialized optional properties. 
This change adds a check on the GetElementByIndex that prevents dereferencing a nullptr. That fixes the crash and results in this view:
![image](https://user-images.githubusercontent.com/82231674/164555550-32d98c48-93db-40e1-a755-a59faf93be33.png)

I am not familiar with this area, so feel free to provide directions if you think this fix should be higer up the chain.