### PR TITLE
Fix EyeLighting to support new Enable IBL material option

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/EyeLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/EyeLighting.azsli
@@ -71,7 +71,7 @@ PbrLightingOutput GetPbrLightingOutput(Surface surface, LightingData lightingDat
     lightingOutput.m_albedo.rgb = surface.albedo * lightingData.diffuseResponse * lightingData.diffuseAmbientOcclusion;
     lightingOutput.m_albedo.a = lightingData.specularOcclusion;
     lightingOutput.m_normal.rgb = EncodeNormalSignedOctahedron(surface.normal);
-    lightingOutput.m_normal.a = o_specularF0_enableMultiScatterCompensation ? 1.0f : 0.0f;
+    lightingOutput.m_normal.a = EncodeUnorm2BitFlags(o_enableIBL, o_specularF0_enableMultiScatterCompensation);
     
     return lightingOutput;
 }


### PR DESCRIPTION
Support for the Enable IBL material option (https://github.com/o3de/o3de/pull/8495) got merged a few days after the Eye material type (https://github.com/o3de/o3de/pull/8129). This broke the IBL component of the Eye material, so this PR is a trivial fix for it, following the pattern used in the other material types.

Signed-off-by: Santi Paprika <santi.gonzalez@huawei.com>