### PR TITLE
Material Component: Support for editing multiple selected entities

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentRequestBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentRequestBus.h
@@ -12,6 +12,7 @@
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/std/string/string.h>
+#include <AzToolsFramework/Entity/EntityTypes.h>
 #include <QPixmap>
 
 namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentRequestBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentRequestBus.h
@@ -32,7 +32,9 @@ namespace AZ
 
             //! Open material instance editor
             virtual void OpenMaterialInspector(
-                const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId) = 0;
+                const AZ::EntityId& entityId,
+                const AzToolsFramework::EntityIdSet& entityIds,
+                const AZ::Render::MaterialAssignmentId& materialAssignmentId) = 0;
 
             //! Generate a material preview image
             virtual void RenderMaterialPreview(

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentRequestBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentRequestBus.h
@@ -30,17 +30,18 @@ namespace AZ
             //! Open source material in material editor
             virtual void OpenMaterialEditor(const AZStd::string& sourcePath) = 0;
 
-            //! Open material instance editor
+            //! Open the material instance editor to preview and edit material property overrides for the primary entity while applying
+            //! changes to all entities in the editable set
             virtual void OpenMaterialInspector(
-                const AZ::EntityId& entityId,
-                const AzToolsFramework::EntityIdSet& entityIds,
+                const AZ::EntityId& primaryEntityId,
+                const AzToolsFramework::EntityIdSet& entityIdsToEdit,
                 const AZ::Render::MaterialAssignmentId& materialAssignmentId) = 0;
 
-            //! Generate a material preview image
+            //! Generate a material preview image for a specific entity and material slot with material and property overrides applied 
             virtual void RenderMaterialPreview(
                 const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId) = 0;
 
-            //! Get recently rendered material preview image
+            //! Get the most recently rendered material preview image for the entity and material slot if one is available
             virtual QPixmap GetRenderedMaterialPreview(
                 const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId) const = 0;
         };

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
@@ -23,6 +23,9 @@ namespace AZ
             virtual MaterialAssignmentMap GetOriginalMaterialAssignments() const = 0;
             //! Get material assignment id matching lod and label substring
             virtual MaterialAssignmentId FindMaterialAssignmentId(const MaterialAssignmentLodIndex lod, const AZStd::string& label) const = 0;
+            //! Get the asset ID for the active material applied at a given slot. It will be the material override if one exists. Otherwise,
+            //! it will be the default material
+            virtual AZ::Data::AssetId GetActiveMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const = 0;
             //! Get default material asset
             virtual AZ::Data::AssetId GetDefaultMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const = 0;
             //! Get material slot label

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
@@ -98,6 +98,7 @@ namespace AZ
                             ->Attribute(AZ::Edit::Attributes::ButtonText, GenerateMaterialsButtonText)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMaterialComponent::OpenMaterialExporterFromRPE)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &EditorMaterialComponent::m_defaultMaterialSlot, "Default Material", "Materials assigned to this slot will be applied to the entire model unless specific model or LOD material overrides are set.")
+                            ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMaterialComponent::OnConfigurationChanged)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &EditorMaterialComponent::m_materialSlots, "Model Materials", "Materials assigned to these slots will be applied to every part of the model with same material slot name unless an overriding LOD material is specified.")
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMaterialComponent::OnConfigurationChanged)
@@ -158,7 +159,7 @@ namespace AZ
 
         void EditorMaterialComponent::AddContextMenuActions(QMenu* menu)
         {
-            const auto& entityIdsToEdit = EditorMaterialComponentUtil::GetSelectedEntitiesFromActiveInspectorMatchingMaterialSlots(GetEntityId());
+            const auto& entityIdsToEdit = EditorMaterialComponentUtil::GetSelectedEntitiesFromActiveInspector();
 
             QAction* action = nullptr;
 
@@ -166,6 +167,7 @@ namespace AZ
 
             action = menu->addAction(GenerateMaterialsButtonText, [this, entityIdsToEdit]() { OpenMaterialExporter(entityIdsToEdit); });
             action->setToolTip(GenerateMaterialsToolTipText);
+            action->setEnabled(EditorMaterialComponentUtil::DoEntitiesHaveMatchingMaterialSlots(GetEntityId(), entityIdsToEdit));
 
             menu->addSeparator();
 
@@ -371,8 +373,8 @@ namespace AZ
 
         AZ::u32 EditorMaterialComponent::OpenMaterialExporterFromRPE()
         {
-            const auto& entityIdsToEdit = EditorMaterialComponentUtil::GetSelectedEntitiesFromActiveInspectorMatchingMaterialSlots(GetEntityId());
-            return OpenMaterialExporter(entityIdsToEdit);
+            return OpenMaterialExporter(EditorMaterialComponentUtil::GetEntitiesMatchingMaterialSlots(
+                GetEntityId(), EditorMaterialComponentUtil::GetSelectedEntitiesFromActiveInspector()));
         }
 
         AZ::u32 EditorMaterialComponent::OpenMaterialExporter(const AzToolsFramework::EntityIdSet& entityIdsToEdit)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
@@ -173,14 +173,14 @@ namespace AZ
 
             action = menu->addAction("Clear All Materials", [this, entityIdsToEdit]() {
                 AzToolsFramework::ScopedUndoBatch undoBatch("Clearing all materials.");
+                m_materialSlotsByLodEnabled = false;
                 for (const AZ::EntityId& entityId : entityIdsToEdit)
                 {
                     AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
                         &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
                     MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearAllMaterialOverrides);
+                    MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
-                m_materialSlotsByLodEnabled = false;
-
                 UpdateMaterialSlots();
             });
             action->setToolTip("Clear all materials and properties then rebuild material slots from the associated model.");
@@ -192,6 +192,7 @@ namespace AZ
                     AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
                         &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
                     MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearModelMaterialOverrides);
+                    MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
                 UpdateMaterialSlots();
             });
@@ -199,14 +200,14 @@ namespace AZ
 
             action = menu->addAction("Clear LOD Materials", [this, entityIdsToEdit]() {
                 AzToolsFramework::ScopedUndoBatch undoBatch("Clearing LOD materials.");
+                m_materialSlotsByLodEnabled = false;
                 for (const AZ::EntityId& entityId : entityIdsToEdit)
                 {
                     AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
                         &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
                     MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearLodMaterialOverrides);
+                    MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
-                m_materialSlotsByLodEnabled = false;
-
                 UpdateMaterialSlots();
             });
             action->setToolTip("Clear LOD materials and properties then rebuild material slots from the associated model.");
@@ -219,6 +220,7 @@ namespace AZ
                         &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
                     MaterialComponentRequestBus::Event(
                         entityId, &MaterialComponentRequestBus::Events::ClearIncompatibleMaterialOverrides);
+                    MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
                 UpdateMaterialSlots();
             });
@@ -231,6 +233,7 @@ namespace AZ
                     AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
                         &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
                     MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearInvalidMaterialOverrides);
+                    MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
                 UpdateMaterialSlots();
             });
@@ -243,6 +246,7 @@ namespace AZ
                     AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
                         &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
                     MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::RepairInvalidMaterialOverrides);
+                    MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
                 UpdateMaterialSlots();
             });
@@ -252,10 +256,15 @@ namespace AZ
                 AzToolsFramework::ScopedUndoBatch undoBatch("Applying automatic property updates.");
                 for (const AZ::EntityId& entityId : entityIdsToEdit)
                 {
+                    AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                        &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
+
                     uint32_t propertiesUpdated = 0;
                     MaterialComponentRequestBus::EventResult(
                         propertiesUpdated, entityId, &MaterialComponentRequestBus::Events::ApplyAutomaticPropertyUpdates);
                     AZ_Printf("EditorMaterialComponent", "Updated %u property(s).", propertiesUpdated);
+
+                    MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
                 UpdateMaterialSlots();
             });

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
@@ -19,6 +19,7 @@
 #include <Material/EditorMaterialComponent.h>
 #include <Material/EditorMaterialComponentExporter.h>
 #include <Material/EditorMaterialComponentSerializer.h>
+#include <Material/EditorMaterialComponentUtil.h>
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
 #include <QAction>
@@ -74,7 +75,6 @@ namespace AZ
 
                 serializeContext->Class<EditorMaterialComponent, BaseClass>()
                     ->Version(5, &EditorMaterialComponent::ConvertVersion)
