### PR TITLE
Fixing SpawnableScriptAssetRef display in SC

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
@@ -21,6 +21,7 @@ namespace AzFramework::Scripts
         {
             serializeContext
                 ->Class<SpawnableScriptAssetRef>()
+                ->Version(0)
                 ->Field("asset", &SpawnableScriptAssetRef::m_asset);
 
             serializeContext->RegisterGenericType<AZStd::vector<SpawnableScriptAssetRef>>();
@@ -31,6 +32,9 @@ namespace AzFramework::Scripts
             {
                 editContext
                     ->Class<SpawnableScriptAssetRef>("SpawnableScriptAssetRef", "A wrapper around spawnable asset to be used as a variable in Script Canvas.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     // m_asset
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SpawnableScriptAssetRef::m_asset, "asset", "")
                     ->Attribute(AZ::Edit::Attributes::ShowProductAssetFileName, false)
@@ -42,13 +46,13 @@ namespace AzFramework::Scripts
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
-            behaviorContext
-                ->Class<SpawnableScriptAssetRef>("SpawnableScriptAssetRef")
-                ->Constructor()
+            behaviorContext->Class<SpawnableScriptAssetRef>("SpawnableScriptAssetRef")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Category, "Prefab/Spawning")
                 ->Attribute(AZ::Script::Attributes::Module, "prefabs")
-                ->Property("asset", BehaviorValueProperty(&SpawnableScriptAssetRef::m_asset));
+                ->Constructor()
+                ->Method("GetAsset", &SpawnableScriptAssetRef::GetAsset)
+                ->Method("SetAsset", &SpawnableScriptAssetRef::SetAsset);
         }
     }
 

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
@@ -33,7 +33,6 @@ namespace AzFramework::Scripts
                 editContext
                     ->Class<SpawnableScriptAssetRef>("SpawnableScriptAssetRef", "A wrapper around spawnable asset to be used as a variable in Script Canvas.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     // m_asset
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SpawnableScriptAssetRef::m_asset, "asset", "")


### PR DESCRIPTION
Addresses https://github.com/o3de/o3de/issues/8973

There's no way to actually hide the variable from Node Palette without it also getting hidden in Variable Manager. However there's a better example to display its getter and setter instead of two identical "asset" fields:
![image](https://user-images.githubusercontent.com/82239319/165671103-9b5b54d9-cb9f-41c1-ac58-bb1184a13677.png)

This doesn't break any currrent Lua/SC scripts in development.

Signed-off-by: Mikhail Naumov <mnaumov@amazon.com>