### PR TITLE
Add new notification for Root Prefab Instance's First Load

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -238,7 +238,8 @@ namespace AzToolsFramework
         auto instanceUpdateExecutorInterface = AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get();
         if (!instanceUpdateExecutorInterface)
         {
-            AZ_Assert(false, "InstanceUpdateExecutorInterface is unavailable for LoadFromStream.");
+            AZ_Assert(false,
+                "InstanceUpdateExecutorInterface is unavailable for PrefabEditorEntityOwnershipService::LoadFromStream.");
             return false;
         }
         instanceUpdateExecutorInterface->QueueRootPrefabLoadedNotificationForNextPropagation();
@@ -346,7 +347,8 @@ namespace AzToolsFramework
         auto instanceUpdateExecutorInterface = AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get();
         if (!instanceUpdateExecutorInterface)
         {
-            AZ_Assert(false, "InstanceUpdateExecutorInterface is unavailable for CreateNewLevelPrefab.");
+            AZ_Assert(false,
+                "InstanceUpdateExecutorInterface is unavailable for PrefabEditorEntityOwnershipService::CreateNewLevelPrefab.");
             return;
         }
         instanceUpdateExecutorInterface->QueueRootPrefabLoadedNotificationForNextPropagation();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -235,7 +235,7 @@ namespace AzToolsFramework
         m_rootInstance->SetTemplateSourcePath(m_loaderInterface->GenerateRelativePath(filename));
         m_rootInstance->SetContainerEntityName("Level");
 
-        AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get()->SetRootPrefabInstanceAsNotLoaded();
+        AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get()->SetRootPrefabInstanceAsNeverLoaded();
         m_prefabSystemComponent->PropagateTemplateChanges(templateId);
         m_isRootPrefabAssigned = true;
 
@@ -336,7 +336,7 @@ namespace AzToolsFramework
             m_prefabSystemComponent->RemoveTemplate(prevTemplateId);
         }
 
-        AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get()->SetRootPrefabInstanceAsNotLoaded();
+        AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get()->SetRootPrefabInstanceAsNeverLoaded();
         m_prefabSystemComponent->PropagateTemplateChanges(templateId);
         m_isRootPrefabAssigned = true;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -21,6 +21,7 @@
 #include <AzToolsFramework/Prefab/Instance/Instance.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceEntityIdMapper.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceEntityMapperInterface.h>
+#include <AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h>
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
 #include <AzToolsFramework/Prefab/PrefabLoader.h>
 #include <AzToolsFramework/Prefab/PrefabFocusInterface.h>
@@ -233,6 +234,8 @@ namespace AzToolsFramework
         m_rootInstance->SetTemplateId(templateId);
         m_rootInstance->SetTemplateSourcePath(m_loaderInterface->GenerateRelativePath(filename));
         m_rootInstance->SetContainerEntityName("Level");
+
+        AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get()->SetRootPrefabInstanceAsNotLoaded();
         m_prefabSystemComponent->PropagateTemplateChanges(templateId);
         m_isRootPrefabAssigned = true;
 
@@ -333,6 +336,7 @@ namespace AzToolsFramework
             m_prefabSystemComponent->RemoveTemplate(prevTemplateId);
         }
 
+        AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get()->SetRootPrefabInstanceAsNotLoaded();
         m_prefabSystemComponent->PropagateTemplateChanges(templateId);
         m_isRootPrefabAssigned = true;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -235,7 +235,7 @@ namespace AzToolsFramework
         m_rootInstance->SetTemplateSourcePath(m_loaderInterface->GenerateRelativePath(filename));
         m_rootInstance->SetContainerEntityName("Level");
 
-        AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get()->SetRootPrefabInstanceAsNeverLoaded();
+        AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get()->QueueRootPrefabLoadedNotificationForNextPropagation();
         m_prefabSystemComponent->PropagateTemplateChanges(templateId);
         m_isRootPrefabAssigned = true;
 
@@ -336,7 +336,7 @@ namespace AzToolsFramework
             m_prefabSystemComponent->RemoveTemplate(prevTemplateId);
         }
 
