### PR TITLE
Changed fallback irradiance color to 1.0f

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -1080,8 +1080,8 @@ namespace AZ
                     {
                         AZ_Warning(
                             "MeshFeatureProcessor", false,
-                            "No irradiance.manualColor or irradiance.color field found. Defaulting to black.");
-                        subMesh.m_irradianceColor = AZ::Colors::Black;
+                            "No irradiance.manualColor or irradiance.color field found. Defaulting to 1.0f.");
+                        subMesh.m_irradianceColor = AZ::Colors::White;
                     }
                 }
             }
@@ -1159,8 +1159,8 @@ namespace AZ
             else
             {
                 AZ_Warning("MeshFeatureProcessor", false, "Unknown irradianceColorSource value: %s, "
-                        "defaulting to black.", irradianceColorSource.GetCStr());
-                subMesh.m_irradianceColor = AZ::Colors::Black;
+                        "defaulting to 1.0f.", irradianceColorSource.GetCStr());
+                subMesh.m_irradianceColor = AZ::Colors::White;
             }
 
 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -87,6 +87,9 @@ namespace AZ
             RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
             uint32_t objectIndex = objectId.GetIndex();
 
+            // lock the mutex to protect the mesh and BLAS lists
+            AZStd::unique_lock<AZStd::mutex> lock(m_mutex);
+
             // check to see if we already have this mesh
             MeshMap::iterator itMesh = m_meshes.find(objectIndex);
             if (itMesh != m_meshes.end())
@@ -94,9 +97,6 @@ namespace AZ
                 AZ_Assert(false, "SetMesh called on an existing Mesh objectId, call RemoveMesh first");
                 return;
             }
-
-            // lock the mutex to protect the mesh and BLAS lists
-            AZStd::unique_lock<AZStd::mutex> lock(m_mutex);
 
             // add the mesh
             m_meshes.insert(AZStd::make_pair(objectIndex, Mesh{ assetId }));


### PR DESCRIPTION
Changed fallback irradiance color to 1.0f.
Moved the lock in RayTracingFeatureProcessor::SetMesh to before the mesh list find operation.

Signed-off-by: dmcdiarmid-ly <63674186+dmcdiarmid-ly@users.noreply.github.com>