### PR TITLE
AZ EnvironmentVariable boolean operator fixes

### DIFF
--- a/Code/Framework/AzCore/AzCore/Interface/Interface.h
+++ b/Code/Framework/AzCore/AzCore/Interface/Interface.h
@@ -23,7 +23,7 @@ namespace AZ
      * pointer is handed to you; the assumption is that the registered system will outlive cached
      * references. A system must register itself with the interface at initialization time by calling
      * @ref Register(); and unregister at shutdown by calling @ref Unregister(). The provided Registrar
-     * class will do this for you automatically.  Registration will only succeed after the 
+     * class will do this for you automatically.  Registration will only succeed after the
      * AZ::Environment has been attached and is ready.
      *
      * Example Usage:
@@ -181,7 +181,7 @@ namespace AZ
         // take the full lock and request it.
         AZStd::unique_lock<AZStd::shared_mutex> lock(s_mutex);
         s_instance = Environment::FindVariable<T*>(GetVariableName());
-        s_instanceAssigned = s_instance.IsValid();
+        s_instanceAssigned = static_cast<bool>(s_instance);
         return s_instance ? s_instance.Get() : nullptr;
     }
 

--- a/Code/Framework/AzCore/AzCore/Module/Environment.h
+++ b/Code/Framework/AzCore/AzCore/Module/Environment.h
@@ -434,22 +434,22 @@ namespace AZ
 
         T& operator*() const
         {
-            AZ_Assert(IsValid(), "You can't dereference a null pointer");
-            AZ_Assert(m_data->IsConstructed(), "You are using an invalid variable, the owner has removed it!");
+            AZ_Assert(m_data, "You can't dereference a null pointer");
+            AZ_Assert(IsConstructed(), "You are using an invalid variable, the owner has removed it!");
             return *reinterpret_cast<T*>(&m_data->m_value);
         }
 
         T* operator->() const
         {
-            AZ_Assert(IsValid(), "You can't dereference a null pointer");
-            AZ_Assert(m_data->IsConstructed(), "You are using an invalid variable, the owner has removed it!");
+            AZ_Assert(m_data, "You can't dereference a null pointer");
+            AZ_Assert(IsConstructed(), "You are using an invalid variable, the owner has removed it!");
             return reinterpret_cast<T*>(&m_data->m_value);
         }
 
         T& Get() const
         {
-            AZ_Assert(IsValid(), "You can't dereference a null pointer");
-            AZ_Assert(m_data->IsConstructed(), "You are using an invalid variable, the owner has removed it!");
+            AZ_Assert(m_data, "You can't dereference a null pointer");
+            AZ_Assert(IsConstructed(), "You are using an invalid variable, the owner has removed it!");
             return *reinterpret_cast<T*>(&m_data->m_value);
         }
 
@@ -465,20 +465,18 @@ namespace AZ
 
         explicit operator bool() const
         {
-            return IsValid();
+            return IsConstructed();
         }
-        bool operator! () const { return !IsValid(); }
+        bool operator! () const
+        {
+            return !IsConstructed();
+        }
 
         void Swap(EnvironmentVariable& rhs)
         {
             HolderType* tmp = m_data;
             m_data = rhs.m_data;
             rhs.m_data = tmp;
-        }
-
-        bool IsValid() const
-        {
-            return m_data;
         }
 
         bool IsOwner() const
@@ -489,12 +487,6 @@ namespace AZ
         bool IsConstructed() const
         {
             return m_data && m_data->IsConstructed();
-        }
-
-        void Construct()
-        {
-            AZ_Assert(IsValid(), "You can't dereference a null pointer");
-            m_data->Construct();
         }
 
     protected:
@@ -540,25 +532,25 @@ namespace AZ
     template <class T>
     bool operator==(EnvironmentVariable<T> const& a, std::nullptr_t)
     {
-        return !a.IsValid();
+        return !a.IsConstructed();
     }
 
     template <class T>
     bool operator!=(EnvironmentVariable<T> const& a, std::nullptr_t)
     {
-        return a.IsValid();
+        return a.IsConstructed();
     }
 
     template <class T>
     bool operator==(std::nullptr_t, EnvironmentVariable<T> const& a)
     {
-        return !a.IsValid();
+        return !a.IsConstructed();
     }
 
     template <class T>
     bool operator!=(std::nullptr_t, EnvironmentVariable<T> const& a)
     {
-        return a.IsValid();
+        return a.IsConstructed();
     }
 
     template <class T>

