### PR TITLE
Use VP9 WebM by default for video encoding

### DIFF
--- a/Code/Editor/Plugins/FFMPEGPlugin/FFMPEGPlugin.cpp
+++ b/Code/Editor/Plugins/FFMPEGPlugin/FFMPEGPlugin.cpp
@@ -129,7 +129,7 @@ void CFFMPEGPlugin::RegisterTheCommand()
     CommandManagerHelper::RegisterCommand<const char*, const char*, const char*, int, int, const char*>(
         GetIEditor()->GetICommandManager(),
         COMMAND_MODULE, COMMAND_NAME, "Encodes a video using ffmpeg.",
-        "plugin.ffmpeg_encode 'input.avi' 'result.mov' 'libx264' 200 30",
+        "plugin.ffmpeg_encode 'input.avi' 'result.webm' 'libvpx-vp9' 200 30",
         AZStd::bind(Command_FFMPEGEncode, _1, _2, _3, _4, _5, _6));
 }
 

--- a/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
+++ b/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
@@ -1119,13 +1119,13 @@ void CSequenceBatchRenderDialog::OnUpdateEnd(IAnimSequence* sequence)
             AzFramework::StringFunc::Path::Join(outputFolder.c_str(), renderItem.prefix.toUtf8().data(), outputFile);
 
             QString inputFile = outputFile.c_str();
-            outputFile += ".mp4";
+            outputFile += ".webm";
 
             // Use a placeholder for the input file, will expand it with replace.
             QString inputFileDefine = "__input_file__";
 
             QString command = QStringLiteral("plugin.ffmpeg_encode '%1' '%2' '%3' %4 %5 '-vf crop=%6:%7:0:0'")
-                .arg(inputFileDefine).arg(outputFile.c_str()).arg("mpeg4")
+                .arg(inputFileDefine).arg(outputFile.c_str()).arg("libvpx-vp9")
                 .arg(10240).arg(renderItem.fps).arg(getResWidth(renderItem.resW)).arg(getResHeight(renderItem.resH));
 
             // Create the input file string, leave the %06d unexpanded for the mpeg tool.


### PR DESCRIPTION
While FFmpeg supports whatever it was compiled to offer, we
should prefer and suggest codecs that are broadly supported across
all platforms.

Today, WebM (with VP9) is supported out of the box on current versions
of Microsoft Windows; Apple macOS, iOS, iPadOS, tvOS, and watchOS; and
virtually all currently available Linux distributions, including
Amazon Linux, Fedora Linux, Red Hat Enterprise Linux/CentOS Stream, and
Ubuntu Linux.

Hardware accelerated decoding is also broadly in place on desktop and mobile
platforms.

Signed-off-by: Neal Gompa <ngompa@fedoraproject.org>