### PR TITLE
Fix missing log messages in console window

### DIFF
--- a/Code/Framework/AzCore/AzCore/Console/ILogger.h
+++ b/Code/Framework/AzCore/AzCore/Console/ILogger.h
@@ -34,6 +34,8 @@ namespace AZ
         // LogLevel, message, file, function, line
         using LogEvent = AZ::Event<LogLevel, const char*, const char*, const char*, int32_t>;
 
+        static const char* GetTraceWindow() { return "Logger"; }
+
         ILogger() = default;
         virtual ~ILogger() = default;
 

--- a/Code/Framework/AzCore/AzCore/Console/ILogger.h
+++ b/Code/Framework/AzCore/AzCore/Console/ILogger.h
@@ -34,8 +34,6 @@ namespace AZ
         // LogLevel, message, file, function, line
         using LogEvent = AZ::Event<LogLevel, const char*, const char*, const char*, int32_t>;
 
-        static const char* GetTraceWindow() { return "Logger"; }
-
         ILogger() = default;
         virtual ~ILogger() = default;
 

--- a/Code/Framework/AzCore/AzCore/Console/LoggerSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/LoggerSystemComponent.cpp
@@ -123,17 +123,17 @@ namespace AZ
         m_logEvent.Signal(level, buffer.c_str(), file, function, line);
         buffer += '\n';
 
+        // use %s to avoid potential format security issues
         switch (level)
         {
         case LogLevel::Warn:
-            AZ_Warning(Debug::Trace::GetDefaultSystemWindow(), true, buffer.c_str());
+            AZ_Warning(Debug::Trace::GetDefaultSystemWindow(), false, "%s", buffer.c_str());
             break;
         case LogLevel::Error:
-            AZ_Error(Debug::Trace::GetDefaultSystemWindow(), true, buffer.c_str());
+            AZ_Error(Debug::Trace::GetDefaultSystemWindow(), false, "%s", buffer.c_str());
             break;
         default:
-            // Catch all else with trace
-            AZ::Debug::Trace::Printf(Debug::Trace::GetDefaultSystemWindow(), buffer.c_str());
+            AZ::Debug::Trace::Printf(Debug::Trace::GetDefaultSystemWindow(), "%s", buffer.c_str());
             break;
         }
     }

--- a/Code/Framework/AzCore/AzCore/Console/LoggerSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/LoggerSystemComponent.cpp
@@ -126,14 +126,14 @@ namespace AZ
         switch (level)
         {
         case LogLevel::Warn:
-            AZ_Warning(ILogger::GetTraceWindow(), true, buffer.c_str());
+            AZ_Warning(Debug::Trace::GetDefaultSystemWindow(), true, buffer.c_str());
             break;
         case LogLevel::Error:
-            AZ_Error(ILogger::GetTraceWindow(), true, buffer.c_str());
+            AZ_Error(Debug::Trace::GetDefaultSystemWindow(), true, buffer.c_str());
             break;
         default:
             // Catch all else with trace
-            AZ::Debug::Trace::Printf(ILogger::GetTraceWindow(), buffer.c_str());
+            AZ::Debug::Trace::Printf(Debug::Trace::GetDefaultSystemWindow(), buffer.c_str());
             break;
         }
     }

--- a/Code/Framework/AzCore/AzCore/Console/LoggerSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/LoggerSystemComponent.cpp
@@ -126,14 +126,14 @@ namespace AZ
         switch (level)
         {
         case LogLevel::Warn:
-            AZ_Warning("Logger", true, buffer.c_str());
+            AZ_Warning(ILogger::GetTraceWindow(), true, buffer.c_str());
             break;
         case LogLevel::Error:
-            AZ_Error("Logger", true, buffer.c_str());
+            AZ_Error(ILogger::GetTraceWindow(), true, buffer.c_str());
             break;
         default:
             // Catch all else with trace
-            AZ::Debug::Trace::Output("Logger", buffer.c_str());
+            AZ::Debug::Trace::Printf(ILogger::GetTraceWindow(), buffer.c_str());
             break;
         }
     }