--- a/Code/Framework/AzCore/Tests/DLL.cpp
+++ b/Code/Framework/AzCore/Tests/DLL.cpp
@@ -124,15 +124,13 @@ namespace UnitTest
 
         envVariable = AZ::Environment::FindVariable<UnitTest::DLLTestVirtualClass>(envVariableName);
         EXPECT_TRUE(envVariable);
-        EXPECT_TRUE(envVariable.IsConstructed());
         EXPECT_EQ(1, envVariable->m_data);
 
         UnloadModule();
 
         // the variable is owned by the module (due to the vtable reference), once the module
-        // is unloaded the variable should be destroyed, but still valid
-        EXPECT_TRUE(envVariable);                    // variable should be valid
-        EXPECT_FALSE(envVariable.IsConstructed());   // but destroyed
+        // is unloaded the variable should be unconstructed
+        EXPECT_FALSE(envVariable);
 
         //////////////////////////////////////////////////////////////////////////
         // load the module and see if we recreate our variable
@@ -143,7 +141,7 @@ namespace UnitTest
         createDLLVar(envVariableName);
 
         envVariable = AZ::Environment::FindVariable<UnitTest::DLLTestVirtualClass>(envVariableName);
-        EXPECT_TRUE(envVariable.IsConstructed()); // createDLLVar should construct the variable if already there
+        EXPECT_TRUE(envVariable); // createDLLVar should construct the variable if already there
         EXPECT_EQ(1, envVariable->m_data);
 
         UnloadModule();
@@ -151,11 +149,11 @@ namespace UnitTest
         //////////////////////////////////////////////////////////////////////////
         // Since the variable is valid till the last reference is gone, we have the option
         // to recreate the variable from a different module
-        EXPECT_TRUE(envVariable.IsValid());          // variable should be valid
-        EXPECT_FALSE(envVariable.IsConstructed());   // but destroyed
+        EXPECT_FALSE(envVariable); // Validate that the variable is not constructed
 
-        envVariable.Construct(); // since the variable is destroyed, we can create it from a different module, the new module will be owner
-        EXPECT_TRUE(envVariable.IsConstructed()); // createDLLVar should construct the variable if already there
+         // since the variable is destroyed, we can create it from a different module, the new module will be owner
+        envVariable = AZ::Environment::CreateVariable<UnitTest::DLLTestVirtualClass>(envVariableName);
+        EXPECT_TRUE(envVariable); // createDLLVar should construct the variable if already there
         EXPECT_EQ(1, envVariable->m_data);
     }
 

