### PR TITLE
Fix lyn12116 test chunks crash (#9056)

### DIFF
--- a/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
@@ -18,9 +18,6 @@
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <AzToolsFramework/API/EditorPythonConsoleBus.h>
 #include <AzToolsFramework/API/EditorPythonRunnerRequestsBus.h>
-#include <Entity/EntityUtilityComponent.h>
-#include <Prefab/PrefabSystemComponentInterface.h>
-#include <Prefab/PrefabSystemScriptingBus.h>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
 #include <SceneAPI/SceneCore/Containers/SceneGraph.h>
 #include <SceneAPI/SceneCore/Containers/SceneManifest.h>
@@ -360,9 +357,6 @@ namespace AZ::SceneAPI::Behaviors
             {
                 return Events::ProcessingResult::Ignored;
             }
-
-            EntityUtilityBus::Broadcast(&EntityUtilityBus::Events::ResetEntityContext);
-            AZ::Interface<Prefab::PrefabSystemComponentInterface>::Get()->RemoveAllTemplates();
 
             // attempt to load the manifest string back to a JSON-scene-manifest
             auto sceneManifestLoader = AZStd::make_unique<AZ::SceneAPI::Containers::SceneManifest>();

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
@@ -304,11 +304,14 @@ namespace AZ::SceneAPI::Behaviors
                 const auto meshNodeIndex = entry.second.m_meshIndex;
                 const auto propertyDataIndex = entry.second.m_propertyMapIndex;
                 const auto meshNodeName = graph.GetNodeName(meshNodeIndex);
+                const auto meshSubId = DataTypes::Utilities::CreateStableUuid(
+                    scene,
+                    azrtti_typeid<AZ::SceneAPI::SceneData::MeshGroup>(),
+                    meshNodeName.GetPath());
 
-                AZStd::string meshNodePath{ meshNodeName.GetPath() };
                 AZStd::string meshGroupName = "default_";
                 meshGroupName += scene.GetName();
-                meshGroupName += meshNodePath;
+                meshGroupName += meshSubId.ToFixedString().c_str();
 
                 // clean up the mesh group name
                 AZStd::replace_if(
@@ -317,6 +320,7 @@ namespace AZ::SceneAPI::Behaviors
                     [](char c) { return (!AZStd::is_alnum(c) && c != '_'); },
                     '_');
 
+                AZStd::string meshNodePath{ meshNodeName.GetPath() };
                 auto meshGroup = AZStd::make_shared<AZ::SceneAPI::SceneData::MeshGroup>();
                 meshGroup->SetName(meshGroupName);
                 meshGroup->GetSceneNodeSelectionList().AddSelectedNode(AZStd::move(meshNodePath));
@@ -328,10 +332,7 @@ namespace AZ::SceneAPI::Behaviors
                         meshGroup->GetSceneNodeSelectionList().RemoveSelectedNode(nodeName.GetPath());
                     }
                 }
-                meshGroup->OverrideId(DataTypes::Utilities::CreateStableUuid(
-                    scene,
-                    azrtti_typeid<AZ::SceneAPI::SceneData::MeshGroup>(),
-                    meshNodeName.GetPath()));
+                meshGroup->OverrideId(meshSubId);
 
                 // this clears out the mesh coordinates each mesh group will be rotated and translated
                 // using the attached scene graph node
@@ -520,7 +521,21 @@ namespace AZ::SceneAPI::Behaviors
 
         // AssetImportRequest
         Events::ProcessingResult UpdateManifest(Containers::Scene& scene, ManifestAction action, RequestingApplication requester) override;
+        Events::ProcessingResult PrepareForAssetLoading(Containers::Scene& scene, RequestingApplication requester) override;
     };
+
+    Events::ProcessingResult PrefabGroupBehavior::ExportEventHandler::PrepareForAssetLoading(
+        [[maybe_unused]] Containers::Scene& scene,
+        RequestingApplication requester)
+    {
+        using namespace AzToolsFramework;
+        if (requester == RequestingApplication::AssetProcessor)
+        {
+            EntityUtilityBus::Broadcast(&EntityUtilityBus::Events::ResetEntityContext);
+            AZ::Interface<AzToolsFramework::Prefab::PrefabSystemComponentInterface>::Get()->RemoveAllTemplates();
+        }
+        return Events::ProcessingResult::Success;
+    }
 
     Events::ProcessingResult PrefabGroupBehavior::ExportEventHandler::UpdateManifest(
         Containers::Scene& scene,


### PR DESCRIPTION
{lyn12116} fix for an Editor crash for test_chunks.fbx

* moved AZ::Interface<Prefab::PrefabSystemComponentInterface>::Get()->RemoveAllTemplates(); logic into PrefabBuilder
* mesh group names shrunk by hashing node path
* only run the RemoveAllTemplates() before an Asset Processor request, not an Editor request

Signed-off-by: Allen Jackson <23512001+jackalbe@users.noreply.github.com>