### PR TITLE
Fix an issue that causes wireframe render incorrectly

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
@@ -195,7 +195,7 @@ namespace AZ::Render
             {
                 EMotionFX::Node* node = instance->GetActor()->GetSkeleton()->GetNode(instance->GetEnabledNode(i));
                 EMotionFX::Mesh* mesh = instance->GetActor()->GetMesh(geomLODLevel, node->GetNodeIndex());
-                const AZ::Transform globalTM = pose->GetWorldSpaceTransform(node->GetNodeIndex()).ToAZTransform();
+                const AZ::Transform globalTM = pose->GetMeshNodeWorldSpaceTransform(geomLODLevel, node->GetNodeIndex()).ToAZTransform();
 
                 m_currentMesh = nullptr;
 


### PR DESCRIPTION
This problem only occur when the root joint have non-freezed transform
![before](https://user-images.githubusercontent.com/69218254/167771547-e59eacd9-8c02-4683-a021-c04cf279ccc2.png)
![after](https://user-images.githubusercontent.com/69218254/167771555-255cdba9-272f-4819-b7e8-6d0448a1ff7b.png)

Signed-off-by: rhhong <rhhong@amazon.com>