-        AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get()->SetRootPrefabInstanceAsNeverLoaded();
+        AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get()->QueueRootPrefabLoadedNotificationForNextPropagation();
         m_prefabSystemComponent->PropagateTemplateChanges(templateId);
         m_isRootPrefabAssigned = true;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -235,7 +235,14 @@ namespace AzToolsFramework
         m_rootInstance->SetTemplateSourcePath(m_loaderInterface->GenerateRelativePath(filename));
         m_rootInstance->SetContainerEntityName("Level");
 
-        AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get()->QueueRootPrefabLoadedNotificationForNextPropagation();
+        auto instanceUpdateExecutorInterface = AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get();
+        if (!instanceUpdateExecutorInterface)
+        {
+            AZ_Assert(false, "InstanceUpdateExecutorInterface is unavailable for LoadFromStream.");
+            return false;
+        }
+        instanceUpdateExecutorInterface->QueueRootPrefabLoadedNotificationForNextPropagation();
+
         m_prefabSystemComponent->PropagateTemplateChanges(templateId);
         m_isRootPrefabAssigned = true;
 
@@ -336,7 +343,14 @@ namespace AzToolsFramework
             m_prefabSystemComponent->RemoveTemplate(prevTemplateId);
         }
 
-        AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get()->QueueRootPrefabLoadedNotificationForNextPropagation();
+        auto instanceUpdateExecutorInterface = AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get();
+        if (!instanceUpdateExecutorInterface)
+        {
+            AZ_Assert(false, "InstanceUpdateExecutorInterface is unavailable for CreateNewLevelPrefab.");
+            return;
+        }
+        instanceUpdateExecutorInterface->QueueRootPrefabLoadedNotificationForNextPropagation();
+
         m_prefabSystemComponent->PropagateTemplateChanges(templateId);
         m_isRootPrefabAssigned = true;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -238,7 +238,7 @@ namespace AzToolsFramework
                             if (!m_isRootPrefabInstanceFirstLoadEnded &&
                                 instanceToUpdate->GetTemplateSourcePath() == m_rootPrefabInstanceSourcePath)
                             {
-                                PrefabPublicNotificationBus::Broadcast(&PrefabPublicNotifications::OnRootPrefabInstanceFirstLoadEnd);
+                                PrefabPublicNotificationBus::Broadcast(&PrefabPublicNotifications::OnRootPrefabInstanceLoaded);
                                 m_isRootPrefabInstanceFirstLoadEnded = true;
                             }
                         }
@@ -265,7 +265,7 @@ namespace AzToolsFramework
             return isUpdateSuccessful;
         }
 
-        void InstanceUpdateExecutor::SetRootPrefabInstanceAsNeverLoaded()
+        void InstanceUpdateExecutor::QueueRootPrefabLoadedNotificationForNextPropagation()
         {
             m_isRootPrefabInstanceFirstLoadEnded = false;
 
@@ -273,11 +273,6 @@ namespace AzToolsFramework
                 AZ::Interface<PrefabEditorEntityOwnershipInterface>::Get();
             m_rootPrefabInstanceSourcePath =
                 prefabEditorEntityOwnershipInterface->GetRootPrefabInstance()->get().GetTemplateSourcePath();
-        }
-
-        bool InstanceUpdateExecutor::IsRootPrefabInstanceFirstLoadEnded() const
-        {
-            return m_isRootPrefabInstanceFirstLoadEnded;
         }
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -235,11 +235,11 @@ namespace AzToolsFramework
                             AzToolsFramework::EditorEntityContextRequestBus::Broadcast(
                                 &AzToolsFramework::EditorEntityContextRequests::HandleEntitiesAdded, newEntities);
 
-                            if (!m_hasRootPrefabInstanceLoaded &&
+                            if (!m_isRootPrefabInstanceFirstLoadEnded &&
                                 instanceToUpdate->GetTemplateSourcePath() == m_rootPrefabInstanceSourcePath)
                             {
-                                PrefabPublicNotificationBus::Broadcast(&PrefabPublicNotifications::OnRootPrefabInstanceFirstLoaded);
-                                m_hasRootPrefabInstanceLoaded = true;
+                                PrefabPublicNotificationBus::Broadcast(&PrefabPublicNotifications::OnRootPrefabInstanceFirstLoadEnd);
+                                m_isRootPrefabInstanceFirstLoadEnded = true;
                             }
                         }
                     }
