### PR TITLE
Action Manager | Refactor callable Python object tracking to prevent memory leaks

### DIFF
--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
@@ -47,7 +47,7 @@ namespace EditorPythonBindings
             properties,
             [h = AZStd::move(handler)]() mutable
             {
-                PyObject_CallObject(h.GetHandler(), NULL);
+                PyObject_CallObject(h.GetHandler(), nullptr);
             }
         );
 

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
@@ -41,7 +41,7 @@ namespace EditorPythonBindings
         const AzToolsFramework::ActionProperties& properties,
         PythonEditorAction handler)
     {
-        return m_actionManagerInterface->RegisterAction(
+        auto outcome = m_actionManagerInterface->RegisterAction(
             contextIdentifier,
             identifier,
             properties,
@@ -50,6 +50,14 @@ namespace EditorPythonBindings
                 PyObject_CallObject(h.GetHandler(), NULL);
             }
         );
+
+        if (outcome.IsSuccess())
+        {
+            // Store the callable to handle reference counting correctly.
+            m_actionHandlerMap.insert({ identifier, PythonActionHandler(handler.GetHandler()) });
+        }
+
+        return outcome;
     }
 
     AzToolsFramework::ActionManagerOperationResult PythonEditorActionHandler::TriggerAction(const AZStd::string& actionIdentifier)
