### PR TITLE
Fix double deletion of entities when unloading a level

### DIFF
--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -544,7 +544,7 @@ namespace LegacyLevelSystem
 
         OnUnloadComplete(m_lastLevelName.c_str());
 
-        // Delete level entities and prefab instances and remove them from the game entity context
+        // Delete level entities and remove them from the game entity context
         AzFramework::RootSpawnableInterface::Get()->ReleaseRootSpawnable();
 
         m_lastLevelName.clear();

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -536,9 +536,6 @@ namespace LegacyLevelSystem
 
         const AZ::TimeMs beginTimeMs = AZ::GetRealElapsedTimeMs();
 
-        // Clear level entities and prefab instances.
-        EBUS_EVENT(AzFramework::GameEntityContextRequestBus, ResetGameContext);
-
         if (gEnv->pMovieSystem)
         {
             gEnv->pMovieSystem->Reset(false, false);
@@ -547,6 +544,7 @@ namespace LegacyLevelSystem
 
         OnUnloadComplete(m_lastLevelName.c_str());
 
+        // Delete level entities and prefab instances and remove them from the game entity context
         AzFramework::RootSpawnableInterface::Get()->ReleaseRootSpawnable();
 
         m_lastLevelName.clear();


### PR DESCRIPTION
When unloading a level (root spawnable), the ReleaseRootSpawnable call already deletes that level's entities and removes them from the game entity context, so there should no longer be a need to also call ResetGameContext.

Calling ResetGameContext results in entities being deleted that are still being referenced in the spawn ticket. Later on when the spawn ticket is released via ReleaseRootSpawnable, the entities get deleted again causing crashes etc.

Fixes #8696.

Signed-off-by: abrmich <abrmich@amazon.com>