### PR TITLE
Added property control for AZ::IO::Path

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
@@ -136,6 +136,8 @@ namespace AZ
             const static AZ::Crc32 ShowProductAssetFileName = AZ_CRC("ShowProductAssetFileName");
             //! Regular expression pattern filter for source files
             const static AZ::Crc32 SourceAssetFilterPattern = AZ_CRC_CE("SourceAssetFilterPattern");
+            //! Extension for a product asset to search for
+            const static AZ::Crc32 ProductAssetExtension = AZ_CRC_CE("ProductAssetExtension");
 
             //! Component icon attributes
             const static AZ::Crc32 Icon = AZ_CRC("Icon", 0x659429db);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabSaveLoadHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabSaveLoadHandler.cpp
@@ -71,7 +71,7 @@ namespace AzToolsFramework
                     ->Field("m_autoNumber", &PrefabUserSettings::m_autoNumber);
             }
         }
-        
+
         PrefabSaveHandler::PrefabSaveHandler()
         {
             s_prefabLoaderInterface = AZ::Interface<PrefabLoaderInterface>::Get();
@@ -121,8 +121,7 @@ namespace AzToolsFramework
             settings->m_saveLocation = path;
         }
 
-        void PrefabSaveHandler::HandleSourceFileType(
-            AZStd::string_view sourceFilePath, AZ::EntityId parentId, AZ::Vector3 position) const
+        void PrefabSaveHandler::HandleSourceFileType(AZStd::string_view sourceFilePath, AZ::EntityId parentId, AZ::Vector3 position) const
         {
             auto instantiatePrefabOutcome = s_prefabPublicInterface->InstantiatePrefab(sourceFilePath, parentId, position);
 
@@ -310,11 +309,13 @@ namespace AzToolsFramework
                 {
                     // Put an error in the console, so the log files have info about this error, or the user can look up the error after
                     // dismissing it.
-                    AZStd::string errorMessage =
+                    constexpr const char* errorMessage =
                         "You can only save prefabs to either your game project folder or the Gems folder. Update the location and try "
                         "again.\n\n"
-                        "You can also review and update your save locations in the AssetProcessorPlatformConfig.ini file.";
-                    AZ_Error("Prefab", false, errorMessage.c_str());
+                        "You can also review and update your save locations in the Registry/AssetProcessorPlatformConfig.setreg file or "
+                        "your Gem's "
+                        "Registry/assetprocessor_settings.setreg file.";
+                    AZ_Error("Prefab", false, errorMessage);
 
                     // Display a pop-up, the logs are easy to miss. This will make sure a user who encounters this error immediately knows
                     // their prefab save has failed.
@@ -322,7 +323,7 @@ namespace AzToolsFramework
                     msgBox.setIcon(QMessageBox::Icon::Warning);
                     msgBox.setTextFormat(Qt::RichText);
                     msgBox.setWindowTitle(QObject::tr("Invalid save location"));
-                    msgBox.setText(QObject::tr(errorMessage.c_str()));
+                    msgBox.setText(QObject::tr(errorMessage));
                     msgBox.setStandardButtons(QMessageBox::Cancel | QMessageBox::Retry);
                     msgBox.setDefaultButton(QMessageBox::Retry);
                     const int response = msgBox.exec();
@@ -570,7 +571,9 @@ namespace AzToolsFramework
                     AzToolsFramework::Prefab::TemplateId unsavedPrefabTemplateId =
                         s_prefabSystemComponentInterface->GetTemplateIdFromFilePath(unsavedPrefabFileName.data());
                     [[maybe_unused]] bool isTemplateSavedSuccessfully = s_prefabLoaderInterface->SaveTemplate(unsavedPrefabTemplateId);
-                    AZ_Error("Prefab", isTemplateSavedSuccessfully, "Prefab '%s' could not be saved successfully.", unsavedPrefabFileName.c_str());
+                    AZ_Error(
+                        "Prefab", isTemplateSavedSuccessfully, "Prefab '%s' could not be saved successfully.",
+                        unsavedPrefabFileName.c_str());
                 }
             }
         }
@@ -601,7 +604,8 @@ namespace AzToolsFramework
             auto prefabTemplate = s_prefabSystemComponentInterface->FindTemplate(templateId);
             AZ::IO::Path prefabTemplatePath = prefabTemplate->get().GetFilePath();
             QLabel* prefabSavedSuccessfullyLabel = new QLabel(
-                QString("Prefab '<b>%1</b>' has been saved. Do you want to save the below dependent prefabs too?").arg(prefabTemplatePath.c_str()),
+                QString("Prefab '<b>%1</b>' has been saved. Do you want to save the below dependent prefabs too?")
+                    .arg(prefabTemplatePath.c_str()),
                 savePrefabDialog.get());
             prefabSavedMessageLayout->addWidget(prefabSavedSuccessfullyIconContainer);
             prefabSavedMessageLayout->addWidget(prefabSavedSuccessfullyLabel);
@@ -623,9 +627,8 @@ namespace AzToolsFramework
                 footerSeparatorLine->setFrameShape(QFrame::HLine);
                 contentLayout->addWidget(footerSeparatorLine);
 
