### PR TITLE
Remedy for scene pipeline threading issue

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
@@ -422,7 +422,8 @@ namespace AZ
 
                         // this assert typically happens when a shader needs a particular Srg (e.g., the ViewSrg) but the code did not bind it,
                         // check the pass code in this callstack to determine why it was not bound
-                        AZ_Assert(false, "ShaderResourceGroup in slot '%d' is null at DrawItem submit time. This is not valid and means the shader is expecting an Srg that is not currently bound in the pipeline. Current bindings: %s",
+                        AZ_Assert(false, "The DrawItem being submitted doesn't provide an SRG for slot '%d', which the shader is expecting. If this slot is for a Pass, View or Scene SRG, this likely means "
+                            "the pass didn't collect it (for the view SRG, check if your pass provides a PipelineViewTag). The SRGs currently provided by the DrawItem are: %s",
                             srgSlot,
                             slotSrgString.c_str());
 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
@@ -422,7 +422,7 @@ namespace AZ
 
                         // this assert typically happens when a shader needs a particular Srg (e.g., the ViewSrg) but the code did not bind it,
                         // check the pass code in this callstack to determine why it was not bound
-                        AZ_Assert(false, "ShaderResourceGroup in slot '%d' is null at DrawItem submit time. This is not valid and means the shader is expecting an Srg that isF not currently bound in the pipeline. Current bindings: %s",
+                        AZ_Assert(false, "ShaderResourceGroup in slot '%d' is null at DrawItem submit time. This is not valid and means the shader is expecting an Srg that is not currently bound in the pipeline. Current bindings: %s",
                             srgSlot,
                             slotSrgString.c_str());
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -658,12 +658,7 @@ namespace AZ
 // This macro will break in pass code (functions that belong to Pass or it's child classes)
 // if the name of the pass being executed is the same as the one specified for targeted debugging
 // in the pass system (see functions with "TargetedPassDebugging" above)
-#define AZ_RPI_BREAK_ON_TARGET_PASS                                                          \
-    if(!GetName().IsEmpty() &&                                                               \
-        GetName() == AZ::RPI::PassSystemInterface::Get()->GetTargetedPassDebuggingName())    \
-    {                                                                                        \
-        AZ::Debug::Trace::Break();                                                           \
-    }
+#define AZ_RPI_BREAK_ON_TARGET_PASS  AZ::RPI::PassSystemInterface::Get()->DebugBreakOnPass(this);
 
 #else
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -36,6 +36,7 @@
     friend class PassFactory;                                                       \
     friend class PassLibrary;                                                       \
     friend class PassSystem;                                                        \
+    friend class PassContainer;                                                     \
     friend class ParentPass;                                                        \
     friend class RenderPipeline;                                                    \
     friend class UnitTest::PassTests;                                               \

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -127,40 +127,40 @@ namespace AZ
             // --- Simple getters/setters ---
 
             //! Returns the name of the pass (example: Bloom)
-            const Name& GetName() const;
+            const Name& GetName() const { return m_name; }
 
             //! Return the path name of the pass (example: Root.SwapChain.Bloom)
-            const Name& GetPathName() const;
+            const Name& GetPathName() const { return m_path; }
 
             //! Returns the depth of this pass in the tree hierarchy (Root depth is 0)
-            uint32_t GetTreeDepth() const;
+            uint32_t GetTreeDepth() const { return m_treeDepth; }
 
             //! Returns the number of input attachment bindings
-            uint32_t GetInputCount() const;
+            uint32_t GetInputCount() const { return uint32_t(m_inputBindingIndices.size()); }
 
             //! Returns the number of input/output attachment bindings
-            uint32_t GetInputOutputCount() const;
+            uint32_t GetInputOutputCount() const { return uint32_t(m_inputOutputBindingIndices.size()); }
 
             //! Returns the number of output attachment bindings
-            uint32_t GetOutputCount() const;
+            uint32_t GetOutputCount() const { return uint32_t(m_outputBindingIndices.size()); }
 
             //! Returns the pass template which was used for create this pass.
             //! It may return nullptr if the pass wasn't create from a template
-            const PassTemplate* GetPassTemplate() const;
+            const PassTemplate* GetPassTemplate() const { return m_template.get(); }
 
             //! Enable/disable this pass
             //! If the pass is disabled, it (and any children if it's a ParentPass) won't be rendered.  
             void SetEnabled(bool enabled);
-            virtual bool IsEnabled() const;
+            virtual bool IsEnabled() const { return m_flags.m_enabled; }
 
-            bool HasDrawListTag() const;
-            bool HasPipelineViewTag() const;
+            bool HasDrawListTag() const { return m_flags.m_hasDrawListTag; }
+            bool HasPipelineViewTag() const { return m_flags.m_hasPipelineViewTag; }
 
             // Searches this pass's attachment bindings for one with the provided Name (nullptr if none found)
             PassAttachmentBinding* FindAttachmentBinding(const Name& slotName);
 
             //! Return the set of attachment bindings
-            PassAttachmentBindingListView GetAttachmentBindings() const;
+            PassAttachmentBindingListView GetAttachmentBindings() const { return m_attachmentBindings; }
 
             //! Casts the pass to a parent pass if valid, else returns nullptr
             ParentPass* AsParent();
@@ -216,7 +216,7 @@ namespace AZ
 
             //! Set render pipeline this pass belongs to
             virtual void SetRenderPipeline(RenderPipeline* pipeline);
-            RenderPipeline* GetRenderPipeline() const;
+            RenderPipeline* GetRenderPipeline() const { return m_pipeline; }
 
             Scene* GetScene() const;
 
@@ -236,10 +236,10 @@ namespace AZ
             PipelineStatisticsResult GetLatestPipelineStatisticsResult() const;
 
             //! Enables/Disables Timestamp queries for this pass
-            virtual void SetTimestampQueryEnabled(bool enable);
+            virtual void SetTimestampQueryEnabled(bool enable) { m_flags.m_timestampQueryEnabled = enable; }
 
             //! Enables/Disables PipelineStatistics queries for this pass
-            virtual void SetPipelineStatisticsQueryEnabled(bool enable);
+            virtual void SetPipelineStatisticsQueryEnabled(bool enable) { m_flags.m_pipelineStatisticsQueryEnabled = enable; }
 
             //! Readback an attachment attached to the specified slot name
             //! @param readback The AttachmentReadback object which is used for readback. Its callback function will be called when readback is finished.
@@ -250,10 +250,10 @@ namespace AZ
             bool ReadbackAttachment(AZStd::shared_ptr<AttachmentReadback> readback, const Name& slotName, PassAttachmentReadbackOption option = PassAttachmentReadbackOption::Output);
 
             //! Returns whether the Timestamp queries is enabled/disabled for this pass
-            bool IsTimestampQueryEnabled() const;
+            bool IsTimestampQueryEnabled() const { return m_flags.m_timestampQueryEnabled; }
 
             //! Returns whether the PipelineStatistics queries is enabled/disabled for this pass
-            bool IsPipelineStatisticsQueryEnabled() const;
+            bool IsPipelineStatisticsQueryEnabled() const { return m_flags.m_pipelineStatisticsQueryEnabled; }
 
             //! Helper function to print spaces to indent the pass
             void PrintIndent(AZStd::string& stringOutput, uint32_t indent) const;
@@ -280,9 +280,9 @@ namespace AZ
             void PrintBindingsWithoutAttachments(uint32_t slotTypeMask) const;
 
             //! Returns pointer to the parent pass
-            ParentPass* GetParent() const;
+            ParentPass* GetParent() const { return m_parent; }
 
-            PassState GetPassState() const;
+            PassState GetPassState() const { return m_state; }
 
             // Update all bindings on this pass that are connected to bindings on other passes
             void UpdateConnectedBindings();
@@ -489,10 +489,10 @@ namespace AZ
 
         private:
             // Return the Timestamp result of this pass
-            virtual TimestampResult GetTimestampResultInternal() const;
+            virtual TimestampResult GetTimestampResultInternal() const { return TimestampResult(); }
 
             // Return the PipelineStatistics result of this pass
-            virtual PipelineStatisticsResult GetPipelineStatisticsResultInternal() const;
+            virtual PipelineStatisticsResult GetPipelineStatisticsResultInternal() const { return PipelineStatisticsResult(); }
 
             // Used to maintain references to imported attachments so they're underlying
             // buffers and images don't get deleted during attachment build phase

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassContainer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassContainer.h
@@ -49,6 +49,14 @@ namespace AZ::RPI
 
         bool m_passesChangedThisFrame = false;
         PassContainerState m_state = PassContainerState::Unitialized;
+
+        template<class Predicate>
+        void EraseFromLists(Predicate predicate)
+        {
+            //erase_if(m_removePassList,      predicate);
+            erase_if(m_buildPassList,       predicate);
+            erase_if(m_initializePassList,  predicate);
+        }
     };
 
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassContainer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassContainer.h
@@ -15,19 +15,6 @@
 
 namespace AZ::RPI
 {
-    // Enum to track the different states of PassContainer (used for validation and debugging)
-    enum class PassContainerState : u32
-    {
-        Unitialized,        // Default state, 
-        RemovingPasses,     // Processing passes queued for Removal. Transitions to Idle
-        BuildingPasses,     // Processing passes queued for Build (and their child passes). Transitions to Idle
-        InitializingPasses, // Processing passes queued for Initialization (and their child passes). Transitions to Idle
-        ValidatingPasses,   // Validating the hierarchy under root pass is in a valid state after Build and Initialization. Transitions to Idle
-        Idle,               // Container is idle and can transition to any other state (except FrameEnd)
-        Rendering,          // Rendering a frame. Transitions to FrameEnd
-        FrameEnd,           // Finishing a frame. Transitions to Idle
-    };
-
     // Helper class used by the PassSystem and RenderPipeline to contain and update passes
     // Passes owned by the container are stored as a tree under the container's root pass
     // The container has queues for pass building, initialization and removal. These queues
@@ -61,11 +48,7 @@ namespace AZ::RPI
         AZStd::vector< Ptr<Pass> > m_removePassList;
         AZStd::vector< Ptr<Pass> > m_initializePassList;
 
-        // State enum used for validation and debugging
-        PassContainerState m_state = PassContainerState::Unitialized;
-
         // Tracks whether any changes to the passes in this container have occurred in the frame
         bool m_passesChangedThisFrame = false;
-
     };
 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassContainer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassContainer.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+// This header file is for declaring types used for RPI System classes to avoid recursive includes
+ 
+#include <Atom/RPI.Public/Base.h>
+#include <Atom/RPI.Public/Pass/Pass.h>
+#include <Atom/RPI.Public/Pass/ParentPass.h>
+
+namespace AZ::RPI
+{
+    // Enum to track the different states of PassContainer (used for validation and debugging)
+    enum class PassContainerState : u32
+    {
+        Unitialized,        // Default state, 
+        RemovingPasses,     // Processing passes queued for Removal. Transitions to Idle
+        BuildingPasses,     // Processing passes queued for Build (and their child passes). Transitions to Idle
+        InitializingPasses, // Processing passes queued for Initialization (and their child passes). Transitions to Idle
+        ValidatingPasses,   // Validating the hierarchy under root pass is in a valid state after Build and Initialization. Transitions to Idle
+        Idle,               // Container is idle and can transition to any other state (except FrameEnd)
+        Rendering,          // Rendering a frame. Transitions to FrameEnd
+        FrameEnd,           // Finishing a frame. Transitions to Idle
+    };
+
+    class PassContainer
+    {
+        friend class PassSystem;
+        friend class RenderPipeline;
+
+        void RemovePasses();
+        void BuildPasses();
+        void InitializePasses();
+        void Validate();
+        void ProcessQueuedChanges(bool& outChanged);
+
+        Ptr<ParentPass> m_rootPass = nullptr;
+
+        // Lists for queuing passes for various function calls
+        // Name of the list reflects the pass function it will call
+        AZStd::vector< Ptr<Pass> > m_buildPassList;
+        AZStd::vector< Ptr<Pass> > m_removePassList;
+        AZStd::vector< Ptr<Pass> > m_initializePassList;
+
+        bool m_passesChangedThisFrame = false;
+        PassContainerState m_state = PassContainerState::Unitialized;
+    };
+
+
+}

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
@@ -11,6 +11,7 @@
 
 #include <Atom/RPI.Public/Pass/ParentPass.h>
 #include <Atom/RPI.Public/Pass/Pass.h>
+#include <Atom/RPI.Public/Pass/PassContainer.h>
 #include <Atom/RPI.Public/Pass/PassLibrary.h>
 #include <Atom/RPI.Public/Pass/PassFactory.h>
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>
@@ -69,13 +70,14 @@ namespace AZ
             bool LoadPassTemplateMappings(const AZStd::string& templateMappingPath) override;
             void WriteTemplateToFile(const PassTemplate& passTemplate, AZStd::string_view assetFilePath) override;
             void DebugPrintPassHierarchy() override;
-            bool IsHotReloading() const override;
-            void SetHotReloading(bool hotReloading) override;
             void SetTargetedPassDebuggingName(const AZ::Name& targetPassName) override;
             const AZ::Name& GetTargetedPassDebuggingName() const override;
             void ConnectEvent(OnReadyLoadTemplatesEvent::Handler& handler) override;
             PassSystemState GetState() const override;
             SwapChainPass* FindSwapChainPass(AzFramework::NativeWindowHandle windowHandle) const override;
+            void DebugBreakOnPass(const Pass* pass) const override;
+            void AddRenderPipeline(RenderPipelinePtr renderPipeline) override;
+            void RemoveRenderPipeline(RenderPipelinePtr renderPipeline) override;
 
             // PassSystemInterface statistics related functions
             void IncrementFrameDrawItemCount(u32 numDrawItems) override;
@@ -126,11 +128,10 @@ namespace AZ
             // Resets the frame statistic counters
             void ResetFrameStatistics();
 
-            // Lists for queuing passes for various function calls
-            // Name of the list reflects the pass function it will call
-            AZStd::vector< Ptr<Pass> > m_buildPassList;
-            AZStd::vector< Ptr<Pass> > m_removePassList;
-            AZStd::vector< Ptr<Pass> > m_initializePassList;
+            // Collection of passes that don't belong to any rendering pipeline
+            PassContainer m_passesWithoutPipeline;
+
+            AZStd::vector< RenderPipelinePtr > m_renderPipelines;
 
             // Library of pass descriptors that can be instantiated through data driven pass requests
             PassLibrary m_passLibrary;
@@ -140,9 +141,6 @@ namespace AZ
 
             // The root of the pass tree hierarchy
             Ptr<ParentPass> m_rootPass = nullptr;
-
-            // Whether the Pass Hierarchy changed
-            bool m_passHierarchyChanged = true;
 
             // Whether the Pass System is currently hot reloading passes 
             bool m_isHotReloading = false;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
@@ -129,10 +129,11 @@ namespace AZ
             // Resets the frame statistic counters
             void ResetFrameStatistics();
 
+            // List of render pipelines to be rendered by the pass system
+            AZStd::vector< RenderPipeline* > m_renderPipelines;
+
             // Collection of passes that don't belong to any rendering pipeline
             PassContainer m_passesWithoutPipeline;
-
-            AZStd::vector< RenderPipeline* > m_renderPipelines;
 
             // Library of pass descriptors that can be instantiated through data driven pass requests
             PassLibrary m_passLibrary;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
@@ -78,6 +78,7 @@ namespace AZ
             void DebugBreakOnPass(const Pass* pass) const override;
             void AddRenderPipeline(RenderPipeline* renderPipeline) override;
             void RemoveRenderPipeline(RenderPipeline* renderPipeline) override;
+            void AddNonePipelinePass(const Ptr<Pass>& pass) override;
 
             // PassSystemInterface statistics related functions
             void IncrementFrameDrawItemCount(u32 numDrawItems) override;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
@@ -76,8 +76,8 @@ namespace AZ
             PassSystemState GetState() const override;
             SwapChainPass* FindSwapChainPass(AzFramework::NativeWindowHandle windowHandle) const override;
             void DebugBreakOnPass(const Pass* pass) const override;
-            void AddRenderPipeline(RenderPipelinePtr renderPipeline) override;
-            void RemoveRenderPipeline(RenderPipelinePtr renderPipeline) override;
+            void AddRenderPipeline(RenderPipeline* renderPipeline) override;
+            void RemoveRenderPipeline(RenderPipeline* renderPipeline) override;
 
             // PassSystemInterface statistics related functions
             void IncrementFrameDrawItemCount(u32 numDrawItems) override;
@@ -131,7 +131,7 @@ namespace AZ
             // Collection of passes that don't belong to any rendering pipeline
             PassContainer m_passesWithoutPipeline;
 
-            AZStd::vector< RenderPipelinePtr > m_renderPipelines;
+            AZStd::vector< RenderPipeline* > m_renderPipelines;
 
             // Library of pass descriptors that can be instantiated through data driven pass requests
             PassLibrary m_passLibrary;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystemInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystemInterface.h
@@ -12,6 +12,7 @@
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/string/string_view.h>
 
+#include <Atom/RPI.Public/Base.h>
 #include <Atom/RPI.Public/Pass/PassDefines.h>
 
 #include <Atom/RPI.Reflect/Base.h>
@@ -39,32 +40,15 @@ namespace AZ
         // Enum to track the different execution phases of the Pass System
         enum class PassSystemState : u32
         {
-            // Default state, 
-            Unitialized,
-
-            // Initial Pass System setup. Transitions to Idle
-            InitializingPassSystem,
-
-            // Pass System is processing passes queued for Removal. Transitions to Idle
-            RemovingPasses,
-
-            // Pass System is processing passes queued for Build (and their child passes). Transitions to Idle
-            BuildingPasses,
-
-            // Pass System is processing passes queued for Initialization (and their child passes). Transitions to Idle
-            InitializingPasses,
-
-            // Pass System is validating that the Pass hierarchy is in a valid state after Build and Initialization. Transitions to Idle
-            ValidatingPasses,
-
-            // Pass System is idle and can transition to any other state (except FrameEnd)
-            Idle,
-
-            // Pass System is currently rendering a frame. Transitions to FrameEnd
-            Rendering,
-
-            // Pass System is finishing rendering a frame. Transitions to Idle
-            FrameEnd,
+            Unitialized,            // Default state
+            InitializingPassSystem, // Initial Pass System setup. Transitions to Idle
+            RemovingPasses,         // Processing passes queued for Removal. Transitions to Idle
+            BuildingPasses,         // Processing passes queued for Build (and their child passes). Transitions to Idle
+            InitializingPasses,     // Processing passes queued for Initialization (and their child passes). Transitions to Idle
+            ValidatingPasses,       // Validating that the Pass hierarchy is in a valid state after Build and Initialization. Transitions to Idle
+            Idle,                   // Idle state. Can transition to any other state (except FrameEnd)
+            Rendering,              // Rendering a frame. Transitions to FrameEnd
+            FrameEnd,               // Finishing a frame. Transitions to Idle
         };
 
         //! Frame counters used for collecting statistics
@@ -101,6 +85,9 @@ namespace AZ
             //! Returns the root of the pass hierarchy
             virtual const Ptr<ParentPass>& GetRootPass() = 0;
 
+            virtual void AddRenderPipeline(RenderPipelinePtr renderPipeline) = 0;
+            virtual void RemoveRenderPipeline(RenderPipelinePtr renderPipeline) = 0;
+
             //! Processes pass tree changes that were queued by QueueFor*() functions. This is called
             //! automatically in FrameUpdate(), but may be called manually when needed, like when 
             //! initializing a scene;
@@ -118,12 +105,6 @@ namespace AZ
 
             //! Prints the entire pass hierarchy from the root
             virtual void DebugPrintPassHierarchy() = 0;
-
-            //! Returns whether the Pass System is currently hot reloading
-            virtual bool IsHotReloading() const = 0;
-
-            //! Sets whether the Pass System is currently hot reloading
-            virtual void SetHotReloading(bool hotReloading) = 0;
 
             //! The pass system enables targeted debugging of a specific pass given the name of the pass
             //! These are the setters and getters for the specific Pass's name
@@ -151,6 +132,12 @@ namespace AZ
 
             // Get frame statistics from the Pass System
             virtual PassSystemFrameStatistics GetFrameStatistics() = 0;
+
+            // Function for debug breaking into a pass given provided the criteria for the break are met
+            // By default the criteria is that the pass's name matches the TargetedPassDebuggingName (see above)
+            // Users can add customize the logic in this function for their own debug purposes, but these customizations
+            // should never be submitted.
+            virtual void DebugBreakOnPass(const Pass* pass) const = 0;
 
             // --- Pass Factory related functionality ---
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystemInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystemInterface.h
@@ -85,8 +85,8 @@ namespace AZ
             //! Returns the root of the pass hierarchy
             virtual const Ptr<ParentPass>& GetRootPass() = 0;
 
-            virtual void AddRenderPipeline(RenderPipelinePtr renderPipeline) = 0;
-            virtual void RemoveRenderPipeline(RenderPipelinePtr renderPipeline) = 0;
+            virtual void AddRenderPipeline(RenderPipeline* renderPipeline) = 0;
+            virtual void RemoveRenderPipeline(RenderPipeline* renderPipeline) = 0;
 
             //! Processes pass tree changes that were queued by QueueFor*() functions. This is called
             //! automatically in FrameUpdate(), but may be called manually when needed, like when 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystemInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystemInterface.h
@@ -85,8 +85,14 @@ namespace AZ
             //! Returns the root of the pass hierarchy
             virtual const Ptr<ParentPass>& GetRootPass() = 0;
 
+            //! Registers a render pipeline with the pass system
             virtual void AddRenderPipeline(RenderPipeline* renderPipeline) = 0;
+
+            //! Removes a render pipeline from the pass system
             virtual void RemoveRenderPipeline(RenderPipeline* renderPipeline) = 0;
+
+            //! Function for adding passes that do not pertain to any render pipeline
+            virtual void AddNonePipelinePass(const Ptr<Pass>& pass) = 0;
 
             //! Processes pass tree changes that were queued by QueueFor*() functions. This is called
             //! automatically in FrameUpdate(), but may be called manually when needed, like when 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystemInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystemInterface.h
@@ -91,7 +91,7 @@ namespace AZ
             //! Removes a render pipeline from the pass system
             virtual void RemoveRenderPipeline(RenderPipeline* renderPipeline) = 0;
 
-            //! Function for adding passes that do not pertain to any render pipeline
+            //! Used to add passes that do not belong to any render pipeline
             virtual void AddNonePipelinePass(const Ptr<Pass>& pass) = 0;
 
             //! Processes pass tree changes that were queued by QueueFor*() functions. This is called
@@ -139,10 +139,10 @@ namespace AZ
             // Get frame statistics from the Pass System
             virtual PassSystemFrameStatistics GetFrameStatistics() = 0;
 
-            // Function for debug breaking into a pass given provided the criteria for the break are met
-            // By default the criteria is that the pass's name matches the TargetedPassDebuggingName (see above)
-            // Users can add customize the logic in this function for their own debug purposes, but these customizations
-            // should never be submitted.
+            // Function for debug breaking into a pass provided the criteria for the break are met
+            // The default criteria is that the pass's name matches the TargetedPassDebuggingName (see above)
+            // Users can customize the logic in this function to suit their own debugging needs
+            // BUT these customizations should never be submitted and remain local changes only
             virtual void DebugBreakOnPass(const Pass* pass) const = 0;
 
             // --- Pass Factory related functionality ---

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassUtils.h
@@ -18,50 +18,53 @@
 #include <Atom/RPI.Reflect/Pass/PassRequest.h>
 #include <Atom/RPI.Reflect/Pass/PassTemplate.h>
 
-namespace AZ::RPI
+namespace AZ
 {
-    namespace PassUtils
+    namespace RPI
     {
-        //! Function for applying shader data mappings from a PassDescriptor to a shader resource group
-        bool BindDataMappingsToSrg(const PassDescriptor& descriptor, ShaderResourceGroup* shaderResourceGroup);
-
-        //! Retrieves PassData from a PassDescriptor
-        const PassData* GetPassData(const PassDescriptor& descriptor);
-
-        //! Finds all PipelineGlobalConnections in the descriptor and adds them to the provided list
-        void ExtractPipelineGlobalConnections(const AZStd::shared_ptr<PassData>& passData, PipelineGlobalConnectionList& outList);
-
-        //! Retrieves PassData from a PassDescriptor
-        AZStd::shared_ptr<PassData> GetPassDataPtr(const PassDescriptor& descriptor);
-
-        //! Templated function for retrieving specific data types from a PassDescriptor
-        template<typename PassDataType>
-        const PassDataType* GetPassData(const PassDescriptor& descriptor)
+        namespace PassUtils
         {
-            const PassDataType* passData = nullptr;
+            //! Function for applying shader data mappings from a PassDescriptor to a shader resource group
+            bool BindDataMappingsToSrg(const PassDescriptor& descriptor, ShaderResourceGroup* shaderResourceGroup);
 
-            // Try custom data from PassRequest
-            if (descriptor.m_passRequest != nullptr)
+            //! Retrieves PassData from a PassDescriptor
+            const PassData* GetPassData(const PassDescriptor& descriptor);
+
+            //! Finds all PipelineGlobalConnections in the descriptor and adds them to the provided list
+            void ExtractPipelineGlobalConnections(const AZStd::shared_ptr<PassData>& passData, PipelineGlobalConnectionList& outList);
+
+            //! Retrieves PassData from a PassDescriptor
+            AZStd::shared_ptr<PassData> GetPassDataPtr(const PassDescriptor& descriptor);
+
+            //! Templated function for retrieving specific data types from a PassDescriptor
+            template<typename PassDataType>
+            const PassDataType* GetPassData(const PassDescriptor& descriptor)
             {
-                passData = azrtti_cast<const PassDataType*>(descriptor.m_passRequest->m_passData.get());
+                const PassDataType* passData = nullptr;
+
+                // Try custom data from PassRequest
+                if (descriptor.m_passRequest != nullptr)
+                {
+                    passData = azrtti_cast<const PassDataType*>(descriptor.m_passRequest->m_passData.get());
+                }
+
+                // Try custom data from PassTemplate
+                if (passData == nullptr && descriptor.m_passTemplate != nullptr)
+                {
+                    passData = azrtti_cast<const PassDataType*>(descriptor.m_passTemplate->m_passData.get());
+                }
+
+                if (passData == nullptr)
+                {
+                    passData = azrtti_cast<const PassDataType*>(descriptor.m_passData.get());
+                }
+
+                return passData;
             }
 
-            // Try custom data from PassTemplate
-            if (passData == nullptr && descriptor.m_passTemplate != nullptr)
-            {
-                passData = azrtti_cast<const PassDataType*>(descriptor.m_passTemplate->m_passData.get());
-            }
-
-            if (passData == nullptr)
-            {
-                passData = azrtti_cast<const PassDataType*>(descriptor.m_passData.get());
-            }
-
-            return passData;
+            void SortPassListAscending(AZStd::vector< Ptr<Pass> >& passList);
+            void SortPassListDescending(AZStd::vector< Ptr<Pass> >& passList);
         }
-
-        void SortPassListAscending(AZStd::vector< Ptr<Pass> >& passList);
-        void SortPassListDescending(AZStd::vector< Ptr<Pass> >& passList);
     }
 }
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
@@ -139,6 +139,9 @@ namespace AZ
 
             const Ptr<ParentPass>& GetRootPass() const;
 
+            //! Processes passes in the pipeline that are queued for build, initialization or removal
+            void ProcessQueuedPassChanges();
+
             //! This function need to be called by Pass class when any passes are added/removed in this pipeline's pass tree.
             void SetPassModified();
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
@@ -11,6 +11,7 @@
 #include <Atom/RHI/DrawList.h>
 
 #include <Atom/RPI.Public/Base.h>
+#include <Atom/RPI.Public/Pass/PassContainer.h>
 #include <Atom/RPI.Public/Pass/ParentPass.h>
 
 #include <Atom/RPI.Reflect/Pass/PassAsset.h>
@@ -80,6 +81,7 @@ namespace AZ
         class RenderPipeline
         {
             friend class Pass;
+            friend class PassSystem;
             friend class Scene;
 
         public:
@@ -240,6 +242,9 @@ namespace AZ
             // Build pipeline views from the pipeline pass tree. It's usually called when pass tree changed.
             void BuildPipelineViews();
 
+            void PassSystemFrameBegin(Pass::FramePrepareParams params);
+            void PassSystemFrameEnd();
+
             //////////////////////////////////////////////////
             // Functions accessed by Scene class
             
@@ -261,14 +266,12 @@ namespace AZ
             // End of functions accessed by Scene class
             //////////////////////////////////////////////////
 
-
             RenderMode m_renderMode = RenderMode::RenderEveryTick;
 
             // The Scene this pipeline was added to.
             Scene* m_scene = nullptr;
 
-            // Pass tree which contains all the passes in this render pipeline.
-            Ptr<ParentPass> m_rootPass;
+            PassContainer m_passes;
 
             // Attachment bindings/connections that can be referenced from any pass in the pipeline in a global manner
             AZStd::vector<PipelineGlobalBinding> m_pipelineGlobalConnections;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
@@ -245,7 +245,10 @@ namespace AZ
             // Build pipeline views from the pipeline pass tree. It's usually called when pass tree changed.
             void BuildPipelineViews();
 
+            // Called by Pass System at the start of rendering the frame
             void PassSystemFrameBegin(Pass::FramePrepareParams params);
+
+            // Called by Pass System at the end of rendering the frame
             void PassSystemFrameEnd();
 
             //////////////////////////////////////////////////
@@ -274,6 +277,7 @@ namespace AZ
             // The Scene this pipeline was added to.
             Scene* m_scene = nullptr;
 
+            // Holds the passes belonging to the pipeline
             PassContainer m_passes;
 
             // Attachment bindings/connections that can be referenced from any pass in the pipeline in a global manner

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -201,7 +201,7 @@ namespace AZ
 
 
             // Helper function to wait for end of TaskGraph and then delete the TaskGraphEvent
-            void WaitAndCleanTGEvent(AZStd::unique_ptr<AZ::TaskGraphEvent>&& completionTGEvent);
+            void WaitAndCleanTGEvent();
 
             // Helper function for wait and clean up a completion job
             void WaitAndCleanCompletionJob(AZ::JobCompletion*& completionJob);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -23,7 +23,6 @@
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/std/algorithm.h>
 
-#pragma optimize("", off)
 
 namespace AZ
 {
@@ -243,5 +242,3 @@ namespace AZ
         
     }   // namespace RPI
 }   // namespace AZ
-
-#pragma optimize("", on)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -23,6 +23,8 @@
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/std/algorithm.h>
 
+#pragma optimize("", off)
+
 namespace AZ
 {
     namespace RPI
@@ -241,3 +243,5 @@ namespace AZ
         
     }   // namespace RPI
 }   // namespace AZ
