### PR TITLE
[Terrain] Clipmap smart update initial version

### DIFF
--- a/Gems/Terrain/Assets/Passes/TerrainDetailClipmapGenerationPass.pass
+++ b/Gems/Terrain/Assets/Passes/TerrainDetailClipmapGenerationPass.pass
@@ -7,7 +7,7 @@
             "Name": "TerrainDetailClipmapGenerationPassTemplate",
             "PassClass": "TerrainDetailClipmapGenerationPass",
             "PassData": {
-                "$type": "TerrainClipmapGenerationPassData",
+                "$type": "ComputePassData",
                 "ShaderAsset": {
                     "FilePath": "Shaders/Terrain/TerrainDetailClipmapGenerationPass.shader"
                 },

--- a/Gems/Terrain/Assets/Passes/TerrainDetailClipmapGenerationPass.pass
+++ b/Gems/Terrain/Assets/Passes/TerrainDetailClipmapGenerationPass.pass
@@ -7,14 +7,11 @@
             "Name": "TerrainDetailClipmapGenerationPassTemplate",
             "PassClass": "TerrainDetailClipmapGenerationPass",
             "PassData": {
-                "$type": "ComputePassData",
+                "$type": "TerrainClipmapGenerationPassData",
                 "ShaderAsset": {
                     "FilePath": "Shaders/Terrain/TerrainDetailClipmapGenerationPass.shader"
                 },
-                "PipelineViewTag": "MainCamera",
-                "Target Thread Count X": 1024,
-                "Target Thread Count Y": 1024,
-                "Target Thread Count Z": 1
+                "PipelineViewTag": "MainCamera"
             }
         }
     }

--- a/Gems/Terrain/Assets/Passes/TerrainMacroClipmapGenerationPass.pass
+++ b/Gems/Terrain/Assets/Passes/TerrainMacroClipmapGenerationPass.pass
@@ -7,14 +7,11 @@
             "Name": "TerrainMacroClipmapGenerationPassTemplate",
             "PassClass": "TerrainMacroClipmapGenerationPass",
             "PassData": {
-                "$type": "ComputePassData",
+                "$type": "TerrainClipmapGenerationPassData",
                 "ShaderAsset": {
                     "FilePath": "Shaders/Terrain/TerrainMacroClipmapGenerationPass.shader"
                 },
-                "PipelineViewTag": "MainCamera",
-                "Target Thread Count X": 1024,
-                "Target Thread Count Y": 1024,
-                "Target Thread Count Z": 1
+                "PipelineViewTag": "MainCamera"
             }
         }
     }

--- a/Gems/Terrain/Assets/Passes/TerrainMacroClipmapGenerationPass.pass
+++ b/Gems/Terrain/Assets/Passes/TerrainMacroClipmapGenerationPass.pass
@@ -7,7 +7,7 @@
             "Name": "TerrainMacroClipmapGenerationPassTemplate",
             "PassClass": "TerrainMacroClipmapGenerationPass",
             "PassData": {
-                "$type": "TerrainClipmapGenerationPassData",
+                "$type": "ComputePassData",
                 "ShaderAsset": {
                     "FilePath": "Shaders/Terrain/TerrainMacroClipmapGenerationPass.shader"
                 },

--- a/Gems/Terrain/Assets/Shaders/Terrain/ClipmapComputeHelpers.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/ClipmapComputeHelpers.azsli
@@ -58,6 +58,12 @@ uint2 GetCurrentDetailClipmapCenter(uint clipmapLevel)
     return TerrainSrg::m_clipmapData.m_detailClipmapCenters[clipmapLevel].zw;
 }
 
+float GetClipmapToWorldScale(float maxRenderRadius, float clipmapScaleInv)
+{
+    // maxRenderRadius only covers half of the clipmap, needs double.
+    return maxRenderRadius * 2.0 * clipmapScaleInv / TerrainSrg::m_clipmapData.m_clipmapSizeFloat;
+}
+
 // Get the world position at the pixel position in a clipmap.
 // Note: clipmap center is dynamic because we are using toroidal addressing. It's not always at the middle.
 float2 GetWorldPosition(uint2 clipmapCenter, uint2 pixelPosition, uint clipmapLevel, float clipmapScaleInv, float maxRenderRadius)
@@ -81,9 +87,12 @@ float2 GetWorldPosition(uint2 clipmapCenter, uint2 pixelPosition, uint clipmapLe
     int2 distance = int2(pixelPosition) - int2(clipmapCenter);
     int2 clipmapSize = int2(TerrainSrg::m_clipmapData.m_clipmapSizeUint, TerrainSrg::m_clipmapData.m_clipmapSizeUint);
     int2 halfClipmapSize = clipmapSize / 2;
+    // Biggest distance is both pixels are at diagnal vertices. distance would be -(size - 1).
+    // See the above illustration for adding halfClipmapSize.
+    // Adding another clipmapSize will guarantee the distance to be positive, and fall into the next periodical interval.
     distance = (distance + halfClipmapSize + clipmapSize) % clipmapSize - halfClipmapSize;
 
-    float2 viewRelativePosition = distance * (maxRenderRadius * 2.0f * clipmapScaleInv / TerrainSrg::m_clipmapData.m_clipmapSizeFloat);
+    float2 viewRelativePosition = distance * GetClipmapToWorldScale(maxRenderRadius, clipmapScaleInv);
     return TerrainSrg::m_clipmapData.m_currentViewPosition + viewRelativePosition;
 }
 
@@ -105,13 +114,13 @@ float2 GetCurrentWorldPositionFromDetailClipmaps(uint2 pixelPosition, uint clipm
 
 float2 ddxPosition(float maxRenderRadius, float clipmapScaleInv)
 {
-    float dx = maxRenderRadius * 2.0 * clipmapScaleInv / TerrainSrg::m_clipmapData.m_clipmapSizeFloat;
+    float dx = GetClipmapToWorldScale(maxRenderRadius, clipmapScaleInv);
     return float2(dx, 0.0);
 }
 
 float2 ddyPosition(float maxRenderRadius, float clipmapScaleInv)
 {
-    float dy = maxRenderRadius * 2.0 * clipmapScaleInv / TerrainSrg::m_clipmapData.m_clipmapSizeFloat;
+    float dy = GetClipmapToWorldScale(maxRenderRadius, clipmapScaleInv);
     return float2(0.0, dy);
 }
 

--- a/Gems/Terrain/Assets/Shaders/Terrain/ClipmapComputeHelpers.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/ClipmapComputeHelpers.azsli
@@ -38,71 +38,80 @@ float GetDetailClipmapScaleInv(uint clipmapLevel)
     return TerrainSrg::m_clipmapData.m_clipmapScaleInv[clipmapLevel].y;
 }
 
-float2 GetPreviousMacroClipmapCenter(uint clipmapLevel)
+uint2 GetPreviousMacroClipmapCenter(uint clipmapLevel)
 {
     return TerrainSrg::m_clipmapData.m_macroClipmapCenters[clipmapLevel].xy;
 }
 
-float2 GetCurrentMacroClipmapCenter(uint clipmapLevel)
+uint2 GetCurrentMacroClipmapCenter(uint clipmapLevel)
 {
     return TerrainSrg::m_clipmapData.m_macroClipmapCenters[clipmapLevel].zw;
 }
 
-float2 GetPreviousDetailClipmapCenter(uint clipmapLevel)
+uint2 GetPreviousDetailClipmapCenter(uint clipmapLevel)
 {
     return TerrainSrg::m_clipmapData.m_detailClipmapCenters[clipmapLevel].xy;
 }
 
-float2 GetCurrentDetailClipmapCenter(uint clipmapLevel)
+uint2 GetCurrentDetailClipmapCenter(uint clipmapLevel)
 {
     return TerrainSrg::m_clipmapData.m_detailClipmapCenters[clipmapLevel].zw;
 }
 
 // Get the world position at the pixel position in a clipmap.
 // Note: clipmap center is dynamic because we are using toroidal addressing. It's not always at the middle.
-float2 GetWorldPosition(float2 clipmapCenter, uint2 pixelPosition, uint clipmapLevel, float clipmapScaleInv, float maxRenderDistance)
+float2 GetWorldPosition(uint2 clipmapCenter, uint2 pixelPosition, uint clipmapLevel, float clipmapScaleInv, float maxRenderRadius)
 {
-    float2 normalizedPixelPosition = (pixelPosition.xy + 0.5) / TerrainSrg::m_clipmapData.m_clipmapSize;
+    /*
+     ___________________________
+    |-2,-2 |      |      |      |   Taking a 4x4 clipmap as an example.
+    |      |      |      |      |   Due to discreteness, center is set at the bottom right of
+    |______|______|______|______|   the actual geometrical center,
+    |      |-1,-1 |      |      |   The distance to the clipmap center is ranged between
+    |      |      |      |      |   [-clipmapSize/2, clipmapSize/2 - 1].
+    |______|______|______|______|   This property fits the modulate operation, at shifted clipmapSize/2,
+    |      |      |center|      |   assuming the size of the clipmap is always even.
+    |      |      |0,0   |      |
+    |______|______|______|______|
+    |      |      |      |1,1   |
+    |      |      |      |      |
+    |______|______|______|______|
 
-    float2 distance = normalizedPixelPosition - clipmapCenter;
+    */
+    int2 distance = int2(pixelPosition) - int2(clipmapCenter);
+    int2 clipmapSize = int2(TerrainSrg::m_clipmapData.m_clipmapSizeUint, TerrainSrg::m_clipmapData.m_clipmapSizeUint);
+    int2 halfClipmapSize = clipmapSize / 2;
+    distance = (distance + halfClipmapSize + clipmapSize) % clipmapSize - halfClipmapSize;
 
-    // Toroidal addressing:
-    // If distance is out of the normalized range (-0.5, 0.5), meaning we need to start from the other side.
-    // The logic is equivalent to a modulation. Using step function for acceleration.
-    distance.x -= step(0.5, distance.x);
-    distance.x += step(distance.x, -0.5);
-    distance.y -= step(0.5, distance.y);
-    distance.y += step(distance.y, -0.5);
-
-    float2 viewRelativePosition = distance * (maxRenderDistance * 2.0f * clipmapScaleInv);
+    float2 viewRelativePosition = distance * (maxRenderRadius * 2.0f * clipmapScaleInv / TerrainSrg::m_clipmapData.m_clipmapSizeFloat);
     return TerrainSrg::m_clipmapData.m_currentViewPosition + viewRelativePosition;
 }
 
 float2 GetCurrentWorldPositionFromMacroClipmaps(uint2 pixelPosition, uint clipmapLevel)
 {
-    float2 currentClipmapCenter = GetCurrentMacroClipmapCenter(clipmapLevel);
+    uint2 currentClipmapCenter = GetCurrentMacroClipmapCenter(clipmapLevel);
     float clipmapScaleInv = GetMacroClipmapScaleInv(clipmapLevel);
-    float maxRenderDistance = TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius;
-    return GetWorldPosition(currentClipmapCenter, pixelPosition, clipmapLevel, clipmapScaleInv, maxRenderDistance);
+    float maxRenderRadius = TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius;
+    return GetWorldPosition(currentClipmapCenter, pixelPosition, clipmapLevel, clipmapScaleInv, maxRenderRadius);
 }
 
 float2 GetCurrentWorldPositionFromDetailClipmaps(uint2 pixelPosition, uint clipmapLevel)
 {
-    float2 currentClipmapCenter = GetCurrentDetailClipmapCenter(clipmapLevel);
+    uint2 currentClipmapCenter = GetCurrentDetailClipmapCenter(clipmapLevel);
     float clipmapScaleInv = GetDetailClipmapScaleInv(clipmapLevel);
-    float maxRenderDistance = TerrainSrg::m_clipmapData.m_detailClipmapMaxRenderRadius;
-    return GetWorldPosition(currentClipmapCenter, pixelPosition, clipmapLevel, clipmapScaleInv, maxRenderDistance);
+    float maxRenderRadius = TerrainSrg::m_clipmapData.m_detailClipmapMaxRenderRadius;
+    return GetWorldPosition(currentClipmapCenter, pixelPosition, clipmapLevel, clipmapScaleInv, maxRenderRadius);
 }
 
