### PR TITLE
9366 disable flaky phys tests

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main.py
@@ -177,6 +177,7 @@ class TestAutomation(EditorTestSuite):
     class RigidBody_KinematicModeWorks(EditorSharedTest):
         from .tests.rigid_body import RigidBody_KinematicModeWorks as test_module
 
+    @pytest.mark.skip(reason="GHI #9364: Test Periodically Fails")
     class ForceRegion_LinearDampingForceOnRigidBodies(EditorSharedTest):
         from .tests.force_region import ForceRegion_LinearDampingForceOnRigidBodies as test_module
 
@@ -292,6 +293,7 @@ class TestAutomation(EditorTestSuite):
     class Material_EmptyLibraryUsesDefault(EditorSharedTest):
         from .tests.material import Material_EmptyLibraryUsesDefault as test_module
 
+    @pytest.mark.skip(reason="GHI #9365: Test periodically fails")
     class ForceRegion_NoQuiverOnHighLinearDampingForce(EditorSharedTest):
         from .tests.force_region import ForceRegion_NoQuiverOnHighLinearDampingForce as test_module
 
@@ -333,6 +335,7 @@ class TestAutomation(EditorTestSuite):
     class RigidBody_EnablingGravityWorksPoC(EditorSharedTest):
         from .tests.rigid_body import RigidBody_EnablingGravityWorksPoC as test_module
 
+    @pytest.mark.xfail(reason="GHI #9368: Test Sporadically Fails")
     class Collider_ColliderRotationOffset(EditorSharedTest):
         from .tests.collider import Collider_ColliderRotationOffset as test_module
 


### PR DESCRIPTION
Disabling the following Physics TestSuite_Main flaky tests identified in the GHIs noted below.

Verified that automation suite was still able to run and no results present for skipped tests to save resources  on tests we don't trust until tests are back online.

#9364 ForceRegion_LinearDampingForceOnRigidBodies
#9365 ForceRegion_NoQuiverOnHighLinearDampingForce
#9368 Collider_ColliderRotationOffset