### PR TITLE
Atom Tools: update base application handling for automated testing return values and fix problems with idle wait frames

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/material_editor_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/material_editor_utils.py
@@ -51,11 +51,11 @@ def open_material(file_path):
     return azlmbr.atomtools.AtomToolsDocumentSystemRequestBus(bus.Broadcast, "OpenDocument", file_path)
 
 
-def is_open(document_id):
+def is_document_open(document_id):
     """
     :return: bool
     """
-    return azlmbr.atomtools.AtomToolsDocumentRequestBus(bus.Event, "IsOpen", document_id)
+    return azlmbr.atomtools.AtomToolsDocumentSystemRequestBus(bus.Broadcast, "IsDocumentOpen", document_id)
 
 
 def save_document(document_id):

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomMaterialEditor_BasicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomMaterialEditor_BasicTests.py
@@ -74,7 +74,7 @@ def run():
 
     # 1) Test Case: Opening an Existing Asset
     document_id = material_editor.open_material(MATERIAL_TYPE_PATH)
-    print(f"Material opened: {material_editor.is_open(document_id)}")
+    print(f"Material opened: {material_editor.is_document_open(document_id)}")
 
     # Verify if the test material exists initially
     target_path = os.path.join(azlmbr.paths.projectroot, "Materials", NEW_MATERIAL)
@@ -88,8 +88,8 @@ def run():
 
     # Verify if the newly created document is open
     new_document_id = material_editor.open_material(target_path)
-    material_editor.wait_for_condition(lambda: material_editor.is_open(new_document_id))
-    print(f"New Material opened: {material_editor.is_open(new_document_id)}")
+    material_editor.wait_for_condition(lambda: material_editor.is_document_open(new_document_id))
+    print(f"New Material opened: {material_editor.is_document_open(new_document_id)}")
 
     # 3) Test Case: Closing Selected Material
     print(f"Material closed: {material_editor.close_document(new_document_id)}")
@@ -109,7 +109,7 @@ def run():
         for material in [TEST_MATERIAL_1, TEST_MATERIAL_2, TEST_MATERIAL_3]
     )
     result = material_editor.close_all_except_selected(document1_id)
-    print(f"Close All Except Selected worked as expected: {result and material_editor.is_open(document1_id)}")
+    print(f"Close All Except Selected worked as expected: {result and material_editor.is_document_open(document1_id)}")
 
     # 6) Test Case: Saving Material
     document_id = material_editor.open_material(os.path.join(TEST_DATA_PATH, TEST_MATERIAL_1))
@@ -203,17 +203,18 @@ def run():
     material_editor.save_all()
     material_editor.close_all_documents()
 
+    # Confirm documents closed
+    print(f"Document1 closed as expected: {material_editor.wait_for_condition(lambda: not material_editor.is_document_open(document1_id), 2.0)}")
+    print(f"Document2 closed as expected: {material_editor.wait_for_condition(lambda: not material_editor.is_document_open(document2_id), 2.0)}")
+    print(f"Document3 closed as expected: {material_editor.wait_for_condition(lambda: not material_editor.is_document_open(document3_id), 2.0)}")
+
     # 10) Verify Asset Browser pane visibility
     verify_pane_visibility("Asset Browser")
 
     # 11) Verify Material Inspector pane visibility
     verify_pane_visibility("Inspector")
 
-    # Confirm documents closed and exit Material Editor
-    material_editor.wait_for_condition(lambda:
-                                       (not material_editor.is_open(document1_id)) and
-                                       (not material_editor.is_open(document2_id)) and
-                                       (not material_editor.is_open(document3_id)), 2.0)
+    # exit Material Editor
     material_editor.exit()
 
 

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomMaterialEditor_BasicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomMaterialEditor_BasicTests.py
@@ -113,7 +113,7 @@ def run():
 
     # 6) Test Case: Saving Material
     document_id = material_editor.open_material(os.path.join(TEST_DATA_PATH, TEST_MATERIAL_1))
-    property_name = azlmbr.name.Name("baseColor.color")
+    property_name = "baseColor.color"
     initial_color = material_editor.get_property(document_id, property_name)
     # Assign new color to the material file and save the actual material
     expected_color = math.Color(0.25, 0.25, 0.25, 1.0)
@@ -171,14 +171,14 @@ def run():
     # 9) Test Case: Saving all Open Materials
     # Open first material and make change to the values
     document1_id = material_editor.open_material(os.path.join(TEST_DATA_PATH, TEST_MATERIAL_1))
-    property1_name = azlmbr.name.Name("metallic.factor")
+    property1_name = "metallic.factor"
     initial_metallic_factor = material_editor.get_property(document1_id, property1_name)
     expected_metallic_factor = 0.444
     material_editor.set_property(document1_id, property1_name, expected_metallic_factor)
 
     # Open second material and make change to the values
     document2_id = material_editor.open_material(os.path.join(TEST_DATA_PATH, TEST_MATERIAL_2))
-    property2_name = azlmbr.name.Name("baseColor.color")
+    property2_name = "baseColor.color"
     initial_color = material_editor.get_property(document2_id, property2_name)
     expected_color = math.Color(0.4156, 0.0196, 0.6862, 1.0)
     material_editor.set_property(document2_id, property2_name, expected_color)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.cpp
@@ -69,9 +69,20 @@ namespace AzToolsFramework
                     }
                     Q_EMIT Updated();
                 });
+
+            connect(&m_watcher, &QFutureWatcher<void>::canceled, this, [this]()
+                {
+                    m_state = State::Unloaded;
+                    Q_EMIT Updated();
+                });
         }
 
-        Thumbnail::~Thumbnail() = default;
+        Thumbnail::~Thumbnail()
+        {
+            m_watcher.disconnect();
+            m_watcher.cancel();
+            m_watcher.waitForFinished();
+        }
 
         bool Thumbnail::operator==(const Thumbnail& other) const
         {
@@ -83,11 +94,12 @@ namespace AzToolsFramework
             if (m_state == State::Unloaded)
             {
                 m_state = State::Loading;
-                QThreadPool* threadPool = {};
-                ThumbnailerRequestBus::BroadcastResult(threadPool, &ThumbnailerRequestBus::Handler::GetThreadPool);
-                QFuture<void> future = QtConcurrent::run(threadPool, [this](){ LoadThread(); });
-                m_watcher.setFuture(future);
+                m_watcher.setFuture(QtConcurrent::run([this](){ LoadThread(); }));
             }
+        }
+
+        void Thumbnail::UpdateTime([[maybe_unused]] float deltaTime)
+        {
         }
 
         const QPixmap& Thumbnail::GetPixmap() const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.h
@@ -13,9 +13,9 @@
 AZ_PUSH_DISABLE_WARNING(4127 4251 4800, "-Wunknown-warning-option") // 4127: conditional expression is constant
                                                                     // 4251: 'QLocale::d': class 'QSharedDataPointer<QLocalePrivate>' needs to have dll-interface to be used by clients of class 'QLocale'
                                                                     // 4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
+#include <QFutureWatcher>
 #include <QObject>
 #include <QPixmap>
-#include <QFutureWatcher>
 AZ_POP_DISABLE_WARNING
 #endif
 