-float2 ddxPosition(float maxRenderDistance, float clipmapScaleInv)
+float2 ddxPosition(float maxRenderRadius, float clipmapScaleInv)
 {
-    float dx = maxRenderDistance * 2.0 * clipmapScaleInv / TerrainSrg::m_clipmapData.m_clipmapSize;
+    float dx = maxRenderRadius * 2.0 * clipmapScaleInv / TerrainSrg::m_clipmapData.m_clipmapSizeFloat;
     return float2(dx, 0.0);
 }
 
-float2 ddyPosition(float maxRenderDistance, float clipmapScaleInv)
+float2 ddyPosition(float maxRenderRadius, float clipmapScaleInv)
 {
-    float dy = maxRenderDistance * 2.0 * clipmapScaleInv / TerrainSrg::m_clipmapData.m_clipmapSize;
+    float dy = maxRenderRadius * 2.0 * clipmapScaleInv / TerrainSrg::m_clipmapData.m_clipmapSizeFloat;
     return float2(0.0, dy);
 }
 
@@ -177,9 +186,8 @@ ClipmapLevel CalculateClosestClipmapLevel(
 
 BilinearUvs GetBilinearUvs(uint2 u0v0)
 {
-    uint clipmapSize = (uint)TerrainSrg::m_clipmapData.m_clipmapSize;
-    uint u1 = (u0v0.x + 1) % clipmapSize;
-    uint v1 = (u0v0.y + 1) % clipmapSize;
+    uint u1 = (u0v0.x + 1) % TerrainSrg::m_clipmapData.m_clipmapSizeUint;
+    uint v1 = (u0v0.y + 1) % TerrainSrg::m_clipmapData.m_clipmapSizeUint;
 
     BilinearUvs uvs;
     uvs.m_u0v0 = u0v0;
@@ -194,16 +202,16 @@ BilinearUvs CalculateClipmapUv(
     float2 distanceFromViewPosition,
     float maxRenderDistance,
     float clipmapScaleInv,
-    float2 clipmapCenter
+    uint2 clipmapCenter
 )
 {
     float2 normalizedDistance = distanceFromViewPosition / (maxRenderDistance * 2.0 * clipmapScaleInv);
-    float2 normalizedPixelPosition = clipmapCenter + normalizedDistance;
+    float2 normalizedPixelPosition = (clipmapCenter + float2(0.5, 0.5)) / TerrainSrg::m_clipmapData.m_clipmapSizeFloat + normalizedDistance;
     // By toroidal addressing, the normalized position can only fall into [-1.0, 2.0].
     // We can use fraction after shifting 1.0 to get the actual position.
     normalizedPixelPosition = frac(normalizedPixelPosition + float2(1.0, 1.0));
 
-    float2 exactUV = normalizedPixelPosition * TerrainSrg::m_clipmapData.m_clipmapSize;
+    float2 exactUV = normalizedPixelPosition * TerrainSrg::m_clipmapData.m_clipmapSizeFloat;
 
     uint2 u0v0 = uint2(exactUV);
     BilinearUvs uvs = GetBilinearUvs(u0v0);

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailClipmapGenerationPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailClipmapGenerationPass.azsl
@@ -38,7 +38,7 @@ void MainCS(
 
     for (uint clipmapLevel = 0; clipmapLevel < TerrainSrg::m_clipmapData.m_detailClipmapStackSize; ++clipmapLevel)
     {
-        for (uint updateRegionIndex = 0; updateRegionIndex < 6; ++updateRegionIndex)
+        for (uint updateRegionIndex = 0; updateRegionIndex < UpdateRegionMax; ++updateRegionIndex)
         {
             uint4 updateRegion = TerrainSrg::m_clipmapData.m_detailClipmapBoundsRegions[clipmapLevel + DetailClipmapStackSizeMax * updateRegionIndex];
             uint2 size = uint2(updateRegion.z - updateRegion.x, updateRegion.w - updateRegion.y);

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailClipmapGenerationPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailClipmapGenerationPass.azsl
@@ -10,6 +10,11 @@
 #include "ClipmapComputeHelpers.azsli"
 #include "TerrainDetailHelpers.azsli"
 
+#define THREAD_NUM_X 8
+#define THREAD_NUM_Y 8
+#define NO_DETAIL 0.0
+#define HAS_DETAIL 1.0
+
 ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {
     Texture2DArray<float4> m_macroColorClipmaps;
@@ -23,102 +28,124 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     RWTexture2DArray<float> m_detailOcclusionClipmaps;
 }
 
-[numthreads(32,32,1)]
+[numthreads(THREAD_NUM_X,THREAD_NUM_Y,1)]
 void MainCS(
-    uint3 dispatchThreadID : SV_DispatchThreadID)
+    uint3 groupID : SV_GroupID,
+    uint3 groupThreadID : SV_GroupThreadID)
 {
-    uint2 pixelPosition = dispatchThreadID.xy;
-
     for (uint clipmapLevel = 0; clipmapLevel < TerrainSrg::m_clipmapData.m_detailClipmapStackSize; ++clipmapLevel)
     {
-        uint3 texelIndex = uint3(dispatchThreadID.xy, clipmapLevel);
-
-        float2 worldPosition = GetCurrentWorldPositionFromDetailClipmaps(pixelPosition, clipmapLevel);
-
-        if (any(worldPosition < TerrainSrg::m_clipmapData.m_worldBoundsMin) || any(worldPosition > TerrainSrg::m_clipmapData.m_worldBoundsMax))
+        for (uint updateRegionIndex = 0; updateRegionIndex < 6; ++updateRegionIndex)
         {
-            // alpha represents hasDetailSurface
-            PassSrg::m_detailColorClipmaps[texelIndex] = float4(TerrainMaterialSrg::m_baseColor.rgb, 0.0);
-            PassSrg::m_detailNormalClipmaps[texelIndex] = float2(0.0, 0.0);
-            PassSrg::m_detailHeightClipmaps[texelIndex] = 0.0;
-            PassSrg::m_detailRoughnessClipmaps[texelIndex] = 0.0;
-            PassSrg::m_detailSpecularF0Clipmaps[texelIndex] = 0.0;
-            PassSrg::m_detailMetalnessClipmaps[texelIndex] = 0.0;
-            PassSrg::m_detailOcclusionClipmaps[texelIndex] = 0.0;
-            continue;
-        }
+            uint4 updateRegion = TerrainSrg::m_clipmapData.m_detailClipmapBoundsRegions[clipmapLevel + DetailClipmapStackSizeMax * updateRegionIndex];
+            uint2 size = uint2(updateRegion.z - updateRegion.x, updateRegion.w - updateRegion.y);
+            uint totalNumberOfTexels = size.x * size.y;
 
-        DetailSurface detailSurface;
-        float2 detailRegionCoord = worldPosition * TerrainSrg::m_detailMaterialIdScale;
-        float2 detailUv = worldPosition * TerrainMaterialSrg::m_detailTextureMultiplier;
-        float clipmapScaleInv = GetDetailClipmapScaleInv(clipmapLevel);
-        float2 detailUvDdx = ddxPosition(TerrainSrg::m_clipmapData.m_detailClipmapMaxRenderRadius, clipmapScaleInv) * TerrainMaterialSrg::m_detailTextureMultiplier;
-        float2 detailUvDdy = ddyPosition(TerrainSrg::m_clipmapData.m_detailClipmapMaxRenderRadius, clipmapScaleInv) * TerrainMaterialSrg::m_detailTextureMultiplier;
+            uint numberOfGroups = TerrainSrg::m_clipmapData.m_detailDispatchGroupCountX * TerrainSrg::m_clipmapData.m_detailDispatchGroupCountY;
+            uint totalStride = (totalNumberOfTexels + numberOfGroups - 1) / numberOfGroups;
+            uint totalBegin = min(totalStride * (groupID.x + groupID.y * TerrainSrg::m_clipmapData.m_detailDispatchGroupCountX), totalNumberOfTexels);
+            uint totalEnd = min(totalBegin + totalStride, totalNumberOfTexels);
 
-        float2 distance = worldPosition - TerrainSrg::m_clipmapData.m_currentViewPosition;
-        ClipmapLevel macroClipmapLevel = CalculateClosestClipmapLevel(
-            distance,
-            TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius,
-            TerrainSrg::m_clipmapData.m_macroClipmapScaleBase,
-            TerrainSrg::m_clipmapData.m_macroClipmapStackSize
-        );
+            uint groupTotal = totalEnd - totalBegin;
+            uint numberOfGroupThreads = THREAD_NUM_X * THREAD_NUM_Y;
+            uint groupStride = (groupTotal + numberOfGroupThreads - 1) / numberOfGroupThreads;
+            uint groupBegin = min(groupStride * (groupThreadID.x + groupThreadID.y * THREAD_NUM_X), groupTotal);
+            uint groupEnd = min(groupBegin + groupStride, groupTotal);
 
-        float3 macroColor;
-        if (macroClipmapLevel.m_nextLevel == TerrainSrg::m_clipmapData.m_macroClipmapStackSize)
-        {
-            BilinearUvs macroClipmapUvs = CalculateClipmapUv(
-                distance,
-                TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius,
-                GetMacroClipmapScaleInv(macroClipmapLevel.m_closestLevel),
-                GetCurrentMacroClipmapCenter(macroClipmapLevel.m_closestLevel)
-            );
+            for (uint i = groupBegin; i < groupEnd; ++i)
+            {
+                uint texelFlatIndex = totalBegin + i;
+                uint2 texelPosition = uint2(texelFlatIndex % size.x + updateRegion.x, texelFlatIndex / size.x + updateRegion.y);
+                uint3 texelIndex = uint3(texelPosition, clipmapLevel);
 
-            macroColor = ColorBilinearSampling(TerrainSrg::m_macroColorClipmaps, macroClipmapUvs, macroClipmapLevel.m_closestLevel).rgb;
-        }
-        else
-        {
-            BilinearUvs macroClipmapUvs1 = CalculateClipmapUv(
-                distance,
-                TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius,
-                GetMacroClipmapScaleInv(macroClipmapLevel.m_closestLevel),
-                GetCurrentMacroClipmapCenter(macroClipmapLevel.m_closestLevel)
-            );
+                float2 worldPosition = GetCurrentWorldPositionFromDetailClipmaps(texelPosition, clipmapLevel);
 
-            BilinearUvs macroClipmapUvs2 = CalculateClipmapUv(
-                distance,
-                TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius,
-                GetMacroClipmapScaleInv(macroClipmapLevel.m_nextLevel),
-                GetCurrentMacroClipmapCenter(macroClipmapLevel.m_nextLevel)
-            );
+                if (any(worldPosition < TerrainSrg::m_clipmapData.m_worldBoundsMin) || any(worldPosition > TerrainSrg::m_clipmapData.m_worldBoundsMax))
+                {
+                    // alpha represents hasDetailSurface
+                    PassSrg::m_detailColorClipmaps[texelIndex] = float4(TerrainMaterialSrg::m_baseColor.rgb, NO_DETAIL);
+                    PassSrg::m_detailNormalClipmaps[texelIndex] = float2(0.0, 0.0);
+                    PassSrg::m_detailHeightClipmaps[texelIndex] = 0.0;
+                    PassSrg::m_detailRoughnessClipmaps[texelIndex] = 0.0;
+                    PassSrg::m_detailSpecularF0Clipmaps[texelIndex] = 0.0;
+                    PassSrg::m_detailMetalnessClipmaps[texelIndex] = 0.0;
+                    PassSrg::m_detailOcclusionClipmaps[texelIndex] = 0.0;
+                    continue;
+                }
 
-            macroColor = ColorTrilinearSampling(TerrainSrg::m_macroColorClipmaps, macroClipmapUvs1, macroClipmapUvs2, macroClipmapLevel).rgb;
-        }
+                DetailSurface detailSurface;
+                float2 detailRegionCoord = worldPosition * TerrainSrg::m_detailMaterialIdScale;
+                float2 detailUv = worldPosition * TerrainMaterialSrg::m_detailTextureMultiplier;
+                float clipmapScaleInv = GetDetailClipmapScaleInv(clipmapLevel);
+                float2 detailUvDdx = ddxPosition(TerrainSrg::m_clipmapData.m_detailClipmapMaxRenderRadius, clipmapScaleInv) * TerrainMaterialSrg::m_detailTextureMultiplier;
+                float2 detailUvDdy = ddyPosition(TerrainSrg::m_clipmapData.m_detailClipmapMaxRenderRadius, clipmapScaleInv) * TerrainMaterialSrg::m_detailTextureMultiplier;
 
-        bool hasDetailSurface = GetDetailSurface(detailSurface, detailRegionCoord, detailUv, detailUvDdx, detailUvDdy, macroColor);
+                float2 distance = worldPosition - TerrainSrg::m_clipmapData.m_currentViewPosition;
+                ClipmapLevel macroClipmapLevel = CalculateClosestClipmapLevel(
+                    distance,
+                    TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius,
+                    TerrainSrg::m_clipmapData.m_macroClipmapScaleBase,
+                    TerrainSrg::m_clipmapData.m_macroClipmapStackSize
+                );
 
-        if (hasDetailSurface)
-        {
-            float3 normal = normalize(detailSurface.m_normal);
+                float3 macroColor;
+                if (macroClipmapLevel.m_nextLevel == TerrainSrg::m_clipmapData.m_macroClipmapStackSize)
+                {
+                    BilinearUvs macroClipmapUvs = CalculateClipmapUv(
+                        distance,
+                        TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius,
+                        GetMacroClipmapScaleInv(macroClipmapLevel.m_closestLevel),
+                        GetCurrentMacroClipmapCenter(macroClipmapLevel.m_closestLevel)
+                    );
 
-            // alpha represents hasDetailSurface
-            PassSrg::m_detailColorClipmaps[texelIndex] = float4(detailSurface.m_color, 1.0);
-            PassSrg::m_detailNormalClipmaps[texelIndex] = float2(normal.xy);
-            PassSrg::m_detailHeightClipmaps[texelIndex] = detailSurface.m_height;
-            PassSrg::m_detailRoughnessClipmaps[texelIndex] = detailSurface.m_roughness;
-            PassSrg::m_detailSpecularF0Clipmaps[texelIndex] = detailSurface.m_specularF0;
-            PassSrg::m_detailMetalnessClipmaps[texelIndex] = detailSurface.m_metalness;
-            PassSrg::m_detailOcclusionClipmaps[texelIndex] = detailSurface.m_occlusion;
-        }
-        else
-        {
-            // alpha represents hasDetailSurface
-            PassSrg::m_detailColorClipmaps[texelIndex] = float4(TerrainMaterialSrg::m_baseColor.rgb, 0.0);
-            PassSrg::m_detailNormalClipmaps[texelIndex] = float2(0.0, 0.0);
-            PassSrg::m_detailHeightClipmaps[texelIndex] = 0.0;
-            PassSrg::m_detailRoughnessClipmaps[texelIndex] = 0.0;
-            PassSrg::m_detailSpecularF0Clipmaps[texelIndex] = 0.0;
-            PassSrg::m_detailMetalnessClipmaps[texelIndex] = 0.0;
-            PassSrg::m_detailOcclusionClipmaps[texelIndex] = 0.0;
+                    macroColor = ColorBilinearSampling(TerrainSrg::m_macroColorClipmaps, macroClipmapUvs, macroClipmapLevel.m_closestLevel).rgb;
+                }
+                else
+                {
+                    BilinearUvs macroClipmapUvs1 = CalculateClipmapUv(
+                        distance,
+                        TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius,
+                        GetMacroClipmapScaleInv(macroClipmapLevel.m_closestLevel),
+                        GetCurrentMacroClipmapCenter(macroClipmapLevel.m_closestLevel)
+                    );
+
+                    BilinearUvs macroClipmapUvs2 = CalculateClipmapUv(
+                        distance,
+                        TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius,
+                        GetMacroClipmapScaleInv(macroClipmapLevel.m_nextLevel),
+                        GetCurrentMacroClipmapCenter(macroClipmapLevel.m_nextLevel)
+                    );
+
+                    macroColor = ColorTrilinearSampling(TerrainSrg::m_macroColorClipmaps, macroClipmapUvs1, macroClipmapUvs2, macroClipmapLevel).rgb;
+                }
+
+                bool hasDetailSurface = GetDetailSurface(detailSurface, detailRegionCoord, detailUv, detailUvDdx, detailUvDdy, macroColor);
+
+                if (hasDetailSurface)
+                {
+                    float3 normal = normalize(detailSurface.m_normal);
+
+                    // alpha represents hasDetailSurface
+                    PassSrg::m_detailColorClipmaps[texelIndex] = float4(detailSurface.m_color, HAS_DETAIL);
+                    PassSrg::m_detailNormalClipmaps[texelIndex] = float2(normal.xy);
+                    PassSrg::m_detailHeightClipmaps[texelIndex] = detailSurface.m_height;
+                    PassSrg::m_detailRoughnessClipmaps[texelIndex] = detailSurface.m_roughness;
+                    PassSrg::m_detailSpecularF0Clipmaps[texelIndex] = detailSurface.m_specularF0;
+                    PassSrg::m_detailMetalnessClipmaps[texelIndex] = detailSurface.m_metalness;
+                    PassSrg::m_detailOcclusionClipmaps[texelIndex] = detailSurface.m_occlusion;
+                }
+                else
+                {
+                    // alpha represents hasDetailSurface
+                    PassSrg::m_detailColorClipmaps[texelIndex] = float4(TerrainMaterialSrg::m_baseColor.rgb, NO_DETAIL);
+                    PassSrg::m_detailNormalClipmaps[texelIndex] = float2(0.0, 0.0);
+                    PassSrg::m_detailHeightClipmaps[texelIndex] = 0.0;
+                    PassSrg::m_detailRoughnessClipmaps[texelIndex] = 0.0;
+                    PassSrg::m_detailSpecularF0Clipmaps[texelIndex] = 0.0;
+                    PassSrg::m_detailMetalnessClipmaps[texelIndex] = 0.0;
+                    PassSrg::m_detailOcclusionClipmaps[texelIndex] = 0.0;
+                }
+            }
         }
     }
 }

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailClipmapGenerationPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailClipmapGenerationPass.azsl
@@ -33,6 +33,9 @@ void MainCS(
     uint3 groupID : SV_GroupID,
     uint3 groupThreadID : SV_GroupThreadID)
 {
+    uint numberOfGroups = TerrainSrg::m_clipmapData.m_detailDispatchGroupCountX * TerrainSrg::m_clipmapData.m_detailDispatchGroupCountY;
+    uint numberOfGroupThreads = THREAD_NUM_X * THREAD_NUM_Y;
+
     for (uint clipmapLevel = 0; clipmapLevel < TerrainSrg::m_clipmapData.m_detailClipmapStackSize; ++clipmapLevel)
     {
         for (uint updateRegionIndex = 0; updateRegionIndex < 6; ++updateRegionIndex)
@@ -41,13 +44,11 @@ void MainCS(
             uint2 size = uint2(updateRegion.z - updateRegion.x, updateRegion.w - updateRegion.y);
             uint totalNumberOfTexels = size.x * size.y;
 
-            uint numberOfGroups = TerrainSrg::m_clipmapData.m_detailDispatchGroupCountX * TerrainSrg::m_clipmapData.m_detailDispatchGroupCountY;
             uint totalStride = (totalNumberOfTexels + numberOfGroups - 1) / numberOfGroups;
             uint totalBegin = min(totalStride * (groupID.x + groupID.y * TerrainSrg::m_clipmapData.m_detailDispatchGroupCountX), totalNumberOfTexels);
             uint totalEnd = min(totalBegin + totalStride, totalNumberOfTexels);
 
             uint groupTotal = totalEnd - totalBegin;
-            uint numberOfGroupThreads = THREAD_NUM_X * THREAD_NUM_Y;
             uint groupStride = (groupTotal + numberOfGroupThreads - 1) / numberOfGroupThreads;
             uint groupBegin = min(groupStride * (groupThreadID.x + groupThreadID.y * THREAD_NUM_X), groupTotal);
             uint groupEnd = min(groupBegin + groupStride, groupTotal);

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroClipmapGenerationPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroClipmapGenerationPass.azsl
@@ -10,33 +10,58 @@
 #include "ClipmapComputeHelpers.azsli"
 #include "TerrainMacroHelpers.azsli"
 
+#define THREAD_NUM_X 8
+#define THREAD_NUM_Y 8
+
 ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {
     RWTexture2DArray<float4> m_macroColorClipmaps;
     RWTexture2DArray<float2> m_macroNormalClipmaps;
 }
 
-[numthreads(32,32,1)]
+[numthreads(THREAD_NUM_X,THREAD_NUM_Y,1)]
 void MainCS(
-    uint3 dispatchThreadID : SV_DispatchThreadID)
+    uint3 groupID : SV_GroupID,
+    uint3 groupThreadID : SV_GroupThreadID)
 {
-    uint2 pixelPosition = dispatchThreadID.xy;
-
     for (uint clipmapLevel = 0; clipmapLevel < TerrainSrg::m_clipmapData.m_macroClipmapStackSize; ++clipmapLevel)
     {
-        uint3 texelIndex = uint3(dispatchThreadID.xy, clipmapLevel);
+        for (uint updateRegionIndex = 0; updateRegionIndex < 6; ++updateRegionIndex)
+        {
+            uint4 updateRegion = TerrainSrg::m_clipmapData.m_macroClipmapBoundsRegions[clipmapLevel + MacroClipmapStackSizeMax * updateRegionIndex];
+            uint2 size = uint2(updateRegion.z - updateRegion.x, updateRegion.w - updateRegion.y);
+            uint totalNumberOfTexels = size.x * size.y;
 
-        float2 worldPosition = GetCurrentWorldPositionFromMacroClipmaps(pixelPosition, clipmapLevel);
-        float clipmapScaleInv = GetMacroClipmapScaleInv(clipmapLevel);
-        float2 positionDdx = ddxPosition(TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius, clipmapScaleInv);
-        float2 positionDdy = ddyPosition(TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius, clipmapScaleInv);
+            uint numberOfGroups = TerrainSrg::m_clipmapData.m_macroDispatchGroupCountX * TerrainSrg::m_clipmapData.m_macroDispatchGroupCountY;
+            uint totalStride = (totalNumberOfTexels + numberOfGroups - 1) / numberOfGroups;
+            uint totalBegin = min(totalStride * (groupID.x + groupID.y * TerrainSrg::m_clipmapData.m_macroDispatchGroupCountX), totalNumberOfTexels);
+            uint totalEnd = min(totalBegin + totalStride, totalNumberOfTexels);
 
-        float3 macroColor;
-        float3 macroNormal;
-        SampleMacroTexture(worldPosition, positionDdx, positionDdy, macroColor, macroNormal);
+            uint groupTotal = totalEnd - totalBegin;
+            uint numberOfGroupThreads = THREAD_NUM_X * THREAD_NUM_Y;
+            uint groupStride = (groupTotal + numberOfGroupThreads - 1) / numberOfGroupThreads;
+            uint groupBegin = min(groupStride * (groupThreadID.x + groupThreadID.y * THREAD_NUM_X), groupTotal);
+            uint groupEnd = min(groupBegin + groupStride, groupTotal);
 
-        PassSrg::m_macroColorClipmaps[texelIndex] = float4(macroColor, 1.0);
-        PassSrg::m_macroNormalClipmaps[texelIndex] = macroNormal.xy;
+            for (uint i = groupBegin; i < groupEnd; ++i)
+            {
+                uint texelFlatIndex = totalBegin + i;
+                uint2 texelPosition = uint2(texelFlatIndex % size.x + updateRegion.x, texelFlatIndex / size.x + updateRegion.y);
+                uint3 texelIndex = uint3(texelPosition, clipmapLevel);
+
+                float2 worldPosition = GetCurrentWorldPositionFromMacroClipmaps(texelPosition, clipmapLevel);
+                float clipmapScaleInv = GetMacroClipmapScaleInv(clipmapLevel);
+                float2 positionDdx = ddxPosition(TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius, clipmapScaleInv);
+                float2 positionDdy = ddyPosition(TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius, clipmapScaleInv);
+
+                float3 macroColor;
+                float3 macroNormal;
+                SampleMacroTexture(worldPosition, positionDdx, positionDdy, macroColor, macroNormal);
+
+                PassSrg::m_macroColorClipmaps[texelIndex] = float4(macroColor, 1.0);
+                PassSrg::m_macroNormalClipmaps[texelIndex] = macroNormal.xy;
+            }
+        }
     }
 }
 

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroClipmapGenerationPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroClipmapGenerationPass.azsl
@@ -24,6 +24,9 @@ void MainCS(
     uint3 groupID : SV_GroupID,
     uint3 groupThreadID : SV_GroupThreadID)
 {
+    uint numberOfGroups = TerrainSrg::m_clipmapData.m_macroDispatchGroupCountX * TerrainSrg::m_clipmapData.m_macroDispatchGroupCountY;
+    uint numberOfGroupThreads = THREAD_NUM_X * THREAD_NUM_Y;
+
     for (uint clipmapLevel = 0; clipmapLevel < TerrainSrg::m_clipmapData.m_macroClipmapStackSize; ++clipmapLevel)
     {
         for (uint updateRegionIndex = 0; updateRegionIndex < 6; ++updateRegionIndex)
@@ -32,13 +35,11 @@ void MainCS(
             uint2 size = uint2(updateRegion.z - updateRegion.x, updateRegion.w - updateRegion.y);
             uint totalNumberOfTexels = size.x * size.y;
 
-            uint numberOfGroups = TerrainSrg::m_clipmapData.m_macroDispatchGroupCountX * TerrainSrg::m_clipmapData.m_macroDispatchGroupCountY;
             uint totalStride = (totalNumberOfTexels + numberOfGroups - 1) / numberOfGroups;
             uint totalBegin = min(totalStride * (groupID.x + groupID.y * TerrainSrg::m_clipmapData.m_macroDispatchGroupCountX), totalNumberOfTexels);
             uint totalEnd = min(totalBegin + totalStride, totalNumberOfTexels);
 
             uint groupTotal = totalEnd - totalBegin;
-            uint numberOfGroupThreads = THREAD_NUM_X * THREAD_NUM_Y;
             uint groupStride = (groupTotal + numberOfGroupThreads - 1) / numberOfGroupThreads;
             uint groupBegin = min(groupStride * (groupThreadID.x + groupThreadID.y * THREAD_NUM_X), groupTotal);
             uint groupEnd = min(groupBegin + groupStride, groupTotal);

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroClipmapGenerationPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroClipmapGenerationPass.azsl
@@ -29,7 +29,7 @@ void MainCS(
 
     for (uint clipmapLevel = 0; clipmapLevel < TerrainSrg::m_clipmapData.m_macroClipmapStackSize; ++clipmapLevel)
     {
-        for (uint updateRegionIndex = 0; updateRegionIndex < 6; ++updateRegionIndex)
+        for (uint updateRegionIndex = 0; updateRegionIndex < UpdateRegionMax; ++updateRegionIndex)
         {
             uint4 updateRegion = TerrainSrg::m_clipmapData.m_macroClipmapBoundsRegions[clipmapLevel + MacroClipmapStackSizeMax * updateRegionIndex];
             uint2 size = uint2(updateRegion.z - updateRegion.x, updateRegion.w - updateRegion.y);

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainSrg.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainSrg.azsli
@@ -13,8 +13,11 @@
 static const uint MacroClipmapStackSizeMax = 16u;
 static const uint DetailClipmapStackSizeMax = 16u;
 static const uint StackSizeMax = 16u; // = max(MacroClipmapStackSizeMax, DetailClipmapStackSizeMax)
-static const uint MacroClipmapStackSizeMax_x6 = 96u;
-static const uint DetailClipmapStackSizeMax_x6 = 96u;
+// Each clipmap can have at most 6 update regions based on the current algorithm.
+// Due to compilation limitation, the size of arrays must be direct constant.
+static const uint UpdateRegionMax = 6u;
+static const uint MacroClipmapUpdateRegionMax = 96u; // = MacroClipmapStackSizeMax * 6
+static const uint DetailClipmapUpdateRegionMax = 96u; // = DetailClipmapStackSizeMax * 6
 
 ShaderResourceGroupSemantic SRG_Terrain
 {
@@ -124,9 +127,12 @@ ShaderResourceGroup TerrainSrg : SRG_Terrain
         // x: macro; y: detail
         float4 m_clipmapScaleInv[StackSizeMax];
 
-        uint4 m_macroClipmapBoundsRegions[MacroClipmapStackSizeMax_x6];
-        uint4 m_detailClipmapBoundsRegions[DetailClipmapStackSizeMax_x6];
+        // The region of the clipmap that needs update.
+        // Each clipmap can have 0-6 regions to update each frame.
+        uint4 m_macroClipmapBoundsRegions[MacroClipmapUpdateRegionMax];
+        uint4 m_detailClipmapBoundsRegions[DetailClipmapUpdateRegionMax];
 
+        // Numbers match the compute shader invoking call dispatch(X, Y, 1).
         uint m_macroDispatchGroupCountX;
         uint m_macroDispatchGroupCountY;
         uint m_detailDispatchGroupCountX;

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainSrg.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainSrg.azsli
@@ -13,6 +13,8 @@
 static const uint MacroClipmapStackSizeMax = 16u;
 static const uint DetailClipmapStackSizeMax = 16u;
 static const uint StackSizeMax = 16u; // = max(MacroClipmapStackSizeMax, DetailClipmapStackSizeMax)
+static const uint MacroClipmapStackSizeMax_x6 = 96u;
+static const uint DetailClipmapStackSizeMax_x6 = 96u;
 
 ShaderResourceGroupSemantic SRG_Terrain
 {
@@ -104,23 +106,31 @@ ShaderResourceGroup TerrainSrg : SRG_Terrain
         uint m_detailClipmapStackSize;
 
         //! The size of the clipmap image in each layer.
-        float m_clipmapSize;
-        
-        uint m_padding;
+        //! Given 2 copies in different types to save casting.
+        float m_clipmapSizeFloat;
+        uint m_clipmapSizeUint;
 
-        // Clipmap centers in normalized UV coordinates [0, 1].
+        // Clipmap centers in texel coordinates ranging [0, size).
         // xy represent previous clipmap centers, zw represent current clipmap centers.
         // (Array elements will always be padded to 16, a float4 size. Storing both centers in float4 saves bandwidth.)
         // They are used for toroidal addressing and may move each frame based on the view point movement.
         // The move distance is scaled differently in each layer.
-        float4 m_macroClipmapCenters[MacroClipmapStackSizeMax];
-        float4 m_detailClipmapCenters[DetailClipmapStackSizeMax];
+        uint4 m_macroClipmapCenters[MacroClipmapStackSizeMax];
+        uint4 m_detailClipmapCenters[DetailClipmapStackSizeMax];
 
         // A list of reciprocal the clipmap scale [s],
         // where 1 pixel in the current layer of clipmap represents s meters. 
         // Fast lookup list to avoid redundant calculation in shaders.
         // x: macro; y: detail
         float4 m_clipmapScaleInv[StackSizeMax];
+
+        uint4 m_macroClipmapBoundsRegions[MacroClipmapStackSizeMax_x6];
+        uint4 m_detailClipmapBoundsRegions[DetailClipmapStackSizeMax_x6];
+
+        uint m_macroDispatchGroupCountX;
+        uint m_macroDispatchGroupCountY;
+        uint m_detailDispatchGroupCountX;
+        uint m_detailDispatchGroupCountY;
     };
 
     // Clipmap SRG

--- a/Gems/Terrain/Code/Source/Components/TerrainSystemComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainSystemComponent.cpp
@@ -35,6 +35,8 @@ namespace Terrain
                 ;
             }
         }
+
+        TerrainClipmapGenerationPassData::Reflect(context);
     }
 
     void TerrainSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)

--- a/Gems/Terrain/Code/Source/Components/TerrainSystemComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainSystemComponent.cpp
@@ -35,8 +35,6 @@ namespace Terrain
                 ;
             }
         }
-
-        TerrainClipmapGenerationPassData::Reflect(context);
     }
 
     void TerrainSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)

--- a/Gems/Terrain/Code/Source/TerrainRenderer/ClipmapBounds.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/ClipmapBounds.cpp
@@ -34,6 +34,9 @@ namespace Terrain
 
         // recalculate m_center
         m_center = GetSnappedCenter(GetClipSpaceVector(desc.m_worldSpaceCenter));
+
+        m_modCenter.m_x = (m_size + (m_center.m_x % m_size)) % m_size;
+        m_modCenter.m_y = (m_size + (m_center.m_y % m_size)) % m_size;
     }
     
     auto ClipmapBounds::UpdateCenter(const AZ::Vector2& newCenter, AZ::Aabb* untouchedRegion) -> ClipmapBoundsRegionList
@@ -276,11 +279,9 @@ namespace Terrain
         );
     }
 
-    AZ::Vector2 ClipmapBounds::GetNormalizedCenter() const
+    Vector2i ClipmapBounds::GetModCenter() const
     {
-        AZ::Vector2 normalizedCenter(aznumeric_cast<float>(m_modCenter.m_x) + 0.5f, aznumeric_cast<float>(m_modCenter.m_y) + 0.5f);
-        normalizedCenter /= aznumeric_cast<float>(m_size);
-        return normalizedCenter;
+        return m_modCenter;
     }
 
 }

--- a/Gems/Terrain/Code/Source/TerrainRenderer/ClipmapBounds.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/ClipmapBounds.h
@@ -52,6 +52,8 @@ namespace Terrain
         bool operator!=(const ClipmapBoundsRegion& other) const;
     };
 
+    using ClipmapBoundsRegionList = AZStd::vector<ClipmapBoundsRegion>;
+
     // This class manages a single clipmap region. A clipmap is a virtual view into a much larger
     // region, where the clipmap view is centered around a point like the current camera position.
     // The clipmap texture wraps to form a repeating grid and never moves, but only data within
@@ -93,10 +95,8 @@ namespace Terrain
         explicit ClipmapBounds(const ClipmapBoundsDescriptor& desc);
         ~ClipmapBounds() = default;
 
-        using ClipmapBoundsRegionList = AZStd::vector<ClipmapBoundsRegion>;
-
         //! Updates the clipmap bounds using a world coordinate center position and returns
-        //! 0-2 regions that need to be updated due to moving beyond the margins. These update
+        //! 0-6 regions that need to be updated due to moving beyond the margins. These update
         //! regions will always be at least the size of the margin, and will represent horizontal
         //! and/or vertical strips along the edges of the clipmap. An optional untouched region
         //! aabb can be passed to this function to get an aabb of areas inside the bounds of the
@@ -106,7 +106,7 @@ namespace Terrain
         ClipmapBoundsRegionList UpdateCenter(const AZ::Vector2& newCenter, AZ::Aabb* untouchedRegion = nullptr);
         
         //! Updates the clipmap bounds using a position in clipmap space (no scaling) and returns
-        //! 0-2 regions that need to be updated due to moving beyond the margins. These update
+        //! 0-6 regions that need to be updated due to moving beyond the margins. These update
         //! regions will always be at least the size of the margin, and will represent horizontal
         //! and/or vertical strips along the edges of the clipmap. An optional untouched region
         //! aabb can be passed to this function to get an aabb of areas inside the bounds of the
@@ -114,6 +114,9 @@ namespace Terrain
         //! of the bounds of the clipmap is dirty, but areas that will already be updated due
         //! to the center moving shouldn't be updated twice.
         ClipmapBoundsRegionList UpdateCenter(const Vector2i& newCenter, AZ::Aabb* untouchedRegion = nullptr);
+
+        //! The biggest possible number of regions can return when calling UpdateCenter();
+        static const uint32_t MaxUpdateRegions = 6;
 
         //! Takes in a single world space region and transforms it into 0-4 regions in the clipmap clamped
         //! to the bounds of the clipmap.
@@ -131,8 +134,8 @@ namespace Terrain
         //! 0.25 and margin of 4 would have a safe distance of (1024 * 0.5 - 4) * 0.25 = 127.0f.
         float GetWorldSpaceSafeDistance() const;
 
-        //! Returns the normalized center of the clipmap within [0, 1].
-        AZ::Vector2 GetNormalizedCenter() const;
+        //! Returns the modulated center of the clipmap.
+        Vector2i GetModCenter() const;
     private:
 
         //! Returns the center point snapped to a multiple of m_clipmapUpdateMultiple. This isn't
@@ -156,7 +159,6 @@ namespace Terrain
         int32_t m_clipmapUpdateMultiple;
         float m_scale;
         float m_rcpScale;
-
     };
 
 }