+
+#pragma optimize("", on)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -36,6 +36,7 @@
 #include <Atom/RPI.Reflect/Pass/PassName.h>
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 
+#pragma optimize("", off)
 
 namespace AZ
 {
@@ -1363,17 +1364,23 @@ namespace AZ
 
         void Pass::SetRenderPipeline(RenderPipeline* pipeline)
         {
+            AZ_Assert(!m_pipeline || !pipeline || m_pipeline == pipeline,
+                "Switching passes between pipelines is not supported and may result in undefined behavior");
+
             if (m_pipeline != pipeline)
             {
                 m_pipeline = pipeline;
 
-                // Re-queue
-                PassState currentState = m_state;
-                m_queueState = PassQueueState::NoQueue;
-                QueueForBuildAndInitialization();
-                if (currentState == PassState::Reset)
+                // Re-queue for new pipeline. 
+                if (m_pipeline != nullptr)
                 {
-                    m_state = PassState::Reset;
+                    PassState currentState = m_state;
+                    m_queueState = PassQueueState::NoQueue;
+                    QueueForBuildAndInitialization();
+                    if (currentState == PassState::Reset)
+                    {
+                        m_state = PassState::Reset;
+                    }
                 }
             }
         }
@@ -1746,3 +1753,4 @@ namespace AZ
     }   // namespace RPI
 }   // namespace AZ
 
