### PR TITLE
Add tuple support to python bindings.

### DIFF
--- a/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflection.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflection.inl
@@ -739,12 +739,15 @@ namespace AZ
 
                 BehaviorContext::ClassBuilder<ContainerType> builder = behaviorContext->Class<ContainerType>();
                 builder->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                    ->Attribute(AZ::Script::Attributes::Module, "std")
                     ->Attribute(AZ::ScriptCanvasAttributes::VariableCreationForbidden, AttributeIsValid::IfPresent)
                     ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
                     ->Attribute(AZ::ScriptCanvasAttributes::PrettyName, ScriptCanvasOnDemandReflection::OnDemandPrettyName<ContainerType>::Get(*behaviorContext))
                     ->Attribute(AZ::ScriptCanvasAttributes::ReturnValueTypesFunction, unpackFunctionHolder)
                     ->Attribute(AZ::ScriptCanvasAttributes::TupleConstructorFunction, constructorHolder)
-                    ;
+                    ->template Constructor<T...>()
+                ;
 
                 ReflectUnpackMethods<T...>(builder, AZStd::make_index_sequence<sizeof...(T)>{});
 

--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -2874,6 +2874,11 @@ namespace AZ
         }
     };
 
+    AZ_INLINE const Uuid GetGenericClassTupleTypeId()
+    {
+        return Uuid("{F98DF943-F870-4FE2-B6A9-3E8BC5861782}");
+    };
+
     /// Generic specialization for AZStd::tuple
     template<typename... Types>
     struct SerializeGenericTypeInfo< AZStd::tuple<Types...> >