--- a/Gems/Terrain/Code/Source/TerrainRenderer/ClipmapBounds.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/ClipmapBounds.h
@@ -116,7 +116,7 @@ namespace Terrain
         ClipmapBoundsRegionList UpdateCenter(const Vector2i& newCenter, AZ::Aabb* untouchedRegion = nullptr);
 
         //! The biggest possible number of regions can return when calling UpdateCenter();
-        static const uint32_t MaxUpdateRegions = 6;
+        static constexpr uint32_t MaxUpdateRegions = 6;
 
         //! Takes in a single world space region and transforms it into 0-4 regions in the clipmap clamped
         //! to the bounds of the clipmap.

--- a/Gems/Terrain/Code/Source/TerrainRenderer/Passes/TerrainClipmapComputePass.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/Passes/TerrainClipmapComputePass.cpp
@@ -20,8 +20,6 @@
 #include <Atom/RHI/FrameGraphBuilder.h>
 #include <Atom/RHI/CommandList.h>
 
-#pragma optimize("", off)
-
 namespace Terrain
 {
     TerrainClipmapGenerationPass::TerrainClipmapGenerationPass(const AZ::RPI::PassDescriptor& descriptor)
@@ -343,5 +341,3 @@ namespace Terrain
         TerrainClipmapGenerationPass::CompileResources(context);
     }
 } // namespace Terrain
