### PR TITLE
Remove libffi package check

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -1783,7 +1783,7 @@ namespace AZ
             /// Returns true if the container is a smart pointer.
             bool IsSmartPointer() const override             { return true; }
 
-            /// Returns true if the container elements can be addressesd by index, otherwise false.
+            /// Returns true if the container elements can be addressed by index, otherwise false.
             bool CanAccessElementsByIndex() const override   { return false; }
 
             /// Reserve element
@@ -1796,6 +1796,7 @@ namespace AZ
             }
 
             /// Get an element's address by its index (called before the element is loaded).
+            /// Caller should ensure CanAccessElementsByIndex returns true for this to be valid.
             void* GetElementByIndex(void* instance, const SerializeContext::ClassElement* classElement, size_t index) override
             {
                 (void)classElement;
@@ -1808,7 +1809,7 @@ namespace AZ
                     return false;
                 };
                 EnumElements(instance, captureValue);
-                typename T::value_type *valuePtr = *reinterpret_cast<typename T::value_type**>(ptrToRawPtr);
+                typename T::value_type* valuePtr = *reinterpret_cast<typename T::value_type**>(ptrToRawPtr);
                 return valuePtr;
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
@@ -531,7 +531,12 @@ namespace AzToolsFramework
                         if (genericClassInfo->GetNumTemplatedArguments() == 1)
                         {
                             void* ptrAddress = dataNode->GetInstance(0);
-                            void* ptrValue = container->GetElementByIndex(ptrAddress, classElement, 0);
+                            void* ptrValue = nullptr;
+                            if (container->CanAccessElementsByIndex())
+                            {
+                                container->GetElementByIndex(ptrAddress, classElement, 0);
+                            }
+
                             AZ::Uuid pointeeType;
                             // If the pointer is non-null, find the polymorphic type info
                             if (ptrValue)

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -536,9 +536,6 @@ namespace LegacyLevelSystem
 
         const AZ::TimeMs beginTimeMs = AZ::GetRealElapsedTimeMs();
 
-        // Clear level entities and prefab instances.
-        EBUS_EVENT(AzFramework::GameEntityContextRequestBus, ResetGameContext);
-
         if (gEnv->pMovieSystem)
         {
             gEnv->pMovieSystem->Reset(false, false);
@@ -547,6 +544,7 @@ namespace LegacyLevelSystem
 
         OnUnloadComplete(m_lastLevelName.c_str());
 
+        // Delete level entities and remove them from the game entity context
         AzFramework::RootSpawnableInterface::Get()->ReleaseRootSpawnable();
 
         m_lastLevelName.clear();

--- a/Code/Tools/CrashHandler/Tools/ToolsCrashHandler.cpp
+++ b/Code/Tools/CrashHandler/Tools/ToolsCrashHandler.cpp
@@ -32,7 +32,7 @@ namespace CrashHandler
 #if defined(CRASH_HANDLER_URL)
         return MAKE_DEFINE_STRING(CRASH_HANDLER_URL);
 #else
-        return "https://lumberyard.sp.backtrace.io:8443/";
+        return "";
 #endif
     }
 
@@ -46,7 +46,7 @@ namespace CrashHandler
 #if defined(CRASH_HANDLER_TOKEN)
         return MAKE_DEFINE_STRING(CRASH_HANDLER_TOKEN);
 #else
-        return "8f562f6bf0ecb674e5f64344d76e6afeccb3244b4a9ea191ee61dc4e3528c5bd";
+        return "";
 #endif
     }
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
@@ -322,7 +322,14 @@ namespace O3DE::ProjectManager
 
     QPair<int, int> GemItemDelegate::CalcColumnXBounds(HeaderOrder header) const
     {
-        return m_headerWidget->CalcColumnXBounds(static_cast<int>(header));
+        if (m_headerWidget)
+        {
+            return m_headerWidget->CalcColumnXBounds(static_cast<int>(header));
+        }
+        else
+        {
+            return QPair<int, int>(0, 0);
+        }
     }
 
     QRect GemItemDelegate::CalcButtonRect(const QRect& contentRect) const

--- a/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationProviderBus.h
+++ b/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationProviderBus.h
@@ -29,7 +29,10 @@ namespace AWSClientAuth
         //! @return bool True if valid access token available, else False
         virtual bool IsSignedIn(const ProviderNameEnum& providerName) = 0;
 
