### PR TITLE
Fix memory leak when storing the generic class info for Assets

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetSerializer.h
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetSerializer.h
@@ -92,15 +92,55 @@ namespace AZ {
             }
         };
 
+        class DataConverter
+            : public SerializeContext::IDataConverter
+        {
+        public:
+            bool CanConvertFromType(
+                const TypeId& convertibleTypeId,
+                const SerializeContext::ClassData& classData,
+                SerializeContext& /*serializeContext*/) override
+            {
+                return classData.m_typeId == convertibleTypeId ||
+                    (convertibleTypeId == GetAssetClassId() && classData.m_typeId == azrtti_typeid<ThisType>()) ||
+                    (convertibleTypeId == azrtti_typeid<Data::Asset<Data::AssetData>>() && classData.m_typeId == azrtti_typeid<ThisType>());
+            }
+
+            bool ConvertFromType(
+                void*& convertibleTypePtr,
+                const TypeId& convertibleTypeId,
+                void* classPtr,
+                const SerializeContext::ClassData& classData,
+                SerializeContext& serializeContext) override
+            {
+                if (CanConvertFromType(convertibleTypeId, classData, serializeContext))
+                {
+                    convertibleTypePtr = classPtr;
+                    return true;
+                }
+
+                return false;
+            }
+        };
+
         class GenericClassGenericAsset
             : public GenericClassInfo
         {
         public:
             GenericClassGenericAsset()
-                : m_classData{ SerializeContext::ClassData::Create<ThisType>("Asset", GetAssetClassId(), &m_factory, &AssetSerializer::s_serializer) }
+                : m_classData{ SerializeContext::ClassData::Create<ThisType>("Asset", GetSpecializedTypeId(), &m_factory, &AssetSerializer::s_serializer) }
             {
-                m_classData.m_version = 2;
+                m_classData.m_version = 3;
+                m_classData.m_dataConverter = &m_dataConverter;
             }
+            // The default implementation of the special member functions would
+            // not update the `m_classData.m_dataConverter` pointer, so delete
+            // them.
+            GenericClassGenericAsset(const GenericClassGenericAsset& rhs) = delete;
+            GenericClassGenericAsset(GenericClassGenericAsset&& rhs) = delete;
+            GenericClassGenericAsset& operator=(const GenericClassGenericAsset& rhs) = delete;
+            GenericClassGenericAsset& operator=(GenericClassGenericAsset&& rhs) = delete;
+            ~GenericClassGenericAsset() override = default;
 
             SerializeContext::ClassData* GetClassData() override
             {
@@ -120,7 +160,7 @@ namespace AZ {
 
             const Uuid& GetSpecializedTypeId() const override
             {
-                return GetAssetClassId();
+                return azrtti_typeid<ThisType>();
             }
 
             const Uuid& GetGenericTypeId() const override
@@ -132,13 +172,25 @@ namespace AZ {
             {
                 if (serializeContext)
                 {
-                    serializeContext->RegisterGenericClassInfo(GetSpecializedTypeId(), this, &AZ::AnyTypeInfoConcept<Data::Asset<Data::AssetData>>::CreateAny);
-                    serializeContext->RegisterGenericClassInfo(azrtti_typeid<ThisType>(), this, &AZ::AnyTypeInfoConcept<ThisType>::CreateAny);
+                    serializeContext->RegisterGenericClassInfo(GetSpecializedTypeId(), this, &AZ::AnyTypeInfoConcept<ThisType>::CreateAny);
+                    if constexpr (AZStd::is_same_v<ThisType, Data::Asset<Data::AssetData>>)
+                    {
+                        serializeContext->RegisterGenericClassInfo(GetAssetClassId(), this, &AZ::AnyTypeInfoConcept<ThisType>::CreateAny);
+                    }
+                    else
+                    {
+                        if (!serializeContext->FindGenericClassInfo(GetAssetClassId()))
+                        {
+                            SerializeGenericTypeInfo<Data::Asset<Data::AssetData>>::GetGenericInfo()->Reflect(serializeContext);
+                        }
+                    }
                 }
             }
 
             Factory m_factory;
             SerializeContext::ClassData m_classData;
+        private:
+            DataConverter m_dataConverter{};
         };
 
         using ClassInfoType = GenericClassGenericAsset;

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSerializer.cpp
@@ -204,10 +204,7 @@ namespace AZ
             return context.Report(Tasks::RetrieveInfo, Outcomes::Unknown,
                 AZStd::string::format("Failed to retrieve rtti information for %s.", elementClassData->m_name));
         }
-        // The SerializeGenericTypeInfo<Data::Asset<T>>::GenericClassGenericAsset is a special case
-        // The ClassData typeId is set to the GetAssetClassId(), while the RTTI is set using azrtti_typid<Data::Asset<T>>
-        AZ_Assert(elementClassData->m_azRtti->GetTypeId() == elementClassData->m_typeId
-            || elementClassData->m_typeId == GetAssetClassId(), "Type id mismatch in '%s' during serialization to a json file. (%s vs %s)",
+        AZ_Assert(elementClassData->m_azRtti->GetTypeId() == elementClassData->m_typeId, "Type id mismatch in '%s' during serialization to a json file. (%s vs %s)",
             elementClassData->m_name, elementClassData->m_azRtti->GetTypeId().ToString<AZStd::string>().c_str(), elementClassData->m_typeId.ToString<AZStd::string>().c_str());
 
         if (classElement.m_flags & SerializeContext::ClassElement::FLG_NO_DEFAULT_VALUE)

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
@@ -2395,7 +2395,8 @@ namespace AZ
 
         if (classData->m_serializer)
         {
-            if (classData->m_typeId == GetAssetClassId())
+            if (const auto* genericInfo = elementData ? elementData->m_genericClassInfo : FindGenericClassInfo(classData->m_typeId);
+                    genericInfo && genericInfo->GetGenericTypeId() == GetAssetClassId())
             {
                 // Optimized clone path for asset references.
                 static_cast<AssetSerializer*>(classData->m_serializer.get())->Clone(srcPtr, destPtr);

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
@@ -2531,7 +2531,7 @@ namespace AZ
         using GenericClassInfoType = typename SerializeGenericTypeInfo<T>::ClassInfoType;
         static_assert(AZStd::is_base_of<AZ::GenericClassInfo, GenericClassInfoType>::value, "GenericClassInfoType must be be derived from AZ::GenericClassInfo");
 
-        const AZ::TypeId& canonicalTypeId = AzTypeInfo<T>::Uuid();
+        const AZ::TypeId& canonicalTypeId = azrtti_typeid<T>();
         auto findIt = m_moduleLocalGenericClassInfos.find(canonicalTypeId);
         if (findIt != m_moduleLocalGenericClassInfos.end())
         {

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/InMemorySpawnableAssetContainer.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/InMemorySpawnableAssetContainer.cpp
@@ -178,11 +178,11 @@ namespace AzFramework
 
         for (AZ::Data::Asset<AZ::Data::AssetData>& asset : spawnable.m_assets)
         {
-            auto callback = [&blockingAssets](
+            auto callback = [sc, &blockingAssets](
                                 void* object, const AZ::SerializeContext::ClassData* classData,
-                                [[maybe_unused]]const AZ::SerializeContext::ClassElement* elementData) -> bool
+                                const AZ::SerializeContext::ClassElement* elementData) -> bool
             {
-                if (classData->m_typeId == AZ::GetAssetClassId())
+                if (const auto* genericInfo = elementData ? elementData->m_genericClassInfo : sc->FindGenericClassInfo(classData->m_typeId); genericInfo && genericInfo->GetGenericTypeId() == AZ::GetAssetClassId())
                 {
                     auto asset = reinterpret_cast<AZ::Data::Asset<AZ::Data::AssetData>*>(object);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
@@ -288,6 +288,15 @@ namespace AzToolsFramework
         virtual void WriteGUIValuesIntoProperty(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
         static bool ReadValuesIntoGUIInternal(size_t index, PropertyAssetCtrl* GUI, const property_t& instance, InstanceDataNode* node);
         virtual bool ReadValuesIntoGUI(size_t index, PropertyAssetCtrl* GUI, const property_t& instance, InstanceDataNode* node)  override;
+    protected:
+        AZ::Data::Asset<AZ::Data::AssetData>* CastTo(void* instance, const InstanceDataNode* node, const AZ::Uuid& /*fromId*/, const AZ::Uuid& /*toId*/) const override
+        {
+            if (node->GetElementMetadata()->m_genericClassInfo && node->GetElementMetadata()->m_genericClassInfo->GetGenericTypeId() == AZ::GetAssetClassId())
+            {
+                return static_cast<AZ::Data::Asset<AZ::Data::AssetData>*>(instance);
+            }
+            return nullptr;
+        }
     };
 
     class SimpleAssetPropertyHandlerDefault

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -21,6 +21,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystemInterface.h>
 #include <AzToolsFramework/UI/PropertyEditor/InstanceDataHierarchy.h>
+#include <AzCore/Asset/AssetSerializer.h>
 
 class QWidget;
 class QColor;
@@ -464,6 +465,11 @@ namespace AzToolsFramework
             return AZ::SerializeTypeInfo<PropertyType>::GetUuid();
         }
 
+        virtual PropertyType* CastTo(void* instance, const InstanceDataNode* node, const AZ::Uuid& fromId, const AZ::Uuid& toId) const
+        {
+            return static_cast<PropertyType*>(node->GetSerializeContext()->DownCast(instance, fromId, toId));
+        }
+
         virtual void WriteGUIValuesIntoProperty_Internal(QWidget* widget, InstanceDataNode* node) override
         {
             WidgetType* wid = static_cast<WidgetType*>(widget);
@@ -475,7 +481,7 @@ namespace AzToolsFramework
             {
                 void* instanceData = node->GetInstance(idx);
 
-                PropertyType* actualCast = static_cast<PropertyType*>(node->GetSerializeContext()->DownCast(instanceData, actualUUID, desiredUUID));
+                PropertyType* actualCast = CastTo(instanceData, node, actualUUID, desiredUUID);
                 AZ_Assert(actualCast, "Could not cast from the existing type ID to the actual typeid required by the editor.");
                 WriteGUIValuesIntoProperty(idx, wid, *actualCast, node);
             }
@@ -505,7 +511,7 @@ namespace AzToolsFramework
             {
                 void* instanceData = node->GetInstance(idx);
 
-                PropertyType* actualCast = static_cast<PropertyType*>(node->GetSerializeContext()->DownCast(instanceData, actualUUID, desiredUUID));
+                PropertyType* actualCast = CastTo(instanceData, node, actualUUID, desiredUUID);
                 AZ_Assert(actualCast, "Could not cast from the existing type ID to the actual typeid required by the editor.");
                 if (!ReadValuesIntoGUI(idx, wid, *actualCast, node))
                 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
@@ -263,19 +263,19 @@ namespace AzToolsFramework
                         return true;
                     },
                     handlerType);
-                if (classes.empty())
+                for (auto cls = classes.begin(); cls != classes.end(); ++cls)
                 {
-                    return pHandlerFound;
-                }
-                else
-                {
-                    for (auto cls = classes.begin(); cls != classes.end(); ++cls)
+                    pHandlerFound = ResolvePropertyHandler(handlerName, (*cls)->m_typeId);
+                    if (pHandlerFound)
                     {
-                        pHandlerFound = ResolvePropertyHandler(handlerName, (*cls)->m_typeId);
-                        if (pHandlerFound)
-                        {
-                            return pHandlerFound;
-                        }
+                        return pHandlerFound;
+                    }
+                }
+                if (const auto* genericInfo = sc->FindGenericClassInfo(handlerType))
+                {
+                    if (genericInfo->GetGenericTypeId() != handlerType)
+                    {
+                        return ResolvePropertyHandler(handlerName, genericInfo->GetGenericTypeId());
                     }
                 }
             }

--- a/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/SerializationDependencies.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/SerializationDependencies.cpp
@@ -24,16 +24,16 @@ namespace AssetBuilderSDK
         {
             return false;
         }
-        if (classData->m_typeId == AZ::GetAssetClassId())
+        const auto isAssetClass = [&serializeContext, classData, classElement]
         {
-            auto* asset = reinterpret_cast<AZ::Data::Asset<AZ::Data::AssetData>*>(instancePointer);
-
-            if (asset->GetId().IsValid())
+            if (classData->m_typeId == AZ::GetAssetClassId() && classData->m_version <= 2)
             {
-                productDependencySet[asset->GetId()] = AZ::Data::ProductDependencyInfo::CreateFlags(asset->GetAutoLoadBehavior());
+                return true;
             }
-        }
-        else if (classData->m_typeId == azrtti_typeid<AZ::Data::AssetId>())
+            const auto* genericInfo = classElement ? classElement->m_genericClassInfo : serializeContext.FindGenericClassInfo(classData->m_typeId);
+            return genericInfo && genericInfo->GetGenericTypeId() == AZ::GetAssetClassId();
+        };
+        if (classData->m_typeId == azrtti_typeid<AZ::Data::AssetId>())
         {
             auto* assetId = reinterpret_cast<AZ::Data::AssetId*>(instancePointer);
 
@@ -71,6 +71,15 @@ namespace AssetBuilderSDK
                 }
 
                 productPathDependencySet.emplace(filePath, ProductPathDependencyType::ProductFile);
+            }
+        }
+        else if (isAssetClass())
+        {
+            auto* asset = reinterpret_cast<AZ::Data::Asset<AZ::Data::AssetData>*>(instancePointer);
+
+            if (asset->GetId().IsValid())
+            {
+                productDependencySet[asset->GetId()] = AZ::Data::ProductDependencyInfo::CreateFlags(asset->GetAutoLoadBehavior());
             }
         }
         else if(enumerateChildren)

--- a/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYEntityOutliner.cpp
+++ b/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYEntityOutliner.cpp
@@ -883,7 +883,7 @@ namespace ImGui
                 (float)t->GetBasisY().GetX(), (float)t->GetBasisY().GetY(), (float)t->GetBasisY().GetZ(),
                 (float)t->GetBasisZ().GetX(), (float)t->GetBasisZ().GetY(), (float)t->GetBasisZ().GetZ());
         }
-        else if (classElement->m_typeId == AZ::GetAssetClassId())
+        else if (const auto* genericInfo = classElement->m_genericClassInfo; genericInfo && genericInfo->GetGenericTypeId() == AZ::GetAssetClassId())
         {
             const AZ::Data::Asset<AZ::Data::AssetData> *a = reinterpret_cast<const AZ::Data::Asset<AZ::Data::AssetData> *>(instance);
             value = AZStd::string::format("\"%s\"", a->GetHint().c_str());

--- a/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
@@ -67,8 +67,6 @@ def _get_build_directory(config):
         logger.debug(f'Custom build directory set via cli arg to: {custom_build_directory}')
         if not os.path.exists(custom_build_directory):
             raise ValueError(f'Pytest custom argument "--build-directory" does not exist at: {custom_build_directory}')
-        if custom_build_directory.endswith('debug'):
-            pytest.exit("Python debug modules are not available. LyTestTools test skipped.", 0)
     else:
         # only warn when unset, allowing non-LyTT tests to still use pytest
         logger.warning(f'Pytest custom argument "--build-directory" was not provided, tests using LyTestTools will fail')


### PR DESCRIPTION
Asset types are serialized with a custom serializer that uses the generic
serialization API. This allows for the serializer to be templated on the
asset type. Normally, the serialize context tries to create those generic
serializers only once, by keeping a map of AZ::TypeId->Serializer*. It
would look in the map to see if a serializer was already present, and only
if it wasn't found, it would create the serializer for that type.

However, the GenericClassInfo is allowed to override the typeid that
should be used to identify the types it handles. The map lookup was done
with the "canonical" typeid (ie, the result of AzTypeInfo<T>::Uuid()),
but then stored based on the generic's specialized typeid, (ie, the
result of SerializeGenericTypeInfo<T>::ClassInfoType::GetSpecializedTypeId()).
Consequently the lookup for a serializer of any asset type would never find
a previously made serializer. To make matters worse, the code that inserts
into the map does not check for pre-existing values, so it would overwrite
the existing Serializer*, resulting in a memory leak.

This fixes that issue by having the GenericTypeInfo for Assets return
the real specialized typeid for the asset type in the
`GetSpecializedTypeId()` method. Then The use the actual derived
Data::Asset<Data::AssetType>> typeid to query the Generic Asset ClassId.
That value will then be compared against GetAssetClassId() in the
serialization code.

Signed-off-by: Chris Burel <burelc@amazon.com>