@@ -2884,7 +2889,7 @@ namespace AZ
             : public GenericClassInfo
         {
         public:
-            AZ_TYPE_INFO(GenericClassTuple, "{F98DF943-F870-4FE2-B6A9-3E8BC5861782}");
+            AZ_TYPE_INFO(GenericClassTuple, GetGenericClassTupleTypeId());
             GenericClassTuple()
                 : m_classData{ SerializeContext::ClassData::Create<TupleType>("AZStd::tuple", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_tupleContainer) }
             {

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializationUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializationUtils.cpp
@@ -446,6 +446,20 @@ namespace AZ::Utils
         return false;
     }
 
+    bool IsTupleContainerType(const AZ::Uuid& type)
+    {
+        AZ::SerializeContext* serializeContext = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
+
+        if (serializeContext)
+        {
+            GenericClassInfo* classInfo = serializeContext->FindGenericClassInfo(type);
+            return classInfo && classInfo->GetGenericTypeId() == AZ::GetGenericClassTupleTypeId();
+        }
+
+        return false;
+    }
+
     AZ::TypeId GetGenericContainerType(const AZ::TypeId& type)
     {
         AZ::SerializeContext* serializeContext = nullptr;

--- a/Code/Framework/AzCore/AzCore/Serialization/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Utils.h
@@ -94,6 +94,7 @@ namespace AZ
         bool IsContainerType(const AZ::Uuid& type);
         bool IsOutcomeType(const AZ::Uuid& type);
         bool IsPairContainerType(const AZ::Uuid& type);
+        bool IsTupleContainerType(const AZ::Uuid& type);
 
         AZ::TypeId GetGenericContainerType(const AZ::TypeId& type);
         bool IsGenericContainerType(const AZ::TypeId& type);

--- a/Gems/EditorPythonBindings/Code/Source/PythonMarshalComponent.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonMarshalComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Source/PythonMarshalComponent.h>
+#include <Source/PythonMarshalTuple.h>
 #include <Source/PythonUtility.h>
 #include <Source/PythonProxyObject.h>
 #include <Source/PythonTypeCasters.h>
@@ -1648,6 +1649,11 @@ namespace EditorPythonBindings
                 else if (AZ::Utils::IsPairContainerType(typeId))
                 {
                     registrant(typeId, AZStd::make_unique<TypeConverterPair>(serializeContext->FindGenericClassInfo(typeId), classData, typeId));
+                }
+                else if (AZ::Utils::IsTupleContainerType(typeId))
+                {
+                    registrant(
+                        typeId, AZStd::make_unique<TypeConverterTuple>(serializeContext->FindGenericClassInfo(typeId), classData, typeId));
                 }
                 else if (AZ::Utils::IsSetContainerType(typeId))
                 {

--- a/Gems/EditorPythonBindings/Code/Source/PythonMarshalComponent.h
+++ b/Gems/EditorPythonBindings/Code/Source/PythonMarshalComponent.h
@@ -94,4 +94,15 @@ namespace EditorPythonBindings
         using TypeConverterMap = AZStd::unordered_map<AZ::TypeId, TypeConverterPointer>;
         TypeConverterMap m_typeConverterMap;
     };
+
+    namespace Container
+    {
+        AZStd::optional<PythonMarshalTypeRequests::PythonValueResult> ProcessBehaviorObject(AZ::BehaviorObject& behaviorObject);
+        AZStd::optional<PythonMarshalTypeRequests::BehaviorValueResult> ProcessPythonObject(
+            PythonMarshalTypeRequests::BehaviorTraits traits,
+            pybind11::object pythonObj,
+            const AZ::TypeId& elementTypeId,
+            AZ::BehaviorValueParameter& outValue);
+
+    } // namespace Container
 }

--- a/Gems/EditorPythonBindings/Code/Source/PythonMarshalTuple.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonMarshalTuple.cpp
@@ -151,18 +151,18 @@ namespace EditorPythonBindings
         {
             // Python list, just grab raw pointers to each object.
             pybind11::list pyList(pyObj);
-            for (auto& item : pyList)
+            for (size_t listIdx = 0; listIdx < pyList.size(); listIdx++)
             {
-                items.push_back(item.ptr());
+                items.push_back(pyList[listIdx].ptr());
             }
         }
         else if (IsValidTuple(pyObj))
         {
             // Python tuple, just grab raw pointers to each object.
             pybind11::tuple pyTuple(pyObj);
-            for (auto& item : pyTuple)
+            for (size_t tupleIdx = 0; tupleIdx < pyTuple.size(); tupleIdx++)
             {
-                items.push_back(item.ptr());
+                items.push_back(pyTuple[tupleIdx].ptr());
             }
         }
         else if (IsCompatibleProxy(pyObj))

--- a/Gems/EditorPythonBindings/Code/Source/PythonMarshalTuple.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonMarshalTuple.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Source/PythonMarshalTuple.h>
+#include <Source/PythonProxyObject.h>
+#include <AzCore/Serialization/Utils.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+#include <pybind11/embed.h>
+#include <pybind11/pytypes.h>
+
+namespace EditorPythonBindings
+{
+    // Check to see if the input object is a valid Python list.
+    bool TypeConverterTuple::IsValidList(pybind11::object pyObj) const
+    {
+        return PyList_Check(pyObj.ptr()) != false;
+    }
+
+    // Check to see if the input object is a valid Python tuple.
+    bool TypeConverterTuple::IsValidTuple(pybind11::object pyObj) const
+    {
+        return PyTuple_Check(pyObj.ptr()) != false;
+    }
+
+    // Check to see if the input object is a valid Python proxy object of a C++ tuple.
+    bool TypeConverterTuple::IsCompatibleProxy(pybind11::object pyObj) const
+    {
+        if (pybind11::isinstance<EditorPythonBindings::PythonProxyObject>(pyObj))
+        {
+            auto behaviorObject = pybind11::cast<EditorPythonBindings::PythonProxyObject*>(pyObj)->GetBehaviorObject();
+            AZ::Uuid typeId = behaviorObject.value()->m_typeId;
+
+            return AZ::Utils::IsTupleContainerType(typeId);
+        }
+
+        return false;
+    }
+
+    // If the input object is either a Python list, Python tuple, or Proxy object of a C++ tuple, it can be converted
+    // (or at least attempted to be converted) to a C++ tuple type.
+    bool TypeConverterTuple::CanConvertPythonToBehaviorValue(
+        [[maybe_unused]] PythonMarshalTypeRequests::BehaviorTraits traits, pybind11::object pyObj) const
+    {
+        return IsValidList(pyObj) || IsValidTuple(pyObj) || IsCompatibleProxy(pyObj);
+    }
+
+    // Given a Python object, clone it into a specific element in the tuple.
+    bool TypeConverterTuple::LoadPythonToTupleElement(
+        PyObject* pyItem,
+        PythonMarshalTypeRequests::BehaviorTraits traits,
+        const AZ::SerializeContext::ClassElement* itemElement,
+        AZ::SerializeContext::IDataContainer* tupleContainer,
+        size_t index,
+        AZ::SerializeContext* serializeContext,
+        void* newTuple)
+    {
+        pybind11::object pyObj{ pybind11::reinterpret_borrow<pybind11::object>(pyItem) };
+        AZ::BehaviorValueParameter behaviorItem;
+        auto behaviorResult = Container::ProcessPythonObject(traits, pyObj, itemElement->m_typeId, behaviorItem);
+        if (behaviorResult && behaviorResult.value().first)
+        {
+            void* itemAddress = tupleContainer->GetElementByIndex(newTuple, itemElement, index);
+            AZ_Assert(
+                itemAddress, "Element reserved for associative container's tuple, but unable to retrieve address of the item:%d", index);
+            serializeContext->CloneObjectInplace(itemAddress, behaviorItem.m_value, itemElement->m_typeId);
+        }
+        else
+        {
+            AZ_Warning(
+                "python", false, "Could not convert to tuple element type %s for the tuple<>; failed to marshal Python input %s",
+                itemElement->m_name, Convert::GetPythonTypeName(pyObj).c_str());
+            return false;
+        }
+        return true;
+    }
+
+    // Convert a Python list / Python tuple / ProxyObject tuple to a C++ tuple.
+    AZStd::optional<PythonMarshalTypeRequests::BehaviorValueResult> TypeConverterTuple::PythonToBehaviorValueParameter(
+        PythonMarshalTypeRequests::BehaviorTraits traits, pybind11::object pyObj, AZ::BehaviorValueParameter& outValue)
+    {
+        if (!CanConvertPythonToBehaviorValue(traits, pyObj))
+        {
+            AZ_Warning("python", false, "Cannot convert tuple container for %s", m_classData->m_name);
+            return AZStd::nullopt;
+        }
+
+        const AZ::BehaviorClass* behaviorClass = AZ::BehaviorContextHelper::GetClass(m_typeId);
+        if (!behaviorClass)
+        {
+            AZ_Warning("python", false, "Missing tuple behavior class for %s", m_typeId.ToString<AZStd::string>().c_str());
+            return AZStd::nullopt;
+        }
+
+        AZ::SerializeContext* serializeContext = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
+        if (!serializeContext)
+        {
+            return AZStd::nullopt;
+        }
+
+        // prepare the AZStd::tuple<> container
+        AZ::BehaviorObject tupleInstance = behaviorClass->Create();
+        AZ::SerializeContext::IDataContainer* tupleDataContainer = m_classData->m_container;
+
+        // get the element types
+        AZStd::vector<const AZ::SerializeContext::ClassElement*> elements;
+        bool allTypesValid = true;
+
+        auto elementTypeEnumCallback =
+            [&elements, &allTypesValid](const AZ::Uuid&, const AZ::SerializeContext::ClassElement* genericClassElement)
+        {
+            if (genericClassElement->m_flags & AZ::SerializeContext::ClassElement::Flags::FLG_POINTER)
+            {
+                AZ_Error("python", false, "Python marshalling does not handle naked pointers; not converting the tuple");
+                allTypesValid = false;
+                return false;
+            }
+
+            // Empty tuples are created with one element entry with an invalid type, so we need to check for and skip that.
+            // Everything with a valid type gets added.
+            if (genericClassElement->m_typeId != AZ::TypeId::CreateNull())
+            {
+                elements.push_back(genericClassElement);
+            }
+            return true;
+        };
+        tupleDataContainer->EnumTypes(elementTypeEnumCallback);
+
+        if (!allTypesValid)
+        {
+            AZ_Error("python", false, "Could not convert tuple elements.");
+            return AZStd::nullopt;
+        }
+
+        // load python items into tuple elements. If the input is a PythonProxyObject, keep a copy of the object returned
+        // for each tuple value, not just its pointer, so that it doesn't get deallocated while we're converting the data.
+        AZStd::vector<pybind11::object> proxyItems;
+        AZStd::vector<PyObject*> items;
+
+        if (IsValidList(pyObj))
+        {
+            // Python list, just grab raw pointers to each object.
+            pybind11::list pyList(pyObj);
+            for (auto& item : pyList)
+            {
+                items.push_back(item.ptr());
+            }
+        }
+        else if (IsValidTuple(pyObj))
+        {
+            // Python tuple, just grab raw pointers to each object.
+            pybind11::tuple pyTuple(pyObj);
+            for (auto& item : pyTuple)
+            {
+                items.push_back(item.ptr());
+            }
+        }
+        else if (IsCompatibleProxy(pyObj))
+        {
+            // Python Proxy Object that's a C++ tuple. This is a bit more complicated, because there's no easy way to detect
+            // the number of properties and get them in the right order. 
+            // OnDemandReflection<AZStd::tuple<T...>> exposes "GetN" in the proxy object, so we'll keep calling that with increasing
+            // numbers until it stops working.
+            EditorPythonBindings::PythonProxyObject* proxy = pybind11::cast<EditorPythonBindings::PythonProxyObject*>(pyObj);
+            bool propertyFound = true;
+            do
+            {
+                // Generate method names like Get0(), Get1(), Get2(), etc. and call them.
+                constexpr AZStd::size_t MaxPropertyNameSize = 32;
+                auto propertyName = AZStd::fixed_string<MaxPropertyNameSize>::format("Get%zu", items.size());
+                auto item = proxy->Invoke(propertyName.c_str(), {});
+
+                // For each item that's returned, save both a copy of the object to keep it from deallocating, and the raw pointer
+                // that we'll use for the conversion step.
+                if (!item.is_none())
+                {
+                    proxyItems.push_back(item);
+                    items.push_back(item.ptr());
+                }
+                else
+                {
+                    propertyFound = false;
+                }
+            } while (propertyFound);
+        }
+
+        if (elements.size() != items.size())
+        {
+            AZ_Error("python", false, "Tuple requires %zu elements but received %zu elements.", elements.size(), items.size());
+            return AZStd::nullopt;
+        }
+
+        // For each object found, create a copy of the value as the correct element in the C++ tuple.
+        // Also, save the pointers for each allocation that we do so that we can free them in the case of an error during conversion.
+        AZStd::vector<void*> reservedElements;
+        for (size_t itemIdx = 0; itemIdx < elements.size(); itemIdx++)
+        {
+            // Allocate space for each element.
+            void* reserved = tupleDataContainer->ReserveElement(tupleInstance.m_address, elements[itemIdx]);
+            AZ_Assert(reserved, "Could not allocate tuple's element %zu via ReserveElement()", itemIdx);
+
+            // Track the allocated space.
+            reservedElements.push_back(reserved);
+
+            // Attempt to convert the value. If it fails to convert, free everything we've allocated so far and return.
+            if (items[itemIdx] &&
+                !LoadPythonToTupleElement(
+                    items[itemIdx], traits, elements[itemIdx], tupleDataContainer, itemIdx, serializeContext, tupleInstance.m_address))
+            {
+                for (auto& reservedElement : reservedElements)
+                {
+                    tupleDataContainer->FreeReservedElement(tupleInstance.m_address, reservedElement, serializeContext);
+                }
+                return AZStd::nullopt;
+            }
+        }
+
+        outValue.m_value = tupleInstance.m_address;
+        outValue.m_typeId = tupleInstance.m_typeId;
+        outValue.m_traits = traits;
+
+        auto tupleInstanceDeleter = [behaviorClass, tupleInstance]()
+        {
+            behaviorClass->Destroy(tupleInstance);
+        };
+
+        return PythonMarshalTypeRequests::BehaviorValueResult{ true, tupleInstanceDeleter };
+    }
+
+    // Convert a C++ tuple into a Python list.
+    AZStd::optional<PythonMarshalTypeRequests::PythonValueResult> TypeConverterTuple::BehaviorValueParameterToPython(
+        AZ::BehaviorValueParameter& behaviorValue)
+    {
+        // the class data must have a container interface
+        AZ::SerializeContext::IDataContainer* containerInterface = m_classData->m_container;
+
+        if (!containerInterface)
+        {
+            AZ_Warning("python", false, "Container interface is missing from class %s.", m_classData->m_name);
+            return AZStd::nullopt;
+        }
+
+        if (!behaviorValue.ConvertTo(m_typeId))
+        {
+            AZ_Warning("python", false, "Cannot convert behavior value %s.", behaviorValue.m_name);
+            return AZStd::nullopt;
+        }
+
+        auto cleanUpList = AZStd::make_shared<AZStd::vector<PythonMarshalTypeRequests::DeallocateFunction>>();
+
+        // return tuple as list, if conversion failed for an element it will remain as 'none'
+        pybind11::list pythonList;
+                
+        auto tupleElementCallback = [cleanUpList, &pythonList]
+            (void* instancePair, const AZ::Uuid& elementClassId,
+                [[maybe_unused]] const AZ::SerializeContext::ClassData* elementGenericClassData,
+                [[maybe_unused]] const AZ::SerializeContext::ClassElement* genericClassElement)
+        {
+            AZ::BehaviorObject behaviorObjectValue(instancePair, elementClassId);
+            auto result = Container::ProcessBehaviorObject(behaviorObjectValue);
+
+            if (result.has_value())
+            {
+                // If the element was converted, we'll add it to the list of results.
+                PythonMarshalTypeRequests::DeallocateFunction deallocateFunction = result.value().second;
+                if (result.value().second)
+                {
+                    // If it has a deallocate function, we'll add that to our list of deallocators to get called on cleanup.
+                    cleanUpList->emplace_back(AZStd::move(result.value().second));
+                }
+
+                pybind11::object pythonResult = result.value().first;
+                pythonList.append(pythonResult);
+            }
+            else
+            {
+                // The element couldn't be converted, so we'll add 'none' as a placeholder in the list.
+                AZ_Warning("python", false, "BehaviorObject was not processed, python item will remain 'none'.");
+                pythonList.append(pybind11::none());
+            }
+
+            return true;
+        };
+        containerInterface->EnumElements(behaviorValue.m_value, tupleElementCallback);
+
+        PythonMarshalTypeRequests::PythonValueResult result;
+        result.first = pythonList;
+
+        if (!cleanUpList->empty())
+        {
+            AZStd::weak_ptr<AZStd::vector<PythonMarshalTypeRequests::DeallocateFunction>> cleanUp(cleanUpList);
+            result.second = [cleanUp]()
+            {
+                auto cleanupList = cleanUp.lock();
+                if (cleanupList)
+                {
+                    AZStd::for_each(cleanupList->begin(), cleanupList->end(), [](auto& deleteMe) { deleteMe(); });
+                }
+            };
+        }
+
+        return result;
+    }
+}

--- a/Gems/EditorPythonBindings/Code/Source/PythonMarshalTuple.h
+++ b/Gems/EditorPythonBindings/Code/Source/PythonMarshalTuple.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Source/PythonMarshalComponent.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace EditorPythonBindings
+{
+    class TypeConverterTuple final : public PythonMarshalComponent::TypeConverter
+    {
+    public:
+        TypeConverterTuple(
+            [[maybe_unused]] AZ::GenericClassInfo* genericClassInfo,
+            const AZ::SerializeContext::ClassData* classData,
+            const AZ::TypeId& typeId)
+            : m_classData(classData)
+            , m_typeId(typeId)
+        {
+        }
+
+        AZStd::optional<PythonMarshalTypeRequests::BehaviorValueResult> PythonToBehaviorValueParameter(
+            PythonMarshalTypeRequests::BehaviorTraits traits, pybind11::object pyObj, AZ::BehaviorValueParameter& outValue) override;
+
+        AZStd::optional<PythonMarshalTypeRequests::PythonValueResult> BehaviorValueParameterToPython(
+            AZ::BehaviorValueParameter& behaviorValue) override;
+
+        bool CanConvertPythonToBehaviorValue(PythonMarshalTypeRequests::BehaviorTraits traits, pybind11::object pyObj) const override;
+
+    protected:
+        const AZ::SerializeContext::ClassData* m_classData = nullptr;
+        const AZ::TypeId m_typeId = {};
+
+        bool IsValidList(pybind11::object pyObj) const;
+        bool IsValidTuple(pybind11::object pyObj) const;
+        bool IsCompatibleProxy(pybind11::object pyObj) const;
+
+        static bool LoadPythonToTupleElement(
+            PyObject* pyItem,
+            PythonMarshalTypeRequests::BehaviorTraits traits,
+            const AZ::SerializeContext::ClassElement* itemElement,
+            AZ::SerializeContext::IDataContainer* tupleContainer,
+            size_t index,
+            AZ::SerializeContext* serializeContext,
+            void* newTuple);
+    };
+} // namespace EditorPythonBindings

--- a/Gems/EditorPythonBindings/Code/Tests/PythonPairTests.cpp
+++ b/Gems/EditorPythonBindings/Code/Tests/PythonPairTests.cpp
@@ -188,8 +188,15 @@ namespace UnitTest
                 test_pair.second = True
 
                 test.accept_pair_of_boolToBool(test_pair)
+
+                # Test out the pair as a single return value that's a list
                 result = test.return_pair_of_boolToBool()
                 if (len(result) == 2 and result[0] == False and result[1] == True):
+                    print ('PairTypeTest_UseConstructed')
+
+                # Test out the pair as two comma-separated return values extracted from the list
+                a, b = test.return_pair_of_boolToBool()
+                if (a == False and b == True):
                     print ('PairTypeTest_UseConstructed')
             )");
         }