-                QLabel* prefabSavePreferenceHint = new QLabel(
-                    "You can prevent this from showing in the future by updating your preferences.",
-                    savePrefabDialog.get());
+                QLabel* prefabSavePreferenceHint =
+                    new QLabel("You can prevent this from showing in the future by updating your preferences.", savePrefabDialog.get());
                 prefabSavePreferenceHint->setToolTip(
                     "Go to 'Edit > Editor Settings > Global Preferences... > Prefab Save Settings' to update your preference");
                 prefabSavePreferenceHint->setObjectName(PrefabSavePreferenceHint);
@@ -714,7 +717,8 @@ namespace AzToolsFramework
                 unsavedPrefabsLayout->addWidget(prefabNameLabel);
             }
 
-            AZStd::unique_ptr<AzQtComponents::Card> unsavedPrefabsContainer = AZStd::make_unique<AzQtComponents::Card>(AzToolsFramework::GetActiveWindow());
+            AZStd::unique_ptr<AzQtComponents::Card> unsavedPrefabsContainer =
+                AZStd::make_unique<AzQtComponents::Card>(AzToolsFramework::GetActiveWindow());
             unsavedPrefabsContainer->setObjectName(SaveDependentPrefabsCard);
             unsavedPrefabsContainer->setTitle("Unsaved Prefabs");
             unsavedPrefabsContainer->header()->setHasContextMenu(false);
@@ -729,5 +733,5 @@ namespace AzToolsFramework
 
             return AZStd::move(unsavedPrefabsContainer);
         }
-    }
-}
+    } // namespace Prefab
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
@@ -40,6 +40,10 @@ namespace AzToolsFramework
         QObject::connect(
             m_browseEdit, &AzQtComponents::BrowseEdit::attachedButtonTriggered, this, &PropertyFilePathCtrl::OnOpenButtonClicked);
 
+        // Whenever the browse edit has text, the clear button will be automatically shown
+        // since we enabled it with setClearButtonEnabled.
+        // When it is pressed, it clears the browse edit text for us, but we need to do
+        // some extra logic as well to clear our internal state and trigger our value changed.
         QToolButton* clearButton = AzQtComponents::LineEdit::getClearButton(m_browseEdit->lineEdit());
         AZ_Assert(clearButton, "Clear button missing from BrowseEdit");
         QObject::connect(clearButton, &QToolButton::clicked, this, &PropertyFilePathCtrl::OnClearButtonClicked);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
@@ -34,9 +34,11 @@ namespace AzToolsFramework
 
         m_browseEdit = new AzQtComponents::BrowseEdit(this);
         m_browseEdit->lineEdit()->setFocusPolicy(Qt::StrongFocus);
+        m_browseEdit->setLineEditReadOnly(true);
         m_browseEdit->setClearButtonEnabled(true);
         m_browseEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
         QObject::connect(m_browseEdit, &AzQtComponents::BrowseEdit::attachedButtonTriggered, this, &PropertyFilePathCtrl::OnOpenButtonClicked);
+        QObject::connect(m_browseEdit->lineEdit(), &QLineEdit::textChanged, this, &PropertyFilePathCtrl::FilePathChanged);
 
         QToolButton* clearButton = AzQtComponents::LineEdit::getClearButton(m_browseEdit->lineEdit());
         AZ_Assert(clearButton, "Clear button missing from BrowseEdit");
@@ -57,7 +59,7 @@ namespace AzToolsFramework
         m_currentFilePath = filePath;
         m_browseEdit->setText(filePath.c_str());
 
-        Q_EMIT valueChanged(m_currentFilePath);
+        Q_EMIT FilePathChanged();
     }
 
     AZ::IO::Path PropertyFilePathCtrl::GetFilePath() const