-                    ->Field("message", &EditorMaterialComponent::m_message)
                     ->Field("defaultMaterialSlot", &EditorMaterialComponent::m_defaultMaterialSlot)
                     ->Field("materialSlots", &EditorMaterialComponent::m_materialSlots)
                     ->Field("materialSlotsByLodEnabled", &EditorMaterialComponent::m_materialSlotsByLodEnabled)
@@ -93,27 +93,18 @@ namespace AZ
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                             ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://o3de.org/docs/user-guide/components/reference/atom/material/")
                             ->Attribute(AZ::Edit::Attributes::PrimaryAssetType, AZ::AzTypeInfo<RPI::MaterialAsset>::Uuid())
-                        ->DataElement(AZ::Edit::UIHandlers::MultiLineEdit, &EditorMaterialComponent::m_message, "Message", "")
-                            ->Attribute(AZ_CRC("PlaceholderText", 0xa23ec278), "Component cannot be edited with multiple entities selected")
-                            ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
-                            ->Attribute(AZ::Edit::Attributes::Visibility, &EditorMaterialComponent::GetMessageVisibility)
-                            ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
                         ->UIElement(AZ::Edit::UIHandlers::Button, GenerateMaterialsButtonText, GenerateMaterialsToolTipText)
                             ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
                             ->Attribute(AZ::Edit::Attributes::ButtonText, GenerateMaterialsButtonText)
-                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMaterialComponent::OpenMaterialExporter)
-                            ->Attribute(AZ::Edit::Attributes::Visibility, &EditorMaterialComponent::GetEditorVisibility)
+                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMaterialComponent::OpenMaterialExporterFromRPE)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &EditorMaterialComponent::m_defaultMaterialSlot, "Default Material", "Materials assigned to this slot will be applied to the entire model unless specific model or LOD material overrides are set.")
-                            ->Attribute(AZ::Edit::Attributes::Visibility, &EditorMaterialComponent::GetDefaultMaterialVisibility)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMaterialComponent::OnConfigurationChanged)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &EditorMaterialComponent::m_materialSlots, "Model Materials", "Materials assigned to these slots will be applied to every part of the model with same material slot name unless an overriding LOD material is specified.")
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMaterialComponent::OnConfigurationChanged)
-                            ->Attribute(AZ::Edit::Attributes::Visibility, &EditorMaterialComponent::GetEditorVisibility)
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                             ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &EditorMaterialComponent::m_materialSlotsByLodEnabled, "Enable LOD Materials", "When this flag is enabled, materials can be specified per LOD.")
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMaterialComponent::OnLodsToggled)
-                            ->Attribute(AZ::Edit::Attributes::Visibility, &EditorMaterialComponent::GetEditorVisibility)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &EditorMaterialComponent::m_materialSlotsByLod, "LOD Materials", "Materials assigned to these slots will take precedence over all other materials settings.")
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMaterialComponent::OnConfigurationChanged)
                             ->Attribute(AZ::Edit::Attributes::IndexedChildNameLabelOverride, &EditorMaterialComponent::GetLabelForLod)
