### PR TITLE
Linux strip debug info improvements

### DIFF
--- a/cmake/Platform/Linux/DetachDebugSymbols.cmake
+++ b/cmake/Platform/Linux/DetachDebugSymbols.cmake
@@ -1,0 +1,42 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+
+if(NOT ${CMAKE_ARGC} EQUAL 6)
+    message(FATAL_ERROR "DetachDebugSymbols script called with the wrong number of arguments: ${CMAKE_ARGC}")
+endif()
+
+string(TOLOWER ${CMAKE_ARGV4} STATIC_LIBRARY_SUFFIX)
+string(TOLOWER ${CMAKE_ARGV5} DEBUG_SYMBOL_EXT)
+
+
+find_program(GNU_STRIP_TOOL strip)
+find_program(GNU_OBJCOPY objcopy)
+
+get_filename_component(file_extension ${CMAKE_ARGV3} LAST_EXT)
+
+if (GNU_STRIP_TOOL AND GNU_OBJCOPY)
+
+    if (NOT ${file_extension} STREQUAL ${STATIC_LIBRARY_SUFFIX})
+
+        message(STATUS "Detaching debug symbols from ${CMAKE_ARGV3} into ${CMAKE_ARGV3}.${DEBUG_SYMBOL_EXT}")
+
+        execute_process(COMMAND
+            ${GNU_OBJCOPY} --only-keep-debug ${CMAKE_ARGV3} ${CMAKE_ARGV3}.${DEBUG_SYMBOL_EXT}
+        )
+
+        execute_process(COMMAND
+            ${GNU_STRIP_TOOL} --strip-debug ${CMAKE_ARGV3}
+        )
+
+        execute_process(COMMAND
+            ${GNU_OBJCOPY} --add-gnu-debuglink=${CMAKE_ARGV3}.dbg ${CMAKE_ARGV3}
+        )
+    endif()
+
+endif()

--- a/cmake/Platform/Linux/DetachDebugSymbols.cmake
+++ b/cmake/Platform/Linux/DetachDebugSymbols.cmake
@@ -14,28 +14,37 @@ endif()
 string(TOLOWER ${CMAKE_ARGV4} STATIC_LIBRARY_SUFFIX)
 string(TOLOWER ${CMAKE_ARGV5} DEBUG_SYMBOL_EXT)
 
-
+# Make sure that both gnu tools 'strip' and 'objcopy' are available
 find_program(GNU_STRIP_TOOL strip)
 find_program(GNU_OBJCOPY objcopy)
 
-get_filename_component(file_extension ${CMAKE_ARGV3} LAST_EXT)
-
 if (GNU_STRIP_TOOL AND GNU_OBJCOPY)
 
+    # Only perform the debug symbol detachment on non-static libraries. (You cannot add the gnu debug link on an static library)
+    get_filename_component(file_extension ${CMAKE_ARGV3} LAST_EXT)
     if (NOT ${file_extension} STREQUAL ${STATIC_LIBRARY_SUFFIX})
 
-        message(STATUS "Detaching debug symbols from ${CMAKE_ARGV3} into ${CMAKE_ARGV3}.${DEBUG_SYMBOL_EXT}")
+        # When specifying the location of the debug info file, just use the filename so that the debugger will search
+        # for the name through the set of known locations. Using the absolute filename will cause the debugger to look
+        # only for that absolute path, which is not portable
+        get_filename_component(file_path ${CMAKE_ARGV3} DIRECTORY)
+        get_filename_component(filename_only ${CMAKE_ARGV3} NAME)
 