@@ -265,9 +265,9 @@ namespace AzToolsFramework
             return isUpdateSuccessful;
         }
 
-        void InstanceUpdateExecutor::SetRootPrefabInstanceAsNotLoaded()
+        void InstanceUpdateExecutor::SetRootPrefabInstanceAsNeverLoaded()
         {
-            m_hasRootPrefabInstanceLoaded = false;
+            m_isRootPrefabInstanceFirstLoadEnded = false;
 
             PrefabEditorEntityOwnershipInterface* prefabEditorEntityOwnershipInterface =
                 AZ::Interface<PrefabEditorEntityOwnershipInterface>::Get();
@@ -275,9 +275,9 @@ namespace AzToolsFramework
                 prefabEditorEntityOwnershipInterface->GetRootPrefabInstance()->get().GetTemplateSourcePath();
         }
 
-        bool InstanceUpdateExecutor::HasRootPrefabInstanceLoaded() const
+        bool InstanceUpdateExecutor::IsRootPrefabInstanceFirstLoadEnded() const
         {
-            return m_hasRootPrefabInstanceLoaded;
+            return m_isRootPrefabInstanceFirstLoadEnded;
         }
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -235,11 +235,11 @@ namespace AzToolsFramework
                             AzToolsFramework::EditorEntityContextRequestBus::Broadcast(
                                 &AzToolsFramework::EditorEntityContextRequests::HandleEntitiesAdded, newEntities);
 
-                            if (!m_isRootPrefabInstanceFirstLoadEnded &&
+                            if (!m_isRootPrefabInstanceLoaded &&
                                 instanceToUpdate->GetTemplateSourcePath() == m_rootPrefabInstanceSourcePath)
                             {
                                 PrefabPublicNotificationBus::Broadcast(&PrefabPublicNotifications::OnRootPrefabInstanceLoaded);
-                                m_isRootPrefabInstanceFirstLoadEnded = true;
+                                m_isRootPrefabInstanceLoaded = true;
                             }
                         }
                     }
@@ -267,7 +267,7 @@ namespace AzToolsFramework
 
         void InstanceUpdateExecutor::QueueRootPrefabLoadedNotificationForNextPropagation()
         {
-            m_isRootPrefabInstanceFirstLoadEnded = false;
+            m_isRootPrefabInstanceLoaded = false;
 
             PrefabEditorEntityOwnershipInterface* prefabEditorEntityOwnershipInterface =
                 AZ::Interface<PrefabEditorEntityOwnershipInterface>::Get();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Interface/Interface.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipInterface.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Prefab/Instance/Instance.h>
 #include <AzToolsFramework/Prefab/Instance/TemplateInstanceMapperInterface.h>
@@ -233,6 +234,13 @@ namespace AzToolsFramework
 
                             AzToolsFramework::EditorEntityContextRequestBus::Broadcast(
                                 &AzToolsFramework::EditorEntityContextRequests::HandleEntitiesAdded, newEntities);
+
+                            if (!m_hasRootPrefabInstanceLoaded &&
+                                instanceToUpdate->GetTemplateSourcePath() == m_rootPrefabInstanceSourcePath)
+                            {
+                                PrefabPublicNotificationBus::Broadcast(&PrefabPublicNotifications::OnRootPrefabInstanceFirstLoaded);
+                                m_hasRootPrefabInstanceLoaded = true;
+                            }
                         }
                     }
                     for (auto entityIdIterator = selectedEntityIds.begin(); entityIdIterator != selectedEntityIds.end(); entityIdIterator++)
@@ -255,6 +263,21 @@ namespace AzToolsFramework
             }
 
             return isUpdateSuccessful;