@@ -203,7 +210,7 @@ namespace UnitTest
 
         EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::PairTypeTest_ConstructBoolDefault)]);
         EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::PairTypeTest_ConstructBoolParams)]);
-        EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::PairTypeTest_UseConstructed)]);
+        EXPECT_EQ(2, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::PairTypeTest_UseConstructed)]);
     }
 
     TEST_F(PythonReflectionPairTests, SimpleTypes_ConvertedCorrectly)

--- a/Gems/EditorPythonBindings/Code/Tests/PythonTupleTests.cpp
+++ b/Gems/EditorPythonBindings/Code/Tests/PythonTupleTests.cpp
@@ -1,0 +1,590 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Source/PythonCommon.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/embed.h>
+
+#include "PythonTraceMessageSink.h"
+#include "PythonTestingUtility.h"
+
+#include <Source/PythonSystemComponent.h>
+#include <Source/PythonReflectionComponent.h>
+#include <Source/PythonMarshalComponent.h>
+#include <Source/PythonProxyObject.h>
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzFramework/StringFunc/StringFunc.h>
+
+#include "PythonPairTests.h"
+
+namespace UnitTest
+{
+    //////////////////////////////////////////////////////////////////////////
+    // test class/structs
+
+    struct PythonReflectionTupleTypes
+    {
+        AZ_TYPE_INFO(PythonReflectionTupleTypes, "{D5C9223B-8F12-49A9-8EDF-603357C3A6DF}");
+
+        template <typename... Args>
+        struct TupleOf
+        {
+            using TupleType = AZStd::tuple<Args...>;
+            TupleType m_tuple;
+
+            explicit TupleOf(const TupleType& tuple)
+            {
+                m_tuple = tuple;
+            }
+
+            const TupleType& ReturnTuple() const
+            {
+                return m_tuple;
+            }
+
+            void AcceptTuple(const TupleType& other)
+            {
+                m_tuple = other;
+            }
+
+            void RegisterGenericType(AZ::SerializeContext& serializeContext)
+            {
+                serializeContext.RegisterGenericType<TupleType>();
+            }
+        };
+
+        TupleOf<> m_tupleOfEmptiness{ AZStd::make_tuple() };
+        TupleOf<bool, int, float> m_tupleOfBasicTypes{ AZStd::make_tuple(true, 2, 3.0f) };
+        TupleOf<AZStd::string, AZStd::string> m_tupleOfStrings { AZStd::make_tuple("one", "two")};
+        TupleOf<bool, AZStd::string, MyCustomType> m_tupleWithCustomType{ AZStd::make_tuple(true, "one", MyCustomType()) };
+
+        void Reflect(AZ::ReflectContext* context)
+        {
+            MyCustomType::Reflect(context);
+
+            if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                m_tupleOfEmptiness.RegisterGenericType(*serializeContext);
+                m_tupleOfBasicTypes.RegisterGenericType(*serializeContext);
+                m_tupleOfStrings.RegisterGenericType(*serializeContext);
+                m_tupleWithCustomType.RegisterGenericType(*serializeContext);
+            }
+
+            if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<PythonReflectionTupleTypes>()
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Module, "test.tuple")
+                    ->Method(
+                        "return_empty_tuple",
+                        [](PythonReflectionTupleTypes* self)
+                        {
+                            return self->m_tupleOfEmptiness.ReturnTuple();
+                        },
+                        nullptr, "")
+                    ->Method(
+                        "accept_empty_tuple",
+                        [](PythonReflectionTupleTypes* self, const TupleOf<>::TupleType& tuple)
+                        {
+                            self->m_tupleOfEmptiness.AcceptTuple(tuple);
+                        },
+                        nullptr, "")
+                    ->Method(
+                        "return_tuple_of_basic_types",
+                        [](PythonReflectionTupleTypes* self)
+                        {
+                            return self->m_tupleOfBasicTypes.ReturnTuple();
+                        },
+                        nullptr, "")
+                    ->Method(
+                        "accept_tuple_of_basic_types",
+                        [](PythonReflectionTupleTypes* self, const TupleOf<bool, int, float>::TupleType& tuple)
+                        {
+                            self->m_tupleOfBasicTypes.AcceptTuple(tuple);
+                        },
+                        nullptr, "")
+                    ->Method(
+                        "return_tuple_of_strings",
+                        [](PythonReflectionTupleTypes* self)
+                        {
+                            return self->m_tupleOfStrings.ReturnTuple();
+                        },
+                        nullptr, "")
+                    ->Method(
+                        "accept_tuple_of_strings",
+                        [](PythonReflectionTupleTypes* self, const TupleOf<AZStd::string, AZStd::string>::TupleType& tuple)
+                        {
+                            self->m_tupleOfStrings.AcceptTuple(tuple);
+                        },
+                        nullptr, "")
+                    ->Method(
+                        "return_tuple_with_custom_type",
+                        [](PythonReflectionTupleTypes* self)
+                        {
+                            return self->m_tupleWithCustomType.ReturnTuple();
+                        },
+                        nullptr, "")
+                    ->Method(
+                        "accept_tuple_with_custom_type",
+                        [](PythonReflectionTupleTypes* self, const TupleOf<bool, AZStd::string, MyCustomType>::TupleType& tuple)
+                        {
+                            self->m_tupleWithCustomType.AcceptTuple(tuple);
+                        },
+                        nullptr, "")
+                    ;
+            }
+        }
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // fixtures
+
+    struct PythonReflectionTupleTests
+        : public PythonTestingFixture
+    {
+        PythonTraceMessageSink m_testSink;
+
+        void SetUp() override
+        {
+            PythonTestingFixture::SetUp();
+            PythonTestingFixture::RegisterComponentDescriptors();
+        }
+
+        void TearDown() override
+        {
+            // clearing up memory
+            m_testSink.CleanUp();
+            PythonTestingFixture::TearDown();
+        }
+    };
+
+    TEST_F(PythonReflectionTupleTests, SimpleTuplesConstructed)
+    {
+        enum class LogTypes
+        {
+            Skip = 0,
+            TupleTypeTest_ConstructWithDefaultValues,
+            TupleTypeTest_ConstructWithParameters,
+            TupleTypeTest_UseConstructedAsParameterToCpp,
+            TupleTypeTest_ReturnTupleAsListFromCpp,
+            TupleTypeTest_TupleReturnedAsListWithCorrectValues,
+            TupleTypeTest_TupleReturnedWithCorrectValues,
+            TupleTypeTest_UsePythonListAsParameter,
+            TupleTypeTest_PythonListReturnedWithCorrectValues
+        };
+
+        m_testSink.m_evaluateMessage = [](const char* window, const char* message) -> int
+        {
+            if (AzFramework::StringFunc::Equal(window, "python"))
+            {
+                if (AzFramework::StringFunc::StartsWith(message, "TupleTypeTest_ConstructWithDefaultValues"))
+                {
+                    return static_cast<int>(LogTypes::TupleTypeTest_ConstructWithDefaultValues);
+                }
+                else if (AzFramework::StringFunc::StartsWith(message, "TupleTypeTest_ConstructWithParameters"))
+                {
+                    return static_cast<int>(LogTypes::TupleTypeTest_ConstructWithParameters);
+                }
+                else if (AzFramework::StringFunc::StartsWith(message, "TupleTypeTest_UseConstructedAsParameterToCpp"))
+                {
+                    return static_cast<int>(LogTypes::TupleTypeTest_UseConstructedAsParameterToCpp);
+                }
+                else if (AzFramework::StringFunc::StartsWith(message, "TupleTypeTest_ReturnTupleAsListFromCpp"))
+                {
+                    return static_cast<int>(LogTypes::TupleTypeTest_ReturnTupleAsListFromCpp);
+                }
+                else if (AzFramework::StringFunc::StartsWith(message, "TupleTypeTest_TupleReturnedAsListWithCorrectValues"))
+                {
+                    return static_cast<int>(LogTypes::TupleTypeTest_TupleReturnedAsListWithCorrectValues);
+                }
+                else if (AzFramework::StringFunc::StartsWith(message, "TupleTypeTest_TupleReturnedWithCorrectValues"))
+                {
+                    return static_cast<int>(LogTypes::TupleTypeTest_TupleReturnedWithCorrectValues);
+                }
+                else if (AzFramework::StringFunc::StartsWith(message, "TupleTypeTest_UsePythonListAsParameter"))
+                {
+                    return static_cast<int>(LogTypes::TupleTypeTest_UsePythonListAsParameter);
+                }
+                else if (AzFramework::StringFunc::StartsWith(message, "TupleTypeTest_PythonListReturnedWithCorrectValues"))
+                {
+                    return static_cast<int>(LogTypes::TupleTypeTest_PythonListReturnedWithCorrectValues);
+                }
+            }
+            return static_cast<int>(LogTypes::Skip);
+        };
+
+        PythonReflectionTupleTypes pythonReflectionTupleTypes;
+        pythonReflectionTupleTypes.Reflect(m_app.GetSerializeContext());
+        pythonReflectionTupleTypes.Reflect(m_app.GetBehaviorContext());
+
+        AZ::Entity e;
+        Activate(e);
+
+        SimulateEditorBecomingInitialized();
+
+        try
+        {
+            pybind11::exec(R"(
+                import azlmbr.test.tuple
+                import azlmbr.object
+                import azlmbr.std
+
+                # Create the test fixture
+                test = azlmbr.object.create('PythonReflectionTupleTypes')
+
+                # Create a tuple with default values - note the odd naming syntax :(
+                test_tuple = azlmbr.object.create('tuple<bool int float >')
+                if (test_tuple):
+                    print ('TupleTypeTest_ConstructWithDefaultValues')
+
+                # Create a tuple with parameters and verify that the parameters can be read back correctly.
+                test_tuple = azlmbr.object.construct('tuple<bool int float >', True, 5, 10.0)
+                if (test_tuple and test_tuple.Get0() == True and test_tuple.Get1() == 5 and test_tuple.Get2() == 10.0):
+                    print ('TupleTypeTest_ConstructWithParameters')
+
+                # Use the tuple as a parameter to a reflected C++ method
+                test.accept_tuple_of_basic_types(test_tuple)
+                print ('TupleTypeTest_UseConstructedAsParameterToCpp')
+
+                # Test out the tuple as a single return value that's a list
+                result = test.return_tuple_of_basic_types()
+                if (result and len(result) == 3):
+                    print ('TupleTypeTest_ReturnTupleAsListFromCpp')
+
+                # Verify the results that were returned are the same ones we sent in.
+                if (result and len(result) == 3 and result[0] == True and result[1] == 5 and result[2] == 10.0):
+                    print ('TupleTypeTest_TupleReturnedAsListWithCorrectValues')
+
+                # Test out the tuple as comma-separated return values extracted from the list
+                a, b, c = test.return_tuple_of_basic_types()
+                if (a == True and b == 5 and c == 10.0):
+                    print ('TupleTypeTest_TupleReturnedWithCorrectValues')
+
+                # Use the tuple as a parameter to a reflected C++ method
+                test.accept_tuple_of_basic_types([False, 10, 20.0])
+                print ('TupleTypeTest_UsePythonListAsParameter')
+
+                a, b, c = test.return_tuple_of_basic_types()
+                if (a == False and b == 10 and c == 20.0):
+                    print ('TupleTypeTest_PythonListReturnedWithCorrectValues')
+
+            )");
+        } catch ([[maybe_unused]] const pybind11::error_already_set& ex)
+        {
+            AZ_Warning("UnitTest", false, "Failed with Python exception of %s", ex.what());
+            FAIL();
+        }
+
+        e.Deactivate();
+
+        EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleTypeTest_ConstructWithDefaultValues)]);
+        EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleTypeTest_ConstructWithParameters)]);
+        EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleTypeTest_UseConstructedAsParameterToCpp)]);
+        EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleTypeTest_ReturnTupleAsListFromCpp)]);
+        EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleTypeTest_TupleReturnedAsListWithCorrectValues)]);
+        EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleTypeTest_TupleReturnedWithCorrectValues)]);
+        EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleTypeTest_UsePythonListAsParameter)]);
+        EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleTypeTest_PythonListReturnedWithCorrectValues)]);
+    }
+
+    TEST_F(PythonReflectionTupleTests, EmptyTupleConvertedCorrectly)
+    {
+        enum class LogTypes
+        {
+            Skip = 0,
+            TupleTypeTest_Input,
+            TupleTypeTest_Output,
+        };
+
+        m_testSink.m_evaluateMessage = [](const char* window, const char* message) -> int
+        {
+            if (AzFramework::StringFunc::Equal(window, "python"))
+            {
+                if (AzFramework::StringFunc::StartsWith(message, "TupleTypeTest_Input"))
+                {
+                    return static_cast<int>(LogTypes::TupleTypeTest_Input);
+                }
+                else if (AzFramework::StringFunc::StartsWith(message, "TupleTypeTest_Output"))
+                {
+                    return static_cast<int>(LogTypes::TupleTypeTest_Output);
+                }
+            }
+            return static_cast<int>(LogTypes::Skip);
+        };
+
+        PythonReflectionTupleTypes pythonReflectionTupleTypes;
+        pythonReflectionTupleTypes.Reflect(m_app.GetSerializeContext());
+        pythonReflectionTupleTypes.Reflect(m_app.GetBehaviorContext());
+
+        AZ::Entity e;
+        Activate(e);
+
+        SimulateEditorBecomingInitialized();
+
+        try
+        {
+            pybind11::exec(R"(
+                import azlmbr.test.tuple
+                import azlmbr.object
+                import azlmbr.std
+
+                # Create the test fixture
+                test = azlmbr.object.create('PythonReflectionTupleTypes')
+
+                # Verify that an empty tuple is returned correctly
+                result = test.return_empty_tuple()
+                if (len(result) == 0):
+                    print ('TupleTypeTest_Output_empty')
+
+                # Create a tuple from a Python list and verify the values are correct
+                test.accept_empty_tuple([])
+                result = test.return_empty_tuple()
+                if (len(result) == 0):
+                    print ('TupleTypeTest_Input_empty_list')
+
+                # Create a tuple from a Python tuple and verify the values are correct
+                test.accept_empty_tuple(())
+                result = test.return_empty_tuple()
+                if (len(result) == 0):
+                    print ('TupleTypeTest_Input_empty')
+            )");
+        } catch ([[maybe_unused]] const pybind11::error_already_set& ex)
+        {
+            AZ_Warning("UnitTest", false, "Failed with Python exception of %s", ex.what());
+            FAIL();
+        }
+
+        e.Deactivate();
+
+        EXPECT_EQ(2, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleTypeTest_Input)]);
+        EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleTypeTest_Output)]);
+    }
+
+    TEST_F(PythonReflectionTupleTests, InputsAndOutputsConvertedCorrectly)
+    {
+        enum class LogTypes
+        {
+            Skip = 0,
+            TupleTypeTest_Input,
+            TupleTypeTest_Output,
+        };
+
+        m_testSink.m_evaluateMessage = [](const char* window, const char* message) -> int
+        {
+            if (AzFramework::StringFunc::Equal(window, "python"))
+            {
+                if (AzFramework::StringFunc::StartsWith(message, "TupleTypeTest_Input"))
+                {
+                    return static_cast<int>(LogTypes::TupleTypeTest_Input);
+                }
+                else if (AzFramework::StringFunc::StartsWith(message, "TupleTypeTest_Output"))
+                {
+                    return static_cast<int>(LogTypes::TupleTypeTest_Output);
+                }
+            }
+            return static_cast<int>(LogTypes::Skip);
+        };
+
+        PythonReflectionTupleTypes pythonReflectionTupleTypes;
+        pythonReflectionTupleTypes.Reflect(m_app.GetSerializeContext());
+        pythonReflectionTupleTypes.Reflect(m_app.GetBehaviorContext());
+
+        AZ::Entity e;
+        Activate(e);
+
+        SimulateEditorBecomingInitialized();
+
+        try
+        {
+            pybind11::exec(R"(
+                import azlmbr.test.tuple
+                import azlmbr.object
+                import azlmbr.std
+
+                # Create the test fixture
+                test = azlmbr.object.create('PythonReflectionTupleTypes')
+
+                # Verify that a tuple of basic types (bool, int, float) is returned correctly
+                result = test.return_tuple_of_basic_types()
+                if (len(result) == 3):
+                    print ('TupleTypeTest_Output_bool_int_float')
+
+                # Create a tuple from a Python list and verify the values are correct
+                test.accept_tuple_of_basic_types([True, 42, 1000.0])
+                result = test.return_tuple_of_basic_types()
+                if (len(result) == 3 and result[0] == True and result[1] == 42 and result[2] == 1000.0):
+                        print ('TupleTypeTest_Input_bool_int_float_list')
+
+                # Create a tuple from a Python tuple and verify the values are correct
+                test.accept_tuple_of_basic_types((False, 24, -25.0))
+                result = test.return_tuple_of_basic_types()
+                if (len(result) == 3 and result[0] == False and result[1] == 24 and result[2] == -25.0):
+                        print ('TupleTypeTest_Input_bool_int_float')
+
+                # Verify that a tuple of strings (string, string) is returned correctly
+                result = test.return_tuple_of_strings()
+                if (len(result) == 2):
+                    print ('TupleTypeTest_Output_string_string')
+
+                # Create a tuple from a Python list and verify the values are correct
+                test.accept_tuple_of_strings(['ghi', 'jkl'])
+                result = test.return_tuple_of_strings()
+                if (len(result) == 2 and result[0] == 'ghi' and result[1] == 'jkl'):
+                    print ('TupleTypeTest_Input_string_string_list')
+
+                # Create a tuple from a Python tuple and verify the values are correct
+                test.accept_tuple_of_strings(('abc', 'def'))
+                result = test.return_tuple_of_strings()
+                if (len(result) == 2 and result[0] == 'abc' and result[1] == 'def'):
+                    print ('TupleTypeTest_Input_string_string')
+            )");
+        } catch ([[maybe_unused]] const pybind11::error_already_set& ex)
+        {
+            AZ_Warning("UnitTest", false, "Failed with Python exception of %s", ex.what());
+            FAIL();
+        }
+
+        e.Deactivate();
+
+        EXPECT_EQ(4, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleTypeTest_Input)]);
+        EXPECT_EQ(2, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleTypeTest_Output)]);
+    }
+
+    TEST_F(PythonReflectionTupleTests, CustomTypesConvertedCorrectly)
+    {
+        enum class LogTypes
+        {
+            Skip = 0,
+            TupleCustomTypeTest_Input,
+            TupleCustomTypeTest_Output,
+        };
+
+        m_testSink.m_evaluateMessage = [](const char* window, const char* message) -> int
+        {
+            if (AzFramework::StringFunc::Equal(window, "python"))
+            {
+                if (AzFramework::StringFunc::StartsWith(message, "TupleCustomTypeTest_Input"))
+                {
+                    return static_cast<int>(LogTypes::TupleCustomTypeTest_Input);
+                }
+                else if (AzFramework::StringFunc::StartsWith(message, "TupleCustomTypeTest_Output"))
+                {
+                    return static_cast<int>(LogTypes::TupleCustomTypeTest_Output);
+                }
+            }
+            return static_cast<int>(LogTypes::Skip);
+        };
+
+        PythonReflectionTupleTypes pythonReflectionPairTypes;
+        pythonReflectionPairTypes.Reflect(m_app.GetSerializeContext());
+        pythonReflectionPairTypes.Reflect(m_app.GetBehaviorContext());
+
+        AZ::Entity e;
+        Activate(e);
+
+        SimulateEditorBecomingInitialized();
+
+        try
+        {
+            pybind11::exec(R"(
+                import azlmbr.test.pair
+                import azlmbr.object
+                import azlmbr.std
+
+                # Create the test fixture
+                test = azlmbr.object.create('PythonReflectionTupleTypes')
+
+                result = test.return_tuple_with_custom_type()
+                if (len(result) == 3):
+                    print ('TupleCustomTypeTest_Output')
+
+                custom = azlmbr.object.create('MyCustomType')
+                custom.set_data(42)
+                test.accept_tuple_with_custom_type((True, 'def', custom))
+                result = test.return_tuple_with_custom_type()
+                if (len(result) == 3 and result[0] == True and result[1] == 'def' and result[2].get_data() == 42):
+                        print ('TupleCustomTypeTest_Input')
+            )");
+        } catch ([[maybe_unused]] const pybind11::error_already_set& ex)
+        {
+            AZ_Warning("UnitTest", false, "Failed with Python exception of %s", ex.what());
+            FAIL();
+        }
+
+        e.Deactivate();
+
+        EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleCustomTypeTest_Input)]);
+        EXPECT_EQ(1, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleCustomTypeTest_Output)]);
+    }
+
+    TEST_F(PythonReflectionTupleTests, UnsupportedTypesLogErrors)
+    {
+        enum class LogTypes
+        {
+            Skip = 0,
+            TupleUnsupportedTypeTest_CannotConvert
+        };
+
+        m_testSink.m_evaluateMessage = [](const char* window, const char* message) -> int
+        {
+            if (AzFramework::StringFunc::Equal(window, "python"))
+            {
+                if (AzFramework::StringFunc::Contains(message, "accept_tuple_of_basic_types"))
+                {
+                    return static_cast<int>(LogTypes::TupleUnsupportedTypeTest_CannotConvert);
+                }
+            }
+            return static_cast<int>(LogTypes::Skip);
+        };
+
+        PythonReflectionTupleTypes pythonReflectionDictionaryTypes;
+        pythonReflectionDictionaryTypes.Reflect(m_app.GetSerializeContext());
+        pythonReflectionDictionaryTypes.Reflect(m_app.GetBehaviorContext());
+
+        AZ::Entity e;
+        Activate(e);
+
+        SimulateEditorBecomingInitialized();
+
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        try
+        {
+            pybind11::exec(R"(
+                import azlmbr.test.pair
+                import azlmbr.object
+                import azlmbr.std
+
+                # Create the test fixture
+                test = azlmbr.object.create('PythonReflectionTupleTypes')
+
+                # This should fail because it's passing [bool, int] to a tuple expecting [bool, int, float]
+                test.accept_tuple_of_basic_types([True, 5])
+
+                # This should fail because it's passing [int, string, bool] to a tuple expecting [bool, int, float]
+                test.accept_tuple_of_basic_types([5, 'abc', True])
+
+                # This should fail because it's passing [bool, int, float, float] to a tuple expecting [bool, int, float]
+                test.accept_tuple_of_basic_types([True, 5, 10.0, 10.0])
+
+                # This should fail because it's passing a set instead of a tuple or list
+                test.accept_tuple_of_basic_types({True, 5, 10.0})
+            )");
+        } catch ([[maybe_unused]] const pybind11::error_already_set& ex)
+        {
+            AZ_Warning("UnitTest", false, "Failed with Python exception of %s", ex.what());
+            FAIL();
+        }
+        AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
+
+        e.Deactivate();
+
+        EXPECT_EQ(4, m_testSink.m_evaluationMap[static_cast<int>(LogTypes::TupleUnsupportedTypeTest_CannotConvert)]);
+    }
+}
+
+

