### PR TITLE
Make profiling lua script write out meta data

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Assets/Scripts/Profiling/OutputProfileData.lua
+++ b/Gems/AtomLyIntegration/CommonFeatures/Assets/Scripts/Profiling/OutputProfileData.lua
@@ -44,7 +44,7 @@ function OutputProfileData:TryDisconnect()
 end
 
 function OutputProfileData:TryQuitOnComplete()
-    if (self.quitOnComplete and not System.IsEditor()) then
+    if (self.quitOnComplete) then
         g_SettingsRegistry:SetString(ConsoleCommandQuitRegistryKey, "")
     end
 end

--- a/Gems/AtomLyIntegration/CommonFeatures/Assets/Scripts/Profiling/OutputProfileData.lua
+++ b/Gems/AtomLyIntegration/CommonFeatures/Assets/Scripts/Profiling/OutputProfileData.lua
@@ -98,7 +98,8 @@ function OutputProfileData:OnActivate()
         self.profileCaptureNotificationHandler = ProfilingCaptureNotificationBus.Connect(self)
 
         -- output test metadata
-        ProfilingCaptureRequestBus.Broadcast.CaptureBenchmarkMetadata(self.profileName, tostring(self.outputFolder) .. "/benchmark_metadata.json")
+        ProfilingCaptureRequestBus.Broadcast.CaptureBenchmarkMetadata(
+            self.profileName, tostring(self.outputFolder) .. "/benchmark_metadata.json")
     end
 end
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Assets/Scripts/Profiling/OutputProfileData.lua
+++ b/Gems/AtomLyIntegration/CommonFeatures/Assets/Scripts/Profiling/OutputProfileData.lua
@@ -39,11 +39,8 @@ local SourceProjectUserPathRegistryKey <const> = "/O3DE/Runtime/FilePaths/Source
 local ConsoleCommandQuitRegistryKey <const> = "/Amazon/AzCore/Runtime/ConsoleCommands/quit"
 
 function OutputProfileData:TryDisconnect()
-    if (self.active) then
-        self.active = false
-        self.profileCaptureNotificationHandler:Disconnect()
-        self.tickHandler:Disconnect()
-    end
+    self.profileCaptureNotificationHandler:Disconnect()
+    self.tickHandler:Disconnect()
 end
 
 function OutputProfileData:TryQuitOnComplete()
@@ -100,11 +97,17 @@ function OutputProfileData:OnActivate()
         -- register for ebus callbacks
         self.tickHandler = TickBus.Connect(self)
         self.profileCaptureNotificationHandler = ProfilingCaptureNotificationBus.Connect(self)
-        self.active = true
+
+        -- output test metadata
+        ProfilingCaptureRequestBus.Broadcast.CaptureBenchmarkMetadata(self.profileName, tostring(self.outputFolder) .. "/benchmark_metadata.json")
     end
 end
 
 function OutputProfileData:OnTick()
+    if (not self.active) then -- wait for benchmark metadata to get written before starting
+        return
+    end
+
     self.frameCount = self.frameCount + 1
     if (self.frameCount <= self.frameDelayCount) then
         return
@@ -123,6 +126,19 @@ end
 function OutputProfileData:OnCaptureCpuFrameTimeFinished(successful, capture_output_path)
     if (self.captureInProgress and self.cpuTimingsOutputPath == capture_output_path) then
         self:CaptureFinished()
+    end
+end
+
+function OutputProfileData:OnCaptureBenchmarkMetadataFinished(successful, info)
+    if (not successful) then
+        Debug:Log("OutputProfileData - Failed to capture benchmark metadata, aborting data collection")
+        -- force profile to end asap without trying to record
+        self.frameCount = self.frameDelayCount
+        self.captureCount = self.FrameCaptureCount
+        self:TryDisconnect()
+        self:TryQuitOnComplete()
+    else
+        self.active = true
     end
 end
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Assets/Scripts/Profiling/OutputProfileData.lua
+++ b/Gems/AtomLyIntegration/CommonFeatures/Assets/Scripts/Profiling/OutputProfileData.lua
@@ -44,7 +44,7 @@ function OutputProfileData:TryDisconnect()
 end
 
 function OutputProfileData:TryQuitOnComplete()
-    if (self.quitOnComplete) then
+    if (self.quitOnComplete and not System.IsEditor()) then
         g_SettingsRegistry:SetString(ConsoleCommandQuitRegistryKey, "")
     end
 end
@@ -68,7 +68,6 @@ function OutputProfileData:OnActivate()
         local frameTimeRecordingActivateValue = g_SettingsRegistry:GetBool(FrameTimeRecordingActiveRegistryKey)
         if (not frameTimeRecordingActivateValue:has_value() or not frameTimeRecordingActivateValue:value()) then
             Debug:Log("OutputProfileData:OnActivate - Missing registry setting to activate frame time recording, aborting data collection")
-            self:TryQuitOnComplete()
             return
         end
 

--- a/Tools/LyTestTools/ly_test_tools/log/log_monitor.py
+++ b/Tools/LyTestTools/ly_test_tools/log/log_monitor.py
@@ -84,7 +84,7 @@ class LogMonitor(object):
         waiter.wait_for(
             lambda: os.path.exists(self.log_file_path),
             timeout=self.log_creation_max_wait_time,
-            exc=f"Log file '{self.log_file_path}' was never created by another process.",
+            exc=LogMonitorException(f"Log file '{self.log_file_path}' was never created by another process."),
             interval=1,
         )
 


### PR DESCRIPTION
Additionally re-organize the benchmark upload python to make only having cpu data or gpu data acceptable. It's now only an error if there is no data or either kind.