+        }
+
+        void InstanceUpdateExecutor::SetRootPrefabInstanceAsNotLoaded()
+        {
+            m_hasRootPrefabInstanceLoaded = false;
+
+            PrefabEditorEntityOwnershipInterface* prefabEditorEntityOwnershipInterface =
+                AZ::Interface<PrefabEditorEntityOwnershipInterface>::Get();
+            m_rootPrefabInstanceSourcePath =
+                prefabEditorEntityOwnershipInterface->GetRootPrefabInstance()->get().GetTemplateSourcePath();
+        }
+
+        bool InstanceUpdateExecutor::HasRootPrefabInstanceLoaded() const
+        {
+            return m_hasRootPrefabInstanceLoaded;
         }
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -35,8 +35,8 @@ namespace AzToolsFramework
             bool UpdateTemplateInstancesInQueue() override;
             void RemoveTemplateInstanceFromQueue(const Instance* instance) override;
 
-            void SetRootPrefabInstanceAsNotLoaded() override;
-            bool HasRootPrefabInstanceLoaded() const override;
+            void SetRootPrefabInstanceAsNeverLoaded() override;
+            bool IsRootPrefabInstanceFirstLoadEnded() const override;
 
             void RegisterInstanceUpdateExecutorInterface();
             void UnregisterInstanceUpdateExecutorInterface();
@@ -45,7 +45,7 @@ namespace AzToolsFramework
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
             TemplateInstanceMapperInterface* m_templateInstanceMapperInterface = nullptr;
             int m_instanceCountToUpdateInBatch = 0;
-            bool m_hasRootPrefabInstanceLoaded = false;
+            bool m_isRootPrefabInstanceFirstLoadEnded = false;
             AZ::IO::Path m_rootPrefabInstanceSourcePath;
             AZStd::deque<Instance*> m_instancesUpdateQueue;
             bool m_updatingTemplateInstancesInQueue { false };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -34,9 +34,7 @@ namespace AzToolsFramework
             void AddTemplateInstancesToQueue(TemplateId instanceTemplateId, InstanceOptionalConstReference instanceToExclude = AZStd::nullopt) override;
             bool UpdateTemplateInstancesInQueue() override;
             void RemoveTemplateInstanceFromQueue(const Instance* instance) override;
-
-            void SetRootPrefabInstanceAsNeverLoaded() override;
-            bool IsRootPrefabInstanceFirstLoadEnded() const override;
+            void QueueRootPrefabLoadedNotificationForNextPropagation() override;
 
             void RegisterInstanceUpdateExecutorInterface();
             void UnregisterInstanceUpdateExecutorInterface();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -43,7 +43,7 @@ namespace AzToolsFramework
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
             TemplateInstanceMapperInterface* m_templateInstanceMapperInterface = nullptr;
             int m_instanceCountToUpdateInBatch = 0;
-            bool m_isRootPrefabInstanceFirstLoadEnded = false;
+            bool m_isRootPrefabInstanceLoaded = false;
             AZ::IO::Path m_rootPrefabInstanceSourcePath;
             AZStd::deque<Instance*> m_instancesUpdateQueue;
             bool m_updatingTemplateInstancesInQueue { false };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -33,7 +33,10 @@ namespace AzToolsFramework
 
             void AddTemplateInstancesToQueue(TemplateId instanceTemplateId, InstanceOptionalConstReference instanceToExclude = AZStd::nullopt) override;
             bool UpdateTemplateInstancesInQueue() override;
-            virtual void RemoveTemplateInstanceFromQueue(const Instance* instance) override;
+            void RemoveTemplateInstanceFromQueue(const Instance* instance) override;
+
+            void SetRootPrefabInstanceAsNotLoaded() override;
+            bool HasRootPrefabInstanceLoaded() const override;
 
             void RegisterInstanceUpdateExecutorInterface();
             void UnregisterInstanceUpdateExecutorInterface();
@@ -42,6 +45,8 @@ namespace AzToolsFramework
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
             TemplateInstanceMapperInterface* m_templateInstanceMapperInterface = nullptr;
             int m_instanceCountToUpdateInBatch = 0;
+            bool m_hasRootPrefabInstanceLoaded = false;
+            AZ::IO::Path m_rootPrefabInstanceSourcePath;
             AZStd::deque<Instance*> m_instancesUpdateQueue;
             bool m_updatingTemplateInstancesInQueue { false };
         };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