@@ -94,6 +102,60 @@ namespace EditorPythonBindings
         {
             m_allocationMap.erase(handleEntry);
             azfree(reinterpret_cast<void*>(handle));
+        }
+    }
+
+    PythonEditorActionHandler::PythonActionHandler::PythonActionHandler(PyObject* handler)
+        : m_handler(handler)
+    {
+        // Increment the reference counter for the handler on the Python side to ensure the function isn't garbage collected.
+        if (m_handler)
+        {
+            Py_INCREF(m_handler);
+        }
+    }
+
+    PythonEditorActionHandler::PythonActionHandler::PythonActionHandler(const PythonActionHandler& obj)
+        : m_handler(obj.m_handler)
+    {
+        if (m_handler)
+        {
+            Py_INCREF(m_handler);
+        }
+    }
+
+    PythonEditorActionHandler::PythonActionHandler::PythonActionHandler(PythonActionHandler&& obj)
+        : m_handler(obj.m_handler)
+    {
+        // Reference counter does not need to be touched since we're moving ownership.
+        obj.m_handler = nullptr;
+    }
+
+    PythonEditorActionHandler::PythonActionHandler& PythonEditorActionHandler::PythonActionHandler::operator=(
+        const PythonActionHandler& obj)
+    {
+        if (m_handler)
+        {
+            Py_DECREF(m_handler);
+        }
+
+        m_handler = obj.m_handler;
+
+        if (m_handler)
+        {
+            Py_INCREF(m_handler);
+        }
+
+        return *this;
+    }
+
+    PythonEditorActionHandler::PythonActionHandler::~PythonActionHandler()
+    {
+        if (m_handler)
+        {
+            Py_DECREF(m_handler);
+            // Clear the pointer in case the destructor is called multiple times.
+            m_handler = nullptr;
         }
     }
 

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.h
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.h
@@ -17,8 +17,8 @@ namespace AzToolsFramework
 namespace EditorPythonBindings
 {
     class PythonEditorActionHandler final
-        : public EditorPythonBindings::CustomTypeBindingNotificationBus::Handler
-        , public ActionManagerRequestBus::Handler
+        : public ActionManagerRequestBus::Handler
+        , private EditorPythonBindings::CustomTypeBindingNotificationBus::Handler
     {
     public:
         using Handle = EditorPythonBindings::CustomTypeBindingNotifications::ValueHandle;
@@ -36,6 +36,7 @@ namespace EditorPythonBindings
             PythonEditorAction handler) override;
         ActionManagerOperationResult TriggerAction(const AZStd::string& actionIdentifier) override;
 
+    private:
         AZStd::unordered_map<void*, AZ::TypeId> m_allocationMap;
 
         AllocationHandle AllocateDefault() override;
@@ -45,7 +46,21 @@ namespace EditorPythonBindings
         bool CanConvertPythonToBehavior(AZ::BehaviorParameter::Traits traits, PyObject* pyObj) const override;
         void CleanUpValue(ValueHandle handle) override;
 
-    private:
+        class PythonActionHandler
+        {
+        public:
+            explicit PythonActionHandler(PyObject* handler);
+            PythonActionHandler(const PythonActionHandler& obj);
+            PythonActionHandler(PythonActionHandler&& obj);
+            PythonActionHandler& operator=(const PythonActionHandler& obj);
+            virtual ~PythonActionHandler();
+
+        private:
+            PyObject* m_handler = nullptr;
+        };
+
+        AZStd::unordered_map<AZStd::string, PythonActionHandler> m_actionHandlerMap;
+
         AzToolsFramework::ActionManagerInterface* m_actionManagerInterface = nullptr;
     };
 

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonEditorAction.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonEditorAction.cpp
@@ -13,54 +13,6 @@ namespace EditorPythonBindings
     PythonEditorAction::PythonEditorAction(PyObject* handler)
         : m_handler(handler)
     {
-        // Increment the reference counter for the handler on the Python side to ensure the function isn't garbage collected.
-        if (m_handler)
-        {
-            Py_INCREF(m_handler);
-        }
-    }
-
-    PythonEditorAction::PythonEditorAction(const PythonEditorAction& obj)
-        : m_handler(obj.m_handler)
-    {
-        if (m_handler)
-        {
-            Py_INCREF(m_handler);
-        }
-    }
-
-    PythonEditorAction::PythonEditorAction(PythonEditorAction&& obj)
-        : m_handler(obj.m_handler)
-    {
-        // Reference counter does not need to be touched since we're moving ownership.
-        obj.m_handler = nullptr;
-    }
-
-    PythonEditorAction& PythonEditorAction::operator=(const PythonEditorAction& obj)
-    {
-        if (m_handler)
-        {
-            Py_DECREF(m_handler);
-        }
-
-        m_handler = obj.m_handler;
-
-        if (m_handler)
-        {
-            Py_INCREF(m_handler);
-        }
-
-        return *this;
-    }
-
-    PythonEditorAction::~PythonEditorAction()
-    {
-        if (m_handler)
-        {
-            Py_DECREF(m_handler);
-            // Clear the pointer in case the destructor is called multiple times.
-            m_handler = nullptr;
-        }
     }
 
     PyObject* PythonEditorAction::GetHandler()

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonEditorAction.h
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonEditorAction.h
@@ -16,17 +16,13 @@
 
 namespace EditorPythonBindings
 {
-    class PythonEditorAction
+    class PythonEditorAction final
     {
     public:
         AZ_TYPE_INFO(PythonEditorAction, "{1A5676D2-767B-4C2F-BC35-9CDDCE1430BB}");
         AZ_CLASS_ALLOCATOR(PythonEditorAction, AZ::SystemAllocator, 0);
 
         explicit PythonEditorAction(PyObject* handler);
-        PythonEditorAction(const PythonEditorAction& obj);
-        PythonEditorAction(PythonEditorAction&& obj);
-        PythonEditorAction& operator=(const PythonEditorAction& obj);
-        virtual ~PythonEditorAction();
 
         PyObject* GetHandler();
         const PyObject* GetHandler() const;


### PR DESCRIPTION
As part of an investigation by @burelc-amzn ( https://github.com/o3de/o3de/pull/9279 ), it came up that `BehaviorArgument` will not invoke the destructor for stored objects when they get deallocated. As such, this would cause a memory leak on the Python side since callable objects referenced from the Action Manager would not be garbage collected when the system stopped referencing them.

Resolved the issue by splitting off the PyObject marshaling (`PythonEditorAction`) from the reference counting management (`PythonActionHandler`). This additionally allows us to easily un-register actions if that is ever needed.

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>