### PR TITLE
Fix render target override issue in UiCanvasOnMesh component

### DIFF
--- a/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
@@ -977,6 +977,7 @@ void UiCanvasComponent::SetAttachmentImageAsset(const AZ::Data::Asset<AZ::RPI::A
     {
         DestroyRenderTarget();
         m_attachmentImageAsset = attachmentImageAsset;
+        MarkRenderGraphDirty();
     }
 }
 

--- a/Gems/LyShine/Code/Source/World/UiCanvasOnMeshComponent.cpp
+++ b/Gems/LyShine/Code/Source/World/UiCanvasOnMeshComponent.cpp
@@ -169,7 +169,7 @@ void UiCanvasOnMeshComponent::OnCanvasLoadedIntoEntity(AZ::EntityId uiCanvasEnti
 {
     if (uiCanvasEntity.IsValid() && m_attachmentImageAssetOverride)
     {
-        UiCanvasBus::Event(GetEntityId(), &UiCanvasInterface::SetAttachmentImageAsset, m_attachmentImageAssetOverride);
+        UiCanvasBus::Event(uiCanvasEntity, &UiCanvasInterface::SetAttachmentImageAsset, m_attachmentImageAssetOverride);
     }
 }
 
@@ -229,6 +229,15 @@ void UiCanvasOnMeshComponent::Activate()
     UiCanvasOnMeshBus::Handler::BusConnect(GetEntityId());
     UiCanvasAssetRefNotificationBus::Handler::BusConnect(GetEntityId());
     UiCanvasManagerNotificationBus::Handler::BusConnect();
+
+    // Check if a UI canvas has already been loaded into the entity
+    AZ::EntityId canvasEntityId;
+    UiCanvasRefBus::EventResult(
+        canvasEntityId, GetEntityId(), &UiCanvasRefBus::Events::GetCanvas);
+    if (canvasEntityId.IsValid())
+    {
+        OnCanvasLoadedIntoEntity(canvasEntityId);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The UiCanvasOnMesh component wasn't getting the "OnCanvasLoaded" event from the UiCanvasRef bus if the UI canvas was set to load automatically in the UiCanvasAssetRef component. This is because the UiCanvasOnMesh component has a dependency on the UiCanvasAssetRef component so it is activated after the UiCanvasAssetRef component is activated and therefore connects to the bus after the canvas has already been loaded.

Signed-off-by: abrmich <abrmich@amazon.com>