### PR TITLE
Fixed typo in Prebuilt Gem instructions title

### DIFF
--- a/Templates/PrebuiltGem/Template/README.md
+++ b/Templates/PrebuiltGem/Template/README.md
@@ -1,4 +1,4 @@
-# Pre-Built Gem hook insutrctions
+# Pre-Built Gem Hook Instructions
 
 The following are instructions on how to reference pre-existing static libraries, shared libraries or executable files into the Pre-Build Gem CMake target
 

--- a/Templates/PrebuiltGem/Template/README.md
+++ b/Templates/PrebuiltGem/Template/README.md
@@ -1,6 +1,6 @@
 # Pre-Built Gem Hook Instructions
 
-The following are instructions on how to reference pre-existing static libraries, shared libraries or executable files into the Pre-Build Gem CMake target
+The following are instructions on how to reference pre-existing static libraries, shared libraries or executable files into the Pre-Built Gem CMake target
 
 ## How to Hook Pre-Built Binaries into the CMake targets
 


### PR DESCRIPTION
Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>