--- a/Code/Framework/AzCore/Tests/Console/LoggerSystemComponentTests.cpp
+++ b/Code/Framework/AzCore/Tests/Console/LoggerSystemComponentTests.cpp
@@ -93,7 +93,9 @@ namespace UnitTest
 
     TEST_F(LoggerSystemComponentTests, LogErrorTest)
     {
+        AZ_TEST_START_TRACE_SUPPRESSION;
         AZLOG_ERROR("test error");
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         EXPECT_EQ(m_lastLogLevel, AZ::LogLevel::Error);
         EXPECT_EQ(strcmp("test error", m_lastLogMessage.c_str()), 0);
     }

--- a/Gems/AtomLyIntegration/ImguiAtom/Code/Source/DebugConsole.cpp
+++ b/Gems/AtomLyIntegration/ImguiAtom/Code/Source/DebugConsole.cpp
@@ -176,11 +176,11 @@ namespace AZ
         AZ::Color color = GetColorForLogLevel(logLevel);
         if (strcmp(window, AZ::Debug::Trace::GetDefaultSystemWindow()) == 0)
         {
-            AddDebugLog( debugLogString, color);
+            AddDebugLog(debugLogString, color);
         }
         else
         {
-            AddDebugLog( AZStd::string::format("(%s) - %s", window, debugLogString), color);
+            AddDebugLog(AZStd::string::format("(%s) - %s", window, debugLogString), color);
         }
     }
 

--- a/Gems/AtomLyIntegration/ImguiAtom/Code/Source/DebugConsole.cpp
+++ b/Gems/AtomLyIntegration/ImguiAtom/Code/Source/DebugConsole.cpp
@@ -66,17 +66,6 @@ namespace AZ
     ////////////////////////////////////////////////////////////////////////////////////////////////
     DebugConsole::DebugConsole(int maxEntriesToDisplay, int maxInputHistorySize)
         : InputChannelEventListener(InputChannelEventListener::GetPriorityFirst(), true)
-        , m_logHandler
-        (
-            [this](AZ::LogLevel logLevel,
-                   const char* message,
-                   [[maybe_unused]]const char* file,
-                   [[maybe_unused]]const char* function,
-                   [[maybe_unused]]int32_t line)
-            {
-                AddDebugLog(message, GetColorForLogLevel(logLevel));
-            }
-        )
         , m_inputContext(DebugConsoleInputContext, {nullptr, InputChannelEventListener::GetPriorityFirst(), true, true})
         , m_maxEntriesToDisplay(maxEntriesToDisplay)
         , m_maxInputHistorySize(maxInputHistorySize)
@@ -121,19 +110,10 @@ namespace AZ
         inputFilter->IncludeChannelName(inputMappingToggleConsole->GetInputChannelId().GetNameCrc32());
         SetFilter(inputFilter);
 
-        // Bind our custom log handler.
-        AZ::ILogger* loggerInstance = AZ::Interface<AZ::ILogger>::Get();
-        AZ_Assert(loggerInstance, "Failed to get ILogger instance. Log handler not bound.")
-        if (loggerInstance)
-        {
-            loggerInstance->BindLogHandler(m_logHandler);
-        }
-
         // Connect to receive render tick events.
         auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
         const AZ::Name contextName = atomViewportRequests->GetDefaultViewportContextName();
         AZ::RPI::ViewportContextNotificationBus::Handler::BusConnect(contextName);
-
 
         AZ::Debug::TraceMessageBus::Handler::BusConnect();
     }
@@ -145,9 +125,6 @@ namespace AZ
 
         // Disconnect to stop receiving render tick events.
         AZ::RPI::ViewportContextNotificationBus::Handler::BusDisconnect();
-
-        // Disconnect our custom log handler.
-        m_logHandler.Disconnect();
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -188,9 +165,16 @@ namespace AZ
         }
     }
 
