### PR TITLE
Invalidates thumbnail state when the asset is removed from the catalog asset

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnail.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnail.cpp
@@ -74,6 +74,16 @@ namespace AZ
             }
         }
 
+        void SharedThumbnail::OnCatalogAssetRemoved(const AZ::Data::AssetId& assetId, const AZ::Data::AssetInfo& /*assetInfo*/)
+        {
+            if (m_assetInfo.m_assetId == assetId)
+            {
+                // Removing the thumbnail from the catalog asset doesn't remove it from the thumbnail cache.
+                // Therefore marking the state as unloaded ensures that a new pixmap will be rendered on the next access.
+                m_state = State::Unloaded;
+            }
+        }
+
         //////////////////////////////////////////////////////////////////////////
         // SharedThumbnailCache
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnail.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnail.h
@@ -41,6 +41,7 @@ namespace AZ
         private:
             // AzFramework::AssetCatalogEventBus::Handler interface overrides...
             void OnCatalogAssetChanged(const AZ::Data::AssetId& assetId) override;
+            void OnCatalogAssetRemoved(const AZ::Data::AssetId& assetId, const AZ::Data::AssetInfo& assetInfo) override;
 
             AZStd::binary_semaphore m_renderWait;
             Data::AssetInfo m_assetInfo;


### PR DESCRIPTION
SharedThumbnail intances invalidate their state `m_state = State::Unloaded` when they are notified that their underlying `assetId` is removed from the catalog. This puts the SharedThumbnail object in a state where it will get re-rendered if a thumbnail with the same `SharedThumbnailKey` is requested.

Fixes #7902

Signed-off-by: Sebastien Demers <sebastien.demers91@gmail.com>