### PR TITLE
make Lua dependency regex more robust

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Builders/LuaBuilder/LuaBuilderWorker.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/LuaBuilder/LuaBuilderWorker.cpp
@@ -283,7 +283,7 @@ namespace LuaBuilder
             // Group 2: quotation mark ("), apostrophe ('), or empty
             // Group 3: specified path or variable (variable will be indicated by empty group 2)
             // Group 4: Same as group 2
-            AZStd::regex requireRegex(R"(\b(?:(require)|Script\.ReloadScript)\s*[\( ]\s*("|'|)([^"')]*)("|'|)\s*\)?)");
+            AZStd::regex requireRegex(R"(\b(?:(require)|Script\.ReloadScript)\s*(?:\(|(?="|'))\s*("|'|)([^"')]*)(\2)\s*\)?)");
             // Regex to match lines looking like a path (containing a /)
             // Group 1: the string contents
             AZStd::regex pathRegex(R"~("((?=[^"]*\/)[^"\n<>:"|?*]{2,})")~");

--- a/Gems/LmbrCentral/Code/Tests/Builders/LuaBuilderTests.cpp
+++ b/Gems/LmbrCentral/Code/Tests/Builders/LuaBuilderTests.cpp
@@ -62,6 +62,59 @@ namespace UnitTest
         AZ::ComponentApplication::Descriptor m_descriptor;
     };
 
+    TEST_F(LuaBuilderTests, ParseLuaScript_DependencyRegexStress_Success)
+    {
+        LuaBuilderWorker worker;
+
+        AssetBuilderSDK::ProductPathDependencySet pathDependencies;
+
+        char resolvedPath[AZ_MAX_PATH_LEN];
+        AZ::IO::FileIOBase::GetInstance()->ResolvePath("@gemroot:LmbrCentral@/Code/Tests/Lua/dependencyRegexStress.lua", resolvedPath, AZ_MAX_PATH_LEN);
+
+        worker.ParseDependencies(AZStd::string(resolvedPath), pathDependencies);
+
+        ASSERT_THAT(pathDependencies,
+            testing::UnorderedElementsAre(
+                ProductPathDependency("test0.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/test1.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/separated/test2.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/separated/test3.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/test4.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("test5.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/test6.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("test7.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/test8.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/test9.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/test10.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/test11.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/test12.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/test13.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/test14.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/test15.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/test16.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("test17.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("local_test0.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/local_test1.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/separated/local_test2.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/separated/local_test3.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/local_test4.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("local_test5.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/local_test6.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("local_test7.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/local_test8.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/local_test9.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/local_test10.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/local_test11.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/local_test12.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/local_test13.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/local_test14.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/local_test15.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("folder/local_test16.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile),
+                ProductPathDependency("local_test17.luac", AssetBuilderSDK::ProductPathDependencyType::ProductFile)
+            )
+        );
+    }
+
     TEST_F(LuaBuilderTests, ParseLuaScript_UsingRequire_ShouldFindDependencies)
     {
         LuaBuilderWorker worker;

--- a/Gems/LmbrCentral/Code/Tests/Builders/LuaBuilderTests.cpp
+++ b/Gems/LmbrCentral/Code/Tests/Builders/LuaBuilderTests.cpp
@@ -68,10 +68,10 @@ namespace UnitTest
 
         AssetBuilderSDK::ProductPathDependencySet pathDependencies;
 
-        char resolvedPath[AZ_MAX_PATH_LEN];
-        AZ::IO::FileIOBase::GetInstance()->ResolvePath("@gemroot:LmbrCentral@/Code/Tests/Lua/dependencyRegexStress.lua", resolvedPath, AZ_MAX_PATH_LEN);
+        AZ::IO::FixedMaxPath resolvedPath;
+        AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedPath, "@gemroot:LmbrCentral@/Code/Tests/Lua/dependencyRegexStress.lua");
 
-        worker.ParseDependencies(AZStd::string(resolvedPath), pathDependencies);
+        worker.ParseDependencies(resolvedPath.c_str(), pathDependencies);
 
         ASSERT_THAT(pathDependencies,
             testing::UnorderedElementsAre(
@@ -121,10 +121,10 @@ namespace UnitTest
 
         AssetBuilderSDK::ProductPathDependencySet pathDependencies;
 
-        char resolvedPath[AZ_MAX_PATH_LEN];
-        AZ::IO::FileIOBase::GetInstance()->ResolvePath("@gemroot:LmbrCentral@/Code/Tests/Lua/test1.lua", resolvedPath, AZ_MAX_PATH_LEN);
+        AZ::IO::FixedMaxPath resolvedPath;
+        AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedPath, "@gemroot:LmbrCentral@/Code/Tests/Lua/test1.lua");
 
-        worker.ParseDependencies(AZStd::string(resolvedPath), pathDependencies);
+        worker.ParseDependencies(resolvedPath.c_str(), pathDependencies);
 
         ASSERT_THAT(pathDependencies,
             testing::UnorderedElementsAre(
@@ -140,10 +140,10 @@ namespace UnitTest
 
         AssetBuilderSDK::ProductPathDependencySet pathDependencies;
 
-        char resolvedPath[AZ_MAX_PATH_LEN];
-        AZ::IO::FileIOBase::GetInstance()->ResolvePath("@gemroot:LmbrCentral@/Code/Tests/Lua/test2.lua", resolvedPath, AZ_MAX_PATH_LEN);
+        AZ::IO::FixedMaxPath resolvedPath;
+        AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedPath, "@gemroot:LmbrCentral@/Code/Tests/Lua/test2.lua");
 
-        worker.ParseDependencies(AZStd::string(resolvedPath), pathDependencies);
+        worker.ParseDependencies(resolvedPath.c_str(), pathDependencies);
 
         ASSERT_THAT(pathDependencies,
             testing::UnorderedElementsAre(
@@ -157,10 +157,10 @@ namespace UnitTest
 
         AssetBuilderSDK::ProductPathDependencySet pathDependencies;
 
-        char resolvedPath[AZ_MAX_PATH_LEN];
-        AZ::IO::FileIOBase::GetInstance()->ResolvePath("@gemroot:LmbrCentral@/Code/Tests/Lua/test3_general_dependencies.lua", resolvedPath, AZ_MAX_PATH_LEN);
+        AZ::IO::FixedMaxPath resolvedPath;
+        AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedPath, "@gemroot:LmbrCentral@/Code/Tests/Lua/test3_general_dependencies.lua");
 
-        worker.ParseDependencies(AZStd::string(resolvedPath), pathDependencies);
+        worker.ParseDependencies(resolvedPath.c_str(), pathDependencies);
 
         ASSERT_THAT(pathDependencies,
             testing::UnorderedElementsAre(
@@ -174,10 +174,10 @@ namespace UnitTest
 
         AssetBuilderSDK::ProductPathDependencySet pathDependencies;
 
-        char resolvedPath[AZ_MAX_PATH_LEN];
-        AZ::IO::FileIOBase::GetInstance()->ResolvePath("@gemroot:LmbrCentral@/Code/Tests/Lua/test4_console_command.lua", resolvedPath, AZ_MAX_PATH_LEN);
+        AZ::IO::FixedMaxPath resolvedPath;
+        AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedPath, "@gemroot:LmbrCentral@/Code/Tests/Lua/test4_console_command.lua");
 
-        worker.ParseDependencies(AZStd::string(resolvedPath), pathDependencies);
+        worker.ParseDependencies(resolvedPath.c_str(), pathDependencies);
 
         ASSERT_THAT(pathDependencies,
             testing::UnorderedElementsAre(
@@ -192,12 +192,12 @@ namespace UnitTest
 
         AssetBuilderSDK::ProductPathDependencySet pathDependencies;
 
-        char resolvedPath[AZ_MAX_PATH_LEN];
-        AZ::IO::FileIOBase::GetInstance()->ResolvePath(testFileUnresolvedPath.c_str(), resolvedPath, AZ_MAX_PATH_LEN);
+        AZ::IO::FixedMaxPath resolvedPath;
+        AZ::IO::FileIOBase::GetInstance()->ResolvePath(testFileUnresolvedPath.c_str());
 
-        EXPECT_TRUE(AZ::IO::FileIOBase::GetInstance()->Exists(resolvedPath));
+        EXPECT_TRUE(AZ::IO::FileIOBase::GetInstance()->Exists(resolvedPath.c_str()));
 
-        worker.ParseDependencies(AZStd::string(resolvedPath), pathDependencies);
+        worker.ParseDependencies(resolvedPath.c_str(), pathDependencies);
 
         EXPECT_TRUE(pathDependencies.empty());
     }
@@ -223,10 +223,10 @@ namespace UnitTest
 
         AssetBuilderSDK::ProductPathDependencySet pathDependencies;
 
-        char resolvedPath[AZ_MAX_PATH_LEN];
-        AZ::IO::FileIOBase::GetInstance()->ResolvePath("@gemroot:LmbrCentral@/Code/Tests/Lua/test8_negated_block_comment.lua", resolvedPath, AZ_MAX_PATH_LEN);
+        AZ::IO::FixedMaxPath resolvedPath;
+        AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedPath, "@gemroot:LmbrCentral@/Code/Tests/Lua/test8_negated_block_comment.lua");
 
-        worker.ParseDependencies(AZStd::string(resolvedPath), pathDependencies);
+        worker.ParseDependencies(resolvedPath.c_str(), pathDependencies);
 
         ASSERT_THAT(pathDependencies,
             testing::UnorderedElementsAre(

--- a/Gems/LmbrCentral/Code/Tests/Lua/dependencyRegexStress.lua
+++ b/Gems/LmbrCentral/Code/Tests/Lua/dependencyRegexStress.lua
@@ -1,0 +1,48 @@
+----------------------------------------------------------------------------------------------------
+--
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
+--
+-- SPDX-License-Identifier: Apache-2.0 OR MIT
+--
+--
+--
+----------------------------------------------------------------------------------------------------
+require("test0")
+require("folder.test1")
+require("folder.separated.test2")
+require("folder/separated/test3")
+require'folder.test4'
+require'test5'
+require"folder.test6"
+require"test7"
+require "folder.test8"
+require("folder.test9")
+require( "folder.test10")
+require( "folder.test11" )
+require ("folder.test12") 
+require ( "folder.test13")
+require ( "folder.test14" )
+require 'folder.test15'
+require "folder.test16"
+require("test17") -- tests greedy operation in regex...
+if _G.value ~= true then  end 
+local result0 = require("local_test0")
+local result1 = require("folder.local_test1")
+local result2 = require("folder.separated.local_test2")
+local result3 = require("folder/separated/local_test3")
+local result4 = require'folder.local_test4'
+local result5 = require'local_test5'
+local result6 = require"folder.local_test6"
+local result7 = require"local_test7"
+local result8 = require "folder.local_test8"
+local result9 = require("folder.local_test9")
+local result10 = require( "folder.local_test10")
+local result11 = require( "folder.local_test11" )
+local result12 = require ("folder.local_test12") 
+local result13 = require ( "folder.local_test13")
+local result14 = require ( "folder.local_test14" )
+local result15 = require 'folder.local_test15'
+local result16 = require "folder.local_test16"
+local result17 = require("local_test17") -- tests greedy operation in regex
+if _G.value ~= true then  end 


### PR DESCRIPTION
The Lua dependency regex could miss a few standards uses of 'require', so the regex has been updated and a stressful regex has been added.

Signed-off-by: carlitosan <82187351+carlitosan@users.noreply.github.com>