### PR TITLE
Crash when baking a Reflection Probe (GPU device removed)

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/EnvironmentCubeMapPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/EnvironmentCubeMapPipeline.pass
@@ -394,7 +394,8 @@
                         "ShaderAsset": {
                             "FilePath": "Shaders/Reflections/ReflectionComposite.shader"
                         },
-                        "StencilRef": 1 // See RenderCommon.h and ReflectionComposite.shader
+                        "StencilRef": 1, // See RenderCommon.h and ReflectionComposite.shader
+                        "PipelineViewTag": "MainCamera"
                     }
                 },
                 {


### PR DESCRIPTION
Added the PipelineViewTag to the ReflectionComposite pass in the EnvironmentCubeMapPipeline.