### PR TITLE
Some overload node name fix and detect deprecate node when using upgrade tool

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
@@ -287,7 +287,7 @@ namespace AZ
                 ->Attribute(AZ::Script::Attributes::MethodOverride, &Internal::GetSinCosMultipleReturn)
             ->Method<bool(double, double, double)>("IsClose", &AZ::IsClose, context.MakeDefaultValues(static_cast<double>(Constants::FloatEpsilon)))
             ->Method<float(float)>("Abs", &GetAbs)
-            ->Method("Divide By Number", [](float lhs, float rhs) { return lhs / rhs; })
+            ->Method("Divide By Number", [](float lhs, float rhs) { return lhs / rhs; }, { "Source", "The source value gets divided." }, { { { "Divisor", "The number gets divided by." } } })
             ->Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Divide By Number (/)", "Math"))
             ->Attribute(AZ::ScriptCanvasAttributes::OperatorOverride, AZ::Script::Attributes::OperatorType::Div)
             ->Attribute(AZ::ScriptCanvasAttributes::OverloadArgumentGroup, AZ::OverloadArgumentGroupInfo({ "DivideGroup", "" }, { "DivideGroup" }))

--- a/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
@@ -287,7 +287,7 @@ namespace AZ
                 ->Attribute(AZ::Script::Attributes::MethodOverride, &Internal::GetSinCosMultipleReturn)
             ->Method<bool(double, double, double)>("IsClose", &AZ::IsClose, context.MakeDefaultValues(static_cast<double>(Constants::FloatEpsilon)))
             ->Method<float(float)>("Abs", &GetAbs)
-            ->Method("Divide By Number", [](float lhs, float rhs) { return lhs / rhs; }, { "Source", "The source value gets divided." }, { { { "Divisor", "The number gets divided by." } } })
+            ->Method("Divide By Number", [](float lhs, float rhs) { return lhs / rhs; }, { "Source", "The source value gets divided." }, { { { "Divisor", "The value that divides Source." } } })
             ->Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Divide By Number (/)", "Math"))
             ->Attribute(AZ::ScriptCanvasAttributes::OperatorOverride, AZ::Script::Attributes::OperatorType::Div)
             ->Attribute(AZ::ScriptCanvasAttributes::OverloadArgumentGroup, AZ::OverloadArgumentGroupInfo({ "DivideGroup", "" }, { "DivideGroup" }))

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.cpp
@@ -235,7 +235,7 @@ namespace AZ
                 Method("GetElement", &Vector2::GetElement)->
                 Method("SetElement", &Vector2::SetElement, { { {"Index", ""}, {"Value",""} } })->
                     Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::All)->
-                Method("GetLength", &Vector2::GetLength)->
+                Method("GetLength", &Vector2::GetLength, { "Source", "The source value to calculate its magnitude." }, {})->
                     Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Length", "Math"))->
                 Method("GetLengthSq", &Vector2::GetLengthSq)->
                 Method("SetLength", &Vector2::SetLength)->
@@ -309,7 +309,7 @@ namespace AZ
                 Method("Madd", &Vector2::Madd)->
                     Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::All)->
                 Method("ConstructFromValues", &Internal::ConstructVector2)->
-                Method<Vector2(Vector2::*)(float) const>("DivideFloatExplicit", &Vector2::operator/)->
+                Method<Vector2(Vector2::*)(float) const>("DivideFloatExplicit", &Vector2::operator/, { "Source", "The source value gets divided." }, { { { "Divisor", "The number gets divided by." } } })->
                     Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Divide By Number (/)", "Math"))->
                     Attribute(AZ::ScriptCanvasAttributes::OverloadArgumentGroup, AZ::OverloadArgumentGroupInfo({ "DivideGroup", "" }, { "DivideGroup" }))
                 ;

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.cpp
@@ -235,7 +235,7 @@ namespace AZ
                 Method("GetElement", &Vector2::GetElement)->
                 Method("SetElement", &Vector2::SetElement, { { {"Index", ""}, {"Value",""} } })->
                     Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::All)->
-                Method("GetLength", &Vector2::GetLength, { "Source", "The source value to calculate its magnitude." }, {})->
+                Method("GetLength", &Vector2::GetLength, { "Source", "The source of the magnitude calculation." }, {})->
                     Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Length", "Math"))->
                 Method("GetLengthSq", &Vector2::GetLengthSq)->
                 Method("SetLength", &Vector2::SetLength)->
@@ -309,7 +309,7 @@ namespace AZ
                 Method("Madd", &Vector2::Madd)->
                     Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::All)->
                 Method("ConstructFromValues", &Internal::ConstructVector2)->