@@ -261,7 +263,7 @@ namespace AzToolsFramework
     {
         PropertyFilePathCtrl* newCtrl = aznew PropertyFilePathCtrl(parent);
 
-        QObject::connect(newCtrl, &PropertyFilePathCtrl::valueChanged, this, [newCtrl]()
+        QObject::connect(newCtrl, &PropertyFilePathCtrl::FilePathChanged, this, [newCtrl]()
         {
             PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::RequestWrite, newCtrl);
             PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
@@ -38,7 +38,6 @@ namespace AzToolsFramework
         m_browseEdit->setClearButtonEnabled(true);
         m_browseEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
         QObject::connect(m_browseEdit, &AzQtComponents::BrowseEdit::attachedButtonTriggered, this, &PropertyFilePathCtrl::OnOpenButtonClicked);
-        QObject::connect(m_browseEdit->lineEdit(), &QLineEdit::textChanged, this, &PropertyFilePathCtrl::FilePathChanged);
 
         QToolButton* clearButton = AzQtComponents::LineEdit::getClearButton(m_browseEdit->lineEdit());
         AZ_Assert(clearButton, "Clear button missing from BrowseEdit");
@@ -227,6 +226,8 @@ namespace AzToolsFramework
     {
         m_currentFilePath.clear();
         m_browseEdit->lineEdit()->clearFocus();
+
+        Q_EMIT FilePathChanged();
     }
 
     void PropertyFilePathHandler::ConsumeAttribute(PropertyFilePathCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, [[maybe_unused]] const char* debugName)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
@@ -153,23 +153,22 @@ namespace AzToolsFramework
                     return QString();
                 }
 
-                // Find an asset safe folder that already has existing sub-path that
-                // would satisfy the relative path for the file
-                for (const AZStd::string& assetSafeFolder : assetSafeFolders)
+                // Find an asset safe folder that already has the existing parent-path that
+                // would satisfy the relative path currently stored.
+                //
+                // Example: m_currentFilePath has a value of "my/sub/folder/image.png"
+                // It will keep looking until it finds an asset safe folder that has
+                // a matching sub-directory structure that exists:
+                //      <ASSET_SAFE_FOLDER>/my/sub/folder
+                for (AZ::IO::Path candidateFilePath : assetSafeFolders)
                 {
-                    AZ::IO::Path assetSafeFolderPath(assetSafeFolder);
-                    AZ::IO::Path relativeFolderPath = assetSafeFolderPath;
+                    candidateFilePath /= m_currentFilePath;
 
-                    if (m_currentFilePath.HasParentPath())
+                    if (AZ::IO::FixedMaxPath parentCandidatePath = candidateFilePath.ParentPath();
+                        AZ::IO::SystemFile::IsDirectory(parentCandidatePath.c_str()))
                     {
-                        relativeFolderPath /= m_currentFilePath.ParentPath();
-                    }
-
-                    if (AZ::IO::SystemFile::IsDirectory(relativeFolderPath.c_str()))
-                    {
-                        auto absoluteFilePath = (assetSafeFolderPath / m_currentFilePath);
                         preselectedFilePath =
-                            QString::fromUtf8(absoluteFilePath.c_str(), static_cast<int>(absoluteFilePath.Native().size()));
+                            QString::fromUtf8(candidateFilePath.c_str(), static_cast<int>(candidateFilePath.Native().size()));
                         break;
                     }
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "PropertyFilePathCtrl.h"
+
+AZ_PUSH_DISABLE_WARNING(4244 4251, "-Wunknown-warning-option")
+#include <QDir>
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QToolButton>
+AZ_POP_DISABLE_WARNING
+
+#include <AzCore/Utils/Utils.h>
+
+#include <AzQtComponents/Components/Widgets/BrowseEdit.h>
+#include <AzQtComponents/Components/Widgets/FileDialog.h>
+
+#include <AzToolsFramework/API/EditorAssetSystemAPI.h>
+#include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
+
+namespace AzToolsFramework
+{
+    PropertyFilePathCtrl::PropertyFilePathCtrl(QWidget* parent)
+        : QWidget(parent)
+    {
+        QHBoxLayout* layout = new QHBoxLayout(this);
+
+        m_browseEdit = new AzQtComponents::BrowseEdit(this);
+        m_browseEdit->lineEdit()->setFocusPolicy(Qt::StrongFocus);
+        m_browseEdit->setClearButtonEnabled(true);
+        m_browseEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+        QObject::connect(m_browseEdit, &AzQtComponents::BrowseEdit::attachedButtonTriggered, this, &PropertyFilePathCtrl::OnOpenButtonClicked);
+
+        QToolButton* clearButton = AzQtComponents::LineEdit::getClearButton(m_browseEdit->lineEdit());
+        AZ_Assert(clearButton, "Clear button missing from BrowseEdit");
+        QObject::connect(clearButton, &QToolButton::clicked, this, &PropertyFilePathCtrl::OnClearButtonClicked);
+
+        layout->setContentsMargins(0, 0, 0, 0);
+        layout->setSpacing(2);
+        layout->addWidget(m_browseEdit);
+
+        setLayout(layout);
+
+        setFocusProxy(m_browseEdit->lineEdit());
+        setFocusPolicy(m_browseEdit->lineEdit()->focusPolicy());
+    };
+
+    void PropertyFilePathCtrl::SetFilePath(AZ::IO::Path filePath)
+    {
+        m_currentFilePath = filePath;
+        m_browseEdit->setText(filePath.c_str());
+
+        Q_EMIT valueChanged(m_currentFilePath);
+    }
+
+    AZ::IO::Path PropertyFilePathCtrl::GetFilePath() const
+    {
+        return m_currentFilePath;
+    }
+
+    void PropertyFilePathCtrl::SetFilter(const QString& filter)
+    {
+        m_filter = filter;
+    }
+
+    void PropertyFilePathCtrl::SetProductExtension(const AZStd::string& extension)
+    {
+        m_productExtension = extension;
+    }
+
+    void PropertyFilePathCtrl::SetDefaultFileName(const AZStd::string& fileName)
+    {
+        m_defaultFileName = fileName;
+    }
+
+    void PropertyFilePathCtrl::OnOpenButtonClicked()
+    {
+        QString preselectedFilePath;
+
+        // If we don't have any output file set yet, then generate a default
+        // option for the user
+        if (m_currentFilePath.empty())
+        {
+            AZ::IO::Path defaultPath = AZ::IO::Path(AZ::Utils::GetProjectPath());
+
+            // If a default filename has been specified, append it to
+            // the project path to be the default path
+            if (!m_defaultFileName.empty())
+            {
+                defaultPath /= AZ::IO::Path(m_defaultFileName);
+            }
+
+            preselectedFilePath = defaultPath.c_str();
+        }
+        // Otherwise, we need to find the proper absolute path based on the relative path
+        // that is stored
+        else
+        {
+            // The GetFullSourcePathFromRelativeProductPath API only works on product paths,
+            // so we need to append the product extension to try and find it
+            AZStd::string relativePath = m_currentFilePath.String() + m_productExtension;
+
+            AZStd::string fullPath;
+            bool fullPathIsValid;
+            AssetSystemRequestBus::BroadcastResult(
+                fullPathIsValid, &AssetSystemRequestBus::Events::GetFullSourcePathFromRelativeProductPath, relativePath,
+                fullPath);
+
+            // The full source path asset exists on disk, so use that as
+            // the pre-selected file when the user opens the file picker dialog
+            if (fullPathIsValid)
+            {
+                preselectedFilePath = fullPath.c_str();
+            }
+            // GetFullSourcePathFromRelativeProductPath failed so the file doesn't exist on disk yet
+            // So we need to find it by searching in the asset safe folders
+            else
+            {
+                bool assetSafeFoldersRetrieved = false;
+                AZStd::vector<AZStd::string> assetSafeFolders;
+                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+                    assetSafeFoldersRetrieved, &AzToolsFramework::AssetSystemRequestBus::Events::GetAssetSafeFolders, assetSafeFolders);
+
+                if (!assetSafeFoldersRetrieved)
+                {
+                    AZ_Error("PropertyFilePathCtrl", false, "Could not acquire a list of asset safe folders from the database.");
+                    return;
+                }
+
+                // Find an asset safe folder that already has existing sub-path that
+                // would satisfy the relative path for the file
+                for (const AZStd::string& assetSafeFolder : assetSafeFolders)
+                {
+                    AZ::IO::Path assetSafeFolderPath(assetSafeFolder);
+                    AZ::IO::Path relativeFolderPath = assetSafeFolderPath;
+
+                    if (m_currentFilePath.HasParentPath())
+                    {
+                        relativeFolderPath /= m_currentFilePath.ParentPath();
+                    }
+
+                    QDir currentFilePathDirectory(relativeFolderPath.c_str());
+                    if (currentFilePathDirectory.exists())
+                    {
+                        auto absoluteFilePath = (assetSafeFolderPath / m_currentFilePath);
+                        preselectedFilePath = absoluteFilePath.c_str();
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Popup a native file dialog to choose a new or existing file
+        // Using the AzQtComponents::FileDialog::GetSaveFileName helper will protect the user from entering
+        // a filename with invalid characters for the AP
+        QString newFilePath = AzQtComponents::FileDialog::GetSaveFileName(
+            this, QObject::tr("Open/Save File"), preselectedFilePath, m_filter);
+
+        // If the newFilePath is empty, then the dialog was cancelled,
+        // so don't process any further.
+        if (newFilePath.isEmpty())
+        {
+            return;
+        }
+
+        // Generate a relative path given the absolute path that was picked.
+        // If the absolute path wasn't inside an asset safe folder, then
+        // the call to GenerateRelativeSourcePath will fail.
+        AZStd::string absolutePath(newFilePath.toUtf8().constData());
+        AZStd::string relativePath, rootFilePath;
+        bool relativePathIsValid;
+        AssetSystemRequestBus::BroadcastResult(
+            relativePathIsValid, &AssetSystemRequestBus::Events::GenerateRelativeSourcePath, absolutePath,
+            relativePath, rootFilePath);
+
+        // We have a valid relative path, so update our entry.
+        if (relativePathIsValid)
+        {
+            SetFilePath(relativePath);
+        }
+        // The user chose a path outside of an asset safe folder,
+        // so give them a warning dialog explaining why it can't be saved there
+        else
+        {
+            AZStd::string errorMessage =
+                "You can only save assets to either your game project folder or the Gems folder. Update the location and try "
+                "again.\n\n"
+                "You can also review and update your save locations in the AssetProcessorPlatformConfig.ini file.";
+            AZ_Error("PropertyFilePathCtrl", false, errorMessage.c_str());
+
+            QMessageBox* errorDialog = new QMessageBox(GetActiveWindow());
+            errorDialog->setIcon(QMessageBox::Icon::Warning);
+            errorDialog->setTextFormat(Qt::RichText);
+            errorDialog->setWindowTitle(QObject::tr("Invalid save location"));
+            errorDialog->setText(QObject::tr(errorMessage.c_str()));
+            errorDialog->setStandardButtons(QMessageBox::Cancel | QMessageBox::Retry);
+            errorDialog->setDefaultButton(QMessageBox::Retry);
+
+            QObject::connect(errorDialog, &QDialog::finished, [this, errorDialog](int resultCode)
+            {
+                // If the user wants to retry, re-open the file dialog
+                // It will automatically be re-opened relative to the default
+                // asset safe folder (typically the project root)
+                if (resultCode == QMessageBox::Retry)
+                {
+                    OnOpenButtonClicked();
+                }
+
+                // Make sure our error dialog gets deleted after it is dismissed.
+                errorDialog->deleteLater();
+            });
+
+            errorDialog->open();
+        }
+    }
+
+    void PropertyFilePathCtrl::OnClearButtonClicked()
+    {
+        m_currentFilePath.clear();
+        m_browseEdit->lineEdit()->clearFocus();
+    }
+
+    void PropertyFilePathHandler::ConsumeAttribute(PropertyFilePathCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, [[maybe_unused]] const char* debugName)
+    {
+        if (attrib == AZ::Edit::Attributes::SourceAssetFilterPattern)
+        {
+            AZStd::string filter;
+            if (attrValue->Read<AZStd::string>(filter))
+            {
+                GUI->SetFilter(filter.c_str());
+            }
+        }
+        else if (attrib == AZ::Edit::Attributes::DefaultAsset)
+        {
+            AZStd::string defaultAsset;
+            if (attrValue->Read<AZStd::string>(defaultAsset))
+            {
+                GUI->SetDefaultFileName(defaultAsset);
+            }
+        }
+    }
+
+    AZ::u32 PropertyFilePathHandler::GetHandlerName() const
+    {
+        return AZ_CRC_CE("FilePath");
+    }
+
+    bool PropertyFilePathHandler::IsDefaultHandler() const
+    {
+        return true;
+    }
+
+    QWidget* PropertyFilePathHandler::CreateGUI(QWidget* parent)
+    {
+        PropertyFilePathCtrl* newCtrl = aznew PropertyFilePathCtrl(parent);
+
+        QObject::connect(newCtrl, &PropertyFilePathCtrl::valueChanged, this, [newCtrl]()
+        {
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::RequestWrite, newCtrl);
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
+        });
+
+        return newCtrl;
+    }
+
+    void PropertyFilePathHandler::WriteGUIValuesIntoProperty(size_t index, PropertyFilePathCtrl* GUI, property_t& instance, InstanceDataNode* node)
+    {
+        AZ_UNUSED(index);
+        AZ_UNUSED(node);
+
+        AZ::IO::Path filePath = GUI->GetFilePath();
+        instance = static_cast<property_t>(filePath);
+    }
+
+    bool PropertyFilePathHandler::ReadValuesIntoGUI(size_t index, PropertyFilePathCtrl* GUI, const property_t& instance, InstanceDataNode* node)
+    {
+        AZ_UNUSED(index);
+        AZ_UNUSED(node);
+
+        GUI->blockSignals(true);
+
+        GUI->SetFilePath(instance);
+
+        GUI->blockSignals(false);
+
+        return false;
+    }
+
+    void RegisterFilePathHandler()
+    {
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::RegisterPropertyType, aznew PropertyFilePathHandler());
+    }
+}
+
+#include "UI/PropertyEditor/moc_PropertyFilePathCtrl.cpp"

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
@@ -45,7 +45,6 @@ namespace AzToolsFramework
         QObject::connect(clearButton, &QToolButton::clicked, this, &PropertyFilePathCtrl::OnClearButtonClicked);
 
         layout->setContentsMargins(0, 0, 0, 0);
-        layout->setSpacing(2);
         layout->addWidget(m_browseEdit);
 
         setLayout(layout);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
@@ -37,7 +37,8 @@ namespace AzToolsFramework
         m_browseEdit->setLineEditReadOnly(true);
         m_browseEdit->setClearButtonEnabled(true);
         m_browseEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-        QObject::connect(m_browseEdit, &AzQtComponents::BrowseEdit::attachedButtonTriggered, this, &PropertyFilePathCtrl::OnOpenButtonClicked);
+        QObject::connect(
+            m_browseEdit, &AzQtComponents::BrowseEdit::attachedButtonTriggered, this, &PropertyFilePathCtrl::OnOpenButtonClicked);
 
         QToolButton* clearButton = AzQtComponents::LineEdit::getClearButton(m_browseEdit->lineEdit());
         AZ_Assert(clearButton, "Clear button missing from BrowseEdit");
@@ -111,8 +112,7 @@ namespace AzToolsFramework
             AZStd::string fullPath;
             bool fullPathIsValid;
             AssetSystemRequestBus::BroadcastResult(
-                fullPathIsValid, &AssetSystemRequestBus::Events::GetFullSourcePathFromRelativeProductPath, relativePath,
-                fullPath);
+                fullPathIsValid, &AssetSystemRequestBus::Events::GetFullSourcePathFromRelativeProductPath, relativePath, fullPath);
 
             // The full source path asset exists on disk, so use that as
             // the pre-selected file when the user opens the file picker dialog
@@ -161,8 +161,8 @@ namespace AzToolsFramework
         // Popup a native file dialog to choose a new or existing file
         // Using the AzQtComponents::FileDialog::GetSaveFileName helper will protect the user from entering
         // a filename with invalid characters for the AP
-        QString newFilePath = AzQtComponents::FileDialog::GetSaveFileName(
-            this, QObject::tr("Open/Save File"), preselectedFilePath, m_filter);
+        QString newFilePath =
+            AzQtComponents::FileDialog::GetSaveFileName(this, QObject::tr("Open/Save File"), preselectedFilePath, m_filter);
 
         // If the newFilePath is empty, then the dialog was cancelled,
         // so don't process any further.
@@ -178,8 +178,7 @@ namespace AzToolsFramework
         AZStd::string relativePath, rootFilePath;
         bool relativePathIsValid;
         AssetSystemRequestBus::BroadcastResult(
-            relativePathIsValid, &AssetSystemRequestBus::Events::GenerateRelativeSourcePath, absolutePath,
-            relativePath, rootFilePath);
+            relativePathIsValid, &AssetSystemRequestBus::Events::GenerateRelativeSourcePath, absolutePath, relativePath, rootFilePath);
 
         // We have a valid relative path, so update our entry.
         if (relativePathIsValid)
@@ -204,19 +203,21 @@ namespace AzToolsFramework
             errorDialog->setStandardButtons(QMessageBox::Cancel | QMessageBox::Retry);
             errorDialog->setDefaultButton(QMessageBox::Retry);
 
-            QObject::connect(errorDialog, &QDialog::finished, [this, errorDialog](int resultCode)
-            {
-                // If the user wants to retry, re-open the file dialog
-                // It will automatically be re-opened relative to the default
-                // asset safe folder (typically the project root)
-                if (resultCode == QMessageBox::Retry)
+            QObject::connect(
+                errorDialog, &QDialog::finished,
+                [this, errorDialog](int resultCode)
                 {
-                    OnOpenButtonClicked();
-                }
+                    // If the user wants to retry, re-open the file dialog
+                    // It will automatically be re-opened relative to the default
+                    // asset safe folder (typically the project root)
+                    if (resultCode == QMessageBox::Retry)
+                    {
+                        OnOpenButtonClicked();
+                    }
 
-                // Make sure our error dialog gets deleted after it is dismissed.
-                errorDialog->deleteLater();
-            });
+                    // Make sure our error dialog gets deleted after it is dismissed.
+                    errorDialog->deleteLater();
+                });
 
             errorDialog->open();
         }
