### PR TITLE
Adds seperated level load test

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Level_Loads.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Level_Loads.py
@@ -17,7 +17,27 @@ TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), "tests")
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
 class TestAutomation(EditorTestSuite):
+        
+    @pytest.mark.test_case_id("C36530722")
+    class Editor_levelLoad_Atom_hermanubis(EditorBatchedTest):
+        from Atom.tests import levelLoad_Atom_hermanubis as test_module
 
-    @pytest.mark.test_case_id("C36529679")
-    class AtomLevelLoadTest_Editor(EditorBatchedTest):
-        from Atom.tests import hydra_Atom_LevelLoadTest as test_module
+    @pytest.mark.test_case_id("C36530724")
+    class Editor_levelLoad_Atom_hermanubis_high(EditorBatchedTest):
+        from Atom.tests import levelLoad_Atom_hermanubis_high as test_module
+
+    @pytest.mark.test_case_id("C36530725")
+    class Editor_levelLoad_Atom_macbeth_shaderballs(EditorBatchedTest):
+        from Atom.tests import levelLoad_Atom_macbeth_shaderballs as test_module
+
+    @pytest.mark.test_case_id("C36530726")
+    class Editor_levelLoad_Atom_PbrMaterialChart(EditorBatchedTest):
+        from Atom.tests import levelLoad_Atom_PbrMaterialChart as test_module
+
+    @pytest.mark.test_case_id("C36530727")
+    class Editor_levelLoad_Atom_ShadowTest(EditorBatchedTest):
+        from Atom.tests import levelLoad_Atom_ShadowTest as test_module
+
+    @pytest.mark.test_case_id("C36530728")
+    class Editor_levelLoad_Atom_Sponza(EditorBatchedTest):
+        from Atom.tests import levelLoad_Atom_Sponza as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_PbrMaterialChart.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_PbrMaterialChart.py
@@ -1,0 +1,78 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+class Tests:
+    pbrmaterialchart_high_level_load = (
+        "PbrMaterialChart level loaded",
+        "P0: PbrMaterialChart level failed to load")
+    pbrmaterialchart_enter_game_mode = (
+        "PbrMaterialChart entered gameplay successfully",
+        "P0: PbrMaterialChart failed to enter gameplay")
+    pbrmaterialchart_exit_game_mode = (
+        "PbrMaterialChart exited gameplay successfully",
+        "P0: PbrMaterialChart failed to exit gameplay")
+    empty_level_load = (
+        "Empty level loaded successfully, Editor remains stable",
+        "P0: Empty level fails to load, editor is either hung or crashed")
+
+
+def Atom_Editor_LevelLoad_PbrMaterialChart():
+    """
+    Summary:
+    Loads the "PbrMaterialChart" level within an instance of Editor.exe using the null renderer. Test verifies that
+    the level loads, can enter/exit gameplay, and that Editor.exe remains stable throughout this process.
+
+    Test setup:
+    - Launch Editor.exe
+
+    Expected Behavior:
+    Test verifies that level loads, enters/exits game mode, and editor remains stable.
+
+    Test Steps:
+    1) Load level, confirm that correct level is loaded, and report results
+    2) Validate that editor can enter gameplay successfully
+    3) Validate that editor can exit gameplay successfully
+    4) Open an empty level to verify editor remains stable
+    5) Look for errors or asserts.
+
+    :return: None
+    """
+
+    import azlmbr.legacy.general as general
+
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+
+    with Tracer() as error_tracer:
+
+        # 1. Load level PbrMaterialChart, confirm that correct level is loaded, and report results
+        TestHelper.init_idle()
+        TestHelper.open_level("Graphics", "PbrMaterialChart")
+        Report.result(Tests.pbrmaterialchart_high_level_load, "PbrMaterialChart" == general.get_current_level_name())
+
+        # 2. Validate that editor can enter gameplay successfully.
+        TestHelper.enter_game_mode(Tests.pbrmaterialchart_enter_game_mode)
+        general.idle_wait_frames(1)
+
+        # 3. Validate that editor can exit gameplay successfully.
+        TestHelper.exit_game_mode(Tests.pbrmaterialchart_exit_game_mode)
+        general.idle_wait_frames(1)
+
+        # 4. Open an empty level to verify editor remains stable.
+        TestHelper.open_level("Graphics", "base_empty")
+        Report.result(Tests.empty_level_load, "base_empty" == general.get_current_level_name())
+
+        # 5. Look for errors or asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(Atom_Editor_LevelLoad_PbrMaterialChart)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_ShadowTest.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_ShadowTest.py
@@ -1,0 +1,78 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+class Tests:
+    shadowtest_level_load = (
+        "Shadowtest level loaded",
+        "P0: Shadowtest level failed to load")
+    shadowtest_level_enter_game_mode = (
+        "Shadowtest entered gameplay successfully",
+        "P0: Shadowtest failed to enter gameplay")
+    shadowtest_level_exit_game_mode = (
+        "Shadowtest exited gameplay successfully",
+        "P0: Shadowtest failed to exit gameplay")
+    empty_level_load = (
+        "Empty level loaded successfully, Editor remains stable",
+        "P0: Empty level fails to load, editor is either hung or crashed")
+
+
+def Atom_Editor_LevelLoad_ShadowTest():
+    """
+    Summary:
+    Loads the "Shadowtest" level within an instance of Editor.exe using the null renderer. Test verifies that
+    the level loads, can enter/exit gameplay, and that Editor.exe remains stable throughout this process.
+
+    Test setup:
+    - Launch Editor.exe
+
+    Expected Behavior:
+    Test verifies that level loads, enters/exits game mode, and editor remains stable.
+
+    Test Steps:
+    1) Load level, confirm that correct level is loaded, and report results
+    2) Validate that editor can enter gameplay successfully
+    3) Validate that editor can exit gameplay successfully
+    4) Open an empty level to verify editor remains stable
+    5) Look for errors or asserts.
+
+    :return: None
+    """
+
+    import azlmbr.legacy.general as general
+
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+
+    with Tracer() as error_tracer:
+
+        # 1. Load level ShadowTest, confirm that correct level is loaded, and report results
+        TestHelper.init_idle()
+        TestHelper.open_level("Graphics", "ShadowTest")
+        Report.result(Tests.shadowtest_level_load, "ShadowTest" == general.get_current_level_name())
+
+        # 2. Validate that editor can enter gameplay successfully.
+        TestHelper.enter_game_mode(Tests.shadowtest_level_enter_game_mode)
+        general.idle_wait_frames(1)
+
+        # 3. Validate that editor can exit gameplay successfully.
+        TestHelper.exit_game_mode(Tests.shadowtest_level_exit_game_mode)
+        general.idle_wait_frames(1)
+
+        # 4. Open an empty level to verify editor remains stable.
+        TestHelper.open_level("Graphics", "base_empty")
+        Report.result(Tests.empty_level_load, "base_empty" == general.get_current_level_name())
+
+        # 5. Look for errors or asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(Atom_Editor_LevelLoad_ShadowTest)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_Sponza.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_Sponza.py
@@ -76,4 +76,3 @@ def Atom_Editor_LevelLoad_Sponza():
 if __name__ == "__main__":
     from editor_python_test_tools.utils import Report
     Report.start_test(Atom_Editor_LevelLoad_Sponza)
