### PR TITLE
Fixed UIElement ordering issue

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
@@ -724,7 +724,6 @@ class AtomComponentProperties:
           - 'Minimum Screen Coverage' portion of the screen at which the mesh is culled; 0 (never culled) to 1
           - 'Quality Decay Rate' rate at which the mesh degrades; 0 (never) to 1 (lowest quality imediately)
           - 'Lod Override' which specific LOD to always use; default or other named LOD
-          - 'Add Material Component' the button to add a material; set True to add a material component
         :param property: From the last element of the property tree path. Default 'name' for component name string.
         :return: Full property path OR component name if no property specified.
         :rtype: str
@@ -741,7 +740,6 @@ class AtomComponentProperties:
             'Minimum Screen Coverage': 'Controller|Configuration|Lod Configuration|Minimum Screen Coverage',
             'Quality Decay Rate': 'Controller|Configuration|Lod Configuration|Quality Decay Rate',
             'Lod Override': 'Controller|Configuration|Lod Configuration|Lod Override',
-            'Add Material Component': 'Add Material Component',
         }
         return properties[property]
 

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MeshAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MeshAdded.py
@@ -124,9 +124,12 @@ def AtomEditorComponents_Mesh_AddedToEntity():
 
     import os
 
+    from PySide2 import QtWidgets
+
     import azlmbr.legacy.general as general
     from Atom.atom_utils.atom_constants import (MESH_LOD_TYPE,
                                                 AtomComponentProperties)
+    from editor_python_test_tools import pyside_utils
     from editor_python_test_tools.asset_utils import Asset
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.utils import Report, TestHelper, Tracer
@@ -253,8 +256,12 @@ def AtomEditorComponents_Mesh_AddedToEntity():
                           AtomComponentProperties.mesh('Lod Type')) == MESH_LOD_TYPE['default'])
 
         # 16. Set Mesh component Add Material Component and confirm a Material component added
-        mesh_component.set_component_property_value(
-            AtomComponentProperties.mesh('Add Material Component'), value=True)
+        # Make sure the Entity Inspector is open and trigger the "Add Material Component" button
+        general.open_pane("Entity Inspector")
+        editor_window = pyside_utils.get_editor_main_window()
+        entity_inspector = editor_window.findChild(QtWidgets.QDockWidget, "Entity Inspector")
+        add_material_component_button = pyside_utils.find_child_by_pattern(entity_inspector, "Add Material Component")
+        add_material_component_button.click()
         Report.result(Tests.has_material, mesh_entity.has_component(AtomComponentProperties.material()))
 
         # 17. Remove Mesh component then UNDO the remove

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ReflectedPropertyEditorPage.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ReflectedPropertyEditorPage.cpp
@@ -43,6 +43,7 @@ void LevelThree::Reflect(AZ::ReflectContext* context)
         {
             edit->Class<LevelThree>("Level 3", "A deeply nested component")
                 ->DataElement(AZ::Edit::UIHandlers::CheckBox, &LevelThree::m_bool, "Horizontal limit", "A deeply nested CheckBox")
+                ->UIElement(AZ::Edit::UIHandlers::CheckBox, "Nested UIElement", "A deeply nested UIElement with no data element")
                 ;
         }
     }
@@ -222,6 +223,9 @@ void GalleryComponent::Reflect(AZ::ReflectContext* context)
                 ->DataElement(AZ::Edit::UIHandlers::Vector4, &GalleryComponent::m_vector4, "Vector4", "An AZ::Edit::UIHandlers::Vector4 example")
                 ->DataElement(AZ::Edit::UIHandlers::Vector4, &GalleryComponent::m_vector4Suffix, "Vector4 (suffix)", "An AZ::Edit::UIHandlers::Vector4 with suffix example")
                     ->Attribute(AZ::Edit::Attributes::Suffix, " m")
+                ->UIElement(AZ::Edit::UIHandlers::Button, "ButtonWithNoDataElement", "Test having a UIElement Button with no serialized data element")
+                    ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
+                    ->Attribute(AZ::Edit::Attributes::ButtonText, "Button without element")
                 ->DataElement(AZ::Edit::UIHandlers::Default, &GalleryComponent::m_levelOne, "Level 1", "The first level in deeply nested tree")
                 ->ClassElement(AZ::Edit::ClassElements::Group, "Collision")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -1206,7 +1206,6 @@ namespace AzToolsFramework
                 serializeContext->Class<Components::TransformComponent, EditorComponentBase>()->
                     Field("Parent Entity", &TransformComponent::m_parentEntityId)->
                     Field("Transform Data", &TransformComponent::m_editorTransform)->
