### PR TITLE
Default test results into build directory, warn when unset

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
@@ -88,7 +88,7 @@ def _get_output_path(config):
     else:
         custom_build_directory = config.getoption('--build-directory', '')
         if custom_build_directory: # default into known build folder
-            default_output_path = os.path.join(custom_build_directory, 'build', 'Testing', 'LyTestTools')
+            default_output_path = os.path.join(custom_build_directory, 'Testing', 'LyTestTools')
         else:  # should already create a separate warning in _get_build_directory()
             default_output_path = os.getcwd()
         output_path = os.path.join(default_output_path,

--- a/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
@@ -66,12 +66,12 @@ def _get_build_directory(config):
     if custom_build_directory:
         logger.debug(f'Custom build directory set via cli arg to: {custom_build_directory}')
         if not os.path.exists(custom_build_directory):
-            raise ValueError(f'Pytest argument "--build-directory" does not exist at: {custom_build_directory}')
+            raise ValueError(f'Pytest custom argument "--build-directory" does not exist at: {custom_build_directory}')
         if custom_build_directory.endswith('debug'):
             pytest.exit("Python debug modules are not available. LyTestTools test skipped.", 0)
     else:
         # only warn when unset, allowing non-LyTT tests to still use pytest
-        logger.warning(f'Pytest argument "--build-directory" was not provided, tests using LyTestTools will fail')
+        logger.warning(f'Pytest custom argument "--build-directory" was not provided, tests using LyTestTools will fail')
 
     return custom_build_directory
 
@@ -86,12 +86,17 @@ def _get_output_path(config):
         logger.debug(f'Custom output_path set to: {str(custom_output_path)}')
         output_path = custom_output_path
     else:
-        # from pytest_runner
-        output_path = os.path.join(os.getcwd(),
+        custom_build_directory = config.getoption('--build-directory', '')
+        if custom_build_directory: # default into known build folder
+            default_output_path = custom_build_directory
+        else: # should create a separate warning in _get_build_directory()
+            default_output_path = os.getcwd()
+        output_path = os.path.join(default_output_path,
                                    "TestResults",
                                    datetime.now().strftime(TIMESTAMP_FORMAT),
                                    "pytest_results")
-        logger.debug(f'Defaulting output_path to: {str(output_path)}')
+        logger.warning(f'Pytest custom argument "--output-path" was not provided, '
+                       f'defaulting TestResults output to: {str(output_path)}')
 
     os.makedirs(output_path, exist_ok=True)
     return output_path

--- a/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
@@ -88,15 +88,14 @@ def _get_output_path(config):
     else:
         custom_build_directory = config.getoption('--build-directory', '')
         if custom_build_directory: # default into known build folder
-            default_output_path = custom_build_directory
-        else: # should create a separate warning in _get_build_directory()
+            default_output_path = os.path.join(custom_build_directory, 'build', 'Testing', 'LyTestTools')
+        else:  # should already create a separate warning in _get_build_directory()
             default_output_path = os.getcwd()
         output_path = os.path.join(default_output_path,
-                                   "TestResults",
-                                   datetime.now().strftime(TIMESTAMP_FORMAT),
-                                   "pytest_results")
+                                   "pytest_results",
+                                   datetime.now().strftime(TIMESTAMP_FORMAT))
         logger.warning(f'Pytest custom argument "--output-path" was not provided, '
-                       f'defaulting TestResults output to: {str(output_path)}')
+                       f'defaulting Test Results output to: {str(output_path)}')
 
     os.makedirs(output_path, exist_ok=True)
     return output_path

--- a/Tools/LyTestTools/tests/unit/test_fixtures.py
+++ b/Tools/LyTestTools/tests/unit/test_fixtures.py
@@ -87,9 +87,8 @@ class TestFixtures(object):
         mock_config.getoption.return_value = None
 
         expected = os.path.join(mock_cwd,
-                                'TestResults',
-                                '2019-10-11T00-00-00-000000',
-                                'pytest_results')
+                                'pytest_results',
+                                '2019-10-11T00-00-00-000000')
         actual = test_tools_fixtures._get_output_path(mock_config)
 
         assert actual == expected


### PR DESCRIPTION
Fix for https://github.com/o3de/o3de/issues/6971

When running through CTest, this output directory is normally set to:
`../o3de/<cmake_build_dir>/Testing/LyTestTools/<ctest_module_name>/`

When unset, the output will first try to redirect to:
`../o3de/<user_provided_cmake_build_dir>/Testing/LyTestTools/pytest_results/<timestamp>/`

If the user does not provide a build directory for LyTestTools, it will redirect to:
`<cwd>/pytest_results/<timestamp>/`

...and output a warning to notify the user that results were stored in a default location.

Signed-off-by: sweeneys <sweeneys@amazon.com>