-
-#pragma optimize("", on)

--- a/Gems/Terrain/Code/Source/TerrainRenderer/Passes/TerrainClipmapComputePass.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/Passes/TerrainClipmapComputePass.cpp
@@ -94,21 +94,7 @@ namespace Terrain
         }
 
         // Load Shader
-        AZ::Data::Asset<AZ::RPI::ShaderAsset> shaderAsset;
-        if (passData->m_shaderReference.m_assetId.IsValid())
-        {
-            shaderAsset = AZ::RPI::FindShaderAsset(passData->m_shaderReference.m_assetId, passData->m_shaderReference.m_filePath);
-        }
-
-        if (!shaderAsset.GetId().IsValid())
-        {
-            AZ_Error(
-                "PassSystem", false, "[TerrainClipmapGenerationPass '%s']: Failed to load shader '%s'!", GetPathName().GetCStr(),
-                passData->m_shaderReference.m_filePath.data());
-            return;
-        }
-
-        m_shader = AZ::RPI::Shader::FindOrCreate(shaderAsset);
+        m_shader = AZ::RPI::LoadShader(passData->m_shaderReference.m_assetId, passData->m_shaderReference.m_filePath);
         if (m_shader == nullptr)
         {
             AZ_Error(
@@ -121,8 +107,7 @@ namespace Terrain
         const auto passSrgLayout = m_shader->FindShaderResourceGroupLayout(AZ::RPI::SrgBindingSlot::Pass);
         if (passSrgLayout)
         {
-            m_shaderResourceGroup =
-                AZ::RPI::ShaderResourceGroup::Create(shaderAsset, m_shader->GetSupervariantIndex(), passSrgLayout->GetName());
+            m_shaderResourceGroup = AZ::RPI::ShaderResourceGroup::Create(m_shader->GetAsset(), m_shader->GetSupervariantIndex(), passSrgLayout->GetName());
 
             AZ_Assert(
                 m_shaderResourceGroup, "[TerrainClipmapGenerationPass '%s']: Failed to create SRG from shader asset '%s'",
@@ -135,7 +120,7 @@ namespace Terrain
         const auto drawSrgLayout = m_shader->FindShaderResourceGroupLayout(AZ::RPI::SrgBindingSlot::Draw);
         if (drawSrgLayout)
         {
-            m_drawSrg = AZ::RPI::ShaderResourceGroup::Create(shaderAsset, m_shader->GetSupervariantIndex(), drawSrgLayout->GetName());
+            m_drawSrg = AZ::RPI::ShaderResourceGroup::Create(m_shader->GetAsset(), m_shader->GetSupervariantIndex(), drawSrgLayout->GetName());
         }
 
         AZ::RHI::DispatchDirect dispatchArgs;

--- a/Gems/Terrain/Code/Source/TerrainRenderer/Passes/TerrainClipmapComputePass.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/Passes/TerrainClipmapComputePass.cpp
@@ -22,131 +22,6 @@
 
 namespace Terrain
 {
-    TerrainClipmapGenerationPass::TerrainClipmapGenerationPass(const AZ::RPI::PassDescriptor& descriptor)
-        : AZ::RPI::RenderPass(descriptor)
-        , m_passDescriptor(descriptor)
-    {
-        LoadShader();
-    }
-
-    void TerrainClipmapGenerationPass::SetupFrameGraphDependencies(AZ::RHI::FrameGraphInterface frameGraph)
-    {
-        AZ::RPI::RenderPass::SetupFrameGraphDependencies(frameGraph);
-        frameGraph.SetEstimatedItemCount(1);
-    }
-
-    void TerrainClipmapGenerationPass::CompileResources(const AZ::RHI::FrameGraphCompileContext& context)
-    {
-        if (m_shaderResourceGroup != nullptr)
-        {
-            BindPassSrg(context, m_shaderResourceGroup);
-            m_shaderResourceGroup->Compile();
-        }
-        if (m_drawSrg != nullptr)
-        {
-            BindSrg(m_drawSrg->GetRHIShaderResourceGroup());
-            m_drawSrg->Compile();
-        }
-    }
-
-    void TerrainClipmapGenerationPass::BuildCommandListInternal(const AZ::RHI::FrameGraphExecuteContext& context)
-    {
-        //! Skip invoking the compute shader.
-        if (m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX == 0 ||
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY == 0)
-        {
-            return;
-        }
-
-        AZ::RHI::CommandList* commandList = context.GetCommandList();
-
-        SetSrgsForDispatch(commandList);
-
-        commandList->Submit(m_dispatchItem);
-    }
-
-    void TerrainClipmapGenerationPass::OnShaderReinitialized([[maybe_unused]] const AZ::RPI::Shader& shader)
-    {
-        LoadShader();
-    }
-
-    void TerrainClipmapGenerationPass::OnShaderAssetReinitialized(
-        [[maybe_unused]] const AZ::Data::Asset<AZ::RPI::ShaderAsset>& shaderAsset)
-    {
-        LoadShader();
-    }
-
-    void TerrainClipmapGenerationPass::OnShaderVariantReinitialized([[maybe_unused]] const AZ::RPI::ShaderVariant& shaderVariant)
-    {
-        LoadShader();
-    }
-
-    void TerrainClipmapGenerationPass::LoadShader()
-    {
-        // Load ComputePassData...
-        const TerrainClipmapGenerationPassData* passData = AZ::RPI::PassUtils::GetPassData<TerrainClipmapGenerationPassData>(m_passDescriptor);
-        if (passData == nullptr)
-        {
-            AZ_Error(
-                "PassSystem", false, "[TerrainClipmapGenerationPass '%s']: Trying to construct without valid pass data!",
-                GetPathName().GetCStr());
-            return;
-        }
-
-        // Load Shader
-        m_shader = AZ::RPI::LoadShader(passData->m_shaderReference.m_assetId, passData->m_shaderReference.m_filePath);
-        if (m_shader == nullptr)
-        {
-            AZ_Error(
-                "PassSystem", false, "[TerrainClipmapGenerationPass '%s']: Failed to load shader '%s'!", GetPathName().GetCStr(),
-                passData->m_shaderReference.m_filePath.data());
-            return;
-        }
-
-        // Load Pass SRG...
-        const auto passSrgLayout = m_shader->FindShaderResourceGroupLayout(AZ::RPI::SrgBindingSlot::Pass);
-        if (passSrgLayout)
-        {
-            m_shaderResourceGroup = AZ::RPI::ShaderResourceGroup::Create(m_shader->GetAsset(), m_shader->GetSupervariantIndex(), passSrgLayout->GetName());
-
-            AZ_Assert(
-                m_shaderResourceGroup, "[TerrainClipmapGenerationPass '%s']: Failed to create SRG from shader asset '%s'",
-                GetPathName().GetCStr(), passData->m_shaderReference.m_filePath.data());
-
-            AZ::RPI::PassUtils::BindDataMappingsToSrg(m_passDescriptor, m_shaderResourceGroup.get());
-        }
-
-        // Load Draw SRG...
-        const auto drawSrgLayout = m_shader->FindShaderResourceGroupLayout(AZ::RPI::SrgBindingSlot::Draw);
-        if (drawSrgLayout)
-        {
-            m_drawSrg = AZ::RPI::ShaderResourceGroup::Create(m_shader->GetAsset(), m_shader->GetSupervariantIndex(), drawSrgLayout->GetName());
-        }
-
-        AZ::RHI::DispatchDirect dispatchArgs;
-
-        const auto outcome = AZ::RPI::GetComputeShaderNumThreads(m_shader->GetAsset(), dispatchArgs);
-        if (!outcome.IsSuccess())
-        {
-            AZ_Error(
-                "PassSystem", false, "[TerrainClipmapGenerationPass '%s']: Shader '%.*s' contains invalid numthreads arguments:\n%s",
-                GetPathName().GetCStr(), passData->m_shaderReference.m_filePath.size(), passData->m_shaderReference.m_filePath.data(),
-                outcome.GetError().c_str());
-        }
-
-        m_dispatchItem.m_arguments = dispatchArgs;
-
-        // Setup pipeline state...
-        AZ::RHI::PipelineStateDescriptorForDispatch pipelineStateDescriptor;
-        const auto& shaderVariant = m_shader->GetVariant(AZ::RPI::ShaderAsset::RootShaderVariantStableId);
-        shaderVariant.ConfigurePipelineState(pipelineStateDescriptor);
-
-        m_dispatchItem.m_pipelineState = m_shader->AcquirePipelineState(pipelineStateDescriptor);
-
-        AZ::RPI::ShaderReloadNotificationBus::Handler::BusDisconnect();
-        AZ::RPI::ShaderReloadNotificationBus::Handler::BusConnect(passData->m_shaderReference.m_assetId);
-    }
-
     AZ::RPI::Ptr<TerrainMacroClipmapGenerationPass> TerrainMacroClipmapGenerationPass::Create(const AZ::RPI::PassDescriptor& descriptor)
     {
         AZ::RPI::Ptr<TerrainMacroClipmapGenerationPass> pass = aznew TerrainMacroClipmapGenerationPass(descriptor);
@@ -154,7 +29,7 @@ namespace Terrain
     }
 
     TerrainMacroClipmapGenerationPass::TerrainMacroClipmapGenerationPass(const AZ::RPI::PassDescriptor& descriptor)
-        : TerrainClipmapGenerationPass(descriptor)
+        : AZ::RPI::ComputePass(descriptor)
     {
     }
 
@@ -215,14 +90,27 @@ namespace Terrain
                 m_needsUpdate = false;
             }
         }
-        else
+
+        AZ::RPI::ComputePass::CompileResources(context);
+    }
+
+    bool TerrainMacroClipmapGenerationPass::IsEnabled() const
+    {
+        if (!AZ::RPI::Pass::IsEnabled())
         {
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = 0;
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = 0;
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;
+            return false;
         }
 
-        TerrainClipmapGenerationPass::CompileResources(context);
+        AZ::RPI::Scene* scene = m_pipeline->GetScene();
+        TerrainFeatureProcessor* terrainFeatureProcessor = scene->GetFeatureProcessor<TerrainFeatureProcessor>();
+        if (!terrainFeatureProcessor)
+        {
+            return false;
+        }
+
+        const TerrainClipmapManager& clipmapManager = terrainFeatureProcessor->GetClipmapManager();
+
+        return clipmapManager.HasMacroClipmapUpdate();
     }
 
     AZ::RPI::Ptr<TerrainDetailClipmapGenerationPass> TerrainDetailClipmapGenerationPass::Create(const AZ::RPI::PassDescriptor& descriptor)
@@ -232,7 +120,7 @@ namespace Terrain
     }
 
     TerrainDetailClipmapGenerationPass::TerrainDetailClipmapGenerationPass(const AZ::RPI::PassDescriptor& descriptor)
-        : TerrainClipmapGenerationPass(descriptor)
+        : AZ::RPI::ComputePass(descriptor)
         , m_clipmapImageIndex{
             AZ::RHI::ShaderInputNameIndex(TerrainClipmapManager::ClipmapImageShaderInput[TerrainClipmapManager::ClipmapName::MacroColor]),
             AZ::RHI::ShaderInputNameIndex(TerrainClipmapManager::ClipmapImageShaderInput[TerrainClipmapManager::ClipmapName::MacroNormal]),
@@ -256,6 +144,14 @@ namespace Terrain
             const TerrainClipmapManager& clipmapManager = terrainFeatureProcessor->GetClipmapManager();
             AZ::RHI::FrameGraphAttachmentInterface attachmentDatabase = frameGraph.GetAttachmentDatabase();
 
+            //! If this frame, macro clipmap update is skipped but detail is not,
+            //! then the detail pass will be responsible for importing the clipmaps.
+            if (!clipmapManager.HasMacroClipmapUpdate())
+            {
+                clipmapManager.ImportClipmap(TerrainClipmapManager::ClipmapName::MacroColor, attachmentDatabase);
+                clipmapManager.ImportClipmap(TerrainClipmapManager::ClipmapName::MacroNormal, attachmentDatabase);
+            }
+
             clipmapManager.ImportClipmap(TerrainClipmapManager::ClipmapName::DetailColor, attachmentDatabase);
             clipmapManager.ImportClipmap(TerrainClipmapManager::ClipmapName::DetailNormal, attachmentDatabase);
             clipmapManager.ImportClipmap(TerrainClipmapManager::ClipmapName::DetailHeight, attachmentDatabase);
@@ -275,7 +171,7 @@ namespace Terrain
             clipmapManager.UseClipmap(TerrainClipmapManager::ClipmapName::DetailOcclusion, AZ::RHI::ScopeAttachmentAccess::ReadWrite, frameGraph);
         }
 
-        TerrainClipmapGenerationPass::SetupFrameGraphDependencies(frameGraph);
+        AZ::RPI::ComputePass::SetupFrameGraphDependencies(frameGraph);
     }
 
     void TerrainDetailClipmapGenerationPass::CompileResources(const AZ::RHI::FrameGraphCompileContext& context)
