### PR TITLE
Fix Linux installer issue caused by new debug stripping options

### DIFF
--- a/cmake/Platform/Linux/LYWrappers_linux.cmake
+++ b/cmake/Platform/Linux/LYWrappers_linux.cmake
@@ -68,6 +68,12 @@ function(ly_apply_debug_strip_options target)
         return()
     endif()
 
+    # If the target is IMPORTED, then there is no post-build process
+    get_target_property(is_imported ${target} IMPORTED)
+    if (${is_imported})
+        return()
+    endif()
+
     # Check the target type
     get_target_property(target_type ${target} TYPE)
 


### PR DESCRIPTION
Add check to prevent IMPORTED targets from attempting to do a post-build strip of debug symbols

Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>