@@ -230,7 +231,8 @@ namespace AzToolsFramework
         Q_EMIT FilePathChanged();
     }
 
-    void PropertyFilePathHandler::ConsumeAttribute(PropertyFilePathCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, [[maybe_unused]] const char* debugName)
+    void PropertyFilePathHandler::ConsumeAttribute(
+        PropertyFilePathCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, [[maybe_unused]] const char* debugName)
     {
         if (attrib == AZ::Edit::Attributes::SourceAssetFilterPattern)
         {
@@ -264,16 +266,19 @@ namespace AzToolsFramework
     {
         PropertyFilePathCtrl* newCtrl = aznew PropertyFilePathCtrl(parent);
 
-        QObject::connect(newCtrl, &PropertyFilePathCtrl::FilePathChanged, this, [newCtrl]()
-        {
-            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::RequestWrite, newCtrl);
-            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
-        });
+        QObject::connect(
+            newCtrl, &PropertyFilePathCtrl::FilePathChanged, this,
+            [newCtrl]()
+            {
+                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::RequestWrite, newCtrl);
+                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
+            });
 
         return newCtrl;
     }
 
-    void PropertyFilePathHandler::WriteGUIValuesIntoProperty(size_t index, PropertyFilePathCtrl* GUI, property_t& instance, InstanceDataNode* node)
+    void PropertyFilePathHandler::WriteGUIValuesIntoProperty(
+        size_t index, PropertyFilePathCtrl* GUI, property_t& instance, InstanceDataNode* node)
     {
         AZ_UNUSED(index);
         AZ_UNUSED(node);
@@ -282,7 +287,8 @@ namespace AzToolsFramework
         instance = static_cast<property_t>(filePath);
     }
 
