### PR TITLE
[Asset Processor] Use native separators when copying full asset path

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -1495,7 +1495,7 @@ void MainWindow::ShowJobViewContextMenu(const QPoint& pos)
 
     menu.addAction(tr("Copy"), this, [&]()
     {
-        QGuiApplication::clipboard()->setText(FindAbsoluteFilePath(item));
+        QGuiApplication::clipboard()->setText(QDir::toNativeSeparators(FindAbsoluteFilePath(item)));
     });
 
     // Get the internal path to the log file
@@ -1657,7 +1657,7 @@ void MainWindow::ShowSourceAssetContextMenu(const QPoint& pos)
         AZ::Outcome<QString> pathToSource = GetAbsolutePathToSource(*cachedAsset);
         if (pathToSource.IsSuccess())
         {
-            QGuiApplication::clipboard()->setText(pathToSource.GetValue());
+            QGuiApplication::clipboard()->setText(QDir::toNativeSeparators(pathToSource.GetValue()));
         }
     });
 
@@ -1758,7 +1758,7 @@ void MainWindow::ShowProductAssetContextMenu(const QPoint& pos)
         AZ::Outcome<QString> pathToProduct = GetAbsolutePathToProduct(*cachedAsset);
         if (pathToProduct.IsSuccess())
         {
-            QGuiApplication::clipboard()->setText(pathToProduct.GetValue());
+            QGuiApplication::clipboard()->setText(QDir::toNativeSeparators(pathToProduct.GetValue()));
         }
     });
 


### PR DESCRIPTION
Resolves #8808.

There were a few locations in the Asset Processor where copying an asset's full path to clipboard would only ever yield paths with a forward slash separator.

This commit converts those paths to use native separators so that they can be used within their respective environments directly after copying.

Affects paths copied from:
- Assets > Source Assets > [context menu] > Copy full path
- Assets > Product Assets > [context menu] > Copy full path
- Jobs > [context menu] > Copy

![8088_assetProcessPathSeparatorFix](https://user-images.githubusercontent.com/104796591/167736195-13f38795-b2af-49a6-986d-f9b63ed50252.gif)

Signed-off-by: amzn-tmryan <104796591+amzn-tmryan@users.noreply.github.com>