+#pragma optimize("", on)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -619,6 +619,8 @@ namespace AZ
                     AZ_RPI_PASS_WARNING(false,
                         "Pass::ProcessConnection - Pass [%s] is no longer part of the heirarchy and about to be removed",
                         m_path.GetCStr());
+
+                    __debugbreak();
                 }
                 else if (foundPass)
                 {
@@ -626,6 +628,8 @@ namespace AZ
                         m_path.GetCStr(),
                         connectedSlotName.GetCStr(),
                         connectedPassName.GetCStr());
+
+                    __debugbreak();
                 }
                 else
                 {
@@ -633,6 +637,8 @@ namespace AZ
                         false, "Pass::ProcessConnection - Pass [%s] could not find neighbor or child pass named [%s].",
                         m_path.GetCStr(),
                         connectedPassName.GetCStr());
+
+                    __debugbreak();
                 }
             }
         }
@@ -1356,6 +1362,12 @@ namespace AZ
             }
 
             AZ_Assert(m_state == PassState::Idle, "Pass::FrameBegin - Pass [%s] is attempting to render, but is not in the Idle state.", m_path.GetCStr());
+
+            if (m_state != PassState::Idle)
+            {
+                __debugbreak();
+            }
+
             m_state = PassState::Rendering;
 
             UpdateConnectedInputBindings();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -98,17 +98,10 @@ namespace AZ
             return desc;
         }
 