-    bool PropertyFilePathHandler::ReadValuesIntoGUI(size_t index, PropertyFilePathCtrl* GUI, const property_t& instance, InstanceDataNode* node)
+    bool PropertyFilePathHandler::ReadValuesIntoGUI(
+        size_t index, PropertyFilePathCtrl* GUI, const property_t& instance, InstanceDataNode* node)
     {
         AZ_UNUSED(index);
         AZ_UNUSED(node);
@@ -301,6 +307,6 @@ namespace AzToolsFramework
         PropertyTypeRegistrationMessages::Bus::Broadcast(
             &PropertyTypeRegistrationMessages::RegisterPropertyType, aznew PropertyFilePathHandler());
     }
-}
+} // namespace AzToolsFramework
 
 #include "UI/PropertyEditor/moc_PropertyFilePathCtrl.cpp"

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
@@ -278,21 +278,15 @@ namespace AzToolsFramework
     }
 
     void PropertyFilePathHandler::WriteGUIValuesIntoProperty(
-        size_t index, PropertyFilePathCtrl* GUI, property_t& instance, InstanceDataNode* node)
+        [[maybe_unused]] size_t index, PropertyFilePathCtrl* GUI, property_t& instance, [[maybe_unused]] InstanceDataNode* node)
     {
-        AZ_UNUSED(index);
-        AZ_UNUSED(node);
-
         AZ::IO::Path filePath = GUI->GetFilePath();
         instance = static_cast<property_t>(filePath);
     }
 
     bool PropertyFilePathHandler::ReadValuesIntoGUI(
-        size_t index, PropertyFilePathCtrl* GUI, const property_t& instance, InstanceDataNode* node)
+        [[maybe_unused]] size_t index, PropertyFilePathCtrl* GUI, const property_t& instance, [[maybe_unused]] InstanceDataNode* node)
     {
-        AZ_UNUSED(index);
-        AZ_UNUSED(node);
-
         GUI->blockSignals(true);
 
         GUI->SetFilePath(instance);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.cpp
@@ -57,7 +57,7 @@ namespace AzToolsFramework
         setFocusPolicy(m_browseEdit->lineEdit()->focusPolicy());
     };
 
