### PR TITLE
Fix LyTestTools cannot run more than 10 editor batched tests

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -1488,7 +1488,7 @@ void CCryEditApp::RunInitPythonScript(CEditCommandLineInfo& cmdInfo)
                 fileList.push_back(elem);
             }, ';', false /* keepEmptyStrings */
         );
-    
+
         if (cmdInfo.m_pythonArgs.length() > 0 || cmdInfo.m_bRunPythonTestScript)
         {
             QByteArray pythonArgsStr = cmdInfo.m_pythonArgs.toUtf8();

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -1488,7 +1488,7 @@ void CCryEditApp::RunInitPythonScript(CEditCommandLineInfo& cmdInfo)
                 fileList.push_back(elem);
             }, ';', false /* keepEmptyStrings */
         );
-        
+    
         if (cmdInfo.m_pythonArgs.length() > 0 || cmdInfo.m_bRunPythonTestScript)
         {
             QByteArray pythonArgsStr = cmdInfo.m_pythonArgs.toUtf8();

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -472,7 +472,6 @@ public:
     bool m_bRunPythonScript = false;
     bool m_bRunPythonTestScript = false;
     bool m_bShowVersionInfo = false;
-    bool m_bCommandLineFile = false;
     QString m_exportFile;
     QString m_strFileName;
     QString m_appRoot;
@@ -481,7 +480,6 @@ public:
     QString m_pythonTestCase;
     QString m_execFile;
     QString m_execLineCmd;
-    QString m_cmdLineFileName;
 
     bool m_bSkipWelcomeScreenDialog = false;
     bool m_bAutotestMode = false;
@@ -1488,8 +1486,7 @@ void CCryEditApp::RunInitPythonScript(CEditCommandLineInfo& cmdInfo)
             [&fileList](AZStd::string_view elem)
             {
                 fileList.push_back(elem);
-            },
-            ';', false /* keepEmptyStrings */
+            }, ';', false /* keepEmptyStrings */
         );
         
         if (cmdInfo.m_pythonArgs.length() > 0 || cmdInfo.m_bRunPythonTestScript)

--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -878,7 +878,6 @@ class EditorTestSuite:
         editor_utils.cycle_crash_report(run_id, workspace)
 
         results = {}
-        temp_batched_file = None
 
         # We create a file containing a semicolon separated list for the Editor to read
         temp_batched_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt')
@@ -889,6 +888,7 @@ class EditorTestSuite:
         temp_batched_file.write(editor_utils.get_testcase_module_filepath(test_spec_list[-1].test_module)
                                 .replace('\\', '\\\\'))
         temp_batched_file.flush()
+        temp_batched_file.close()
 
         cmdline = [
             "--runpythontest", temp_batched_file.name,
@@ -989,7 +989,6 @@ class EditorTestSuite:
                                                          self.timeout_editor_shared_test, result.editor_log)
         finally:
             if temp_batched_file:
-                temp_batched_file.close()
                 os.unlink(temp_batched_file.name)
         return results
     

--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -879,26 +879,26 @@ class EditorTestSuite:
 
         results = {}
         temp_batched_file = None
-        test_filenames_str = ";".join(editor_utils.get_testcase_module_filepath(test_spec.test_module) for test_spec in test_spec_list)
+
+        # The Editor cannot handle more than 10 args, so we instead create a file containing a semicolon separated list
+        if len(test_spec_list) > 10:
+            temp_batched_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt')
+            for test_spec in test_spec_list[:-1]:
+                temp_batched_file.write(editor_utils.get_testcase_module_filepath(test_spec.test_module)
+                                        .replace('\\', '\\\\')+';')
+            # The last entry does not have a semicolon
+            temp_batched_file.write(editor_utils.get_testcase_module_filepath(test_spec_list[-1].test_module)
+                                    .replace('\\', '\\\\'))
+            temp_batched_file.flush()
+            test_filenames = temp_batched_file.name
+        else:
+            test_filenames = ";".join(
+                editor_utils.get_testcase_module_filepath(test_spec.test_module) for test_spec in test_spec_list)
+
         cmdline = [
-            "--runpythontest", test_filenames_str,
+            "--runpythontest", test_filenames,
             "-logfile", f"@log@/{log_name}",
             "-project-log-path", editor_utils.retrieve_log_path(run_id, workspace)] + test_cmdline_args
-
-        if len(test_spec_list) > 10:
-            temp_batched_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-            # with open(temp_batched_file, 'w') as opened_batched_file:
-            for test_spec in test_spec_list:
-                temp_batched_file.write(editor_utils.get_testcase_module_filepath(test_spec.test_module)+'\n')
-            temp_batched_file.flush()
-            cmdline = [
-                '--command-line-file', temp_batched_file,
-                "-logfile", f"@log@/{log_name}",
-                "-project-log-path", editor_utils.retrieve_log_path(run_id, workspace)
-            ] + test_cmdline_args
-            temp_batched_file.close()
-            os.unlink(temp_batched_file.name)
-
         editor.args.extend(cmdline)
         editor.start(backupFiles = False, launch_ap = False, configure_settings=False)
 
