### PR TITLE
Motion Matching: Made debug draw independent of the mm instance

### DIFF
--- a/Gems/MotionMatching/Code/Source/Feature.h
+++ b/Gems/MotionMatching/Code/Source/Feature.h
@@ -119,7 +119,8 @@ namespace EMotionFX::MotionMatching
             [[maybe_unused]] const FrameCostContext& context) {}
 
         virtual void DebugDraw([[maybe_unused]] AzFramework::DebugDisplayRequests& debugDisplay,
-            [[maybe_unused]] MotionMatchingInstance* instance,
+            [[maybe_unused]] const Pose& currentPose,
+            [[maybe_unused]] const FeatureMatrix& featureMatrix,
             [[maybe_unused]] size_t frameIndex) {}
 
         void SetDebugDrawColor(const AZ::Color& color);

--- a/Gems/MotionMatching/Code/Source/FeaturePosition.cpp
+++ b/Gems/MotionMatching/Code/Source/FeaturePosition.cpp
@@ -44,16 +44,14 @@ namespace EMotionFX::MotionMatching
     }
 
     void FeaturePosition::DebugDraw(AzFramework::DebugDisplayRequests& debugDisplay,
-        MotionMatchingInstance* instance,
+        const Pose& currentPose,
+        const FeatureMatrix& featureMatrix,
         size_t frameIndex)
     {
-        const MotionMatchingData* data = instance->GetData();
-        const ActorInstance* actorInstance = instance->GetActorInstance();
-        const Pose* pose = actorInstance->GetTransformData()->GetCurrentPose();
-        const Transform jointModelTM = pose->GetModelSpaceTransform(m_jointIndex);
-        const Transform relativeToWorldTM = pose->GetWorldSpaceTransform(m_relativeToNodeIndex);
+        const Transform jointModelTM = currentPose.GetModelSpaceTransform(m_jointIndex);
+        const Transform relativeToWorldTM = currentPose.GetWorldSpaceTransform(m_relativeToNodeIndex);
 
-        const AZ::Vector3 position = GetFeatureData(data->GetFeatureMatrix(), frameIndex);
+        const AZ::Vector3 position = GetFeatureData(featureMatrix, frameIndex);
         const AZ::Vector3 transformedPos = relativeToWorldTM.TransformPoint(position);
 
         constexpr float markerSize = 0.03f;

--- a/Gems/MotionMatching/Code/Source/FeaturePosition.h
+++ b/Gems/MotionMatching/Code/Source/FeaturePosition.h
@@ -38,7 +38,8 @@ namespace EMotionFX::MotionMatching
 
         void ExtractFeatureValues(const ExtractFeatureContext& context) override;
         void DebugDraw(AzFramework::DebugDisplayRequests& debugDisplay,
-            MotionMatchingInstance* instance,
+            const Pose& currentPose,
+            const FeatureMatrix& featureMatrix,
             size_t frameIndex) override;
 
         float CalculateFrameCost(size_t frameIndex, const FrameCostContext& context) const override;

--- a/Gems/MotionMatching/Code/Source/FeatureTrajectory.cpp
+++ b/Gems/MotionMatching/Code/Source/FeatureTrajectory.cpp
@@ -197,7 +197,7 @@ namespace EMotionFX::MotionMatching
     }
 
     void FeatureTrajectory::DebugDrawTrajectory(AzFramework::DebugDisplayRequests& debugDisplay,
-        MotionMatchingInstance* instance,
+        const FeatureMatrix& featureMatrix,
         size_t frameIndex,
         const Transform& worldSpaceTransform,
         const AZ::Color& color,
@@ -210,7 +210,6 @@ namespace EMotionFX::MotionMatching
         }
 
         constexpr float markerSize = 0.02f;
-        const FeatureMatrix& featureMatrix = instance->GetData()->GetFeatureMatrix();
 
         debugDisplay.DepthTestOff();
         debugDisplay.SetColor(color);
