### PR TITLE
Blast material asset property shows (default) when no assets assigned.

### DIFF
--- a/Gems/Blast/Code/Source/Editor/EditorBlastFamilyComponent.cpp
+++ b/Gems/Blast/Code/Source/Editor/EditorBlastFamilyComponent.cpp
@@ -45,6 +45,7 @@ namespace Blast
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &EditorBlastFamilyComponent::m_blastMaterialAsset, "Blast Material",
                         "Assigned blast material asset")
+                        ->Attribute(AZ::Edit::Attributes::DefaultAsset, &EditorBlastFamilyComponent::GetDefaultBlastAssetId)
                         ->Attribute(AZ_CRC_CE("EditButton"), "")
                         ->Attribute(AZ_CRC_CE("EditDescription"), "Open in Asset Editor")
                         ->Attribute(AZ_CRC_CE("DisableEditButtonWhenNoAssetSelected"), true)
@@ -132,5 +133,13 @@ namespace Blast
     AZ::Data::AssetId EditorBlastFamilyComponent::GetPhysicsMaterialLibraryAssetId() const
     {
         return AZ::Interface<AzPhysics::SystemInterface>::Get()->GetConfiguration()->m_materialLibraryAsset.GetId();
+    }
+
+    AZ::Data::AssetId EditorBlastFamilyComponent::GetDefaultBlastAssetId() const
+    {
+        // Used for Edit Context.
+        // When the blast material asset property doesn't have an asset assigned it
+        // will show "(default)" to indicate that the default material will be used.
+        return {};
     }
 } // namespace Blast

--- a/Gems/Blast/Code/Source/Editor/EditorBlastFamilyComponent.h
+++ b/Gems/Blast/Code/Source/Editor/EditorBlastFamilyComponent.h
@@ -51,6 +51,8 @@ namespace Blast
         /// Return the physics material library asset id. Used to supply MaterialIdWidget with material library.
         AZ::Data::AssetId GetPhysicsMaterialLibraryAssetId() const;
 
+        AZ::Data::AssetId GetDefaultBlastAssetId() const;
+
         // Configurations
         AZ::Data::Asset<BlastAsset> m_blastAsset;
         AZ::Data::Asset<MaterialAsset> m_blastMaterialAsset;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27999040/165764324-3d0cf116-d80e-4507-a757-1354ac0d81cd.png)

Signed-off-by: moraaar <moraaar@amazon.com>