@@ -85,8 +85,8 @@ namespace AzToolsFramework
             ~Thumbnail() override;
             bool operator == (const Thumbnail& other) const;
             void Load();
+            virtual void UpdateTime(float deltaTime);
             const QPixmap& GetPixmap() const;
-            virtual void UpdateTime(float /*deltaTime*/) {}
             SharedThumbnailKey GetKey() const;
             State GetState() const;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerBus.h
@@ -37,9 +37,6 @@ namespace AzToolsFramework
 
             //! Return whether the thumbnail is loading.
             virtual bool IsLoading(SharedThumbnailKey thumbnailKey) = 0;
-
-            //! Get thread pool for drawing thumbnails
-            virtual QThreadPool* GetThreadPool() = 0;
         };
 
         using ThumbnailerRequestBus = AZ::EBus<ThumbnailerRequests>;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
@@ -25,11 +25,16 @@ namespace AzToolsFramework
         ThumbnailerComponent::ThumbnailerComponent()
             : m_missingThumbnail(new MissingThumbnail())
             , m_loadingThumbnail(new LoadingThumbnail())
-            , m_threadPool(this)
         {
         }
 
-        ThumbnailerComponent::~ThumbnailerComponent() = default;
+        ThumbnailerComponent::~ThumbnailerComponent()
+        {
+            ThumbnailerRequestBus::Handler::BusDisconnect();
+            m_providers.clear();
+            m_missingThumbnail.reset();
+            m_loadingThumbnail.reset();
+        }
 
         void ThumbnailerComponent::Activate()
         {
@@ -40,6 +45,8 @@ namespace AzToolsFramework
         {
             ThumbnailerRequestBus::Handler::BusDisconnect();
             m_providers.clear();
+            m_missingThumbnail.reset();
+            m_loadingThumbnail.reset();
         }
 
         void ThumbnailerComponent::Reflect(AZ::ReflectContext* context)
@@ -106,20 +113,20 @@ namespace AzToolsFramework
                     if (thumbnail->GetState() == Thumbnail::State::Unloaded)
                     {
                         // listen to the loading signal, so the anyone using it will update loading animation
-                        AzQtComponents::StyledBusyLabel* busyLabel;
+                        AzQtComponents::StyledBusyLabel* busyLabel = {};
                         AssetBrowser::AssetBrowserComponentRequestBus::BroadcastResult(busyLabel, &AssetBrowser::AssetBrowserComponentRequests::GetStyledBusyLabel);
-                        QObject::connect(m_loadingThumbnail.data(), &Thumbnail::Updated, key.data(), &ThumbnailKey::ThumbnailUpdatedSignal);
-                        QObject::connect(busyLabel, &AzQtComponents::StyledBusyLabel::repaintNeeded, this, &ThumbnailerComponent::RedrawThumbnail);
+                        connect(m_loadingThumbnail.data(), &Thumbnail::Updated, key.data(), &ThumbnailKey::ThumbnailUpdatedSignal);
+                        connect(busyLabel, &AzQtComponents::StyledBusyLabel::repaintNeeded, this, &ThumbnailerComponent::RedrawThumbnail);
 
                         // once the thumbnail is loaded, disconnect it from loading thumbnail
-                        QObject::connect(thumbnail.data(), &Thumbnail::Updated, this , [this, key, thumbnail, busyLabel]()
+                        connect(thumbnail.data(), &Thumbnail::Updated, this, [this, key, thumbnail, busyLabel]()
                             {
-                                QObject::disconnect(m_loadingThumbnail.data(), &Thumbnail::Updated, key.data(), &ThumbnailKey::ThumbnailUpdatedSignal);
-                                QObject::disconnect(busyLabel, &AzQtComponents::StyledBusyLabel::repaintNeeded, this, &ThumbnailerComponent::RedrawThumbnail);
+                                disconnect(m_loadingThumbnail.data(), nullptr, key.data(), nullptr);
+                                disconnect(busyLabel, nullptr, this, nullptr);
+                                disconnect(thumbnail.data(), nullptr, nullptr, nullptr);
 
-                                thumbnail->disconnect();
-                                QObject::connect(thumbnail.data(), &Thumbnail::Updated, key.data(), &ThumbnailKey::ThumbnailUpdatedSignal);
-                                QObject::connect(key.data(), &ThumbnailKey::UpdateThumbnailSignal, thumbnail.data(), &Thumbnail::Update);
+                                connect(thumbnail.data(), &Thumbnail::Updated, key.data(), &ThumbnailKey::ThumbnailUpdatedSignal);
+                                connect(key.data(), &ThumbnailKey::UpdateThumbnailSignal, thumbnail.data(), &Thumbnail::Update);
 
                                 key->SetReady(true);
                                 Q_EMIT key->ThumbnailUpdatedSignal();
@@ -150,11 +157,6 @@ namespace AzToolsFramework
                 }
             }
             return false;
-        }
-
-        QThreadPool* ThumbnailerComponent::GetThreadPool()
-        {
-            return &m_threadPool;
         }
 
         void ThumbnailerComponent::RedrawThumbnail()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.h
@@ -49,7 +49,6 @@ namespace AzToolsFramework
             void UnregisterThumbnailProvider(const char* providerName) override;
             SharedThumbnail GetThumbnail(SharedThumbnailKey thumbnailKey) override;
             bool IsLoading(SharedThumbnailKey thumbnailKey) override;
-            QThreadPool* GetThreadPool() override;
 
             void RedrawThumbnail();
 
@@ -69,9 +68,6 @@ namespace AzToolsFramework
             SharedThumbnail m_missingThumbnail;
             //! Default loading thumbnail used when thumbnail is found by is not yet generated
             SharedThumbnail m_loadingThumbnail;
-            //! There is only a limited number of threads on global threadPool, because there can be many thumbnails rendering at once
-            //! an individual threadPool is needed to avoid deadlocks
-            QThreadPool m_threadPool;
         };
     } // Thumbnailer
 } // namespace AssetBrowser

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerNullComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerNullComponent.cpp
@@ -63,10 +63,5 @@ namespace AzToolsFramework
         {
             return false;
         }
-
-        QThreadPool* ThumbnailerNullComponent::GetThreadPool()
-        {
-            return nullptr;
-        }
     } // namespace Thumbnailer
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerNullComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerNullComponent.h
@@ -44,7 +44,6 @@ namespace AzToolsFramework
             void UnregisterThumbnailProvider(const char* providerName) override;
             AzToolsFramework::Thumbnailer::SharedThumbnail GetThumbnail(AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey) override;
             bool IsLoading(AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey) override;
-            QThreadPool* GetThreadPool() override;
 
         private:
             AzToolsFramework::Thumbnailer::SharedThumbnail m_nullThumbnail;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
@@ -119,8 +119,6 @@ namespace AtomToolsFramework
         const AZStd::string m_targetName;
         const AZ::Crc32 m_toolId = {};
 
-        bool m_isAutoTestMode = false;
-
         // Disable warning for dll export since this member won't be used outside this class
         AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         AZ::IO::FileDescriptorRedirector m_stdoutRedirection = AZ::IO::FileDescriptorRedirector(1); // < 1 for STDOUT

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
@@ -60,7 +60,6 @@ namespace AtomToolsFramework
         void StartCommon(AZ::Entity* systemEntity) override;
         void Destroy() override;
         void RunMainLoop() override;
