### PR TITLE
bugfix(Whitebox): add small margin to prevent z-fighting when working with polygon manipulator

### DIFF
--- a/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxManipulatorViews.cpp
+++ b/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxManipulatorViews.cpp
@@ -51,6 +51,7 @@ namespace WhiteBox
         polygonBounds.m_triangles = TransformToWorldSpace(manipulatorState.m_worldFromLocal, m_triangles);
 
         // draw fill
+        debugDisplay.PushMatrix(m_polygonViewOverlapOffset);
         debugDisplay.DepthTestOn();
         debugDisplay.SetColor(m_fillColor);
         debugDisplay.DrawTriangles(polygonBounds.m_triangles, m_fillColor);
@@ -73,6 +74,7 @@ namespace WhiteBox
         }
 
         debugDisplay.DepthTestOff();
+        debugDisplay.PopMatrix();
 
         RefreshBoundInternal(managerId, manipulatorId, polygonBounds);
     }

--- a/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxManipulatorViews.h
+++ b/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxManipulatorViews.h
@@ -36,6 +36,7 @@ namespace WhiteBox
             AzFramework::DebugDisplayRequests& debugDisplay, const AzFramework::CameraState& cameraState,
             const AzToolsFramework::ViewportInteraction::MouseInteraction& mouseInteraction) override;
 
+        AZ::Transform m_polygonViewOverlapOffset;
         AZStd::vector<AZ::Vector3> m_triangles;
         Api::VertexPositionsCollection m_outlines;
 

--- a/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxPolygonTranslationModifier.cpp
+++ b/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxPolygonTranslationModifier.cpp
@@ -20,6 +20,11 @@
 
 namespace WhiteBox
 {
+
+    AZ_CVAR(
+        float, ed_whiteBoxPolygonViewOverlapOffset, 0.004f, nullptr, AZ::ConsoleFunctorFlags::Null,
+        "The offset highlighted polygon");
+    
     AZ_CLASS_ALLOCATOR_IMPL(PolygonTranslationModifier, AZ::SystemAllocator, 0)
 
     PolygonTranslationModifier::PolygonTranslationModifier(
@@ -279,8 +284,7 @@ namespace WhiteBox
             whiteBox, m_entityComponentIdPair, &EditorWhiteBoxComponentRequests::GetWhiteBoxMesh);
 
         Api::VertexPositionsCollection outlines = Api::PolygonBorderVertexPositions(*whiteBox, m_polygonHandle);
-        AZStd::vector<AZ::Vector3> triangles = Api::PolygonFacesPositions(*whiteBox, m_polygonHandle);
-
+        AZStd::vector<AZ::Vector3> triangles = Api::PolygonFacesPositions(*whiteBox, m_polygonHandle);        
         const AZ::Vector3 polygonMidpoint = Api::PolygonMidpoint(*whiteBox, m_polygonHandle);
 
         // translate points into local space of the manipulator (see UpdateIntersectionPoint)
@@ -289,8 +293,9 @@ namespace WhiteBox
         {
             TranslatePoints(outline, -polygonMidpoint);
         }
-
-        TranslatePoints(triangles, -polygonMidpoint);
+        
+        const AZ::Vector3 normal = Api::PolygonNormal(*whiteBox, m_polygonHandle);
+        TranslatePoints(triangles, -polygonMidpoint + normal * ed_whiteBoxPolygonViewOverlapOffset);
 
         if (!m_polygonView)
         {

--- a/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxPolygonTranslationModifier.cpp
+++ b/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxPolygonTranslationModifier.cpp
@@ -295,7 +295,7 @@ namespace WhiteBox
         }
         
         const AZ::Vector3 normal = Api::PolygonNormal(*whiteBox, m_polygonHandle);
-        TranslatePoints(triangles, -polygonMidpoint + normal * ed_whiteBoxPolygonViewOverlapOffset);
+        TranslatePoints(triangles, -polygonMidpoint);
 
         if (!m_polygonView)
         {
@@ -307,6 +307,7 @@ namespace WhiteBox
             m_polygonView->m_triangles = triangles;
         }
 
+        m_polygonView->m_polygonViewOverlapOffset = AZ::Transform::CreateTranslation(normal * ed_whiteBoxPolygonViewOverlapOffset);
         m_polygonView->m_fillColor = m_fillColor;
         m_polygonView->m_outlineColor = m_outlineColor;
 


### PR DESCRIPTION
this is not a perfect solution but it addresses the problem where the manipulator is z-fighting in whitebox. might make sense to make this a post processing affect i.e render the polygon separately and use the depth test to highlight the selected polygon maybe? 

if you get close to the mesh you can see where the selected region is floating by a small margin. this is better then the current situation where this will z-fight. 

![image](https://user-images.githubusercontent.com/854359/166133477-3c32e476-7d5e-49f5-bea3-2d3a493911a0.png)
