### PR TITLE
updating sphere_5lod asset to use Atom testdata version

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
@@ -221,7 +221,7 @@ def AtomEditorComponents_Material_AddedToEntity():
         mesh_component.set_component_property_value(AtomComponentProperties.mesh('Mesh Asset'), model.id)
         general.idle_wait_frames(1)
         # Update mesh asset to a model with 5 LOD materials
-        model_path = os.path.join('Objects', 'sphere_5lods_fbx_psphere_base_1.azmodel')
+        model_path = os.path.join('testdata', 'objects', 'modelhotreload', 'sphere_5lods.azmodel')
         model = Asset.find_asset_by_path(model_path)
         mesh_component.set_component_property_value(AtomComponentProperties.mesh('Mesh Asset'), model.id)
         general.idle_wait_frames(1)
@@ -243,7 +243,9 @@ def AtomEditorComponents_Material_AddedToEntity():
         # Asset path for lambert0 is 'objects/sphere_5lods_lambert0_11781189446760285338.azmaterial'; numbers may vary
         default_asset = Asset(item.GetDefaultAssetId())
         default_asset_path = default_asset.get_path()
-        Report.result(Tests.model_material_asset_path, default_asset_path.startswith('objects/sphere_5lods_lambert0_'))
+        Report.result(
+            Tests.model_material_asset_path,
+            default_asset_path.startswith('testdata/objects/modelhotreload/sphere_5lods_lambert0_'))
 
         # 15. Enable the use of LOD materials
         material_component.set_component_property_value(AtomComponentProperties.material('Enable LOD Materials'), True)
@@ -265,7 +267,7 @@ def AtomEditorComponents_Material_AddedToEntity():
         active_asset_path = active_asset.get_path()
         Report.result(
             Tests.lod_material_asset_path,
-            active_asset_path.startswith('objects/sphere_5lods_lambert0_'))
+            active_asset_path.startswith('testdata/objects/modelhotreload/sphere_5lods_lambert0_'))
 
         # Setup a material for overrides in further testing
         material_path = os.path.join('Materials', 'Presets', 'PBR', 'metal_gold.azmaterial')
@@ -290,7 +292,7 @@ def AtomEditorComponents_Material_AddedToEntity():
         active_asset_path = active_asset.get_path()
         Report.result(
             Tests.lod_material_asset_path,
-            active_asset_path.startswith('objects/sphere_5lods_lambert0_'))
+            active_asset_path.startswith('testdata/objects/modelhotreload/sphere_5lods_lambert0_'))
 
         # 20. Set the Default Material asset to an override using set component property by path
         material_component.set_component_property_value(

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MeshAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MeshAdded.py
@@ -173,7 +173,7 @@ def AtomEditorComponents_Mesh_AddedToEntity():
         Report.result(Tests.creation_redo, mesh_entity.exists())
 
         # 5. Set Mesh component asset property
-        model_path = os.path.join('Objects', 'sphere_5lods_fbx_psphere_base_1.azmodel')
+        model_path = os.path.join('testdata', 'objects', 'modelhotreload', 'sphere_5lods.azmodel')
         model = Asset.find_asset_by_path(model_path)
         mesh_component.set_component_property_value(AtomComponentProperties.mesh('Mesh Asset'), model.id)
         Report.result(Tests.mesh_asset_specified,


### PR DESCRIPTION
updates the model used for these tests to ./Gems/Atom/TestData/TestData/Objects/ModelHotReload/sphere_5lods.fbx
updates test lines which expect this new path for LOD default mesh paths
relates to https://github.com/o3de/o3de/issues/7795

Report:
[SUCCESS] Success: Material Entity successfully created
[SUCCESS] Success: Entity has a Material component
[SUCCESS] Success: UNDO Entity creation success
[SUCCESS] Success: REDO Entity creation success
[SUCCESS] Success: Material component disabled
[SUCCESS] Success: Entity has an Actor component
[SUCCESS] Success: Material component enabled
[SUCCESS] Success: Entity Actor component gone
[SUCCESS] Success: Material component disabled
[SUCCESS] Success: Entity has a Mesh component
[SUCCESS] Success: Material component enabled
[SUCCESS] Success: Mesh Asset set
[SUCCESS] Success: Model Material count is 5 as expected
[SUCCESS] Success: Model Material zero index is labeled lambert0
[SUCCESS] Success: Asset path of the Material Model index zero is as expected
[SUCCESS] Success: Enable LOD Materials property set to True
[SUCCESS] Success: LOD Material count is 5 as expected
[SUCCESS] Success: Asset path of LOD Material index zero first item is as expected
[SUCCESS] Success: LOD material zero is set to metal_gold.azmaterial id
[SUCCESS] Success: LOD material zero is set to metal_gold.azmaterial id
[SUCCESS] Success: Asset path of LOD Material index zero first item is as expected
[SUCCESS] Success: Default Material set to metal_gold.azmaterial
[SUCCESS] Success: Default Material cleared with MaterialComponentRequestBus
[SUCCESS] Success: Default Material set to metal_gold.azmaterial
[SUCCESS] Success: Entered game mode
[SUCCESS] Success: Exited game mode
[SUCCESS] Success: Entity is hidden
[SUCCESS] Success: Entity is visible
[SUCCESS] Success: Entity deleted
[SUCCESS] Success: UNDO deletion success
[SUCCESS] Success: REDO deletion success
Test result:  SUCCESS

.\python\python.cmd -m pytest --build-directory atom_dev/bin/profile  .\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main.py
====================================== test session starts ======
platform win32 -- Python 3.7.12, pytest-5.3.2, py-1.11.0, pluggy-0.13.1
rootdir: D:\workspace\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 27 items

AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main.py ............................ [100%]

====================================== 28 passed in 43.06s

Signed-off-by: Scott Murray <scottmur@amazon.com>