@@ -994,7 +994,8 @@ class EditorTestSuite:
                                                          self.timeout_editor_shared_test, result.editor_log)
         finally:
             if temp_batched_file:
-                ly_test_tools.environment.file_system.delete([self.tmp_path], True, True)
+                temp_batched_file.close()
+                os.unlink(temp_batched_file.name)
         return results
     
     def _run_single_test(self, request: _pytest.fixtures.FixtureRequest,

--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -880,23 +880,18 @@ class EditorTestSuite:
         results = {}
         temp_batched_file = None
 
-        # The Editor cannot handle more than 10 args, so we instead create a file containing a semicolon separated list
-        if len(test_spec_list) > 10:
-            temp_batched_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt')
-            for test_spec in test_spec_list[:-1]:
-                temp_batched_file.write(editor_utils.get_testcase_module_filepath(test_spec.test_module)
-                                        .replace('\\', '\\\\')+';')
-            # The last entry does not have a semicolon
-            temp_batched_file.write(editor_utils.get_testcase_module_filepath(test_spec_list[-1].test_module)
-                                    .replace('\\', '\\\\'))
-            temp_batched_file.flush()
-            test_filenames = temp_batched_file.name
-        else:
-            test_filenames = ";".join(
-                editor_utils.get_testcase_module_filepath(test_spec.test_module) for test_spec in test_spec_list)
+        # We create a file containing a semicolon separated list for the Editor to read
+        temp_batched_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt')
+        for test_spec in test_spec_list[:-1]:
+            temp_batched_file.write(editor_utils.get_testcase_module_filepath(test_spec.test_module)
+                                    .replace('\\', '\\\\')+';')
+        # The last entry does not have a semicolon
+        temp_batched_file.write(editor_utils.get_testcase_module_filepath(test_spec_list[-1].test_module)
+                                .replace('\\', '\\\\'))
+        temp_batched_file.flush()
 
         cmdline = [
-            "--runpythontest", test_filenames,
+            "--runpythontest", temp_batched_file.name,
             "-logfile", f"@log@/{log_name}",
             "-project-log-path", editor_utils.retrieve_log_path(run_id, workspace)] + test_cmdline_args
         editor.args.extend(cmdline)

--- a/Tools/LyTestTools/tests/unit/test_o3de_editor_test.py
+++ b/Tools/LyTestTools/tests/unit/test_o3de_editor_test.py
@@ -678,6 +678,8 @@ class TestRunningTests(unittest.TestCase):
 
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_testcase_module_filepath')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
+    @mock.patch('os.unlink', mock.MagicMock())
+    @mock.patch('tempfile.NamedTemporaryFile', mock.MagicMock())
     @mock.patch('os.path.join', mock.MagicMock())
     @mock.patch('os.path.splitext', mock.MagicMock())
     def test_ExecEditorMultitest_AllTestsPass_ReturnsPasses(self, mock_cycle_crash, mock_get_filepath):
@@ -707,6 +709,8 @@ class TestRunningTests(unittest.TestCase):
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_testcase_module_filepath')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
+    @mock.patch('os.unlink', mock.MagicMock())
+    @mock.patch('tempfile.NamedTemporaryFile', mock.MagicMock())
     @mock.patch('os.path.join', mock.MagicMock())
     @mock.patch('os.path.splitext', mock.MagicMock())
     def test_ExecEditorMultitest_OneFailure_CallsCorrectFunc(self, mock_cycle_crash, mock_get_testcase_filepath,
@@ -735,6 +739,8 @@ class TestRunningTests(unittest.TestCase):
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_testcase_module_filepath')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
+    @mock.patch('os.unlink', mock.MagicMock())
+    @mock.patch('tempfile.NamedTemporaryFile', mock.MagicMock())
     @mock.patch('os.path.join', mock.MagicMock())
     @mock.patch('os.path.basename', mock.MagicMock())
     def test_ExecEditorMultitest_OneCrash_ReportsOnUnknownResult(self, mock_cycle_crash, mock_get_testcase_filepath,
@@ -771,6 +777,8 @@ class TestRunningTests(unittest.TestCase):
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_testcase_module_filepath')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
+    @mock.patch('os.unlink', mock.MagicMock())
+    @mock.patch('tempfile.NamedTemporaryFile', mock.MagicMock())
     @mock.patch('os.path.join', mock.MagicMock())
     @mock.patch('os.path.basename', mock.MagicMock())
     def test_ExecEditorMultitest_ManyUnknown_ReportsUnknownResults(self, mock_cycle_crash, mock_get_testcase_filepath,


### PR DESCRIPTION
Added Editor functionality to accept a file that contains a semicolon separated list of python modules. Also added LyTestTools functionality to create a temp file and passes it when there are too many batched tests.

Tested by running LyTestTools unit tests + locally modifying and running Physics test suite to use BatchedEditorTests.