--- a/Code/Framework/AzCore/Tests/DLLMainTest.cpp
+++ b/Code/Framework/AzCore/Tests/DLLMainTest.cpp
@@ -51,6 +51,7 @@ class DllModule
 {
 public:
     AZ_RTTI(DllModule, "{99C6BF95-847F-4EEE-BB60-9B26D02FF577}", AZ::Module);
+    AZ_CLASS_ALLOCATOR(DllModule, AZ::SystemAllocator, 0);
 
     DllModule()
     {

--- a/Code/Framework/AzCore/Tests/StreamerTests.cpp
+++ b/Code/Framework/AzCore/Tests/StreamerTests.cpp
@@ -273,20 +273,6 @@ namespace AZ::IO
             delete m_application;
             m_application = nullptr;
 
-            for (size_t i = 0; i < m_testFileCount; ++i)
-            {
-                AZStd::string name = AZStd::string::format("TestFile_%zu.test", i);
-
-#if AZ_TRAIT_TEST_APPEND_ROOT_FOLDER_TO_PATH
-                AZ::IO::Path testFullPath(AZ_TRAIT_TEST_ROOT_FOLDER);
-#else
-                AZ::IO::Path testFullPath;
-#endif
-                testFullPath /= name;
-
-                FileIOBase::GetInstance()->DestroyPath(testFullPath.c_str());
-            }
-
             FileIOBase::SetInstance(m_prevFileIO);
 
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Destroy();
@@ -314,11 +300,7 @@ namespace AZ::IO
         {
             AZStd::string name = AZStd::string::format("TestFile_%zu.test", m_testFileCount++);
 
-#if AZ_TRAIT_TEST_APPEND_ROOT_FOLDER_TO_PATH
-            AZ::IO::Path testFullPath(AZ_TRAIT_TEST_ROOT_FOLDER);
-#else
-            AZ::IO::Path testFullPath;
-#endif
+            AZ::IO::Path testFullPath = m_tempDirectory.GetDirectory();
             testFullPath /= name;
 
             AZStd::unique_ptr<MockFileBase> result = CreateMockFile();
@@ -374,6 +356,7 @@ namespace AZ::IO
             ASSERT_TRUE(readSuccessful);
         }
 
+        AZ::Test::ScopedAutoTempDirectory m_tempDirectory;
         UnitTest::TestFileIOBase m_fileIO;
         FileIOBase* m_prevFileIO{ nullptr };
         IStreamer* m_streamer{ nullptr };

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderReloadDebugTracker.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderReloadDebugTracker.cpp
@@ -32,10 +32,10 @@ namespace AZ
             ShaderReloadDebugTrackerInternal::s_enabled.Reset();
             ShaderReloadDebugTrackerInternal::s_indent.Reset();
         }
-        
+
         void ShaderReloadDebugTracker::MakeReady()
         {
-            if (!ShaderReloadDebugTrackerInternal::s_enabled.IsValid())
+            if (!ShaderReloadDebugTrackerInternal::s_enabled)
             {
                 ShaderReloadDebugTrackerInternal::s_enabled = AZ::Environment::CreateVariable<bool>(AZ::Crc32(ShaderReloadDebugTrackerInternal::EnabledVariableName), false);
                 ShaderReloadDebugTrackerInternal::s_indent = AZ::Environment::CreateVariable<int>(AZ::Crc32(ShaderReloadDebugTrackerInternal::IndentVariableName), 0);
@@ -54,7 +54,7 @@ namespace AZ
             return false;
 #endif
         }
-        
+
         void ShaderReloadDebugTracker::AddIndent()
         {
             MakeReady();
@@ -66,7 +66,7 @@ namespace AZ
             MakeReady();
             ShaderReloadDebugTrackerInternal::s_indent.Get() -= IndentSpaces;
         }
-        
+
         int ShaderReloadDebugTracker::GetIndent()
         {
             MakeReady();

--- a/Gems/WhiteBox/Code/Tests/WhiteBoxPhysicsTest.cpp
+++ b/Gems/WhiteBox/Code/Tests/WhiteBoxPhysicsTest.cpp
@@ -47,7 +47,7 @@ namespace UnitTest
 
     void EditorWhiteBoxPhysicsTestEnvironment::AddGemsAndComponents()
     {
-        AddDynamicModulePaths({"PhysX.Editor"});
+        AddDynamicModulePaths({"PhysX.Editor.Gem"});
         AddComponentDescriptors(
             {AzToolsFramework::EditorEntityContextComponent::CreateDescriptor(),
              WhiteBox::EditorWhiteBoxComponent::CreateDescriptor(), WhiteBox::WhiteBoxComponent::CreateDescriptor(),

--- a/Gems/WhiteBox/Code/Tests/WhiteBoxPhysicsTest.cpp
+++ b/Gems/WhiteBox/Code/Tests/WhiteBoxPhysicsTest.cpp
@@ -47,7 +47,7 @@ namespace UnitTest
 
     void EditorWhiteBoxPhysicsTestEnvironment::AddGemsAndComponents()
     {
-        AddDynamicModulePaths({"PhysX.Editor.Gem"});
+        AddDynamicModulePaths({"PhysX.Editor"});
         AddComponentDescriptors(
             {AzToolsFramework::EditorEntityContextComponent::CreateDescriptor(),
              WhiteBox::EditorWhiteBoxComponent::CreateDescriptor(), WhiteBox::WhiteBoxComponent::CreateDescriptor(),


### PR DESCRIPTION
Updated the EnvironmentVariable class boolean checks.

The `operator bool` and `operator!` now check if the EnvironmentVariableHolderType type is non-nullptr and is in a constructed state.

This makes it consistent with the `operator*` and `operator->` methods and allows the construct as follows to always work
```
if (environmentVariable)
{
   auto value = *environmentVariable;
}
```

Also removed the `Construct` environment variable class as it allows invoking the constructor over an already constructed value stored in the EnvironmentVariableHolder.

The `Construct` function itself required the EnvironmentVariable to be in a very specific state where the EnvironmentVariable has been constructed before and the destroyed in order to use safely.

The function that should be used to re-create an environment variable is the `AZ::Environment::CreateVariable` function.

fixes #9274 

Also updated the AzCore Serialization and Streamer test to write out the a temporary directory instead of the current working directory to prevent pollution of test files within the user's working directory.