-        void ExitMainLoop() override;
 
     protected:
         void OnIdle();

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
@@ -58,8 +58,9 @@ namespace AtomToolsFramework
         void CreateStaticModules(AZStd::vector<AZ::Module*>& outModules) override;
         const char* GetCurrentConfigurationName() const override;
         void StartCommon(AZ::Entity* systemEntity) override;
-        void Tick() override;
         void Destroy() override;
+        void RunMainLoop() override;
+        void ExitMainLoop() override;
 
     protected:
         void OnIdle();
@@ -120,8 +121,8 @@ namespace AtomToolsFramework
         const AZ::Crc32 m_toolId = {};
 
         // Disable warning for dll export since this member won't be used outside this class
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
+        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING;
         AZ::IO::FileDescriptorRedirector m_stdoutRedirection = AZ::IO::FileDescriptorRedirector(1); // < 1 for STDOUT
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
+        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
@@ -104,7 +104,8 @@ namespace AtomToolsFramework
         void closeEvent(QCloseEvent* closeEvent) override;
 
         template<typename Functor>
-        QAction* CreateAction(const QString& text, Functor functor, const QKeySequence& shortcut = 0);
+        QAction* CreateActionAtPosition(
+            QMenu* parent, QAction* position, const QString& text, Functor functor, const QKeySequence& shortcut = 0);
 
         QMenu* m_menuOpenRecent = {};
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystem.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystem.h
@@ -52,6 +52,7 @@ namespace AtomToolsFramework
         bool SaveDocumentAsChild(const AZ::Uuid& documentId, const AZStd::string& targetPath) override;
         bool SaveAllDocuments() override;
         AZ::u32 GetDocumentCount() const override;
+        bool IsDocumentOpen(const AZ::Uuid& documentId) const override;
 
     private:
         // AtomToolsDocumentNotificationBus::Handler overrides...

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h
@@ -84,6 +84,10 @@ namespace AtomToolsFramework
 
         //! Get number of allocated documents
         virtual AZ::u32 GetDocumentCount() const = 0;
+
+        //! Determine if a document is open in the system
+        //! @param documentId unique id of document to check
+        virtual bool IsDocumentOpen(const AZ::Uuid& documentId) const = 0;
     };
 
     using AtomToolsDocumentSystemRequestBus = AZ::EBus<AtomToolsDocumentSystemRequests>;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -475,7 +475,9 @@ namespace AtomToolsFramework
         {
             pythonTestCases.push_back(commandLine.GetSwitchValue(pythonTestCaseSwitchName, pythonTestCaseIndex));
         }
-        pythonTestCases.resize(pythonScripts.size());
+
+        // The number of test case strings must be identical to the number of test scripts even if they are empty
+        pythonTestCases.resize(pythonTestScripts.size());
 
         if (!pythonTestScripts.empty())
         {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -64,12 +64,8 @@ namespace AtomToolsFramework
 
         installEventFilter(new AzQtComponents::GlobalEventFilter(this));
 
-        AZ::IO::FixedMaxPath engineRootPath;
-        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
-        {
-            settingsRegistry->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
-        }
-
+        const AZ::IO::FixedMaxPath engineRootPath(
+            GetSettingsValue(AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder, AZStd::string()));
         m_styleManager.reset(new AzQtComponents::StyleManager(this));
         m_styleManager->initialize(this, engineRootPath);
 
@@ -209,13 +205,22 @@ namespace AtomToolsFramework
             editorPythonEventsInterface->StartPython();
         }
 
-        // Delay command line processing until first update 
-        QTimer::singleShot(0, [this]() { ProcessCommandLine(m_commandLine); OnIdle(); });
-    }
-    void AtomToolsApplication::Tick()
-    {
-        TickSystem();
-        Base::Tick();
+        // Handle command line options for setting up a test environment that should not be affected forwarding commands from other
+        // instances of an application
+        if (m_commandLine.HasSwitch("autotest_mode") || m_commandLine.HasSwitch("runpythontest"))
+        {
+            // Nullroute all stdout to null for automated tests, this way we make sure
+            // that the test result output is not polluted with unrelated output data.
+            RedirectStdoutToNull();
+        }
+        else
+        {
+            // Enable native UI for some low level system popup message when it's not in automated test mode
+            if (auto nativeUI = AZ::Interface<AZ::NativeUI::NativeUIRequests>::Get(); nativeUI != nullptr)
+            {
+                nativeUI->SetMode(AZ::NativeUI::Mode::ENABLED);
+            }
+        }
     }
 
     void AtomToolsApplication::Destroy()
@@ -252,21 +257,37 @@ namespace AtomToolsFramework
 #endif
     }
 
+    void AtomToolsApplication::RunMainLoop()
+    {
+        // Start initial command line processing and application update as part of the Qt event loop 
+        QTimer::singleShot(0, this, [this]() { ProcessCommandLine(m_commandLine); OnIdle(); });
+        exec();
+    }
+
+    void AtomToolsApplication::ExitMainLoop()
+    {
+        m_exitMainLoopRequested = true;
+    }
+
     void AtomToolsApplication::OnIdle()
     {
-        if (WasExitMainLoopRequested())
+        // Process a single application tick unless exit was requested
+        if (!WasExitMainLoopRequested())
         {
-            quit();
+            PumpSystemEventLoopUntilEmpty();
+            TickSystem();
+            Tick();
+
+            // Rescheduling the update every frame with an interval based on the state of the application.
+            // This allows the tool to free up resources for other processes when it's not in focus.
+            const int updateInterval = (applicationState() & Qt::ApplicationActive)
+                ? aznumeric_cast<int>(GetSettingsValue<AZ::u64>("/O3DE/AtomToolsFramework/Application/UpdateIntervalWhenActive", 1))
+                : aznumeric_cast<int>(GetSettingsValue<AZ::u64>("/O3DE/AtomToolsFramework/Application/UpdateIntervalWhenNotActive", 250));
+            QTimer::singleShot(updateInterval, this, &AtomToolsApplication::OnIdle);
             return;
         }
 
-        PumpSystemEventLoopUntilEmpty();
-        Tick();
-
-        const int updateInterval = (applicationState() & Qt::ApplicationActive)
-            ? aznumeric_cast<int>(GetSettingsValue<AZ::u64>("/O3DE/AtomToolsFramework/Application/UpdateIntervalWhenActive", 1))
-            : aznumeric_cast<int>(GetSettingsValue<AZ::u64>("/O3DE/AtomToolsFramework/Application/UpdateIntervalWhenNotActive", 250));
-        QTimer::singleShot(updateInterval, [this]() { OnIdle(); });
+        QTimer::singleShot(0, this, &QApplication::quit);
     }
 
     void AtomToolsApplication::OnMainWindowClosing()
