### PR TITLE
Changing the Private Gem library target to be a STATIC library from an OBJECT library

### DIFF
--- a/Templates/CppToolGem/Template/Code/CMakeLists.txt
+++ b/Templates/CppToolGem/Template/Code/CMakeLists.txt
@@ -34,16 +34,16 @@ ly_add_target(
            AZ::AzCore
 )
 
-# Add the ${Name}.Private.Object target
-# Note: We include the common files and the platform specific files which are set in
-# 1.${NameLower}_private_files.cmake
-# 2.${pal_dir}/${NameLower}_private_files.cmake
+# The ${Name}.Private.Object target is an internal target
+# It should not be used outside of this Gems CMakeLists.txt
 ly_add_target(
-    NAME ${Name}.Private.Object OBJECT
+    NAME ${Name}.Private.Object STATIC
     NAMESPACE Gem
     FILES_CMAKE
         ${NameLower}_private_files.cmake
         ${pal_dir}/${NameLower}_private_files.cmake
+    TARGET_PROPERTIES
+        O3DE_PRIVATE_TARGET TRUE
     INCLUDE_DIRECTORIES
         PRIVATE
             Include
@@ -101,15 +101,17 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     )
 
     # The ${Name}.Editor.Private.Object target is an internal target
-    # which is only to be used by this Gem's CMakeLists.txt and any Subdirectories
-    # Other Gems should not use this target
+    # which is only to be used by this gems CMakeLists.txt and any subdirectories
+    # Other gems should not use this target
     ly_add_target(
-        NAME ${Name}.Editor.Private.Object OBJECT
+        NAME ${Name}.Editor.Private.Object STATIC
         NAMESPACE Gem
         AUTOMOC
         AUTORCC
         FILES_CMAKE
             ${NameLower}_editor_private_files.cmake
+        TARGET_PROPERTIES
+            O3DE_PRIVATE_TARGET TRUE
         INCLUDE_DIRECTORIES
             PRIVATE
                 Include

--- a/Templates/DefaultGem/Template/Code/CMakeLists.txt
+++ b/Templates/DefaultGem/Template/Code/CMakeLists.txt
@@ -34,16 +34,16 @@ ly_add_target(
            AZ::AzCore
 )
 
-# Add the ${Name}.Private.Object target
-# Note: We include the common files and the platform specific files which are set in
-# 1.${NameLower}_private_files.cmake
-# 2.${pal_dir}/${NameLower}_private_files.cmake
+# The ${Name}.Private.Object target is an internal target
+# It should not be used outside of this Gems CMakeLists.txt
 ly_add_target(
-    NAME ${Name}.Private.Object OBJECT
+    NAME ${Name}.Private.Object STATIC
     NAMESPACE Gem
     FILES_CMAKE
         ${NameLower}_private_files.cmake
         ${pal_dir}/${NameLower}_private_files.cmake
+    TARGET_PROPERTIES
+        O3DE_PRIVATE_TARGET TRUE
     INCLUDE_DIRECTORIES
         PRIVATE
             Include
@@ -101,13 +101,15 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     )
 
     # The ${Name}.Editor.Private.Object target is an internal target
-    # which is only to be used by this Gem's CMakeLists.txt and any Subdirectories
-    # Other Gems should not use this target
+    # which is only to be used by this gems CMakeLists.txt and any subdirectories
+    # Other gems should not use this target
     ly_add_target(
-        NAME ${Name}.Editor.Private.Object OBJECT
+        NAME ${Name}.Editor.Private.Object STATIC
         NAMESPACE Gem
         FILES_CMAKE
             ${NameLower}_editor_private_files.cmake
+        TARGET_PROPERTIES
+            O3DE_PRIVATE_TARGET TRUE
         INCLUDE_DIRECTORIES
             PRIVATE
                 Include

--- a/Templates/PythonToolGem/Template/Code/CMakeLists.txt
+++ b/Templates/PythonToolGem/Template/Code/CMakeLists.txt
@@ -39,14 +39,16 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     )
 
     # The ${Name}.Editor.Private.Object target is an internal target
-    # which is only to be used by this Gem's CMakeLists.txt and any Subdirectories
-    # Other Gems should not use this target
+    # which is only to be used by this gems CMakeLists.txt and any subdirectories
+    # Other gems should not use this target
     ly_add_target(
-        NAME ${Name}.Editor.Private.Object OBJECT
+        NAME ${Name}.Editor.Private.Object STATIC
         NAMESPACE Gem
         AUTORCC
         FILES_CMAKE
             ${NameLower}_editor_private_files.cmake
+        TARGET_PROPERTIES
+            O3DE_PRIVATE_TARGET TRUE
         INCLUDE_DIRECTORIES
             PRIVATE
                 Include


### PR DESCRIPTION

The Trade-offs between an OBJECT and a STATIC LIBRARY are as follows

OBJECT_LIBRARY
---
1. Dead stripping isn't performed by default using clang/gcc
1. Symbols with external linkage are added to any linked shared library/executable
1. A duplicate copy of the object file isn't in an archive file

STATIC_LIBRARY
---
1. Dead stripping is performed by default using clang/gcc
1. Symbols with external linkage which are not used are not added to any linked shared library/executable
1. A duplicate copy of the object file existing the STATIC library.

For Gems the trade offs are the differences in shared library
size(.dll/.so/.dylib) size(larger for OBJECT libraries) vs a static
library that is only used internally within the gem and is not for
public consumption(Unneeded file in the build/install directory).

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>