### PR TITLE
Update NetworkRigidBody to Require NetworkTransform

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Common.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Common.jinja
@@ -316,6 +316,10 @@ namespace {{ Component.attrib['Namespace'] }}
         AZ_MULTIPLAYER_COMPONENT({{ Component.attrib['Namespace'] }}::{{ ComponentName }}, s_{{ LowerFirst(ComponentName) }}ConcreteUuid, {{ Component.attrib['Namespace'] }}::{{ ComponentNameBase }});
 
         static void Reflect(AZ::ReflectContext* context);
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
 
         void OnInit() override;
         void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
@@ -391,6 +395,26 @@ namespace {{ Component.attrib['Namespace'] }}
                 ->Version(1);
         }
         {{ ComponentNameBase }}::Reflect(context);
+    }
+
+    void {{ ComponentName }}::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        {{ ComponentNameBase }}::GetProvidedServices(provided);
+    }
+
+    void {{ ComponentName }}::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        {{ ComponentNameBase }}::GetRequiredServices(required);
+    }
+
+    void {{ ComponentName }}::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+        {{ ComponentNameBase }}::GetDependentServices(dependent);
+    }
+
+    void {{ ComponentName }}::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        {{ ComponentNameBase }}::GetIncompatibleServices(incompatible);
     }
 
     void {{ ComponentName }}::OnInit()

--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Common.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Common.jinja
@@ -316,10 +316,6 @@ namespace {{ Component.attrib['Namespace'] }}
         AZ_MULTIPLAYER_COMPONENT({{ Component.attrib['Namespace'] }}::{{ ComponentName }}, s_{{ LowerFirst(ComponentName) }}ConcreteUuid, {{ Component.attrib['Namespace'] }}::{{ ComponentNameBase }});
 
         static void Reflect(AZ::ReflectContext* context);
-        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
-        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
-        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
-        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
 
         void OnInit() override;
         void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
@@ -395,26 +391,6 @@ namespace {{ Component.attrib['Namespace'] }}
                 ->Version(1);
         }
         {{ ComponentNameBase }}::Reflect(context);
-    }
-
-    void {{ ComponentName }}::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
-    {
-        {{ ComponentNameBase }}::GetProvidedServices(provided);
-    }
-
-    void {{ ComponentName }}::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
-    {
-        {{ ComponentNameBase }}::GetRequiredServices(required);
-    }
-
-    void {{ ComponentName }}::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
-    {
-        {{ ComponentNameBase }}::GetDependentServices(dependent);
-    }
-
-    void {{ ComponentName }}::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
-    {
-        {{ ComponentNameBase }}::GetIncompatibleServices(incompatible);
     }
 
     void {{ ComponentName }}::OnInit()

--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Header.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Header.jinja
@@ -463,7 +463,7 @@ namespace {{ Component.attrib['Namespace'] }}
         {{ AutoComponentMacros.DeclareRpcEventGetters(Component, 'Authority', 'Autonomous')|indent(8) -}}
 
 {% for Service in Component.iter('ComponentRelation') %}
-{%      if (Service.attrib['HasController']|booleanTrue) and (Service.attrib['Constraint'] != 'Incompatible') %}
+{%      if (Service.attrib['Constraint'] != 'Incompatible') and (Service.attrib['HasController']|booleanTrue)  %}
         {{ Service.attrib['Namespace'] }}::{{ Service.attrib['Name'] }}Controller* Get{{ Service.attrib['Name'] }}Controller();
 {%      endif %}
 {% endfor %}

--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
@@ -1483,7 +1483,7 @@ namespace {{ Component.attrib['Namespace'] }}
     {{ DefineRpcInvocations(Component, ControllerBaseName, 'Authority', 'Client', true)|indent(4) }}
 
 {% for Service in Component.iter('ComponentRelation') %}
-{%      if (Service.attrib['HasController']|booleanTrue) and (Service.attrib['Constraint'] != 'Incompatible') %}
+{%      if (Service.attrib['Constraint'] != 'Incompatible') and (Service.attrib['HasController']|booleanTrue)%}
     {{ Service.attrib['Namespace'] }}::{{ Service.attrib['Name'] }}Controller* {{ ControllerBaseName }}::Get{{ Service.attrib['Name'] }}Controller()
     {
         Multiplayer::MultiplayerComponent* controllerComponent = GetParent().Get{{ Service.attrib['Name'] }}();

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkCharacterComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkCharacterComponent.h
@@ -47,7 +47,6 @@ namespace Multiplayer
 
         static void Reflect(AZ::ReflectContext* context);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
-        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
 
         NetworkCharacterComponent();
 

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkRigidBodyComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkRigidBodyComponent.h
@@ -39,6 +39,7 @@ namespace Multiplayer
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
         static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
 
         NetworkRigidBodyComponent();
 

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkRigidBodyComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkRigidBodyComponent.h
@@ -37,7 +37,6 @@ namespace Multiplayer
 
         static void Reflect(AZ::ReflectContext* context);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
-        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
 
         NetworkRigidBodyComponent();
 

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkRigidBodyComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkRigidBodyComponent.h
@@ -36,10 +36,8 @@ namespace Multiplayer
             Multiplayer::NetworkRigidBodyComponent, s_networkRigidBodyComponentConcreteUuid, Multiplayer::NetworkRigidBodyComponentBase);
 
         static void Reflect(AZ::ReflectContext* context);
