### PR TITLE
Fix duplicated slot name on Undo/Redo action

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
@@ -2267,11 +2267,15 @@ namespace ScriptCanvas
             return AZ::Failure(AZStd::string("Trying to add a slot with an Invalid Slot Descriptor"));
         }
 
-        auto slotNameIter = m_slotNameMap.find(slotConfiguration.m_name);
-        if (slotConfiguration.m_addUniqueSlotByNameAndType && slotNameIter != m_slotNameMap.end() && slotNameIter->second->GetDescriptor() == slotConfiguration.GetSlotDescriptor())
+        auto findResult = m_slotNameMap.equal_range(slotConfiguration.m_name);
+        for (auto slotNameIter = findResult.first; slotNameIter != findResult.second; ++slotNameIter)
         {
-            iterOut = slotNameIter->second;
-            return AZ::Failure(AZStd::string::format("Slot with name %s already exist", slotConfiguration.m_name.data()));
+            if (slotConfiguration.m_addUniqueSlotByNameAndType &&
+                slotNameIter->second->GetDescriptor() == slotConfiguration.GetSlotDescriptor())
+            {
+                iterOut = slotNameIter->second;
+                return AZ::Failure(AZStd::string::format("Slot with name %s already exist", slotConfiguration.m_name.data()));
+            }
         }
 
         SlotIterator insertIter = (insertIndex < 0 || insertIndex >= azlossy_cast<AZ::s64>(m_slots.size())) ? m_slots.end() : AZStd::next(m_slots.begin(), insertIndex);


### PR DESCRIPTION
## Details
Background: when we Undo/Redo, we will rebuild the graph from previous stored snapshot. Each node has a cached slot name map AZStd::unordered_multimap<AZStd::string, SlotIterator> m_slotNameMap, and it is maintained so we don't really need to re-configure all slots.

The issue is m_slotNameMap is a multimap, we prevent slot with same name and same type, but it allows slot with same name but different type, which is the reported issue.

So when we try to rebuild graph for that node, it searches against m_slotNameMap, find a same name but different slot type, so it will try to create a new slot.

Fix is to use equal_range to get all matched slot name in the multimap which can capture existing slot.

https://user-images.githubusercontent.com/5900509/166067759-5d82f53a-5500-46d2-a256-0925757b24ec.mp4


Signed-off-by: onecent1101 <liug@amazon.com>