-                    Field("AddNonUniformScaleButton", &TransformComponent::m_addNonUniformScaleButton)->
                     Field("Cached World Transform", &TransformComponent::m_cachedWorldTransform)->
                     Field("Cached World Transform Parent", &TransformComponent::m_cachedWorldTransformParent)->
                     Field("Parent Activation Transform Mode", &TransformComponent::m_parentActivationTransformMode)->
@@ -1232,7 +1231,7 @@ namespace AzToolsFramework
                         DataElement(AZ::Edit::UIHandlers::Default, &TransformComponent::m_editorTransform, "Values", "")->
                             Attribute(AZ::Edit::Attributes::ChangeNotify, &TransformComponent::TransformChangedInspector)->
                             Attribute(AZ::Edit::Attributes::AutoExpand, true)->
-                        DataElement(AZ::Edit::UIHandlers::Button, &TransformComponent::m_addNonUniformScaleButton, "", "")->
+                        UIElement(AZ::Edit::UIHandlers::Button, "", "")->
                             Attribute(AZ::Edit::Attributes::ButtonText, "Add non-uniform scale")->
                             Attribute(AZ::Edit::Attributes::ReadOnly, &TransformComponent::IsAddNonUniformScaleButtonReadOnly)->
                             Attribute(AZ::Edit::Attributes::ChangeNotify, &TransformComponent::OnAddNonUniformScaleButtonPressed)->

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
@@ -241,10 +241,6 @@ namespace AzToolsFramework
             bool m_worldTransformDirty = true;
             bool m_isStatic = false;
 
-            // This is a workaround for a bug which causes the button to appear with incorrect placement if a UI
-            // element is used rather than a data element.
-            bool m_addNonUniformScaleButton = false;
-
             // Used to check whether entity was just created vs manually reactivated. Set true after OnEntityActivated is called the first time.
             bool m_initialized = false;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/InstanceDataHierarchy.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/InstanceDataHierarchy.cpp
@@ -554,6 +554,14 @@ namespace AzToolsFramework
 
                 // If we're looking at element data that's part of the child list, keep track of the index for adjacent UIElement insertion
                 // Children appear in the order specified by m_elements, so we can scan as we go
+                // There can be elements in the child list that have no edit data, so they won't appear
+                // in nodeEditData->m_elements, so we need to skip over them but still need to track
+                // them as a valid child index since they do appear in the nodes child list
+                while (nodeIt != node->m_children.end() && !nodeIt->m_classElement->m_editData)
+                {
+                    ++m_childIndexOverride;
+                    ++nodeIt;
+                }
                 if (nodeIt != node->m_children.end() && nodeIt->m_classElement->m_editData == &element)
                 {
                     ++m_childIndexOverride;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
@@ -28,7 +28,6 @@ namespace AZ
 
                 serializeContext->Class<EditorMeshComponent, BaseClass>()
                     ->Version(2, ConvertToEditorRenderComponentAdapter<1>)
-                    ->Field("addMaterialComponentFlag", &EditorMeshComponent::m_addMaterialComponentFlag)
                     ->Field("meshStats", &EditorMeshComponent::m_stats)
                     ;
 
@@ -49,7 +48,7 @@ namespace AZ
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                             ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://o3de.org/docs/user-guide/components/reference/atom/mesh/")
                             ->Attribute(AZ::Edit::Attributes::PrimaryAssetType, AZ::AzTypeInfo<RPI::ModelAsset>::Uuid())
-                        ->DataElement(AZ::Edit::UIHandlers::Button, &EditorMeshComponent::m_addMaterialComponentFlag, "Add Material Component", "Add Material Component")
+                        ->UIElement(AZ::Edit::UIHandlers::Button, "Add Material Component", "Add Material Component")
                             ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
                             ->Attribute(AZ::Edit::Attributes::ButtonText, "Add Material Component")
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMeshComponent::AddEditorMaterialComponent)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.h
@@ -72,9 +72,6 @@ namespace AZ
             bool HasEditorMaterialComponent() const;
             AZ::u32 GetEditorMaterialComponentVisibility() const;
 
-            // Flag used for button placement
-            bool m_addMaterialComponentFlag = false;
-
             // Stats for current mesh asset
             EditorMeshStats m_stats;
         };

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -59,7 +59,6 @@ namespace EMotionFX
                     ->Field("UpdateJointTransformsWhenOutOfView", &EditorActorComponent::m_forceUpdateJointsOOV)
                     ->Field("LodLevel", &EditorActorComponent::m_lodLevel)
                     ->Field("BBoxConfig", &EditorActorComponent::m_bboxConfig)
