### PR TITLE
Fix material editor toolbar icon and tooltips for tonemapping button

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportToolBar.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportToolBar.h
@@ -37,8 +37,5 @@ namespace AtomToolsFramework
         QAction* m_toggleGrid = {};
         QAction* m_toggleShadowCatcher = {};
         QAction* m_toggleAlternateSkybox = {};
-
-        AZStd::unordered_map<AZ::Render::DisplayMapperOperationType, QString> m_operationNames;
-        AZStd::unordered_map<AZ::Render::DisplayMapperOperationType, QAction*> m_operationActions;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/Icons/toneMapping.svg
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/Icons/toneMapping.svg
@@ -4,8 +4,6 @@
     <title>Icons / Toolbar / Tone Mapping</title>
     <desc>Created with Sketch.</desc>
     <g id="Icons-/-Toolbar-/-Tone-Mapping" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <rect fill="#444444" x="0" y="0" width="24" height="24"></rect>
-        <rect id="Icon-Background" x="0" y="0" width="24" height="24"></rect>
         <path d="M21,3 L21,21 L3,21 L3,3 L21,3 Z M19,5 L5,5 L5,19 L19,19 L19,5 Z" id="Combined-Shape" fill="#FFFFFF"></path>
         <path d="M4.5,19.5 C7.10977381,19.3752859 9.2645953,18.2113806 10.9644645,16.0082842 C13.5142682,12.7036395 12.2106423,9.58363419 14.3305826,7 C15.7438762,5.27757721 17.4670153,4.44424388 19.5,4.5" id="Line-2" stroke="#FFFFFF" stroke-width="2" stroke-linecap="square"></path>
         <rect id="Rectangle" fill="#FFFFFF" x="5" y="3" width="16" height="2"></rect>

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/Icons/toneMapping.svg
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/Icons/toneMapping.svg
@@ -4,8 +4,6 @@
     <title>Icons / Toolbar / Tone Mapping</title>
     <desc>Created with Sketch.</desc>
     <g id="Icons-/-Toolbar-/-Tone-Mapping" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <rect fill="#444444" x="0" y="0" width="24" height="24"></rect>
-        <rect id="Icon-Background" x="0" y="0" width="24" height="24"></rect>
         <path d="M21,3 L21,21 L3,21 L3,3 L21,3 Z M19,5 L5,5 L5,19 L19,19 L19,5 Z" id="Combined-Shape" fill="#FFFFFF"></path>
         <path d="M4.5,19.5 C7.10977381,19.3752859 9.2645953,18.2113806 10.9644645,16.0082842 C13.5142682,12.7036395 12.2106423,9.58363419 14.3305826,7 C15.7438762,5.27757721 17.4670153,4.44424388 19.5,4.5" id="Line-2" stroke="#FFFFFF" stroke-width="2" stroke-linecap="square"></path>
         <rect id="Rectangle" fill="#FFFFFF" x="5" y="3" width="16" height="2"></rect>


### PR DESCRIPTION
The tool button was not showing tooltips but they reappear using the action.
Removed background from button icon art that interfered with button states.

Addresses https://github.com/o3de/o3de/issues/8641

Signed-off-by: Guthrie Adams <guthadam@amazon.com>