-        // --- Enable/Disable ---
-
         void Pass::SetEnabled(bool enabled)
         {
             m_flags.m_enabled = enabled;
             OnHierarchyChange();
-        }
-
-        bool Pass::IsEnabled() const
-        {
-            return m_flags.m_enabled;
         }
 
         // --- Error Logging ---
@@ -184,18 +177,6 @@ namespace AZ
             m_state = PassState::Orphaned;
         }
 
-        // --- Getters & Setters ---
-
-        PassState Pass::GetPassState() const
-        {
-            return m_state;
-        }
-
-        ParentPass* Pass::GetParent() const
-        {
-            return m_parent;
-        }
-
         ParentPass* Pass::AsParent()
         {
             return azrtti_cast<ParentPass*>(this);
@@ -206,40 +187,7 @@ namespace AZ
             return azrtti_cast<const ParentPass*>(this);
         }
 
-        const Name& Pass::GetName() const
-        {
-            return m_name;
-        }
-
-        const Name& Pass::GetPathName() const
-        {
-            return m_path;
-        }
-
-        uint32_t Pass::GetTreeDepth() const
-        {
-            return m_treeDepth;
-        }
-
-        PassAttachmentBindingListView Pass::GetAttachmentBindings() const
-        {
-            return m_attachmentBindings;
-        }
-
-        uint32_t Pass::GetInputCount() const
-        {
-            return uint32_t(m_inputBindingIndices.size());
-        }
-
-        uint32_t Pass::GetInputOutputCount() const
-        {
-            return uint32_t(m_inputOutputBindingIndices.size());
-        }
-
-        uint32_t Pass::GetOutputCount() const
-        {
-            return uint32_t(m_outputBindingIndices.size());
-        }
+        // --- Bindings ---
 
         PassAttachmentBinding& Pass::GetInputBinding(uint32_t index)
         {
@@ -257,11 +205,6 @@ namespace AZ
         {
             uint32_t bindingIndex = m_outputBindingIndices[index];
             return m_attachmentBindings[bindingIndex];
-        }
-
-        const PassTemplate* Pass::GetPassTemplate() const
-        {
-            return m_template.get();
         }
 
         void Pass::AddAttachmentBinding(PassAttachmentBinding attachmentBinding)
@@ -1405,21 +1348,11 @@ namespace AZ
         }
 
         // --- RenderPipeline, PipelineViewTag and DrawListTag ---
-        
-        bool Pass::HasDrawListTag() const
-        {
-            return m_flags.m_hasDrawListTag;
-        }
-        
+                
         RHI::DrawListTag Pass::GetDrawListTag() const
         {
             static RHI::DrawListTag invalidTag;
             return invalidTag;
-        }
-
-        bool Pass::HasPipelineViewTag() const
-        {
-            return m_flags.m_hasPipelineViewTag;
         }
 
         const PipelineViewTag& Pass::GetPipelineViewTag() const
@@ -1430,14 +1363,21 @@ namespace AZ
 
         void Pass::SetRenderPipeline(RenderPipeline* pipeline)
         {
-            m_pipeline = pipeline;
+            if (m_pipeline != pipeline)
+            {
+                m_pipeline = pipeline;
+
+                // Re-queue
+                PassState currentState = m_state;
+                m_queueState = PassQueueState::NoQueue;
+                QueueForBuildAndInitialization();
+                if (currentState == PassState::Reset)
+                {
+                    m_state = PassState::Reset;
+                }
+            }
         }
         
-        RenderPipeline* Pass::GetRenderPipeline() const
-        {
-            return m_pipeline;
-        }
-
         void Pass::ManualPipelineBuildAndInitialize()
         {
             Build();
@@ -1509,26 +1449,6 @@ namespace AZ
             return GetPipelineStatisticsResultInternal();
         }
 
-        TimestampResult Pass::GetTimestampResultInternal() const
-        {
-            return TimestampResult();
-        }
-
-        PipelineStatisticsResult Pass::GetPipelineStatisticsResultInternal() const
-        {
-            return PipelineStatisticsResult();
-        }
-
-        void Pass::SetTimestampQueryEnabled(bool enable)
-        {
-            m_flags.m_timestampQueryEnabled = enable;
-        }
-
-        void Pass::SetPipelineStatisticsQueryEnabled(bool enable)
-        {
-            m_flags.m_pipelineStatisticsQueryEnabled = enable;
-        }
-
         bool Pass::ReadbackAttachment(AZStd::shared_ptr<AttachmentReadback> readback, const Name& slotName, PassAttachmentReadbackOption option)
         {
             // Return false if it's already readback
@@ -1586,16 +1506,6 @@ namespace AZ
             {
                 m_attachmentCopy.lock()->FrameBegin(params);
             }
-        }
-
-        bool Pass::IsTimestampQueryEnabled() const
-        {
-            return m_flags.m_timestampQueryEnabled;
-        }
-
-        bool Pass::IsPipelineStatisticsQueryEnabled() const
-        {
-            return m_flags.m_pipelineStatisticsQueryEnabled;
         }
 
         void Pass::PrintIndent(AZStd::string& stringOutput, uint32_t indent) const

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -36,7 +36,6 @@
 #include <Atom/RPI.Reflect/Pass/PassName.h>
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 
-#pragma optimize("", off)
 
 namespace AZ
 {
@@ -563,8 +562,6 @@ namespace AZ
                     AZ_RPI_PASS_WARNING(false,
                         "Pass::ProcessConnection - Pass [%s] is no longer part of the heirarchy and about to be removed",
                         m_path.GetCStr());
-
-                    __debugbreak();
                 }
                 else if (foundPass)
                 {
@@ -572,8 +569,6 @@ namespace AZ
                         m_path.GetCStr(),
                         connectedSlotName.GetCStr(),
                         connectedPassName.GetCStr());
-
-                    __debugbreak();
                 }
                 else
                 {
@@ -581,8 +576,6 @@ namespace AZ
                         false, "Pass::ProcessConnection - Pass [%s] could not find neighbor or child pass named [%s].",
                         m_path.GetCStr(),
                         connectedPassName.GetCStr());
-
-                    __debugbreak();
                 }
             }
         }