-        //! Get cached tokens from last last successful sign-in for the provider.
+        //! [Deprecated] Get cached tokens from last successful sign-in for the provider.
+        //! To enhance security, only the refresh token is cached and will be returned by this function.
+        //! If you need the access or ID tokens, all authentication tokens (access token, ID token and refresh token)
+        //! can be retrieved by implementing custom handlers for AuthenticationProviderNotifications in your project code.
         //! @param providerName Provider to get authentication tokens.
         //! @return AuthenticationTokens tokens from successful authentication.
         virtual AuthenticationTokens GetAuthenticationTokens(const ProviderNameEnum& providerName) = 0;

--- a/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationTokens.h
+++ b/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationTokens.h
@@ -24,7 +24,7 @@ namespace AWSClientAuth
         AZ_TYPE_INFO(AuthenticationTokens, "{F965D1B2-9DE3-4900-B44B-E58D9F083ACB}");
         AuthenticationTokens();
         AuthenticationTokens(const AuthenticationTokens& other);
-        AuthenticationTokens(const AZStd::string& accessToken, const AZStd::string& refreshToken, const AZStd::string& openidToken
+        AuthenticationTokens(const AZStd::string& accessToken, const AZStd::string& refreshToken, const AZStd::string& openIdToken
             , const ProviderNameEnum& providerName, int tokensExpireTimeSeconds);
 
         //! Compares current time stamp to expired time stamp.

--- a/Gems/AWSClientAuth/Code/Include/Authorization/ClientAuthAWSCredentials.h
+++ b/Gems/AWSClientAuth/Code/Include/Authorization/ClientAuthAWSCredentials.h
@@ -34,10 +34,10 @@ namespace AWSClientAuth
         }
 
         ClientAuthAWSCredentials(const AZStd::string& accessKeyId, const AZStd::string& secretKey, const AZStd::string& sessionToken)
+            : m_accessKeyId(accessKeyId)
+            , m_secretKey(secretKey)
+            , m_sessionToken(sessionToken)
         {
-            m_accessKeyId = accessKeyId;
-            m_secretKey = secretKey;
-            m_sessionToken = sessionToken;
         }
 
         //! Gets the access key

--- a/Gems/AWSClientAuth/Code/Source/Authentication/AWSCognitoAuthenticationProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authentication/AWSCognitoAuthenticationProvider.cpp
@@ -51,8 +51,11 @@ namespace AWSClientAuth
                 {
                     Aws::CognitoIdentityProvider::Model::AuthenticationResultType authenticationResult = initiateAuthResult.GetAuthenticationResult();
                     UpdateTokens(authenticationResult);
-                    AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnPasswordGrantSingleFactorSignInSuccess
-                        , m_authenticationTokens);
+
+                    AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnPasswordGrantSingleFactorSignInSuccess,
+                        AuthenticationTokens(authenticationResult.GetAccessToken().c_str(),
+                            authenticationResult.GetRefreshToken().c_str(), authenticationResult.GetIdToken().c_str(),
+                            ProviderNameEnum::AWSCognitoIDP, authenticationResult.GetExpiresIn()));
                 }
                 else
                 {
@@ -126,8 +129,11 @@ namespace AWSClientAuth
                 {
                     Aws::CognitoIdentityProvider::Model::AuthenticationResultType authenticationResult = respondToAuthChallengeResult.GetAuthenticationResult();
                     UpdateTokens(authenticationResult);
-                    AuthenticationProviderNotificationBus::Broadcast(
-                        &AuthenticationProviderNotifications::OnPasswordGrantMultiFactorConfirmSignInSuccess, m_authenticationTokens);
+
+                    AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnPasswordGrantMultiFactorConfirmSignInSuccess,
+                        AuthenticationTokens(authenticationResult.GetAccessToken().c_str(),
+                            authenticationResult.GetRefreshToken().c_str(), authenticationResult.GetIdToken().c_str(),
+                            ProviderNameEnum::AWSCognitoIDP, authenticationResult.GetExpiresIn()));
                 }
             }
             else