-    void DebugConsole::AddDebugLog(const char* window, const char* debugLogString, const AZ::Color& color)
+    void DebugConsole::AddDebugLog(const char* window, const char* debugLogString, AZ::LogLevel logLevel)
     {
-        if (strcmp(window, AZ::Debug::Trace::GetDefaultSystemWindow()) == 0)
+        AZ::ILogger* logger = AZ::Interface<AZ::ILogger>::Get();
+        if (logger == nullptr || logLevel < logger->GetLogLevel())
+        {
+            return;
+        }
+
+        AZ::Color color = GetColorForLogLevel(logLevel);
+        if (strcmp(window, AZ::Debug::Trace::GetDefaultSystemWindow()) == 0 || strcmp(window, ILogger::GetTraceWindow()) == 0)
         {
             AddDebugLog( debugLogString, color);
         }
@@ -215,19 +199,19 @@ namespace AZ
 
     bool DebugConsole::OnPreError(const char* window, [[maybe_unused]] const char* fileName, [[maybe_unused]] int line, [[maybe_unused]] const char* func, const char* message)
     {
-        AddDebugLog(window, message, GetColorForLogLevel(AZ::LogLevel::Error));
+        AddDebugLog(window, message, AZ::LogLevel::Error);
         return false;
     }
 
     bool DebugConsole::OnPreWarning(const char* window, [[maybe_unused]] const char* fileName, [[maybe_unused]] int line, [[maybe_unused]] const char* func, const char* message)
     {
-        AddDebugLog(window, message, GetColorForLogLevel(AZ::LogLevel::Warn));
+        AddDebugLog(window, message, AZ::LogLevel::Warn);
         return false;
     }
 
     bool DebugConsole::OnPrintf(const char* window, const char* message)
     {
-        AddDebugLog(window, message, GetColorForLogLevel(AZ::LogLevel::Trace));
+        AddDebugLog(window, message, AZ::LogLevel::Notice); // Notice is one level below warning
         return false;
     }
 

--- a/Gems/AtomLyIntegration/ImguiAtom/Code/Source/DebugConsole.cpp
+++ b/Gems/AtomLyIntegration/ImguiAtom/Code/Source/DebugConsole.cpp
@@ -174,7 +174,7 @@ namespace AZ
         }
 
         AZ::Color color = GetColorForLogLevel(logLevel);
-        if (strcmp(window, AZ::Debug::Trace::GetDefaultSystemWindow()) == 0 || strcmp(window, ILogger::GetTraceWindow()) == 0)
+        if (strcmp(window, AZ::Debug::Trace::GetDefaultSystemWindow()) == 0)
         {
             AddDebugLog( debugLogString, color);
         }

--- a/Gems/AtomLyIntegration/ImguiAtom/Code/Source/DebugConsole.h
+++ b/Gems/AtomLyIntegration/ImguiAtom/Code/Source/DebugConsole.h
@@ -16,6 +16,7 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Console/ILogger.h>
 #include <AzCore/Math/Color.h>
+#include <AzCore/Debug/TraceMessageBus.h>
 
 #include <AzCore/std/containers/deque.h>
 #include <AzCore/std/string/string.h>
@@ -39,6 +40,7 @@ namespace AZ
     //! - The fourth finger press on a touch screen.
     class DebugConsole : public AzFramework::InputChannelEventListener
                        , public AZ::RPI::ViewportContextNotificationBus::Handler