@@ -405,23 +426,6 @@ namespace AtomToolsFramework
 
     void AtomToolsApplication::ProcessCommandLine(const AZ::CommandLine& commandLine)
     {
-        const bool automatedTest = commandLine.HasSwitch("autotest_mode") || commandLine.HasSwitch("runpythontest");
-        if (automatedTest)
-        {
-            // Nullroute all stdout to null for automated tests, this way we make sure
-            // that the test result output is not polluted with unrelated output data.
-            RedirectStdoutToNull();
-        }
-
-        if (!automatedTest)
-        {
-            // Enable native UI for some low level system popup message when it's not in automated test mode
-            if (auto nativeUI = AZ::Interface<AZ::NativeUI::NativeUIRequests>::Get(); nativeUI != nullptr)
-            {
-                nativeUI->SetMode(AZ::NativeUI::Mode::ENABLED);
-            }
-        }
-
         if (commandLine.HasSwitch("activatewindow"))
         {
             AtomToolsMainWindowRequestBus::Event(m_toolId, &AtomToolsMainWindowRequestBus::Handler::ActivateWindow);
@@ -433,30 +437,88 @@ namespace AtomToolsFramework
             const AZStd::string& timeoutValue = commandLine.GetSwitchValue(timeoputSwitchName, 0);
             const uint32_t timeoutInMs = atoi(timeoutValue.c_str());
             AZ_Printf(m_targetName.c_str(), "Timeout scheduled, shutting down in %u ms", timeoutInMs);
-            QTimer::singleShot(timeoutInMs, [this] {
+            QTimer::singleShot(timeoutInMs, this, [this]{
                 AZ_Printf(m_targetName.c_str(), "Timeout reached, shutting down");
                 ExitMainLoop();
             });
         }
 
         // Process command line options for running one or more python scripts on startup
-        auto runScripts = [&commandLine, this](const AZStd::string& runPythonScriptSwitchName)
+        const size_t pythonScriptCount = commandLine.GetNumSwitchValues("runpython");
+        AZStd::vector<AZStd::string_view> pythonScripts;
+        pythonScripts.reserve(pythonScriptCount);
+        for (size_t pythonScriptIndex = 0; pythonScriptIndex < pythonScriptCount; ++pythonScriptIndex)
         {
-            size_t runPythonScriptCount = commandLine.GetNumSwitchValues(runPythonScriptSwitchName);
-            for (size_t runPythonScriptIndex = 0; runPythonScriptIndex < runPythonScriptCount; ++runPythonScriptIndex)
+            pythonScripts.push_back(commandLine.GetSwitchValue("runpython", pythonScriptIndex));
+        }
+
+        const size_t pythonTestScriptCount = commandLine.GetNumSwitchValues("runpythontest");
+        AZStd::vector<AZStd::string_view> pythonTestScripts;
+        pythonTestScripts.reserve(pythonTestScriptCount);
+        for (size_t pythonTestScriptIndex = 0; pythonTestScriptIndex < pythonTestScriptCount; ++pythonTestScriptIndex)
+        {
+            pythonTestScripts.push_back(commandLine.GetSwitchValue("runpythontest", pythonTestScriptIndex));
+        }
+
+        const char* pythonArgSwitchName = "runpythonargs";
+        const size_t pythonArgCount = commandLine.GetNumSwitchValues(pythonArgSwitchName);
+        AZStd::vector<AZStd::string_view> pythonArgs;
+        pythonArgs.reserve(pythonArgCount);
+        for (size_t pythonArgIndex = 0; pythonArgIndex < pythonArgCount; ++pythonArgIndex)
+        {
+            pythonArgs.push_back(commandLine.GetSwitchValue(pythonArgSwitchName, pythonArgIndex));
+        }
+
+        const char* pythonTestCaseSwitchName = "runpythontestcase";
+        const size_t pythonTestCaseCount = commandLine.GetNumSwitchValues(pythonTestCaseSwitchName);
+        AZStd::vector<AZStd::string_view> pythonTestCases;
+        pythonTestCases.reserve(pythonTestCaseCount);
+        for (size_t pythonTestCaseIndex = 0; pythonTestCaseIndex < pythonTestCaseCount; ++pythonTestCaseIndex)
+        {
+            pythonTestCases.push_back(commandLine.GetSwitchValue(pythonTestCaseSwitchName, pythonTestCaseIndex));
+        }
+        pythonTestCases.resize(pythonScripts.size());
+
+        if (!pythonTestScripts.empty())
+        {
+            bool success = true;
+            AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(
+                [&](AzToolsFramework::EditorPythonRunnerRequests* pythonRunnerRequests)
+                {
+                    for (int i = 0; i < pythonTestScripts.size(); ++i)
+                    {
+                        bool cur_success =
+                            pythonRunnerRequests->ExecuteByFilenameAsTest(pythonTestScripts[i], pythonTestCases[i], pythonArgs);
+                        success = success && cur_success;
+                    }
+                });
+
+            if (success)
             {
-                const AZStd::vector<AZStd::string_view> runPythonArgs;
-                const AZStd::string runPythonScriptPath = commandLine.GetSwitchValue(runPythonScriptSwitchName, runPythonScriptIndex);
-                AZ_Printf(m_targetName.c_str(), "Launching script: %s", runPythonScriptPath.c_str());
-
-                AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(
-                    &AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilenameWithArgs, runPythonScriptPath, runPythonArgs);
+                ExitMainLoop();
             }
-        };
-        runScripts("runpython");
-        runScripts("runpythontest");
+            else
+            {
+                // Close down the application with 0xF exit code indicating failure of the test
+                AZ::Debug::Trace::Terminate(0xF);
+            }
+        }
 
-        if (automatedTest || commandLine.HasSwitch("exitaftercommands"))
+        if (!pythonScripts.empty())
+        {
+            AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(
+                [&](AzToolsFramework::EditorPythonRunnerRequests* pythonRunnerRequests)
+                {
+                    for (const auto& filename : pythonScripts)
+                    {
+                        pythonRunnerRequests->ExecuteByFilenameWithArgs(filename, pythonArgs);
+                    }
+                });
+        }
+
+        if (commandLine.HasSwitch("autotest_mode") ||
+            commandLine.HasSwitch("runpythontest") ||
+            commandLine.HasSwitch("exitaftercommands"))
         {
             ExitMainLoop();
         }
@@ -514,7 +576,7 @@ namespace AtomToolsFramework
                     {
                         AZ::CommandLine commandLine;
                         commandLine.Parse(tokens);
-                        QTimer::singleShot(0, [this, commandLine]() { ProcessCommandLine(commandLine); });
+                        QTimer::singleShot(0, this, [this, commandLine]() { ProcessCommandLine(commandLine); });
                     }
                 }
             });
@@ -576,46 +638,37 @@ namespace AtomToolsFramework
         AZ_Error(m_targetName.c_str(), false, "Python: " AZ_STRING_FORMAT, AZ_STRING_ARG(message));
     }
 
