### PR TITLE
Fix the CDK version for AWSI automation tests to avoid installing CDK v2

### DIFF
--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -355,6 +355,7 @@
     "COMMAND": "deploy_cdk_applications.sh",
     "PARAMETERS": {
       "NVM_VERSION": "v0.39.1",
+      "CDK_VERSION": "1.154.0",
       "PYTHON_RUNTIME": "python-3.7.12-rev2-linux"
     }
   },
@@ -366,6 +367,7 @@
     "COMMAND": "destroy_cdk_applications.sh",
     "PARAMETERS": {
       "NVM_VERSION": "v0.39.1",
+      "CDK_VERSION": "1.154.0",
       "PYTHON_RUNTIME": "python-3.7.12-rev2-linux"
     }
   }

--- a/scripts/build/Platform/Linux/deploy_cdk_applications.sh
+++ b/scripts/build/Platform/Linux/deploy_cdk_applications.sh
@@ -54,15 +54,15 @@ export NVM_DIR="$HOME/.nvm"
 echo [cdk_installation] Install the current version of nodejs
 nvm install node
 
-echo [cdk_installation] Install the latest version of CDK
+echo [cdk_installation] Install aws-cdk@$CDK_VERSION
 if ! npm uninstall -g aws-cdk;
 then
     echo [cdk_bootstrap] Failed to uninstall the current version of CDK
     exit 1
 fi
-if ! npm install -g aws-cdk@latest;
+if ! npm install -g aws-cdk@$CDK_VERSION;
 then
-    echo [cdk_bootstrap] Failed to install the latest version of CDK
+    echo [cdk_bootstrap] Failed to install aws-cdk@$CDK_VERSION
     exit 1
 fi
 

--- a/scripts/build/Platform/Linux/destroy_cdk_applications.sh
+++ b/scripts/build/Platform/Linux/destroy_cdk_applications.sh
@@ -57,15 +57,15 @@ export NVM_DIR="$HOME/.nvm"
 echo [cdk_installation] Install the current version of nodejs
 nvm install node
 
-echo [cdk_installation] Install the latest version of CDK
+echo [cdk_installation] Install aws-cdk@$CDK_VERSION
 if ! npm uninstall -g aws-cdk;
 then
     echo [cdk_bootstrap] Failed to uninstall the current version of CDK
     exit 1
 fi
-if ! npm install -g aws-cdk@latest;
+if ! npm install -g aws-cdk@$CDK_VERSION;
 then
-    echo [cdk_bootstrap] Failed to install the latest version of CDK
+    echo [cdk_bootstrap] Failed to install aws-cdk@$CDK_VERSION
     exit 1
 fi
 

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -457,7 +457,9 @@
       "NONBLOCKING_STEP": "True"
     },
     "COMMAND": "deploy_cdk_applications.cmd",
-    "PARAMETERS": {}
+    "PARAMETERS": {
+      "CDK_VERSION": "1.154.0"
+    }
   },
   "awsi_destruction": {
     "TAGS": [],
@@ -465,6 +467,8 @@
       "NONBLOCKING_STEP": "True"
     },
     "COMMAND": "destroy_cdk_applications.cmd",
-    "PARAMETERS": {}
+    "PARAMETERS": {
+      "CDK_VERSION": "1.154.0"
+    }
   }
 }

--- a/scripts/build/Platform/Windows/deploy_cdk_applications.cmd
+++ b/scripts/build/Platform/Windows/deploy_cdk_applications.cmd
@@ -17,15 +17,15 @@ SET SOURCE_DIRECTORY=%CD%
 SET PATH=%SOURCE_DIRECTORY%\python;%PATH%
 SET GEM_DIRECTORY=%SOURCE_DIRECTORY%\Gems
 
-ECHO [cdk_installation] Install the latest version of CDK
+ECHO [cdk_installation] Install aws-cdk@%CDK_VERSION%
 CALL npm uninstall -g aws-cdk
 IF ERRORLEVEL 1 (
     ECHO [cdk_bootstrap] Failed to uninstall the current version of CDK
     exit /b 1
 )
-CALL npm install -g aws-cdk@latest
+CALL npm install -g aws-cdk@%CDK_VERSION%
 IF ERRORLEVEL 1 (
-    ECHO [cdk_bootstrap] Failed to install the latest version of CDK
+    ECHO [cdk_bootstrap] Failed to install aws-cdk@%CDK_VERSION%
     exit /b 1
 )
 

--- a/scripts/build/Platform/Windows/destroy_cdk_applications.cmd
+++ b/scripts/build/Platform/Windows/destroy_cdk_applications.cmd
@@ -17,15 +17,15 @@ SET SOURCE_DIRECTORY=%CD%
 SET PATH=%SOURCE_DIRECTORY%\python;%PATH%
 SET GEM_DIRECTORY=%SOURCE_DIRECTORY%\Gems
 
-ECHO [cdk_installation] Install the latest version of CDK
+ECHO [cdk_installation] Install aws-cdk@%CDK_VERSION%
 CALL npm uninstall -g aws-cdk
 IF ERRORLEVEL 1 (
     ECHO [cdk_bootstrap] Failed to uninstall the current version of CDK
     exit /b 1
 )
-CALL npm install -g aws-cdk@latest
+CALL npm install -g aws-cdk@%CDK_VERSION%
 IF ERRORLEVEL 1 (
-    ECHO [cdk_bootstrap] Failed to install the latest version of CDK
+    ECHO [cdk_bootstrap] Failed to install aws-cdk@%CDK_VERSION%
     exit /b 1
 )
 


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

CDK applications shipped with AWSI gems are created with CDK v1 while the deploy/destroy scripts try to install the latest version of CDK (v2), which causes incompatible CDK operations. This PR is for fixing the CDK version used by the scripts.

Verified the deploy/destroy scripts locally on Windows and Linux.