+                       , public AZ::Debug::TraceMessageBus::Handler
     {
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! The default maximum number of entries to display in the debug log.
@@ -67,6 +69,11 @@ namespace AZ
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Destructor
         ~DebugConsole() override;
+
+        //! AZ::Debug::TraceMessageBus
+        bool OnPreError(const char* window, const char* fileName, int line, const char* func, const char* message) override;
+        bool OnPreWarning(const char* window, const char* fileName, int line, const char* func, const char* message) override;
+        bool OnPrintf(const char* window, const char* message) override;
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! \ref AZ::RPI::ViewportContextRequestsInterface
@@ -111,6 +118,8 @@ namespace AZ
         void ToggleIsShowing();
 
     private:
+        void AddDebugLog(const char* window, const char* debugLogString, const AZ::Color& color = AZ::Colors::White);
+
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Variables
         AZStd::deque<AZStd::pair<AZStd::string, AZ::Color>> m_debugLogEntires; //!< All debug logs.

--- a/Gems/AtomLyIntegration/ImguiAtom/Code/Source/DebugConsole.h
+++ b/Gems/AtomLyIntegration/ImguiAtom/Code/Source/DebugConsole.h
@@ -118,13 +118,12 @@ namespace AZ
         void ToggleIsShowing();
 
     private:
-        void AddDebugLog(const char* window, const char* debugLogString, const AZ::Color& color = AZ::Colors::White);
+        void AddDebugLog(const char* window, const char* debugLogString, AZ::LogLevel logLevel);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Variables
         AZStd::deque<AZStd::pair<AZStd::string, AZ::Color>> m_debugLogEntires; //!< All debug logs.
         AZStd::deque<AZStd::string> m_textInputHistory; //!< History of input that has been entered.
-        AZ::ILogger::LogEvent::Handler m_logHandler; //!< Handler that receives log events to display.
         AzFramework::InputContext m_inputContext; //!< Input context used to open/close the console.
         char m_inputBuffer[1028] = {}; //!< The character buffer used to accept text input.
         AzFramework::SystemCursorState m_previousSystemCursorState; //! The last system cursor state.


### PR DESCRIPTION
Before this fix, only a handful of logs were visible in the in-game console - namely audio and networking, but all other logs are not visible.

This change restores all missing log messages in the console window, until the log reckoning takes place.  
- DebugConsole now receives logs messages from `AZ::Debug::TraceMessageBus`, `m_logHandler` is removed
- LoggerSystemComponent sends messages through `Debug::Trace::Printf` instead of `Debug::Trace::Output`

### Testing
- verified logs appear in console in the game launcher

![image (15)](https://user-images.githubusercontent.com/26804013/165196864-5dfd4b79-e373-472a-ac46-a417e64fb5fa.png)

- fixed `LoggerSystemComponent` AZLOG_ERROR unit test
```
[==========] Running 10 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 10 tests from LoggerSystemComponentTests
[ RUN      ] LoggerSystemComponentTests.LogTraceTest
[       OK ] LoggerSystemComponentTests.LogTraceTest (0 ms)
[ RUN      ] LoggerSystemComponentTests.LogDebugTest
[       OK ] LoggerSystemComponentTests.LogDebugTest (0 ms)
[ RUN      ] LoggerSystemComponentTests.LogInfoTest
[       OK ] LoggerSystemComponentTests.LogInfoTest (0 ms)
[ RUN      ] LoggerSystemComponentTests.LogNoticeTest
[       OK ] LoggerSystemComponentTests.LogNoticeTest (0 ms)
[ RUN      ] LoggerSystemComponentTests.LogWarnTest
[       OK ] LoggerSystemComponentTests.LogWarnTest (0 ms)
[ RUN      ] LoggerSystemComponentTests.LogErrorTest
[       OK ] LoggerSystemComponentTests.LogErrorTest (0 ms)
[ RUN      ] LoggerSystemComponentTests.LogFatalTest
[       OK ] LoggerSystemComponentTests.LogFatalTest (0 ms)
[ RUN      ] LoggerSystemComponentTests.LogLevelTest
[       OK ] LoggerSystemComponentTests.LogLevelTest (0 ms)
[ RUN      ] LoggerSystemComponentTests.TaggedLogEnableDisableTest
[       OK ] LoggerSystemComponentTests.TaggedLogEnableDisableTest (0 ms)
[ RUN      ] LoggerSystemComponentTests.TaggedLogToggleTest
[       OK ] LoggerSystemComponentTests.TaggedLogToggleTest (0 ms)
[----------] 10 tests from LoggerSystemComponentTests (11 ms total)

[----------] Global test environment tear-down
[==========] 10 tests from 1 test case ran. (15 ms total)
[  PASSED  ] 10 tests.
``` 

Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>