-    // Copied from PyIdleWaitFrames in CryEdit.cpp
     void AtomToolsApplication::PyIdleWaitFrames(uint32_t frames)
     {
-        struct Ticker : public AZ::TickBus::Handler
-        {
-            Ticker(QEventLoop* loop, uint32_t targetFrames)
-                : m_loop(loop)
-                , m_targetFrames(targetFrames)
-            {
-                AZ::TickBus::Handler::BusConnect();
-            }
-            ~Ticker()
-            {
-                AZ::TickBus::Handler::BusDisconnect();
-            }
-
-            void OnTick(float deltaTime, AZ::ScriptTimePoint time) override
-            {
-                AZ_UNUSED(deltaTime);
-                AZ_UNUSED(time);
-                if (++m_elapsedFrames == m_targetFrames)
-                {
-                    m_loop->quit();
-                }
-            }
-            QEventLoop* m_loop = nullptr;
-            uint32_t m_elapsedFrames = 0;
-            uint32_t m_targetFrames = 0;
-        };
-
+        // Create a child event loop that takes control of updating the application for a set number of frames.
+        // When executed from a script, this continues to update the application but allows the script to pause until the number of frames
+        // have passed.
         QEventLoop loop;
-        Ticker ticker(&loop, frames);
+        QTimer timer;
+
+        uint32_t frame = 0;
+        QObject::connect(&timer, &QTimer::timeout, &loop, [&]() {
+            auto app = AtomToolsApplication::GetInstance();
+            if (app && !app->WasExitMainLoopRequested() && frame++ < frames)
+            {
+                app->PumpSystemEventLoopUntilEmpty();
+                app->TickSystem();
+                app->Tick();
+                return;
+            }
+
+            timer.stop();
+            loop.quit();
+        });
+
+        timer.setInterval(0);
+        timer.start();
         loop.exec();
     }
 
     void AtomToolsApplication::PyExit()
     {
-        QTimer::singleShot(0, []() { 
-            AtomToolsApplication::GetInstance()->ExitMainLoop();
-        });
+        AtomToolsApplication::GetInstance()->ExitMainLoop();
     }
 
     void AtomToolsApplication::PyTestOutput(const AZStd::string& output)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -68,7 +68,7 @@ namespace AtomToolsFramework
         QAction* insertPostion = !m_menuFile->actions().empty() ? m_menuFile->actions().front() : nullptr;
 
         // Generating the main menu manually because it's easier and we will have some dynamic or data driven entries
-        m_actionNew = CreateAction("&New...", [this]() {
+        m_actionNew = CreateActionAtPosition(m_menuFile, insertPostion, "&New...", [this]() {
             AZStd::string openPath;
             AZStd::string savePath;
             if (GetCreateDocumentParams(openPath, savePath))
@@ -77,15 +77,13 @@ namespace AtomToolsFramework
                     m_toolId, &AtomToolsDocumentSystemRequestBus::Events::CreateDocumentFromFilePath, openPath, savePath);
             }
         }, QKeySequence::New);
-        m_menuFile->insertAction(insertPostion, m_actionNew);
 
