### PR TITLE
Fix search field escape character issue

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
@@ -335,13 +335,13 @@ namespace GraphCanvas
         // Then ignore all whitespace by adding \s* (regex optional whitespace match) in between every other character.
         // We use \s* instead of simply removing all whitespace from the filter and node-names in order to preserve the node-name and accurately highlight the matching portion.
         // Example: "OnGraphStart" or "On Graph Start"
-        m_filter = QRegExp::escape(filter.simplified().replace(" ", ""));
+        m_filter = filter.simplified().replace(" ", "");
         
-        QString regExIgnoreWhitespace(m_filter[0]);
+        QString regExIgnoreWhitespace = QRegExp::escape(QString(m_filter[0]));
         for (int i = 1; i < m_filter.size(); ++i)
         {
             regExIgnoreWhitespace.append("\\s*");
-            regExIgnoreWhitespace.append(m_filter[i]);
+            regExIgnoreWhitespace.append(QRegExp::escape(QString(m_filter[i])));
         }
         
         m_filterRegex = QRegExp(regExIgnoreWhitespace, Qt::CaseInsensitive);


### PR DESCRIPTION
## Details 
Issue is when user gives search filter, we use QRegExp::escape to get string with every regexp special character escaped with a backslash.
For example, "+" -> "\\+"
After that, we also insert whitespace match between each character.
Which leads to "\\+" -> "\\\s*+\\s*"

Fix is to use QRegExp::escape for each character, not at very beginning for whole string.

## Testing

https://user-images.githubusercontent.com/5900509/164568796-311826f3-1d38-427c-8854-9f460e327bdb.mp4



Signed-off-by: onecent1101 <liug@amazon.com>