-        execute_process(COMMAND
-            ${GNU_OBJCOPY} --only-keep-debug ${CMAKE_ARGV3} ${CMAKE_ARGV3}.${DEBUG_SYMBOL_EXT}
+        message(STATUS "Detaching debug symbols from ${CMAKE_ARGV3} into ${filename_only}.${DEBUG_SYMBOL_EXT}")
+
+        # First extract out the debug symbols into a separate file 
+        execute_process(COMMAND 
+                            ${GNU_OBJCOPY} --only-keep-debug ${CMAKE_ARGV3} ${CMAKE_ARGV3}.${DEBUG_SYMBOL_EXT}
         )
-
-        execute_process(COMMAND
-            ${GNU_STRIP_TOOL} --strip-debug ${CMAKE_ARGV3}
+        # Then strip out the debug symbols completely from the shared library or executable
+        execute_process(COMMAND 
+                            ${GNU_STRIP_TOOL} --strip-debug ${CMAKE_ARGV3}
         )
-
-        execute_process(COMMAND
-            ${GNU_OBJCOPY} --add-gnu-debuglink=${CMAKE_ARGV3}.dbg ${CMAKE_ARGV3}
+        # Then re-link the debug information by creating a .gnu_debuglink section to the filename
+        execute_process(COMMAND 
+                            ${GNU_OBJCOPY} --add-gnu-debuglink=${filename_only}.${DEBUG_SYMBOL_EXT} ${CMAKE_ARGV3}
+                        WORKING_DIRECTORY 
+                            file_path
         )
     endif()
 

--- a/cmake/Platform/Linux/LYWrappers_linux.cmake
+++ b/cmake/Platform/Linux/LYWrappers_linux.cmake
@@ -55,16 +55,31 @@ endfunction()
 function(ly_apply_debug_strip_options target)
 
     find_program(GNU_STRIP_TOOL strip)
-    if (NOT GNU_STRIP_TOOL OR NOT ${LY_STRIP_DEBUG_SYMBOLS})
+    if (NOT GNU_STRIP_TOOL)
         return()
     endif()
 
-    add_custom_command(TARGET ${target} POST_BUILD
-        COMMAND "${CMAKE_COMMAND}" -P "${LY_ROOT_FOLDER}/cmake/Platform/Linux/StripDebugSymbols.cmake"
-                "$<TARGET_FILE:${target}>"
-                "$<CONFIG>"
-        COMMENT "Stripping debug symbols ..."
-        VERBATIM
-    )
+    if (${LY_STRIP_DEBUG_SYMBOLS})
+
+        add_custom_command(TARGET ${target} POST_BUILD
+            COMMAND "${CMAKE_COMMAND}" -P "${LY_ROOT_FOLDER}/cmake/Platform/Linux/StripDebugSymbols.cmake"
+                    "$<TARGET_FILE:${target}>"
+                    "$<CONFIG>"
+            COMMENT "Stripping debug symbols ..."
+            VERBATIM
+        )
+
+    else()
+
+        add_custom_command(TARGET ${target} POST_BUILD
+            COMMAND "${CMAKE_COMMAND}" -P "${LY_ROOT_FOLDER}/cmake/Platform/Linux/DetachDebugSymbols.cmake"
+                    "$<TARGET_FILE:${target}>"
+                    "${CMAKE_STATIC_LIBRARY_SUFFIX}"
+                    "dbg"
+            COMMENT "Detaching debug symbols ..."
+            VERBATIM
+        )
+
+    endif()
 
 endfunction()

--- a/cmake/Platform/Mac/LYWrappers_mac.cmake
+++ b/cmake/Platform/Mac/LYWrappers_mac.cmake
@@ -102,3 +102,7 @@ function(ly_add_bundle_resources)
     endif()
 
 endfunction()
+
+function(ly_apply_debug_strip_options target)
+    #Noop
+endfunction()


### PR DESCRIPTION
Adding to the optional debug-strip option in Linux, this change will now detach the debug info database file from the compiled shared library/executable and link it in as a separate debug file when used for debugging (if the debug stripping option is FALSE). 
This uses the mechanism described in [objcopy](https://man7.org/linux/man-pages/man1/objcopy.1.html) (see ```--add-gnu-debuglink```)

Also fix an issue on Mac where ```ly_apply_debug_strip_options``` was not defined (caused by LYWrappers_mac.cmake not including LYWrappers_common.cmake like the other platforms)