### PR TITLE
feat: add Ray and LineSegment to AZCore/Math

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/LineSegment.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/LineSegment.cpp
@@ -7,38 +7,43 @@
  */
 
 #include <AzCore/Math/LineSegment.h>
+#include <AzCore/Math/Ray.h>
 
-namespace O3DE
+namespace AZ
 {
-    LineSegment::LineSegment(const AZ::Vector3& start, const AZ::Vector3& end):
-        m_start(start),
-        m_end(end)
+    LineSegment::LineSegment(const AZ::Vector3& start, const AZ::Vector3& end)
+        : m_start(start)
+        , m_end(end)
     {
+    }
+
+    LineSegment::LineSegment(const LineSegment& rhs)
+        : m_start(rhs.m_start)
+        , m_end(rhs.m_end)
+    {
+    }
+
+    LineSegment LineSegment::CreateFromRayAndLength(const Ray& ray, float length) {
+        return LineSegment(ray.GetOrigin(), ray.GetOrigin() + (ray.GetDirection() * length));
     }
 
     const AZ::Vector3& LineSegment::GetStart() const
     {
         return m_start;
     }
+
     const AZ::Vector3& LineSegment::GetEnd() const
     {
         return m_end;
     }
 
-        
-    LineSegment& LineSegment::operator=(const LineSegment& rhs) {
-        m_start = rhs.m_start;
-        m_end = rhs.m_end;
-        return (*this);
+    AZ::Vector3 LineSegment::GetDifference() const {
+        return (m_end - m_start);
     }
 
-    bool LineSegment::operator==(const LineSegment& rhs) const
-    {
-        return m_start == rhs.m_start && m_end == rhs.m_end;
-    }
-    bool LineSegment::operator!=(const LineSegment& rhs) const
-    {
-        return m_start != rhs.m_start && m_end != rhs.m_end;
+    AZ::Vector3 LineSegment::GetPoint(float t) const {
+        return GetDifference().Lerp(AZ::Vector3(), t) + m_start;
     }
 
-} // namespace O3DE
+
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Math/LineSegment.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/LineSegment.cpp
@@ -17,7 +17,8 @@ namespace AZ
     {
     }
 
-    LineSegment LineSegment::CreateFromRayAndLength(const Ray& ray, float length) {
+    LineSegment LineSegment::CreateFromRayAndLength(const Ray& ray, float length)
+    {
         return LineSegment(ray.GetOrigin(), ray.GetOrigin() + (ray.GetDirection() * length));
     }
 
@@ -31,11 +32,13 @@ namespace AZ
         return m_end;
     }
 
-    AZ::Vector3 LineSegment::GetDifference() const {
-        return (m_end - m_start);
+    AZ::Vector3 LineSegment::GetDifference() const
+    {
+        return m_end - m_start;
     }
 
-    AZ::Vector3 LineSegment::GetPoint(float t) const {
+    AZ::Vector3 LineSegment::GetPoint(float t) const
+    {
         return m_start.Lerp(m_end, t);
     }
 

--- a/Code/Framework/AzCore/AzCore/Math/LineSegment.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/LineSegment.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/LineSegment.h>
+
+namespace O3DE
+{
+    LineSegment::LineSegment(const AZ::Vector3& start, const AZ::Vector3& end):
+        m_start(start),
+        m_end(end)
+    {
+    }
+
+    const AZ::Vector3& LineSegment::GetStart() const
+    {
+        return m_start;
+    }
+    const AZ::Vector3& LineSegment::getEnd() const
+    {
+        return m_end;
+    }
+
+        
+    LineSegment& LineSegment::operator=(const LineSegment& rhs) {
+        m_start = rhs.m_start;
+        m_end = rhs.m_end;
+        return (*this);
+    }
+
+    bool LineSegment::operator==(const LineSegment& rhs) const
+    {
+        return m_start == rhs.m_start && m_end == rhs.m_end;
+    }
+    bool LineSegment::operator!=(const LineSegment& rhs) const
+    {
+        return m_start != rhs.m_start && m_end != rhs.m_end;
+    }
+
+} // namespace O3DE

--- a/Code/Framework/AzCore/AzCore/Math/LineSegment.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/LineSegment.cpp
@@ -20,7 +20,7 @@ namespace O3DE
     {
         return m_start;
     }
-    const AZ::Vector3& LineSegment::getEnd() const
+    const AZ::Vector3& LineSegment::GetEnd() const
     {
         return m_end;
     }

--- a/Code/Framework/AzCore/AzCore/Math/LineSegment.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/LineSegment.cpp
@@ -17,12 +17,6 @@ namespace AZ
     {
     }
 
-    LineSegment::LineSegment(const LineSegment& rhs)
-        : m_start(rhs.m_start)
-        , m_end(rhs.m_end)
-    {
-    }
-
     LineSegment LineSegment::CreateFromRayAndLength(const Ray& ray, float length) {
         return LineSegment(ray.GetOrigin(), ray.GetOrigin() + (ray.GetDirection() * length));
     }
@@ -42,8 +36,7 @@ namespace AZ
     }
 
     AZ::Vector3 LineSegment::GetPoint(float t) const {
-        return GetDifference().Lerp(AZ::Vector3(), t) + m_start;
+        return m_start.Lerp(m_end, t);
     }
-
 
 } // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Math/LineSegment.h
+++ b/Code/Framework/AzCore/AzCore/Math/LineSegment.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/RTTI/TypeInfoSimple.h>
+
+namespace O3DE
+{
+    class LineSegment
+    {
+    public:
+        AZ_TYPE_INFO(LineSegment, "{7557da1e-cc20-11ec-9d64-0242ac120002}");
+
+        explicit LineSegment(const AZ::Vector3& start, const AZ::Vector3& end);
+
+        const AZ::Vector3& GetStart() const;
+        const AZ::Vector3& getEnd() const;
+
+        const AZ::Vector3 Get();
+        
+        LineSegment& operator=(const LineSegment& rhs);
+        bool operator==(const LineSegment& rhs) const;
+        bool operator!=(const LineSegment& rhs) const;
+
+    private:
+        AZ::Vector3 m_start;
+        AZ::Vector3 m_end;
+    };
+
+} // namespace O3DE

--- a/Code/Framework/AzCore/AzCore/Math/LineSegment.h
+++ b/Code/Framework/AzCore/AzCore/Math/LineSegment.h
@@ -22,7 +22,6 @@ namespace AZ
 
         LineSegment() = default;
         LineSegment(const AZ::Vector3& start, const AZ::Vector3& end);
-        LineSegment(const LineSegment& rhs);
 
         static LineSegment CreateFromRayAndLength(const Ray& segment, float length);
 

--- a/Code/Framework/AzCore/AzCore/Math/LineSegment.h
+++ b/Code/Framework/AzCore/AzCore/Math/LineSegment.h
@@ -21,13 +21,24 @@ namespace O3DE
         explicit LineSegment(const AZ::Vector3& start, const AZ::Vector3& end);
 
         const AZ::Vector3& GetStart() const;
-        const AZ::Vector3& getEnd() const;
-
-        const AZ::Vector3 Get();
+        const AZ::Vector3& GetEnd() const;
         
         LineSegment& operator=(const LineSegment& rhs);
         bool operator==(const LineSegment& rhs) const;
         bool operator!=(const LineSegment& rhs) const;
+
+        //TODO: implement
+        //!
+        float GetLength();
+    
+        //!
+        AZ::Vector3 GetDirection();
+        
+        //!
+        AZ::Vector3 GetPoint(float t);
+        
+        //!
+        bool IsPointOnSegment(const AZ::Vector3& point);
 
     private:
         AZ::Vector3 m_start;

--- a/Code/Framework/AzCore/AzCore/Math/LineSegment.h
+++ b/Code/Framework/AzCore/AzCore/Math/LineSegment.h
@@ -11,34 +11,26 @@
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/RTTI/TypeInfoSimple.h>
 
-namespace O3DE
+namespace AZ
 {
+    class Ray;
+
     class LineSegment
     {
     public:
         AZ_TYPE_INFO(LineSegment, "{7557da1e-cc20-11ec-9d64-0242ac120002}");
 
-        explicit LineSegment(const AZ::Vector3& start, const AZ::Vector3& end);
+        LineSegment() = default;
+        LineSegment(const AZ::Vector3& start, const AZ::Vector3& end);
+        LineSegment(const LineSegment& rhs);
+
+        static LineSegment CreateFromRayAndLength(const Ray& segment, float length);
 
         const AZ::Vector3& GetStart() const;
         const AZ::Vector3& GetEnd() const;
-        
-        LineSegment& operator=(const LineSegment& rhs);
-        bool operator==(const LineSegment& rhs) const;
-        bool operator!=(const LineSegment& rhs) const;
-
-        //TODO: implement
-        //!
-        float GetLength();
     
-        //!
-        AZ::Vector3 GetDirection();
-        
-        //!
-        AZ::Vector3 GetPoint(float t);
-        
-        //!
-        bool IsPointOnSegment(const AZ::Vector3& point);
+        AZ::Vector3 GetDifference() const;
+        AZ::Vector3 GetPoint(float t) const;
 
     private:
         AZ::Vector3 m_start;

--- a/Code/Framework/AzCore/AzCore/Math/LineSegment.h
+++ b/Code/Framework/AzCore/AzCore/Math/LineSegment.h
@@ -27,7 +27,7 @@ namespace AZ
 
         const AZ::Vector3& GetStart() const;
         const AZ::Vector3& GetEnd() const;
-    
+
         AZ::Vector3 GetDifference() const;
         AZ::Vector3 GetPoint(float t) const;
 
@@ -36,4 +36,4 @@ namespace AZ
         AZ::Vector3 m_end;
     };
 
-} // namespace O3DE
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Math/LineSegment.h
+++ b/Code/Framework/AzCore/AzCore/Math/LineSegment.h
@@ -9,26 +9,36 @@
 #pragma once
 
 #include <AzCore/Math/Vector3.h>
-#include <AzCore/RTTI/TypeInfoSimple.h>
 
 namespace AZ
 {
     class Ray;
 
+    //! LineSegment defined by two Vector3, an start and a end.
     class LineSegment
     {
     public:
         AZ_TYPE_INFO(LineSegment, "{7557da1e-cc20-11ec-9d64-0242ac120002}");
 
+        //! Default constructor, Creates an empty LineSegment at the origin with a length of 0.
         LineSegment() = default;
+        //! Create a LineSegment with a start and an end. 
         LineSegment(const AZ::Vector3& start, const AZ::Vector3& end);
 
+        //! Create a LineSegment from a ray where origin is the start and 
+        //! the length defines the end of the LineSegment given the direction of the Ray.
         static LineSegment CreateFromRayAndLength(const Ray& segment, float length);
 
         const AZ::Vector3& GetStart() const;
         const AZ::Vector3& GetEnd() const;
 
+        //! The difference between the end the the start.
+         //! @return Direction and mangitude of the LineSegment.
         AZ::Vector3 GetDifference() const;
+
+        //! Returns the point along the segment from start to end -range [0, 1].
+        //! @param t fraction/proportion/percentage along the LineSegment.
+        //! @return The Position give the fraction t.
         AZ::Vector3 GetPoint(float t) const;
 
     private:

--- a/Code/Framework/AzCore/AzCore/Math/Ray.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Ray.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/Ray.h>
+#include <AzCore/Math/
+
+namespace O3DE
+{
+    Ray::Ray(const AZ::Vector3& origin, const AZ::Vector3& direction)
+        : m_origin(origin)
+        , m_direction(direction)
+    {
+        AZ_MATH_ASSERT(m_direction.IsNormalized(), "This normal is not normalized");
+    }
+
+    const AZ::Vector3& Ray::getOrigin() const
+    {
+        return m_origin;
+    }
+    
+    const AZ::Vector3& Ray::getDirection() const
+    {
+        return m_direction;
+    }
+
+    bool Ray::operator==(const Ray& rhs) const
+    {
+        return m_start == rhs.m_start && m_direction == rhs.m_direction;
+    }
+
+    bool Ray::operator!=(const Ray& rhs) const
+    {
+        return m_start != rhs.m_start && m_direction != rhs.m_direction;
+    }
+
+    Ray& Ray::operator=(const Ray& rhs) const
+    {
+        m_origin = rhs.m_origin;
+        m_direction = rhs.m_direction;
+        return *this;
+    }
+} // namespace O3DE

--- a/Code/Framework/AzCore/AzCore/Math/Ray.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Ray.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <AzCore/Math/Ray.h>
-#include <AzCore/Math/
 
 namespace O3DE
 {
@@ -18,12 +17,12 @@ namespace O3DE
         AZ_MATH_ASSERT(m_direction.IsNormalized(), "This normal is not normalized");
     }
 
-    const AZ::Vector3& Ray::getOrigin() const
+    const AZ::Vector3& Ray::GetOrigin() const
     {
         return m_origin;
     }
-    
-    const AZ::Vector3& Ray::getDirection() const
+
+    const AZ::Vector3& Ray::GetDirection() const
     {
         return m_direction;
     }

--- a/Code/Framework/AzCore/AzCore/Math/Ray.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Ray.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include <AzCore/Math/Ray.h>
 #include <AzCore/Math/LineSegment.h>
+#include <AzCore/Math/Ray.h>
 
 namespace AZ
 {
@@ -18,7 +18,8 @@ namespace AZ
         AZ_MATH_ASSERT(m_direction.IsNormalized(), "direction is not normalized");
     }
 
-    Ray Ray::CreateFromLineSegment(const LineSegment& segment) {
+    Ray Ray::CreateFromLineSegment(const LineSegment& segment)
+    {
         return Ray(segment.GetStart(), segment.GetDifference().GetNormalized());
     }
 

--- a/Code/Framework/AzCore/AzCore/Math/Ray.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Ray.cpp
@@ -18,16 +18,9 @@ namespace AZ
         AZ_MATH_ASSERT(m_direction.IsNormalized(), "direction is not normalized");
     }
 
-    Ray::Ray(const Ray& rhs):
-        m_origin(rhs.m_origin),
-        m_direction(rhs.m_direction) {
-        AZ_MATH_ASSERT(m_direction.IsNormalized(), "direction is not normalized");
-    }
-
     Ray Ray::CreateFromLineSegment(const LineSegment& segment) {
         return Ray(segment.GetStart(), segment.GetDifference().GetNormalized());
     }
-
 
     const AZ::Vector3& Ray::GetOrigin() const
     {

--- a/Code/Framework/AzCore/AzCore/Math/Ray.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Ray.cpp
@@ -7,15 +7,27 @@
  */
 
 #include <AzCore/Math/Ray.h>
+#include <AzCore/Math/LineSegment.h>
 
-namespace O3DE
+namespace AZ
 {
     Ray::Ray(const AZ::Vector3& origin, const AZ::Vector3& direction)
         : m_origin(origin)
         , m_direction(direction)
     {
-        AZ_MATH_ASSERT(m_direction.IsNormalized(), "This normal is not normalized");
+        AZ_MATH_ASSERT(m_direction.IsNormalized(), "direction is not normalized");
     }
+
+    Ray::Ray(const Ray& rhs):
+        m_origin(rhs.m_origin),
+        m_direction(rhs.m_direction) {
+        AZ_MATH_ASSERT(m_direction.IsNormalized(), "direction is not normalized");
+    }
+
+    Ray Ray::CreateFromLineSegment(const LineSegment& segment) {
+        return Ray(segment.GetStart(), segment.GetDifference().GetNormalized());
+    }
+
 
     const AZ::Vector3& Ray::GetOrigin() const
     {
@@ -26,21 +38,4 @@ namespace O3DE
     {
         return m_direction;
     }
-
-    bool Ray::operator==(const Ray& rhs) const
-    {
-        return m_start == rhs.m_start && m_direction == rhs.m_direction;
-    }
-
-    bool Ray::operator!=(const Ray& rhs) const
-    {
-        return m_start != rhs.m_start && m_direction != rhs.m_direction;
-    }
-
-    Ray& Ray::operator=(const Ray& rhs) const
-    {
-        m_origin = rhs.m_origin;
-        m_direction = rhs.m_direction;
-        return *this;
-    }
-} // namespace O3DE
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Math/Ray.h
+++ b/Code/Framework/AzCore/AzCore/Math/Ray.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/RTTI/TypeInfoSimple.h>
+
+#include <AzCore/Math/Sphere.h>
+
+namespace O3DE
+{
+    class Ray
+    {
+    public:
+        AZ_TYPE_INFO(Ray, "{0301a872-5bea-4563-8070-85ed243cb57c}");
+
+        explicit Ray(const AZ::Vector3& origin, const AZ::Vector3& direction);
+
+        bool Intersects(const AZ::Aabb aabb) const;
+
+        const AZ::Vector3& getOrigin() const;
+        const AZ::Vector3& getDirection() const;
+
+
+        Ray& operator=(const Ray& rhs);
+        bool operator==(const Ray& rhs) const;
+        bool operator!=(const Ray& rhs) const;
+
+    private:
+        AZ::Vector3 m_origin;
+        AZ::Vector3 m_direction;
+    };
+} // namespace O3DE

--- a/Code/Framework/AzCore/AzCore/Math/Ray.h
+++ b/Code/Framework/AzCore/AzCore/Math/Ray.h
@@ -13,7 +13,6 @@
 
 namespace AZ
 {
-
     class LineSegment;
 
     class Ray
@@ -23,8 +22,7 @@ namespace AZ
 
         Ray() = default;
         Ray(const AZ::Vector3& origin, const AZ::Vector3& direction);
-        Ray(const Ray& rhs);
-
+        
         static Ray CreateFromLineSegment(const LineSegment& segment);
 
         const AZ::Vector3& GetOrigin() const;

--- a/Code/Framework/AzCore/AzCore/Math/Ray.h
+++ b/Code/Framework/AzCore/AzCore/Math/Ray.h
@@ -9,23 +9,30 @@
 #pragma once
 
 #include <AzCore/Math/Vector3.h>
-#include <AzCore/RTTI/TypeInfoSimple.h>
 
 namespace AZ
 {
     class LineSegment;
 
+    //! Ray defined by two Vector3, an orign and a normalized direction.
     class Ray
     {
     public:
         AZ_TYPE_INFO(Ray, "{0301a872-5bea-4563-8070-85ed243cb57c}");
 
+        //! Default constructor, Creates a ray at the origin with a length of 0.
         Ray() = default;
+        //! Creates a Ray with a starting origin and direction. 
+        //! direction has to be normalized to be valid.
         Ray(const AZ::Vector3& origin, const AZ::Vector3& direction);
 
+        //! Create a ray from a LineSegment where the the start of the line segment is
+        //! the orign and the direction points toward the ending point. 
         static Ray CreateFromLineSegment(const LineSegment& segment);
 
+        //! returns the origin.
         const AZ::Vector3& GetOrigin() const;
+        //! returns the normalized direction of the Ray.
         const AZ::Vector3& GetDirection() const;
 
     private:

--- a/Code/Framework/AzCore/AzCore/Math/Ray.h
+++ b/Code/Framework/AzCore/AzCore/Math/Ray.h
@@ -22,11 +22,12 @@ namespace AZ
 
         Ray() = default;
         Ray(const AZ::Vector3& origin, const AZ::Vector3& direction);
-        
+
         static Ray CreateFromLineSegment(const LineSegment& segment);
 
         const AZ::Vector3& GetOrigin() const;
         const AZ::Vector3& GetDirection() const;
+
     private:
         AZ::Vector3 m_origin;
         AZ::Vector3 m_direction;

--- a/Code/Framework/AzCore/AzCore/Math/Ray.h
+++ b/Code/Framework/AzCore/AzCore/Math/Ray.h
@@ -11,28 +11,26 @@
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/RTTI/TypeInfoSimple.h>
 
-#include <AzCore/Math/Sphere.h>
-
-namespace O3DE
+namespace AZ
 {
+
+    class LineSegment;
+
     class Ray
     {
     public:
         AZ_TYPE_INFO(Ray, "{0301a872-5bea-4563-8070-85ed243cb57c}");
 
-        explicit Ray(const AZ::Vector3& origin, const AZ::Vector3& direction);
+        Ray() = default;
+        Ray(const AZ::Vector3& origin, const AZ::Vector3& direction);
+        Ray(const Ray& rhs);
 
-        bool Intersects(const AZ::Aabb aabb) const;
+        static Ray CreateFromLineSegment(const LineSegment& segment);
 
         const AZ::Vector3& GetOrigin() const;
         const AZ::Vector3& GetDirection() const;
-
-        Ray& operator=(const Ray& rhs);
-        bool operator==(const Ray& rhs) const;
-        bool operator!=(const Ray& rhs) const;
-
     private:
         AZ::Vector3 m_origin;
         AZ::Vector3 m_direction;
     };
-} // namespace O3DE
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Math/Ray.h
+++ b/Code/Framework/AzCore/AzCore/Math/Ray.h
@@ -24,9 +24,8 @@ namespace O3DE
 
         bool Intersects(const AZ::Aabb aabb) const;
 
-        const AZ::Vector3& getOrigin() const;
-        const AZ::Vector3& getDirection() const;
-
+        const AZ::Vector3& GetOrigin() const;
+        const AZ::Vector3& GetDirection() const;
 
         Ray& operator=(const Ray& rhs);
         bool operator==(const Ray& rhs) const;

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -295,6 +295,8 @@ set(FILES
     Math/IntersectSegment.inl
     Math/IntersectSegment.cpp
     Math/IntersectSegment.h
+    Math/LineSegment.cpp
+    Math/LineSegment.h
     Math/MathIntrinsics.h
     Math/MathReflection.cpp
     Math/MathReflection.h
@@ -331,6 +333,8 @@ set(FILES
     Math/Quaternion.inl
     Math/Quaternion.h
     Math/Random.h
+    Math/Ray.cpp
+    Math/Ray.h
     Math/Sfmt.cpp
     Math/Sfmt.h
     Math/ShapeIntersection.h

--- a/Code/Framework/AzCore/Tests/Math/LineSegmentTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/LineSegmentTests.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Math/Ray.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
 
 namespace UnitTest
 {
@@ -17,8 +18,8 @@ namespace UnitTest
     TEST(MATH_LineSegment, LineSegment_CreateFromStartAndEnd)
     {
         AZ::LineSegment segment(AZ::Vector3(0.0f, 15.5f, 12.0f), AZ::Vector3(12.0f, 0.0f, 4.0f));
-        EXPECT_TRUE(segment.GetStart().IsClose(AZ::Vector3(0.0f, 15.5f, 12.0f)));
-        EXPECT_TRUE(segment.GetEnd().IsClose(AZ::Vector3(12.0f, 0.0f, 4.0f)));
+        EXPECT_THAT(segment.GetStart(), IsClose(AZ::Vector3(0.0f, 15.5f, 12.0f)));
+        EXPECT_THAT(segment.GetEnd(), IsClose(AZ::Vector3(12.0f, 0.0f, 4.0f)));
     }
 
     TEST(MATH_LineSegment, LineSegment_CreateFromRayAndLength)
@@ -26,21 +27,21 @@ namespace UnitTest
         AZ::Ray ray(AZ::Vector3(0.0f, 0.5f, 12.0f), AZ::Vector3(15.0f, 0.0f, 3.0f).GetNormalized());
         AZ::LineSegment segment = AZ::LineSegment::CreateFromRayAndLength(ray, 25.0f);
 
-        EXPECT_TRUE(segment.GetStart().IsClose(AZ::Vector3(0.0f, 0.5f, 12.0f)));
-        EXPECT_TRUE(segment.GetEnd().IsClose(AZ::Vector3(0.0f, 0.5f, 12.0f) + (AZ::Vector3(15.0f, 0.0f, 3.0f).GetNormalized() * 25.0f)));
+        EXPECT_THAT(segment.GetStart(), IsClose(AZ::Vector3(0.0f, 0.5f, 12.0f)));
+        EXPECT_THAT(segment.GetEnd(), IsClose(AZ::Vector3(0.0f, 0.5f, 12.0f) + (AZ::Vector3(15.0f, 0.0f, 3.0f).GetNormalized() * 25.0f)));
     }
 
     TEST(MATH_LineSegment, LineSegment_GetDifference)
     {
         AZ::LineSegment segment(AZ::Vector3(13.0f, 15.5f, 12.0f), AZ::Vector3(12.0f, 51.0f, 4.0f));
 
-        EXPECT_TRUE(segment.GetDifference().IsClose(AZ::Vector3(-1.0f, 35.5f, -8.0f)));
+        EXPECT_THAT(segment.GetDifference(), IsClose(AZ::Vector3(-1.0f, 35.5f, -8.0f)));
     }
 
     TEST(MATH_LineSegment, LineSegment_GetPoint)
     {
         AZ::LineSegment segment(AZ::Vector3(4.0f, 5.0f, 6.0f), AZ::Vector3(5.0f, 10.0f, 2.0f));
         
-        EXPECT_TRUE(segment.GetPoint(0.5f).IsClose(AZ::Vector3(4.5f, 7.5f, 4.0f)));
+        EXPECT_THAT(segment.GetPoint(0.5f), IsClose(AZ::Vector3(4.5f, 7.5f, 4.0f)));
     }
 }

--- a/Code/Framework/AzCore/Tests/Math/LineSegmentTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/LineSegmentTests.cpp
@@ -6,11 +6,11 @@
  *
  */
 
+#include <AZTestShared/Math/MathTestHelpers.h>
 #include <AzCore/Math/LineSegment.h>
 #include <AzCore/Math/Ray.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/UnitTest/TestTypes.h>
-#include <AZTestShared/Math/MathTestHelpers.h>
 
 namespace UnitTest
 {

--- a/Code/Framework/AzCore/Tests/Math/LineSegmentTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/LineSegmentTests.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/LineSegment.h>
+#include <AzCore/Math/Ray.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/UnitTest/TestTypes.h>
+
+namespace UnitTest
+{
+
+    TEST(MATH_LineSegment, LineSegment_CreateFromStartAndEnd)
+    {
+        AZ::LineSegment segment(AZ::Vector3(0.0f, 15.5f, 12.0f), AZ::Vector3(12.0f, 0.0f, 4.0f));
+        EXPECT_TRUE(segment.GetStart().IsClose(AZ::Vector3(0.0f, 15.5f, 12.0f)));
+        EXPECT_TRUE(segment.GetEnd().IsClose(AZ::Vector3(12.0f, 0.0f, 4.0f)));
+    }
+
+    TEST(MATH_LineSegment, LineSegment_CreateFromRayAndLength)
+    {
+        AZ::Ray ray(AZ::Vector3(0.0f, 0.5f, 12.0f), AZ::Vector3(15.0f, 0.0f, 3.0f).GetNormalized());
+        AZ::LineSegment segment = AZ::LineSegment::CreateFromRayAndLength(ray, 25.0f);
+
+        EXPECT_TRUE(segment.GetStart().IsClose(AZ::Vector3(0.0f, 0.5f, 12.0f)));
+        EXPECT_TRUE(segment.GetEnd().IsClose(AZ::Vector3(0.0f, 0.5f, 12.0f) + (AZ::Vector3(15.0f, 0.0f, 3.0f).GetNormalized() * 25.0f)));
+    }
+
+    TEST(MATH_LineSegment, LineSegment_GetDifference)
+    {
+        AZ::LineSegment segment(AZ::Vector3(13.0f, 15.5f, 12.0f), AZ::Vector3(12.0f, 51.0f, 4.0f));
+
+        EXPECT_TRUE(segment.GetDifference().IsClose(AZ::Vector3(-1.0f, 35.5f, -8.0f)));
+    }
+
+    TEST(MATH_LineSegment, LineSegment_GetPoint)
+    {
+        AZ::LineSegment segment(AZ::Vector3(4.0f, 5.0f, 6.0f), AZ::Vector3(5.0f, 10.0f, 2.0f));
+        
+        EXPECT_TRUE(segment.GetPoint(0.5f).IsClose(AZ::Vector3(4.5f, 7.5f, 4.0f)));
+    }
+}

--- a/Code/Framework/AzCore/Tests/Math/RayTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/RayTests.cpp
@@ -6,10 +6,11 @@
  *
  */
 
-#include <AzCore/Math/Ray.h>
-#include <AzCore/Math/LineSegment.h>
-#include <AzCore/UnitTest/TestTypes.h>
 #include <AZTestShared/Math/MathTestHelpers.h>
+#include <AzCore/Math/LineSegment.h>
+#include <AzCore/Math/Ray.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/UnitTest/TestTypes.h>
 
 namespace UnitTest
 {
@@ -28,4 +29,11 @@ namespace UnitTest
         EXPECT_THAT(ray.GetOrigin(), IsClose(AZ::Vector3(0.0f, 0.5f, 12.0f)));
         EXPECT_THAT(ray.GetDirection(), IsClose((AZ::Vector3(15.0f, 0.0f, 3.0f) - AZ::Vector3(0.0f, 0.5f, 12.0f)).GetNormalized()));
     }
-}
+
+    TEST(MATH_Ray, Ray_CreateDirectionNonNormalizedFail)
+    {
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        AZ::Ray rayUnused = AZ::Ray(AZ::Vector3(), AZ::Vector3(3, 0, 0));
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Math/RayTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/RayTests.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/Ray.h>
+#include <AzCore/Math/LineSegment.h>
+#include <AzCore/UnitTest/TestTypes.h>
+
+namespace UnitTest
+{
+    TEST(MATH_Ray, Ray_CreateFromOriginAndDirection)
+    {
+        AZ::Ray ray(AZ::Vector3(0.0f, 0.5f, 12.0f), AZ::Vector3(3.0f, 0.0f, 4.0f).GetNormalized());
+        EXPECT_TRUE(ray.GetOrigin().IsClose(AZ::Vector3(0.0f, 0.5f, 12.0f)));
+        EXPECT_TRUE(ray.GetDirection().IsClose(AZ::Vector3(3.0f, 0.0f, 4.0f).GetNormalized()));
+    }
+
+    TEST(MATH_Ray, Ray_CreateFromLineSegment)
+    {
+        AZ::LineSegment segment(AZ::Vector3(0.0f, 0.5f, 12.0f), AZ::Vector3(15.0f, 0.0f, 3.0f));
+        AZ::Ray ray = AZ::Ray::CreateFromLineSegment(segment);
+
+        EXPECT_TRUE(ray.GetOrigin().IsClose(AZ::Vector3(0.0f, 0.5f, 12.0f)));
+        EXPECT_TRUE(ray.GetDirection().IsClose((AZ::Vector3(15.0f, 0.0f, 3.0f) - AZ::Vector3(0.0f, 0.5f, 12.0f)).GetNormalized()));
+    }
+}

--- a/Code/Framework/AzCore/Tests/Math/RayTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/RayTests.cpp
@@ -9,14 +9,15 @@
 #include <AzCore/Math/Ray.h>
 #include <AzCore/Math/LineSegment.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
 
 namespace UnitTest
 {
     TEST(MATH_Ray, Ray_CreateFromOriginAndDirection)
     {
         AZ::Ray ray(AZ::Vector3(0.0f, 0.5f, 12.0f), AZ::Vector3(3.0f, 0.0f, 4.0f).GetNormalized());
-        EXPECT_TRUE(ray.GetOrigin().IsClose(AZ::Vector3(0.0f, 0.5f, 12.0f)));
-        EXPECT_TRUE(ray.GetDirection().IsClose(AZ::Vector3(3.0f, 0.0f, 4.0f).GetNormalized()));
+        EXPECT_THAT(ray.GetOrigin(), IsClose(AZ::Vector3(0.0f, 0.5f, 12.0f)));
+        EXPECT_THAT(ray.GetDirection(), IsClose(AZ::Vector3(3.0f, 0.0f, 4.0f).GetNormalized()));
     }
 
     TEST(MATH_Ray, Ray_CreateFromLineSegment)
@@ -24,7 +25,7 @@ namespace UnitTest
         AZ::LineSegment segment(AZ::Vector3(0.0f, 0.5f, 12.0f), AZ::Vector3(15.0f, 0.0f, 3.0f));
         AZ::Ray ray = AZ::Ray::CreateFromLineSegment(segment);
 
-        EXPECT_TRUE(ray.GetOrigin().IsClose(AZ::Vector3(0.0f, 0.5f, 12.0f)));
-        EXPECT_TRUE(ray.GetDirection().IsClose((AZ::Vector3(15.0f, 0.0f, 3.0f) - AZ::Vector3(0.0f, 0.5f, 12.0f)).GetNormalized()));
+        EXPECT_THAT(ray.GetOrigin(), IsClose(AZ::Vector3(0.0f, 0.5f, 12.0f)));
+        EXPECT_THAT(ray.GetDirection(), IsClose((AZ::Vector3(15.0f, 0.0f, 3.0f) - AZ::Vector3(0.0f, 0.5f, 12.0f)).GetNormalized()));
     }
 }

--- a/Code/Framework/AzCore/Tests/Math/RayTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/RayTests.cpp
@@ -34,6 +34,12 @@ namespace UnitTest
     {
         AZ_TEST_START_TRACE_SUPPRESSION;
         AZ::Ray rayUnused = AZ::Ray(AZ::Vector3(), AZ::Vector3(3, 0, 0));
+#ifdef AZ_DEBUG_BUILD
+        // AZ_MATH_ASSERT only asserts during debug builds, so expect an assert here
         AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+#else
+        AZ_TEST_STOP_TRACE_SUPPRESSION(0);
+#endif
     }
+
 } // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -172,6 +172,8 @@ set(FILES
     Math/SfmtTests.cpp
     Math/SimdMathTests.cpp
     Math/SphereTests.cpp
+    Math/RayTests.cpp
+    Math/LineSegmentTests.cpp
     Math/SplineTests.cpp
     Math/TransformPerformanceTests.cpp
     Math/TransformTests.cpp


### PR DESCRIPTION
here is the start of introducing ray and LineSegment primative. I was thinking this could be a good strategy in standardizing things a bit. not sure how I would standardize IntersectSegment.h I was thinking along the lines of just using these primitive types in place of and introducing new method names if not consistent. 

If we do go this route is there any good reason to introduce methods to lets say get intersect ray with X and also having to implement it in the opposite case. i.e intersect AABB and AABB would provide an intersection method for a ray. 

There are some edge cases where we store the reciprocal of the direction. not sure if Ray should track that by default and the two places where I see this being uses Its being calculated when calling the method negating any reason to cache the direction?  

- IntersectRayAABB2
- IntersectRayAABB


discussion: https://discord.com/channels/805939474655346758/816043622558335046/971501493519790130