@@ -31,13 +31,9 @@ namespace AzToolsFramework
             // Remove an Instance from the waiting queue.
             virtual void RemoveTemplateInstanceFromQueue(const Instance* instance) = 0;
 
-            // Set the executor as it never loads root prefab instance.
-            // A notification OnRootPrefabInstanceFirstLoadEnd will fire if root prefab instance
-            // is loaded for the first time after this function is called.
-            virtual void SetRootPrefabInstanceAsNeverLoaded() = 0;
-
-            // Check if root prefab instance's first load is ended after loading level file.
-            virtual bool IsRootPrefabInstanceFirstLoadEnded() const = 0;
+            // A notification OnRootPrefabInstanceLoaded will fire during the propagation if root
+            // prefab instance is loaded for the first time after this function is called.
+            virtual void QueueRootPrefabLoadedNotificationForNextPropagation() = 0;
         };
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
@@ -31,9 +31,13 @@ namespace AzToolsFramework
             // Remove an Instance from the waiting queue.
             virtual void RemoveTemplateInstanceFromQueue(const Instance* instance) = 0;
 
-            virtual void SetRootPrefabInstanceAsNotLoaded() = 0;
+            // Set the executor as it never loads root prefab instance.
+            // A notification OnRootPrefabInstanceFirstLoadEnd will fire if root prefab instance
+            // is loaded for the first time after this function is called.
+            virtual void SetRootPrefabInstanceAsNeverLoaded() = 0;
 
-            virtual bool HasRootPrefabInstanceLoaded() const = 0;
+            // Check if root prefab instance's first load is ended after loading level file.
+            virtual bool IsRootPrefabInstanceFirstLoadEnded() const = 0;
         };
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
@@ -30,6 +30,10 @@ namespace AzToolsFramework
 
             // Remove an Instance from the waiting queue.
             virtual void RemoveTemplateInstanceFromQueue(const Instance* instance) = 0;
+
+            virtual void SetRootPrefabInstanceAsNotLoaded() = 0;
+
+            virtual bool HasRootPrefabInstanceLoaded() const = 0;
         };
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicNotificationBus.h
@@ -23,6 +23,7 @@ namespace AzToolsFramework
 
             virtual void OnPrefabInstancePropagationBegin() {}
             virtual void OnPrefabInstancePropagationEnd() {}
+            virtual void OnRootPrefabInstanceFirstLoaded() {}
 
             virtual void OnPrefabTemplateDirtyFlagUpdated(
                 [[maybe_unused]] TemplateId templateId, [[maybe_unused]] bool status) {}

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicNotificationBus.h
@@ -23,7 +23,7 @@ namespace AzToolsFramework
 
             virtual void OnPrefabInstancePropagationBegin() {}
             virtual void OnPrefabInstancePropagationEnd() {}
-            virtual void OnRootPrefabInstanceFirstLoaded() {}
+            virtual void OnRootPrefabInstanceFirstLoadEnd() {}
 
             virtual void OnPrefabTemplateDirtyFlagUpdated(
                 [[maybe_unused]] TemplateId templateId, [[maybe_unused]] bool status) {}

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicNotificationBus.h
@@ -23,7 +23,7 @@ namespace AzToolsFramework
 
             virtual void OnPrefabInstancePropagationBegin() {}
             virtual void OnPrefabInstancePropagationEnd() {}
-            virtual void OnRootPrefabInstanceFirstLoadEnd() {}
+            virtual void OnRootPrefabInstanceLoaded() {}
 
             virtual void OnPrefabTemplateDirtyFlagUpdated(
                 [[maybe_unused]] TemplateId templateId, [[maybe_unused]] bool status) {}


### PR DESCRIPTION
Add new notification `OnRootPrefabInstanceLoaded` to inform users when the first root prefab instance load is done after loading current level file.

Tested manually with level opening/creating/switching. The breakpoint on code for sending `OnRootPrefabInstanceLoaded` is always triggered once the level being loaded, and all components in the root prefab instance's level container entity is de-serialized correctly when firing the notification.

Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>