@@ -167,94 +158,103 @@ namespace AZ
 
         void EditorMaterialComponent::AddContextMenuActions(QMenu* menu)
         {
-            // Don't add menu options if more than one entity is selected
-            if (!IsEditingAllowed())
-            {
-                return;
-            }
+            const auto& entityIdsToEdit = EditorMaterialComponentUtil::GetSelectedEntitiesFromActiveInspectorMatchingMaterialSlots(GetEntityId());
 
             QAction* action = nullptr;
 
             menu->addSeparator();
 
-            action = menu->addAction(GenerateMaterialsButtonText, [this]() { OpenMaterialExporter(); });
+            action = menu->addAction(GenerateMaterialsButtonText, [this, entityIdsToEdit]() { OpenMaterialExporter(entityIdsToEdit); });
             action->setToolTip(GenerateMaterialsToolTipText);
 
             menu->addSeparator();
 
-            action = menu->addAction("Clear All Materials", [this]() {
+            action = menu->addAction("Clear All Materials", [this, entityIdsToEdit]() {
                 AzToolsFramework::ScopedUndoBatch undoBatch("Clearing all materials.");
-                SetDirty();
-
-                MaterialComponentRequestBus::Event(GetEntityId(), &MaterialComponentRequestBus::Events::ClearAllMaterialOverrides);
-
+                for (const AZ::EntityId& entityId : entityIdsToEdit)
+                {
+                    AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                        &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
+                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearAllMaterialOverrides);
+                }
                 m_materialSlotsByLodEnabled = false;
 
                 UpdateMaterialSlots();
             });
             action->setToolTip("Clear all materials and properties then rebuild material slots from the associated model.");
 
-            action = menu->addAction("Clear Model Materials", [this]() {
+            action = menu->addAction("Clear Model Materials", [this, entityIdsToEdit]() {
                 AzToolsFramework::ScopedUndoBatch undoBatch("Clearing model materials.");
-                SetDirty();
-
-                MaterialComponentRequestBus::Event(GetEntityId(), &MaterialComponentRequestBus::Events::ClearModelMaterialOverrides);
-
+                for (const AZ::EntityId& entityId : entityIdsToEdit)
+                {
+                    AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                        &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
+                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearModelMaterialOverrides);
+                }
                 UpdateMaterialSlots();
             });
             action->setToolTip("Clear model materials and properties then rebuild material slots from the associated model.");
 
-            action = menu->addAction("Clear LOD Materials", [this]() {
+            action = menu->addAction("Clear LOD Materials", [this, entityIdsToEdit]() {
                 AzToolsFramework::ScopedUndoBatch undoBatch("Clearing LOD materials.");
-                SetDirty();
-
-                MaterialComponentRequestBus::Event(GetEntityId(), &MaterialComponentRequestBus::Events::ClearLodMaterialOverrides);
-
+                for (const AZ::EntityId& entityId : entityIdsToEdit)
+                {
+                    AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                        &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
+                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearLodMaterialOverrides);
+                }
                 m_materialSlotsByLodEnabled = false;
 
                 UpdateMaterialSlots();
             });
             action->setToolTip("Clear LOD materials and properties then rebuild material slots from the associated model.");
 
-            action = menu->addAction("Clear Incompatible Materials", [this]() {
+            action = menu->addAction("Clear Incompatible Materials", [this, entityIdsToEdit]() {
                 AzToolsFramework::ScopedUndoBatch undoBatch("Clearing incompatible materials.");
-                SetDirty();
-
-                MaterialComponentRequestBus::Event(GetEntityId(), &MaterialComponentRequestBus::Events::ClearIncompatibleMaterialOverrides);
-
+                for (const AZ::EntityId& entityId : entityIdsToEdit)
+                {
+                    AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                        &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
+                    MaterialComponentRequestBus::Event(
+                        entityId, &MaterialComponentRequestBus::Events::ClearIncompatibleMaterialOverrides);
+                }
                 UpdateMaterialSlots();
             });
             action->setToolTip("Clear residual materials that don't correspond to the associated model.");
 
-            action = menu->addAction("Clear Invalid Materials", [this]() {
+            action = menu->addAction("Clear Invalid Materials", [this, entityIdsToEdit]() {
                 AzToolsFramework::ScopedUndoBatch undoBatch("Clearing invalid materials.");
-                SetDirty();
-
-                MaterialComponentRequestBus::Event(GetEntityId(), &MaterialComponentRequestBus::Events::ClearInvalidMaterialOverrides);
-
+                for (const AZ::EntityId& entityId : entityIdsToEdit)
+                {
+                    AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                        &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
+                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearInvalidMaterialOverrides);
+                }
                 UpdateMaterialSlots();
             });
             action->setToolTip("Clear materials that reference missing assets.");
 
-            action = menu->addAction("Repair Invalid Materials", [this]() {
+            action = menu->addAction("Repair Invalid Materials", [this, entityIdsToEdit]() {
                 AzToolsFramework::ScopedUndoBatch undoBatch("Repairing invalid materials.");
-                SetDirty();
-
-                MaterialComponentRequestBus::Event(GetEntityId(), &MaterialComponentRequestBus::Events::RepairInvalidMaterialOverrides);
-
+                for (const AZ::EntityId& entityId : entityIdsToEdit)
+                {
+                    AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                        &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
+                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::RepairInvalidMaterialOverrides);
+                }
                 UpdateMaterialSlots();
             });
             action->setToolTip("Repair materials that reference missing assets by assigning the default asset.");
             
-            action = menu->addAction("Apply Automatic Property Updates", [this]() {
+            action = menu->addAction("Apply Automatic Property Updates", [this, entityIdsToEdit]() {
                 AzToolsFramework::ScopedUndoBatch undoBatch("Applying automatic property updates.");
-                SetDirty();
-
-                uint32_t propertiesUpdated = 0;
-                MaterialComponentRequestBus::EventResult(propertiesUpdated, GetEntityId(), &MaterialComponentRequestBus::Events::ApplyAutomaticPropertyUpdates);
-
-                AZ_Printf("EditorMaterialComponent", "Updated %u property(s).", propertiesUpdated);
-
+                for (const AZ::EntityId& entityId : entityIdsToEdit)
+                {
+                    uint32_t propertiesUpdated = 0;
+                    MaterialComponentRequestBus::EventResult(
+                        propertiesUpdated, entityId, &MaterialComponentRequestBus::Events::ApplyAutomaticPropertyUpdates);
+                    AZ_Printf("EditorMaterialComponent", "Updated %u property(s).", propertiesUpdated);
+                }
                 UpdateMaterialSlots();
             });
             action->setToolTip("Repair material property overrides that reference missing properties by auto-renaming them where possible.");
@@ -369,11 +369,14 @@ namespace AZ
                 &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_EntireTree);
         }
 
-        AZ::u32 EditorMaterialComponent::OpenMaterialExporter()
+        AZ::u32 EditorMaterialComponent::OpenMaterialExporterFromRPE()
         {
-            AzToolsFramework::ScopedUndoBatch undoBatch("Generating materials.");
-            SetDirty();
+            const auto& entityIdsToEdit = EditorMaterialComponentUtil::GetSelectedEntitiesFromActiveInspectorMatchingMaterialSlots(GetEntityId());
+            return OpenMaterialExporter(entityIdsToEdit);
+        }
 
+        AZ::u32 EditorMaterialComponent::OpenMaterialExporter(const AzToolsFramework::EntityIdSet& entityIdsToEdit)
+        {
             MaterialAssignmentMap originalMaterials;
             MaterialComponentRequestBus::EventResult(
                 originalMaterials, GetEntityId(), &MaterialComponentRequestBus::Events::GetOriginalMaterialAssignments);
@@ -404,6 +407,8 @@ namespace AZ
             // Display the export dialog so that the user can configure how they want different materials to be exported
             if (EditorMaterialComponentExporter::OpenExportDialog(exportItems))
             {
+                AzToolsFramework::ScopedUndoBatch undoBatch("Generating materials.");
+
                 for (const EditorMaterialComponentExporter::ExportItem& exportItem : exportItems)
                 {
                     if (!EditorMaterialComponentExporter::ExportMaterialSourceData(exportItem))
@@ -422,9 +427,15 @@ namespace AZ
                             {
                                 if (m_materialSlotsByLodEnabled || !materialPair.first.IsLodAndSlotId())
                                 {
-                                    MaterialComponentRequestBus::Event(
-                                        GetEntityId(), &MaterialComponentRequestBus::Events::SetMaterialOverride, materialPair.first,
-                                        assetIdOutcome.GetValue());
+                                    for (const AZ::EntityId& entityId : entityIdsToEdit)
+                                    {
+                                        AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                                            &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
+
+                                        MaterialComponentRequestBus::Event(
+                                            entityId, &MaterialComponentRequestBus::Events::SetMaterialOverride, materialPair.first,
+                                            assetIdOutcome.GetValue());
+                                    }
                                 }
                             }
                         }
@@ -454,30 +465,7 @@ namespace AZ
 
         AZ::Crc32 EditorMaterialComponent::GetLodVisibility() const
         {
-            return IsEditingAllowed() && m_materialSlotsByLodEnabled ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
-        }
-
-        AZ::Crc32 EditorMaterialComponent::GetDefaultMaterialVisibility() const
-        {
-            return IsEditingAllowed() ? AZ::Edit::PropertyVisibility::ShowChildrenOnly : AZ::Edit::PropertyVisibility::Hide;
-        }
-
-        AZ::Crc32 EditorMaterialComponent::GetEditorVisibility() const
-        {
-            return IsEditingAllowed() ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
-        }
-
-        AZ::Crc32 EditorMaterialComponent::GetMessageVisibility() const
-        {
-            return IsEditingAllowed() ? AZ::Edit::PropertyVisibility::Hide : AZ::Edit::PropertyVisibility::Show;
-        }
-
-        bool EditorMaterialComponent::IsEditingAllowed() const
-        {
-            AzToolsFramework::EntityIdList selectedEntities;
-            AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-                selectedEntities, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
-            return selectedEntities.size() == 1;
+            return m_materialSlotsByLodEnabled ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
         }
 
         AZStd::string EditorMaterialComponent::GetLabelForLod(int lodIndex) const

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.h
@@ -68,28 +68,16 @@ namespace AZ
 
             // Opens the source material export dialog and updates editor material slots based on
             // selected actions
-            AZ::u32 OpenMaterialExporter();
+            AZ::u32 OpenMaterialExporterFromRPE();
+            AZ::u32 OpenMaterialExporter(const AzToolsFramework::EntityIdSet& entityIdsToEdit);
 
             AZ::u32 OnLodsToggled();
 
             // Get the visibility of the LOD material slots based on the enable flag
             AZ::Crc32 GetLodVisibility() const;
 
-            // Get the visibility of the default material slot based on the enable flag
-            AZ::Crc32 GetDefaultMaterialVisibility() const;
-
-            // Get the visibility of the entire component interface based on the number of selected entities
-            AZ::Crc32 GetEditorVisibility() const;
-
-            // Get the visibility of the 'multiple entity selected' warning message box
-            AZ::Crc32 GetMessageVisibility() const;
-
-            // Evaluate if materials can be edited
-            bool IsEditingAllowed() const;
-
             AZStd::string GetLabelForLod(int lodIndex) const;
 
-            AZStd::string m_message;
             EditorMaterialComponentSlot m_defaultMaterialSlot;
             EditorMaterialComponentSlotContainer m_materialSlots;
             EditorMaterialComponentSlotsByLodContainer m_materialSlotsByLod;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -68,7 +68,7 @@ namespace AZ
             {
                 UnloadMaterial();
 
-                if (!EditorMaterialComponentUtil::DoEntitiesHaveMatchingMaterials(entityId, entityIdsToEdit, materialAssignmentId))
+                if (!EditorMaterialComponentUtil::DoEntitiesHaveMatchingMaterialTypes(entityId, entityIdsToEdit, materialAssignmentId))
                 {
                     UnloadMaterial();
                     return false;
@@ -132,7 +132,7 @@ namespace AZ
                 const AZ::Data::AssetId materialAssetId = GetActiveMaterialAssetIdFromEntity();
                 return m_entityId.IsValid() && m_materialInstance && m_editData.m_materialAsset.IsReady() &&
                     m_editData.m_materialAsset.GetId() == materialAssetId && m_editData.m_materialAssetId == materialAssetId &&
-                    EditorMaterialComponentUtil::DoEntitiesHaveMatchingMaterials(m_entityId, m_entityIdsToEdit, m_materialAssignmentId);
+                    EditorMaterialComponentUtil::DoEntitiesHaveMatchingMaterialTypes(m_entityId, m_entityIdsToEdit, m_materialAssignmentId);
             }
 
             void MaterialPropertyInspector::Reset()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -701,11 +701,16 @@ namespace AZ
 
                 QMenu menu(this);
                 action = menu.addAction("Clear Overrides", [this] {
-                    for (const AZ::EntityId& entityId : m_entityIdsToEdit)
+                    AzToolsFramework::ScopedUndoBatch undoBatch("Clear material property overrides.");
+                        m_editData.m_materialPropertyOverrideMap.clear();
+                        for (const AZ::EntityId& entityId : m_entityIdsToEdit)
                     {
+                        AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                            &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
                         MaterialComponentRequestBus::Event(
                             entityId, &MaterialComponentRequestBus::Events::SetPropertyOverrides, m_materialAssignmentId,
-                            MaterialPropertyOverrideMap());
+                            m_editData.m_materialPropertyOverrideMap);
+                        MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                     }
                     m_updateUI = true;
                     m_updatePreview = true;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
@@ -47,7 +47,10 @@ namespace AZ
                 MaterialPropertyInspector(QWidget* parent = nullptr);
                 ~MaterialPropertyInspector() override;
 
-                bool LoadMaterial(const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId);
+                bool LoadMaterial(
+                    const AZ::EntityId& entityId,
+                    const AzToolsFramework::EntityIdSet& entityIdsToEdit,
+                    const AZ::Render::MaterialAssignmentId& materialAssignmentId);
                 void UnloadMaterial();
                 bool IsLoaded() const;
 
@@ -118,6 +121,7 @@ namespace AZ
                 const char* GetInstanceNodePropertyIndicator(const AzToolsFramework::InstanceDataNode* node) const;
 
                 AZ::EntityId m_entityId;
+                AzToolsFramework::EntityIdSet m_entityIdsToEdit;
                 AZ::Render::MaterialAssignmentId m_materialAssignmentId;
                 EditorMaterialComponentUtil::MaterialEditData m_editData;
                 AZ::Data::Instance<AZ::RPI::Material> m_materialInstance = {};

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
@@ -61,7 +61,7 @@ namespace AZ
                 void UnloadMaterial();
 
                 //! Returns true if all of the edit data has been loaded, the instance has been created, the primary entity and material
-                //! slot has not changed the assigned material, and all of the entities share material types
+                //! slot has not changed the assigned material, and all of the entities share the same material type
                 bool IsLoaded() const;
 
                 // AtomToolsFramework::InspectorRequestBus::Handler overrides...

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
@@ -108,7 +108,7 @@ namespace AZ
                 void AddPropertiesGroup();
 
                 void LoadOverridesFromEntity();
-                void SaveOverridesToEntity(bool commitChanges);
+                void SaveOverridesToEntity(const AtomToolsFramework::DynamicProperty& property, bool commitChanges);
                 void RunEditorMaterialFunctors();
                 void UpdateMaterialInstanceProperty(const AtomToolsFramework::DynamicProperty& property);
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
@@ -126,7 +126,7 @@ namespace AZ
                     ->Method("SetAssetId", &EditorMaterialComponentSlot::SetAssetId)
                     ->Method("Clear", &EditorMaterialComponentSlot::Clear)
                     ->Method("ClearMaterial", &EditorMaterialComponentSlot::ClearMaterial)
-                    ->Method("ClearOverrides", &EditorMaterialComponentSlot::ClearProperties)
+                    ->Method("ClearOverrides", &EditorMaterialComponentSlot::ClearProperties) // This method will be deprecated. Use ClearProperties instead.
                     ->Method("ClearProperties", &EditorMaterialComponentSlot::ClearProperties)
                     ->Method("OpenMaterialExporter", &EditorMaterialComponentSlot::OpenMaterialExporter)
                     ->Method("OpenMaterialEditor", &EditorMaterialComponentSlot::OpenMaterialEditor)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
@@ -365,6 +365,7 @@ namespace AZ
 
         void EditorMaterialComponentSlot::OnMaterialChangedFromRPE() const
         {
+            // Because this function is being from an edit context attribute it will automatically be applied to all selected entities
             OnDataChanged({ m_entityId }, true);
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
@@ -312,7 +312,6 @@ namespace AZ
         {
             const auto& entityIdsToEdit = EditorMaterialComponentUtil::GetSelectedEntitiesFromActiveInspector();
             const bool hasMatchingSlots = EditorMaterialComponentUtil::DoEntitiesHaveMatchingMaterialSlots(m_entityId, entityIdsToEdit);
-            const bool hasMatchingMaterials = EditorMaterialComponentUtil::DoEntitiesHaveMatchingMaterials(m_entityId, entityIdsToEdit, m_id);
             const bool hasMatchingMaterialTypes = EditorMaterialComponentUtil::DoEntitiesHaveMatchingMaterialTypes(m_entityId, entityIdsToEdit, m_id);
 
             QMenu menu;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
@@ -96,7 +96,7 @@ namespace AZ
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                             ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &EditorMaterialComponentSlot::m_materialAsset, "Material Asset", "")
-                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMaterialComponentSlot::OnMaterialChanged)
+                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMaterialComponentSlot::OnMaterialChangedFromRPE)
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                             ->Attribute(AZ::Edit::Attributes::DefaultAsset, &EditorMaterialComponentSlot::GetDefaultAssetId)
                             ->Attribute(AZ::Edit::Attributes::NameLabelOverride, &EditorMaterialComponentSlot::GetLabel)
@@ -122,8 +122,8 @@ namespace AZ
                     ->Method("GetDefaultAssetId", &EditorMaterialComponentSlot::GetDefaultAssetId)
                     ->Method("GetLabel", &EditorMaterialComponentSlot::GetLabel)
                     ->Method("HasSourceData", &EditorMaterialComponentSlot::HasSourceData)
-                    ->Method("SetAssetId", static_cast<void (EditorMaterialComponentSlot::*)(const Data::AssetId&)>(&EditorMaterialComponentSlot::SetAsset))
-                    ->Method("SetAsset", static_cast<void (EditorMaterialComponentSlot::*)(const Data::Asset<RPI::MaterialAsset>&)>(&EditorMaterialComponentSlot::SetAsset))
+                    ->Method("SetAsset", &EditorMaterialComponentSlot::SetAsset)
+                    ->Method("SetAssetId", &EditorMaterialComponentSlot::SetAssetId)
                     ->Method("Clear", &EditorMaterialComponentSlot::Clear)
                     ->Method("ClearMaterial", &EditorMaterialComponentSlot::ClearMaterial)
                     ->Method("ClearOverrides", &EditorMaterialComponentSlot::ClearOverrides)
@@ -190,36 +190,29 @@ namespace AZ
             return !sourcePath.empty() && AZ::StringFunc::Path::IsExtension(sourcePath.c_str(), AZ::RPI::MaterialSourceData::Extension);
         }
 
-        void EditorMaterialComponentSlot::SetAsset(const Data::AssetId& assetId)
-        {
-            m_materialAsset = AZ::Data::Asset<AZ::RPI::MaterialAsset>(assetId, AZ::AzTypeInfo<AZ::RPI::MaterialAsset>::Uuid());
-            MaterialComponentRequestBus::Event(
-                m_entityId, &MaterialComponentRequestBus::Events::SetMaterialOverride, m_id, m_materialAsset.GetId());
-            OnDataChanged();
-        }
-
         void EditorMaterialComponentSlot::SetAsset(const Data::Asset<RPI::MaterialAsset>& asset)
         {
             m_materialAsset = asset;
-            MaterialComponentRequestBus::Event(
-                m_entityId, &MaterialComponentRequestBus::Events::SetMaterialOverride, m_id, m_materialAsset.GetId());
-            OnDataChanged();
+            OnDataChanged({ m_entityId });
+        }
+
+        void EditorMaterialComponentSlot::SetAssetId(const Data::AssetId& assetId)
+        {
+            SetAsset(AZ::Data::Asset<AZ::RPI::MaterialAsset>(assetId, AZ::AzTypeInfo<AZ::RPI::MaterialAsset>::Uuid()));
         }
 
         void EditorMaterialComponentSlot::Clear()
         {
-            m_materialAsset = {};
             MaterialComponentRequestBus::Event(
-                m_entityId, &MaterialComponentRequestBus::Events::SetMaterialOverride, m_id, m_materialAsset.GetId());
-            ClearOverrides();
+                m_entityId, &MaterialComponentRequestBus::Events::SetPropertyOverrides, m_id, MaterialPropertyOverrideMap());
+            MaterialComponentRequestBus::Event(
+                m_entityId, &MaterialComponentRequestBus::Events::SetModelUvOverrides, m_id, AZ::RPI::MaterialModelUvOverrideMap());
+            SetAsset({});
         }
 
         void EditorMaterialComponentSlot::ClearMaterial()
         {
-            m_materialAsset = {};
-            MaterialComponentRequestBus::Event(
-                m_entityId, &MaterialComponentRequestBus::Events::SetMaterialOverride, m_id, m_materialAsset.GetId());
-            OnDataChanged();
+            SetAsset({});
         }
 
         void EditorMaterialComponentSlot::ClearOverrides()
@@ -228,43 +221,28 @@ namespace AZ
                 m_entityId, &MaterialComponentRequestBus::Events::SetPropertyOverrides, m_id, MaterialPropertyOverrideMap());
             MaterialComponentRequestBus::Event(
                 m_entityId, &MaterialComponentRequestBus::Events::SetModelUvOverrides, m_id, AZ::RPI::MaterialModelUvOverrideMap());
-            OnDataChanged();
+            OnDataChanged({ m_entityId });
         }
 
-        void EditorMaterialComponentSlot::OpenMaterialExporter()
+        void EditorMaterialComponentSlot::OpenMaterialExporter(const AzToolsFramework::EntityIdSet& entityIdsToEdit)
         {
             // Because we are generating a source material from this specific slot there is only one entry
             // But we still need to allow the user to reconfigure it using the dialog
             EditorMaterialComponentExporter::ExportItemsContainer exportItems;
-            {
-                exportItems.emplace_back(GetDefaultAssetId(), GetLabel());
-            }
+            exportItems.emplace_back(GetDefaultAssetId(), GetLabel());
 
-            bool changed = false;
             if (EditorMaterialComponentExporter::OpenExportDialog(exportItems))
             {
-                for (const EditorMaterialComponentExporter::ExportItem& exportItem : exportItems)
+                const auto& exportItem = exportItems.front();
+                if (EditorMaterialComponentExporter::ExportMaterialSourceData(exportItem))
                 {
-                    if (!EditorMaterialComponentExporter::ExportMaterialSourceData(exportItem))
-                    {
-                        continue;
-                    }
-
-                    // Generate a new asset ID utilizing the export file path so that we can update this material slot to reference the new
-                    // asset
-                    const auto& assetIdOutcome = AZ::RPI::AssetUtils::MakeAssetId(exportItem.GetExportPath(), 0);
-                    if (assetIdOutcome)
+                    if (const auto& assetIdOutcome = AZ::RPI::AssetUtils::MakeAssetId(exportItem.GetExportPath(), 0))
                     {
                         m_materialAsset = AZ::Data::Asset<AZ::RPI::MaterialAsset>(
                             assetIdOutcome.GetValue(), AZ::AzTypeInfo<AZ::RPI::MaterialAsset>::Uuid());
-                        changed = true;
+                        OnDataChanged(entityIdsToEdit);
                     }
                 }
-            }
-
-            if (changed)
-            {
-                OnMaterialChanged();
             }
         }
 
@@ -277,9 +255,7 @@ namespace AZ
             {
                 if (const auto& assetIdOutcome = AZ::RPI::AssetUtils::MakeAssetId(exportItem.GetExportPath(), 0))
                 {
-                    m_materialAsset =
-                        AZ::Data::Asset<AZ::RPI::MaterialAsset>(assetIdOutcome.GetValue(), AZ::AzTypeInfo<AZ::RPI::MaterialAsset>::Uuid());
-                    OnMaterialChanged();
+                    SetAssetId(assetIdOutcome.GetValue());
                 }
             }
         }
@@ -294,13 +270,13 @@ namespace AZ
             }
         }
 
-        void EditorMaterialComponentSlot::OpenMaterialInspector()
+        void EditorMaterialComponentSlot::OpenMaterialInspector(const AzToolsFramework::EntityIdSet& entityIdsToEdit)
         {
             EditorMaterialSystemComponentRequestBus::Broadcast(
-                &EditorMaterialSystemComponentRequestBus::Events::OpenMaterialInspector, m_entityId, m_id);
+                &EditorMaterialSystemComponentRequestBus::Events::OpenMaterialInspector, m_entityId, entityIdsToEdit, m_id);
         }
 
-        void EditorMaterialComponentSlot::OpenUvNameMapInspector()
+        void EditorMaterialComponentSlot::OpenUvNameMapInspector(const AzToolsFramework::EntityIdSet& entityIdsToEdit)
         {
             if (GetActiveAssetId().IsValid())
             {
@@ -311,27 +287,32 @@ namespace AZ
                 MaterialComponentRequestBus::EventResult(
                     matModUvOverrides, m_entityId, &MaterialComponentRequestBus::Events::GetModelUvOverrides, m_id);
 
-                auto applyMatModUvOverrideChangedCallback = [this](const RPI::MaterialModelUvOverrideMap& matModUvOverrides)
+                auto applyMatModUvOverrideChangedCallback = [&](const RPI::MaterialModelUvOverrideMap& matModUvOverrides)
                 {
-                    MaterialComponentRequestBus::Event(
-                        m_entityId, &MaterialComponentRequestBus::Events::SetModelUvOverrides, m_id, matModUvOverrides);
+                    for (const AZ::EntityId& entityId : entityIdsToEdit)
+                    {
+                        MaterialComponentRequestBus::Event(
+                            entityId, &MaterialComponentRequestBus::Events::SetModelUvOverrides, m_id, matModUvOverrides);
+                    }
                 };
 
                 if (EditorMaterialComponentInspector::OpenInspectorDialog(
                         GetActiveAssetId(), matModUvOverrides, modelUvNames, applyMatModUvOverrideChangedCallback))
                 {
-                    OnDataChanged();
+                    OnDataChanged(entityIdsToEdit);
                 }
             }
         }
 
         void EditorMaterialComponentSlot::OpenPopupMenu([[maybe_unused]] const AZ::Data::AssetId& assetId, [[maybe_unused]] const AZ::Data::AssetType& assetType)
         {
+            const auto& entityIdsToEdit = EditorMaterialComponentUtil::GetSelectedEntitiesFromActiveInspectorMatchingMaterialSlots(m_entityId);
+
             QMenu menu;
 
             QAction* action = nullptr;
 
-            action = menu.addAction("Generate/Manage Source Material...", [this]() { OpenMaterialExporter(); });
+            action = menu.addAction("Generate/Manage Source Material...", [this, entityIdsToEdit]() { OpenMaterialExporter(entityIdsToEdit); });
             action->setEnabled(GetDefaultAssetId().IsValid());
 
             menu.addSeparator();
@@ -339,47 +320,66 @@ namespace AZ
             action = menu.addAction("Edit Source Material...", [this]() { OpenMaterialEditor(); });
             action->setEnabled(HasSourceData());
 
-            action = menu.addAction("Edit Material Instance...", [this]() { OpenMaterialInspector(); });
+            action = menu.addAction("Edit Material Instance...", [this, entityIdsToEdit]() { OpenMaterialInspector(entityIdsToEdit); });
             action->setEnabled(GetActiveAssetId().IsValid());
 
-            action = menu.addAction("Edit Material Instance UV Map...", [this]() { OpenUvNameMapInspector(); });
+            action = menu.addAction("Edit Material Instance UV Map...", [this, entityIdsToEdit]() { OpenUvNameMapInspector(entityIdsToEdit); });
             action->setEnabled(GetActiveAssetId().IsValid());
 
             menu.addSeparator();
 
-            MaterialPropertyOverrideMap propertyOverrides;
-            MaterialComponentRequestBus::EventResult(
-                propertyOverrides, m_entityId, &MaterialComponentRequestBus::Events::GetPropertyOverrides, m_id);
-            RPI::MaterialModelUvOverrideMap matModUvOverrides;
-            MaterialComponentRequestBus::EventResult(
-                matModUvOverrides, m_entityId, &MaterialComponentRequestBus::Events::GetModelUvOverrides, m_id);
+            action = menu.addAction("Clear Material Instance Overrides", [this, entityIdsToEdit]() {
+                for (const AZ::EntityId& entityId : entityIdsToEdit)
+                {
+                    MaterialComponentRequestBus::Event(
+                        entityId, &MaterialComponentRequestBus::Events::SetPropertyOverrides, m_id, MaterialPropertyOverrideMap());
+                    MaterialComponentRequestBus::Event(
+                        entityId, &MaterialComponentRequestBus::Events::SetModelUvOverrides, m_id,
+                        AZ::RPI::MaterialModelUvOverrideMap());
+                }
+                OnDataChanged(entityIdsToEdit);
+            });
 
-            action = menu.addAction("Clear Material Instance Overrides", [this]() { ClearOverrides(); });
-            action->setEnabled(!propertyOverrides.empty() || !matModUvOverrides.empty());
+            action = menu.addAction("Clear", [this, entityIdsToEdit]() {
+                m_materialAsset = {};
+                for (const AZ::EntityId& entityId : entityIdsToEdit)
+                {
+                    MaterialComponentRequestBus::Event(
+                        entityId, &MaterialComponentRequestBus::Events::SetPropertyOverrides, m_id, MaterialPropertyOverrideMap());
+                    MaterialComponentRequestBus::Event(
+                        entityId, &MaterialComponentRequestBus::Events::SetModelUvOverrides, m_id,
+                        AZ::RPI::MaterialModelUvOverrideMap());
+                }
+                OnDataChanged(entityIdsToEdit);
+            });
 
             menu.exec(QCursor::pos());
         }
 
-        void EditorMaterialComponentSlot::OnMaterialChanged() const
+        void EditorMaterialComponentSlot::OnMaterialChangedFromRPE() const
         {
-            MaterialComponentRequestBus::Event(
-                m_entityId, &MaterialComponentRequestBus::Events::SetMaterialOverride, m_id, m_materialAsset.GetId());
-            OnDataChanged();
+            OnDataChanged({ m_entityId });
         }
 
-        void EditorMaterialComponentSlot::OnDataChanged() const
+        void EditorMaterialComponentSlot::OnDataChanged(const AzToolsFramework::EntityIdSet& entityIdsToEdit) const
         {
-            // This is triggered whenever a material slot changes outside of normal inspector interactions
             // Handle undo, update configuration, and refresh the inspector to display the new values
             AzToolsFramework::ScopedUndoBatch undoBatch("Material slot changed.");
-            AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, m_entityId);
 
             EditorMaterialSystemComponentRequestBus::Broadcast(
                 &EditorMaterialSystemComponentRequestBus::Events::RenderMaterialPreview, m_entityId, m_id);
             m_updatePreview = false;
 
-            MaterialComponentNotificationBus::Event(m_entityId, &MaterialComponentNotifications::OnMaterialsEdited);
+            for (const AZ::EntityId& entityId : entityIdsToEdit)
+            {
+                AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                    &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
+
+                MaterialComponentRequestBus::Event(
+                    entityId, &MaterialComponentRequestBus::Events::SetMaterialOverride, m_id, m_materialAsset.GetId());
+
+                MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
+            }
 
             AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
                 &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
@@ -20,8 +20,10 @@ namespace AZ
     namespace Render
     {
         //! Details for a single editable material assignment
-        //! When changes are applied to this material slot, it will attempt to forward all of those changes to applicable selected entities
-        //! and their materials
+        //! EditorMaterialComponentSlot will attempt to forward all changes to selected entities for actions invoked from a context menu or
+        //! entity inspector. The set of selected or pinned entities will be retrieved directly from the inspector. Updates will be
+        //! applied to the entities and their materials using MaterialComponentRequestBus.
+        //! Undo and redo for all of those entities will be managed flip calls to OnDataChanged.
         struct EditorMaterialComponentSlot final
         {
             AZ_RTTI(EditorMaterialComponentSlot, "{344066EB-7C3D-4E92-B53D-3C9EBD546488}");

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
@@ -57,7 +57,7 @@ namespace AZ
             void ClearMaterial();
 
             //! Remove property overrides
-            void ClearOverrides();
+            void ClearProperties();
 
             void OpenMaterialEditor() const;
             void OpenMaterialExporter(const AzToolsFramework::EntityIdSet& entityIdsToEdit);
@@ -73,7 +73,7 @@ namespace AZ
         private:
             void OpenPopupMenu(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType& assetType);
             void OnMaterialChangedFromRPE() const;
-            void OnDataChanged(const AzToolsFramework::EntityIdSet& entityIdsToEdit) const;
+            void OnDataChanged(const AzToolsFramework::EntityIdSet& entityIdsToEdit, bool updateAsset) const;
             mutable bool m_updatePreview = true;
         };
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
@@ -45,10 +45,10 @@ namespace AZ
             bool HasSourceData() const;
 
             //! Assign a new material override asset
-            void SetAsset(const Data::AssetId& assetId);
+            void SetAsset(const Data::Asset<RPI::MaterialAsset>& asset);
 
             //! Assign a new material override asset
-            void SetAsset(const Data::Asset<RPI::MaterialAsset>& asset);
+            void SetAssetId(const Data::AssetId& assetId);
 
             //! Remove material and property overrides
             void Clear();
@@ -59,10 +59,10 @@ namespace AZ
             //! Remove property overrides
             void ClearOverrides();
 
-            void OpenMaterialExporter();
             void OpenMaterialEditor() const;
-            void OpenMaterialInspector();
-            void OpenUvNameMapInspector();
+            void OpenMaterialExporter(const AzToolsFramework::EntityIdSet& entityIdsToEdit);
+            void OpenMaterialInspector(const AzToolsFramework::EntityIdSet& entityIdsToEdit);
+            void OpenUvNameMapInspector(const AzToolsFramework::EntityIdSet& entityIdsToEdit);
 
             void ExportMaterial(const AZStd::string& exportPath, bool overwrite);
 
@@ -72,8 +72,8 @@ namespace AZ
 
         private:
             void OpenPopupMenu(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType& assetType);
-            void OnMaterialChanged() const;
-            void OnDataChanged() const;
+            void OnMaterialChangedFromRPE() const;
+            void OnDataChanged(const AzToolsFramework::EntityIdSet& entityIdsToEdit) const;
             mutable bool m_updatePreview = true;
         };
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
@@ -67,7 +67,7 @@ namespace AZ
             //! Open the material exporter, aka generate source materials dialog, and apply resulting materials to a set of entities
             void OpenMaterialExporter(const AzToolsFramework::EntityIdSet& entityIdsToEdit);
 
-            //! Open the material instance inspector, displaying this entity's active material, applying changes to all entities in the set
+            //! Open the material instance inspector to edit material property overrides for a set of entities 
             void OpenMaterialInspector(const AzToolsFramework::EntityIdSet& entityIdsToEdit);
 
             //! Opens the dialog for you mapping UV channels for models and materials

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
@@ -20,6 +20,8 @@ namespace AZ
     namespace Render
     {
         //! Details for a single editable material assignment
+        //! When changes are applied to this material slot, it will attempt to forward all of those changes to applicable selected entities
+        //! and their materials
         struct EditorMaterialComponentSlot final
         {
             AZ_RTTI(EditorMaterialComponentSlot, "{344066EB-7C3D-4E92-B53D-3C9EBD546488}");
@@ -59,11 +61,19 @@ namespace AZ
             //! Remove property overrides
             void ClearProperties();
 
+            //! Launch the material editor application and open the active material for this slot
             void OpenMaterialEditor() const;
+
+            //! Open the material exporter, aka generate source materials dialog, and apply resulting materials to a set of entities
             void OpenMaterialExporter(const AzToolsFramework::EntityIdSet& entityIdsToEdit);
+
+            //! Open the material instance inspector, displaying this entity's active material, applying changes to all entities in the set
             void OpenMaterialInspector(const AzToolsFramework::EntityIdSet& entityIdsToEdit);
+
+            //! Opens the dialog for you mapping UV channels for models and materials
             void OpenUvNameMapInspector(const AzToolsFramework::EntityIdSet& entityIdsToEdit);
 
+            //! Bypass the UI to export the active material to the export path 
             void ExportMaterial(const AZStd::string& exportPath, bool overwrite);
 
             AZ::EntityId m_entityId;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
@@ -23,7 +23,7 @@ namespace AZ
         //! EditorMaterialComponentSlot will attempt to forward all changes to selected entities for actions invoked from a context menu or
         //! entity inspector. The set of selected or pinned entities will be retrieved directly from the inspector. Updates will be
         //! applied to the entities and their materials using MaterialComponentRequestBus.
-        //! Undo and redo for all of those entities will be managed flip calls to OnDataChanged.
+        //! Undo and redo for all of those entities will be managed by calls to OnDataChanged.
         struct EditorMaterialComponentSlot final
         {
             AZ_RTTI(EditorMaterialComponentSlot, "{344066EB-7C3D-4E92-B53D-3C9EBD546488}");
@@ -72,7 +72,7 @@ namespace AZ
             //! Open the material instance inspector to edit material property overrides for a set of entities 
             void OpenMaterialInspector(const AzToolsFramework::EntityIdSet& entityIdsToEdit);
 
-            //! Opens the dialog for you mapping UV channels for models and materials
+            //! Open the dialog for mapping UV channels for models and materials
             void OpenUvNameMapInspector(const AzToolsFramework::EntityIdSet& entityIdsToEdit);
 
             //! Bypass the UI to export the active material to the export path 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
@@ -178,6 +178,8 @@ namespace AZ
                                 info, &AZ::Data::AssetCatalogRequests::GetAssetInfoById, dependency.m_assetId);
                             if (info.m_assetType == azrtti_typeid<AZ::RPI::MaterialTypeAsset>())
                             {
+                                // Immediately return the first material type that's encountered because the material system currently
+                                // supports only one material type for any hierarchy of materials.
                                 return info.m_assetId;
                             }
                         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
@@ -197,12 +197,8 @@ namespace AZ
                     primaryMaterialAssetId, primaryEntityId, &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId,
                     materialAssignmentId);
                 AZ::Data::AssetId primaryMaterialTypeAssetId = GetMaterialTypeAssetIdFromMaterialAssetId(primaryMaterialAssetId);
-                if (!primaryMaterialTypeAssetId.IsValid())
-                {
-                    return false;
-                }
 
-                return AZStd::all_of(
+                return primaryMaterialTypeAssetId.IsValid() && AZStd::all_of(
                     secondaryEntityIds.begin(), secondaryEntityIds.end(),
                     [&](const AZ::EntityId& secondaryEntityId)
                     {
@@ -211,11 +207,6 @@ namespace AZ
                             secondaryMaterialAssetId, secondaryEntityId, &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId,
                             materialAssignmentId);
                         AZ::Data::AssetId secondaryMaterialTypeAssetId = GetMaterialTypeAssetIdFromMaterialAssetId(secondaryMaterialAssetId);
-                        if (!secondaryMaterialTypeAssetId.IsValid())
-                        {
-                            return false;
-                        }
-
                         return primaryMaterialTypeAssetId == secondaryMaterialTypeAssetId;
                     });
             }
@@ -230,7 +221,7 @@ namespace AZ
                     primaryMaterialAssetId, primaryEntityId, &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId,
                     materialAssignmentId);
 
-                return AZStd::all_of(
+                return primaryMaterialAssetId.IsValid() && AZStd::all_of(
                     secondaryEntityIds.begin(), secondaryEntityIds.end(),
                     [&](const AZ::EntityId& secondaryEntityId)
                     {
@@ -238,7 +229,7 @@ namespace AZ
                         MaterialComponentRequestBus::EventResult(
                             secondaryMaterialAssetId, secondaryEntityId, &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId,
                             materialAssignmentId);
-                        return primaryMaterialAssetId.IsValid() && primaryMaterialAssetId == secondaryMaterialAssetId;
+                        return primaryMaterialAssetId == secondaryMaterialAssetId;
                     });
             }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.h
@@ -15,6 +15,7 @@
 #include <Atom/RPI.Reflect/Material/MaterialTypeAsset.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/std/string/string.h>
+#include <AzToolsFramework/Entity/EntityTypes.h>
 
 namespace AZ
 {
@@ -38,6 +39,9 @@ namespace AZ
 
             bool LoadMaterialEditDataFromAssetId(const AZ::Data::AssetId& assetId, MaterialEditData& editData);
             bool SaveSourceMaterialFromEditData(const AZStd::string& path, const MaterialEditData& editData);
+
+            AzToolsFramework::EntityIdSet GetSelectedEntitiesFromActiveInspector();
+            AzToolsFramework::EntityIdSet GetSelectedEntitiesFromActiveInspectorMatchingMaterialSlots(const AZ::EntityId& focusedEntityId);
         } // namespace EditorMaterialComponentUtil
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.h
@@ -40,6 +40,19 @@ namespace AZ
             bool LoadMaterialEditDataFromAssetId(const AZ::Data::AssetId& assetId, MaterialEditData& editData);
             bool SaveSourceMaterialFromEditData(const AZStd::string& path, const MaterialEditData& editData);
 
+            //! Retrieves the material type asset ID for a given material asset ID
+            AZ::Data::AssetId GetMaterialTypeAssetIdFromMaterialAssetId(const AZ::Data::AssetId& materialAssetId);
+
+            //! Determines if a set of entities have the same active material type on a given material slot
+            //! @param primaryEntityId The entity whose material types will be compared against all others in the set
+            //! @param secondaryEntityIds Set of entities that will be compared against material types on the primaryEntityId
+            //! @param materialAssignmentId ID of the material type slot that will be tested for quality
+            //! @returns True if all of the entities share the same active material type asset on the specified slot
+            bool DoEntitiesHaveMatchingMaterialTypes(
+                const AZ::EntityId& primaryEntityId,
+                const AzToolsFramework::EntityIdSet& secondaryEntityIds,
+                const MaterialAssignmentId& materialAssignmentId);
+
             //! Determines if a set of entities have the same active material on a given material slot
             //! @param primaryEntityId The entity whose materials will be compared against all others in the set
             //! @param secondaryEntityIds Set of entities that will be compared against materials on the primaryEntityId

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.h
@@ -40,8 +40,34 @@ namespace AZ
             bool LoadMaterialEditDataFromAssetId(const AZ::Data::AssetId& assetId, MaterialEditData& editData);
             bool SaveSourceMaterialFromEditData(const AZStd::string& path, const MaterialEditData& editData);
 
+            //! Determines if a set of entities have the same active material on a given material slot
+            //! @param primaryEntityId The entity whose materials will be compared against all others in the set
+            //! @param secondaryEntityIds Set of entities that will be compared against materials on the primaryEntityId
+            //! @param materialAssignmentId ID of the material slot that will be tested for quality
+            //! @returns True if all of the entities share the same active material asset on the specified slot
+            bool DoEntitiesHaveMatchingMaterials(
+                const AZ::EntityId& primaryEntityId,
+                const AzToolsFramework::EntityIdSet& secondaryEntityIds,
+                const MaterialAssignmentId& materialAssignmentId);
+
+            //! Determines if a set of entities have the same material slot configuration, LODs, etc 
+            //! @param primaryEntityId The entity whose material slots will be compared against all others in the set
+            //! @param secondaryEntityIds Set of entities that will be compared against material slots on the primaryEntityId
+            //! @returns True if all of the entities share the same material slot configuration
+            bool DoEntitiesHaveMatchingMaterialSlots(const AZ::EntityId& primaryEntityId, const AzToolsFramework::EntityIdSet& entityIds);
+
+            //! Returns the set of entities selected or pinned in the active entity inspector
+            //! This function is only reliable when called from context menu or edit context attribute handlers guaranteed to be called from
+            //! within the inspector
             AzToolsFramework::EntityIdSet GetSelectedEntitiesFromActiveInspector();
-            AzToolsFramework::EntityIdSet GetSelectedEntitiesFromActiveInspectorMatchingMaterialSlots(const AZ::EntityId& focusedEntityId);
+
+            //! Removes all entries from a set of entity IDs that do not have the same material slot configuration as the primary entity
+            //! @param primaryEntityId The entity whose material slots will be compared against all others in the set
+            //! @param secondaryEntityIds Set of entities that will be compared against material slots on the primaryEntityId
+            //! @returns All of the entity IDs contained within secondaryEntityIds except for the ones whose materials did not match
+            //! primaryEntityId
+            AzToolsFramework::EntityIdSet GetEntitiesMatchingMaterialSlots(
+                const AZ::EntityId& primaryEntityId, const AzToolsFramework::EntityIdSet& secondaryEntityIds);
         } // namespace EditorMaterialComponentUtil
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -151,8 +151,8 @@ namespace AZ
         }
 
         void EditorMaterialSystemComponent::OpenMaterialInspector(
-            const AZ::EntityId& entityId,
-            const AzToolsFramework::EntityIdSet& entityIds,
+            const AZ::EntityId& primaryEntityId,
+            const AzToolsFramework::EntityIdSet& entityIdsToEdit,
             const AZ::Render::MaterialAssignmentId& materialAssignmentId)
         {
             auto dockWidget = AzToolsFramework::InstanceViewPane("Material Property Inspector");
@@ -161,7 +161,7 @@ namespace AZ
                 auto inspector = static_cast<AZ::Render::EditorMaterialComponentInspector::MaterialPropertyInspector*>(dockWidget->widget());
                 if (inspector)
                 {
-                    inspector->LoadMaterial(entityId, entityIds, materialAssignmentId);
+                    inspector->LoadMaterial(primaryEntityId, entityIdsToEdit, materialAssignmentId);
                 }
             }
         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -176,15 +176,10 @@ namespace AZ
             {
                 AZ::Data::AssetId materialAssetId = {};
                 MaterialComponentRequestBus::EventResult(
-                    materialAssetId, entityId, &MaterialComponentRequestBus::Events::GetMaterialOverride, materialAssignmentId);
+                    materialAssetId, entityId, &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId, materialAssignmentId);
                 if (!materialAssetId.IsValid())
                 {
-                    MaterialComponentRequestBus::EventResult(
-                        materialAssetId, entityId, &MaterialComponentRequestBus::Events::GetDefaultMaterialAssetId, materialAssignmentId);
-                    if (!materialAssetId.IsValid())
-                    {
-                        return;
-                    }
+                    return;
                 }
 
                 AZ::Render::MaterialPropertyOverrideMap propertyOverrides;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -151,7 +151,9 @@ namespace AZ
         }
 
         void EditorMaterialSystemComponent::OpenMaterialInspector(
-            const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId)
+            const AZ::EntityId& entityId,
+            const AzToolsFramework::EntityIdSet& entityIds,
+            const AZ::Render::MaterialAssignmentId& materialAssignmentId)
         {
             auto dockWidget = AzToolsFramework::InstanceViewPane("Material Property Inspector");
             if (dockWidget)
@@ -159,7 +161,7 @@ namespace AZ
                 auto inspector = static_cast<AZ::Render::EditorMaterialComponentInspector::MaterialPropertyInspector*>(dockWidget->widget());
                 if (inspector)
                 {
-                    inspector->LoadMaterial(entityId, materialAssignmentId);
+                    inspector->LoadMaterial(entityId, entityIds, materialAssignmentId);
                 }
             }
         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
