### PR TITLE
Fix build error caused due to incompatibility with recent changes in the script system

### DIFF
--- a/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
+++ b/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
@@ -46,8 +46,9 @@ namespace ScriptAutomation
                 inputStream.Close();
                 if (outcome.IsSuccess())
                 {
-                    AZ::Uuid id = AZ::Uuid::CreateRandom();
-                    AZ::Data::Asset<AZ::ScriptAsset> scriptAsset = AZ::Data::AssetManager::Instance().CreateAsset<AZ::ScriptAsset>(AZ::Data::AssetId(id));
+                    AZ::Uuid id = AZ::Uuid::CreateName(productPath);
+                    AZ::Data::Asset<AZ::ScriptAsset> scriptAsset = AZ::Data::AssetManager::Instance().FindOrCreateAsset<AZ::ScriptAsset>(AZ::Data::AssetId(id)
+                        , AZ::Data::AssetLoadBehavior::Default);
                     scriptAsset.Get()->m_data = compileRequest.m_luaScriptDataOut;
 
                     return scriptAsset;

--- a/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
+++ b/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
@@ -65,7 +65,7 @@ namespace ScriptAutomation
                 return {};
             }
         }
-    }
+    } // namespace
 
     void ScriptAutomationSystemComponent::Reflect(AZ::ReflectContext* context)
     {

--- a/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
+++ b/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
@@ -48,7 +48,6 @@ namespace ScriptAutomation
                 {
                     AZ::Uuid id = AZ::Uuid::CreateRandom();
                     AZ::Data::Asset<AZ::ScriptAsset> scriptAsset = AZ::Data::AssetManager::Instance().CreateAsset<AZ::ScriptAsset>(AZ::Data::AssetId(id));
-                    scriptAsset.SetAutoLoadBehavior(AZ::Data::AssetLoadBehavior::PreLoad);
                     scriptAsset.Get()->m_data = compileRequest.m_luaScriptDataOut;
 
                     return scriptAsset;

--- a/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
+++ b/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
@@ -10,60 +10,55 @@
 
 #include <ScriptAutomationScriptBindings.h>
 
-#include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/RTTI/BehaviorContext.h>
-#include <AzCore/Script/ScriptAsset.h>
-#include <AzCore/Script/ScriptContext.h>
+#include <AzCore/Script/ScriptSystemBus.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <AzCore/Serialization/SerializeContext.h>
 
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/Asset/AssetSystemBus.h>
+#include <AzFramework/Script/ScriptComponent.h>
 
 namespace ScriptAutomation
 {
-    namespace
+    AZ::Data::Asset<AZ::ScriptAsset> ScriptAutomationSystemComponent::LoadScriptAssetFromPath(const char* productPath)
     {
-        AZ::Data::Asset<AZ::ScriptAsset> LoadScriptAssetFromPath(const char* productPath)
+        AZ::IO::FixedMaxPath resolvedPath;
+        AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedPath, productPath);
+
+        AZ::IO::FileIOStream inputStream;
+        if (inputStream.Open(resolvedPath.c_str(), AZ::IO::OpenMode::ModeRead))
         {
-            AZ::IO::FixedMaxPath resolvedPath;
-            AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedPath, productPath);
+            AzFramework::ScriptCompileRequest compileRequest;
+            compileRequest.m_sourceFile = resolvedPath.c_str();
+            compileRequest.m_input = &inputStream;
 
-            AZ::Data::AssetId assetId;
-            AZ::Data::AssetCatalogRequestBus::BroadcastResult(
-                assetId,
-                &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath,
-                resolvedPath.c_str(),
-                AZ::AzTypeInfo<AZ::ScriptAsset>::Uuid(),
-                true
-            );
-
-            if (assetId.IsValid())
+            auto outcome = AzFramework::CompileScript(compileRequest, *m_scriptContext.get());
+            if (outcome.IsSuccess())
             {
-                AZ::Data::Asset<AZ::ScriptAsset> asset = AZ::Data::AssetManager::Instance().GetAsset<AZ::ScriptAsset>(
-                    assetId, AZ::Data::AssetLoadBehavior::PreLoad
-                );
-                asset.BlockUntilLoadComplete();
+                AZ::Uuid id = AZ::Uuid::CreateRandom();
+                AZ::Data::Asset<AZ::ScriptAsset> scriptAsset = AZ::Data::AssetManager::Instance().CreateAsset<AZ::ScriptAsset>(AZ::Data::AssetId(id));
+                scriptAsset.SetAutoLoadBehavior(AZ::Data::AssetLoadBehavior::PreLoad);
+                scriptAsset.Get()->m_data = compileRequest.m_luaScriptDataOut;
 
-                if (!asset.IsReady())
-                {
-                    AZ_Assert(false, "Could not load '%s'", resolvedPath.c_str());
-                    return {};
-                }
-
-                return asset;
+                return scriptAsset;
             }
             else
             {
-                AZ_Assert(false, "Unable to find product asset '%s'. Has the source asset finished building?", productPath);
+                AZ_Assert(false, "Failed to compile script asset '%s'. Reason: '%s'", resolvedPath.c_str(), outcome.GetError().c_str());
                 return {};
             }
         }
-    } // namespace
+        else
+        {
+            AZ_Assert(false, "Unable to find product asset '%s'. Has the source asset finished building?", resolvedPath.c_str());
+            return {};
+        }
+    }
 
     void ScriptAutomationSystemComponent::Reflect(AZ::ReflectContext* context)
     {
@@ -131,8 +126,11 @@ namespace ScriptAutomation
     {
         ScriptAutomationRequestBus::Handler::BusConnect();
 
-        m_scriptContext = AZStd::make_unique<AZ::ScriptContext>();
+        m_scriptContext = AZStd::make_unique<AZ::ScriptContext>(m_id);
         m_scriptBehaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
+
+        // Custom script context needs to be registered with ScriptSystem to find reflected methods.
+        EBUS_EVENT(AZ::ScriptSystemRequestBus, AddContext, m_scriptContext.get(), -1);
 
         ReflectScriptBindings(m_scriptBehaviorContext.get());
         m_scriptContext->BindTo(m_scriptBehaviorContext.get());
@@ -267,7 +265,7 @@ namespace ScriptAutomation
             }
         );
 
