### PR TITLE
Fixed inconsistent depth calculations that resulted in noisy clipping…

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/DepthPass_WithPS.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/DepthPass_WithPS.azsli
@@ -100,6 +100,8 @@ struct PSDepthOutput
 
 PSDepthOutput MainPS(VSDepthOutput IN, bool isFrontFace : SV_IsFrontFace)
 {
+    const float3 vertexNormal = normalize(IN.m_normal);
+
     PSDepthOutput OUT;
 
     OUT.m_depth = IN.m_position.z;
@@ -112,7 +114,7 @@ PSDepthOutput MainPS(VSDepthOutput IN, bool isFrontFace : SV_IsFrontFace)
         for (int i = 0; i != UvSetCount; ++i)
         {
             EvaluateTangentFrame(
-                IN.m_normal,
+                vertexNormal,
                 IN.m_worldPosition, 
                 isFrontFace,
                 IN.m_uv[i],
@@ -124,9 +126,9 @@ PSDepthOutput MainPS(VSDepthOutput IN, bool isFrontFace : SV_IsFrontFace)
         }
 
 #if MULTILAYER
-        MultilayerSetPixelDepth(IN.m_blendMask, IN.m_worldPosition, IN.m_normal, tangents, bitangents, IN.m_uv, isFrontFace, OUT.m_depth);
+        MultilayerSetPixelDepth(IN.m_blendMask, IN.m_worldPosition, vertexNormal, tangents, bitangents, IN.m_uv, isFrontFace, OUT.m_depth);
 #else
-        SetPixelDepth(IN.m_worldPosition, IN.m_normal, tangents, bitangents, IN.m_uv, isFrontFace, OUT.m_depth);
+        SetPixelDepth(IN.m_worldPosition, vertexNormal, tangents, bitangents, IN.m_uv, isFrontFace, OUT.m_depth);
 #endif
 
 #if SHADOWS

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedSurface_ForwardPass.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedSurface_ForwardPass.azsli
@@ -96,13 +96,13 @@ PbrLightingOutput ForwardPassPS_Common(VSOutput IN, bool isFrontFace, out float 
     // ------- Tangents & Bitangets -------
     float3 tangents[UvSetCount] = { IN.m_tangent.xyz, IN.m_tangent.xyz };
     float3 bitangents[UvSetCount] = { IN.m_bitangent.xyz, IN.m_bitangent.xyz };
-
-    if ((o_parallax_feature_enabled && !o_enableSubsurfaceScattering) || o_normal_useTexture || (o_clearCoat_enabled && o_clearCoat_normal_useTexture) || o_detail_normal_useTexture)
+    
+    if (ShouldHandleParallax() || o_normal_useTexture || (o_clearCoat_enabled && o_clearCoat_normal_useTexture) || o_detail_normal_useTexture)
     {
         for (int i = 0; i != UvSetCount; ++i)
         {
             EvaluateTangentFrame(
-                IN.m_normal,
+                vertexNormal,
                 IN.m_worldPosition, 
                 isFrontFace,
                 IN.m_uv[i],
@@ -125,7 +125,7 @@ PbrLightingOutput ForwardPassPS_Common(VSOutput IN, bool isFrontFace, out float 
     {
         EnhancedSetPixelDepth(
             IN.m_worldPosition,
-            IN.m_normal,
+            vertexNormal,
             tangents,
             bitangents,
             IN.m_uv,
@@ -155,7 +155,7 @@ PbrLightingOutput ForwardPassPS_Common(VSOutput IN, bool isFrontFace, out float 
     // TODO: this often invokes a separate sample of the base color texture which is wasteful
     float alpha = GetAlphaAndClip(IN.m_uv);
 
-    EvaluateEnhancedSurface(IN.m_normal, IN.m_uv, IN.m_detailUv, tangents, bitangents, isFrontFace, displacementIsClipped, surface, surfaceSettings);
+    EvaluateEnhancedSurface(vertexNormal, IN.m_uv, IN.m_detailUv, tangents, bitangents, isFrontFace, displacementIsClipped, surface, surfaceSettings);
 
     // ------- Lighting Data -------
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialFunctions/EnhancedParallaxDepth.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialFunctions/EnhancedParallaxDepth.azsli
@@ -11,11 +11,11 @@
 #include <Atom/Features/MatrixUtility.azsli>
 
  void EnhancedSetPixelDepth(
-     float3 worldPosition,
+     inout float3 worldPosition,
      float3 normal,
      float3 tangents[UvSetCount],
      float3 bitangents[UvSetCount],
-     float2 uvs[UvSetCount],
+     inout float2 uvs[UvSetCount],
      bool isFrontFace,
      inout float2 detailUv[UvSetCount],
      inout float depthCS,

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_ForwardPass.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_ForwardPass.azsl
@@ -234,7 +234,7 @@ ProcessedMaterialInputs ProcessStandardMaterialInputs(StandardMaterialInputs inp
     inputs.m_sampler = MaterialSrg::m_sampler;                                                                     \
     inputs.m_vertexUv = IN.m_uv;                                                                                   \
     inputs.m_uvMatrix = srgLayerPrefix##m_uvMatrix;                                                                \
-    inputs.m_normal = IN.m_normal;                                                                                 \
+    inputs.m_normal = vertexNormal;                                                                                \
     inputs.m_tangents = tangents;                                                                                  \
     inputs.m_bitangents = bitangents;                                                                              \
     inputs.m_isFrontFace = isFrontFace;                                                                            \
@@ -359,7 +359,7 @@ PbrLightingOutput ForwardPassPS_Common(VSOutput IN, bool isFrontFace, out float 
         
         float parallaxOverallOffset = MaterialSrg::m_displacementMax;
         float parallaxOverallFactor = MaterialSrg::m_displacementMax - MaterialSrg::m_displacementMin;
-        GetParallaxInput(IN.m_normal, tangents[MaterialSrg::m_parallaxUvIndex], bitangents[MaterialSrg::m_parallaxUvIndex], parallaxOverallFactor, parallaxOverallOffset, 
+        GetParallaxInput(vertexNormal, tangents[MaterialSrg::m_parallaxUvIndex], bitangents[MaterialSrg::m_parallaxUvIndex], parallaxOverallFactor, parallaxOverallOffset, 
                          ObjectSrg::GetWorldMatrix(), uvMatrix, uvMatrixInverse,
                          IN.m_uv[MaterialSrg::m_parallaxUvIndex], IN.m_worldPosition, depthNDC, IN.m_position.w, displacementIsClipped);
 
@@ -446,7 +446,7 @@ PbrLightingOutput ForwardPassPS_Common(VSOutput IN, bool isFrontFace, out float 
     }
     // [GFX TODO][ATOM-14591]: This will only work if the normal maps all use the same UV stream. We would need to add support for having them in different UV streams.
     surface.vertexNormal = vertexNormal;
-    surface.normal = normalize(TangentSpaceToWorld(normalTS, IN.m_normal, tangents[MaterialSrg::m_parallaxUvIndex], bitangents[MaterialSrg::m_parallaxUvIndex]));
+    surface.normal = normalize(TangentSpaceToWorld(normalTS, vertexNormal, tangents[MaterialSrg::m_parallaxUvIndex], bitangents[MaterialSrg::m_parallaxUvIndex]));
         
     // ------- Combine Albedo, roughness, specular, roughness ---------
 


### PR DESCRIPTION
… artifacts for parallax surfaces.

At 505bc28f55472a96995b40baeea1aa3021186045 some code in StandardPBR's forward pass was updated to normalized vertex normal in the pixel shader, but a similar change was not made in the depth pass shader. This resulted in different depth values for some pixels, and so they were clipped from the forward pass. I updated the common DepthPass_WithPS.azsli accordingly. Since this depth shader is also used by EnhancedPbr and StandardMultilayerPbr, those had to be updated as well. Also while testing the changes to EnhancedPbr I noticed that parallax wasn't working correctly there, due to some function parameters that were missing "inout", so now EnhancedPbr parallax should work exactly the same as StandardPBR.

![image](https://user-images.githubusercontent.com/55155825/164945899-51faf3ea-770a-4bac-8eb5-7a88674feb9a.png)

Testing:
ASV full test suite, dx12 and vulkan, saw the known issue https://github.com/o3de/o3de/issues/8903 which has been fixed on the dev branch but not merged to stabilization yet. Also three other detail mapping screenshot tests failed the current threshold in a benign way, we should increase the tolerance (see https://github.com/o3de/o3de-atom-sampleviewer/pull/424).
I also used some local changes to make parallaxrock.material use EnhancedPpbr instead of StandardPbr to confirm that now it works just the same as StandardPbr. I will work on updating the parallax tests to include both StandardPbr and EnhancedPbr, but not on the stablization branch as that requires changes that would risk breaking other tests.

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>