### PR TITLE
changed node value from a child to a property for better encapsulation

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.cpp
@@ -137,7 +137,7 @@ namespace AZ::DocumentPropertyEditor
         }
         if (!value.IsNull())
         {
-            Value(AZStd::move(value));
+            Attribute(Nodes::PropertyEditor::Value.GetName(), AZStd::move(value));
         }
     }
 
@@ -146,10 +146,10 @@ namespace AZ::DocumentPropertyEditor
         EndNode<Nodes::PropertyEditor>();
     }
 
-    void AdapterBuilder::Label(AZStd::string_view text, bool copy)
+    void AdapterBuilder::Label(AZStd::string_view text)
     {
         BeginLabel();
-        Value(Dom::Value(text, copy));
+        Attribute(Nodes::Label::Value, text);
         EndLabel();
     }
 } // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.h
@@ -52,7 +52,7 @@ namespace AZ::DocumentPropertyEditor
         void EndPropertyEditor();
 
         //! Inserts a Label node with the specified text.
-        void Label(AZStd::string_view text, bool copy = true);
+        void Label(AZStd::string_view text);
 
         //! Sets the value of the last node. Used for setting the current value of a property editor.
         void Value(Dom::Value value);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -32,6 +32,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
     struct Label : NodeDefinition
     {
         static constexpr AZStd::string_view Name = "Label";
+        static constexpr auto Value = AttributeDefinition<AZStd::string_view>("Value");
     };
 
     //! PropertyEditor: A property editor, of a type dictated by its "type" field,
@@ -41,6 +42,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr AZStd::string_view Name = "PropertyEditor";
         static constexpr auto Type = AttributeDefinition<AZStd::string_view>("Type");
         static constexpr auto OnChanged = CallbackAttributeDefinition<void(const Dom::Value&)>("OnChanged");
+        static constexpr auto Value = AttributeDefinition<AZ::Dom::Value>("Value");
     };
 
     template<typename T>

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/AdapterBuilderTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/AdapterBuilderTests.cpp
@@ -34,20 +34,20 @@ namespace AZ::DocumentPropertyEditor::Tests
         Expect the following structure:
         <Adapter>
             <Row>
-                <Label>label</Label>
-                <PropertyEditor type="TextEditor" attr=2>value</TextEditor>
+                <Label Value="label"/>
+                <PropertyEditor type="TextEditor" attr=2 Value="lorem ipsum"/>
             </Row>
         </Adapter>
         */
         Dom::Value expectedDom = Dom::Value::CreateNode(Nodes::Adapter::Name);
         Dom::Value row = Dom::Value::CreateNode(Nodes::Row::Name);
         Dom::Value label = Dom::Value::CreateNode(Nodes::Label::Name);
-        label.SetNodeValue(Dom::Value("label", true));
+        label[Nodes::Label::Value.GetName()] = Dom::Value("label", true);
         row.ArrayPushBack(label);
         Dom::Value editor = Dom::Value::CreateNode(Nodes::PropertyEditor::Name);
         editor[Nodes::PropertyEditor::Type.GetName()] = Dom::Value("TextEditor", true);
         editor["attr"] = 2;
-        editor.SetNodeValue(Dom::Value("lorem ipsum", true));
+        editor[Nodes::PropertyEditor::Value.GetName()] = Dom::Value("lorem ipsum", true);
         row.ArrayPushBack(editor);
         expectedDom.ArrayPushBack(row);
 

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/CvarAdapterTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/CvarAdapterTests.cpp
@@ -51,7 +51,7 @@ namespace AZ::DocumentPropertyEditor::Tests
             Dom::Value rows = m_adapter->GetContents();
             for (auto it = rows.ArrayBegin(); it != rows.ArrayEnd(); ++it)
             {
-                Dom::Value label = (*it)[0].GetNodeValue();
+                Dom::Value label = (*it)[0][Nodes::Label::Value.GetName()];
                 if (label.GetString() == cvarName)
                 {
                     return *it;
@@ -64,7 +64,7 @@ namespace AZ::DocumentPropertyEditor::Tests
         {
             Dom::Value row = GetEntryRow(cvarName);
             EXPECT_FALSE(row.IsNull());
-            return row[1].GetNodeValue();
+            return row[1][Nodes::PropertyEditor::Value.GetName()];
         }
 
         void SetEntryValue(AZStd::string_view cvarName, Dom::Value value)


### PR DESCRIPTION
Signed-off-by: Alex Montgomery <alexmont@amazon.com>
- changed node value to be a property named "Value" instead of a naked child, for better encapsulation
- fixed tests to accommodate change