@@ -1307,11 +1300,6 @@ namespace AZ
 
             AZ_Assert(m_state == PassState::Idle, "Pass::FrameBegin - Pass [%s] is attempting to render, but is not in the Idle state.", m_path.GetCStr());
 
-            if (m_state != PassState::Idle)
-            {
-                __debugbreak();
-            }
-
             m_state = PassState::Rendering;
 
             UpdateConnectedInputBindings();
@@ -1752,5 +1740,3 @@ namespace AZ
 
     }   // namespace RPI
 }   // namespace AZ
-
-#pragma optimize("", on)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassContainer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassContainer.cpp
@@ -6,10 +6,7 @@
  *
  */
 
-#include <Atom/RPI.Reflect/Pass/RenderPassData.h>
-
 #include <Atom/RPI.Public/Pass/PassContainer.h>
-#include <Atom/RPI.Public/Pass/PassSystemInterface.h>
 #include <Atom/RPI.Public/Pass/PassUtils.h>
 
 namespace AZ::RPI

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassContainer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassContainer.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RPI.Reflect/Pass/RenderPassData.h>
+
+#include <Atom/RPI.Public/Pass/PassContainer.h>
+#include <Atom/RPI.Public/Pass/PassSystemInterface.h>
+#include <Atom/RPI.Public/Pass/PassUtils.h>
+
+namespace AZ::RPI
+{
+    void PassContainer::RemovePasses()
+    {
+        m_state = PassContainerState::RemovingPasses;
+        AZ_PROFILE_SCOPE(RPI, "PassContainer::RemovePasses");
+
+        if (!m_removePassList.empty())
+        {
+            PassUtils::SortPassListDescending(m_removePassList);
+
+            for (const Ptr<Pass>& pass : m_removePassList)
+            {
+                pass->RemoveFromParent();
+            }
+
+            m_removePassList.clear();
+        }
+
+        m_state = PassContainerState::Idle;
+    }
+
+    void PassContainer::BuildPasses()
+    {
+        m_state = PassContainerState::BuildingPasses;
+        AZ_PROFILE_SCOPE(RPI, "PassContainer::BuildPasses");
+
+        m_passesChangedThisFrame = m_passesChangedThisFrame || !m_buildPassList.empty();
+
+        u32 buildCount = 0;
+
+        // While loop is for the event in which passes being built add more pass to m_buildPassList
+        while (!m_buildPassList.empty())
+        {
+            AZ_Assert(m_removePassList.empty(), "Passes shouldn't be queued removal during build attachment process");
+
+            AZStd::vector< Ptr<Pass> > buildListCopy = m_buildPassList;
+            m_buildPassList.clear();
+
+            // Erase passes which were removed from pass tree already (which parent is empty)
+            auto unused = AZStd::remove_if(buildListCopy.begin(), buildListCopy.end(),
+                [](const RHI::Ptr<Pass>& currentPass)
+                {
+                    return !currentPass->m_flags.m_partOfHierarchy;
+                });
+            buildListCopy.erase(unused, buildListCopy.end());
+
+            PassUtils::SortPassListAscending(buildListCopy);
+
+            for (const Ptr<Pass>& pass : buildListCopy)
+            {
+                pass->Reset();
+            }
+            for (const Ptr<Pass>& pass : buildListCopy)
+            {
+                pass->Build(true);
+                ++buildCount;
+            }
+        }
+
+        if (buildCount > 0)
+        {
+            AZ_Assert(!m_initializePassList.empty(), "SHIT! SOMETHING WENT WRONG! WHY DIDN'T WE QUEUE FOR INITIALIZATION??");
+        }
+
+        if (m_passesChangedThisFrame)
+        {
+#if AZ_RPI_ENABLE_PASS_DEBUGGING
+            if (!m_isHotReloading)
+            {
+                AZ_Printf("PassSystem", "\nFinished building passes:\n");
+                DebugPrintPassHierarchy();
+            }
+#endif
+        }
+
+        m_state = PassContainerState::Idle;
+    }
+
+    void PassContainer::InitializePasses()
+    {
+        m_state = PassContainerState::InitializingPasses;
+        AZ_PROFILE_SCOPE(RPI, "PassContainer::InitializePasses");
+
+        m_passesChangedThisFrame = m_passesChangedThisFrame || !m_initializePassList.empty();
+
+        while (!m_initializePassList.empty())
+        {
+            AZStd::vector< Ptr<Pass> > initListCopy = m_initializePassList;
+            m_initializePassList.clear();
+
+            // Erase passes which were removed from pass tree already (which parent is empty)
+            auto unused = AZStd::remove_if(initListCopy.begin(), initListCopy.end(),
+                [](const RHI::Ptr<Pass>& currentPass)
+                {
+                    return !currentPass->m_flags.m_partOfHierarchy;
+                });
+            initListCopy.erase(unused, initListCopy.end());
+
+            PassUtils::SortPassListAscending(initListCopy);
+
+            for (const Ptr<Pass>& pass : initListCopy)
+            {
+                pass->Initialize();
+            }
+        }
+
+        if (m_passesChangedThisFrame)
+        {
+            // Signal all passes that we have finished initialization
+            m_rootPass->OnInitializationFinished();
+        }
+
+        m_state = PassContainerState::Idle;
+    }
+
+    void PassContainer::Validate()
+    {
+        m_state = PassContainerState::ValidatingPasses;
+
+        if (PassValidation::IsEnabled())
+        {
+            if (!m_passesChangedThisFrame)
+            {
+                return;
+            }
+
+            AZ_PROFILE_SCOPE(RPI, "PassSystem: Validate");
+
+            PassValidationResults validationResults;
+            m_rootPass->Validate(validationResults);
+            validationResults.PrintValidationIfError();
+        }
+
+        m_state = PassContainerState::Idle;
+    }
+
+    void PassContainer::ProcessQueuedChanges(bool& outChanged)
+    {
+        AZ_PROFILE_SCOPE(RPI, "PassContainer::ProcessQueuedChanges");
+        RemovePasses();
+        BuildPasses();
+        InitializePasses();
+        Validate();
+
+        outChanged = outChanged || m_passesChangedThisFrame;
+        m_passesChangedThisFrame = false;
+    }
+
+}

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassContainer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassContainer.cpp
@@ -12,6 +12,8 @@
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>
 #include <Atom/RPI.Public/Pass/PassUtils.h>
 
+#pragma optimize("", off)
+
 namespace AZ::RPI
 {
     void PassContainer::RemovePasses()
@@ -42,6 +44,8 @@ namespace AZ::RPI
         m_passesChangedThisFrame = m_passesChangedThisFrame || !m_buildPassList.empty();
 
         u32 buildCount = 0;
+        AZStd::vector< Ptr<Pass> > initialBuildList = m_buildPassList;
+        PassUtils::SortPassListAscending(initialBuildList);
 
         // While loop is for the event in which passes being built add more pass to m_buildPassList
         while (!m_buildPassList.empty())
@@ -52,12 +56,9 @@ namespace AZ::RPI
             m_buildPassList.clear();
 
             // Erase passes which were removed from pass tree already (which parent is empty)
-            auto unused = AZStd::remove_if(buildListCopy.begin(), buildListCopy.end(),
-                [](const RHI::Ptr<Pass>& currentPass)
-                {
+            erase_if(buildListCopy, [](const RHI::Ptr<Pass>& currentPass) {
                     return !currentPass->m_flags.m_partOfHierarchy;
                 });
-            buildListCopy.erase(unused, buildListCopy.end());
 
             PassUtils::SortPassListAscending(buildListCopy);
 
@@ -162,3 +163,5 @@ namespace AZ::RPI
     }
 
 }
+
+#pragma optimize("", on)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
@@ -13,7 +13,6 @@
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzCore/std/sort.h>
 #include <AzCore/Interface/Interface.h>
 
 #include <AzCore/Serialization/Json/JsonUtils.h>
@@ -23,8 +22,9 @@
 #include <Atom/RPI.Public/Pass/FullscreenTrianglePass.h>
 #include <Atom/RPI.Public/Pass/PassDefines.h>
 #include <Atom/RPI.Public/Pass/PassFactory.h>
-#include <Atom/RPI.Public/Pass/PassSystem.h>
 #include <Atom/RPI.Public/Pass/PassLibrary.h>
+#include <Atom/RPI.Public/Pass/PassSystem.h>
+#include <Atom/RPI.Public/Pass/PassUtils.h>
 #include <Atom/RPI.Public/Pass/Specific/SwapChainPass.h>
 #include <Atom/RPI.Public/RenderPipeline.h>
 
@@ -95,9 +95,15 @@ namespace AZ
             Interface<PassSystemInterface>::Register(this);
             m_passLibrary.Init();
             m_passFactory.Init(&m_passLibrary);
+
             m_rootPass = CreatePass<ParentPass>(Name{"Root"});
             m_rootPass->m_flags.m_partOfHierarchy = true;
             m_rootPass->m_flags.m_createChildren = false;
+
+            m_passesWithoutPipeline.m_rootPass = CreatePass<ParentPass>(Name{ "PassesWithoutPipeline" });
+            m_passesWithoutPipeline.m_rootPass->m_flags.m_createChildren = false;
+
+            m_rootPass->AddChild(m_passesWithoutPipeline.m_rootPass);
 
             // Here you can specify the name of a pass you would like to break into during execution
             // If you enable AZ_RPI_ENABLE_PASS_DEBUGGING, then any pass matching the specified name will debug
@@ -125,181 +131,86 @@ namespace AZ
             JsonSerializationUtils::SaveObjectToFile(&passAsset, assetFilePath);
         }
 
