### PR TITLE
Material Canvas: Implemented document serialization, graph saving and loading

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/blank.materialcanvastemplate.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/blank.materialcanvastemplate.azasset
@@ -1,7 +1,7 @@
 {
     "Type": "JsonSerialization",
     "Version": 1,
-    "ClassName": "AZStd::string",
+    "ClassName": "Graph",
     "ClassData": {
     }
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test1.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test1.materialcanvas.azasset
@@ -1,7 +1,263 @@
 {
     "Type": "JsonSerialization",
     "Version": 1,
-    "ClassName": "AZStd::string",
+    "ClassName": "Graph",
     "ClassData": {
+        "m_nodes": [
+            {
+                "Key": 1,
+                "Value": {
+                    "$type": "DynamicNode",
+                    "m_inputDataSlots": [
+                        {
+                            "Key": {
+                                "m_name": "inA"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 0.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inB"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 0.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inG"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 0.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inR"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 0.0
+                                }
+                            }
+                        }
+                    ],
+                    "config": {
+                        "category": "Color Operations",
+                        "title": "Combine Color Channels",
+                        "inputSlots": [
+                            {
+                                "name": "inR",
+                                "displayName": "R",
+                                "description": "Red color channel",
+                                "supportedDataTypes": [
+                                    "float"
+                                ]
+                            },
+                            {
+                                "name": "inG",
+                                "displayName": "G",
+                                "description": "Green color channel",
+                                "supportedDataTypes": [
+                                    "float"
+                                ]
+                            },
+                            {
+                                "name": "inB",
+                                "displayName": "B",
+                                "description": "Blue color channel",
+                                "supportedDataTypes": [
+                                    "float"
+                                ]
+                            },
+                            {
+                                "name": "inA",
+                                "displayName": "A",
+                                "description": "Alpha color channel",
+                                "supportedDataTypes": [
+                                    "float"
+                                ]
+                            }
+                        ],
+                        "outputSlots": [
+                            {
+                                "name": "outColor",
+                                "displayName": "Color",
+                                "description": "Color",
+                                "supportedDataTypes": [
+                                    "Color"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "Key": 2,
+                "Value": {
+                    "$type": "DynamicNode",
+                    "m_inputDataSlots": [
+                        {
+                            "Key": {
+                                "m_name": "inColor"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "Color",
+                                    "Value": [
+                                        1.0,
+                                        1.0,
+                                        1.0,
+                                        1.0
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                    "config": {
+                        "category": "Color Operations",
+                        "title": "Split Color",
+                        "inputSlots": [
+                            {
+                                "name": "inColor",
+                                "displayName": "Color",
+                                "description": "Color",
+                                "supportedDataTypes": [
+                                    "Color"
+                                ]
+                            }
+                        ],
+                        "outputSlots": [
+                            {
+                                "name": "outR",
+                                "displayName": "R",
+                                "description": "Red color channel",
+                                "supportedDataTypes": [
+                                    "float"
+                                ]
+                            },
+                            {
+                                "name": "outG",
+                                "displayName": "G",
+                                "description": "Green color channel",
+                                "supportedDataTypes": [
+                                    "float"
+                                ]
+                            },
+                            {
+                                "name": "outB",
+                                "displayName": "B",
+                                "description": "Blue color channel",
+                                "supportedDataTypes": [
+                                    "float"
+                                ]
+                            },
+                            {
+                                "name": "outA",
+                                "displayName": "A",
+                                "description": "Alpha color channel",
+                                "supportedDataTypes": [
+                                    "float"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "m_connections": [
+            {
+                "m_sourceEndpoint": [
+                    2,
+                    {
+                        "m_name": "outR"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    1,
+                    {
+                        "m_name": "inR"
+                    }
+                ]
+            },
+            {
+                "m_sourceEndpoint": [
+                    2,
+                    {
+                        "m_name": "outR"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    1,
+                    {
+                        "m_name": "inA"
+                    }
+                ]
+            }
+        ],
+        "m_uiMetadata": {
+            "m_nodeMetadata": [
+                {
+                    "Key": 1,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    400.0,
+                                    80.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{6FBB7F31-AD87-4ABD-9CBC-943B3BA20AFB}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 2,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    180.0,
+                                    200.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{2D7D1DF0-90CD-48B0-A659-668AD6BA6A48}"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
     }
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test2.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test2.materialcanvas.azasset
@@ -1,7 +1,7 @@
 {
     "Type": "JsonSerialization",
     "Version": 1,
-    "ClassName": "AZStd::string",
+    "ClassName": "Graph",
     "ClassData": {
     }
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test3.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test3.materialcanvas.azasset
@@ -1,7 +1,7 @@
 {
     "Type": "JsonSerialization",
     "Version": 1,
-    "ClassName": "AZStd::string",
+    "ClassName": "Graph",
     "ClassData": {
     }
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.materialcanvas.azasset
@@ -1,7 +1,7 @@
 {
     "Type": "JsonSerialization",
     "Version": 1,
-    "ClassName": "AZStd::string",
+    "ClassName": "Graph",
     "ClassData": {
     }
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.materialcanvas.azasset
@@ -1,7 +1,7 @@
 {
     "Type": "JsonSerialization",
     "Version": 1,
-    "ClassName": "AZStd::string",
+    "ClassName": "Graph",
     "ClassData": {
     }
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -77,6 +77,8 @@ namespace MaterialCanvas
         GraphModelIntegration::GraphManagerRequestBus::Broadcast(
             &GraphModelIntegration::GraphManagerRequests::DeleteGraphController, m_graphId);
 
+        m_graph.reset();
+
         delete m_sceneEntity;
     }
 
@@ -135,13 +137,23 @@ namespace MaterialCanvas
             return false;
         }
 
-        // Saving and loading a placeholder string asset
         auto loadResult = AZ::JsonSerializationUtils::LoadAnyObjectFromFile(m_absolutePath);
-        if (!loadResult || !loadResult.GetValue().is<AZStd::string>())
+        if (!loadResult || !loadResult.GetValue().is<GraphModel::Graph>())
         {
             return OpenFailed();
         }
 
+        // Cloning loaded data using the serialize context because the graph does not have a copy or move constructor
+        AZ::SerializeContext* serializeContext = {};
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
+        AZ_Assert(serializeContext, "Failed to acquire application serialize context.");
+
+        m_graph.reset(serializeContext->CloneObject(AZStd::any_cast<const GraphModel::Graph>(&loadResult.GetValue())));
+        m_graph->PostLoadSetup(m_graphContext);
+
+        GraphModelIntegration::GraphManagerRequestBus::Broadcast(
+            &GraphModelIntegration::GraphManagerRequests::CreateGraphController, m_graphId, m_graph);
+        GraphModelIntegration::GraphControllerNotificationBus::Handler::BusConnect(m_graphId);
         return OpenSucceeded();
     }
 
@@ -154,9 +166,7 @@ namespace MaterialCanvas
             return false;
         }
 
-        // Saving and loading a placeholder string asset
-        AZStd::string placeholderData;
-        if (!AZ::JsonSerializationUtils::SaveObjectToFile(&placeholderData, m_savePathNormalized))
+        if (!AZ::JsonSerializationUtils::SaveObjectToFile(m_graph.get(), m_savePathNormalized))
         {
             return SaveFailed();
         }
@@ -173,9 +183,7 @@ namespace MaterialCanvas
             return false;
         }
 
-        // Saving and loading a placeholder string asset
-        AZStd::string placeholderData;
-        if (!AZ::JsonSerializationUtils::SaveObjectToFile(&placeholderData, m_savePathNormalized))
+        if (!AZ::JsonSerializationUtils::SaveObjectToFile(m_graph.get(), m_savePathNormalized))
         {
             return SaveFailed();
         }
@@ -192,9 +200,7 @@ namespace MaterialCanvas
             return false;
         }
 
-        // Saving and loading a placeholder string asset
-        AZStd::string placeholderData;
-        if (!AZ::JsonSerializationUtils::SaveObjectToFile(&placeholderData, m_savePathNormalized))
+        if (!AZ::JsonSerializationUtils::SaveObjectToFile(m_graph.get(), m_savePathNormalized))
         {
             return SaveFailed();
         }
@@ -204,7 +210,7 @@ namespace MaterialCanvas
 
     bool MaterialCanvasDocument::IsOpen() const
     {
-        return AtomToolsDocument::IsOpen();
+        return AtomToolsDocument::IsOpen() && m_graph && m_graphId.IsValid();
     }
 
     bool MaterialCanvasDocument::IsModified() const
@@ -233,6 +239,12 @@ namespace MaterialCanvas
 
     void MaterialCanvasDocument::Clear()
     {
+        GraphModelIntegration::GraphControllerNotificationBus::Handler::BusDisconnect();
+        GraphModelIntegration::GraphManagerRequestBus::Broadcast(
+            &GraphModelIntegration::GraphManagerRequests::DeleteGraphController, m_graphId);
+
+        m_graph.reset();
+
         AtomToolsFramework::AtomToolsDocument::Clear();
     }
 


### PR DESCRIPTION
Updated all of the document class save and load functions to handle the graph model data.
Updated all of the test assets to use graph model graphs instead of placeholder strings.

Builds on top of PR #9104 
Only modifies Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp and test assets