@@ -316,13 +212,26 @@ namespace Terrain
                 m_needsUpdate = false;
             }
         }
-        else
+
+        AZ::RPI::ComputePass::CompileResources(context);
+    }
+
+    bool TerrainDetailClipmapGenerationPass::IsEnabled() const
+    {
+        if (!AZ::RPI::Pass::IsEnabled())
         {
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = 0;
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = 0;
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;
+            return false;
         }
 
-        TerrainClipmapGenerationPass::CompileResources(context);
+        AZ::RPI::Scene* scene = m_pipeline->GetScene();
+        TerrainFeatureProcessor* terrainFeatureProcessor = scene->GetFeatureProcessor<TerrainFeatureProcessor>();
+        if (!terrainFeatureProcessor)
+        {
+            return false;
+        }
+
+        const TerrainClipmapManager& clipmapManager = terrainFeatureProcessor->GetClipmapManager();
+
+        return clipmapManager.HasDetailClipmapUpdate();
     }
 } // namespace Terrain

--- a/Gems/Terrain/Code/Source/TerrainRenderer/Passes/TerrainClipmapComputePass.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/Passes/TerrainClipmapComputePass.h
@@ -12,19 +12,78 @@
 #include <Atom/RPI.Public/Pass/ComputePass.h>
 #include <Atom/RPI.Public/Pass/ParentPass.h>
 #include <Atom/RPI.Public/Pass/Pass.h>