+        // 
+
+
+        // --- Queue Functions --- 
+
+
         void PassSystem::QueueForBuild(Pass* pass)
         {
             AZ_Assert(pass != nullptr, "Queuing nullptr pass in PassSystem::QueueForBuild");
-            m_buildPassList.push_back(pass);
+            if (pass == m_rootPass.get())
+            {
+                return;
+            }
+            else if (pass->GetRenderPipeline())
+            {
+                pass->GetRenderPipeline()->m_passes.m_buildPassList.push_back(pass);
+            }
+            else
+            {
+                m_passesWithoutPipeline.m_buildPassList.push_back(pass);
+            }
         }
 
         void PassSystem::QueueForRemoval(Pass* pass)
         {
             AZ_Assert(pass != nullptr, "Queuing nullptr pass in PassSystem::QueueForRemoval");
-            m_removePassList.push_back(pass);
+            if (pass == m_rootPass.get())
+            {
+                return;
+            }
+            else if (pass->GetRenderPipeline())
+            {
+                pass->GetRenderPipeline()->m_passes.m_removePassList.push_back(pass);
+            }
+            else
+            {
+                m_passesWithoutPipeline.m_removePassList.push_back(pass);
+            }
         }
 
         void PassSystem::QueueForInitialization(Pass* pass)
         {
             AZ_Assert(pass != nullptr, "Queuing nullptr pass in PassSystem::QueueForInitialization");
-            m_initializePassList.push_back(pass);
-        }
-
-        // Sort so passes with less depth (closer to the root) are first. Used when changes 
-        // in the parent passes can affect the child passes, like with attachment building.
-        void SortPassListAscending(AZStd::vector< Ptr<Pass> >& passList)
-        {
-            AZStd::sort(passList.begin(), passList.end(),
-                [](const Ptr<Pass>& lhs, const Ptr<Pass>& rhs)
-                {
-                    return (lhs->GetTreeDepth() < rhs->GetTreeDepth());
-                });
-        }
-
-        // Sort so passes with greater depth (further from the root) get called first. Used in the case of
-        // delete, as we want to avoid deleting the parent first since this invalidates the child pointer.
-        void SortPassListDescending(AZStd::vector< Ptr<Pass> >& passList)
-        {
-            AZStd::sort(passList.begin(), passList.end(),
-                [](const Ptr<Pass>& lhs, const Ptr<Pass>& rhs)
-                {
-                    return (lhs->GetTreeDepth() > rhs->GetTreeDepth());
-                }
-            );
-        }
-
-        void PassSystem::RemovePasses()
-        {
-            m_state = PassSystemState::RemovingPasses;
-            AZ_PROFILE_SCOPE(RPI, "PassSystem: RemovePasses");
-
-            if (!m_removePassList.empty())
+            if (pass == m_rootPass.get())
             {
-                SortPassListDescending(m_removePassList);
-
-                for (const Ptr<Pass>& pass : m_removePassList)
-                {
-                    pass->RemoveFromParent();
-                }
-
-                m_removePassList.clear();
+                return;
             }
-
-            m_state = PassSystemState::Idle;
+            else if (pass->GetRenderPipeline())
+            {
+                pass->GetRenderPipeline()->m_passes.m_initializePassList.push_back(pass);
+            }
+            else
+            {
+                m_passesWithoutPipeline.m_initializePassList.push_back(pass);
+            }
         }
 
-        void PassSystem::BuildPasses()
-        {
-            m_state = PassSystemState::BuildingPasses;
-            AZ_PROFILE_SCOPE(RPI, "PassSystem: BuildPasses");
-
-            m_passHierarchyChanged = m_passHierarchyChanged || !m_buildPassList.empty();
-
-            // While loop is for the event in which passes being built add more pass to m_buildPassList
-            while(!m_buildPassList.empty())
-            {
-                AZ_Assert(m_removePassList.empty(), "Passes shouldn't be queued removal during build attachment process");
-
-                AZStd::vector< Ptr<Pass> > buildListCopy = m_buildPassList;
-                m_buildPassList.clear();
-
-                // Erase passes which were removed from pass tree already (which parent is empty)
-                auto unused = AZStd::remove_if(buildListCopy.begin(), buildListCopy.end(),
-                    [](const RHI::Ptr<Pass>& currentPass)
-                    {
-                        return !currentPass->m_flags.m_partOfHierarchy;
-                    });
-                buildListCopy.erase(unused, buildListCopy.end());
-
-                SortPassListAscending(buildListCopy);
-
-                for (const Ptr<Pass>& pass : buildListCopy)
-                {
-                    pass->Reset();
-                }
-                for (const Ptr<Pass>& pass : buildListCopy)
-                {
-                    pass->Build(true);
-                }
-            }
-
-            if (m_passHierarchyChanged)
-            {
-#if AZ_RPI_ENABLE_PASS_DEBUGGING
-                if (!m_isHotReloading)
-                {
-                    AZ_Printf("PassSystem", "\nFinished building passes:\n");
-                    DebugPrintPassHierarchy();
-                }
-#endif
-            }
-
-            m_state = PassSystemState::Idle;
-        }
-
-        void PassSystem::InitializePasses()
-        {
-            m_state = PassSystemState::InitializingPasses;
-            AZ_PROFILE_SCOPE(RPI, "PassSystem: InitializePasses");
-
-            m_passHierarchyChanged = m_passHierarchyChanged || !m_initializePassList.empty();
-
-            while (!m_initializePassList.empty())
-            {
-                AZStd::vector< Ptr<Pass> > initListCopy = m_initializePassList;
-                m_initializePassList.clear();
-
-                // Erase passes which were removed from pass tree already (which parent is empty)
-                auto unused = AZStd::remove_if(initListCopy.begin(), initListCopy.end(),
-                    [](const RHI::Ptr<Pass>& currentPass)
-                    {
-                        return !currentPass->m_flags.m_partOfHierarchy;
-                    });
-                initListCopy.erase(unused, initListCopy.end());
-
-                SortPassListAscending(initListCopy);
-
-                for (const Ptr<Pass>& pass : initListCopy)
-                {
-                    pass->Initialize();
-                }
-            }
-
-            if (m_passHierarchyChanged)
-            {
-                // Signal all passes that we have finished initialization
-                m_rootPass->OnInitializationFinished();
-            }
-
-            m_state = PassSystemState::Idle;
-        }
-
-        void PassSystem::Validate()
-        {
-            m_state = PassSystemState::ValidatingPasses;
-
-            if (PassValidation::IsEnabled())
-            {
-                if (!m_passHierarchyChanged)
-                {
-                    return;
-                }
-
-                AZ_PROFILE_SCOPE(RPI, "PassSystem: Validate");
-
-                PassValidationResults validationResults;
-                m_rootPass->Validate(validationResults);
-                validationResults.PrintValidationIfError();
-            }
-
-            m_state = PassSystemState::Idle;
-        }
+        // --- Frame Update Functions --- 
 
         void PassSystem::ProcessQueuedChanges()
         {
             AZ_PROFILE_SCOPE(RPI, "PassSystem: ProcessQueuedChanges");
-            RemovePasses();
-            BuildPasses();
-            InitializePasses();
-            Validate();
+
+            // Track whether pass hierarchy has changed or not this frame
+            bool change = false;
+
+            for (RenderPipelinePtr& pipeline : m_renderPipelines)
+            {
+                pipeline->m_passes.ProcessQueuedChanges(change);
+            }
+
+            m_passesWithoutPipeline.ProcessQueuedChanges(change);
+
+            if (change)
+            {
+#if AZ_RPI_ENABLE_PASS_DEBUGGING
+                AZ_Printf("PassSystem", "\nFinished building passes:\n");
+                DebugPrintPassHierarchy();
+#endif
+            }
         }
 
         void PassSystem::FrameUpdate(RHI::FrameGraphBuilder& frameGraphBuilder)
@@ -312,9 +223,12 @@ namespace AZ
             m_state = PassSystemState::Rendering;
             Pass::FramePrepareParams params{ &frameGraphBuilder };
 
+            for (RenderPipelinePtr& pipeline : m_renderPipelines)
             {
-                m_rootPass->FrameBegin(params);
+                pipeline->PassSystemFrameBegin(params);
             }
+
+            m_passesWithoutPipeline.m_rootPass->FrameBegin(params);
         }
 
         void PassSystem::FrameEnd()
@@ -323,28 +237,33 @@ namespace AZ
 
             m_state = PassSystemState::FrameEnd;
 
-            m_rootPass->FrameEnd();
+            for (RenderPipelinePtr& pipeline : m_renderPipelines)
+            {
+                pipeline->PassSystemFrameEnd();
+            }
+
+            m_passesWithoutPipeline.m_rootPass->FrameEnd();
 
             // remove any pipelines that are marked as ExecuteOnce
-            // the immediate children of m_rootPass are the top-level nodes of each pipeline
-            for (const Ptr<Pass>& pass : m_rootPass->GetChildren())
+            for (RenderPipelinePtr& pipeline : m_renderPipelines)
             {
-                RenderPipeline* pipeline = pass->m_pipeline;
                 if (pipeline && pipeline->IsExecuteOnce())
                 {
                     pipeline->RemoveFromScene();
                 }
             }
 
-            m_passHierarchyChanged = false;
-
             m_state = PassSystemState::Idle;
         }
 
+        // --- Misc --- 
+
         void PassSystem::Shutdown()
         {
-            RemovePasses();
-            m_buildPassList.clear();
+            // AKM_MARKER
+            //RemovePasses();
+            //m_buildPassList.clear();
+
             m_rootPass = nullptr;
             m_passFactory.Shutdown();
             m_passLibrary.Shutdown();
@@ -357,19 +276,22 @@ namespace AZ
             return m_rootPass;
         }
 
+        void PassSystem::AddRenderPipeline(RenderPipelinePtr renderPipeline)
+        {
+            m_renderPipelines.push_back(renderPipeline);
+            m_rootPass->AddChild(renderPipeline->m_passes.m_rootPass);
+        }
+
+        void PassSystem::RemoveRenderPipeline(RenderPipelinePtr renderPipeline)
+        {
+            erase(m_renderPipelines, renderPipeline);
+            renderPipeline->m_passes.m_rootPass->SetEnabled(false);
+            renderPipeline->m_passes.m_rootPass->QueueForRemoval();
+        }
+
         PassSystemState PassSystem::GetState() const
         {
             return m_state;
-        }
-
-        bool PassSystem::IsHotReloading() const
-        {
-            return m_isHotReloading;
-        }
-
-        void PassSystem::SetHotReloading(bool hotReloading)
-        {
-            m_isHotReloading = hotReloading;
         }
 
         void PassSystem::DebugPrintPassHierarchy()
