### PR TITLE
Diffuse Global Illumination level component P1 test expansion

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DiffuseGlobalIlluminationAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DiffuseGlobalIlluminationAdded.py
@@ -8,22 +8,19 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 class Tests:
     creation_undo = (
         "UNDO Level component addition success",
-        "UNDO Level component addition failed")
+        "P0: UNDO Level component addition failed")
     creation_redo = (
         "REDO Level component addition success",
-        "REDO Level component addition failed")
+        "P0: REDO Level component addition failed")
     diffuse_global_illumination_component = (
         "Level has a Diffuse Global Illumination component",
-        "Level failed to find Diffuse Global Illumination component")
-    diffuse_global_illumination_quality = (
-        "Quality Level set",
-        "Quality Level could not be set")
+        "P0: Level failed to find Diffuse Global Illumination component")
     enter_game_mode = (
         "Entered game mode",
-        "Failed to enter game mode")
+        "P0: Failed to enter game mode")
     exit_game_mode = (
         "Exited game mode",
-        "Couldn't exit game mode")
+        "P0: Couldn't exit game mode")
 
 
 def AtomEditorComponentsLevel_DiffuseGlobalIllumination_AddedToEntity():
@@ -52,7 +49,7 @@ def AtomEditorComponentsLevel_DiffuseGlobalIllumination_AddedToEntity():
 
     import azlmbr.legacy.general as general
 
-    from editor_python_test_tools.editor_entity_utils import EditorLevelEntity
+    from editor_python_test_tools.editor_entity_utils import EditorLevelEntity, EditorEntity
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
     from Atom.atom_utils.atom_constants import AtomComponentProperties, GLOBAL_ILLUMINATION_QUALITY
 
@@ -84,17 +81,28 @@ def AtomEditorComponentsLevel_DiffuseGlobalIllumination_AddedToEntity():
         Report.result(Tests.creation_redo,
                       EditorLevelEntity.has_component(AtomComponentProperties.diffuse_global_illumination()))
 
-        # 4. Set Quality Level property to Low
-        diffuse_global_illumination_component.set_component_property_value(
-            AtomComponentProperties.diffuse_global_illumination('Quality Level'), GLOBAL_ILLUMINATION_QUALITY['Low'])
-        quality = diffuse_global_illumination_component.get_component_property_value(
-            AtomComponentProperties.diffuse_global_illumination('Quality Level'))
-        Report.result(Tests.diffuse_global_illumination_quality, quality == GLOBAL_ILLUMINATION_QUALITY['Low'])
+        # Add a Diffuse Probe Grid since the Diffuse Global Illumination level component sets values for that component
+        diffuse_probe_grid_entity = EditorEntity.create_editor_entity(AtomComponentProperties.diffuse_probe_grid())
+        diffuse_probe_grid_entity.add_component(AtomComponentProperties.diffuse_probe_grid('shapes')[0])
+        diffuse_probe_grid_entity.add_component(AtomComponentProperties.diffuse_probe_grid())
 
-        # 5. Enter/Exit game mode.
-        TestHelper.enter_game_mode(Tests.enter_game_mode)
-        general.idle_wait_frames(1)
-        TestHelper.exit_game_mode(Tests.exit_game_mode)
+        # 4. Set Quality Level property
+        for quality in GLOBAL_ILLUMINATION_QUALITY:
+            diffuse_global_illumination_quality = (
+                f"Quality Level set to {quality}",
+                f"P1: Quality Level could not be set to {quality}")
+            diffuse_global_illumination_component.set_component_property_value(
+                AtomComponentProperties.diffuse_global_illumination('Quality Level'),
+                GLOBAL_ILLUMINATION_QUALITY[quality])
+            get_quality = diffuse_global_illumination_component.get_component_property_value(
+                AtomComponentProperties.diffuse_global_illumination('Quality Level'))
+            Report.result(diffuse_global_illumination_quality, get_quality == GLOBAL_ILLUMINATION_QUALITY[quality])
+
+            # 5. Enter/Exit game mode.
+            general.idle_wait_frames(5)
+            TestHelper.enter_game_mode(Tests.enter_game_mode)
+            general.idle_wait_frames(5)
+            TestHelper.exit_game_mode(Tests.exit_game_mode)
 
         # 6. Look for errors and asserts.
         TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)


### PR DESCRIPTION
adds additional P1 testing to Diffuse Global Illumination level component. we also add a diffuse probe grid since this level component only sets quality on the diffuse probe grid output so testing it without the probe grid is insufficient.

Report:
[SUCCESS] Success: Level has a Diffuse Global Illumination component
[SUCCESS] Success: UNDO Level component addition success
[SUCCESS] Success: REDO Level component addition success
[SUCCESS] Success: Quality Level set to Low
[SUCCESS] Success: Entered game mode
[SUCCESS] Success: Exited game mode
[SUCCESS] Success: Quality Level set to Medium
[SUCCESS] Success: Entered game mode
[SUCCESS] Success: Exited game mode
[SUCCESS] Success: Quality Level set to High
[SUCCESS] Success: Entered game mode
[SUCCESS] Success: Exited game mode
Test result:  SUCCESS

.\scripts\ctest\ctest_entrypoint.cmd --build-path atom_dev --suite main --ctest-executable "C:\Program Files\CMake\bin\ctest.exe" --config profile --tests-regex "AutomatedTesting::Atom_Main_Null" --generate-xml

Test project D:/workspace/o3de/atom_dev
    Start 156: AutomatedTesting::Atom_Main_Null_Render_02.main::TEST_RUN
1/4 Test #156: AutomatedTesting::Atom_Main_Null_Render_02.main::TEST_RUN ...   Passed  102.65 sec
    Start 157: AutomatedTesting::Atom_Main_Null_Render_03.main::TEST_RUN
2/4 Test #157: AutomatedTesting::Atom_Main_Null_Render_03.main::TEST_RUN ...   Passed   39.44 sec
    Start 155: AutomatedTesting::Atom_Main_Null_Render_01.main::TEST_RUN
3/4 Test #155: AutomatedTesting::Atom_Main_Null_Render_01.main::TEST_RUN ...   Passed   36.49 sec
    Start 154: AutomatedTesting::Atom_Main_Null_Render_00.main::TEST_RUN
4/4 Test #154: AutomatedTesting::Atom_Main_Null_Render_00.main::TEST_RUN ...   Passed   27.35 sec

100% tests passed, 0 tests failed out of 4

Label Time Summary:
COMPONENT_Atom      = 205.94 sec*proc (4 tests)
FRAMEWORK_pytest    = 205.94 sec*proc (4 tests)
SUITE_main          = 205.94 sec*proc (4 tests)

Total Test time (real) = 206.36 sec
Signed-off-by: Scott Murray <scottmur@amazon.com>