-        m_actionOpen = CreateAction("&Open...", [this]() {
+        m_actionOpen = CreateActionAtPosition(m_menuFile, insertPostion, "&Open...", [this]() {
             for (const auto& path : GetOpenDocumentParams())
             {
                 AtomToolsDocumentSystemRequestBus::Event(m_toolId, &AtomToolsDocumentSystemRequestBus::Events::OpenDocument, path);
             }
         }, QKeySequence::Open);
-        m_menuFile->insertAction(insertPostion, m_actionOpen);
 
         m_menuOpenRecent = new QMenu("Open Recent", this);
         connect(m_menuOpenRecent, &QMenu::aboutToShow, this, [this]() {
@@ -94,7 +92,7 @@ namespace AtomToolsFramework
         m_menuFile->insertMenu(insertPostion, m_menuOpenRecent);
         m_menuFile->insertSeparator(insertPostion);
 
-        m_actionSave = CreateAction("&Save", [this]() {
+        m_actionSave = CreateActionAtPosition(m_menuFile, insertPostion, "&Save", [this]() {
             const AZ::Uuid documentId = GetCurrentDocumentId();
             bool result = false;
             AtomToolsDocumentSystemRequestBus::EventResult(
@@ -104,9 +102,8 @@ namespace AtomToolsFramework
                 SetStatusError(tr("Document save failed: %1").arg(GetDocumentPath(documentId)));
             }
         }, QKeySequence::Save);
-        m_menuFile->insertAction(insertPostion, m_actionSave);
 
-        m_actionSaveAsCopy = CreateAction("Save &As...", [this]() {
+        m_actionSaveAsCopy = CreateActionAtPosition(m_menuFile, insertPostion, "Save &As...", [this]() {
             const AZ::Uuid documentId = GetCurrentDocumentId();
             const QString documentPath = GetDocumentPath(documentId);
 
@@ -119,9 +116,8 @@ namespace AtomToolsFramework
                 SetStatusError(tr("Document save failed: %1").arg(documentPath));
             }
         }, QKeySequence::SaveAs);
-        m_menuFile->insertAction(insertPostion, m_actionSaveAsCopy);
 
-        m_actionSaveAsChild = CreateAction("Save As &Child...", [this]() {
+        m_actionSaveAsChild = CreateActionAtPosition(m_menuFile, insertPostion, "Save As &Child...", [this]() {
             const AZ::Uuid documentId = GetCurrentDocumentId();
             const QString documentPath = GetDocumentPath(documentId);
 
@@ -134,9 +130,8 @@ namespace AtomToolsFramework
                 SetStatusError(tr("Document save failed: %1").arg(documentPath));
             }
         });
-        m_menuFile->insertAction(insertPostion, m_actionSaveAsChild);
 
-        m_actionSaveAll = CreateAction("Save A&ll", [this]() {
+        m_actionSaveAll = CreateActionAtPosition(m_menuFile, insertPostion, "Save A&ll", [this]() {
             bool result = false;
             AtomToolsDocumentSystemRequestBus::EventResult(
                 result, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::SaveAllDocuments);
@@ -145,31 +140,27 @@ namespace AtomToolsFramework
                 SetStatusError(tr("Document save all failed"));
             }
         });
-        m_menuFile->insertAction(insertPostion, m_actionSaveAll);
         m_menuFile->insertSeparator(insertPostion);
 
-        m_actionClose = CreateAction("&Close", [this]() {
+        m_actionClose = CreateActionAtPosition(m_menuFile, insertPostion, "&Close", [this]() {
             const AZ::Uuid documentId = GetCurrentDocumentId();
             AtomToolsDocumentSystemRequestBus::Event(m_toolId, &AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
         }, QKeySequence::Close);
-        m_menuFile->insertAction(insertPostion, m_actionClose);
 
-        m_actionCloseAll = CreateAction("Close All", [this]() {
+        m_actionCloseAll = CreateActionAtPosition(m_menuFile, insertPostion, "Close All", [this]() {
             AtomToolsDocumentSystemRequestBus::Event(m_toolId, &AtomToolsDocumentSystemRequestBus::Events::CloseAllDocuments);
         });
-        m_menuFile->insertAction(insertPostion, m_actionCloseAll);
 
-        m_actionCloseOthers = CreateAction("Close Others", [this]() {
+        m_actionCloseOthers = CreateActionAtPosition(m_menuFile, insertPostion, "Close Others", [this]() {
             const AZ::Uuid documentId = GetCurrentDocumentId();
             AtomToolsDocumentSystemRequestBus::Event(
                 m_toolId, &AtomToolsDocumentSystemRequestBus::Events::CloseAllDocumentsExcept, documentId);
         });
-        m_menuFile->insertAction(insertPostion, m_actionCloseOthers);
         m_menuFile->insertSeparator(insertPostion);
 
         insertPostion = !m_menuEdit->actions().empty() ? m_menuEdit->actions().front() : nullptr;
 
-        m_actionUndo = CreateAction("&Undo", [this]() {
+        m_actionUndo = CreateActionAtPosition(m_menuEdit, insertPostion, "&Undo", [this]() {
             const AZ::Uuid documentId = GetCurrentDocumentId();
             bool result = false;
             AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsDocumentRequestBus::Events::Undo);
@@ -178,9 +169,8 @@ namespace AtomToolsFramework
                 SetStatusError(tr("Document undo failed: %1").arg(GetDocumentPath(documentId)));
             }
         }, QKeySequence::Undo);
-        m_menuEdit->insertAction(insertPostion, m_actionUndo);
 
-        m_actionRedo = CreateAction("&Redo", [this]() {
+        m_actionRedo = CreateActionAtPosition(m_menuEdit, insertPostion, "&Redo", [this]() {
             const AZ::Uuid documentId = GetCurrentDocumentId();
             bool result = false;
             AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsDocumentRequestBus::Events::Redo);
@@ -189,20 +179,17 @@ namespace AtomToolsFramework
                 SetStatusError(tr("Document redo failed: %1").arg(GetDocumentPath(documentId)));
             }
         }, QKeySequence::Redo);
-        m_menuEdit->insertAction(insertPostion, m_actionRedo);
         m_menuEdit->insertSeparator(insertPostion);
 
         insertPostion = !m_menuView->actions().empty() ? m_menuView->actions().front() : nullptr;
 
-        m_actionPreviousTab = CreateAction("&Previous Tab", [this]() {
+        m_actionPreviousTab = CreateActionAtPosition(m_menuView, insertPostion, "&Previous Tab", [this]() {
             SelectPrevDocumentTab();
         }, Qt::CTRL | Qt::SHIFT | Qt::Key_Tab); //QKeySequence::PreviousChild is mapped incorrectly in Qt
-        m_menuView->insertAction(insertPostion, m_actionPreviousTab);
 
-        m_actionNextTab = CreateAction("&Next Tab", [this]() {
+        m_actionNextTab = CreateActionAtPosition(m_menuView, insertPostion, "&Next Tab", [this]() {
             SelectNextDocumentTab();
         }, Qt::CTRL | Qt::Key_Tab); //QKeySequence::NextChild works as expected but mirroring Previous
-        m_menuView->insertAction(insertPostion, m_actionNextTab);
         m_menuView->insertSeparator(insertPostion);
     }
 
@@ -622,11 +609,13 @@ namespace AtomToolsFramework
     }
 
     template<typename Functor>
-    QAction* AtomToolsDocumentMainWindow::CreateAction(const QString& text, Functor functor, const QKeySequence& shortcut)
+    QAction* AtomToolsDocumentMainWindow::CreateActionAtPosition(
+        QMenu* parent, QAction* position, const QString& text, Functor functor, const QKeySequence& shortcut)
     {
-        QAction* action = new QAction(text, this);
+        QAction* action = new QAction(text, parent);
         action->setShortcut(shortcut);
-        connect(action, &QAction::triggered, this, functor);
+        connect(action, &QAction::triggered, parent, functor);
+        parent->insertAction(position, action);
         return action;
     }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
@@ -28,6 +28,15 @@ AZ_POP_DISABLE_WARNING
 
 namespace AtomToolsFramework
 {
+    void DisplayErrorMessage(QWidget* parent, const QString& title, const QString& text)
+    {
+        AZ_Error("AtomToolsDocumentSystem", false, text.toUtf8().constData());
+        if (GetSettingsValue<bool>("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/DisplayErrorMessageDialogs", true))
+        {
+            QMessageBox::critical(parent, title, text);
+        }
+    }
+
     void AtomToolsDocumentSystem::Reflect(AZ::ReflectContext* context)
     {
         if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
@@ -97,7 +106,10 @@ namespace AtomToolsFramework
         AZStd::unique_ptr<AtomToolsDocumentRequests> document(documentType.CreateDocument(m_toolId));
         if (!document)
         {
-            AZ_Error("AtomToolsDocument", false, "Failed to create new document.");
+            DisplayErrorMessage(
+                GetToolMainWindow(),
+                QObject::tr("Document could not be created"),
+                QObject::tr("Could not create document using type: %1").arg(documentType.m_documentTypeName.c_str()));
             return AZ::Uuid::CreateNull();
         }
 
@@ -138,7 +150,7 @@ namespace AtomToolsFramework
         AZStd::string openPath = sourcePath;
         if (!ValidateDocumentPath(openPath))
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be created"),
                 QObject::tr("Document path is invalid, not in a supported project or gem folder, or marked as non-editable:\n%1").arg(openPath.c_str()));
@@ -148,7 +160,7 @@ namespace AtomToolsFramework
         AZStd::string savePath = targetPath;
         if (!savePath.empty() && !ValidateDocumentPath(savePath))
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be created"),
                 QObject::tr("Document path is invalid, not in a supported project or gem folder, or marked as non-editable:\n%1").arg(savePath.c_str()));
@@ -158,7 +170,7 @@ namespace AtomToolsFramework
         AZ::Uuid documentId = CreateDocumentFromFileType(openPath);
         if (documentId.IsNull())
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be created"),
                 QObject::tr("Failed to create: \n%1\n\n%2").arg(openPath.c_str()).arg(traceRecorder.GetDump().c_str()));
@@ -169,7 +181,7 @@ namespace AtomToolsFramework
         AtomToolsDocumentRequestBus::EventResult(openResult, documentId, &AtomToolsDocumentRequestBus::Events::Open, openPath);
         if (!openResult)
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be opened"),
                 QObject::tr("Failed to open: \n%1\n\n%2").arg(openPath.c_str()).arg(traceRecorder.GetDump().c_str()));
@@ -210,7 +222,7 @@ namespace AtomToolsFramework
         AZStd::string openPath = sourcePath;
         if (!ValidateDocumentPath(openPath))
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be opened"),
                 QObject::tr("Document path is invalid, not in a supported project or gem folder, or marked as non-editable:\n%1").arg(openPath.c_str()));
@@ -266,7 +278,10 @@ namespace AtomToolsFramework
             {
                 if (!SaveDocument(documentId))
                 {
-                    AZ_Error("AtomToolsDocument", false, "Close document failed because document was not saved: %s", documentPath.c_str());
+                    DisplayErrorMessage(
+                        GetToolMainWindow(),
+                        QObject::tr("Document could not be closed"),
+                        QObject::tr("Close document failed because document was not saved: \n%1").arg(documentPath.c_str()));
                     return false;
                 }
             }
@@ -278,7 +293,7 @@ namespace AtomToolsFramework
         AtomToolsDocumentRequestBus::EventResult(closeResult, documentId, &AtomToolsDocumentRequestBus::Events::Close);
         if (!closeResult)
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be closed"),
                 QObject::tr("Failed to close: \n%1\n\n%2").arg(documentPath.c_str()).arg(traceRecorder.GetDump().c_str()));
@@ -329,7 +344,7 @@ namespace AtomToolsFramework
 
         if (!ValidateDocumentPath(savePath))
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Document path is invalid, not in a supported project or gem folder, or marked as non-editable:\n%1").arg(savePath.c_str()));
@@ -339,7 +354,7 @@ namespace AtomToolsFramework
         const QFileInfo saveInfo(savePath.c_str());
         if (saveInfo.exists() && !saveInfo.isWritable())
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Document could not be overwritten:\n%1").arg(savePath.c_str()));
@@ -352,7 +367,7 @@ namespace AtomToolsFramework
         AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsDocumentRequestBus::Events::Save);
         if (!result)
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Failed to save: \n%1\n\n%2").arg(savePath.c_str()).arg(traceRecorder.GetDump().c_str()));
@@ -367,7 +382,7 @@ namespace AtomToolsFramework
         AZStd::string savePath = targetPath;
         if (!ValidateDocumentPath(savePath))
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Document path is invalid, not in a supported project or gem folder, or marked as non-editable:\n%1").arg(savePath.c_str()));
@@ -377,7 +392,7 @@ namespace AtomToolsFramework
         const QFileInfo saveInfo(savePath.c_str());
         if (saveInfo.exists() && !saveInfo.isWritable())
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Document could not be overwritten:\n%1").arg(savePath.c_str()));
@@ -390,7 +405,7 @@ namespace AtomToolsFramework
         AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsDocumentRequestBus::Events::SaveAsCopy, savePath);
         if (!result)
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Failed to save: \n%1\n\n%2").arg(savePath.c_str()).arg(traceRecorder.GetDump().c_str()));
@@ -405,7 +420,7 @@ namespace AtomToolsFramework
         AZStd::string savePath = targetPath;
         if (!ValidateDocumentPath(savePath))
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Document path is invalid, not in a supported project or gem folder, or marked as non-editable:\n%1").arg(savePath.c_str()));
@@ -415,7 +430,7 @@ namespace AtomToolsFramework
         const QFileInfo saveInfo(savePath.c_str());
         if (saveInfo.exists() && !saveInfo.isWritable())
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Document could not be overwritten:\n%1").arg(savePath.c_str()));
@@ -428,7 +443,7 @@ namespace AtomToolsFramework
         AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsDocumentRequestBus::Events::SaveAsChild, savePath);
         if (!result)
         {
-            QMessageBox::critical(
+            DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be saved"),
                 QObject::tr("Failed to save: \n%1\n\n%2").arg(savePath.c_str()).arg(traceRecorder.GetDump().c_str()));
@@ -523,7 +538,7 @@ namespace AtomToolsFramework
             AtomToolsDocumentRequestBus::EventResult(openResult, documentId, &AtomToolsDocumentRequestBus::Events::Open, documentPath);
             if (!openResult)
             {
-                QMessageBox::critical(
+                DisplayErrorMessage(
                     GetToolMainWindow(),
                     QObject::tr("Document could not be opened"),
                     QObject::tr("Failed to open: \n%1\n\n%2").arg(documentPath.c_str()).arg(traceRecorder.GetDump().c_str()));
@@ -551,7 +566,7 @@ namespace AtomToolsFramework
             AtomToolsDocumentRequestBus::EventResult(openResult, documentId, &AtomToolsDocumentRequestBus::Events::Reopen);
             if (!openResult)
             {
-                QMessageBox::critical(
+                DisplayErrorMessage(
                     GetToolMainWindow(),
                     QObject::tr("Document could not be opened"),
                     QObject::tr("Failed to open: \n%1\n\n%2").arg(documentPath.c_str()).arg(traceRecorder.GetDump().c_str()));

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
@@ -73,6 +73,7 @@ namespace AtomToolsFramework
                 ->Event("SaveDocumentAsChild", &AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsChild)
                 ->Event("SaveAllDocuments", &AtomToolsDocumentSystemRequestBus::Events::SaveAllDocuments)
                 ->Event("GetDocumentCount", &AtomToolsDocumentSystemRequestBus::Events::GetDocumentCount)
+                ->Event("IsDocumentOpen", &AtomToolsDocumentSystemRequestBus::Events::IsDocumentOpen)
                 ;
         }
     }
@@ -470,6 +471,13 @@ namespace AtomToolsFramework
     AZ::u32 AtomToolsDocumentSystem::GetDocumentCount() const
     {
         return aznumeric_cast<AZ::u32>(m_documentMap.size());
+    }
+
+    bool AtomToolsDocumentSystem::IsDocumentOpen(const AZ::Uuid& documentId) const
+    {
+        bool result = false;
+        AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsDocumentRequestBus::Events::IsOpen);
+        return result;
     }
 
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -233,7 +233,7 @@ namespace AtomToolsFramework
                 this, QObject::tr("Run Script"), QString(AZ::Utils::GetProjectPath().c_str()), QString("*.py"));
             if (!script.isEmpty())
             {
-                QTimer::singleShot(0, [this, script]() {
+                QTimer::singleShot(0, [script]() {
                     AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(
                         &AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilename, script.toUtf8().constData());
                 });

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -233,8 +233,10 @@ namespace AtomToolsFramework
                 this, QObject::tr("Run Script"), QString(AZ::Utils::GetProjectPath().c_str()), QString("*.py"));
             if (!script.isEmpty())
             {
-                AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(
-                    &AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilename, script.toUtf8().constData());
+                QTimer::singleShot(0, [this, script]() {
+                    AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(
+                        &AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilename, script.toUtf8().constData());
+                });
             }
         });
 

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -230,9 +230,7 @@ namespace MaterialCanvas
         return true;
     }
 
-    // MaterialCanvasDocumentRequestBus::Handler overrides...
-
-    inline GraphCanvas::GraphId MaterialCanvasDocument::GetGraphId() const
+    GraphCanvas::GraphId MaterialCanvasDocument::GetGraphId() const
     {
         return m_graphId;
     }

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/main.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/main.cpp
@@ -15,8 +15,8 @@ int main(int argc, char** argv)
     MaterialCanvas::MaterialCanvasApplication app(&argc, &argv);
     if (app.LaunchLocalServer())
     {
-        app.Start(AZ::ComponentApplication::Descriptor{});
-        app.exec();
+        app.Start({}, {});
+        app.RunMainLoop();
         app.Stop();
     }
 

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
@@ -77,7 +77,7 @@ namespace MaterialEditor
         return &m_materialTypeSourceData;
     }
 
-    void MaterialDocument::SetPropertyValue(const AZ::Name& propertyId, const AZStd::any& value)
+    void MaterialDocument::SetPropertyValue(const AZStd::string& propertyId, const AZStd::any& value)
     {
         if (!IsOpen())
         {
@@ -85,11 +85,13 @@ namespace MaterialEditor
             return;
         }
 
+        const AZ::Name propertyName(propertyId);
+
         AtomToolsFramework::DynamicProperty* foundProperty = {};
         TraverseGroups(m_groups, [&, this](auto& group) {
             for (auto& property : group->m_properties)
             {
-                if (property.GetId() == propertyId)
+                if (property.GetId() == propertyName)
                 {
                     foundProperty = &property;
 
@@ -98,7 +100,7 @@ namespace MaterialEditor
 
                     property.SetValue(AtomToolsFramework::ConvertToEditableType(propertyValue));
 
-                    const auto propertyIndex = m_materialInstance->FindPropertyIndex(propertyId);
+                    const auto propertyIndex = m_materialInstance->FindPropertyIndex(propertyName);
                     if (!propertyIndex.IsNull())
                     {
                         if (m_materialInstance->SetPropertyValue(propertyIndex, propertyValue))
@@ -124,11 +126,11 @@ namespace MaterialEditor
 
         if (!foundProperty)
         {
-            AZ_Error("MaterialDocument", false, "Document property could not be found: '%s'.", propertyId.GetCStr());
+            AZ_Error("MaterialDocument", false, "Document property could not be found: '%s'.", propertyId.c_str());
         }
     }
 
-    const AZStd::any& MaterialDocument::GetPropertyValue(const AZ::Name& propertyId) const
+    const AZStd::any& MaterialDocument::GetPropertyValue(const AZStd::string& propertyId) const
     {
         if (!IsOpen())
         {
@@ -136,10 +138,10 @@ namespace MaterialEditor
             return m_invalidValue;
         }
 
-        auto property = FindProperty(propertyId);
+        auto property = FindProperty(AZ::Name(propertyId));
         if (!property)
         {
-            AZ_Error("MaterialDocument", false, "Document property could not be found: '%s'.", propertyId.GetCStr());
+            AZ_Error("MaterialDocument", false, "Document property could not be found: '%s'.", propertyId.c_str());
             return m_invalidValue;
         }
 
@@ -336,7 +338,7 @@ namespace MaterialEditor
         {
             const auto& propertyName = propertyBeforeEditPair.first;
             const auto& propertyValueForUndo = propertyBeforeEditPair.second;
-            const auto& propertyValueForRedo = GetPropertyValue(propertyName);
+            const auto& propertyValueForRedo = GetPropertyValue(propertyName.GetStringView());
             if (!AtomToolsFramework::ArePropertyValuesEqual(propertyValueForUndo, propertyValueForRedo))
             {
                 propertyValuesForUndo[propertyName] = propertyValueForUndo;
@@ -648,7 +650,7 @@ namespace MaterialEditor
                         propertyConfig.m_dataChangeCallback = [documentId = m_id, propertyId = propertyConfig.m_id](const AZStd::any& value)
                         {
                             MaterialDocumentRequestBus::Event(
-                                documentId, &MaterialDocumentRequestBus::Events::SetPropertyValue, propertyId, value);
+                                documentId, &MaterialDocumentRequestBus::Events::SetPropertyValue, propertyId.GetStringView(), value);
                             return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
                         };
 
@@ -789,7 +791,7 @@ namespace MaterialEditor
         {
             const auto& propertyName = propertyValuePair.first;
             const auto& propertyValue = propertyValuePair.second;
-            SetPropertyValue(propertyName, propertyValue);
+            SetPropertyValue(propertyName.GetStringView(), propertyValue);
         }
     }
 

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.h
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.h
@@ -56,8 +56,8 @@ namespace MaterialEditor
         AZ::Data::Instance<AZ::RPI::Material> GetInstance() const override;
         const AZ::RPI::MaterialSourceData* GetMaterialSourceData() const override;
         const AZ::RPI::MaterialTypeSourceData* GetMaterialTypeSourceData() const override;
-        void SetPropertyValue(const AZ::Name& propertyId, const AZStd::any& value) override;
-        const AZStd::any& GetPropertyValue(const AZ::Name& propertyId) const override;
+        void SetPropertyValue(const AZStd::string& propertyId, const AZStd::any& value) override;
+        const AZStd::any& GetPropertyValue(const AZStd::string& propertyId) const override;
 
     private:
 

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocumentRequestBus.h
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocumentRequestBus.h
@@ -10,9 +10,6 @@
 
 #include <Atom/RPI.Public/Material/Material.h>
 #include <Atom/RPI.Reflect/Material/MaterialAsset.h>
-#include <Atom/RPI.Reflect/Material/MaterialPropertyDescriptor.h>
-#include <AtomToolsFramework/DynamicProperty/DynamicProperty.h>
-#include <AzCore/Asset/AssetCommon.h>
 
 namespace AZ
 {
@@ -48,11 +45,11 @@ namespace MaterialEditor
         virtual const AZ::RPI::MaterialTypeSourceData* GetMaterialTypeSourceData() const = 0;
 
         //! Modify property value
-        virtual void SetPropertyValue(const AZ::Name& propertyFullName, const AZStd::any& value) = 0;
+        virtual void SetPropertyValue(const AZStd::string& propertyFullName, const AZStd::any& value) = 0;
 
         //! Return property value
         //! If the document is not open or the id can't be found, an invalid value is returned instead.
-        virtual const AZStd::any& GetPropertyValue(const AZ::Name& propertyFullName) const = 0;
+        virtual const AZStd::any& GetPropertyValue(const AZStd::string& propertyFullName) const = 0;
     };
 
     using MaterialDocumentRequestBus = AZ::EBus<MaterialDocumentRequests>;

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/main.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/main.cpp
@@ -15,8 +15,8 @@ int main(int argc, char** argv)
     MaterialEditor::MaterialEditorApplication app(&argc, &argv);
     if (app.LaunchLocalServer())
     {
-        app.Start(AZ::ComponentApplication::Descriptor{});
-        app.exec();
+        app.Start({}, {});
+        app.RunMainLoop();
         app.Stop();
     }
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/main.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/main.cpp
@@ -15,8 +15,8 @@ int main(int argc, char** argv)
     ShaderManagementConsole::ShaderManagementConsoleApplication app(&argc, &argv);
     if (app.LaunchLocalServer())
     {
-        app.Start(AZ::ComponentApplication::Descriptor{});
-        app.exec();
+        app.Start({}, {});
+        app.RunMainLoop();
         app.Stop();
     }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/EditorCommonFeaturesSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/EditorCommonFeaturesSystemComponent.cpp
@@ -71,6 +71,7 @@ namespace AZ
         void EditorCommonFeaturesSystemComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
         {
             required.push_back(AZ_CRC_CE("ThumbnailerService"));
+            required.push_back(AZ_CRC_CE("PreviewRendererSystem"));
         }
 
         void EditorCommonFeaturesSystemComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)


### PR DESCRIPTION
Atom tools application was never updated to handle Python arguments or return codes. Additionally, there have been AR stability issues, which seem to be related to calling idle_wait_frames within a Python script. The static function on the C++ side was connecting to the tick bus, counting tick events before allowing the Python script to continue processing. The previous implementation was not updating the main application event loop or sending tick events within the function local event loop. I'm not sure how this ever worked In atom tools or the main editor. The new version calls the application tick functions directly and removes the dependency on the tick bus.

Also required fixing material editor shut down issues caused by the thumbnail system, component service shut down order, and menu actions not being owned correctly.

This is to support the PR in progress for material editor automated test updates https://github.com/o3de/o3de/pull/9286