@@ -179,7 +185,11 @@ namespace AWSClientAuth
                 {
                     Aws::CognitoIdentityProvider::Model::AuthenticationResultType authenticationResult = initiateAuthResult.GetAuthenticationResult();
                     UpdateTokens(authenticationResult);
-                    AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnRefreshTokensSuccess, m_authenticationTokens);
+
+                    AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnRefreshTokensSuccess,
+                        AuthenticationTokens(authenticationResult.GetAccessToken().c_str(),
+                            authenticationResult.GetRefreshToken().c_str(), authenticationResult.GetIdToken().c_str(),
+                            ProviderNameEnum::AWSCognitoIDP, authenticationResult.GetExpiresIn()));
                 }
                 else
                 {
@@ -231,8 +241,10 @@ namespace AWSClientAuth
 
     void AWSCognitoAuthenticationProvider::UpdateTokens(const Aws::CognitoIdentityProvider::Model::AuthenticationResultType& authenticationResult)
     {
-        m_authenticationTokens = AuthenticationTokens(authenticationResult.GetAccessToken().c_str(), authenticationResult.GetRefreshToken().c_str(),
-            authenticationResult.GetIdToken().c_str(), ProviderNameEnum::AWSCognitoIDP,
+        // Storing authentication tokens in memory can be a security concern. The access token and id token are not actually in use by
+        // the authentication provider and shouldn't be stored in the member variable.
+        m_authenticationTokens = AuthenticationTokens("", authenticationResult.GetRefreshToken().c_str(),
+            "", ProviderNameEnum::AWSCognitoIDP,
             authenticationResult.GetExpiresIn());
     }
 } // namespace AWSClientAuth

--- a/Gems/AWSClientAuth/Code/Source/Authentication/AuthenticationTokens.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authentication/AuthenticationTokens.cpp
@@ -19,24 +19,24 @@ namespace AWSClientAuth
     }
 
     AuthenticationTokens::AuthenticationTokens(const AuthenticationTokens& other)
+        : m_accessToken(other.m_accessToken)
+        , m_refreshToken(other.m_refreshToken)
+        , m_openIdToken(other.m_openIdToken)
+        , m_providerName(other.m_providerName)
+        , m_tokensExpireTimeSeconds(other.m_tokensExpireTimeSeconds)
+        , m_tokensExpireTimeStamp(other.m_tokensExpireTimeStamp)
     {
-        m_accessToken = other.m_accessToken;
-        m_refreshToken = other.m_refreshToken;
-        m_openIdToken = other.m_openIdToken;
-        m_providerName = other.m_providerName;
-        m_tokensExpireTimeSeconds = other.m_tokensExpireTimeSeconds;
-        m_tokensExpireTimeStamp = other.m_tokensExpireTimeStamp;
     }
 
     AuthenticationTokens::AuthenticationTokens(
-        const AZStd::string& accessToken, const AZStd::string& refreshToken, const AZStd::string& openidToken, const ProviderNameEnum& providerName, int tokensExpireTimeSeconds)
+        const AZStd::string& accessToken, const AZStd::string& refreshToken, const AZStd::string& openIdToken, const ProviderNameEnum& providerName, int tokensExpireTimeSeconds)
+        : m_accessToken(accessToken)
+        , m_refreshToken(refreshToken)
+        , m_openIdToken(openIdToken)
+        , m_providerName(providerName)
+        , m_tokensExpireTimeSeconds(tokensExpireTimeSeconds)
+        , m_tokensExpireTimeStamp(AZStd::chrono::system_clock::now() + AZStd::chrono::seconds(tokensExpireTimeSeconds))
     {
-        m_accessToken = accessToken;
-        m_refreshToken = refreshToken;
-        m_openIdToken = openidToken;
-        m_providerName = providerName;
-        m_tokensExpireTimeSeconds = tokensExpireTimeSeconds;
-        m_tokensExpireTimeStamp =  AZStd::chrono::system_clock::now() + AZStd::chrono::seconds(tokensExpireTimeSeconds);
     }
 
     //! Compares current time stamp to expired time stamp.

