### PR TITLE
bugfix: resolve tab order problem with component window for propertyAssetCtrl

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -712,7 +712,7 @@ namespace AzToolsFramework
 
     void PropertyAssetCtrl::UpdateTabOrder()
     {
-        setTabOrder(m_browseEdit, m_editButton);
+        setTabOrder(m_browseEdit->lineEdit(), m_editButton);
     }
 
     bool PropertyAssetCtrl::eventFilter(QObject* obj, QEvent* event)


### PR DESCRIPTION
ref issue: https://github.com/o3de/o3de/issues/9130