### PR TITLE
Fix gcc build error related to missing const template qualifier for a…

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingResourceList.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingResourceList.h
@@ -31,7 +31,7 @@ namespace AZ
         {
         public:
 
-            using ResourceVector = AZStd::vector<TResource*>;
+            using ResourceVector = AZStd::vector<const TResource*>;
             using IndexVector = AZStd::vector<uint32_t>;
 
             RayTracingResourceList() = default;
@@ -39,11 +39,11 @@ namespace AZ
 
             // adds a resource to the list, or increments the reference count, and returns the index of the resource
             // Note: the index returned is an indirection index, meaning it is stable when other entries are removed
-            uint32_t AddResource(TResource* resource);
+            uint32_t AddResource(const TResource* resource);
 
             // removes a resource from the list, or decrements the reference count
             // Note: removing a resource will not affect any previously returned indices for other resources
-            void RemoveResource(TResource* resource);
+            void RemoveResource(const TResource* resource);
 
             // returns the resource list
             ResourceVector& GetResourceList() { return m_resources; }
@@ -68,7 +68,7 @@ namespace AZ
                 uint32_t m_count = 0;
             };
 
-            using ResourceMap = AZStd::map<TResource*, IndexMapEntry>;
+            using ResourceMap = AZStd::map<const TResource*, IndexMapEntry>;
 
             ResourceVector m_resources;
             ResourceMap m_resourceMap;
@@ -76,7 +76,7 @@ namespace AZ
         };
 
         template<class TResource>
-        uint32_t RayTracingResourceList<TResource>::AddResource(TResource* resource)
+        uint32_t RayTracingResourceList<TResource>::AddResource(const TResource* resource)
         {
             if (resource == nullptr)
             {
@@ -111,7 +111,7 @@ namespace AZ
         }
 
         template<class TResource>
-        void RayTracingResourceList<TResource>::RemoveResource(TResource* resource)
+        void RayTracingResourceList<TResource>::RemoveResource(const TResource* resource)
         {
             if (resource == nullptr)
             {


### PR DESCRIPTION
Fix gcc build error related to missing const template qualifier for an argument to 'SetBufferViewUnboundedArray'.


```
[2022-04-29T06:00:35.114Z] /data/workspace/o3de/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp: In member function ‘void AZ::Render::RayTracingFeatureProcessor::UpdateRayTracingSceneSrg()’:
[2022-04-29T06:00:35.114Z] /data/workspace/o3de/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp:650:119: error: cannot convert ‘AZ::Render::RayTracingResourceList<AZ::RHI::BufferView>::ResourceVector’ {aka ‘AZStd::vector<AZ::RHI::BufferView*, AZStd::allocator>’} to ‘AZStd::span<const AZ::RHI::BufferView* const>’
[2022-04-29T06:00:35.114Z]   650 |             m_rayTracingSceneSrg->SetBufferViewUnboundedArray(bufferUnboundedArrayIndex, m_meshBuffers.GetResourceList());
[2022-04-29T06:00:35.114Z]       |                                                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
[2022-04-29T06:00:35.114Z]       |                                                                                                                       |
[2022-04-29T06:00:35.114Z]       |                                                                                                                       AZ::Render::RayTracingResourceList<AZ::RHI::BufferView>::ResourceVector {aka AZStd::vector<AZ::RHI::BufferView*, AZStd::allocator>}
[2022-04-29T06:00:35.114Z] In file included from /data/workspace/o3de/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/TransformService/TransformServiceFeatureProcessor.h:16,
[2022-04-29T06:00:35.114Z]                  from /data/workspace/o3de/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h:13,
[2022-04-29T06:00:35.114Z]                  from /data/workspace/o3de/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp:9:
[2022-04-29T06:00:35.114Z] /data/workspace/o3de/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h:174:142: note:   initializing argument 2 of ‘bool AZ::RPI::ShaderResourceGroup::SetBufferViewUnboundedArray(AZ::RHI::ShaderInputBufferUnboundedArrayIndex, AZStd::span<const AZ::RHI::BufferView* const>)’
[2022-04-29T06:00:35.114Z]   174 |             bool SetBufferViewUnboundedArray(RHI::ShaderInputBufferUnboundedArrayIndex inputIndex, AZStd::span<const RHI::BufferView* const> bufferViews);
[2022-04-29T06:00:35.114Z]       |                                                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
```


Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>