--- a/Gems/AWSClientAuth/Code/Source/Authentication/GoogleAuthenticationProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authentication/GoogleAuthenticationProvider.cpp
@@ -122,8 +122,12 @@ namespace AWSClientAuth
                 if (responseCode == Aws::Http::HttpResponseCode::OK)
                 {
                     UpdateTokens(jsonView);
+
                     AuthenticationProviderNotificationBus::Broadcast(
-                        &AuthenticationProviderNotifications::OnDeviceCodeGrantConfirmSignInSuccess, m_authenticationTokens);
+                        &AuthenticationProviderNotifications::OnDeviceCodeGrantConfirmSignInSuccess,
+                        AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
+                            jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(), jsonView.GetString(OAuthIdTokenResponseKey).c_str(),
+                            ProviderNameEnum::Google, jsonView.GetInteger(OAuthExpiresInResponseKey)));
                 }
                 else
                 {
@@ -153,8 +157,11 @@ namespace AWSClientAuth
             if (responseCode == Aws::Http::HttpResponseCode::OK)
             {
                 UpdateTokens(jsonView);
-                AuthenticationProviderNotificationBus::Broadcast(
-                    &AuthenticationProviderNotifications::OnRefreshTokensSuccess, m_authenticationTokens);
+
+                AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnRefreshTokensSuccess,
+                    AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
+                        jsonView.GetString(OAuthRefreshTokenResponseKey).c_str() ,jsonView.GetString(OAuthIdTokenResponseKey).c_str(),
+                        ProviderNameEnum::Google, jsonView.GetInteger(OAuthExpiresInResponseKey)));
             }
             else
             {
@@ -167,8 +174,10 @@ namespace AWSClientAuth
 
     void GoogleAuthenticationProvider::UpdateTokens(const Aws::Utils::Json::JsonView& jsonView)
     {
-        m_authenticationTokens = AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
-            jsonView.GetString(OAuthRefreshTokenResponseKey).c_str() ,jsonView.GetString(OAuthIdTokenResponseKey).c_str(), ProviderNameEnum::Google
+        // Storing authentication tokens in memory can be a security concern. The access token and id token are not actually in use by
+        // the authentication provider and shouldn't be stored in the member variable.
+        m_authenticationTokens = AuthenticationTokens("",
+            jsonView.GetString(OAuthRefreshTokenResponseKey).c_str() ,"", ProviderNameEnum::Google
             , jsonView.GetInteger(OAuthExpiresInResponseKey));
     }
 

--- a/Gems/AWSClientAuth/Code/Source/Authentication/LWAAuthenticationProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authentication/LWAAuthenticationProvider.cpp
@@ -122,8 +122,11 @@ namespace AWSClientAuth
                 {
                     // Id and access token are the same.
                     UpdateTokens(jsonView);
-                    AuthenticationProviderNotificationBus::Broadcast(
-                        &AuthenticationProviderNotifications::OnDeviceCodeGrantConfirmSignInSuccess, m_authenticationTokens);
+
+                    AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnDeviceCodeGrantConfirmSignInSuccess,
+                        AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
+                            jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(), jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
+                            ProviderNameEnum::LoginWithAmazon, jsonView.GetInteger(OAuthExpiresInResponseKey)));
                     m_cachedUserCode = "";
                     m_cachedDeviceCode = "";
                 }
