### PR TITLE
Bug fix for asset appearing multiple times in material editor asset selectors

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
@@ -65,7 +65,9 @@ namespace AtomToolsFramework
 
     void AssetSelectionComboBox::SelectAsset(const AZ::Data::AssetId& assetId)
     {
-        setCurrentIndex(findData(QVariant(QString(assetId.ToString<AZStd::string>().c_str()))));
+        const QVariant assetIdItemData(assetId.ToString<AZStd::string>().c_str());
+        const int index = findData(assetIdItemData);
+        setCurrentIndex(index);
     }
 
     AZ::Data::AssetId AssetSelectionComboBox::GetSelectedAsset() const
@@ -116,11 +118,9 @@ namespace AtomToolsFramework
     {
         if (m_filterCallback && m_filterCallback(assetInfo))
         {
-            int index = findData(QVariant(QString(assetId.ToString<AZStd::string>().c_str())));
-            if (index >= 0)
-            {
-                removeItem(index);
-            }
+            const QVariant assetIdItemData(assetId.ToString<AZStd::string>().c_str());
+            const int index = findData(assetIdItemData);
+            removeItem(index);
         }
     }
 
@@ -128,11 +128,16 @@ namespace AtomToolsFramework
     {
         if (m_filterCallback && m_filterCallback(assetInfo))
         {
-            addItem(
-                GetDisplayNameFromPath(AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId)).c_str(),
-                QVariant(QString(assetInfo.m_assetId.ToString<AZStd::string>().c_str())));
-
-            RegisterThumbnail(assetInfo.m_assetId);
+            // Only add the asset if no item exists with the incoming asset ID
+            const QVariant assetIdItemData(assetInfo.m_assetId.ToString<AZStd::string>().c_str());
+            const int index = findData(assetIdItemData);
+            if (index < 0)
+            {
+                const AZStd::string path = AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId);
+                const AZStd::string displayName = GetDisplayNameFromPath(path);
+                addItem(displayName.c_str(), assetIdItemData);
+                RegisterThumbnail(assetInfo.m_assetId);
+            }
         }
     }
 
@@ -159,7 +164,8 @@ namespace AtomToolsFramework
             auto thumbnailKeyItr = m_thumbnailKeys.find(assetId);
             if (thumbnailKeyItr != m_thumbnailKeys.end())
             {
-                int index = findData(QVariant(QString(assetId.ToString<AZStd::string>().c_str())));
+                const QVariant assetIdItemData(assetId.ToString<AZStd::string>().c_str());
+                const int index = findData(assetIdItemData);
                 if (index >= 0)
                 {
                     AzToolsFramework::Thumbnailer::SharedThumbnail thumbnail;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionGrid.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionGrid.cpp
@@ -65,9 +65,9 @@ namespace AtomToolsFramework
             {
                 if (m_filterCallback(assetInfo))
                 {
-                    CreateListItem(
-                        assetInfo.m_assetId,
-                        GetDisplayNameFromPath(AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId)).c_str());
+                    const AZStd::string path = AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId);
+                    const AZStd::string displayName = GetDisplayNameFromPath(path);
+                    CreateListItem(assetInfo.m_assetId, displayName.c_str());
                 }
             };
 
@@ -87,10 +87,11 @@ namespace AtomToolsFramework
 
     void AssetSelectionGrid::SelectAsset(const AZ::Data::AssetId& assetId)
     {
+        const QVariant assetIdItemData(assetId.ToString<AZStd::string>().c_str());
         for (int i = 0; i < m_ui->m_assetList->count(); ++i)
         {
             QListWidgetItem* item = m_ui->m_assetList->item(i);
-            if (assetId == AZ::Data::AssetId::CreateString(item->data(Qt::UserRole).toString().toUtf8().constData()))
+            if (assetIdItemData == item->data(Qt::UserRole))
             {
                 m_ui->m_assetList->setCurrentItem(item);
                 return;
@@ -123,23 +124,24 @@ namespace AtomToolsFramework
                 AZ::Data::AssetInfo assetInfo = assetCatalogRequests->GetAssetInfoById(assetId);
                 if (m_filterCallback && m_filterCallback(assetInfo))
                 {
-                    CreateListItem(
-                        assetInfo.m_assetId,
-                        GetDisplayNameFromPath(AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId)).c_str());
+                    const AZStd::string path = AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId);
+                    const AZStd::string displayName = GetDisplayNameFromPath(path);
+                    CreateListItem(assetInfo.m_assetId, displayName.c_str());
                 }
                 m_ui->m_assetList->sortItems();
             });
     }
 
     void AssetSelectionGrid::OnCatalogAssetRemoved(
-        const AZ::Data::AssetId& assetId, const AZ::Data::AssetInfo& assetInfo)
+        [[maybe_unused]] const AZ::Data::AssetId& assetId, const AZ::Data::AssetInfo& assetInfo)
     {
         if (m_filterCallback && m_filterCallback(assetInfo))
         {
+            const QVariant assetIdItemData(assetInfo.m_assetId.ToString<AZStd::string>().c_str());
             for (int i = 0; i < m_ui->m_assetList->count(); ++i)
             {
                 QListWidgetItem* item = m_ui->m_assetList->item(i);
-                if (assetId == AZ::Data::AssetId::CreateString(item->data(Qt::UserRole).toString().toUtf8().constData()))
+                if (assetIdItemData == item->data(Qt::UserRole))
                 {
                     m_ui->m_assetList->removeItemWidget(item);
                     return;
@@ -150,7 +152,19 @@ namespace AtomToolsFramework
 
     QListWidgetItem* AssetSelectionGrid::CreateListItem(const AZ::Data::AssetId& assetId, const QString& title)
     {
-        const int itemBorder = aznumeric_cast<int>(
+        // Skip creating this list item if one with the same asset ID is already registered
+        const QVariant assetIdItemData(assetId.ToString<AZStd::string>().c_str());
+        for (int i = 0; i < m_ui->m_assetList->count(); ++i)
+        {
+            QListWidgetItem* item = m_ui->m_assetList->item(i);
+            if (assetIdItemData == item->data(Qt::UserRole))
+            {
+                return item;
+            }
+        }
+
+        const int itemBorder =
+            aznumeric_cast<int>(
             AtomToolsFramework::GetSettingsValue<AZ::u64>("/O3DE/AtomToolsFramework/AssetSelectionGrid/ItemBorder", 4));
         const int itemSpacing = aznumeric_cast<int>(
             AtomToolsFramework::GetSettingsValue<AZ::u64>("/O3DE/AtomToolsFramework/AssetSelectionGrid/ItemSpacing", 10));
@@ -164,7 +178,7 @@ namespace AtomToolsFramework
 
         QListWidgetItem* item = new QListWidgetItem(m_ui->m_assetList);
         item->setData(Qt::DisplayRole, title);
-        item->setData(Qt::UserRole, QString(assetId.ToString<AZStd::string>().c_str()));
+        item->setData(Qt::UserRole, assetIdItemData);
         item->setSizeHint(m_tileSize + QSize(itemBorder, itemBorder + headerHeight));
         m_ui->m_assetList->addItem(item);
 


### PR DESCRIPTION
This addresses an issue where the asset grid or combo box could potentially have the same asset added multiple times.
This will not address the case if an asset in a different folder has the same file name.
That will result in the same name appearing in the list or dropdown multiple times but they will point to the correct asset.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>