-        if (!m_scriptContext->Execute(scriptAsset->GetScriptBuffer().data(), scriptFilePath, scriptAsset->GetScriptBuffer().size()))
+        if (!m_scriptContext->Execute(scriptAsset->m_data.GetScriptBuffer().data(), scriptFilePath, scriptAsset->m_data.GetScriptBuffer().size()))
         {
             // Push an error operation on the back of the queue instead of reporting it immediately so it doesn't get lost
             // in front of a bunch of queued m_scriptOperations.

--- a/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.h
+++ b/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.h
@@ -10,12 +10,14 @@
 
 #include <ScriptAutomation/ScriptAutomationBus.h>
 
-#include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
-#include <AzCore/Script/ScriptAsset.h>
-#include <AzCore/Script/ScriptContext.h>
+
+namespace AZ
+{
+    class ScriptContext;
+} // namespace AZ
 
 namespace ScriptAutomation
 {
@@ -82,9 +84,5 @@ namespace ScriptAutomation
 
         bool m_isStarted = false;
         bool m_exitOnFinish = false;
-    
-    private:
-        AZ::Data::Asset<AZ::ScriptAsset> LoadScriptAssetFromPath(const char* productPath);
-        const AZ::ScriptContextId m_id = 2;
     };
 } // namespace ScriptAutomation

--- a/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.h
+++ b/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.h
@@ -10,14 +10,12 @@
 
 #include <ScriptAutomation/ScriptAutomationBus.h>
 
+#include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
-
-namespace AZ
-{
-    class ScriptContext;
-} // namespace AZ
+#include <AzCore/Script/ScriptAsset.h>
+#include <AzCore/Script/ScriptContext.h>
 
 namespace ScriptAutomation
 {
@@ -84,5 +82,9 @@ namespace ScriptAutomation
 
         bool m_isStarted = false;
         bool m_exitOnFinish = false;
+    
+    private:
+        AZ::Data::Asset<AZ::ScriptAsset> LoadScriptAssetFromPath(const char* productPath);
+        const AZ::ScriptContextId m_id = 2;
     };
 } // namespace ScriptAutomation


### PR DESCRIPTION
Lua scripts are loaded using the serialization system now(Changed in https://github.com/o3de/o3de/pull/9343). The script asset needs to be compiled first. 
Calling `Load` on the `ScriptSystemRequestBus` executes the script immediately. But we want to queue the script for execution. So we compile the script, assign it to a newly created script asset, and return the asset.

Signed-off-by: amzn-sj <srikkant@amazon.com>