@@ -154,7 +157,11 @@ namespace AWSClientAuth
             {
                 // Id and access token are the same.
                 UpdateTokens(jsonView);
-                AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnRefreshTokensSuccess, m_authenticationTokens);
+
+                AuthenticationProviderNotificationBus::Broadcast(&AuthenticationProviderNotifications::OnRefreshTokensSuccess,
+                    AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
+                        jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(), jsonView.GetString(OAuthAccessTokenResponseKey).c_str(),
+                        ProviderNameEnum::LoginWithAmazon, jsonView.GetInteger(OAuthExpiresInResponseKey)));
             }
             else
             {
@@ -167,9 +174,10 @@ namespace AWSClientAuth
 
     void LWAAuthenticationProvider::UpdateTokens(const Aws::Utils::Json::JsonView& jsonView)
     {
-        // For Login with Amazon openId and access tokens are the same.
-        m_authenticationTokens = AuthenticationTokens(jsonView.GetString(OAuthAccessTokenResponseKey).c_str(), jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(),
-            jsonView.GetString(OAuthAccessTokenResponseKey).c_str(), ProviderNameEnum::LoginWithAmazon
+        // Storing authentication tokens in memory can be a security concern. The access token and id token are not actually in use by
+        // the authentication provider and shouldn't be stored in the member variable.
+        m_authenticationTokens = AuthenticationTokens("", jsonView.GetString(OAuthRefreshTokenResponseKey).c_str(),
+            "", ProviderNameEnum::LoginWithAmazon
             , jsonView.GetInteger(OAuthExpiresInResponseKey));
     }
 

--- a/Gems/AWSClientAuth/Code/Tests/Authentication/AWSCognitoAuthenticationProviderTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/Authentication/AWSCognitoAuthenticationProviderTest.cpp
@@ -64,12 +64,12 @@ public:
     {
         AZ_Assert(
         m_cognitoAuthenticationProviderMock.GetAuthenticationTokens().GetAccessToken() ==
-            AWSClientAuthUnitTest::TEST_ACCESS_TOKEN,
-        "Access token expected to match");
+                "",
+            "Access token expected to be empty");
         AZ_Assert(
             m_cognitoAuthenticationProviderMock.GetAuthenticationTokens().GetOpenIdToken() ==
-                AWSClientAuthUnitTest::TEST_ID_TOKEN,
-            "Id token expected to match");
+                "",
+            "Id token expected to be empty");
         AZ_Assert(
             m_cognitoAuthenticationProviderMock.GetAuthenticationTokens().GetRefreshToken() ==
                 AWSClientAuthUnitTest::TEST_REFRESH_TOKEN,

--- a/Gems/AWSClientAuth/Code/Tests/Authentication/AuthenticationProviderManagerScriptCanvasBusTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/Authentication/AuthenticationProviderManagerScriptCanvasBusTest.cpp
@@ -178,7 +178,7 @@ TEST_F(AuthenticationProviderManagerScriptCanvasTest, GetTokensWithRefreshAsync_
     testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>* cognitoProviderMock = (testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>*)m_mockController->m_authenticationProvidersMap[AWSClientAuth::ProviderNameEnum::AWSCognitoIDP].get();
 
      AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 600);
     EXPECT_CALL(*cognitoProviderMock, GetAuthenticationTokens()).Times(1).WillOnce(testing::Return(tokens));
     EXPECT_CALL(*cognitoProviderMock, RefreshTokensAsync()).Times(0);
@@ -215,7 +215,7 @@ TEST_F(AuthenticationProviderManagerScriptCanvasTest, GetTokens_Success)
     testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>* cognitoProviderMock = (testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>*)m_mockController->m_authenticationProvidersMap[AWSClientAuth::ProviderNameEnum::AWSCognitoIDP].get();
 
      AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
     EXPECT_CALL(*cognitoProviderMock, GetAuthenticationTokens()).Times(1).WillOnce(testing::Return(tokens));
@@ -230,7 +230,7 @@ TEST_F(AuthenticationProviderManagerScriptCanvasTest, IsSignedIn_Success)
     testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>* cognitoProviderMock = (testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>*)m_mockController->m_authenticationProvidersMap[AWSClientAuth::ProviderNameEnum::AWSCognitoIDP].get();
 
      AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
     EXPECT_CALL(*cognitoProviderMock, GetAuthenticationTokens()).Times(1).WillOnce(testing::Return(tokens));
     m_mockController->IsSignedIn(AWSClientAuth::ProvideNameEnumStringAWSCognitoIDP);

--- a/Gems/AWSClientAuth/Code/Tests/Authentication/AuthenticationProviderManagerTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/Authentication/AuthenticationProviderManagerTest.cpp
@@ -177,7 +177,7 @@ TEST_F(AuthenticationProviderManagerTest, GetTokensWithRefreshAsync_ValidToken_S
     testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>* cognitoProviderMock = (testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>*)m_mockController->m_authenticationProvidersMap[AWSClientAuth::ProviderNameEnum::AWSCognitoIDP].get();
 
      AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 600);
     EXPECT_CALL(*cognitoProviderMock, GetAuthenticationTokens()).Times(1).WillOnce(testing::Return(tokens));
     EXPECT_CALL(*cognitoProviderMock, RefreshTokensAsync()).Times(0);
@@ -214,7 +214,7 @@ TEST_F(AuthenticationProviderManagerTest, GetTokens_Success)
     testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>* cognitoProviderMock = (testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>*)m_mockController->m_authenticationProvidersMap[AWSClientAuth::ProviderNameEnum::AWSCognitoIDP].get();
 
      AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
     EXPECT_CALL(*cognitoProviderMock, GetAuthenticationTokens()).Times(1).WillOnce(testing::Return(tokens));
@@ -229,7 +229,7 @@ TEST_F(AuthenticationProviderManagerTest, IsSignedIn_Success)
     testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>* cognitoProviderMock = (testing::NiceMock<AWSClientAuthUnitTest::AuthenticationProviderMock>*)m_mockController->m_authenticationProvidersMap[AWSClientAuth::ProviderNameEnum::AWSCognitoIDP].get();
 
      AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
     EXPECT_CALL(*cognitoProviderMock, GetAuthenticationTokens()).Times(1).WillOnce(testing::Return(tokens));
     m_mockController->IsSignedIn(AWSClientAuth::ProviderNameEnum::AWSCognitoIDP);

--- a/Gems/AWSClientAuth/Code/Tests/Authorization/AWSCognitoAuthorizationControllerTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/Authorization/AWSCognitoAuthorizationControllerTest.cpp
@@ -73,7 +73,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, Initialize_Success_GetAWSAccountEm
 TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_WithLogins_Success)
 {
     AWSClientAuth::AuthenticationTokens tokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);
@@ -81,7 +81,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_WithLogins_S
         &AWSClientAuth::AuthenticationProviderNotifications::OnPasswordGrantSingleFactorSignInSuccess, tokens);
 
     AWSClientAuth::AuthenticationTokens tokens1(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::Google, 60);
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnDeviceCodeGrantConfirmSignInSuccess(testing::_)).Times(1);
     AWSClientAuth::AuthenticationProviderNotificationBus::Broadcast(
@@ -132,7 +132,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, MultipleCalls_UsesCacheCredentials
 TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_Fail_GetIdError) // fail
 {
     AWSClientAuth::AuthenticationTokens cognitoTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
     
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);
@@ -156,14 +156,14 @@ TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_Fail_GetIdEr
 TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_Fail_GetCredentialsForIdentityError)
 {
     AWSClientAuth::AuthenticationTokens cognitoTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);
     AWSClientAuth::AuthenticationProviderNotificationBus::Broadcast(
         &AWSClientAuth::AuthenticationProviderNotifications::OnPasswordGrantSingleFactorSignInSuccess, cognitoTokens);
 
     AWSClientAuth::AuthenticationTokens googleTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::Google, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnDeviceCodeGrantConfirmSignInSuccess(testing::_)).Times(1);