+#include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
 #include <Atom/RPI.Reflect/Pass/ComputePassData.h>
 #include <Atom/RPI.Reflect/Pass/PassDescriptor.h>
 #include <TerrainRenderer/TerrainClipmapManager.h>
 
+#include <Atom/RPI.Reflect/Pass/RenderPassData.h>
+
 namespace Terrain
 {
+    struct TerrainClipmapGenerationPassData : public AZ::RPI::RenderPassData
+    {
+        AZ_RTTI(TerrainClipmapGenerationPassData, "{07C90E11-6607-4BD2-B041-96CEF46F8C55}", AZ::RPI::RenderPassData);
+        AZ_CLASS_ALLOCATOR(TerrainClipmapGenerationPassData, AZ::SystemAllocator, 0);
+
+        TerrainClipmapGenerationPassData() = default;
+        virtual ~TerrainClipmapGenerationPassData() = default;
+
+        static void Reflect(AZ::ReflectContext* context)
+        {
+            if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serializeContext->Class<TerrainClipmapGenerationPassData, AZ::RPI::RenderPassData>()->Version(1)->Field(
+                    "ShaderAsset", &TerrainClipmapGenerationPassData::m_shaderReference);
+            }
+        }
+
+        AZ::RPI::AssetReference m_shaderReference;
+    };
+
+    class TerrainClipmapGenerationPass
+        : public AZ::RPI::RenderPass
+        , private AZ::RPI::ShaderReloadNotificationBus::Handler
+    {
+        AZ_RPI_PASS(TerrainClipmapGenerationPass);
+
+    public:
+        AZ_RTTI(Terrain::TerrainClipmapGenerationPass, "{EA713973-1214-498C-BA05-A9A8B1AA99C7}", AZ::RPI::RenderPass);
+        AZ_CLASS_ALLOCATOR(Terrain::TerrainClipmapGenerationPass, AZ::SystemAllocator, 0);
+        virtual ~TerrainClipmapGenerationPass() = default;
+
+        void SetupFrameGraphDependencies(AZ::RHI::FrameGraphInterface frameGraph) override;
+        void CompileResources(const AZ::RHI::FrameGraphCompileContext& context) override;
+        void BuildCommandListInternal(const AZ::RHI::FrameGraphExecuteContext& context) override;
+
+    protected:
+        TerrainClipmapGenerationPass(const AZ::RPI::PassDescriptor& descriptor);
+
+        void OnShaderReinitialized(const AZ::RPI::Shader& shader) override;
+        void OnShaderAssetReinitialized(const AZ::Data::Asset<AZ::RPI::ShaderAsset>& shaderAsset) override;
+        void OnShaderVariantReinitialized(const AZ::RPI::ShaderVariant& shaderVariant) override;
+
+        void LoadShader();
+
+        // Default draw SRG for using the shader option system's variant fallback key
+        AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_drawSrg = nullptr;
+
+        // The draw item submitted by this pass
+        AZ::RHI::DispatchItem m_dispatchItem;
+
+        AZ::RPI::PassDescriptor m_passDescriptor;
+
+        // The compute shader that will be used by the pass
+        AZ::Data::Instance<AZ::RPI::Shader> m_shader = nullptr;
+    };
+
     class TerrainMacroClipmapGenerationPass
-        : public AZ::RPI::ComputePass
+        : public TerrainClipmapGenerationPass
     {
         AZ_RPI_PASS(TerrainMacroClipmapGenerationPass);
 
     public:
-        AZ_RTTI(Terrain::TerrainMacroClipmapGenerationPass, "{E1F7C18F-E77A-496E-ABD7-1EC7D75AA4B0}", AZ::RPI::ComputePass);
+        AZ_RTTI(Terrain::TerrainMacroClipmapGenerationPass, "{E1F7C18F-E77A-496E-ABD7-1EC7D75AA4B0}", TerrainClipmapGenerationPass);
         AZ_CLASS_ALLOCATOR(Terrain::TerrainMacroClipmapGenerationPass, AZ::SystemAllocator, 0);
         virtual ~TerrainMacroClipmapGenerationPass() = default;
 
@@ -45,12 +104,12 @@ namespace Terrain
     };
 
     class TerrainDetailClipmapGenerationPass