--- a/Gems/EditorPythonBindings/Code/editorpythonbindings_common_files.cmake
+++ b/Gems/EditorPythonBindings/Code/editorpythonbindings_common_files.cmake
@@ -15,6 +15,8 @@ set(FILES
     Source/PythonLogSymbolsComponent.h
     Source/PythonMarshalComponent.cpp
     Source/PythonMarshalComponent.h
+    Source/PythonMarshalTuple.cpp
+    Source/PythonMarshalTuple.h
     Source/PythonProxyBus.cpp
     Source/PythonProxyBus.h
     Source/PythonProxyObject.cpp

--- a/Gems/EditorPythonBindings/Code/editorpythonbindings_tests_files.cmake
+++ b/Gems/EditorPythonBindings/Code/editorpythonbindings_tests_files.cmake
@@ -18,6 +18,7 @@ set(FILES
     Tests/PythonLogSymbolsComponentTests.cpp
     Tests/PythonPairTests.cpp
     Tests/PythonPairTests.h
+    Tests/PythonTupleTests.cpp
     Tests/PythonProxyBusTests.cpp
     Tests/PythonProxyObjectTests.cpp
     Tests/PythonReflectionComponentTests.cpp


### PR DESCRIPTION
This allows tuples to be exposed and used explicitly, or implicitly interchanged with python tuples or lists.

When exposing methods to the BehaviorContext, it's recommended that people use AZStd::tuple<> when returning multiple return values so that the method is easy to use from Script Canvas. However, python didn't support tuple reflection, which made the APIs unusable from python. By adding tuple support to python, the APIs become easy to use from both methods.

Ex:
`didHit, position, normal = terrain.TerrainDataRequestBus(bus.Broadcast, 'GetClosestIntersection', math.Vector3(0.0, 0.0, 0.0), math.Vector3(1000.0, 1000.0, 0.0))`


Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>