### PR TITLE
DRAFT: Fix failing physx tests due to bad timeouts

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main.py
@@ -294,7 +294,6 @@ class TestAutomation(EditorTestSuite):
     class Material_EmptyLibraryUsesDefault(EditorSharedTest):
         from .tests.material import Material_EmptyLibraryUsesDefault as test_module
 
-    @pytest.mark.skip(reason="GHI #9365: Test periodically fails")
     class ForceRegion_NoQuiverOnHighLinearDampingForce(EditorSharedTest):
         from .tests.force_region import ForceRegion_NoQuiverOnHighLinearDampingForce as test_module
 

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/force_region/ForceRegion_NoQuiverOnHighLinearDampingForce.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/force_region/ForceRegion_NoQuiverOnHighLinearDampingForce.py
@@ -147,6 +147,7 @@ def ForceRegion_NoQuiverOnHighLinearDampingForce():
 
     # 5) Validate the Sphere remains in Force Region
     # Must wait for the sphere to slow down
+    # Do not increase wait time beyond this. If tests fail due to timeout here, the test should be redesigned
     Report.result(Tests.sphere_stopped_moving, helper.wait_for_condition(
         lambda: sphere.velocity.IsZero(VELOCITY_THRESHOLD), WAIT_TIME_3))
 
@@ -155,6 +156,7 @@ def ForceRegion_NoQuiverOnHighLinearDampingForce():
     Report.result(Tests.sphere_still_above_force_region, (sphere.position.z - force_region.position.z) < SPHERE_STOP_OFFSET)
 
     # 6) Check to see if the sphere is quivering
+    # Do not increase wait time beyond this. If tests fail due to timeout here, the test should be redesigned
     sphere.quiver_reference = sphere.position.z
     Report.result(Tests.no_quiver, not helper.wait_for_condition(sphere_not_quivering, WAIT_TIME_3))
 

--- a/AutomatedTesting/Gem/PythonTests/Physics/utils/physics_constants.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/utils/physics_constants.py
@@ -1,0 +1,24 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+SPDX-License-Identifier: Apache-2.0 OR MIT
+Holds constants used across both hydra and non-hydra scripts.
+"""
+from sys import float_info
+
+"""
+Physx Event Bus
+"""
+GET_WORLD_TRANSLATION = "GetWorldTranslation"
+GET_LINEAR_VELOCITY = "GetLinearVelocity"
+ON_CALCULATE_NET_FORCE = "OnCalculateNetForce"
+
+"""
+General constants
+"""
+WAIT_TIME_1 = 1
+WAIT_TIME_2 = 2
+WAIT_TIME_3 = 3
+WAIT_TIME_5 = 5
+
+FLOAT_THRESHOLD_EPSILON = float_info.epsilon

--- a/AutomatedTesting/Levels/Physics/ForceRegion_WorldSpaceForceOnRigidBodies/ForceRegion_WorldSpaceForceOnRigidBodies.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_WorldSpaceForceOnRigidBodies/ForceRegion_WorldSpaceForceOnRigidBodies.prefab
@@ -38,7 +38,12 @@
             },
             "Component_[7874177159288365422]": {
                 "$type": "EditorEntitySortComponent",
-                "Id": 7874177159288365422
+                "Id": 7874177159288365422,
+                "Child Entity Order": [
+                    "Entity_[265641614290]",
+                    "Entity_[268866031149]",
+                    "Entity_[261346646994]"
+                ]
             },
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
@@ -62,6 +67,20 @@
                 "Component_[10988342756720823337]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10988342756720823337
+                },
+                "Component_[12840451298612265041]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 12840451298612265041,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                3.0
+                            ]
+                        }
+                    }
                 },
                 "Component_[14912243583686116341]": {
                     "$type": "EditorForceRegionComponent",
@@ -197,8 +216,24 @@
                     "Id": 17240895190085733413,
                     "Configuration": {
                         "entityId": "",
-                        "Compute Mass": false
+                        "Compute Mass": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            0.5
+                        ],
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.000000953674316
+                        }
                     }
+                },
+                "Component_[17313103929028864179]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 17313103929028864179,
+                    "GameView": true
                 },
                 "Component_[2183527080045548877]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -208,11 +243,6 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4612975352259350314,
                     "ColliderConfiguration": {
-                        "Position": [
-                            0.0,
-                            0.0,
-                            0.5
-                        ],
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}


### PR DESCRIPTION
**General Automation Improvements**
* Adding Physics Constant Utils file and supporting __init__ files to enable referencing in tests

**#9365**
* Refactored tests for usage Physics Constants
* Increased timeout to 3 seconds after determining that a HIGH SPEC machine gets close to a 1 second timeout

**#9368** 
* STILL FIXING

**Validation**
* Verified tests passed locally 5x in a row