-        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
         static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
-        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
 
         NetworkRigidBodyComponent();
 

--- a/Gems/Multiplayer/Code/Source/AutoGen/NetworkCharacterComponent.AutoComponent.xml
+++ b/Gems/Multiplayer/Code/Source/AutoGen/NetworkCharacterComponent.AutoComponent.xml
@@ -9,4 +9,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <ComponentRelation Constraint="Required" HasController="true" Name="NetworkTransformComponent" Namespace="Multiplayer" Include="Multiplayer/Components/NetworkTransformComponent.h" />
+    <ComponentRelation Constraint="Incompatible" Name="NetworkRigidBodyComponent" />
+
 </Component>

--- a/Gems/Multiplayer/Code/Source/Components/NetworkCharacterComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkCharacterComponent.cpp
@@ -102,11 +102,6 @@ namespace Multiplayer
         required.push_back(AZ_CRC_CE("PhysXCharacterControllerService"));
     }
 
-    void NetworkCharacterComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
-    {
-        incompatible.push_back(AZ_CRC_CE("NetworkRigidBodyService"));
-    }
-
     NetworkCharacterComponent::NetworkCharacterComponent()
         : m_translationEventHandler([this](const AZ::Vector3& translation) { OnTranslationChangedEvent(translation); })
     {

--- a/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
@@ -26,12 +26,6 @@ namespace Multiplayer
         NetworkRigidBodyComponentBase::Reflect(context);
     }
 
-    void NetworkRigidBodyComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
-    {
-        NetworkRigidBodyComponentBase::GetProvidedServices(provided);
-        provided.push_back(AZ_CRC_CE("NetworkRigidBodyService"));
-    }
-
     void NetworkRigidBodyComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         NetworkRigidBodyComponentBase::GetRequiredServices(required);
@@ -43,11 +37,6 @@ namespace Multiplayer
         NetworkRigidBodyComponentBase::GetDependentServices(dependent);
         dependent.push_back(AZ_CRC_CE("TransformService"));
         dependent.push_back(AZ_CRC_CE("PhysXRigidBodyService"));
-    }
-
-    void NetworkRigidBodyComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
-    {
-        NetworkRigidBodyComponentBase::GetIncompatibleServices(incompatible);
     }
 
     NetworkRigidBodyComponent::NetworkRigidBodyComponent()

--- a/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
@@ -50,7 +50,6 @@ namespace Multiplayer
         NetworkRigidBodyComponentBase::GetIncompatibleServices(incompatible);
     }
 
-
     NetworkRigidBodyComponent::NetworkRigidBodyComponent()
         : m_syncRewindHandler([this](){ OnSyncRewind(); })
         , m_transformChangedHandler([this]([[maybe_unused]] const AZ::Transform& localTm, const AZ::Transform& worldTm){ OnTransformUpdate(worldTm); })

--- a/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
@@ -28,19 +28,28 @@ namespace Multiplayer
 
     void NetworkRigidBodyComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
     {
+        NetworkRigidBodyComponentBase::GetProvidedServices(provided);
         provided.push_back(AZ_CRC_CE("NetworkRigidBodyService"));
     }
 
     void NetworkRigidBodyComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
+        NetworkRigidBodyComponentBase::GetRequiredServices(required);
         required.push_back(AZ_CRC_CE("PhysXRigidBodyService"));
     }
 
     void NetworkRigidBodyComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
     {
+        NetworkRigidBodyComponentBase::GetDependentServices(dependent);
         dependent.push_back(AZ_CRC_CE("TransformService"));
         dependent.push_back(AZ_CRC_CE("PhysXRigidBodyService"));
     }
+
+    void NetworkRigidBodyComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        NetworkRigidBodyComponentBase::GetIncompatibleServices(incompatible);
+    }
+
 
     NetworkRigidBodyComponent::NetworkRigidBodyComponent()
         : m_syncRewindHandler([this](){ OnSyncRewind(); })

--- a/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
@@ -32,13 +32,6 @@ namespace Multiplayer
         required.push_back(AZ_CRC_CE("PhysXRigidBodyService"));
     }
 
-    void NetworkRigidBodyComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
-    {
-        NetworkRigidBodyComponentBase::GetDependentServices(dependent);
-        dependent.push_back(AZ_CRC_CE("TransformService"));
-        dependent.push_back(AZ_CRC_CE("PhysXRigidBodyService"));
-    }
-
     NetworkRigidBodyComponent::NetworkRigidBodyComponent()
         : m_syncRewindHandler([this](){ OnSyncRewind(); })
         , m_transformChangedHandler([this]([[maybe_unused]] const AZ::Transform& localTm, const AZ::Transform& worldTm){ OnTransformUpdate(worldTm); })


### PR DESCRIPTION
Updating NetworkRigidBodyComponent to require NetTransform by calling the base class's GetRequiredServices.
Also clean up NetRigidBody's and NetCharacter's incompatibility service; removed redundant services, and allow for XML to define Incompatible services without having to define HasContoller.

Tested by adding the NetworkRigidBodyComponent to an entity and now seeing that it requires adding the NetTransformComponent.
Tested by adding the NetworkRigidBodyComponent to an entity and then NetworkCharacterComponent, and seeing that they are still incompatible.

Resolves #8616

Signed-off-by: Gene Walters <genewalt@amazon.com>