### PR TITLE
chore: simplify Sphere in AZCore Math

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Sphere.h
+++ b/Code/Framework/AzCore/AzCore/Math/Sphere.h
@@ -21,9 +21,7 @@ namespace AZ
         AZ_TYPE_INFO(Sphere, "{34BB6527-81AE-4854-99ED-D1A319DCD0A9}");
 
         Sphere() = default;
-
-        explicit Sphere(const Vector3& center, float radius);
-        Sphere(const Sphere& sphere);
+        Sphere(const Vector3& center, float radius);
 
         static Sphere CreateUnitSphere();
         static Sphere CreateFromAabb(const Aabb& aabb);
@@ -33,7 +31,7 @@ namespace AZ
         void SetCenter(const Vector3& center);
         void SetRadius(float radius);
 
-        // O3DE_DEPRECATION_NOTICE(GHI-XX)
+        // O3DE_DEPRECATION_NOTICE(GHI-9453)
         //! @deprecated can be set through an assignment
         void Set(const Sphere& sphere);
 

--- a/Code/Framework/AzCore/AzCore/Math/Sphere.h
+++ b/Code/Framework/AzCore/AzCore/Math/Sphere.h
@@ -18,12 +18,12 @@ namespace AZ
     class Sphere
     {
     public:
-
         AZ_TYPE_INFO(Sphere, "{34BB6527-81AE-4854-99ED-D1A319DCD0A9}");
 
         Sphere() = default;
 
         explicit Sphere(const Vector3& center, float radius);
+        Sphere(const Sphere& sphere);
 
         static Sphere CreateUnitSphere();
         static Sphere CreateFromAabb(const Aabb& aabb);
@@ -33,20 +33,17 @@ namespace AZ
         void SetCenter(const Vector3& center);
         void SetRadius(float radius);
 
+        // O3DE_DEPRECATION_NOTICE(GHI-XX)
+        //! @deprecated can be set through an assignment
         void Set(const Sphere& sphere);
 
-        Sphere& operator=(const Sphere& rhs);
-
         bool operator==(const Sphere& rhs) const;
-
         bool operator!=(const Sphere& rhs) const;
 
     private:
-
         Vector3 m_center;
         float m_radius;
-
     };
-}
+} // namespace AZ
 
 #include <AzCore/Math/Sphere.inl>

--- a/Code/Framework/AzCore/AzCore/Math/Sphere.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Sphere.inl
@@ -16,11 +16,6 @@ namespace AZ
         m_radius = radius;
     }
 
-    AZ_MATH_INLINE Sphere::Sphere(const Sphere& sphere):
-        m_center(sphere.m_center),
-        m_radius(sphere.m_radius) {
-    }
-
     AZ_MATH_INLINE Sphere Sphere::CreateUnitSphere()
     {
         return Sphere(AZ::Vector3::CreateZero(), 1.0f);

--- a/Code/Framework/AzCore/AzCore/Math/Sphere.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Sphere.inl
@@ -16,6 +16,10 @@ namespace AZ
         m_radius = radius;
     }
 
+    AZ_MATH_INLINE Sphere::Sphere(const Sphere& sphere):
+        m_center(sphere.m_center),
+        m_radius(sphere.m_radius) {
+    }
 
     AZ_MATH_INLINE Sphere Sphere::CreateUnitSphere()
     {
@@ -60,13 +64,6 @@ namespace AZ
     {
         m_center = sphere.m_center;
         m_radius = sphere.m_radius;
-    }
-
-
-    AZ_MATH_INLINE Sphere& Sphere::operator=(const Sphere& rhs)
-    {
-        Set(rhs);
-        return *this;
     }
 
 

--- a/Code/Framework/AzCore/Tests/Math/SphereTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SphereTests.cpp
@@ -59,4 +59,11 @@ namespace UnitTest
         sphere2 = unitSphere;
         EXPECT_TRUE(sphere2 == unitSphere);
     }
+
+    TEST(MATH_Sphere, TestCopyConstructor)
+    {
+        AZ::Sphere unitSphere = AZ::Sphere::CreateUnitSphere();
+        AZ::Sphere sphere2(unitSphere);
+        EXPECT_TRUE(sphere2 == unitSphere);
+    }
 }

--- a/Code/Framework/AzCore/Tests/Math/SphereTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SphereTests.cpp
@@ -14,8 +14,8 @@ namespace UnitTest
     TEST(MATH_Sphere, TestCreateUnitSphere)
     {
         AZ::Sphere unitSphere = AZ::Sphere::CreateUnitSphere();
-        EXPECT_TRUE(unitSphere.GetCenter() == AZ::Vector3::CreateZero());
-        EXPECT_TRUE(unitSphere.GetRadius() == 1.f);
+        EXPECT_EQ(unitSphere.GetCenter(), AZ::Vector3::CreateZero());
+        EXPECT_EQ(unitSphere.GetRadius(), 1.f);
     }
 
     TEST(MATH_Sphere, TestCreateFromAabb)