-                Method<Vector2(Vector2::*)(float) const>("DivideFloatExplicit", &Vector2::operator/, { "Source", "The source value gets divided." }, { { { "Divisor", "The number gets divided by." } } })->
+                Method<Vector2(Vector2::*)(float) const>("DivideFloatExplicit", &Vector2::operator/, { "Source", "The source value gets divided." }, { { { "Divisor", "The value that divides Source." } } })->
                     Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Divide By Number (/)", "Math"))->
                     Attribute(AZ::ScriptCanvasAttributes::OverloadArgumentGroup, AZ::OverloadArgumentGroupInfo({ "DivideGroup", "" }, { "DivideGroup" }))
                 ;

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.cpp
@@ -251,7 +251,7 @@ namespace AZ
                 Method("GetElement", &Vector3::GetElement)->
                 Method("SetElement", &Vector3::SetElement)->
                     Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::All)->
-                Method("GetLength", &Vector3::GetLength)->
+                Method("GetLength", &Vector3::GetLength, { "Source", "The source value to calculate its magnitude." }, {})->
                     Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Length", "Math"))->
                 Method("GetLengthSq", &Vector3::GetLengthSq)->
                 Method("GetLengthReciprocal", &Vector3::GetLengthReciprocal)->
@@ -341,7 +341,7 @@ namespace AZ
                 Method("CreateZero", &Vector3::CreateZero)->
                     Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::All)->
                 Method("ConstructFromValues", &ScriptCanvas::ConstructVector3)->
-                Method<Vector3(Vector3::*)(float) const>("DivideFloatExplicit", &Vector3::operator/)->
+                Method<Vector3(Vector3::*)(float) const>("DivideFloatExplicit", &Vector3::operator/, { "Source", "The source value gets divided." }, { { { "Divisor", "The number gets divided by." } } })->
                     Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Divide By Number (/)", "Math"))->
                     Attribute(AZ::ScriptCanvasAttributes::OverloadArgumentGroup, AZ::OverloadArgumentGroupInfo({ "DivideGroup", "" }, { "DivideGroup" }))
                 ;

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.cpp
@@ -251,7 +251,7 @@ namespace AZ
                 Method("GetElement", &Vector3::GetElement)->
                 Method("SetElement", &Vector3::SetElement)->
                     Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::All)->
-                Method("GetLength", &Vector3::GetLength, { "Source", "The source value to calculate its magnitude." }, {})->
+                Method("GetLength", &Vector3::GetLength, { "Source", "The source of the magnitude calculation." }, {})->
                     Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Length", "Math"))->
                 Method("GetLengthSq", &Vector3::GetLengthSq)->
                 Method("GetLengthReciprocal", &Vector3::GetLengthReciprocal)->
@@ -341,7 +341,7 @@ namespace AZ
                 Method("CreateZero", &Vector3::CreateZero)->
                     Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::All)->
                 Method("ConstructFromValues", &ScriptCanvas::ConstructVector3)->
-                Method<Vector3(Vector3::*)(float) const>("DivideFloatExplicit", &Vector3::operator/, { "Source", "The source value gets divided." }, { { { "Divisor", "The number gets divided by." } } })->
+                Method<Vector3(Vector3::*)(float) const>("DivideFloatExplicit", &Vector3::operator/, { "Source", "The source value gets divided." }, { { { "Divisor", "The value that divides Source." } } })->
                     Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Divide By Number (/)", "Math"))->
                     Attribute(AZ::ScriptCanvasAttributes::OverloadArgumentGroup, AZ::OverloadArgumentGroupInfo({ "DivideGroup", "" }, { "DivideGroup" }))
                 ;

--- a/Code/Framework/AzCore/AzCore/Math/Vector4.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector4.cpp
@@ -261,7 +261,7 @@ namespace AZ
                 Method("GetElement", &Vector4::GetElement)->
                 Method("SetElement", &Vector4::SetElement)->
                     Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::All)->
-                Method("GetLength", &Vector4::GetLength)->
+                Method("GetLength", &Vector4::GetLength, { "Source", "The source value to calculate its magnitude." }, {})->
                     Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Length", "Math"))->
                 Method("GetLengthSq", &Vector4::GetLengthSq)->
                 Method("GetLengthReciprocal", &Vector4::GetLengthReciprocal)->
@@ -314,7 +314,7 @@ namespace AZ
                 Method("CreateZero", &Vector4::CreateZero)->
                     Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::All)->
                 Method("ConstructFromValues", &Internal::ConstructVector4)->