-        : public AZ::RPI::ComputePass
+        : public TerrainClipmapGenerationPass
     {
         AZ_RPI_PASS(TerrainDetailClipmapGenerationPass);
 
     public:
-        AZ_RTTI(Terrain::TerrainDetailClipmapGenerationPass, "{BD504E93-87F4-484E-A17A-E337C3F2279C}", AZ::RPI::ComputePass);
+        AZ_RTTI(Terrain::TerrainDetailClipmapGenerationPass, "{BD504E93-87F4-484E-A17A-E337C3F2279C}", TerrainClipmapGenerationPass);
         AZ_CLASS_ALLOCATOR(Terrain::TerrainDetailClipmapGenerationPass, AZ::SystemAllocator, 0);
         virtual ~TerrainDetailClipmapGenerationPass() = default;
 

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.cpp
@@ -166,6 +166,9 @@ namespace Terrain
 
     void TerrainClipmapManager::InitializeClipmapData()
     {
+        const AZStd::array<uint32_t, 4> zeroUint = { 0, 0, 0, 0 };
+        const AZStd::array<float, 4> zeroFloat = { 0.0f, 0.0f, 0.0f, 0.0f };
+
         AZ::Vector2::CreateZero().StoreToFloat2(m_clipmapData.m_previousViewPosition.data());
         AZ::Vector2::CreateZero().StoreToFloat2(m_clipmapData.m_currentViewPosition.data());
 
@@ -190,6 +193,8 @@ namespace Terrain
         m_clipmapData.m_clipmapSizeFloat = aznumeric_cast<float>(m_config.m_clipmapSize);
         m_clipmapData.m_clipmapSizeUint = m_config.m_clipmapSize;
 
+        m_clipmapData.m_clipmapScaleInv.fill(zeroFloat);
+
         float clipmapScaleInv = 1.0f;
         for (int32_t clipmapIndex = m_macroClipmapStackSize - 1; clipmapIndex >= 0; --clipmapIndex)
         {
@@ -203,9 +208,10 @@ namespace Terrain
             clipmapScaleInv /= m_config.m_detailClipmapScaleBase;
         }
 
-        const AZStd::array<uint32_t, 4> zero = {0, 0, 0, 0};
-        m_clipmapData.m_macroClipmapBoundsRegions.fill(zero);
-        m_clipmapData.m_detailClipmapBoundsRegions.fill(zero);
+        m_clipmapData.m_macroClipmapCenters.fill(zeroUint);
+        m_clipmapData.m_macroClipmapCenters.fill(zeroUint);
+        m_clipmapData.m_macroClipmapBoundsRegions.fill(zeroUint);
+        m_clipmapData.m_detailClipmapBoundsRegions.fill(zeroUint);
     }
 
     void TerrainClipmapManager::InitializeClipmapImages()
@@ -273,7 +279,6 @@ namespace Terrain
     void TerrainClipmapManager::UpdateClipmapData(const AZ::Vector3& cameraPosition)
     {
         const AZStd::array<uint32_t, 4> zero = { 0, 0, 0, 0 };
-        //const AZStd::array<uint32_t, 4> testAABB = { 514, 442, 547, 1024};
 
         // pass current to previous
         m_clipmapData.m_previousViewPosition[0] = m_clipmapData.m_currentViewPosition[0];

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.cpp
@@ -305,9 +305,9 @@ namespace Terrain
         };
 
         // First time update will run through the whole clipmap
-        if (m_fristTimeUpdate)
+        if (m_firstTimeUpdate)
         {
-            m_fristTimeUpdate = false;
+            m_firstTimeUpdate = false;
 
             InitializeClipmapBounds(currentViewPosition);
 
@@ -384,8 +384,6 @@ namespace Terrain
             hasUpdate = hasUpdate || updateRegionList.size() > 0;
         }
 
-        // [TODO] We need some more test to determine if dynamic dispatch number works better.
-        //        Or static numbers better than 64x64.
         if (hasUpdate)
         {
             m_macroTotalDispatchThreadX = 64;
@@ -426,8 +424,6 @@ namespace Terrain
             hasUpdate = hasUpdate || updateRegionList.size() > 0;
         }
 
-        // [TODO] We need some more test to determine if dynamic dispatch number works better.
-        //        Or static numbers better than 64x64.
         if (hasUpdate)
         {
             m_detailTotalDispatchThreadX = 64;

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.cpp
@@ -82,7 +82,6 @@ namespace Terrain
         m_macroClipmapStackSize = m_config.CalculateMacroClipmapStackSize();
         m_detailClipmapStackSize = m_config.CalculateDetailClipmapStackSize();
 
-        InitializeClipmapBounds();
         InitializeClipmapData();
         InitializeClipmapImages();
 
@@ -132,7 +131,7 @@ namespace Terrain
         frameGraph.UseShaderAttachment(desc, access);
     }
 
-    void TerrainClipmapManager::InitializeClipmapBounds()
+    void TerrainClipmapManager::InitializeClipmapBounds(const AZ::Vector2& center)
     {
         m_macroClipmapBounds.resize(m_macroClipmapStackSize);
         float clipToWorldScale = m_config.m_macroClipmapMaxRenderRadius * 2.0f / m_config.m_clipmapSize;
@@ -140,8 +139,8 @@ namespace Terrain
         {
             ClipmapBoundsDescriptor desc;
             desc.m_size = m_config.m_clipmapSize;
-            desc.m_worldSpaceCenter = AZ::Vector2::CreateZero();
-            desc.m_clipmapUpdateMultiple = 4;
+            desc.m_worldSpaceCenter = center;
+            desc.m_clipmapUpdateMultiple = 0;
             desc.m_clipToWorldScale = clipToWorldScale;
 
             m_macroClipmapBounds[clipmapIndex] = ClipmapBounds(desc);
@@ -155,8 +154,8 @@ namespace Terrain
         {
             ClipmapBoundsDescriptor desc;
             desc.m_size = m_config.m_clipmapSize;
-            desc.m_worldSpaceCenter = AZ::Vector2::CreateZero();
-            desc.m_clipmapUpdateMultiple = 4;
+            desc.m_worldSpaceCenter = center;
+            desc.m_clipmapUpdateMultiple = 0;
             desc.m_clipToWorldScale = clipToWorldScale;
 
             m_detailClipmapBounds[clipmapIndex] = ClipmapBounds(desc);
@@ -188,22 +187,25 @@ namespace Terrain
         m_clipmapData.m_macroClipmapStackSize = m_macroClipmapStackSize;
         m_clipmapData.m_detailClipmapStackSize = m_detailClipmapStackSize;
 
-        m_clipmapData.m_clipmapSize = aznumeric_cast<float>(m_config.m_clipmapSize);
+        m_clipmapData.m_clipmapSizeFloat = aznumeric_cast<float>(m_config.m_clipmapSize);
+        m_clipmapData.m_clipmapSizeUint = m_config.m_clipmapSize;
 
         float clipmapScaleInv = 1.0f;
         for (int32_t clipmapIndex = m_macroClipmapStackSize - 1; clipmapIndex >= 0; --clipmapIndex)
         {
-            AZ::Vector4(0.5f).StoreToFloat4(m_clipmapData.m_macroClipmapCenters[clipmapIndex].data());
             m_clipmapData.m_clipmapScaleInv[clipmapIndex][0] = clipmapScaleInv;
             clipmapScaleInv /= m_config.m_macroClipmapScaleBase;
         }
         clipmapScaleInv = 1.0f;
         for (int32_t clipmapIndex = m_detailClipmapStackSize - 1; clipmapIndex >= 0; --clipmapIndex)
         {
-            AZ::Vector4(0.5f).StoreToFloat4(m_clipmapData.m_detailClipmapCenters[clipmapIndex].data());
             m_clipmapData.m_clipmapScaleInv[clipmapIndex][1] = clipmapScaleInv;
             clipmapScaleInv /= m_config.m_detailClipmapScaleBase;
         }
+
+        const AZStd::array<uint32_t, 4> zero = {0, 0, 0, 0};
+        m_clipmapData.m_macroClipmapBoundsRegions.fill(zero);
+        m_clipmapData.m_detailClipmapBoundsRegions.fill(zero);
     }
 
     void TerrainClipmapManager::InitializeClipmapImages()
@@ -270,6 +272,9 @@ namespace Terrain
 
     void TerrainClipmapManager::UpdateClipmapData(const AZ::Vector3& cameraPosition)
     {
+        const AZStd::array<uint32_t, 4> zero = { 0, 0, 0, 0 };
+        //const AZStd::array<uint32_t, 4> testAABB = { 514, 442, 547, 1024};
+
         // pass current to previous
         m_clipmapData.m_previousViewPosition[0] = m_clipmapData.m_currentViewPosition[0];
         m_clipmapData.m_previousViewPosition[1] = m_clipmapData.m_currentViewPosition[1];
@@ -278,28 +283,159 @@ namespace Terrain
         AZ::Vector2 currentViewPosition = AZ::Vector2(cameraPosition.GetX(), cameraPosition.GetY());
         currentViewPosition.StoreToFloat2(m_clipmapData.m_currentViewPosition.data());
 
-        auto UpdateCenter = [&](ClipmapBounds& clipmapBounds, AZStd::array<float, 4>& shaderData) -> void
+        auto UpdateCenter = [&](ClipmapBounds& clipmapBounds, AZStd::array<uint32_t, 4>& shaderData) -> ClipmapBoundsRegionList
         {
-            clipmapBounds.UpdateCenter(currentViewPosition);
+            ClipmapBoundsRegionList updateRegionList = clipmapBounds.UpdateCenter(currentViewPosition);
 
             // copy current to previous slot
             shaderData[0] = shaderData[2];
             shaderData[1] = shaderData[3];
 
             // write current center
-            clipmapBounds.GetNormalizedCenter().StoreToFloat2(&shaderData[2]);
+            Vector2i center = clipmapBounds.GetModCenter();
+            shaderData[2] = center.m_x;
+            shaderData[3] = center.m_y;
+
+            return updateRegionList;
         };
 
+        // First time update will run through the whole clipmap
+        if (m_fristTimeUpdate)
+        {
+            m_fristTimeUpdate = false;
+
+            InitializeClipmapBounds(currentViewPosition);
+
+            AZStd::array<uint32_t, 4> aabb = { 0, 0, m_config.m_clipmapSize, m_config.m_clipmapSize };
+
+            for (uint32_t clipmapIndex = 0; clipmapIndex < m_macroClipmapStackSize; ++clipmapIndex)
+            {
+                m_clipmapData.m_macroClipmapBoundsRegions[clipmapIndex] = aabb;
+
+                for (uint32_t i = 1; i < ClipmapBounds::MaxUpdateRegions; ++i)
+                {
+                    m_clipmapData.m_macroClipmapBoundsRegions[clipmapIndex + ClipmapConfiguration::MacroClipmapStackSizeMax * i] = zero;
+                }
+
+                Vector2i center = m_macroClipmapBounds[clipmapIndex].GetModCenter();
+                m_clipmapData.m_macroClipmapCenters[clipmapIndex][0] = center.m_x;
+                m_clipmapData.m_macroClipmapCenters[clipmapIndex][1] = center.m_y;
+                m_clipmapData.m_macroClipmapCenters[clipmapIndex][2] = center.m_x;
+                m_clipmapData.m_macroClipmapCenters[clipmapIndex][3] = center.m_y;
+            }
+
+            for (uint32_t clipmapIndex = 0; clipmapIndex < m_detailClipmapStackSize; ++clipmapIndex)
+            {
+                m_clipmapData.m_detailClipmapBoundsRegions[clipmapIndex] = aabb;
+
+                for (uint32_t i = 1; i < ClipmapBounds::MaxUpdateRegions; ++i)
+                {
+                    m_clipmapData.m_detailClipmapBoundsRegions[clipmapIndex + ClipmapConfiguration::DetailClipmapStackSizeMax * i] = zero;
+                }
+
+                Vector2i center = m_detailClipmapBounds[clipmapIndex].GetModCenter();
+                m_clipmapData.m_detailClipmapCenters[clipmapIndex][0] = center.m_x;
+                m_clipmapData.m_detailClipmapCenters[clipmapIndex][1] = center.m_y;
+                m_clipmapData.m_detailClipmapCenters[clipmapIndex][2] = center.m_x;
+                m_clipmapData.m_detailClipmapCenters[clipmapIndex][3] = center.m_y;
+            }
+
+            m_macroTotalDispatchThreadX = 1024;
+            m_macroTotalDispatchThreadY = 1024;
+            m_detailTotalDispatchThreadX = 1024;
+            m_detailTotalDispatchThreadY = 1024;
+
+            m_clipmapData.m_macroDispatchGroupCountX = m_macroTotalDispatchThreadX / MacroGroupThreadX;
+            m_clipmapData.m_macroDispatchGroupCountY = m_macroTotalDispatchThreadY / MacroGroupThreadY;
+
+            m_clipmapData.m_detailDispatchGroupCountX = m_detailTotalDispatchThreadX / DetailGroupThreadX;
+            m_clipmapData.m_detailDispatchGroupCountY = m_detailTotalDispatchThreadY / DetailGroupThreadY;
+
+            return;
+        }
+
         // macro clipmap data:
+        bool hasUpdate = false;
         for (uint32_t clipmapIndex = 0; clipmapIndex < m_macroClipmapStackSize; ++clipmapIndex)
         {
-            UpdateCenter(m_macroClipmapBounds[clipmapIndex], m_clipmapData.m_macroClipmapCenters[clipmapIndex]);
+            ClipmapBoundsRegionList updateRegionList = UpdateCenter(m_macroClipmapBounds[clipmapIndex], m_clipmapData.m_macroClipmapCenters[clipmapIndex]);
+
+            for (uint32_t i = 0; i < ClipmapBounds::MaxUpdateRegions; ++i)
+            {
+                if (updateRegionList.size() > i)
+                {
+                    AZStd::array<uint32_t, 4> aabb = { (uint32_t)updateRegionList[i].m_localAabb.m_min.m_x,
+                                                       (uint32_t)updateRegionList[i].m_localAabb.m_min.m_y,
+                                                       (uint32_t)updateRegionList[i].m_localAabb.m_max.m_x,
+                                                       (uint32_t)updateRegionList[i].m_localAabb.m_max.m_y };
+                    m_clipmapData.m_macroClipmapBoundsRegions[clipmapIndex + ClipmapConfiguration::MacroClipmapStackSizeMax * i] = aabb;
+                }
+                else
+                {
+                    m_clipmapData.m_macroClipmapBoundsRegions[clipmapIndex + ClipmapConfiguration::MacroClipmapStackSizeMax * i] = zero;
+                }
+            }
+
+            hasUpdate = hasUpdate || updateRegionList.size() > 0;
+        }
+
+        // [TODO] We need some more test to determine if dynamic dispatch number works better.
+        //        Or static numbers better than 64x64.
+        if (hasUpdate)
+        {
+            m_macroTotalDispatchThreadX = 64;
+            m_macroTotalDispatchThreadY = 64;
+            m_clipmapData.m_macroDispatchGroupCountX = m_macroTotalDispatchThreadX / MacroGroupThreadX;
+            m_clipmapData.m_macroDispatchGroupCountY = m_macroTotalDispatchThreadY / MacroGroupThreadY;
+        }
+        else
+        {
+            m_macroTotalDispatchThreadX = 0;
+            m_macroTotalDispatchThreadY = 0;
+            m_clipmapData.m_macroDispatchGroupCountX = 1;
+            m_clipmapData.m_macroDispatchGroupCountY = 1;
         }
 
         // detail clipmap data:
-        for (int32_t clipmapIndex = m_detailClipmapStackSize - 1; clipmapIndex >= 0; --clipmapIndex)
+        hasUpdate = false;
+        for (uint32_t clipmapIndex = 0; clipmapIndex < m_detailClipmapStackSize; ++clipmapIndex)
         {
-            UpdateCenter(m_detailClipmapBounds[clipmapIndex], m_clipmapData.m_detailClipmapCenters[clipmapIndex]);
+            ClipmapBoundsRegionList updateRegionList = UpdateCenter(m_detailClipmapBounds[clipmapIndex], m_clipmapData.m_detailClipmapCenters[clipmapIndex]);
+
+            for (uint32_t i = 0; i < ClipmapBounds::MaxUpdateRegions; ++i)
+            {
+                if (updateRegionList.size() > i)
+                {
+                    AZStd::array<uint32_t, 4> aabb = { (uint32_t)updateRegionList[i].m_localAabb.m_min.m_x,
+                                                       (uint32_t)updateRegionList[i].m_localAabb.m_min.m_y,
+                                                       (uint32_t)updateRegionList[i].m_localAabb.m_max.m_x,
+                                                       (uint32_t)updateRegionList[i].m_localAabb.m_max.m_y };
+                    m_clipmapData.m_detailClipmapBoundsRegions[clipmapIndex + ClipmapConfiguration::DetailClipmapStackSizeMax * i] = aabb;
+                }
+                else
+                {
+                    m_clipmapData.m_detailClipmapBoundsRegions[clipmapIndex + ClipmapConfiguration::DetailClipmapStackSizeMax * i] = zero;
+                }
+            }
+
+            hasUpdate = hasUpdate || updateRegionList.size() > 0;
+        }
+
+        // [TODO] We need some more test to determine if dynamic dispatch number works better.
+        //        Or static numbers better than 64x64.
+        if (hasUpdate)
+        {
+            m_detailTotalDispatchThreadX = 64;
+            m_detailTotalDispatchThreadY = 64;
+            m_clipmapData.m_detailDispatchGroupCountX = m_detailTotalDispatchThreadX / DetailGroupThreadX;
+            m_clipmapData.m_detailDispatchGroupCountY = m_detailTotalDispatchThreadY / DetailGroupThreadY;
+        }
+        else
+        {
+            m_detailTotalDispatchThreadX = 0;
+            m_detailTotalDispatchThreadY = 0;
+            m_clipmapData.m_detailDispatchGroupCountX = 1;
+            m_clipmapData.m_detailDispatchGroupCountY = 1;
         }
     }
 
@@ -308,5 +444,19 @@ namespace Terrain
         AZ_Assert(clipmapName < ClipmapName::Count, "Must be a valid ClipmapName enum.");
 
         return m_clipmaps[clipmapName];
+    }
+
+    void TerrainClipmapManager::GetMacroDispatchThreadNum(uint32_t& outThreadX, uint32_t& outThreadY, uint32_t& outThreadZ) const
+    {
+        outThreadX = m_macroTotalDispatchThreadX;
+        outThreadY = m_macroTotalDispatchThreadY;
+        outThreadZ = 1;
+    }
+
+    void TerrainClipmapManager::GetDetailDispatchThreadNum(uint32_t& outThreadX, uint32_t& outThreadY, uint32_t& outThreadZ) const
+    {
+        outThreadX = m_detailTotalDispatchThreadX;
+        outThreadY = m_detailTotalDispatchThreadY;
+        outThreadZ = 1;
     }
 }

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.cpp
@@ -460,4 +460,14 @@ namespace Terrain
         outThreadY = m_detailTotalDispatchThreadY;
         outThreadZ = 1;
     }
