### PR TITLE
Added helper for ending a group in EditContext

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
@@ -236,6 +236,9 @@ namespace AZ
              */
             ClassBuilder*  ClassElement(Crc32 elementIdCrc, const char* description);
 
+            //! Helper method to end the current group (if any). This is shorthand for:
+            //!     ->ClassElement(AZ::Edit::ClassElements::Group, "")
+            ClassBuilder* EndGroup();
 
              /**
              * Declare element with attributes that belong to the class SerializeContext::Class, this is a logical structure, you can have one or more GroupElementToggles.
@@ -533,6 +536,13 @@ namespace AZ
     inline EditContext::ClassBuilder* EditContext::ClassBuilder::GroupElementToggle(const char* name, T memberVariable)
     {
         return DataElement(AZ::Edit::ClassElements::Group, memberVariable, name, name, "");
+    }
+
+    inline EditContext::ClassBuilder*
+    EditContext::ClassBuilder::EndGroup()
+    {
+        // Starting a new group with no description ends the current group
+        return ClassElement(AZ::Edit::ClassElements::Group, "");
     }
 
     //=========================================================================

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SceneConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SceneConfiguration.cpp
@@ -51,8 +51,8 @@ namespace AzPhysics
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_enableCcdResweep,
                         "Enable CCD Resweep", "Enable a more accurate but more expensive continuous collision detection method")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &SceneConfiguration::GetCcdVisibility)
-                    ->ClassElement(AZ::Edit::ClassElements::Group, "") // end previous group by starting new unnamed expanded group
-                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->EndGroup()
+
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_enablePcm, "Persistent Contact Manifold", "Enabled the persistent contact manifold narrow-phase algorithm")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_bounceThresholdVelocity,
                         "Bounce Threshold Velocity", "Relative velocity below which colliding objects will not bounce")

--- a/Code/Framework/AzToolsFramework/Tests/InstanceDataHierarchy.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/InstanceDataHierarchy.cpp
@@ -1316,6 +1316,105 @@ namespace UnitTest
         }
     };
 
+    class InstanceDataHierarchyEndGroupTest
+        : public AllocatorsFixture
+    {
+    public:
+        class EndGroupContainer
+            : public AZ::Component
+        {
+        public:
+            AZ_COMPONENT(EndGroupContainer, "{0CFC7838-9B01-4E25-8932-1C1EE4FCEC77}", AZ::Component);
+
+            int m_rootData;
+            bool m_otherRootData;
+            int m_group1Data;
+            int m_group2Data;
+            int m_finalRootData;
+
+            static void Reflect(AZ::ReflectContext* context)
+            {
+                if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
+                {
+                    serialize->Class<EndGroupContainer, AZ::Component>()
+                        ->Field("rootData", &EndGroupContainer::m_rootData)
+                        ->Field("otherRootData", &EndGroupContainer::m_otherRootData)
+                        ->Field("group1Data", &EndGroupContainer::m_group1Data)
+                        ->Field("group2Data", &EndGroupContainer::m_group2Data)
+                        ->Field("finalRootData", &EndGroupContainer::m_finalRootData)
+                        ;
+
+                    if (auto editContext = serialize->GetEditContext())
+                    {
+                        editContext->Class<EndGroupContainer>("EndGroupTest", "")
+                            ->DataElement(nullptr, &EndGroupContainer::m_rootData)
+                            ->DataElement(nullptr, &EndGroupContainer::m_otherRootData)
+
+                            ->ClassElement(AZ::Edit::ClassElements::Group, "First Group")
+                            ->DataElement(nullptr, &EndGroupContainer::m_group1Data)
+
+                            ->ClassElement(AZ::Edit::ClassElements::Group, "Second Group")
+                            ->DataElement(nullptr, &EndGroupContainer::m_group2Data)
+                            ->EndGroup()
+
+                            ->DataElement(nullptr, &EndGroupContainer::m_finalRootData)
+                            ;
+                    }
+                }
+            }
+
+            // AZ::Component overrides ...
+            void Activate() override {}
+            void Deactivate() override {}
+        };
+
+        void run()
+        {
+            using namespace AzToolsFramework;
+
+            AZ::SerializeContext serializeContext;
+            serializeContext.CreateEditContext();
+            AZ::Entity::Reflect(&serializeContext);
+            EndGroupContainer::Reflect(&serializeContext);
+
+            EndGroupContainer test;
+            InstanceDataHierarchy idh;
+            idh.AddRootInstance(&test, azrtti_typeid<EndGroupContainer>());
+            idh.Build(&serializeContext, 0);
+
+            auto children = idh.GetChildren();
+            ASSERT_EQ(children.size(), 6);
+            auto it = children.begin();
+
+            // The first child will be the AZ::Component Id data,
+            // which we don't care about for this test
+            ++it;
+
+            // The next two children are root data, which both should
+            // have no group element
+            EXPECT_STREQ(it->GetElementMetadata()->m_name, "rootData");
+            EXPECT_EQ(it->GetGroupElementMetadata(), nullptr);
+            ++it;
+            EXPECT_STREQ(it->GetElementMetadata()->m_name, "otherRootData");
+            EXPECT_EQ(it->GetGroupElementMetadata(), nullptr);
+
+            // The next data should be in the first group
+            ++it;
+            EXPECT_STREQ(it->GetElementMetadata()->m_name, "group1Data");
+            EXPECT_STREQ(it->GetGroupElementMetadata()->m_description, "First Group");
+
+            // The following data should be in the second group
+            ++it;
+            EXPECT_STREQ(it->GetElementMetadata()->m_name, "group2Data");
+            EXPECT_STREQ(it->GetGroupElementMetadata()->m_description, "Second Group");
+
+            // The final data should have no group since we ended the second group
+            ++it;
+            EXPECT_STREQ(it->GetElementMetadata()->m_name, "finalRootData");
+            EXPECT_EQ(it->GetGroupElementMetadata(), nullptr);
+        }
+    };
+
     class InstanceDataHierarchyAggregateInstanceTest
         : public AllocatorsFixture
     {
@@ -1472,6 +1571,11 @@ namespace UnitTest
     }
 
     TEST_F(InstanceDataHierarchyElementTest, TestLayingOutUIAndDataElements)
+    {
+        run();
+    }
+
+    TEST_F(InstanceDataHierarchyEndGroupTest, TestEndGroup)
     {
         run();
     }

--- a/Gems/GradientSignal/Code/Source/Components/DitherGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/DitherGradientComponent.cpp
@@ -44,6 +44,7 @@ namespace GradientSignal
                     ->DataElement(AZ::Edit::UIHandlers::ComboBox, &DitherGradientConfig::m_patternType, "Pattern Type", "")
                     ->EnumAttribute(DitherGradientConfig::BayerPatternType::PATTERN_SIZE_4x4, "4x4")
                     ->EnumAttribute(DitherGradientConfig::BayerPatternType::PATTERN_SIZE_8x8, "8x8")
+
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Sample Settings")
                     ->DataElement(AZ::Edit::UIHandlers::CheckBox, &DitherGradientConfig::m_useSystemPointsPerUnit, "Use System Points Per Unit", "Automatically sets points per unit.  Value is equal to Sector Density / Sector Size")
                     ->DataElement(AZ::Edit::UIHandlers::Slider, &DitherGradientConfig::m_pointsPerUnit, "Points Per Unit", "Scales input position before sampling")
@@ -51,8 +52,8 @@ namespace GradientSignal
                     ->Attribute(AZ::Edit::Attributes::Min, 0.001f)
                     ->Attribute(AZ::Edit::Attributes::Max, std::numeric_limits<float>::max())
                     ->Attribute(AZ::Edit::Attributes::SoftMax, 100.0f)
-                    ->ClassElement(AZ::Edit::ClassElements::Group, "")
-                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->EndGroup()
+
                     ->DataElement(0, &DitherGradientConfig::m_gradientSampler, "Gradient", "Input gradient whose values will be dithered.")
                     ;
             }

--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientSurfaceDataComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientSurfaceDataComponent.cpp
@@ -39,6 +39,7 @@ namespace GradientSignal
                     ->Attribute(AZ::Edit::Attributes::Category, s_categoryName)
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game", 0x232b318c))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Preview")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
                     ->UIElement("GradientPreviewer", "Previewer")
@@ -46,7 +47,7 @@ namespace GradientSignal
                     ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
                     ->Attribute(AZ_CRC("GradientEntity", 0xe8531817), &EditorGradientSurfaceDataComponent::GetGradientEntityId)
                     ->Attribute(AZ_CRC("GradientFilter", 0x99bf0362), &EditorGradientSurfaceDataComponent::GetFilterFunc)
-                    ->ClassElement(AZ::Edit::ClassElements::Group, "")
+                    ->EndGroup()
                     ;
             }
         }

--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
@@ -199,8 +199,8 @@ namespace PhysX
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_ccdFrictionEnabled,
                         "CCD friction", "When active, friction is applied when continuous collision detection (CCD) collisions are resolved.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::IsCCDEnabled)
-                    ->ClassElement(AZ::Edit::ClassElements::Group, "") // end previous group by starting new unnamed expanded group
-                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->EndGroup()
+
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_maxAngularVelocity,
                         "Maximum angular velocity", "Clamp angular velocities to this maximum value. "
                         "This prevents rigid bodies from rotating at unrealistic velocities after collisions.")

--- a/Gems/Vegetation/Code/Source/Components/DistributionFilterComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/DistributionFilterComponent.cpp
@@ -41,6 +41,7 @@ namespace Vegetation
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Preview")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
                     ->UIElement("GradientPreviewer", "Previewer")
@@ -48,8 +49,8 @@ namespace Vegetation
                     ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
                     ->Attribute(AZ_CRC("GradientSampler", 0xaec97010), &DistributionFilterConfig::GetSampler)
                     ->Attribute(AZ_CRC("GradientFilter", 0x99bf0362), &DistributionFilterConfig::GetFilterFunc)
-                    ->ClassElement(AZ::Edit::ClassElements::Group, "")
-                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->EndGroup()
+
                     ->DataElement(AZ::Edit::UIHandlers::ComboBox, &DistributionFilterConfig::m_filterStage, "Filter Stage", "Determines if filter is applied before (PreProcess) or after (PostProcess) modifiers.")
                     ->EnumAttribute(FilterStage::Default, "Default")
                     ->EnumAttribute(FilterStage::PreProcess, "PreProcess")

--- a/Gems/Vegetation/Code/Source/Descriptor.cpp
+++ b/Gems/Vegetation/Code/Source/Descriptor.cpp
@@ -360,10 +360,10 @@ namespace Vegetation
                         ->DataElement(0, &Descriptor::m_exclusiveSurfaceFilterTags, "Exclusion Tags", "")
                             ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                             ->Attribute(AZ::Edit::Attributes::ReadOnly, &Descriptor::IsSurfaceTagFilterReadOnly)
+                    ->EndGroup()
 
-                    ->ClassElement(AZ::Edit::ClassElements::Group, "")
-                        ->DataElement(0, &Descriptor::m_surfaceTagDistance, "Surface Mask Depth Filter", "")
-                            ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
+                    ->DataElement(0, &Descriptor::m_surfaceTagDistance, "Surface Mask Depth Filter", "")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
 
                     ;
             }


### PR DESCRIPTION
Added helper method to declare the end of a group in the `EditContext`. This functionality already existed by declaring a new group with an empty description, but this wasn't behavior wasn't documented so it wasn't easily discoverable.
- Added helper method to declare the end of a group and documented its behavior
- Added unit test to verify the `EndGroup` properly clears out the `groupData` for following data elements
- Replaced the handful of places in the code-base that were using the empty group description to all use `EndGroup` for consistency and verified they still work as expected

Signed-off-by: Chris Galvan <chgalvan@amazon.com>