### PR TITLE
Fix for Box shapes not rendering correctly when overlapping

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Shape/BoxShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/BoxShape.cpp
@@ -315,8 +315,11 @@ namespace LmbrCentral
 
         if (shapeDrawParams.m_filled)
         {
+            auto state = debugDisplay.GetState();
             debugDisplay.SetColor(shapeDrawParams.m_shapeColor.GetAsVector4());
+            debugDisplay.DepthWriteOff();
             debugDisplay.DrawSolidBox(boxMin, boxMax);
+            debugDisplay.SetState(state);
         }
 
         debugDisplay.SetColor(shapeDrawParams.m_wireColor.GetAsVector4());


### PR DESCRIPTION
 Change turns off depth write for the filled box shape.

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>