@@ -242,16 +241,16 @@ namespace EMotionFX::MotionMatching
     }
 
     void FeatureTrajectory::DebugDraw(AzFramework::DebugDisplayRequests& debugDisplay,
-        MotionMatchingInstance* instance,
+        const Pose& currentPose,
+        const FeatureMatrix& featureMatrix,
         size_t frameIndex)
     {
-        const ActorInstance* actorInstance = instance->GetActorInstance();
-        const Transform transform = actorInstance->GetTransformData()->GetCurrentPose()->GetWorldSpaceTransform(m_jointIndex);
+        const Transform transform = currentPose.GetWorldSpaceTransform(m_jointIndex);
 
-        DebugDrawTrajectory(debugDisplay, instance, frameIndex, transform,
+        DebugDrawTrajectory(debugDisplay, featureMatrix, frameIndex, transform,
             m_debugColor, m_numPastSamples, AZStd::bind(&FeatureTrajectory::CalcPastFrameIndex, this, AZStd::placeholders::_1));
 
-        DebugDrawTrajectory(debugDisplay, instance, frameIndex, transform,
+        DebugDrawTrajectory(debugDisplay, featureMatrix, frameIndex, transform,
             m_debugColor, m_numFutureSamples, AZStd::bind(&FeatureTrajectory::CalcFutureFrameIndex, this, AZStd::placeholders::_1));
     }
 

--- a/Gems/MotionMatching/Code/Source/FeatureTrajectory.h
+++ b/Gems/MotionMatching/Code/Source/FeatureTrajectory.h
@@ -62,7 +62,8 @@ namespace EMotionFX::MotionMatching
         bool Init(const InitSettings& settings) override;
         void ExtractFeatureValues(const ExtractFeatureContext& context) override;
         void DebugDraw(AzFramework::DebugDisplayRequests& debugDisplay,
-            MotionMatchingInstance* instance,
+            const Pose& currentPose,
+            const FeatureMatrix& featureMatrix,
             size_t frameIndex) override;
 
         float CalculateFutureFrameCost(size_t frameIndex, const FrameCostContext& context) const;
@@ -118,7 +119,7 @@ namespace EMotionFX::MotionMatching
         void SetFeatureData(FeatureMatrix& featureMatrix, size_t frameIndex, size_t sampleIndex, const Sample& sample);
 
         void DebugDrawTrajectory(AzFramework::DebugDisplayRequests& debugDisplay,
-            MotionMatchingInstance* instance,
+            const FeatureMatrix& featureMatrix,
             size_t frameIndex,
             const Transform& transform,
             const AZ::Color& color,

--- a/Gems/MotionMatching/Code/Source/FeatureVelocity.cpp
+++ b/Gems/MotionMatching/Code/Source/FeatureVelocity.cpp
@@ -76,19 +76,8 @@ namespace EMotionFX::MotionMatching
     }
 
     void FeatureVelocity::DebugDraw(AzFramework::DebugDisplayRequests& debugDisplay,
-        MotionMatchingInstance* instance,
-        const AZ::Vector3& velocity,
-        size_t jointIndex,
-        size_t relativeToJointIndex,
-        const AZ::Color& color)
-    {
-        const ActorInstance* actorInstance = instance->GetActorInstance();
-        const Pose* pose = actorInstance->GetTransformData()->GetCurrentPose();
-        DebugDraw(debugDisplay, *pose, velocity, jointIndex, relativeToJointIndex, color);
-    }
-
-    void FeatureVelocity::DebugDraw(AzFramework::DebugDisplayRequests& debugDisplay,
-        MotionMatchingInstance* instance,
+        const Pose& currentPose,
+        const FeatureMatrix& featureMatrix,
         size_t frameIndex)
     {
         if (m_jointIndex == InvalidIndex)
@@ -96,9 +85,8 @@ namespace EMotionFX::MotionMatching
             return;
         }
 
-        const MotionMatchingData* data = instance->GetData();
-        const AZ::Vector3 velocity = GetFeatureData(data->GetFeatureMatrix(), frameIndex);
-        DebugDraw(debugDisplay, instance, velocity, m_jointIndex, m_relativeToNodeIndex, m_debugColor);
+        const AZ::Vector3 velocity = GetFeatureData(featureMatrix, frameIndex);
+        DebugDraw(debugDisplay, currentPose, velocity, m_jointIndex, m_relativeToNodeIndex, m_debugColor);
     }
 
     float FeatureVelocity::CalculateFrameCost(size_t frameIndex, const FrameCostContext& context) const

--- a/Gems/MotionMatching/Code/Source/FeatureVelocity.h
+++ b/Gems/MotionMatching/Code/Source/FeatureVelocity.h
@@ -46,15 +46,9 @@ namespace EMotionFX::MotionMatching
             size_t relativeToJointIndex,
             const AZ::Color& color);
 
-        static void DebugDraw(AzFramework::DebugDisplayRequests& debugDisplay,
-            MotionMatchingInstance* instance,
-            const AZ::Vector3& velocity, // in relative-to-joint space
-            size_t jointIndex,
-            size_t relativeToJointIndex,
-            const AZ::Color& color);
-
         void DebugDraw(AzFramework::DebugDisplayRequests& debugDisplay,
-            MotionMatchingInstance* instance,
+            const Pose& currentPose,
+            const FeatureMatrix& featureMatrix,
             size_t frameIndex) override;
 
         float CalculateFrameCost(size_t frameIndex, const FrameCostContext& context) const override;

--- a/Gems/MotionMatching/Code/Source/MotionMatchingInstance.cpp
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingInstance.cpp
@@ -146,6 +146,7 @@ namespace EMotionFX::MotionMatching
 
         const FrameDatabase& frameDatabase = m_data->GetFrameDatabase();
         const FeatureSchema& featureSchema = m_data->GetFeatureSchema();
+        const FeatureMatrix& featureMatrix = m_data->GetFeatureMatrix();
 
         // Find the frame index in the frame database that belongs to the currently used pose.
         const size_t currentFrame = frameDatabase.FindFrameIndex(m_motionInstance->GetMotion(), m_motionInstance->GetCurrentTime());
@@ -153,11 +154,12 @@ namespace EMotionFX::MotionMatching
         // Render the feature debug visualizations for the current frame.
         if (currentFrame != InvalidIndex)
         {
+            const Pose& currentPose = *m_actorInstance->GetTransformData()->GetCurrentPose();
             for (Feature* feature: featureSchema.GetFeatures())
             {
                 if (feature->GetDebugDrawEnabled())
                 {
-                    feature->DebugDraw(debugDisplay, this, currentFrame);
+                    feature->DebugDraw(debugDisplay, currentPose, featureMatrix, currentFrame);
                 }
             }
         }


### PR DESCRIPTION
Replaced the motion matching instance with a current pose and the feature matrix to make the debug draw independent of the motion matching instance.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>