@@ -192,7 +192,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_Fail_GetCred
 TEST_F(AWSCognitoAuthorizationControllerTest, AddRemoveLogins_Succuess)
 {
     AWSClientAuth::AuthenticationTokens cognitoTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);
@@ -210,7 +210,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, AddRemoveLogins_Succuess)
     ASSERT_TRUE(m_mockController->m_persistentCognitoIdentityProvider->GetLogins().size() == 1);
 
     AWSClientAuth::AuthenticationTokens googleTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::Google, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnDeviceCodeGrantConfirmSignInSuccess(testing::_)).Times(1);
@@ -236,7 +236,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, AddRemoveLogins_Succuess)
     ASSERT_TRUE(m_mockController->m_persistentCognitoIdentityProvider->GetLogins().size() == 0);
 
     AWSClientAuth::AuthenticationTokens lwaTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ACCESS_TOKEN,
         AWSClientAuth::ProviderNameEnum::LoginWithAmazon, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantMultiFactorConfirmSignInSuccess(testing::_)).Times(1);
@@ -254,7 +254,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, AddRemoveLogins_Succuess)
 TEST_F(AWSCognitoAuthorizationControllerTest, ResetAuthenticated_ClearsCachedLoginsAndIdentityId_Success)
 {
     AWSClientAuth::AuthenticationTokens cognitoTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);