+
+    bool TerrainClipmapManager::HasMacroClipmapUpdate() const
+    {
+        return m_macroTotalDispatchThreadX != 0 && m_macroTotalDispatchThreadY != 0;
+    }
+
+    bool TerrainClipmapManager::HasDetailClipmapUpdate() const
+    {
+        return m_detailTotalDispatchThreadX != 0 && m_detailTotalDispatchThreadY != 0;
+    }
 }

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.h
@@ -111,8 +111,6 @@ namespace Terrain
         AZ::Data::Instance<AZ::RPI::AttachmentImage> GetClipmapImage(ClipmapName clipmapName) const;
 
         //! Get the dispatch thread num for the clipmap compute shader based on the current frame.
-        //!
-        //!
         void GetMacroDispatchThreadNum(uint32_t& outThreadX, uint32_t& outThreadY, uint32_t& outThreadZ) const;
         void GetDetailDispatchThreadNum(uint32_t& outThreadX, uint32_t& outThreadY, uint32_t& outThreadZ) const;
     private:

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.h
@@ -163,10 +163,11 @@ namespace Terrain
             AZStd::array<AZStd::array<float, 4>, AZStd::max(ClipmapConfiguration::MacroClipmapStackSizeMax, ClipmapConfiguration::DetailClipmapStackSizeMax)> m_clipmapScaleInv;
 
             //! The region of the clipmap that needs update.
-            //! Each clipmap can have 0-2 regions to update each frame.
+            //! Each clipmap can have 0-6 regions to update each frame.
             AZStd::array<AZStd::array<uint32_t, 4>, ClipmapConfiguration::MacroClipmapStackSizeMax * ClipmapBounds::MaxUpdateRegions> m_macroClipmapBoundsRegions;
             AZStd::array<AZStd::array<uint32_t, 4>, ClipmapConfiguration::DetailClipmapStackSizeMax * ClipmapBounds::MaxUpdateRegions> m_detailClipmapBoundsRegions;
 
+            //! Numbers match the compute shader invoking call dispatch(X, Y, 1).
             uint32_t m_macroDispatchGroupCountX = 1;
             uint32_t m_macroDispatchGroupCountY = 1;
             uint32_t m_detailDispatchGroupCountX = 1;
@@ -188,7 +189,7 @@ namespace Terrain
 
         ClipmapConfiguration m_config;
         bool m_isInitialized = false;
-        bool m_fristTimeUpdate = true;
+        bool m_firstTimeUpdate = true;
 
         //! Dispatch threads for the compute pass.
         uint32_t m_macroTotalDispatchThreadX = 0;
@@ -196,7 +197,7 @@ namespace Terrain
         uint32_t m_detailTotalDispatchThreadX = 0;
         uint32_t m_detailTotalDispatchThreadY = 0;
 
-        //! Group threads difined in the compute shader.
+        //! Group threads defined in the compute shader.
         static constexpr uint32_t MacroGroupThreadX = 8;
         static constexpr uint32_t MacroGroupThreadY = 8;
         static constexpr uint32_t DetailGroupThreadX = 8;

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
@@ -812,7 +812,7 @@ namespace Terrain
     {
         
         AZ::Aabb untouchedRegion = AZ::Aabb::CreateNull();
-        ClipmapBounds::ClipmapBoundsRegionList edgeUpdatedRegions =
+        ClipmapBoundsRegionList edgeUpdatedRegions =
             m_detailMaterialIdBounds.UpdateCenter(AZ::Vector2(cameraPosition.GetX(), cameraPosition.GetY()), &untouchedRegion);
         
         if (!m_detailTextureImage)
@@ -827,7 +827,7 @@ namespace Terrain
             m_detailTextureImage = AZ::RPI::AttachmentImage::Create(*imagePool.get(), imageDescriptor, TerrainDetailName, nullptr, nullptr);
             AZ_Error(TerrainDetailMaterialManagerName, m_detailTextureImage, "Failed to initialize the detail texture image.");
 
-            ClipmapBounds::ClipmapBoundsRegionList updateRegions = m_detailMaterialIdBounds.TransformRegion(m_detailMaterialIdBounds.GetWorldBounds());
+            ClipmapBoundsRegionList updateRegions = m_detailMaterialIdBounds.TransformRegion(m_detailMaterialIdBounds.GetWorldBounds());
             for (const auto& region : updateRegions)
             {
                 UpdateDetailTexture(region.m_worldAabb, region.m_localAabb);
@@ -846,7 +846,7 @@ namespace Terrain
                 m_dirtyDetailRegion = m_dirtyDetailRegion.GetClamped(untouchedRegion);
                 if (m_dirtyDetailRegion.IsValid())
                 {
-                    ClipmapBounds::ClipmapBoundsRegionList updateRegions = m_detailMaterialIdBounds.TransformRegion(m_dirtyDetailRegion);
+                    ClipmapBoundsRegionList updateRegions = m_detailMaterialIdBounds.TransformRegion(m_dirtyDetailRegion);
                     for (const auto& region : updateRegions)
                     {
                         UpdateDetailTexture(region.m_worldAabb, region.m_localAabb);

--- a/Gems/Terrain/Code/Tests/ClipmapBoundsTests.cpp
+++ b/Gems/Terrain/Code/Tests/ClipmapBoundsTests.cpp
@@ -52,7 +52,7 @@ namespace UnitTest
         };
         
         // Check each quadrant returned
-        AZStd::vector<Terrain::ClipmapBoundsRegion> expected;
+        Terrain::ClipmapBoundsRegionList expected;
         expected.resize(4);
 
         expected.at(0).m_localAabb = Terrain::Aabb2i({localBoundary.m_x, localBoundary.m_y}, {intSize, intSize});
@@ -274,7 +274,7 @@ namespace UnitTest
 
         {
             AZ::Aabb untouchedRegion = AZ::Aabb::CreateNull();
-            auto output = bounds.UpdateCenter(AZ::Vector2(20.0f, 20.0f), &untouchedRegion);
+            auto output = bounds.UpdateCenter(AZ::Vector2(-20.0f, -20.0f), &untouchedRegion);
             ASSERT_EQ(output.size(), 4);
 
             // Instead of checking bounds directly, do several checks to make sure the bounds are appropriate. Since
@@ -333,4 +333,25 @@ namespace UnitTest
         }
 
     }
+
+    TEST_F(ClipmapBoundsTests, MaxUpdateRegionTest)
+    {
+        for (int32_t i = -5; i <= 5; ++i)
+        {
+            for (int32_t j = -5; j <= 5; ++j)
+            {
+                Terrain::ClipmapBoundsDescriptor desc;
+                desc.m_worldSpaceCenter = AZ::Vector2(0.0f, 0.0f);
+                desc.m_clipmapUpdateMultiple = 0;
+                desc.m_clipToWorldScale = 1.0f;
+                desc.m_size = 1024;
+                Terrain::ClipmapBounds bounds(desc);
+
+                auto list = bounds.UpdateCenter(AZ::Vector2(256.0f * i, 256.0f * j));
+
+                EXPECT_LE(list.size(), Terrain::ClipmapBounds::MaxUpdateRegions);
+            }
+        }
+    }
+
 }

--- a/Gems/Terrain/Code/Tests/ClipmapBoundsTests.cpp
+++ b/Gems/Terrain/Code/Tests/ClipmapBoundsTests.cpp
@@ -352,7 +352,7 @@ namespace UnitTest
 
                 auto list = bounds.UpdateCenter(AZ::Vector2(256.0f * i, 256.0f * j));
 
-                uint32_t size = list.size();
+                uint32_t size = aznumeric_cast<uint32_t>(list.size());
                 EXPECT_LE(size, Terrain::ClipmapBounds::MaxUpdateRegions);
             }
         }

--- a/Gems/Terrain/Code/Tests/ClipmapBoundsTests.cpp
+++ b/Gems/Terrain/Code/Tests/ClipmapBoundsTests.cpp
@@ -274,7 +274,7 @@ namespace UnitTest
 
         {
             AZ::Aabb untouchedRegion = AZ::Aabb::CreateNull();
-            auto output = bounds.UpdateCenter(AZ::Vector2(-20.0f, -20.0f), &untouchedRegion);
+            auto output = bounds.UpdateCenter(AZ::Vector2(20.0f, 20.0f), &untouchedRegion);
             ASSERT_EQ(output.size(), 4);
 
             // Instead of checking bounds directly, do several checks to make sure the bounds are appropriate. Since
@@ -334,8 +334,11 @@ namespace UnitTest
 
     }
 
+    // This test is to ensure clipmap update compute shader receives 6 regions at most.
     TEST_F(ClipmapBoundsTests, MaxUpdateRegionTest)
     {
+        // The initial clipmap is divided into 4 parts.
+        // By traversing the 11x11 grid, all possible overlapping cases can be covered.
         for (int32_t i = -5; i <= 5; ++i)
         {
             for (int32_t j = -5; j <= 5; ++j)

--- a/Gems/Terrain/Code/Tests/ClipmapBoundsTests.cpp
+++ b/Gems/Terrain/Code/Tests/ClipmapBoundsTests.cpp
@@ -352,7 +352,8 @@ namespace UnitTest
 
                 auto list = bounds.UpdateCenter(AZ::Vector2(256.0f * i, 256.0f * j));
 
-                EXPECT_LE(list.size(), Terrain::ClipmapBounds::MaxUpdateRegions);
+                uint32_t size = list.size();
+                EXPECT_LE(size, Terrain::ClipmapBounds::MaxUpdateRegions);
             }
         }
     }


### PR DESCRIPTION
1. Created a special base pass for clipmap updating.
2. Clipmap compute pass will now be invoked only if there is a region to be updated.
3. The compute pass will distribute the region evenly to each compute thread. It is still dispatching at static thread numbers. We'll need some tests for dynamic numbers.
5. Fixed mod center no initialization in ClipmapBounds and added another test case for update region numbers.

To do:
1. There are still some float rounding issues within clipmap updating and sampling. One is by the precision of the rcp of the clipmap scale. Another is the actual view position doesn't match the clipmap center. Will fix these in later PR.
2. Add the margin for each clipmap to allow lazy update. This is partially done in the ClipmapCenter class using m_clipmapUpdateMultiple.