### PR TITLE
Re-enable shader reloader test (passing again on Linux)

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
@@ -100,4 +100,17 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         COMPONENT
             Atom
     )
+    ly_add_pytest(
+        NAME AutomatedTesting::Atom_Main_DevTests
+        TEST_SUITE main
+        PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Null_Render_Dev_Tests.py
+        TEST_SERIAL
+        TIMEOUT 300
+        RUNTIME_DEPENDENCIES
+            AssetProcessor
+            AutomatedTesting.Assets
+            Editor
+        COMPONENT
+            Atom
+    )
 endif()

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Dev_Tests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Dev_Tests.py
@@ -1,0 +1,22 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+import logging
+import os
+import pytest
+
+from ly_test_tools.o3de.editor_test import EditorBatchedTest, EditorTestSuite
+
+logger = logging.getLogger(__name__)
+TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), "tests")
+
+
+@pytest.mark.parametrize("project", ["AutomatedTesting"])
+@pytest.mark.parametrize("launcher_platform", ['windows_editor'])
+class TestDevAutomation(EditorTestSuite):
+
+    class ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges(EditorBatchedTest):
+        from Atom.tests import hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
@@ -31,9 +31,6 @@ class TestAutomation(EditorTestSuite):
     class AtomLevelLoadTest_Editor_Sandbox(EditorSharedTest):
         from Atom.tests import hydra_Atom_LevelLoadTest_Sandbox as test_module
 
-    class ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges(EditorSharedTest):
-        from Atom.tests import hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges as test_module
-
 
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("launcher_platform", ['windows_generic'])


### PR DESCRIPTION
- Moving the shader reloader test out of sandbox and into its own suite for dev tests.
- PR will be opened as draft first since I cannot reproduce on my Linux machine, want to make sure AR plays nice before fully opening this up for reviews.