@@ -308,7 +308,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, ResetAnonymous_ClearsCachedLoginsA
 TEST_F(AWSCognitoAuthorizationControllerTest, GetCredentialsProvider_ForPersistedLogins_ResultIsAuthenticatedCredentials)
 {
     AWSClientAuth::AuthenticationTokens cognitoTokens(
-        AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+        AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
         AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
     EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);
@@ -361,7 +361,7 @@ TEST_F(
 
     testThreads.emplace_back(AZStd::thread([&]() {
         AWSClientAuth::AuthenticationTokens cognitoTokens(
-            AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
+            AWSClientAuthUnitTest::TEST_ACCESS_TOKEN, AWSClientAuthUnitTest::TEST_REFRESH_TOKEN, AWSClientAuthUnitTest::TEST_ID_TOKEN,
             AWSClientAuth::ProviderNameEnum::AWSCognitoIDP, 60);
 
         EXPECT_CALL(m_authenticationProviderNotificationsBusMock, OnPasswordGrantSingleFactorSignInSuccess(testing::_)).Times(1);

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -566,6 +566,7 @@ namespace AZ
             const uint32_t fontTextureIndex = 0;
             m_resourceGroup->SetImage(m_texturesIndex, m_fontAtlas, fontTextureIndex);
             io.Fonts->TexID = reinterpret_cast<ImTextureID>(m_fontAtlas.get());
+            m_imguiFontTexId = io.Fonts->TexID;
 
             // ImGuiPass will support binding 16 textures at most per frame. 
             const uint8_t instanceData[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
@@ -605,7 +606,7 @@ namespace AZ
             // Create all the DrawIndexeds so they can be submitted in parallel on BuildCommandListInternal()
             uint32_t vertexOffset = 0;
             uint32_t indexOffset = 0;
-
+            
             m_userTextures.clear();
             for (ImDrawData& drawData : m_drawData)
             {
@@ -625,7 +626,7 @@ namespace AZ
 
                         // check if texture id needs to be bound to the srg
                         uint32_t index = 0;
-                        if (drawCmd.TextureId != ImGui::GetIO().Fonts->TexID)
+                        if (drawCmd.TextureId && drawCmd.TextureId != m_imguiFontTexId)
                         {
                             if (m_userTextures.size() < MaxUserTextures)
                             {
@@ -659,7 +660,7 @@ namespace AZ
                 }
             }
             m_drawData.clear();
-
+            
             auto imguiContextScope = ImguiContextScope(m_imguiContext);
             ImGui::GetIO().MouseWheel = m_lastFrameMouseWheel;
             m_lastFrameMouseWheel = 0.0;

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
@@ -168,6 +168,9 @@ namespace AZ
             AZStd::unordered_map<Data::Instance<RPI::StreamingImage>, uint32_t> m_userTextures;
             Data::Instance<RPI::Buffer> m_instanceBuffer;
             RHI::StreamBufferView m_instanceBufferView;
+
+            // cache the font text id
+            void* m_imguiFontTexId = nullptr;
         };
     }   // namespace RPI
 }   // namespace AZ

--- a/Gems/Atom/RPI/Assets/seedList.seed
+++ b/Gems/Atom/RPI/Assets/seedList.seed
@@ -2,27 +2,27 @@
 	<Class name="AZStd::vector" type="{82FC5264-88D0-57CD-9307-FC52E4DAD550}">
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
 			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{454C374E-E2FA-5DD3-81D8-08BE5904112C}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="AZ::Uuid" field="guid" value="{AC37FCC4-ACF3-5EB7-B66E-D552DB55BA43}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
 				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			</Class>
 			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shader/decomposemsimage.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/decomposemsimage.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
 			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{7DCE2AC7-7EDA-5C04-A1E3-C7465B4CD8B7}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="AZ::Uuid" field="guid" value="{624D96E2-CB87-5105-991E-01C17C9BCD20}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
 				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			</Class>
 			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shader/imagepreview.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/imagepreview.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
 			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{A1B7396F-7D03-5A88-B71E-29441B04C123}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="AZ::Uuid" field="guid" value="{DECFE8B1-6410-513D-902E-4601CB425B53}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
 				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			</Class>
 			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shader/sceneandviewsrgs.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/sceneandviewsrgs.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
 			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">

--- a/Gems/LyShine/Assets/seedList.seed
+++ b/Gems/LyShine/Assets/seedList.seed
@@ -18,11 +18,11 @@
 		</Class>
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
 			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{FE938F56-8238-5614-857E-25769CF225A6}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="AZ::Uuid" field="guid" value="{C7BCB5E8-3E6B-5531-A3D9-CEE93E103F69}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
 				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			</Class>
 			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/lyshineui.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+			<Class name="AZStd::string" field="pathHint" value="lyshine/shaders/lyshineui.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
 			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">

--- a/cmake/Platform/Linux/Packaging/postinst.in
+++ b/cmake/Platform/Linux/Packaging/postinst.in
@@ -10,10 +10,6 @@
 set -o errexit # exit on the first failure encountered
 
 {
-    if [[ ! -f "/usr/lib/x86_64-linux-gnu/libffi.so.6" ]]; then
-        sudo ln -s /usr/lib/x86_64-linux-gnu/libffi.so.7 /usr/lib/x86_64-linux-gnu/libffi.so.6
-    fi
-
     pushd @CPACK_PACKAGING_INSTALL_PREFIX@
     python/get_python.sh
     chown -R $SUDO_USER .


### PR DESCRIPTION
The original check to make sure libffi.so.6 exists (and to link against libffi.so.7 assuming the install is done on Ubuntu 20.04) is no longer needed with the python 3P package version python-3.7.12-rev2-linux.