-    

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_Sponza.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_Sponza.py
@@ -1,0 +1,79 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+class Tests:
+    sponza_level_load = (
+        "Sponza level loaded",
+        "P0: Sponza level failed to load")
+    sponza_enter_game_mode = (
+        "Sponza entered gameplay successfully",
+        "P0: Sponza failed to enter gameplay")
+    sponza_exit_game_mode = (
+        "Sponza exited gameplay successfully",
+        "P0: Sponza failed to exit gameplay")
+    empty_level_load = (
+        "Empty level loaded successfully, Editor remains stable",
+        "P0: Empty level fails to load, editor is either hung or crashed")
+
+
+def Atom_Editor_LevelLoad_Sponza():
+    """
+    Summary:
+    Loads the "Sponza" level within an instance of Editor.exe using the null renderer. Test verifies that
+    the level loads, can enter/exit gameplay, and that Editor.exe remains stable throughout this process.
+
+    Test setup:
+    - Launch Editor.exe
+
+    Expected Behavior:
+    Test verifies that level loads, enters/exits game mode, and editor remains stable.
+
+    Test Steps:
+    1) Load level, confirm that correct level is loaded, and report results
+    2) Validate that editor can enter gameplay successfully
+    3) Validate that editor can exit gameplay successfully
+    4) Open an empty level to verify editor remains stable
+    5) Look for errors or asserts.
+
+    :return: None
+    """
+
+    import azlmbr.legacy.general as general
+
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+
+    with Tracer() as error_tracer:
+
+        # 1. Load level Sponza, confirm that correct level is loaded, and report results
+        TestHelper.init_idle()
+        TestHelper.open_level("Graphics", "Sponza")
+        Report.result(Tests.sponza_level_load, "Sponza" == general.get_current_level_name())
+
+        # 2. Validate that editor can enter gameplay successfully.
+        TestHelper.enter_game_mode(Tests.sponza_enter_game_mode)
+        general.idle_wait_frames(1)
+
+        # 3. Validate that editor can exit gameplay successfully.
+        TestHelper.exit_game_mode(Tests.sponza_exit_game_mode)
+        general.idle_wait_frames(1)
+
+        # 4. Open an empty level to verify editor remains stable.
+        TestHelper.open_level("Graphics", "base_empty")
+        Report.result(Tests.empty_level_load, "base_empty" == general.get_current_level_name())
+
+        # 5. Look for errors or asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(Atom_Editor_LevelLoad_Sponza)
+    

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_hermanubis.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_hermanubis.py
@@ -1,0 +1,78 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+class Tests:
+    hermanubis_level_load = (
+        "hermanubis level loaded",
+        "P0: hermanubis level failed to load")
+    hermanubis_enter_game_mode = (
+        "hermanubis entered gameplay successfully",
+        "P0: hermanubis failed to enter gameplay")
+    hermanubis_exit_game_mode = (
+        "hermanubis exited gameplay successfully",
+        "P0: hermanubis failed to exit gameplay")
+    empty_level_load = (
+        "Empty level loaded successfully, Editor remains stable",
+        "P0: Empty level fails to load, editor is either hung or crashed")
+
+
+def Atom_Editor_LevelLoad_hermanubis():
+    """
+    Summary:
+    Loads the "hermanubis" level within an instance of Editor.exe using the null renderer. Test verifies that
+    the level loads, can enter/exit gameplay, and that Editor.exe remains stable throughout this process.
+
+    Test setup:
+    - Launch Editor.exe
+
+    Expected Behavior:
+    Test verifies that level loads, enters/exits game mode, and editor remains stable.
+
+    Test Steps:
+    1) Load level, confirm that correct level is loaded, and report results
+    2) Validate that editor can enter gameplay successfully
+    3) Validate that editor can exit gameplay successfully
+    4) Open an empty level to verify editor remains stable
+    5) Look for errors or asserts.
+
+    :return: None
+    """
+
+    import azlmbr.legacy.general as general
+
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+
+    with Tracer() as error_tracer:
+
+        # 1. Load level hermanubis, confirm that correct level is loaded, and report results.
+        TestHelper.init_idle()
+        TestHelper.open_level("Graphics", "hermanubis")
+        Report.result(Tests.hermanubis_level_load, "hermanubis" == general.get_current_level_name())
+
+        # 2. Validate that editor can enter gameplay successfully.
+        TestHelper.enter_game_mode(Tests.hermanubis_enter_game_mode)
+        general.idle_wait_frames(1)
+
+        # 3. Validate that editor can exit gameplay successfully.
+        TestHelper.exit_game_mode(Tests.hermanubis_exit_game_mode)
+        general.idle_wait_frames(1)
+
+        # 4. Open an empty level to verify editor remains stable.
+        TestHelper.open_level("Graphics", "base_empty")
+        Report.result(Tests.empty_level_load, "base_empty" == general.get_current_level_name())
+
+        # 5. Look for errors or asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(Atom_Editor_LevelLoad_hermanubis)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_hermanubis_high.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_hermanubis_high.py
@@ -1,0 +1,78 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+class Tests:
+    hermanubis_high_level_load = (
+        "hermanubis_high level loaded",
+        "P0: hermanubis_high level failed to load")
+    hermanubis_high_enter_game_mode = (
+        "hermanubis_high entered gameplay successfully",
+        "P0: hermanubis_high failed to enter gameplay")
+    hermanubis_high_exit_game_mode = (
+        "hermanubis_high exited gameplay successfully",
+        "P0: hermanubis_high failed to exit gameplay")
+    empty_level_load = (
+        "Empty level loaded successfully, Editor remains stable",
+        "P0: Empty level fails to load, editor is either hung or crashed")
+
+
+def Atom_Editor_LevelLoad_hermanubis_high():
+    """
+    Summary:
+    Loads the "hermanubis_high" level within an instance of Editor.exe using the null renderer. Test verifies that
+    the level loads, can enter/exit gameplay, and that Editor.exe remains stable throughout this process.
+
+    Test setup:
+    - Launch Editor.exe
+
+    Expected Behavior:
+    Test verifies that level loads, enters/exits game mode, and editor remains stable.
+
+    Test Steps:
+    1) Load level, confirm that correct level is loaded, and report results
+    2) Validate that editor can enter gameplay successfully
+    3) Validate that editor can exit gameplay successfully
+    4) Open an empty level to verify editor remains stable
+    5) Look for errors or asserts.
+
+    :return: None
+    """
+
+    import azlmbr.legacy.general as general
+
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+
+    with Tracer() as error_tracer:
+
+        # 1. Load level hermanubis_high, confirm that correct level is loaded, and report results
+        TestHelper.init_idle()
+        TestHelper.open_level("Graphics", "hermanubis_high")
+        Report.result(Tests.hermanubis_high_level_load, "hermanubis_high" == general.get_current_level_name())
+
+        # 2. Validate that editor can enter gameplay successfully.
+        TestHelper.enter_game_mode(Tests.hermanubis_high_enter_game_mode)
+        general.idle_wait_frames(1)
+
+        # 3. Validate that editor can exit gameplay successfully.
+        TestHelper.exit_game_mode(Tests.hermanubis_high_exit_game_mode)
+        general.idle_wait_frames(1)
+
+        # 4. Open an empty level to verify editor remains stable.
+        TestHelper.open_level("Graphics", "base_empty")
+        Report.result(Tests.empty_level_load, "base_empty" == general.get_current_level_name())
+
+        # 5. Look for errors or asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(Atom_Editor_LevelLoad_hermanubis_high)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_macbeth_shaderballs.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/levelLoad_Atom_macbeth_shaderballs.py
@@ -1,0 +1,78 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+class Tests:
+    macbeth_shaderballs_level_load = (
+        "macbeth_shaderballs level loaded",
+        "P0: macbeth_shaderballs level failed to load")
+    macbeth_shaderballs_enter_game_mode = (
+        "macbeth_shaderballs entered gameplay successfully",
+        "P0: macbeth_shaderballs failed to enter gameplay")
+    macbeth_shaderballs_exit_game_mode = (
+        "macbeth_shaderballs exited gameplay successfully",
+        "P0: macbeth_shaderballs failed to exit gameplay")
+    empty_level_load = (
+        "Empty level loaded successfully, Editor remains stable",
+        "P0: Empty level fails to load, editor is either hung or crashed")
+
+
+def Atom_Editor_LevelLoad_macbeth_shaderballs():
+    """
+    Summary:
+    Loads the "macbeth_shaderballs" level within an instance of Editor.exe using the null renderer. Test verifies that
+    the level loads, can enter/exit gameplay, and that Editor.exe remains stable throughout this process.
+
+    Test setup:
+    - Launch Editor.exe
+
+    Expected Behavior:
+    Test verifies that level loads, enters/exits game mode, and editor remains stable.
+
+    Test Steps:
+    1) Load level, confirm that correct level is loaded, and report results
+    2) Validate that editor can enter gameplay successfully
+    3) Validate that editor can exit gameplay successfully
+    4) Open an empty level to verify editor remains stable
+    5) Look for errors or asserts.
+
+    :return: None
+    """
+
+    import azlmbr.legacy.general as general
+
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+
+    with Tracer() as error_tracer:
+
+        # 1. Load level macbeth_shaderballs, confirm that correct level is loaded, and report results
+        TestHelper.init_idle()
+        TestHelper.open_level("Graphics", "macbeth_shaderballs")
+        Report.result(Tests.macbeth_shaderballs_level_load, "macbeth_shaderballs" == general.get_current_level_name())
+
+        # 2. Validate that editor can enter gameplay successfully.
+        TestHelper.enter_game_mode(Tests.macbeth_shaderballs_enter_game_mode)
+        general.idle_wait_frames(1)
+
+        # 3. Validate that editor can exit gameplay successfully.
+        TestHelper.exit_game_mode(Tests.macbeth_shaderballs_exit_game_mode)
+        general.idle_wait_frames(1)
+
+        # 4. Open an empty level to verify editor remains stable.
+        TestHelper.open_level("Graphics", "base_empty")
+        Report.result(Tests.empty_level_load, "base_empty" == general.get_current_level_name())
+
+        # 5. Look for errors or asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(Atom_Editor_LevelLoad_macbeth_shaderballs)


### PR DESCRIPTION
Updated level load script in order to separate them into individual tests, as well as add a check to load an empty level ("base_empty") to ensure editor stability. These are P0 tests using the null renderer to ensure the level loads, and does not affect editor stability.

Here is more information on why this change is being implemented:

We initially had a version of the null renderer level load test that ran through each level in a loop (see "hydra_Atom_LevelLoadTest.py"). This version did catch several level load errors, but it did not contain the information needed to follow up on the issue. Since all levels were in a loop, they were all under the same timeout limitations, and it was unclear which specific level failed when the editor crashed/stalled. Separating them provides 2 benefits:

Each test script will have their own timeout values
We can tell which individual level crashes/hangs the editor by attempting load an empty level after loading the target level,
Results of local "TestSuite_Main_Null_Render_Level_Loads.py" run:

================================================= test session starts =================================================
platform win32 -- Python 3.7.12, pytest-5.3.2, py-1.11.0, pluggy-0.13.1
rootdir: C:\LY_Git\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 6 items

AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Null_Render_Level_Loads.py .......                          [100%]

================================================= 7 passed in 38.49s ==================================================