### PR TITLE
Fix multiple issues with material overrides updating or previewing consistently

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
@@ -39,7 +39,7 @@ namespace AZ
                 , public AZ::TickBus::Handler
                 , public MaterialComponentNotificationBus::Handler
                 , public EditorMaterialSystemComponentNotificationBus::Handler
-           {
+            {
                 Q_OBJECT
             public:
                 AZ_CLASS_ALLOCATOR(MaterialPropertyInspector, AZ::SystemAllocator, 0);
@@ -66,15 +66,16 @@ namespace AZ
                 const EditorMaterialComponentUtil::MaterialEditData& GetEditData() const;
 
             private:
+                AZ::Data::AssetId GetActiveMaterialAssetIdFromEntity() const;
 
                 // AzToolsFramework::IPropertyEditorNotify overrides...
-                void BeforePropertyModified(AzToolsFramework::InstanceDataNode* pNode) override;
+                void BeforePropertyModified([[maybe_unused]] AzToolsFramework::InstanceDataNode* pNode) override{};
                 void AfterPropertyModified(AzToolsFramework::InstanceDataNode* pNode) override;
-                void SetPropertyEditingActive([[maybe_unused]] AzToolsFramework::InstanceDataNode* pNode) override {}
+                void SetPropertyEditingActive([[maybe_unused]] AzToolsFramework::InstanceDataNode* pNode) override{};
                 void SetPropertyEditingComplete(AzToolsFramework::InstanceDataNode* pNode) override;
-                void SealUndoStack() override {}
-                void RequestPropertyContextMenu([[maybe_unused]] AzToolsFramework::InstanceDataNode*, const QPoint&) override {}
-                void PropertySelectionChanged([[maybe_unused]] AzToolsFramework::InstanceDataNode*, bool) override {}
+                void SealUndoStack() override{};
+                void RequestPropertyContextMenu([[maybe_unused]] AzToolsFramework::InstanceDataNode*, const QPoint&) override{};
+                void PropertySelectionChanged([[maybe_unused]] AzToolsFramework::InstanceDataNode*, bool) override{};
 
                 // AZ::EntitySystemBus::Handler overrides...
                 void OnEntityInitialized(const AZ::EntityId& entityId) override;
@@ -110,14 +111,11 @@ namespace AZ
 
                 bool AddEditorMaterialFunctors(
                     const AZStd::vector<AZ::RPI::Ptr<AZ::RPI::MaterialFunctorSourceDataHolder>>& functorSourceDataHolders,
-                    const AZ::RPI::MaterialNameContext& nameContext);   
+                    const AZ::RPI::MaterialNameContext& nameContext);
 
                 AZ::Crc32 GetGroupSaveStateKey(const AZStd::string& groupName) const;
                 bool IsInstanceNodePropertyModifed(const AzToolsFramework::InstanceDataNode* node) const;
                 const char* GetInstanceNodePropertyIndicator(const AzToolsFramework::InstanceDataNode* node) const;
-
-                // Tracking the property that is actively being edited in the inspector
-                const AtomToolsFramework::DynamicProperty* m_activeProperty = {};
 
                 AZ::EntityId m_entityId;
                 AZ::Render::MaterialAssignmentId m_materialAssignmentId;
@@ -131,7 +129,7 @@ namespace AZ
                 bool m_updatePreview = {};
                 QLabel* m_overviewText = {};
                 QLabel* m_overviewImage = {};
-           };
+            };
         } // namespace EditorMaterialComponentInspector
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentRequestBus.h>
+#include <AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentNotificationBus.h>
+#include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/EntityBus.h>
@@ -28,6 +30,7 @@ namespace AZ
             , public AZ::EntitySystemBus::Handler
             , public EditorMaterialSystemComponentNotificationBus::Handler
             , public EditorMaterialSystemComponentRequestBus::Handler
+            , public MaterialReceiverNotificationBus::Router
             , public AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler
             , public AzToolsFramework::EditorMenuNotificationBus::Handler
             , public AzToolsFramework::EditorEvents::Bus::Handler
@@ -57,11 +60,14 @@ namespace AZ
                 const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId) const override;
 
             // AZ::EntitySystemBus::Handler overrides...
-            void OnEntityDestroyed(const AZ::EntityId& entityId) override;
+            void OnEntityDeactivated(const AZ::EntityId& entityId) override;
 
             //! EditorMaterialSystemComponentNotificationBus::Handler overrides...
             void OnRenderMaterialPreviewComplete(
                 const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId, const QPixmap& pixmap) override;