@@ -29,18 +29,18 @@ namespace UnitTest
     TEST(MATH_Sphere, TestConstructFromVec3AndRadius)
     {
         AZ::Sphere sphere1(AZ::Vector3(10.f, 10.f, 10.f), 15.f);
-        EXPECT_TRUE(sphere1.GetCenter() == AZ::Vector3(10.f, 10.f, 10.f));
-        EXPECT_TRUE(sphere1.GetRadius() == 15.f);
+        EXPECT_EQ(sphere1.GetCenter(), AZ::Vector3(10.f, 10.f, 10.f));
+        EXPECT_EQ(sphere1.GetRadius(), 15.f);
     }
 
     TEST(MATH_Sphere, TestSet)
     {
         AZ::Sphere sphere1(AZ::Vector3(10.f, 10.f, 10.f), 15.f);
         AZ::Sphere sphere2(AZ::Vector3(12.f, 12.f, 12.f), 13.f);
-        EXPECT_TRUE(sphere2 != sphere1);
+        EXPECT_NE(sphere2, sphere1);
 
         sphere1.Set(sphere2);
-        EXPECT_TRUE(sphere2 == sphere1);
+        EXPECT_EQ(sphere2, sphere1);
     }
 
     TEST(MATH_Sphere, TestSetCenterAndRadius)
@@ -49,7 +49,7 @@ namespace UnitTest
         AZ::Sphere sphere3(AZ::Vector3(10.f, 10.f, 10.f), 15.f);
         sphere3.SetCenter(AZ::Vector3(12.f, 12.f, 12.f));
         sphere3.SetRadius(13.f);
-        EXPECT_TRUE(sphere2 == sphere3);
+        EXPECT_EQ(sphere2, sphere3);
     }
 
     TEST(MATH_Sphere, TestAssignment)
@@ -57,13 +57,13 @@ namespace UnitTest
         AZ::Sphere unitSphere = AZ::Sphere::CreateUnitSphere();
         AZ::Sphere sphere2(AZ::Vector3(12.f, 12.f, 12.f), 13.f);
         sphere2 = unitSphere;
-        EXPECT_TRUE(sphere2 == unitSphere);
+        EXPECT_EQ(sphere2, unitSphere);
     }
 
     TEST(MATH_Sphere, TestCopyConstructor)
     {
         AZ::Sphere unitSphere = AZ::Sphere::CreateUnitSphere();
         AZ::Sphere sphere2(unitSphere);
-        EXPECT_TRUE(sphere2 == unitSphere);
+        EXPECT_EQ(sphere2, unitSphere);
     }
-}
+} // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Math/SphereTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SphereTests.cpp
@@ -8,29 +8,30 @@
 
 #include <AzCore/Math/Sphere.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
 
 namespace UnitTest
 {
     TEST(MATH_Sphere, TestCreateUnitSphere)
     {
         AZ::Sphere unitSphere = AZ::Sphere::CreateUnitSphere();
-        EXPECT_EQ(unitSphere.GetCenter(), AZ::Vector3::CreateZero());
-        EXPECT_EQ(unitSphere.GetRadius(), 1.f);
+        EXPECT_THAT(unitSphere.GetCenter(), IsClose(AZ::Vector3::CreateZero()));
+        EXPECT_NEAR(unitSphere.GetRadius(), 1.f, 0.0001f);
     }
 
     TEST(MATH_Sphere, TestCreateFromAabb)
     {
         AZ::Aabb testBox = AZ::Aabb::CreateFromMinMax(AZ::Vector3(-1.0f), AZ::Vector3(1.0f));
         AZ::Sphere testSphere = AZ::Sphere::CreateFromAabb(testBox);
-        EXPECT_TRUE(testSphere.GetCenter().IsClose(AZ::Vector3::CreateZero()));
+        EXPECT_THAT(testSphere.GetCenter(), IsClose(AZ::Vector3::CreateZero()));
         EXPECT_NEAR(testSphere.GetRadius(), 1.f, 0.0001f);
     }
 
     TEST(MATH_Sphere, TestConstructFromVec3AndRadius)
     {
         AZ::Sphere sphere1(AZ::Vector3(10.f, 10.f, 10.f), 15.f);
-        EXPECT_EQ(sphere1.GetCenter(), AZ::Vector3(10.f, 10.f, 10.f));
-        EXPECT_EQ(sphere1.GetRadius(), 15.f);
+        EXPECT_THAT(sphere1.GetCenter(), IsClose(AZ::Vector3(10.f, 10.f, 10.f)));
+        EXPECT_NEAR(sphere1.GetRadius(), 15.f, 0.0001f);
     }
 
     TEST(MATH_Sphere, TestSet)


### PR DESCRIPTION
small refactor of Sphere in AZCore Math. I think it would be worthwhile to make tall these API's consistent. not sure what that would entail. The default Set is unnecessary when you can just use a direct assignment copy constructor is useful when declaring a sphere. 

- introduced copy constructor
- use default assignment operator
- deprecate Set