### PR TITLE
Fixed Network Component Names in Editor 

### DIFF
--- a/Code/Framework/AzCore/AzCore/StringFunc/StringFunc.cpp
+++ b/Code/Framework/AzCore/AzCore/StringFunc/StringFunc.cpp
@@ -9,7 +9,7 @@
 
 #include <AzCore/std/functional.h>
 #include <AzCore/std/string/conversions.h>
-#include <AzCore/std/containers/array.h>
+#include <AzCore/std/string/regex.h>
 #include <AzCore/std/containers/fixed_vector.h>
 #include <AzCore/Memory/Memory.h>
 #include <AzCore/Memory/OSAllocator.h>
@@ -20,6 +20,7 @@
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Vector4.h>
 #include <AzCore/AzCore_Traits_Platform.h>
+
 
 namespace AZ::StringFunc::Internal
 {
@@ -739,6 +740,14 @@ namespace AZ::StringFunc
     bool Strip(AZStd::string& inout, const char* stripCharacters, bool bCaseSensitive, bool bStripBeginning, bool bStripEnding)
     {
         return Internal::Strip(inout, stripCharacters, bCaseSensitive, bStripBeginning, bStripEnding);
+    }
+
+    void SplitCamelCase(AZStd::string& inout)
+    {
+        AZStd::regex splitRegex(R"(/[a-z]+|[0-9]+|(?:[A-Z][a-z]+)|(?:[A-Z]+(?=(?:[A-Z][a-z])|[^AZa-z]|[$\d\n]))/g)");
+        inout = regex_replace(inout, splitRegex, " $&");
+        inout = LStrip(inout);
+        Replace(inout, "  ", " ");
     }
 
     AZStd::string& TrimWhiteSpace(AZStd::string& value, bool leading, bool trailing)

--- a/Code/Framework/AzCore/AzCore/StringFunc/StringFunc.h
+++ b/Code/Framework/AzCore/AzCore/StringFunc/StringFunc.h
@@ -9,13 +9,11 @@
 #pragma once
 
 #include <AzCore/IO/Path/Path_fwd.h>
-#include <AzCore/std/function/function_fwd.h>
 #include <AzCore/std/string/fixed_string.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/containers/set.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/optional.h>
-#include <AzCore/Casting/numeric_cast.h>
 
 //---------------------------------------------------------------------
 // FILENAME CONSTRAINTS
@@ -256,6 +254,12 @@ namespace AZ
         */
         bool Strip(AZStd::string& inout, const char stripCharacter = ' ', bool bCaseSensitive = false, bool bStripBeginning = false, bool bStripEnding = false);
         bool Strip(AZStd::string& inout, const char* stripCharacters = " ", bool bCaseSensitive = false, bool bStripBeginning = false, bool bStripEnding = false);
+
+        //! SplitCamelCase
+        /*! Utility function that splits camel-case syntax string into separate words
+        Example: StringFunc::SplitCamelCase(s = "NetworkTransformComponent"); s == "Network Transform Component"
+        */
+        void SplitCamelCase(AZStd::string& inout);
 
         //! Tokenize
         /*! Tokenize a c-string, into a vector of AZStd::string(s) optionally keeping empty string

--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
@@ -1521,7 +1521,15 @@ namespace {{ Component.attrib['Namespace'] }}
             AZ::EditContext* editContext = serializeContext->GetEditContext();
             if (editContext)
             {
-                editContext->Class<{{ ComponentBaseName }}>("{{ ComponentBaseName }}", "{{ Component.attrib['Description'] }}")
+                const AZStd::string componentSuffix = " Component";
+                AZStd::string baseComponentEditorName = "{{ ComponentBaseName }}";
+                AZ::StringFunc::SplitCamelCase(baseComponentEditorName);
+                if (baseComponentEditorName.ends_with(componentSuffix))
+                {
+                    baseComponentEditorName.erase(baseComponentEditorName.length()-componentSuffix.length());
+                }
+
+                editContext->Class<{{ ComponentBaseName }}>(baseComponentEditorName.c_str(), "{{ Component.attrib['Description'] }}")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "{{ Component.attrib['Namespace'] }}")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
@@ -1532,7 +1540,13 @@ namespace {{ Component.attrib['Namespace'] }}
                     {{ DefineArchetypePropertyEditReflection(Component, ComponentBaseName)|indent(20) }};
 {% if ComponentDerived %}
 
-                editContext->Class<{{ ComponentName }}>("{{ ComponentName }}", "{{ Component.attrib['Description'] }}")
+                AZStd::string componentEditorName = "{{ ComponentName }}";
+                AZ::StringFunc::SplitCamelCase(componentEditorName);
+                if (componentEditorName.ends_with(componentSuffix))
+                {
+                    componentEditorName.erase(componentEditorName.length()-componentSuffix.length());
+                }
+                editContext->Class<{{ ComponentName }}>(componentEditorName.c_str(), "{{ Component.attrib['Description'] }}")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "{{ Component.attrib['Namespace'] }}")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"));

--- a/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
+++ b/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
@@ -91,7 +91,7 @@ namespace ScriptCanvasEditorTools
                 entry.m_details.m_name = prettyName;
             }
 
-            SplitCamelCase(entry.m_details.m_name);
+            AZ::StringFunc::SplitCamelCase(entry.m_details.m_name);
 
             for (auto event : behaviorEBus->m_events)
             {
@@ -118,7 +118,7 @@ namespace ScriptCanvasEditorTools
                 eventEntry.m_details.m_name = prettyName.empty() ? eventName : prettyName;
                 eventEntry.m_details.m_tooltip = Helpers::ReadStringAttribute(event.second.m_attributes, AZ::Script::Attributes::ToolTip);
 
-                SplitCamelCase(eventEntry.m_details.m_name);
+                AZ::StringFunc::SplitCamelCase(eventEntry.m_details.m_name);
 
                 eventEntry.m_entry.m_name = "In";
                 eventEntry.m_entry.m_tooltip = AZStd::string::format("When signaled, this will invoke %s", eventEntry.m_details.m_name.c_str());
@@ -149,7 +149,7 @@ namespace ScriptCanvasEditorTools
 
                     argument.m_typeId = argumentType.ToString<AZStd::string>();
 
-                    SplitCamelCase(argument.m_details.m_name);
+                    AZ::StringFunc::SplitCamelCase(argument.m_details.m_name);
 
                     eventEntry.m_arguments.push_back(argument);
                 }
@@ -225,7 +225,7 @@ namespace ScriptCanvasEditorTools
         details.m_category = Helpers::GetStringAttribute(behaviorClass, AZ::Script::Attributes::Category);
         details.m_tooltip = Helpers::GetStringAttribute(behaviorClass, AZ::Script::Attributes::ToolTip);
 
-        SplitCamelCase(details.m_name);
+        AZ::StringFunc::SplitCamelCase(details.m_name);
 
         if (!behaviorClass->m_methods.empty())
         {
@@ -250,7 +250,7 @@ namespace ScriptCanvasEditorTools
 
                 AZStd::string prefix = className + "::";
                 AZ::StringFunc::Replace(methodEntry.m_details.m_name, prefix.c_str(), "");
-                SplitCamelCase(methodEntry.m_details.m_name);
+                AZ::StringFunc::SplitCamelCase(methodEntry.m_details.m_name);
 
                 methodEntry.m_entry.m_name = "In";
                 methodEntry.m_entry.m_tooltip = AZStd::string::format("When signaled, this will invoke %s", methodEntry.m_details.m_name.c_str());
@@ -325,7 +325,7 @@ namespace ScriptCanvasEditorTools
         entry.m_context = ScriptCanvasEditor::TranslationHelper::AssetContext::AZEventContext;
         entry.m_details.m_name = azEventEntry.m_eventName;
 
-        SplitCamelCase(entry.m_details.m_name);
+        AZ::StringFunc::SplitCamelCase(entry.m_details.m_name);
 
         for (const ScriptCanvas::Slot& slot : nodeComponent->GetSlots())
         {
@@ -457,7 +457,7 @@ namespace ScriptCanvasEditorTools
                 details.m_name = cleanName;
             }
 
-            SplitCamelCase(details.m_name);
+            AZ::StringFunc::SplitCamelCase(details.m_name);
 
             // Tooltip attribute takes priority over the edit data description
             AZStd::string tooltip = Helpers::GetStringAttribute(classData, AZ::Script::Attributes::ToolTip);
@@ -649,7 +649,7 @@ namespace ScriptCanvasEditorTools
 
                 EntryDetails& details = entry.m_details;
                 details.m_name = behaviorClass->m_name;
-                SplitCamelCase(details.m_name);
+                AZ::StringFunc::SplitCamelCase(details.m_name);
 
                 // Get the pretty name
                 AZStd::string prettyName;
@@ -683,7 +683,7 @@ namespace ScriptCanvasEditorTools
 
                         methodEntry.m_details.m_tooltip = Helpers::GetStringAttribute(behaviorMethod, AZ::Script::Attributes::ToolTip);
                         methodEntry.m_details.m_name = methodPair.second->m_name;
-                        SplitCamelCase(methodEntry.m_details.m_name);
+                        AZ::StringFunc::SplitCamelCase(methodEntry.m_details.m_name);
 
                         // Strip the className from the methodName
                         AZStd::string qualifiedName = behaviorClass->m_name + "::";
@@ -736,7 +736,7 @@ namespace ScriptCanvasEditorTools
         entry.m_key = methodName;
         entry.m_context = ScriptCanvasEditor::TranslationHelper::AssetContext::BehaviorGlobalMethodContext;
         entry.m_details.m_name = methodName;
-        SplitCamelCase(entry.m_details.m_name);
+        AZ::StringFunc::SplitCamelCase(entry.m_details.m_name);
 
         AZ::BehaviorMethod* behaviorMethod = behaviorMethodEntry->second;
         if (behaviorMethod)
@@ -748,7 +748,7 @@ namespace ScriptCanvasEditorTools
             method.m_details.m_name = cleanName;
             method.m_details.m_tooltip = behaviorMethod->m_debugDescription ? behaviorMethod->m_debugDescription : "";
 
-            SplitCamelCase(method.m_details.m_name);
+            AZ::StringFunc::SplitCamelCase(method.m_details.m_name);
 
             TranslateMethod(behaviorMethod, method);
 
@@ -846,7 +846,7 @@ namespace ScriptCanvasEditorTools
                 const AZStd::string* argToolTip = behaviorMethod->GetArgumentToolTip(argIndex);
                 argument.m_details.m_tooltip = (argToolTip && !argToolTip->empty()) ? *argToolTip : argumentDescription;
 
-                SplitCamelCase(argument.m_details.m_name);
+                AZ::StringFunc::SplitCamelCase(argument.m_details.m_name);
 
                 methodEntry.m_arguments.push_back(argument);
             }
@@ -873,7 +873,7 @@ namespace ScriptCanvasEditorTools
                 result.m_details.m_name = resultName;
                 result.m_details.m_tooltip = resultDescription;
 
-                SplitCamelCase(result.m_details.m_name);
+                AZ::StringFunc::SplitCamelCase(result.m_details.m_name);
 
                 methodEntry.m_results.push_back(result);
             }
@@ -898,7 +898,7 @@ namespace ScriptCanvasEditorTools
             entry->m_context = context;
 
             entry->m_details.m_name = className;
-            SplitCamelCase(entry->m_details.m_name);
+            AZ::StringFunc::SplitCamelCase(entry->m_details.m_name);
         }
 
         if (behaviorProperty->m_getter)
@@ -915,13 +915,13 @@ namespace ScriptCanvasEditorTools
             method.m_details.m_name = methodName;
             method.m_details.m_tooltip = behaviorProperty->m_getter->m_debugDescription ? behaviorProperty->m_getter->m_debugDescription : "";
 
-            SplitCamelCase(method.m_details.m_name);
+            AZ::StringFunc::SplitCamelCase(method.m_details.m_name);
 
             TranslateMethod(behaviorProperty->m_getter, method);
 
             // We know this is a getter, so there will only be one parameter, we will use the method name as a best
             // guess for the argument name
-            SplitCamelCase(cleanName);
+            AZ::StringFunc::SplitCamelCase(cleanName);
             method.m_results[0].m_details.m_name = cleanName;
 
             entry->m_methods.push_back(method);
@@ -943,13 +943,13 @@ namespace ScriptCanvasEditorTools
             method.m_details.m_name = methodName;
             method.m_details.m_tooltip = behaviorProperty->m_setter->m_debugDescription ? behaviorProperty->m_getter->m_debugDescription : "";
 
-            SplitCamelCase(method.m_details.m_name);
+            AZ::StringFunc::SplitCamelCase(method.m_details.m_name);
 
             TranslateMethod(behaviorProperty->m_setter, method);
 
             // We know this is a setter, so there will only be one parameter, we will use the method name as a best
             // guess for the argument name
-            SplitCamelCase(cleanName);
+            AZ::StringFunc::SplitCamelCase(cleanName);
             method.m_arguments[1].m_details.m_name = cleanName;
 
             entry->m_methods.push_back(method);
@@ -979,7 +979,7 @@ namespace ScriptCanvasEditorTools
             entry.m_details.m_tooltip = behaviorEbus->m_toolTip;
             entry.m_details.m_category = "EBus Handlers";
 
-            SplitCamelCase(entry.m_details.m_name);
+            AZ::StringFunc::SplitCamelCase(entry.m_details.m_name);
 
             for (const AZ::BehaviorEBusHandler::BusForwarderEvent& event : handler->GetEvents())
             {
@@ -991,7 +991,7 @@ namespace ScriptCanvasEditorTools
                 methodEntry.m_details.m_tooltip = "";
                 methodEntry.m_details.m_name = event.m_name;
 
-                SplitCamelCase(methodEntry.m_details.m_name);
+                AZ::StringFunc::SplitCamelCase(methodEntry.m_details.m_name);
 
                 // Arguments (Input Slots)
                 if (!event.m_parameters.empty())
@@ -1037,7 +1037,7 @@ namespace ScriptCanvasEditorTools
                         argument.m_details.m_name = argumentName;
                         argument.m_details.m_tooltip = argumentDescription;
 
-                        SplitCamelCase(argument.m_details.m_name);
+                        AZ::StringFunc::SplitCamelCase(argument.m_details.m_name);
 
                         methodEntry.m_arguments.push_back(argument);
                     }
@@ -1069,7 +1069,7 @@ namespace ScriptCanvasEditorTools
                     result.m_details.m_name = resultName;
                     result.m_details.m_tooltip = resultDescription;
 
-                    SplitCamelCase(result.m_details.m_name);
+                    AZ::StringFunc::SplitCamelCase(result.m_details.m_name);
 
                     methodEntry.m_results.push_back(result);
                 }
@@ -1317,14 +1317,6 @@ namespace ScriptCanvasEditorTools
 
  //       AzQtComponents::ShowFileOnDesktop(endPath.c_str());
 
-    }
-
-    void TranslationGeneration::SplitCamelCase(AZStd::string& text)
-    {
-        AZStd::regex splitRegex(R"(/[a-z]+|[0-9]+|(?:[A-Z][a-z]+)|(?:[A-Z]+(?=(?:[A-Z][a-z])|[^AZa-z]|[$\d\n]))/g)");
-        text = AZStd::regex_replace(text, splitRegex, " $&");
-        text = AZ::StringFunc::LStrip(text);
-        AZ::StringFunc::Replace(text, "  ", " ");
     }
 
     namespace Helpers

--- a/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.h
+++ b/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.h
@@ -158,9 +158,6 @@ namespace ScriptCanvasEditorTools
         //! Utility function that saves a TranslationFormat object in the desired JSON format
         void SaveJSONData(const AZStd::string& filename, TranslationFormat& translationRoot);
 
-        //! Utility function that splits camel-case syntax string into separate words
-        void SplitCamelCase(AZStd::string&);
-
         //! Evaluates if the specified object has exclusion flags and should be skipped from generation
         template <typename T>
         bool ShouldSkip(const T* object) const


### PR DESCRIPTION
Moved function to split camel case strings from ScriptCanvas to AZ::StringFunc. Update network component jinja to add spaces and strip out 'Component' so it matches other component names.

Testing by recompiling, running editor, and seeing network component names look correct from the Add Component dropdown menu.

Fixes GHI #6353
Signed-off-by: Gene Walters <genewalt@amazon.com>