### PR TITLE
Feature lyn12585 enable archivecomponent ap

### DIFF
--- a/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.cpp
@@ -11,6 +11,7 @@
 #include <QCoreApplication>
 #include <tests/assetmanager/MockAssetProcessorManager.h>
 #include <tests/assetmanager/MockFileProcessor.h>
+#include <AzToolsFramework/Archive/ArchiveComponent.h>
 
 namespace UnitTests
 {
@@ -87,5 +88,14 @@ namespace UnitTests
 
         EXPECT_TRUE(m_mockFileProcessor->m_events[Added].WaitAndCheck()) << "File Processor Added event failed";
         EXPECT_TRUE(m_mockFileProcessor->m_events[Deleted].WaitAndCheck()) << "File Processor Deleted event failed";
+    }
+
+    TEST(AssetProcessorAZApplicationTest, AssetProcessorAZApplication_ArchiveComponent_Exists)
+    {
+        int argc = 0;
+        AssetProcessorAZApplication assetProcessorAZApplication {&argc, nullptr};
+        auto componentList = assetProcessorAZApplication.GetRequiredSystemComponents();
+        auto iterator = AZStd::find(componentList.begin(), componentList.end(), azrtti_typeid<AzToolsFramework::ArchiveComponent>());
+        EXPECT_NE(iterator, componentList.end()) << "AzToolsFramework::ArchiveComponent is not a required component";
     }
 }

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
@@ -25,6 +25,7 @@
 
 #include <QSettings>
 
+#include <AzToolsFramework/Archive/ArchiveComponent.h>
 #include <AzFramework/Asset/AssetCatalogComponent.h>
 #include <AzToolsFramework/Entity/EditorEntityFixupComponent.h>
 #include <AzToolsFramework/ToolsComponents/ToolsAssetCatalogComponent.h>
@@ -139,6 +140,7 @@ AZ::ComponentTypeList AssetProcessorAZApplication::GetRequiredSystemComponents()
             || *iter == AZ::Uuid("{624a7be2-3c7e-4119-aee2-1db2bdb6cc89}") // ScriptDebugAgent
             || *iter == AZ::Uuid("{CAF3A025-FAC9-4537-B99E-0A800A9326DF}") // InputSystemComponent
             || *iter == azrtti_typeid<AssetProcessor::ToolsAssetCatalogComponent>()
+            || *iter == azrtti_typeid<AzToolsFramework::ArchiveComponent>() // AP manages compressed files using ArchiveComponent
            )
         {
             // AP does not require the above components to be active

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
@@ -140,7 +140,6 @@ AZ::ComponentTypeList AssetProcessorAZApplication::GetRequiredSystemComponents()
             || *iter == AZ::Uuid("{624a7be2-3c7e-4119-aee2-1db2bdb6cc89}") // ScriptDebugAgent
             || *iter == AZ::Uuid("{CAF3A025-FAC9-4537-B99E-0A800A9326DF}") // InputSystemComponent
             || *iter == azrtti_typeid<AssetProcessor::ToolsAssetCatalogComponent>()
-            || *iter == azrtti_typeid<AzToolsFramework::ArchiveComponent>() // AP manages compressed files using ArchiveComponent
            )
         {
             // AP does not require the above components to be active
@@ -154,6 +153,7 @@ AZ::ComponentTypeList AssetProcessorAZApplication::GetRequiredSystemComponents()
 
     components.push_back(azrtti_typeid<AzToolsFramework::PerforceComponent>());
     components.push_back(azrtti_typeid<AzToolsFramework::Prefab::PrefabSystemComponent>());
+    components.push_back(azrtti_typeid<AzToolsFramework::ArchiveComponent>()); // AP manages compressed files using ArchiveComponent
 
     return components;
 }

--- a/Code/Tools/AssetProcessor/native/utilities/AssetUtilEBusHelper.h
+++ b/Code/Tools/AssetProcessor/native/utilities/AssetUtilEBusHelper.h
@@ -249,4 +249,21 @@ namespace AssetProcessor
     };
 
     using AssetServerBus = AZ::EBus<AssetServerBusTraits>;
+
+    // This EBUS is used to retrieve asset server information
+    class AssetServerInfoBusTraits
+        : public AZ::EBusTraits
+    {
+    public:
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single; // single listener
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single; // single bus
+        using MutexType = AZStd::recursive_mutex;
+
+        virtual ~AssetServerInfoBusTraits() = default;
+
+        virtual const AZStd::string& ComputeArchiveFilePath(const AssetProcessor::BuilderParams& builderParams) = 0;
+    };
+
+    using  AssetServerInfoBus = AZ::EBus<AssetServerInfoBusTraits>;
+
 } // namespace AssetProcessor


### PR DESCRIPTION
 {lyn12585} ACS Patch: Enable ArchiveComponent in Asset Processor

* added ArchiveComponent as a required component to ApplicationManager
*  adding AssetServerInfoBus to compute a fallback filename for an archive
* clean up archive file name from the job key
* surrounding .valid() around the future<bool> if ArchiveCommandsBus is not set up