### PR TITLE
Change default irradiance color source to Manual

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/IrradiancePropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/IrradiancePropertyGroup.json
@@ -10,7 +10,7 @@
             "description": "Where to get the irradiance color from? This color can be automatically derived from the diffuse base color (BaseColor: including average texture color if textured; BaseColorTint: base color only, ignoring texture), or the manually provided color below (Manual).",
             "type": "Enum",
             "enumValues": [ "BaseColor", "BaseColorTint", "Manual"],
-            "defaultValue": "BaseColor"
+            "defaultValue": "Manual"
         },
         {
             "name": "manualColor",


### PR DESCRIPTION
The default irradiance color was recently changed to use the BaseColor texture average, but this is not compatible with mesh textures that are UV-unwrapped or low intensity.

This PR changes the default back to the Manual irradiance color.

Signed-off-by: dmcdiarmid-ly <63674186+dmcdiarmid-ly@users.noreply.github.com>