@@ -415,6 +337,18 @@ namespace AZ
         void PassSystem::IncrementFrameRenderPassCount()
         {
             ++m_frameStatistics.m_numRenderPassesExecuted;
+        }
+
+        void PassSystem::DebugBreakOnPass(const Pass* pass) const
+        {
+            // Users can leverage this function and customize it's logic to facilitate their own debugging
+            // However, any customization should be reverted and never submitted. The default logic just checks
+            // the pass's name against the TargetedPassDebuggingName
+
+            if (!pass->GetName().IsEmpty() && pass->GetName() == GetTargetedPassDebuggingName())
+            {
+                AZ::Debug::Trace::Break();
+            }
         }
 
         // --- Pass Factory Functions --- 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassUtils.cpp
@@ -11,7 +11,6 @@
 #include <Atom/RPI.Reflect/Pass/RenderPassData.h>
 
 #include <Atom/RPI.Public/Pass/Pass.h>
-#include <Atom/RPI.Public/Pass/PassSystemInterface.h>
 #include <Atom/RPI.Public/Pass/PassUtils.h>
 
 namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassUtils.cpp
@@ -6,101 +6,124 @@
  *
  */
 
+#include <AzCore/std/sort.h>
+
 #include <Atom/RPI.Reflect/Pass/RenderPassData.h>
 
+#include <Atom/RPI.Public/Pass/Pass.h>
+#include <Atom/RPI.Public/Pass/PassSystemInterface.h>
 #include <Atom/RPI.Public/Pass/PassUtils.h>
 
-namespace AZ
+namespace AZ::RPI
 {
-    namespace RPI
+    namespace PassUtils
     {
-        namespace PassUtils
+        const PassData* GetPassData(const PassDescriptor& descriptor)
         {
-            const PassData* GetPassData(const PassDescriptor& descriptor)
-            {
-                const PassData* passData = nullptr;
+            const PassData* passData = nullptr;
 
-                // Try custom data from PassRequest
-                if (descriptor.m_passRequest != nullptr)
+            // Try custom data from PassRequest
+            if (descriptor.m_passRequest != nullptr)
+            {
+                passData = descriptor.m_passRequest->m_passData.get();
+            }
+            // Try custom data from PassTemplate
+            if (passData == nullptr && descriptor.m_passTemplate != nullptr)
+            {
+                passData = descriptor.m_passTemplate->m_passData.get();
+            }
+            if (passData == nullptr)
+            {
+                passData = descriptor.m_passData.get();
+            }
+            return passData;
+        }
+
+        AZStd::shared_ptr<PassData> GetPassDataPtr(const PassDescriptor& descriptor)
+        {
+            AZStd::shared_ptr<PassData> passData = nullptr;
+
+            if (descriptor.m_passRequest != nullptr)
+            {
+                passData = descriptor.m_passRequest->m_passData;
+            }
+            if (passData == nullptr && descriptor.m_passTemplate != nullptr)
+            {
+                passData = descriptor.m_passTemplate->m_passData;
+            }
+            if (passData == nullptr)
+            {
+                passData = descriptor.m_passData;
+            }
+            return passData;
+        }
+
+        void ExtractPipelineGlobalConnections(const AZStd::shared_ptr<PassData>& passData, PipelineGlobalConnectionList& outList)
+        {
+            for (const PipelineGlobalConnection& connection : passData->m_pipelineGlobalConnections)
+            {
+                outList.push_back(connection);
+            }
+        }
+
+        bool BindDataMappingsToSrg(const PassDescriptor& descriptor, ShaderResourceGroup* shaderResourceGroup)
+        {
+            bool success = true;
+
+            // Apply mappings from PassTemplate
+            const RenderPassData* passData = nullptr;
+            if (descriptor.m_passTemplate != nullptr)
+            {
+                passData = azrtti_cast<const RenderPassData*>(descriptor.m_passTemplate->m_passData.get());
+                if (passData)
                 {
-                    passData = descriptor.m_passRequest->m_passData.get();
+                    success = shaderResourceGroup->ApplyDataMappings(passData->m_mappings);
                 }
-                // Try custom data from PassTemplate
-                if (passData == nullptr && descriptor.m_passTemplate != nullptr)
-                {
-                    passData = descriptor.m_passTemplate->m_passData.get();
-                }
-                if (passData == nullptr)
-                {
-                    passData = descriptor.m_passData.get();
-                }
-                return passData;
             }
 
-            AZStd::shared_ptr<PassData> GetPassDataPtr(const PassDescriptor& descriptor)
+            // Apply mappings from PassRequest
+            passData = nullptr;
+            if (descriptor.m_passRequest != nullptr)
             {
-                AZStd::shared_ptr<PassData> passData = nullptr;
-
-                if (descriptor.m_passRequest != nullptr)
-                {
-                    passData = descriptor.m_passRequest->m_passData;
-                }
-                if (passData == nullptr && descriptor.m_passTemplate != nullptr)
-                {
-                    passData = descriptor.m_passTemplate->m_passData;
-                }
-                if (passData == nullptr)
-                {
-                    passData = descriptor.m_passData;
-                }
-                return passData;
-            }
-
-            void ExtractPipelineGlobalConnections(const AZStd::shared_ptr<PassData>& passData, PipelineGlobalConnectionList& outList)
-            {
-                for (const PipelineGlobalConnection& connection : passData->m_pipelineGlobalConnections)
-                {
-                    outList.push_back(connection);
-                }
-            }
-
-            bool BindDataMappingsToSrg(const PassDescriptor& descriptor, ShaderResourceGroup* shaderResourceGroup)
-            {
-                bool success = true;
-
-                // Apply mappings from PassTemplate
-                const RenderPassData* passData = nullptr;
-                if (descriptor.m_passTemplate != nullptr)
-                {
-                    passData = azrtti_cast<const RenderPassData*>(descriptor.m_passTemplate->m_passData.get());
-                    if (passData)
-                    {
-                        success = shaderResourceGroup->ApplyDataMappings(passData->m_mappings);
-                    }
-                }
-
-                // Apply mappings from PassRequest
-                passData = nullptr;
-                if (descriptor.m_passRequest != nullptr)
-                {
-                    passData = azrtti_cast<const RenderPassData*>(descriptor.m_passRequest->m_passData.get());
-                    if (passData)
-                    {
-                        success = success && shaderResourceGroup->ApplyDataMappings(passData->m_mappings);
-                    }
-                }
-
-                // Apply mappings from custom data in the descriptor
-                passData = azrtti_cast<const RenderPassData*>(descriptor.m_passData.get());
+                passData = azrtti_cast<const RenderPassData*>(descriptor.m_passRequest->m_passData.get());
                 if (passData)
                 {
                     success = success && shaderResourceGroup->ApplyDataMappings(passData->m_mappings);
                 }
-
-                return success;
             }
 
+            // Apply mappings from custom data in the descriptor
+            passData = azrtti_cast<const RenderPassData*>(descriptor.m_passData.get());
+            if (passData)
+            {
+                success = success && shaderResourceGroup->ApplyDataMappings(passData->m_mappings);
+            }
 
-        }   // namespace PassUtils
-    }   // namespace RPI
-}   // namespace AZ
+            return success;
+        }
+
+        // Sort so passes with less depth (closer to the root) are first. Used when changes 
+        // in the parent passes can affect the child passes, like with attachment building.
+        void SortPassListAscending(AZStd::vector< Ptr<Pass> >& passList)
+        {
+            AZStd::sort(passList.begin(), passList.end(),
+                [](const Ptr<Pass>& lhs, const Ptr<Pass>& rhs)
+                {
+                    return (lhs->GetTreeDepth() < rhs->GetTreeDepth());
+                });
+        }
+
+        // Sort so passes with greater depth (further from the root) get called first. Used in the case of
+        // delete, as we want to avoid deleting the parent first since this invalidates the child pointer.
+        void SortPassListDescending(AZStd::vector< Ptr<Pass> >& passList)
+        {
+            AZStd::sort(passList.begin(), passList.end(),
+                [](const Ptr<Pass>& lhs, const Ptr<Pass>& rhs)
+                {
+                    return (lhs->GetTreeDepth() > rhs->GetTreeDepth());
+                }
+            );
+        }
+
+    }
+}

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -26,6 +26,8 @@
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/View.h>
 
+#pragma optimize("", off)
+
 namespace AZ
 {
     namespace RPI
@@ -564,3 +566,5 @@ namespace AZ
         }
     }   // namespace RPI
 }   // namespace AZ
+
+#pragma optimize("", on)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -26,7 +26,6 @@
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/View.h>
 
-
 namespace AZ
 {
     namespace RPI

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -26,7 +26,6 @@
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/View.h>
 
-#pragma optimize("", off)
 
 namespace AZ
 {
@@ -566,5 +565,3 @@ namespace AZ
         }
     }   // namespace RPI
 }   // namespace AZ
-
-#pragma optimize("", on)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -308,13 +308,17 @@ namespace AZ
             m_drawFilterMask = 0;
         }
 
+        void RenderPipeline::ProcessQueuedPassChanges()
+        {
+            m_passes.ProcessQueuedChanges();
+        }
+
         void RenderPipeline::OnPassModified()
         {
             if (m_needsPassRecreate)
             {
                 // Process any queued changes before we attempt to reload the pipeline
-                bool changed = false;
-                m_passes.ProcessQueuedChanges(changed);
+                m_passes.ProcessQueuedChanges();
 
                 // Attempt to re-create hierarchy under root pass
                 Ptr<ParentPass> newRoot = azrtti_cast<ParentPass*>(m_passes.m_rootPass->Recreate().get());
@@ -374,7 +378,7 @@ namespace AZ
         {
             if (m_scene == nullptr)
             {
-                AZ_Assert(false, "Pipeline isn't added to the any scene");
+                AZ_Assert(false, "RenderPipeline::RemoveFromScene: Pipeline [%s] isn't added to any scene", m_nameId.GetCStr());
                 return;
             }
 
@@ -639,4 +643,5 @@ namespace AZ
         }
     }
 }
