### PR TITLE
Moved gradient preview popout icon to the left corner

### DIFF
--- a/Gems/GradientSignal/Code/Source/UI/GradientPreviewWidget.cpp
+++ b/Gems/GradientSignal/Code/Source/UI/GradientPreviewWidget.cpp
@@ -31,7 +31,7 @@ namespace GradientSignal
 
             QVBoxLayout* layout = new QVBoxLayout(this);
             layout->setContentsMargins(QMargins(IconMargin, IconMargin, IconMargin, IconMargin));
-            layout->setAlignment(Qt::AlignTop | Qt::AlignRight);
+            layout->setAlignment(Qt::AlignTop | Qt::AlignLeft);
 
             QIcon icon;
             icon.addPixmap(QPixmap(":/Application/popout-overlay.svg"), QIcon::Normal);


### PR DESCRIPTION
Moved the gradient preview popout icon to be in the upper left corner instead of upper right. This change was suggested after a UX review that found when the Entity Inspector is shrunk to its minimum allowable size, the value column gets truncated which cuts off the image and causes the popout icon to be overlapped as well.

BEFORE:
![GradientPreviewPopout_BEFORE](https://user-images.githubusercontent.com/7519264/166518772-ca2616e3-4709-4b5f-a0dd-6ae592d8c257.png)

AFTER:
![GradientPreviewPopout_AFTER](https://user-images.githubusercontent.com/7519264/166518790-d80fced0-3b6a-4e79-b18b-e0079f75c435.png)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>