-    void PropertyFilePathCtrl::SetFilePath(AZ::IO::Path filePath)
+    void PropertyFilePathCtrl::SetFilePath(const AZ::IO::Path& filePath)
     {
         m_currentFilePath = filePath;
         m_browseEdit->setText(filePath.c_str());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/Memory/SystemAllocator.h>
+
+#include <QString>
+#include <QWidget>
+
+#include "PropertyEditorAPI.h"
+#endif
+
+
+namespace AzQtComponents
+{
+    class BrowseEdit;
+}
+
+namespace AzToolsFramework
+{
+    // A control for representing an AZ::IO::Path field with
+    // a BrowseEdit whose popup button triggers a native
+    // file dialog
+    class PropertyFilePathCtrl
+        : public QWidget
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(PropertyFilePathCtrl, AZ::SystemAllocator, 0);
+
+        PropertyFilePathCtrl(QWidget* parent = nullptr);
+
+        AZ::IO::Path GetFilePath() const;
+        void SetFilter(const QString& filter);
+        void SetProductExtension(const AZStd::string& extension);
+        void SetDefaultFileName(const AZStd::string& fileName);
+  
+    Q_SIGNALS:
+        void valueChanged(AZ::IO::Path newPath);
+
+    public Q_SLOTS:
+        void SetFilePath(AZ::IO::Path filePath);
+
+    private:
+        AzQtComponents::BrowseEdit* m_browseEdit = nullptr;
+        AZ::IO::Path m_currentFilePath;
+        QString m_filter;
+        AZStd::string m_productExtension;
+        AZStd::string m_defaultFileName;
+
+        void OnOpenButtonClicked();
+        void OnClearButtonClicked();
+    };
+
+    class PropertyFilePathHandler
+        : public QObject
+        , public PropertyHandler<AZ::IO::Path, PropertyFilePathCtrl>
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(PropertyFilePathHandler, AZ::SystemAllocator, 0);
+
+        AZ::u32 GetHandlerName() const override;
+
+        // Override to be true so that the user to be able to either specify no handler or "Default"
+        // and this handler will be found based on type match (AZ::IO::Path)
+        bool IsDefaultHandler() const override;
+
+        QWidget* CreateGUI(QWidget* parent) override;
+        void ConsumeAttribute(PropertyFilePathCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
+        void WriteGUIValuesIntoProperty(size_t index, PropertyFilePathCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
+        bool ReadValuesIntoGUI(size_t index, PropertyFilePathCtrl* GUI, const property_t& instance, InstanceDataNode* node)  override;
+    };
+
+    void RegisterFilePathHandler();
+};

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
@@ -18,7 +18,6 @@
 #include "PropertyEditorAPI.h"
 #endif
 
-
 namespace AzQtComponents
 {
     class BrowseEdit;
@@ -29,8 +28,7 @@ namespace AzToolsFramework
     // A control for representing an AZ::IO::Path field with
     // a BrowseEdit whose popup button triggers a native
     // file dialog
-    class PropertyFilePathCtrl
-        : public QWidget
+    class PropertyFilePathCtrl : public QWidget
     {
         Q_OBJECT
     public:
@@ -42,7 +40,7 @@ namespace AzToolsFramework
         void SetFilter(const QString& filter);
         void SetProductExtension(const AZStd::string& extension);
         void SetDefaultFileName(const AZStd::string& fileName);
-  
+
     Q_SIGNALS:
         void FilePathChanged();
 
@@ -75,10 +73,11 @@ namespace AzToolsFramework
         bool IsDefaultHandler() const override;
 
         QWidget* CreateGUI(QWidget* parent) override;
-        void ConsumeAttribute(PropertyFilePathCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
+        void ConsumeAttribute(
+            PropertyFilePathCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
         void WriteGUIValuesIntoProperty(size_t index, PropertyFilePathCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
-        bool ReadValuesIntoGUI(size_t index, PropertyFilePathCtrl* GUI, const property_t& instance, InstanceDataNode* node)  override;
+        bool ReadValuesIntoGUI(size_t index, PropertyFilePathCtrl* GUI, const property_t& instance, InstanceDataNode* node) override;
     };
 
     void RegisterFilePathHandler();
-};
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
@@ -45,7 +45,7 @@ namespace AzToolsFramework
         void FilePathChanged();
 
     public Q_SLOTS:
-        void SetFilePath(AZ::IO::Path filePath);
+        void SetFilePath(const AZ::IO::Path& filePath);
 
     private:
         AzQtComponents::BrowseEdit* m_browseEdit = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
@@ -44,7 +44,7 @@ namespace AzToolsFramework
         void SetDefaultFileName(const AZStd::string& fileName);
   
     Q_SIGNALS:
-        void valueChanged(AZ::IO::Path newPath);
+        void FilePathChanged();
 
     public Q_SLOTS:
         void SetFilePath(AZ::IO::Path filePath);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
@@ -36,10 +36,10 @@ namespace AzToolsFramework
 
         PropertyFilePathCtrl(QWidget* parent = nullptr);
 
-        AZ::IO::Path GetFilePath() const;
+        const AZ::IO::Path& GetFilePath() const;
         void SetFilter(const QString& filter);
-        void SetProductExtension(const AZStd::string& extension);
-        void SetDefaultFileName(const AZStd::string& fileName);
+        void SetProductExtension(AZStd::string extension);
+        void SetDefaultFileName(AZ::IO::Path fileName);
 
     Q_SIGNALS:
         void FilePathChanged();
@@ -52,7 +52,7 @@ namespace AzToolsFramework
         AZ::IO::Path m_currentFilePath;
         QString m_filter;
         AZStd::string m_productExtension;
-        AZStd::string m_defaultFileName;
+        AZ::IO::Path m_defaultFileName;
 
         void OnOpenButtonClicked();
         QString GetPreselectedFilePath() const;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
@@ -25,9 +25,9 @@ namespace AzQtComponents
 
 namespace AzToolsFramework
 {
-    // A control for representing an AZ::IO::Path field with
-    // a BrowseEdit whose popup button triggers a native
-    // file dialog
+    //! A control for representing an AZ::IO::Path field with
+    //! a BrowseEdit whose popup button triggers a native
+    //! file dialog.
     class PropertyFilePathCtrl : public QWidget
     {
         Q_OBJECT

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyFilePathCtrl.h
@@ -55,6 +55,8 @@ namespace AzToolsFramework
         AZStd::string m_defaultFileName;
 
         void OnOpenButtonClicked();
+        QString GetPreselectedFilePath() const;
+        void HandleNewFilePathSelected(const QString& newFilePath);
         void OnClearButtonClicked();
     };
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
@@ -16,6 +16,7 @@ namespace AzToolsFramework
 {
     void RegisterIntSpinBoxHandlers();
     void RegisterIntSliderHandlers();
+    void RegisterFilePathHandler();
     void RegisterDoubleSpinBoxHandlers();
     void RegisterDoubleSliderHandlers();
     void RegisterColorPropertyHandlers();
@@ -170,6 +171,7 @@ namespace AzToolsFramework
             RegisterCrcHandler();
             RegisterIntSpinBoxHandlers();
             RegisterIntSliderHandlers();
+            RegisterFilePathHandler();
             RegisterDoubleSpinBoxHandlers();
             RegisterDoubleSliderHandlers();
             RegisterColorPropertyHandlers();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -409,6 +409,8 @@ set(FILES
     UI/PropertyEditor/PropertyEntityIdCtrl.cpp
     UI/PropertyEditor/PropertyEnumComboBoxCtrl.hxx
     UI/PropertyEditor/PropertyEnumComboBoxCtrl.cpp
+    UI/PropertyEditor/PropertyFilePathCtrl.h
+    UI/PropertyEditor/PropertyFilePathCtrl.cpp
     UI/PropertyEditor/PropertyIntCtrlCommon.h
     UI/PropertyEditor/PropertyIntSliderCtrl.hxx
     UI/PropertyEditor/PropertyIntSliderCtrl.cpp


### PR DESCRIPTION
Added a property control for `AZ::IO::Path` fields. This is necessary for fields that can't use an asset reference (e.g. if they need to be able to specify a file path for an asset that hasn't been created yet).
- Browse edit with a popout button that launches a native file dialog
- Can configure filter for specific extensions
- Optionally specify a default file-name for a field with no value yet when launching the file dialog
- Protects user from entering file name with invalid AP characters by using `AzQtComponents::FileDialog::GetSaveFileName`
- Appropriately handles file paths for assets that already exist + ones that haven't been created yet
- Prevents user from choosing a file path outside of the configured asset safe folders
- Updated create prefab workflow error message when picking a path outside of the configured safe asset folders with up-to-date verbiage since the `AssetProcessorPlatformConfig.ini` no longer exists

Example of it in-use on a new component (separate PR to follow):
![FilePathPropertyField](https://user-images.githubusercontent.com/7519264/165391135-49f51462-0825-4e70-826b-0e4e81ab7df8.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>