### PR TITLE
{lyn12122} fixes for empty scene manifest loading

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Events/AssetImportRequest.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Events/AssetImportRequest.cpp
@@ -158,8 +158,10 @@ namespace AZ
                 }
 
                 ManifestAction action = ManifestAction::Update;
-                // If the result for manifest is ignored it means no manifest was found.
-                if (filesLoaded.GetManifestResult() == ProcessingResult::Failure || filesLoaded.GetManifestResult() == ProcessingResult::Ignored)
+                // If the result for manifest is ignored it means no manifest was found or it was empty.
+                if (filesLoaded.GetManifestResult() == ProcessingResult::Failure ||
+                    filesLoaded.GetManifestResult() == ProcessingResult::Ignored ||
+                    scene->GetManifest().IsEmpty())
                 {
                     scene->GetManifest().Clear();
                     action = ManifestAction::ConstructDefault;

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
@@ -99,6 +99,11 @@ namespace SceneBuilder
 
         auto manifestObject = document.GetObject();
         auto valuesIterator = manifestObject.FindMember("values");
+        if (valuesIterator == manifestObject.MemberEnd())
+        {
+            // a blank or unexpected JSON formated .assetinfo file
+            return;
+        }
         auto valuesArray = valuesIterator->value.GetArray();
 
         AZStd::vector<AZStd::string> paths;

--- a/Gems/SceneProcessing/Code/Tests/SceneBuilder/SceneBuilderTests.cpp
+++ b/Gems/SceneProcessing/Code/Tests/SceneBuilder/SceneBuilderTests.cpp
@@ -273,6 +273,16 @@ TEST_F(SourceDependencyTests, SourceDependencyTest)
     ASSERT_STREQ(dependencies[1].m_sourceFileDependencyPath.c_str(), "value.png");
 }
 
+TEST_F(SourceDependencyTests, PopulateSourceDependencies_WithEmptyManifest_ShouldFailWithNoException)
+{
+    ImportHandler handler;
+    AZStd::vector<AssetBuilderSDK::SourceFileDependency> dependencies;
+
+    SceneBuilderWorker::PopulateSourceDependencies("{}", dependencies);
+
+    ASSERT_EQ(dependencies.size(), 0);
+}
+
 struct SourceDependencyMockedIOTests : UnitTest::ScopedAllocatorSetupFixture
     , UnitTest::SetRestoreFileIOBaseRAII
 {


### PR DESCRIPTION
{lyn12122} fixes for empty scene manifest loading

* Handle empty scene manifest by constructing a default scene rule set
* Check empty scene manifest during scene work building

Signed-off-by: Allen Jackson <23512001+jackalbe@users.noreply.github.com>