-                    ->Field("AddMaterialComponentFlag", &EditorActorComponent::m_addMaterialComponentFlag)
                     ;
 
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
@@ -161,7 +160,7 @@ namespace EMotionFX
                         ->DataElement(0, &EditorActorComponent::m_bboxConfig,
                                       "Bounding box configuration", "")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorActorComponent::OnBBoxConfigChanged)
-                        ->DataElement(AZ::Edit::UIHandlers::Button, &EditorActorComponent::m_addMaterialComponentFlag, "Add Material Component", "Add Material Component")
+                        ->UIElement(AZ::Edit::UIHandlers::Button, "Add Material Component", "Add Material Component")
                         ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
                         ->Attribute(AZ::Edit::Attributes::ButtonText, "Add Material Component")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorActorComponent::AddEditorMaterialComponent)

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
@@ -178,7 +178,6 @@ namespace EMotionFX
             ActorComponent::BoundingBoxConfiguration m_bboxConfig;
             bool                                m_forceUpdateJointsOOV = false;
             ActorRenderFlags                    m_renderFlags;              ///< Actor render flag               
-            bool m_addMaterialComponentFlag = false;                        ///< Flag used for button placement
             // \todo attachmentTarget node nr
 
             // Note: LOD work in progress. For now we use one material instead of a list of material, because we don't have the support for LOD with multiple scene files.

--- a/Gems/PhysX/Code/Editor/DebugDraw.cpp
+++ b/Gems/PhysX/Code/Editor/DebugDraw.cpp
@@ -139,7 +139,6 @@ namespace PhysX
                 serializeContext->Class<Collider>()
                     ->Version(1)
                     ->Field("LocallyEnabled", &Collider::m_locallyEnabled)
-                    ->Field("GlobalButtonState", &Collider::m_globalButtonState)
                     ;
 
                 if (auto editContext = serializeContext->GetEditContext())
@@ -156,7 +155,7 @@ namespace PhysX
                             ->Attribute(AZ::Edit::Attributes::Visibility,
                                 VisibilityFunc{ []() { return IsGlobalColliderDebugCheck(GlobalCollisionDebugState::Manual); } })
                             ->Attribute(AZ::Edit::Attributes::ReadOnly, &IsDrawColliderReadOnly)
-                        ->DataElement(AZ::Edit::UIHandlers::Button, &Collider::m_globalButtonState, "Draw collider",
+                        ->UIElement(AZ::Edit::UIHandlers::Button, "Draw collider",
                             "Display collider geometry in the viewport.")
                             ->Attribute(AZ::Edit::Attributes::ButtonText, "Global override")
                             ->Attribute(AZ::Edit::Attributes::ButtonTooltip,

--- a/Gems/PhysX/Code/Editor/DebugDraw.h
+++ b/Gems/PhysX/Code/Editor/DebugDraw.h
@@ -155,7 +155,6 @@ namespace PhysX
 
             AZStd::string GetEntityName() const;
 
-            bool m_globalButtonState = false; //!< Button linked to the global debug preference.
             bool m_locallyEnabled = true; //!< Local setting to enable displaying the collider in editor view.
             AZ::EntityId m_entityId;
             const DisplayCallback* m_displayCallback = nullptr;


### PR DESCRIPTION
Fixes #9478 

Fixed issue when trying to use an `UIElement` without a backing data element getting an incorrect/random order in the RPE (usually getting pinned to the top regardless of expected order).

The logic that was iterating through the children on the node in the `InstanceDataHierarchy` didn't handle the case where a child was found that had no edit data (which occurs on anything that is trying to be reflected from an `AZ::Component` because it has an `Id` parameter that is serialized but not exposed to the `EditContext`). So the logic wouldn't move forward past this child, which would result (usually) in any `UIElement` being pinned to the top, since it would never be able to correctly find the child index of the child that came before the `UIElement`.

Made the following changes:
- Logic in `InstanceDataHierarchy` remains the same with the addition of it skipping over elements that don't have any edit data
- Updated unit test that was previously checking `UIElement` ordering to derive from `AZ::Component` in order to expose the ordering issue
- Updated RPE page in the control gallery to showcase using `UIElements` without a data element (without this change, the `UIElements` would show up at the top)
- Updated a few places in the code-base that were using the workaround of having a dummy variable be serialized (but never actually used) in order to control the ordering of a button to instead just use a `UIElement` with no data element, and verified the buttons still show up in the expected order
- Fixed Atom automated test to actually click the "Add Material Component" button that was previously relying on the workaround by changing the boolean data element value

![UIElementsCorrectOrder](https://user-images.githubusercontent.com/7519264/168656908-a819c4a6-664a-4ba9-aa8d-596e390b2c25.png)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>