### PR TITLE
Compile fixes for release config

### DIFF
--- a/Gems/ScriptAutomation/Code/Source/ScriptAutomationScriptBindings.cpp
+++ b/Gems/ScriptAutomation/Code/Source/ScriptAutomationScriptBindings.cpp
@@ -22,7 +22,7 @@ namespace ScriptAutomation
     {
         void Print(const AZStd::string& message [[maybe_unused]])
         {
-#ifndef RELEASE //AZ_TracePrintf does nothing in release, ignore this call
+#ifndef _RELEASE //AZ_TracePrintf does nothing in release, ignore this call
             auto func = [message]()
             {
                 AZ_TracePrintf("ScriptAutomation", "Script: %s\n", message.c_str());
@@ -34,7 +34,7 @@ namespace ScriptAutomation
 
         void Warning(const AZStd::string& message [[maybe_unused]])
         {
-#ifndef RELEASE //AZ_Warning does nothing in release, ignore this call
+#ifndef _RELEASE //AZ_Warning does nothing in release, ignore this call
             auto func = [message]()
             {
                 AZ_Warning("ScriptAutomation", false, "Script: %s", message.c_str());
@@ -46,7 +46,7 @@ namespace ScriptAutomation
 
         void Error(const AZStd::string& message [[maybe_unused]])
         {
-#ifndef RELEASE //AZ_Error does nothing in release, ignore this call
+#ifndef _RELEASE //AZ_Error does nothing in release, ignore this call
             auto func = [message]()
             {
                 AZ_Error("ScriptAutomation", false, "Script: %s", message.c_str());

--- a/Gems/ScriptAutomation/Code/Source/ScriptAutomationScriptBindings.cpp
+++ b/Gems/ScriptAutomation/Code/Source/ScriptAutomationScriptBindings.cpp
@@ -20,34 +20,40 @@ namespace ScriptAutomation
 {
     namespace Bindings
     {
-        void Print(const AZStd::string& message)
+        void Print(const AZStd::string& message [[maybe_unused]])
         {
+#ifndef RELEASE //AZ_TracePrintf does nothing in release, ignore this call
             auto func = [message]()
             {
                 AZ_TracePrintf("ScriptAutomation", "Script: %s\n", message.c_str());
             };
 
             ScriptAutomationInterface::Get()->QueueScriptOperation(AZStd::move(func));
+#endif
         }
 
-        void Warning(const AZStd::string& message)
+        void Warning(const AZStd::string& message [[maybe_unused]])
         {
+#ifndef RELEASE //AZ_Warning does nothing in release, ignore this call
             auto func = [message]()
             {
                 AZ_Warning("ScriptAutomation", false, "Script: %s", message.c_str());
             };
 
             ScriptAutomationInterface::Get()->QueueScriptOperation(AZStd::move(func));
+#endif
         }
 
-        void Error(const AZStd::string& message)
+        void Error(const AZStd::string& message [[maybe_unused]])
         {
+#ifndef RELEASE //AZ_Error does nothing in release, ignore this call
             auto func = [message]()
             {
                 AZ_Error("ScriptAutomation", false, "Script: %s", message.c_str());
             };
 
             ScriptAutomationInterface::Get()->QueueScriptOperation(AZStd::move(func));
+#endif
         }
 
         void ExecuteConsoleCommand(const AZStd::string& command)

--- a/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
+++ b/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
@@ -253,7 +253,7 @@ namespace ScriptAutomation
         AZ::Data::Asset<AZ::ScriptAsset> scriptAsset = LoadScriptAssetFromPath(scriptFilePath, *m_scriptContext.get());
         if (!scriptAsset)
         {
-#ifndef RELEASE // AZ_Error is a no-op in release builds
+#ifndef _RELEASE // AZ_Error is a no-op in release builds
             // Push an error operation on the back of the queue instead of reporting it immediately so it doesn't get lost
             // in front of a bunch of queued m_scriptOperations.
             QueueScriptOperation([scriptFilePath]()
@@ -265,7 +265,7 @@ namespace ScriptAutomation
             return;
         }
 
-#ifndef RELEASE // AZ_Error is a no-op in release builds
+#ifndef _RELEASE // AZ_Error is a no-op in release builds
         QueueScriptOperation([scriptFilePath]()
             {
                 AZ_Printf("ScriptAutomation", "Running script '%s'...\n", scriptFilePath);
@@ -275,7 +275,7 @@ namespace ScriptAutomation
 
         if (!m_scriptContext->Execute(scriptAsset->m_data.GetScriptBuffer().data(), scriptFilePath, scriptAsset->m_data.GetScriptBuffer().size()))
         {
-#ifndef RELEASE // AZ_Error is a no-op in release builds
+#ifndef _RELEASE // AZ_Error is a no-op in release builds
             // Push an error operation on the back of the queue instead of reporting it immediately so it doesn't get lost
             // in front of a bunch of queued m_scriptOperations.
             QueueScriptOperation([scriptFilePath]()

--- a/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
+++ b/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
@@ -248,11 +248,12 @@ namespace ScriptAutomation
         m_scriptOperations.push(AZStd::move(operation));
     }
 
-    void ScriptAutomationSystemComponent::ExecuteScript(const char* scriptFilePath)
+    void ScriptAutomationSystemComponent::ExecuteScript(const char* scriptFilePath [[maybe_unused]])
     {
         AZ::Data::Asset<AZ::ScriptAsset> scriptAsset = LoadScriptAssetFromPath(scriptFilePath, *m_scriptContext.get());
         if (!scriptAsset)
         {
+#ifndef RELEASE // AZ_Error is a no-op in release builds
             // Push an error operation on the back of the queue instead of reporting it immediately so it doesn't get lost
             // in front of a bunch of queued m_scriptOperations.
             QueueScriptOperation([scriptFilePath]()
@@ -260,17 +261,21 @@ namespace ScriptAutomation
                     AZ_Error("ScriptAutomation", false, "Script: Could not find or load script asset '%s'.", scriptFilePath);
                 }
             );
+#endif
             return;
         }
 
+#ifndef RELEASE // AZ_Error is a no-op in release builds
         QueueScriptOperation([scriptFilePath]()
             {
                 AZ_Printf("ScriptAutomation", "Running script '%s'...\n", scriptFilePath);
             }
         );
+#endif
 
         if (!m_scriptContext->Execute(scriptAsset->m_data.GetScriptBuffer().data(), scriptFilePath, scriptAsset->m_data.GetScriptBuffer().size()))
         {
+#ifndef RELEASE // AZ_Error is a no-op in release builds
             // Push an error operation on the back of the queue instead of reporting it immediately so it doesn't get lost
             // in front of a bunch of queued m_scriptOperations.
             QueueScriptOperation([scriptFilePath]()
@@ -278,6 +283,7 @@ namespace ScriptAutomation
                     AZ_Error("ScriptAutomation", false, "Script: Error running script '%s'.", scriptFilePath);
                 }
             );
+#endif
         }
     }
 } // namespace ScriptAutomation


### PR DESCRIPTION
Mark parameters used in AZ_Error/Warning/TracePrintf as maybe_unused
ifdef out lambda's that just call those macros

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>