-                Method<Vector4(Vector4::*)(float) const>("DivideFloatExplicit", &Vector4::operator/)->
+                Method<Vector4(Vector4::*)(float) const>("DivideFloatExplicit", &Vector4::operator/, { "Source", "The source value gets divided." }, { { { "Divisor", "The number gets divided by." } } })->
                     Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Divide By Number (/)", "Math"))->
                     Attribute(AZ::ScriptCanvasAttributes::OverloadArgumentGroup, AZ::OverloadArgumentGroupInfo({ "DivideGroup", "" }, { "DivideGroup" }))
                 ;

--- a/Code/Framework/AzCore/AzCore/Math/Vector4.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector4.cpp
@@ -261,7 +261,7 @@ namespace AZ
                 Method("GetElement", &Vector4::GetElement)->
                 Method("SetElement", &Vector4::SetElement)->
                     Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::All)->
-                Method("GetLength", &Vector4::GetLength, { "Source", "The source value to calculate its magnitude." }, {})->
+                Method("GetLength", &Vector4::GetLength, { "Source", "The source of the magnitude calculation." }, {})->
                     Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Length", "Math"))->
                 Method("GetLengthSq", &Vector4::GetLengthSq)->
                 Method("GetLengthReciprocal", &Vector4::GetLengthReciprocal)->
@@ -314,7 +314,7 @@ namespace AZ
                 Method("CreateZero", &Vector4::CreateZero)->
                     Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::All)->
                 Method("ConstructFromValues", &Internal::ConstructVector4)->
-                Method<Vector4(Vector4::*)(float) const>("DivideFloatExplicit", &Vector4::operator/, { "Source", "The source value gets divided." }, { { { "Divisor", "The number gets divided by." } } })->
+                Method<Vector4(Vector4::*)(float) const>("DivideFloatExplicit", &Vector4::operator/, { "Source", "The source value gets divided." }, { { { "Divisor", "The value that divides Source." } } })->
                     Attribute(AZ::ScriptCanvasAttributes::ExplicitOverloadCrc, ExplicitOverloadInfo("Divide By Number (/)", "Math"))->
                     Attribute(AZ::ScriptCanvasAttributes::OverloadArgumentGroup, AZ::OverloadArgumentGroupInfo({ "DivideGroup", "" }, { "DivideGroup" }))
                 ;

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -3778,7 +3778,7 @@ namespace ScriptCanvasEditor
         m_upgradeSM.SetAsset(source);
         m_upgradeSM.SetConfig(upgradeConfig);
 
-        if (upgradeRequest == UpgradeRequest::Forced || !GetVersion().IsLatest())
+        if (upgradeRequest == UpgradeRequest::Forced || !GetVersion().IsLatest() || HasDeprecatedNode())
         {
             m_upgradeSM.Run(Start::StateID());
             return true;

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Controller.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Controller.cpp
@@ -123,9 +123,9 @@ namespace ScriptCanvasEditor
                     , "InspectAsset: %s, failed to load valid graph"
                     , asset.Path().c_str());
 
-                return graphComponent
-                    && (!graphComponent->GetVersion().IsLatest() || m_view->forceUpgrade->isChecked())
-                        ? ScanConfiguration::Filter::Include
+                return graphComponent &&
+                        (!graphComponent->GetVersion().IsLatest() || graphComponent->HasDeprecatedNode() || m_view->forceUpgrade->isChecked())
+                    ? ScanConfiguration::Filter::Include
                         : ScanConfiguration::Filter::Exclude;
             };
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Graph.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Graph.cpp
@@ -173,6 +173,18 @@ namespace ScriptCanvas
         return m_versionData;
     }
 
+    bool Graph::HasDeprecatedNode() const
+    {
+        for (auto& nodeRef : m_graphData.m_nodes)
+        {
+            if (auto node = FindNode(nodeRef->GetId()); node->IsDeprecated())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     void Graph::Activate()
     {
         m_variableRequests = nullptr;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Graph.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Graph.h
@@ -66,6 +66,7 @@ namespace ScriptCanvas
 
         void MarkVersion();
         const VersionData& GetVersion() const;
+        bool HasDeprecatedNode() const;
 
         void Parse(ValidationResults& validationResults);
 


### PR DESCRIPTION
## Details
* Fix method overload node name for Vector2, Vector3, Vector4 and Quaternion
* Add check to upgrade tool when graph contains deprecated node

## Testing
Changes involves ScriptCanvas editor usage only, tested locally by checking corresponding node name, and also use graph upgrade tool to make sure it can pickup expected graph in list

Signed-off-by: onecent1101 <liug@amazon.com>