### PR TITLE
Group w/wo children item in node palette

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
@@ -195,6 +195,15 @@ namespace GraphCanvas
 
         if (m_filter.isEmpty())
         {
+            // When item has no children, put it at front; otherwise follow alphabetical order
+            if (model->hasChildren(source_left) && !model->hasChildren(source_right))
+            {
+                return false;
+            }
+            else if (!model->hasChildren(source_left) && model->hasChildren(source_right))
+            {
+                return true;
+            }
             return left < right;
         }
         else


### PR DESCRIPTION
## Details
Little tweak to improve node palette category
Put item without children at front, otherwise follow alphabetical order

Signed-off-by: onecent1101 <liug@amazon.com>