@@ -55,8 +55,8 @@ namespace AZ
             //! EditorMaterialSystemComponentRequestBus::Handler overrides...
             void OpenMaterialEditor(const AZStd::string& sourcePath) override;
             void OpenMaterialInspector(
-                const AZ::EntityId& entityId,
-                const AzToolsFramework::EntityIdSet& entityIds,
+                const AZ::EntityId& primaryEntityId,
+                const AzToolsFramework::EntityIdSet& entityIdsToEdit,
                 const AZ::Render::MaterialAssignmentId& materialAssignmentId) override;
             void RenderMaterialPreview(const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId) override;
             QPixmap GetRenderedMaterialPreview(

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
@@ -54,7 +54,10 @@ namespace AZ
         private:
             //! EditorMaterialSystemComponentRequestBus::Handler overrides...
             void OpenMaterialEditor(const AZStd::string& sourcePath) override;
-            void OpenMaterialInspector(const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId) override;
+            void OpenMaterialInspector(
+                const AZ::EntityId& entityId,
+                const AzToolsFramework::EntityIdSet& entityIds,
+                const AZ::Render::MaterialAssignmentId& materialAssignmentId) override;
             void RenderMaterialPreview(const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId) override;
             QPixmap GetRenderedMaterialPreview(
                 const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId) const override;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -467,9 +467,12 @@ namespace AZ
         void MaterialComponentController::SetMaterialOverride(
             const MaterialAssignmentId& materialAssignmentId, const AZ::Data::AssetId& materialAssetId)
         {
-            m_configuration.m_materials[materialAssignmentId].m_materialAsset =
-                AZ::Data::Asset<AZ::RPI::MaterialAsset>(materialAssetId, AZ::AzTypeInfo<AZ::RPI::MaterialAsset>::Uuid());
-            LoadMaterials();
+            auto& materialAsset = m_configuration.m_materials[materialAssignmentId].m_materialAsset;
+            if (materialAsset.GetId() != materialAssetId)
+            {
+                materialAsset = AZ::Data::Asset<AZ::RPI::MaterialAsset>(materialAssetId, AZ::AzTypeInfo<AZ::RPI::MaterialAsset>::Uuid());
+                LoadMaterials();
+            }
         }
 
         AZ::Data::AssetId MaterialComponentController::GetMaterialOverride(const MaterialAssignmentId& materialAssignmentId) const

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -36,6 +36,7 @@ namespace AZ
                     ->Attribute(AZ::Script::Attributes::Module, "render")
                     ->Event("GetOriginalMaterialAssignments", &MaterialComponentRequestBus::Events::GetOriginalMaterialAssignments)
                     ->Event("FindMaterialAssignmentId", &MaterialComponentRequestBus::Events::FindMaterialAssignmentId)
+                    ->Event("GetActiveMaterialAssetId", &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId)
                     ->Event("GetDefaultMaterialAssetId", &MaterialComponentRequestBus::Events::GetDefaultMaterialAssetId)
                     ->Event("GetMaterialSlotLabel", &MaterialComponentRequestBus::Events::GetMaterialSlotLabel)
                     ->Event("SetMaterialOverrides", &MaterialComponentRequestBus::Events::SetMaterialOverrides)
@@ -296,6 +297,12 @@ namespace AZ
             MaterialReceiverRequestBus::EventResult(
                 materialAssignmentId, m_entityId, &MaterialReceiverRequestBus::Events::FindMaterialAssignmentId, lod, label);
             return materialAssignmentId;
+        }
+
+        AZ::Data::AssetId MaterialComponentController::GetActiveMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const
+        {
+            const AZ::Data::AssetId materialAssetId = GetMaterialOverride(materialAssignmentId);
+            return materialAssetId.IsValid() ? materialAssetId : GetDefaultMaterialAssetId(materialAssignmentId);
         }
 
         AZ::Data::AssetId MaterialComponentController::GetDefaultMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -48,6 +48,7 @@ namespace AZ
             //! MaterialComponentRequestBus overrides...
             MaterialAssignmentMap GetOriginalMaterialAssignments() const override;
             MaterialAssignmentId FindMaterialAssignmentId(const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
+            AZ::Data::AssetId GetActiveMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const override;
             AZ::Data::AssetId GetDefaultMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const override;
             AZStd::string GetMaterialSlotLabel(const MaterialAssignmentId& materialAssignmentId) const override;
             void SetMaterialOverrides(const MaterialAssignmentMap& materials) override;


### PR DESCRIPTION
This change adds support to the material component and material instance inspector for editing material and property overrides across multiple selected entities. Prior to this, the material component would disable most editing features and display a warning message to the user whenever the number of selected entities != 1. This logic did not account for pinned inspectors, which maintain their own set of selected entities after they have been pinned. Multiple bugs and feature requests have been reported related to the messaging and lack of multi material customization.

- The material component no longer displays a warning message about having multiple entities selected.
- The material component and its dialogs respect and apply changes to the set of selected entities in the active inspector.
- The material component contextually enables or disables individual user options depending on if the selected set of entities have the same material type or slot configuration.
- The material component supports generating source materials across multiple entities if they have the same set of material slots. Note that the system automatically disables the generate source materials button on the component if multiple entities are selected. However, it is still available through the context menu.
- The material component instance editor supports pinning and editing selected entities that match the primary entity material type. 

** We might seek input on whether or not the instance inspector should require that all of the selected entities have the exact same active material and property overrides on the slot being edited, not just the material type. With this change, you can select multiple entities with different materials that share the same material type and tune individual properties. For example, you can change base color or metallic factor across a selection containing entities with completely different PBR materials, colors, and textures. It could lead to confusion that not every material in the selection matches the preview in the inspector. Then again maybe we should disable the preview if multiple entities are selected.

https://github.com/o3de/o3de/issues/7427
https://github.com/o3de/o3de/issues/8984
https://github.com/o3de/o3de/issues/9096
https://github.com/o3de/o3de/issues/8514
ATOM-15091
ATOM-17616