+
+            //! MaterialReceiverNotificationBus::Router overrides...
+            void OnMaterialAssignmentsChanged() override;
 
             //! AssetBrowserInteractionNotificationBus::Handler overrides...
             AzToolsFramework::AssetBrowser::SourceFileDetails GetSourceFileDetails(const char* fullSourceFileName) override;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -160,7 +160,6 @@ namespace AZ
             AZStd::swap(m_materialsWithDirtyProperties, materialsWithDirtyProperties);
 
             // Iterate through all MaterialAssignmentId's that have property overrides and attempt to apply them
-            // if material instance is already compiling, delay application of property overrides until next frame
             for (const auto& materialAssignmentId : materialsWithDirtyProperties)
             {
                 const auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
@@ -168,7 +167,7 @@ namespace AZ
                 {
                     if (!materialIt->second.ApplyProperties())
                     {
-                        // If a material cannot currently be compiled then it must be queued again
+                        // If the material had properties to apply and it could not be compiled then queue it again
                         m_materialsWithDirtyProperties.emplace(materialAssignmentId);
                     }
                 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -406,7 +406,8 @@ namespace AZ
                 m_meshHandle = m_meshFeatureProcessor->AcquireMesh(meshDescriptor, materials);
                 m_meshFeatureProcessor->ConnectModelChangeEventHandler(m_meshHandle, m_changeEventHandler);
 
-                const AZ::Transform& transform = m_transformInterface ? m_transformInterface->GetWorldTM() : AZ::Transform::CreateIdentity();
+                const AZ::Transform& transform =
+                    m_transformInterface ? m_transformInterface->GetWorldTM() : AZ::Transform::CreateIdentity();
 
                 m_meshFeatureProcessor->SetTransform(m_meshHandle, transform, m_cachedNonUniformScale);
                 m_meshFeatureProcessor->SetSortKey(m_meshHandle, m_configuration.m_sortKey);
@@ -418,6 +419,12 @@ namespace AZ
                 // If the model instance or asset already exists, announce a model change to let others know it's loaded.
                 HandleModelChange(m_meshFeatureProcessor->GetModel(m_meshHandle));
             }
+            else
+            {
+                // If there is no model asset to be loaded then we need to invalidate the material slot configuration
+                MaterialReceiverNotificationBus::Event(
+                    m_entityComponentIdPair.GetEntityId(), &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentsChanged);
+            }
         }
 
         void MeshComponentController::UnregisterModel()
@@ -427,6 +434,10 @@ namespace AZ
                 MeshComponentNotificationBus::Event(
                     m_entityComponentIdPair.GetEntityId(), &MeshComponentNotificationBus::Events::OnModelPreDestroy);
                 m_meshFeatureProcessor->ReleaseMesh(m_meshHandle);
+
+                // Model has been released which invalidates the material slot configuration
+                MaterialReceiverNotificationBus::Event(
+                    m_entityComponentIdPair.GetEntityId(), &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentsChanged);
             }
         }
 


### PR DESCRIPTION
Fix multiple issues with material overrides updating or previewing consistently

- Fixed problem where the mesh component was not notifying material component that slots had changed if the mesh asset was cleared.
- Fixed a problem with the material assignments applying property overrides consistently. The function that applies properties was returning failure if the material instance could not currently be compiled. The function now attempts to apply the property overrides if there are any and will return true if it recompiled or nothing needed to be recompiled. This keeps the material component from continuously requeueing certain materials, which prevented it from sending the notification that the instances were updated.
- Changed the material component instance inspector to do a reload if the active material asset ID does not match. This fixes the problem where the material preview would not reset if materials were cleared or the slots changed.
- Changed the material system component to clear the preview image cache for entities that are deactivated and if the material assignment slots change for an entity with saved previews.
- Updated the material instance inspector overview panel to display the material slot LOD.

- Tested that materials update in editor whatever properties are changed in the instance inspector with and without LODs.
- LOD materials take priority over the others but update correctly and give control back to model materials and the default material if they are removed.

- Tested overriding multiple materials and properties on different entities, entering and exiting game mode to verify that materials and properties were applied and restored correctly.

- Tested adding removing undo redo copy paste and changing models/materials to verify that previews updated and reset under expected conditions.

https://github.com/o3de/o3de/issues/8156
https://github.com/o3de/o3de/issues/8864
https://github.com/o3de/o3de/issues/8869
https://github.com/o3de/o3de/issues/8920
https://github.com/o3de/o3de/issues/7928

Signed-off-by: Guthrie Adams <guthadam@amazon.com>