+
 #pragma optimize("", on)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -23,6 +23,8 @@
 
 #include <Atom/RPI.Reflect/System/AnyAsset.h>
 
+#pragma optimize("", off)
+
 namespace AZ
 {
     namespace RPI
@@ -293,14 +295,14 @@ namespace AZ
         {
             AZ_Assert(m_scene == nullptr, "Pipeline was added to another scene");
             m_scene = scene;
-            PassSystemInterface::Get()->AddRenderPipeline(RenderPipelinePtr(this));
+            PassSystemInterface::Get()->AddRenderPipeline(this);
         }
 
         void RenderPipeline::OnRemovedFromScene([[maybe_unused]] Scene* scene)
         {
             AZ_Assert(m_scene == scene, "Pipeline isn't added to the specified scene");
             m_scene = nullptr;
-            PassSystemInterface::Get()->RemoveRenderPipeline(RenderPipelinePtr(this));
+            PassSystemInterface::Get()->RemoveRenderPipeline(this);
 
             m_drawFilterTag.Reset();
             m_drawFilterMask = 0;
@@ -637,3 +639,4 @@ namespace AZ
         }
     }
 }
+#pragma optimize("", on)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -23,7 +23,6 @@
 
 #include <Atom/RPI.Reflect/System/AnyAsset.h>
 
-#pragma optimize("", off)
 
 namespace AZ
 {
@@ -643,5 +642,3 @@ namespace AZ
         }
     }
 }
-
-#pragma optimize("", on)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -26,7 +26,6 @@
 
 #include <AzFramework/Entity/EntityContext.h>
 
-#pragma optimize("", off)
 
 namespace AZ
 {
@@ -1031,5 +1030,3 @@ namespace AZ
         }
     }
 }
-
-#pragma optimize("", on)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -113,8 +113,7 @@ namespace AZ
         {
             if (m_taskGraphActive)
             {
-                WaitAndCleanTGEvent(AZStd::move(m_simulationFinishedTGEvent));
-                m_simulationFinishedTGEvent.reset();
+                WaitAndCleanTGEvent();
             }
             else
             {
@@ -382,6 +381,8 @@ namespace AZ
                         m_defaultPipeline = m_pipelines[0];
                     }
 
+                    // AKM_MARKER
+                    // Comment/replace the call to ProcessQueuedChanges here?
                     AZ::RPI::PassSystemInterface::Get()->ProcessQueuedChanges();
                     RebuildPipelineStatesLookup();
 
@@ -458,8 +459,7 @@ namespace AZ
             // If previous simulation job wasn't done, wait for it to finish.
             if (m_taskGraphActive)
             {
-                WaitAndCleanTGEvent(AZStd::move(m_simulationFinishedTGEvent));
-                m_simulationFinishedTGEvent.reset();
+                WaitAndCleanTGEvent();
             }
             else
             {
@@ -489,14 +489,14 @@ namespace AZ
             }
         }
 
-        void Scene::WaitAndCleanTGEvent(AZStd::unique_ptr<AZ::TaskGraphEvent>&&  completionTGEvent)
+        void Scene::WaitAndCleanTGEvent()
         {
             AZ_PROFILE_SCOPE(RPI, "Scene: WaitAndCleanTGEvent");
-            if (completionTGEvent)
+            if (m_simulationFinishedTGEvent)
             {
-                completionTGEvent->Wait();
+                m_simulationFinishedTGEvent->Wait();
             }
-            // allow completionTGEvent to go out of scope and be deleted
+            m_simulationFinishedTGEvent = nullptr;
         }
 
         void Scene::WaitAndCleanCompletionJob(AZ::JobCompletion*& completionJob)
@@ -678,8 +678,7 @@ namespace AZ
 
             if (m_taskGraphActive)
             {
-                WaitAndCleanTGEvent(AZStd::move(m_simulationFinishedTGEvent));
-                m_simulationFinishedTGEvent.reset();
+                WaitAndCleanTGEvent();
             }
             else
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -26,6 +26,8 @@
 
 #include <AzFramework/Entity/EntityContext.h>
 
+#pragma optimize("", off)
+
 namespace AZ
 {
     namespace RPI
@@ -1036,3 +1038,5 @@ namespace AZ
         }
     }
 }
+
+#pragma optimize("", on)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -123,15 +123,13 @@ namespace AZ
             }
             SceneRequestBus::Handler::BusDisconnect();
 
-            // Remove all the render pipelines. Need to process queued changes with pass system before and after remove render pipelines
-            AZ::RPI::PassSystemInterface::Get()->ProcessQueuedChanges();
+            // Remove all the render pipelines.
             for (auto it = m_pipelines.begin(); it != m_pipelines.end(); ++it)
             {
                 RenderPipelinePtr pipelineToRemove = (*it);
                 pipelineToRemove->OnRemovedFromScene(this);
             }
             m_pipelines.clear();
-            AZ::RPI::PassSystemInterface::Get()->ProcessQueuedChanges();
 
             Deactivate();
 
@@ -313,7 +311,7 @@ namespace AZ
             {
                 fp->ApplyRenderPipelineChange(pipeline);
             }
-            AZ::RPI::PassSystemInterface::Get()->ProcessQueuedChanges();
+            pipeline->ProcessQueuedPassChanges();
         }
 
         void Scene::AddRenderPipeline(RenderPipelinePtr pipeline)
@@ -345,7 +343,7 @@ namespace AZ
 
             TryApplyRenderPipelineChanges(pipeline.get());
 
-            PassSystemInterface::Get()->ProcessQueuedChanges();
+            pipeline->ProcessQueuedPassChanges();
             pipeline->BuildPipelineViews();
 
             // Force to update the lookup table since adding render pipeline would effect any pipeline states created before pass system tick
@@ -361,8 +359,6 @@ namespace AZ
             {
                 if (pipelineId == (*it)->GetId())
                 {
-                    // process queued changes first before remove pipeline passes
-                    AZ::RPI::PassSystemInterface::Get()->ProcessQueuedChanges();
                     RenderPipelinePtr pipelineToRemove = (*it);
 
                     if (m_defaultPipeline == pipelineToRemove)
@@ -383,9 +379,6 @@ namespace AZ
                         m_defaultPipeline = m_pipelines[0];
                     }
 
-                    // AKM_MARKER
-                    // Comment/replace the call to ProcessQueuedChanges here?
-                    AZ::RPI::PassSystemInterface::Get()->ProcessQueuedChanges();
                     RebuildPipelineStatesLookup();
 
                     removed = true;

--- a/Gems/Atom/RPI/Code/atom_rpi_public_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_public_files.cmake
@@ -64,6 +64,7 @@ set(FILES
     Include/Atom/RPI.Public/Pass/ParentPass.h
     Include/Atom/RPI.Public/Pass/Pass.h
     Include/Atom/RPI.Public/Pass/PassAttachment.h
+    Include/Atom/RPI.Public/Pass/PassContainer.h
     Include/Atom/RPI.Public/Pass/PassDefines.h
     Include/Atom/RPI.Public/Pass/PassFactory.h
     Include/Atom/RPI.Public/Pass/PassFilter.h
@@ -143,6 +144,7 @@ set(FILES
     Source/RPI.Public/Pass/ParentPass.cpp
     Source/RPI.Public/Pass/Pass.cpp
     Source/RPI.Public/Pass/PassAttachment.cpp
+    Source/RPI.Public/Pass/PassContainer.cpp
     Source/RPI.Public/Pass/PassFactory.cpp
     Source/RPI.Public/Pass/PassFilter.cpp
     Source/RPI.Public/Pass/PassLibrary.cpp

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.inl
@@ -123,7 +123,7 @@ namespace AZ::Render
             {
                 if (!m_previewPass->GetParent())
                 {
-                    RPI::PassSystemInterface::Get()->GetRootPass()->AddChild(m_previewPass);
+                    RPI::PassSystemInterface::Get()->AddNonePipelinePass(m_previewPass);
                 }
                 AZ::RPI::PassAttachment* attachment = FindPassAttachment(m_selectedPass, m_attachmentId);
                 if (attachment)

--- a/Gems/AtomTressFX/Assets/Passes/HairShortCutResolveDepth.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairShortCutResolveDepth.pass
@@ -29,7 +29,8 @@
                 "ShaderAsset": {
                     // Looking for it in the Shaders directory relative to the Assets directory
                     "FilePath": "Shaders/HairShortCutResolveDepth.shader"
-                }
+                },
+                "PipelineViewTag": "MainCamera"
             }
         }
     }


### PR DESCRIPTION
Quite a few changes here, will try to capture them all in this description as best I can.

Main Problem/Solution: Scenes can update their FP in a multithreaded way. Scenes also update their render pipelines, which can call PassSystem functions that will affect all passes, not just passes limited to that render pipeline. So extracted some of the pass system functionality in a new class called PassContainer (the bulk of it's functions are just moved from PassSystem). Now the RenderPipeline can update it's PassContainer instead of relying on global PassSystem functions, and threading issues are avoided. This needed some touch ups around how passes are queued for update, which is what most changes in the Pass and Pass System pertain to.

Other improvements:
- Got a fix for https://github.com/o3de/o3de/issues/9275, the cause of which was a missing PipelineViewTag in one of the hair passes
-  Moved one line getters/setters from Pass.cpp to Pass.h to make Pass.cpp less bloated and more readable (might also slightly help performance with function in-lining, who knows)
- Updated an assert in the RHI CommandList.h to be easier to understand and give hints as to what might be the cause.
- Changed pass debug break macro to use a new Pass System function. This allows users to customize the function and add their own logic for debug breaking on pass execution, such as only breaking into the pass when certain conditions are met.
- WaitAndCleanTGEvent() in Scene now directly uses m_simulationFinishedTGEvent instead of getting it passed in as a param, which simplifies code and readability a bit (was a change I made during my debugging, decided to keep it)