### PR TITLE
Add translation support for global method

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/EBusHandlerEventNodeDescriptorComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/EBusHandlerEventNodeDescriptorComponent.cpp
@@ -191,7 +191,7 @@ namespace ScriptCanvasEditor
                             auto graphCanvasSlotId = Nodes::DisplayScriptCanvasSlot(GetEntityId(), (*scriptCanvasSlot), 0);
 
                             GraphCanvas::TranslationKey key;
-                            key << "EBusHandler" << eventHandler->GetEBusName() << "methods" << m_eventName;
+                            key << ScriptCanvasEditor::TranslationHelper::AssetContext::EBusHandlerContext << eventHandler->GetEBusName() << "methods" << m_eventName;
                             if (scriptCanvasSlot->IsExecution() && scriptCanvasSlot->IsOutput())
                             {
                                 key << "exit";
@@ -228,7 +228,7 @@ namespace ScriptCanvasEditor
                                 if (scriptCanvasSlot->IsData())
                                 {
                                     GraphCanvas::TranslationKey key;
-                                    key = "EBusHandler";
+                                    key = ScriptCanvasEditor::TranslationHelper::AssetContext::EBusHandlerContext;
                                     key << eventHandler->GetEBusName() << "methods" << m_eventName << "params" << index << "details";
 
                                     details.m_name = scriptCanvasSlot->GetName();

--- a/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/EBusHandlerNodeDescriptorComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/EBusHandlerNodeDescriptorComponent.cpp
@@ -541,7 +541,7 @@ namespace ScriptCanvasEditor
                         if (slotType == GraphCanvas::SlotTypes::DataSlot)
                         {
                             GraphCanvas::TranslationKey key;
-                            key << Translation::GlobalKeys::EBusHandlerIDKey << ".details";
+                            key << ScriptCanvasEditor::TranslationHelper::GlobalKeys::EBusHandlerIDKey << ".details";
                             GraphCanvas::TranslationRequests::Details details;
                             GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
                             GraphCanvas::SlotRequestBus::Event(testSlotId, &GraphCanvas::SlotRequests::SetDetails, details.m_name, details.m_tooltip);

--- a/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/ScriptEventReceiverNodeDescriptorComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/ScriptEventReceiverNodeDescriptorComponent.cpp
@@ -561,7 +561,7 @@ namespace ScriptCanvasEditor
                         if (slotType == GraphCanvas::SlotTypes::DataSlot)
                         {
                             GraphCanvas::TranslationKey key;
-                            key << Translation::GlobalKeys::EBusHandlerIDKey << "details";
+                            key << ScriptCanvasEditor::TranslationHelper::GlobalKeys::EBusHandlerIDKey << "details";
                             GraphCanvas::TranslationRequests::Details details;
                             GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
                             GraphCanvas::SlotRequestBus::Event(testSlotId, &GraphCanvas::SlotRequests::SetDetails, details.m_name, details.m_tooltip);

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
@@ -186,7 +186,7 @@ namespace ScriptCanvasEditor::Nodes
         return nodeIds;
     }
 
-    NodeIdPair CreateGlobalMethodNode(AZStd::string_view methodName, const ScriptCanvas::ScriptCanvasId& scriptCanvasId)
+    NodeIdPair CreateGlobalMethodNode(AZStd::string_view methodName, bool isProperty, const ScriptCanvas::ScriptCanvasId& scriptCanvasId)
     {
         AZ_PROFILE_FUNCTION(ScriptCanvas);
         NodeIdPair nodeIds;
@@ -208,7 +208,7 @@ namespace ScriptCanvasEditor::Nodes
         AZ::EntityId graphCanvasGraphId;
         EditorGraphRequestBus::EventResult(graphCanvasGraphId, scriptCanvasId, &EditorGraphRequests::GetGraphCanvasGraphId);
 
-        nodeIds.m_graphCanvasId = DisplayMethodNode(graphCanvasGraphId, methodNode);
+        nodeIds.m_graphCanvasId = DisplayMethodNode(graphCanvasGraphId, methodNode, isProperty);
 
         return nodeIds;
     }

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.h
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.h
@@ -31,7 +31,7 @@ namespace ScriptCanvasEditor::Nodes
     NodeIdPair CreateNode(const AZ::Uuid& classData, const ScriptCanvas::ScriptCanvasId& scriptCanvasId, const StyleConfiguration& styleConfiguration);
     NodeIdPair CreateObjectMethodNode(AZStd::string_view className, AZStd::string_view methodName, const ScriptCanvas::ScriptCanvasId& scriptCanvasId, ScriptCanvas::PropertyStatus propertyStatus);
     NodeIdPair CreateObjectMethodOverloadNode(AZStd::string_view className, AZStd::string_view methodName, const ScriptCanvas::ScriptCanvasId& scriptCanvasGraphId);
-    NodeIdPair CreateGlobalMethodNode(AZStd::string_view methodName, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
+    NodeIdPair CreateGlobalMethodNode(AZStd::string_view methodName, bool isProperty, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
     NodeIdPair CreateEbusWrapperNode(AZStd::string_view busName, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
 
     // Script Events

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.h
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.h
@@ -45,7 +45,7 @@ namespace ScriptCanvasEditor::Nodes
     AZ::EntityId DisplayEbusEventNode(AZ::EntityId graphCanvasGraphId, const AZStd::string& busName, const AZStd::string& eventName, const ScriptCanvas::EBusEventId& eventId);
     AZ::EntityId DisplayEbusWrapperNode(AZ::EntityId graphCanvasGraphId, const ScriptCanvas::Nodes::Core::EBusEventHandler* busNode);
     AZ::EntityId DisplayGetVariableNode(AZ::EntityId graphCanvasGraphId, const ScriptCanvas::Nodes::Core::GetVariableNode* variableNode);
-    AZ::EntityId DisplayMethodNode(AZ::EntityId graphCanvasGraphId, const ScriptCanvas::Nodes::Core::Method* methodNode);
+    AZ::EntityId DisplayMethodNode(AZ::EntityId graphCanvasGraphId, const ScriptCanvas::Nodes::Core::Method* methodNode, bool isAccessor = false);
     AZ::EntityId DisplaySetVariableNode(AZ::EntityId graphCanvasGraphId, const ScriptCanvas::Nodes::Core::SetVariableNode* variableNode);
 
     // AZ Event

--- a/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.h
+++ b/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.h
@@ -11,21 +11,40 @@
 #include <Source/Translation/TranslationBus.h>
 #include <ScriptCanvas/Data/Data.h>
 
-namespace Translation
-{
-    namespace GlobalKeys
-    {
-        static constexpr const char* EBusSenderIDKey = "Globals.EBusSenderBusId";
-        static constexpr const char* EBusHandlerIDKey = "Globals.EBusHandlerBusId";
-        static constexpr const char* MissingFunctionKey = "Globals.MissingFunction";
-        static constexpr const char* EBusHandlerOutSlot = "Globals.EBusHandler.OutSlot";
-    }
-}
-
 namespace ScriptCanvasEditor
 {
     namespace TranslationHelper
     {
+        namespace GlobalKeys
+        {
+            static constexpr const char* EBusSenderIDKey = "Globals.EBusSenderBusId";
+            static constexpr const char* EBusHandlerIDKey = "Globals.EBusHandlerBusId";
+            static constexpr const char* MissingFunctionKey = "Globals.MissingFunction";
+            static constexpr const char* EBusHandlerOutSlot = "Globals.EBusHandler.OutSlot";
+        } // namespace GlobalKeys
+
+        namespace AssetContext
+        {
+            static constexpr char AZEventContext[] = "AZEventHandler";
+            static constexpr char BehaviorClassContext[] = "BehaviorClass";
+            static constexpr char BehaviorGlobalMethodContext[] = "BehaviorMethod";
+            static constexpr char BehaviorGlobalPropertyContext[] = "Constant";
+            static constexpr char CustomNodeContext[] = "ScriptCanvas::Node";
+            static constexpr char EBusHandlerContext[] = "EBusHandler";
+            static constexpr char EBusSenderContext[] = "EBusSender";
+        } // namespace AssetContext
+
+        namespace AssetPath
+        {
+            static constexpr char AZEventPath[] = "AZEvents";
+            static constexpr char BehaviorClassPath[] = "Classes";
+            static constexpr char BehaviorGlobalMethodPath[] = "GlobalMethods";
+            static constexpr char BehaviorGlobalPropertyPath[] = "Properties";
+            static constexpr char CustomNodePath[] = "Nodes";
+            static constexpr char EBusHandlerPath[] = "EBus\\Handlers";
+            static constexpr char EBusSenderPath[] = "EBus\\Senders";
+        } // namespace AssetPath
+
         inline AZStd::string GetSafeTypeName(ScriptCanvas::Data::Type dataType)
         {
             if (!dataType.IsValid())
@@ -48,4 +67,3 @@ namespace ScriptCanvasEditor
         }
     }
 }
-

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/EBusNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/EBusNodePaletteTreeItemTypes.cpp
@@ -98,7 +98,7 @@ namespace ScriptCanvasEditor
         , m_propertyStatus(propertyStatus)
     {
         GraphCanvas::TranslationKey key;
-        key << "EBusSender" << busName << "methods" << eventName << "details";
+        key << ScriptCanvasEditor::TranslationHelper::AssetContext::EBusSenderContext << busName << "methods" << eventName << "details";
 
         GraphCanvas::TranslationRequests::Details details;
         details.m_name = eventName;
@@ -135,6 +135,23 @@ namespace ScriptCanvasEditor
     ScriptCanvas::EBusEventId EBusSendEventPaletteTreeItem::GetEventId() const
     {
         return m_eventId;
+    }
+
+    AZ::IO::Path EBusSendEventPaletteTreeItem::GetTranslationDataPath() const
+    {
+        return AZ::IO::Path(ScriptCanvasEditor::TranslationHelper::AssetPath::EBusSenderPath) / GetBusName();
+    }
+
+    void EBusSendEventPaletteTreeItem::GenerateTranslationData()
+    {
+        AZ::BehaviorContext* behaviorContext{};
+        AZ::ComponentApplicationBus::BroadcastResult(behaviorContext, &AZ::ComponentApplicationRequests::GetBehaviorContext);
+
+        const char* ebusName = m_busName.toUtf8().data();
+        auto behaviorEbus = behaviorContext->m_ebuses.find(ebusName);
+
+        ScriptCanvasEditorTools::TranslationGeneration translation;
+        translation.TranslateEBus(behaviorEbus->second);
     }
 
     ScriptCanvas::PropertyStatus EBusSendEventPaletteTreeItem::GetPropertyStatus() const
@@ -297,7 +314,7 @@ namespace ScriptCanvasEditor
         , m_eventId(eventId)
     {
         GraphCanvas::TranslationKey key;
-        key << "EBusHandler" << busName << "methods" << eventName << "details";
+        key << ScriptCanvasEditor::TranslationHelper::AssetContext::EBusHandlerContext << busName << "methods" << eventName << "details";
 
         GraphCanvas::TranslationRequests::Details details;
         details.m_name = m_eventName;
@@ -336,5 +353,21 @@ namespace ScriptCanvasEditor
     ScriptCanvas::EBusEventId EBusHandleEventPaletteTreeItem::GetEventId() const
     {
         return m_eventId;
+    }
+
+    AZ::IO::Path EBusHandleEventPaletteTreeItem::GetTranslationDataPath() const
+    {
+        return AZ::IO::Path(ScriptCanvasEditor::TranslationHelper::AssetPath::EBusHandlerPath) / GetBusName();
+    }
+
+    void EBusHandleEventPaletteTreeItem::GenerateTranslationData()
+    {
+        AZ::BehaviorContext* behaviorContext{};
+        AZ::ComponentApplicationBus::BroadcastResult(behaviorContext, &AZ::ComponentApplicationRequests::GetBehaviorContext);
+
+        auto behaviorEbus = behaviorContext->m_ebuses.find(m_busName.c_str());
+
+        ScriptCanvasEditorTools::TranslationGeneration translation;
+        translation.TranslateEBus(behaviorEbus->second);
     }
 }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/EBusNodePaletteTreeItemTypes.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/EBusNodePaletteTreeItemTypes.h
@@ -63,23 +63,8 @@ namespace ScriptCanvasEditor
 
         ScriptCanvas::PropertyStatus GetPropertyStatus() const;
 
-        AZ::IO::Path GetTranslationDataPath() const override
-        {
-            return AZ::IO::Path("EBus\\Senders") / GetBusName();
-        }
-
-        void GenerateTranslationData() override
-        {
-            AZ::BehaviorContext* behaviorContext{};
-            AZ::ComponentApplicationBus::BroadcastResult(behaviorContext, &AZ::ComponentApplicationRequests::GetBehaviorContext);
-
-            const char* ebusName = m_busName.toUtf8().data();
-            auto behaviorEbus = behaviorContext->m_ebuses.find(ebusName);
-
-            ScriptCanvasEditorTools::TranslationGeneration translation;
-            translation.TranslateEBus(behaviorEbus->second);
-        }
-
+        AZ::IO::Path GetTranslationDataPath() const override;
+        void GenerateTranslationData() override;
 
     private:
         bool m_isOverload;
@@ -173,21 +158,8 @@ namespace ScriptCanvasEditor
         ScriptCanvas::EBusBusId GetBusId() const;
         ScriptCanvas::EBusEventId GetEventId() const;
 
-        AZ::IO::Path GetTranslationDataPath() const override
-        {
-            return AZ::IO::Path("EBus\\Handlers") / GetBusName();
-        }
-
-        void GenerateTranslationData() override
-        {
-            AZ::BehaviorContext* behaviorContext{};
-            AZ::ComponentApplicationBus::BroadcastResult(behaviorContext, &AZ::ComponentApplicationRequests::GetBehaviorContext);
-
-            auto behaviorEbus = behaviorContext->m_ebuses.find(m_busName.c_str());
-
-            ScriptCanvasEditorTools::TranslationGeneration translation;
-            translation.TranslateEBus(behaviorEbus->second);
-        }
+        AZ::IO::Path GetTranslationDataPath() const override;
+        void GenerateTranslationData() override;
 
     private:
         AZStd::string m_busName;

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.h
@@ -59,25 +59,8 @@ namespace ScriptCanvasEditor
         bool IsOverload() const;
         ScriptCanvas::PropertyStatus GetPropertyStatus() const;
 
-        AZ::IO::Path GetTranslationDataPath() const override
-        {
-            return AZ::IO::Path("Classes") / GetClassMethodName();
-        }
-
-        void GenerateTranslationData() override
-        {
-            AZ::BehaviorContext* behaviorContext{};
-            AZ::ComponentApplicationBus::BroadcastResult(behaviorContext, &AZ::ComponentApplicationRequests::GetBehaviorContext);
-
-            const char* className = m_className.toUtf8().data();
-            if (behaviorContext->m_classes.contains(className))
-            {
-                auto behaviorClass = behaviorContext->m_classes.find(className);
-
-                ScriptCanvasEditorTools::TranslationGeneration translation;
-                translation.TranslateBehaviorClass(behaviorClass->second);
-            }
-        }
+        AZ::IO::Path GetTranslationDataPath() const override;
+        void GenerateTranslationData() override;
 
     private:
         bool m_isOverload = false;
@@ -99,13 +82,14 @@ namespace ScriptCanvasEditor
         static void Reflect(AZ::ReflectContext* reflectContext);
 
         CreateGlobalMethodMimeEvent() = default;
-        CreateGlobalMethodMimeEvent(AZStd::string methodName);
+        CreateGlobalMethodMimeEvent(AZStd::string methodName, bool isProperty);
 
     protected:
         ScriptCanvasEditor::NodeIdPair CreateNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId) const override;
 
     private:
         AZStd::string m_methodName;
+        bool m_isProperty;
     };
 
     //! GlobalMethod Node Palette Tree Item
@@ -130,6 +114,7 @@ namespace ScriptCanvasEditor
 
     private:
         AZStd::string m_methodName;
+        bool m_isProperty;
     };
     //! <GlobalMethod>
 
@@ -172,19 +157,8 @@ namespace ScriptCanvasEditor
         AZ::Uuid GetTypeId() const;
         const ScriptCanvasEditor::CustomNodeModelInformation& GetInfo() const { return m_info; }
 
-        AZ::IO::Path GetTranslationDataPath() const override
-        {
-            AZStd::string filename = AZStd::string::format("%s_%s", GetInfo().m_categoryPath.c_str(), GetName().toUtf8().data());
-            filename = GraphCanvas::TranslationKey::Sanitize(filename);
-
-            return AZ::IO::Path("Nodes") / filename;
-        }
-
-        void GenerateTranslationData() override
-        {
-            ScriptCanvasEditorTools::TranslationGeneration translation;
-            translation.TranslateNode(m_typeId);
-        }
+        AZ::IO::Path GetTranslationDataPath() const override;
+        void GenerateTranslationData() override;
 
     private:
         AZ::Uuid m_typeId;

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
@@ -163,7 +163,7 @@ namespace
             return; // skip this method
         }
 
-        nodePaletteModel.RegisterMethodNode(behaviorContext, behaviorMethod);
+        nodePaletteModel.RegisterGlobalMethodNode(behaviorContext, behaviorMethod);
     }
 
     //! Retrieve the list of EBuses t hat should not be exposed in the ScriptCanvasEditor Node Palette
@@ -462,7 +462,7 @@ namespace
                 AZStd::string categoryPath;
 
                 GraphCanvas::TranslationKey key;
-                key << "BehaviorClass" << behaviorClass->m_name.c_str() << "details";
+                key << ScriptCanvasEditor::TranslationHelper::AssetContext::BehaviorClassContext << behaviorClass->m_name.c_str() << "details";
 
                 GraphCanvas::TranslationRequests::Details details;
                 GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
@@ -579,7 +579,7 @@ namespace
             {
 
                 GraphCanvas::TranslationKey key;
-                key << "EBusHandler" << behaviorEbus.m_name.c_str() << "details";
+                key << ScriptCanvasEditor::TranslationHelper::AssetContext::EBusHandlerContext << behaviorEbus.m_name.c_str() << "details";
 
                 GraphCanvas::TranslationRequests::Details details;
                 GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
@@ -624,7 +624,7 @@ namespace
         if (!behaviorEbus.m_events.empty())
         {
             GraphCanvas::TranslationKey key;
-            key << "EBusSender" << behaviorEbus.m_name.c_str() << "details";
+            key << ScriptCanvasEditor::TranslationHelper::AssetContext::EBusSenderContext << behaviorEbus.m_name.c_str() << "details";
 
             GraphCanvas::TranslationRequests::Details details;
             GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
@@ -904,7 +904,7 @@ namespace ScriptCanvasEditor
             if (classData && classData->m_editData && classData->m_editData->m_name)
             {
                 GraphCanvas::TranslationKey key;
-                key << "ScriptCanvas::Node" << classData->m_typeId.ToString<AZStd::string>().c_str() << "details";
+                key << ScriptCanvasEditor::TranslationHelper::AssetContext::CustomNodeContext << classData->m_typeId.ToString<AZStd::string>().c_str() << "details";
 
                 GraphCanvas::TranslationRequests::Details details;
                 GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
@@ -1007,7 +1007,7 @@ namespace ScriptCanvasEditor
             methodModelInformation->m_titlePaletteOverride = "MethodNodeTitlePalette";
 
             GraphCanvas::TranslationKey catkey;
-            catkey << "BehaviorClass" << methodClass.c_str() << "details";
+            catkey << ScriptCanvasEditor::TranslationHelper::AssetContext::BehaviorClassContext << methodClass.c_str() << "details";
             GraphCanvas::TranslationRequests::Details catdetails;
             GraphCanvas::TranslationRequestBus::BroadcastResult(catdetails, &GraphCanvas::TranslationRequests::GetDetails, catkey, catdetails);
 
@@ -1021,7 +1021,7 @@ namespace ScriptCanvasEditor
                 context = (propertyStatus == ScriptCanvas::PropertyStatus::Getter) ? "Getter" : "Setter";
             }
             updatedMethodName += methodName;
-            key << "BehaviorClass" << methodClass << "methods" << updatedMethodName << context  << "details";
+            key << ScriptCanvasEditor::TranslationHelper::AssetContext::BehaviorClassContext << methodClass << "methods" << updatedMethodName << context << "details";
 
             GraphCanvas::TranslationRequests::Details details;
             GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
@@ -1053,7 +1053,7 @@ namespace ScriptCanvasEditor
             auto  methodModelInformation = AZStd::make_unique<GlobalMethodNodeModelInformation>();
             methodModelInformation->m_nodeIdentifier = nodeIdentifier;
             methodModelInformation->m_methodName = behaviorMethod.m_name;
-
+            methodModelInformation->m_isProperty = true;
             methodModelInformation->m_titlePaletteOverride = "MethodNodeTitlePalette";
 
             AZStd::string name = behaviorProperty->m_name;
@@ -1061,7 +1061,7 @@ namespace ScriptCanvasEditor
             AZ::StringFunc::Replace(name, "::Setter", "");
 
             GraphCanvas::TranslationKey key;
-            key << "Constant" << name << "details";
+            key << ScriptCanvasEditor::TranslationHelper::AssetContext::BehaviorGlobalPropertyContext << name << "details";
 
             GraphCanvas::TranslationRequests::Details details;
             GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
@@ -1080,9 +1080,9 @@ namespace ScriptCanvasEditor
         }
     }
 
-    void NodePaletteModel::RegisterMethodNode(const AZ::BehaviorContext& behaviorContext, const AZ::BehaviorMethod& behaviorMethod)
+    void NodePaletteModel::RegisterGlobalMethodNode(const AZ::BehaviorContext& behaviorContext, const AZ::BehaviorMethod& behaviorMethod)
     {
-        AZ_PROFILE_SCOPE(NodePaletteModel, "NodePaletteModel::RegisterMethodNode");
+        AZ_PROFILE_SCOPE(NodePaletteModel, "NodePaletteModel::RegisterGlobalMethodNode");
 
         // Construct Node Identifier using the BehaviorMethod name and the ScriptCanvas Method typeid
         ScriptCanvas::NodeTypeIdentifier nodeIdentifier =
@@ -1094,10 +1094,11 @@ namespace ScriptCanvasEditor
             auto  methodModelInformation = AZStd::make_unique<GlobalMethodNodeModelInformation>();
             methodModelInformation->m_methodName = behaviorMethod.m_name;
             methodModelInformation->m_nodeIdentifier = nodeIdentifier;
+            methodModelInformation->m_isProperty = false;
             methodModelInformation->m_titlePaletteOverride = "MethodNodeTitlePalette";
 
             GraphCanvas::TranslationKey key;
-            key << "BehaviorMethod" << behaviorMethod.m_name.c_str() << "details";
+            key << ScriptCanvasEditor::TranslationHelper::AssetContext::BehaviorGlobalMethodContext << behaviorMethod.m_name.c_str() << "details";
 
             GraphCanvas::TranslationRequests::Details details;
             GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
@@ -1120,7 +1121,6 @@ namespace ScriptCanvasEditor
 
     void NodePaletteModel::RegisterEBusHandlerNodeModelInformation(AZStd::string_view categoryPath, AZStd::string_view busName, AZStd::string_view eventName, const ScriptCanvas::EBusBusId& busId, const AZ::BehaviorEBusHandler::BusForwarderEvent& forwardEvent)
     {
-
         AZ_PROFILE_SCOPE(NodePaletteModel, "NodePaletteModel::RegisterEBusHandlerNodeModelInformation");
         ScriptCanvas::NodeTypeIdentifier nodeIdentifier = ScriptCanvas::NodeUtils::ConstructEBusEventReceiverIdentifier(busId, forwardEvent.m_eventId);
 
@@ -1140,7 +1140,7 @@ namespace ScriptCanvasEditor
             handlerInformation->m_eventId = forwardEvent.m_eventId;
 
             GraphCanvas::TranslationKey key;
-            key << "EBusHandler" << busName << "methods" << eventName << "details";
+            key << ScriptCanvasEditor::TranslationHelper::AssetContext::EBusHandlerContext << busName << "methods" << eventName << "details";
 
             GraphCanvas::TranslationRequests::Details details;
             GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
@@ -1183,7 +1183,7 @@ namespace ScriptCanvasEditor
             senderInformation->m_eventId = eventId;
 
             GraphCanvas::TranslationKey key;
-            key << "EBusSender" << busName << "methods" << eventName << "details";
+            key << ScriptCanvasEditor::TranslationHelper::AssetContext::EBusSenderContext << busName << "methods" << eventName << "details";
 
             GraphCanvas::TranslationRequests::Details details;
             GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
@@ -79,7 +79,7 @@ namespace ScriptCanvasEditor
 
         void RegisterCustomNode(AZStd::string_view categoryPath, const AZ::Uuid& uuid, AZStd::string_view name, const AZ::SerializeContext::ClassData* classData);
         void RegisterClassNode(const AZStd::string& categoryPath, const AZStd::string& methodClass, const AZStd::string& methodName, const AZ::BehaviorMethod* behaviorMethod, const AZ::BehaviorContext* behaviorContext, ScriptCanvas::PropertyStatus propertyStatus, bool isOverload);
-        void RegisterMethodNode(const AZ::BehaviorContext& behaviorContext, const AZ::BehaviorMethod& behaviorMethod);
+        void RegisterGlobalMethodNode(const AZ::BehaviorContext& behaviorContext, const AZ::BehaviorMethod& behaviorMethod);
         void RegisterGlobalConstant(const AZ::BehaviorContext& behaviorContext, const AZ::BehaviorProperty* behaviorProperty, const AZ::BehaviorMethod& behaviorMethod);
 
 
@@ -165,6 +165,7 @@ namespace ScriptCanvasEditor
         AZ_CLASS_ALLOCATOR(GlobalMethodNodeModelInformation, AZ::SystemAllocator, 0);
 
         AZStd::string m_methodName;
+        bool m_isProperty;
     };
 
     struct EBusHandlerNodeModelInformation

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/MethodConfiguration.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/MethodConfiguration.cpp
@@ -92,17 +92,6 @@ namespace ScriptCanvas
                     className = outputConfig.config.m_prettyClassName;
                 }
 
-                GraphCanvas::TranslationKey key;
-                key << "BehaviorClass" << className << "methods" << *outputConfig.config.m_lookupName << "results" << resultIndex << "details";
-
-                GraphCanvas::TranslationRequests::Details details;
-                GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
-
-                if (!details.m_name.empty())
-                {
-                    resultSlotName = details.m_name;
-                }
-
                 SlotId addedSlotId;
 
                 if (outputConfig.isReturnValueOverloaded)

--- a/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.h
+++ b/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.h
@@ -22,6 +22,7 @@ namespace AZ
     class BehaviorContext;
     class BehaviorEBus;
     class BehaviorMethod;
+    struct BehaviorParameter;
     class BehaviorProperty;
     class Entity;
     class SerializeContext;
@@ -125,6 +126,9 @@ namespace ScriptCanvasEditorTools
         //! Generates the translation data for all global properties and methods in the BehaviorContext
         void TranslateBehaviorGlobals();
 
+        //! Generates the translation data for the specified global method in the BehaviorContext (global, by name)
+        void TranslateBehaviorGlobalMethod(const AZStd::string& methodName);
+
         //! Generates the translation data for the specified property in the BehaviorContext (global, by name)
         void TranslateBehaviorProperty(const AZStd::string& propertyName);
 
@@ -141,6 +145,12 @@ namespace ScriptCanvasEditorTools
 
         //! Utility to populate a BehaviorMethod's translation data
         void TranslateMethod(AZ::BehaviorMethod* behaviorMethod, Method& methodEntry);
+
+        //! Utility function to populate BehaviorMethod arguments translation data
+        void TranslateMethodArguments(const AZ::BehaviorMethod* behaviorMethod, Method& methodEntry);
+
+        //! Utility function to populate BehaviorMethod results translation data
+        void TranslateMethodResults(const AZ::BehaviorParameter* resultParameter, Method& methodEntry);
 
         //! Generates the translation data for a BehaviorEBus that has an BehaviorEBusHandler
         bool TranslateEBusHandler(const AZ::BehaviorEBus* behaviorEbus, TranslationFormat& translationRoot);
@@ -204,6 +214,8 @@ namespace ScriptCanvasEditorTools
 
         //! Get the category for a ScriptCanvas node library
         AZStd::string GetLibraryCategory(const AZ::SerializeContext& serializeContext, const AZStd::string& nodeName);
+
+        AZStd::vector<AZ::TypeId> GetUnpackedTypes(const AZ::TypeId& typeID);
     }
 
 }


### PR DESCRIPTION
## Details
With this change, we can create .names file for BC global methods

Extra changes:
1. Use private helper function to reduce redundancy in TranslationGeneration
2. Fix translation bug for method with multi results
3. Cleanup lots of create on the fly string 

Signed-off-by: onecent1101 <liug@amazon.com>