### PR TITLE
Cherry pick: fix AzEventHandler node reflection with custom serializer (#9393)

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/AzEventHandler.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/AzEventHandler.h
@@ -15,6 +15,8 @@
 
 namespace ScriptCanvas::Nodes::Core
 {
+    class AzEventEntrySerializer;
+
     struct AzEventEntry
     {
         static void Reflect(AZ::ReflectContext* context);
@@ -30,6 +32,8 @@ namespace ScriptCanvas::Nodes::Core
     class AzEventHandler
         : public Node
     {
+        friend class AzEventEntrySerializer;
+
     public:
         SCRIPTCANVAS_NODE(AzEventHandler);
         
@@ -49,9 +53,7 @@ namespace ScriptCanvas::Nodes::Core
         void CollectVariableReferences(AZStd::unordered_set<ScriptCanvas::VariableId>& variableIds) const override;
         bool ContainsReferencesToVariables(const AZStd::unordered_set<ScriptCanvas::VariableId>& variableIds) const override;
 
-        size_t GenerateFingerprint() const override;
-
-        
+        size_t GenerateFingerprint() const override;        
 
         AZ::Outcome<Grammar::LexicalScope, void> GetFunctionCallLexicalScope(const Slot* slot) const override;
 


### PR DESCRIPTION
Fixes https://github.com/o3de/o3de/issues/9243

Fixes a bug that causes ScriptCanvas graphs that contain an AZ::Event node to double their file size every time they are saved. Eventually, this can lead to a crash when attempting to open the file. This fix seamlessly repairs all previous content, users will not see the error, but will only see a reduction in file size whenever they next save the erroneous graphs.

* fix AzEventHandler node reflection with custom serializer

Signed-off-by: carlitosan <82187351+carlitosan@users.noreply.github.com>

* fix Linux compile error

Signed-off-by: carlitosan <82187351+carlitosan@users.noreply.github.com>
