### PR TITLE
Fixed link to Asset Processor docs from Import Assets dialog

### DIFF
--- a/Code/Editor/AssetImporter/UI/SelectDestinationDialog.cpp
+++ b/Code/Editor/AssetImporter/UI/SelectDestinationDialog.cpp
@@ -20,7 +20,7 @@ AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 
-static const char* g_assetProcessorLink = "<a href=\"https://o3de.org/docs/user-guide/assets/pipeline/processor-ui/\">Asset Processor</a>";
+static const char* g_assetProcessorLink = "<a href=\"https://www.o3de.org/docs/user-guide/assets/asset-processor/\">Asset Processor</a>";
 static const char* g_copyFilesMessage = "The original file will remain outside of the project and the %1 will not monitor the file.";
 static const char* g_moveFilesMessage = "The original file will be moved inside of the project and the %1 will monitor the file for changes.";
 static const char* g_selectDestinationFilesPath = "AssetImporter/SelectDestinationFilesPath";

--- a/Code/Editor/AssetImporter/UI/SelectDestinationDialog.ui
+++ b/Code/Editor/AssetImporter/UI/SelectDestinationDialog.ui
@@ -29,7 +29,7 @@
    <enum>Qt::StrongFocus</enum>
   </property>
   <property name="windowTitle">
-   <string>Import Asset(s)</string>
+   <string>Import Assets</string>
   </property>
   <property name="class" stdset="0">
    <string>AssetImporterDialog</string>


### PR DESCRIPTION
Also changed dialog title to Import Assets.

Resolves: #9210

Manually tested in a clean Windows profile build of development branch as of commit 204a10fe4ee6e2f8cefeaed9a2d900004853c34f morning of May 11th.

Signed-off-by: Mike Cronin <58789750+micronAMZN@users.noreply.github.com>