### PR TITLE
MaterialEditor support for editor_test.py framework.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
@@ -100,4 +100,17 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         COMPONENT
             Atom
     )
+    ly_add_pytest(
+        NAME AutomatedTesting::Atom_Main_Null_Render_MaterialEditor
+        TEST_SUITE main
+        TEST_SERIAL
+        TIMEOUT 700
+        PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Main_Null_Render_MaterialEditor.py
+        RUNTIME_DEPENDENCIES
+            AssetProcessor
+            AutomatedTesting.Assets
+            Editor
+        COMPONENT
+            Atom
+    )
 endif()

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
@@ -9,9 +9,9 @@ import os
 
 import pytest
 
-import editor_python_test_tools.hydra_test_utils as hydra
 import ly_test_tools.environment.file_system as file_system
 from ly_test_tools.o3de.editor_test import EditorSingleTest, EditorTestSuite
+from ly_test_tools.o3de.material_editor_test import MaterialEditorSingleTest, MaterialEditorTestSuite
 from Atom.atom_utils.atom_component_helper import compare_screenshot_to_golden_image, golden_images_directory
 
 DEFAULT_SUBFOLDER_PATH = 'user/PythonTests/Automated/Screenshots'
@@ -153,36 +153,18 @@ class TestAutomation(EditorTestSuite):
                                                       similarity_threshold=0.96) is True
 
 
-@pytest.mark.parametrize("project", ["AutomatedTesting"])
-@pytest.mark.parametrize("launcher_platform", ['windows_generic'])
-class TestMaterialEditor(object):
+@pytest.mark.parametrize("launcher_platform", ['windows_material_editor'])
+class TestMaterialEditor(MaterialEditorTestSuite):
+    # Remove -BatchMode from global_extra_cmdline_args since we need rendering for these tests.
+    global_extra_cmdline_args = []
+    use_null_renderer = False
 
-    @pytest.mark.parametrize("cfg_args,expected_lines", [
-        pytest.param("-rhi=dx12", ["Registering dx12 RHI"]),
-        pytest.param("-rhi=Vulkan", ["Registering vulkan RHI"])
-    ])
-    @pytest.mark.parametrize("exe_file_name", ["MaterialEditor"])
-    @pytest.mark.test_case_id("C30973986")  # Material Editor Launching in Dx12
-    @pytest.mark.test_case_id("C30973987")  # Material Editor Launching in Vulkan
-    def test_MaterialEditorLaunch_AllRHIOptionsSucceed(
-            self, request, workspace, project, launcher_platform, generic_launcher, exe_file_name, cfg_args,
-            expected_lines):
-        """
-        Tests each valid RHI option (Null RHI excluded) can be launched with the MaterialEditor.
-        Checks for the specific expected_lines messaging for each RHI type.
-        """
+    class MaterialEditor_Atom_LaunchMaterialEditorDX12(MaterialEditorSingleTest):
+        extra_cmdline_args = ["-rhi=dx12"]
 
-        hydra.launch_and_validate_results(
-            request,
-            os.path.join(os.path.dirname(__file__), "tests"),
-            generic_launcher,
-            editor_script="",
-            run_python="--runpython",
-            timeout=60,
-            expected_lines=expected_lines,
-            unexpected_lines=[],
-            halt_on_unexpected=False,
-            null_renderer=False,
-            cfg_args=[cfg_args],
-            log_file_name="MaterialEditor.log",
-        )
+        from Atom.tests import MaterialEditor_Atom_LaunchMaterialEditor as test_module
+
+    class MaterialEditor_Atom_LaunchMaterialEditorVulkan(MaterialEditorSingleTest):
+        extra_cmdline_args = ["-rhi=Vulkan"]
+
+        from Atom.tests import MaterialEditor_Atom_LaunchMaterialEditor as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_MaterialEditor.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_MaterialEditor.py
@@ -1,0 +1,23 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+import logging
+import os
+import pytest
+
+from ly_test_tools.o3de.material_editor_test import MaterialEditorBatchedTest, MaterialEditorTestSuite
+
+logger = logging.getLogger(__name__)
+TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), "tests")
+
+
+@pytest.mark.parametrize("project", ["AutomatedTesting"])
+@pytest.mark.parametrize("launcher_platform", ['windows_material_editor'])
+class TestMaterialEditor(MaterialEditorTestSuite):
+
+    class MaterialEditor_Atom_LaunchMaterialEditor(MaterialEditorBatchedTest):
+
+        from Atom.tests import MaterialEditor_Atom_LaunchMaterialEditor as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_LaunchMaterialEditor.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_LaunchMaterialEditor.py
@@ -1,0 +1,52 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+
+class Tests:
+    material_editor_launched = (
+        "Inspector pane is visible, MaterialEditor launch succeeded",
+        "P0: Inspector pane not visible, MaterialEditor launch failed"
+    )
+
+
+def MaterialEditor_Launched_SuccessfullyLaunched():
+    """
+    Summary:
+    Tests that the MaterialEditor can be launched successfully.
+
+    Expected Behavior:
+    The MaterialEditor executable can be launched and doesn't cause any crashes or errors.
+
+    Test Steps:
+    1) Verify Material Inspector pane visibility to confirm the MaterialEditor launched.
+    2) Look for errors and asserts.
+
+    :return: None
+    """
+
+    import Atom.atom_utils.material_editor_utils as material_editor
+
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+
+    with Tracer() as error_tracer:
+        # 1. Verify Material Inspector pane visibility to confirm the MaterialEditor launched.
+        material_editor.set_pane_visibility("Inspector", True)
+        Report.result(
+            Tests.material_editor_launched,
+            material_editor.is_pane_visible("Inspector") == True)
+
+    # 2. Look for errors and asserts.
+    TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+    for error_info in error_tracer.errors:
+        Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+    for assert_info in error_tracer.asserts:
+        Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(MaterialEditor_Launched_SuccessfullyLaunched)

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
@@ -13,7 +13,10 @@ import traceback
 from typing import Callable, Tuple
 
 import azlmbr
-import azlmbr.legacy.general as general
+try:
+    import azlmbr.legacy.general as general  # Editor test.
+except ModuleNotFoundError:  # MaterialEditor test.
+    import azlmbr.atomtools.general as general
 import azlmbr.multiplayer as multiplayer
 import azlmbr.debug
 import ly_test_tools.environment.waiter as waiter
@@ -307,7 +310,7 @@ class Report:
             Report._exception = traceback.format_exc()
 
         success, report_str = Report.get_report(test_function)
-        # Print on the o3de console, for debugging purpuses
+        # Print on the o3de console, for debugging purposes
         print(report_str)
         # Print the report on the piped stdout of the application
         general.test_output(report_str)

--- a/Tools/LyTestTools/ly_test_tools/__init__.py
+++ b/Tools/LyTestTools/ly_test_tools/__init__.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 # Supported platforms
 ALL_PLATFORM_OPTIONS = ['android', 'ios', 'linux', 'mac', 'windows']
-ALL_LAUNCHER_OPTIONS = ['android', 'base', 'linux', 'mac', 'windows', 'windows_editor', 'windows_dedicated', 'windows_generic']
+ALL_LAUNCHER_OPTIONS = ['android', 'base', 'linux', 'mac', 'windows', 'windows_editor', 'windows_dedicated', 'windows_generic', 'windows_material_editor']
 ANDROID = False
 IOS = False  # Not implemented - see SPEC-2505
 LINUX = sys.platform.startswith('linux')
@@ -25,6 +25,7 @@ HOST_OS_PLATFORM = 'unknown'
 HOST_OS_EDITOR = 'unknown'
 HOST_OS_DEDICATED_SERVER = 'unknown'
 HOST_OS_GENERIC_EXECUTABLE = 'unknown'
+HOST_OS_MATERIAL_EDITOR = 'unknown'
 LAUNCHERS = {}
 for launcher_option in ALL_LAUNCHER_OPTIONS:
     LAUNCHERS[launcher_option] = None
@@ -35,19 +36,22 @@ if WINDOWS:
     HOST_OS_EDITOR = 'windows_editor'
     HOST_OS_DEDICATED_SERVER = 'windows_dedicated'
     HOST_OS_GENERIC_EXECUTABLE = 'windows_generic'
+    HOST_OS_MATERIAL_EDITOR = 'windows_material_editor'
     import ly_test_tools.mobile.android
     from ly_test_tools.launchers import (
-        AndroidLauncher, WinLauncher, DedicatedWinLauncher, WinEditor, WinGenericLauncher)
+        AndroidLauncher, WinLauncher, DedicatedWinLauncher, WinEditor, WinGenericLauncher, WinMaterialEditor)
     ANDROID = ly_test_tools.mobile.android.can_run_android()
     LAUNCHERS['windows'] = WinLauncher
     LAUNCHERS['windows_editor'] = WinEditor
     LAUNCHERS['windows_dedicated'] = DedicatedWinLauncher
     LAUNCHERS['windows_generic'] = WinGenericLauncher
+    LAUNCHERS['windows_material_editor'] = WinMaterialEditor
     LAUNCHERS['android'] = AndroidLauncher
 elif MAC:
     HOST_OS_PLATFORM = 'mac'
     HOST_OS_EDITOR = NotImplementedError('LyTestTools does not yet support Mac editor')
     HOST_OS_DEDICATED_SERVER = NotImplementedError('LyTestTools does not yet support Mac dedicated server')
+    HOST_OS_MATERIAL_EDITOR = NotImplementedError('LyTestTools does not yet support Mac material_editor')
     from ly_test_tools.launchers import MacLauncher
     LAUNCHERS['mac'] = MacLauncher
 elif LINUX:
@@ -55,10 +59,12 @@ elif LINUX:
     HOST_OS_EDITOR = 'linux_editor'
     HOST_OS_DEDICATED_SERVER = 'linux_dedicated'
     HOST_OS_GENERIC_EXECUTABLE = 'linux_generic'
-    from ly_test_tools.launchers.platforms.linux.launcher import (LinuxLauncher, LinuxEditor, DedicatedLinuxLauncher, LinuxGenericLauncher)
+    HOST_OS_MATERIAL_EDITOR = 'linux_material_editor'
+    from ly_test_tools.launchers.platforms.linux.launcher import (LinuxLauncher, LinuxEditor, DedicatedLinuxLauncher, LinuxGenericLauncher, LinuxMaterialEditor)
     LAUNCHERS['linux'] = LinuxLauncher
     LAUNCHERS['linux_editor'] = LinuxEditor
     LAUNCHERS['linux_dedicated'] = DedicatedLinuxLauncher
     LAUNCHERS['linux_generic'] = LinuxGenericLauncher
+    LAUNCHERS['linux_material_editor'] = LinuxMaterialEditor
 else:
     logger.warning(f'WARNING: LyTestTools only supports Windows, Mac, and Linux. Unexpectedly detected HOST_OS_PLATFORM: "{HOST_OS_PLATFORM}".')

--- a/Tools/LyTestTools/ly_test_tools/_internal/managers/abstract_resource_locator.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/managers/abstract_resource_locator.py
@@ -414,3 +414,14 @@ class AbstractResourceLocator(object):
             "crash_log() is not implemented on the base AbstractResourceLocator() class. "
             "It must be defined by the inheriting class - "
             "i.e. _WindowsResourceLocator(AbstractResourceLocator).crash_log()")
+
+    @abstractmethod
+    def material_editor_log(self):
+        """
+        Return path to the project's MaterialEditor log dir using the builds project and platform
+        :return: path to MaterialEditor.log
+        """
+        raise NotImplementedError(
+            "material_editor_log() is not implemented on the base AbstractResourceLocator() class. "
+            "It must be defined by the inheriting class - "
+            "i.e. _WindowsResourceLocator(AbstractResourceLocator).material_editor_log()")

--- a/Tools/LyTestTools/ly_test_tools/_internal/managers/platforms/linux.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/managers/platforms/linux.py
@@ -60,6 +60,14 @@ class _LinuxResourceManager(AbstractResourceLocator):
         """
         return os.path.join(self.project_log(), "crash.log")
 
+    def material_editor_log(self):
+        """
+        Return path to the project's MaterialEditor log dir using the builds project and platform
+        :return: path to MaterialEditor.log
+        """
+        return os.path.join(self.project_log(), "MaterialEditor.log")
+
+
 class LinuxWorkspaceManager(AbstractWorkspaceManager):
     """
     A Linux host WorkspaceManager. Contains Mac overridden functions for the AbstractWorkspaceManager class.

--- a/Tools/LyTestTools/ly_test_tools/_internal/managers/platforms/windows.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/managers/platforms/windows.py
@@ -75,6 +75,14 @@ class _WindowsResourceLocator(AbstractResourceLocator):
         """
         return os.path.join(self.project_log(), "error.log")
 
+    def material_editor_log(self):
+        """
+        Return path to the project's MaterialEditor log dir using the builds project and platform
+        :return: path to MaterialEditor.log
+        """
+        return os.path.join(self.project_log(), "MaterialEditor.log")
+
+
 class WindowsWorkspaceManager(AbstractWorkspaceManager):
     """
     A Windows host WorkspaceManager. Contains Windows overridden functions for the AbstractWorkspaceManager class.

--- a/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
@@ -289,6 +289,20 @@ def _dedicated_launcher(request, workspace, launcher_platform, level=""):
 
 
 @pytest.fixture(scope="function")
+def material_editor(workspace, request, crash_log_watchdog):
+    # type: (...) -> ly_test_tools.launchers.platforms.base.Launcher
+    return _material_editor(
+        request=request,
+        workspace=workspace,
+        launcher_platform=get_fixture_argument(request, 'launcher_platform', HOST_OS_PLATFORM))
+
+
+def _material_editor(request, workspace, launcher_platform):
+    """Separate implementation to call directly during unit tests"""
+    return ly_test_tools.launchers.launcher_helper.create_material_editor(workspace, launcher_platform)
+
+
+@pytest.fixture(scope="function")
 def generic_launcher(workspace, request, crash_log_watchdog):
     # type: (...) -> ly_test_tools.launchers.platforms.base.Launcher
     return _generic_launcher(

--- a/Tools/LyTestTools/ly_test_tools/launchers/__init__.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/__init__.py
@@ -6,7 +6,9 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 from ly_test_tools.launchers.platforms.base import Launcher
-from ly_test_tools.launchers.platforms.linux.launcher import LinuxLauncher, LinuxEditor, DedicatedLinuxLauncher
+from ly_test_tools.launchers.platforms.linux.launcher import (
+    LinuxLauncher, LinuxEditor, DedicatedLinuxLauncher, LinuxMaterialEditor)
 from ly_test_tools.launchers.platforms.mac.launcher import MacLauncher
-from ly_test_tools.launchers.platforms.win.launcher import WinLauncher, DedicatedWinLauncher, WinEditor, WinGenericLauncher
+from ly_test_tools.launchers.platforms.win.launcher import (
+    WinLauncher, DedicatedWinLauncher, WinEditor, WinGenericLauncher, WinMaterialEditor)
 from ly_test_tools.launchers.platforms.android.launcher import AndroidLauncher

--- a/Tools/LyTestTools/ly_test_tools/launchers/launcher_helper.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/launcher_helper.py
@@ -122,6 +122,24 @@ def create_editor(workspace, launcher_platform=ly_test_tools.HOST_OS_EDITOR, arg
     return launcher_class(workspace, args)
 
 
+def create_material_editor(workspace, launcher_platform=ly_test_tools.HOST_OS_MATERIAL_EDITOR, args=None):
+    # type: (workspace_manager.AbstractWorkspaceManager, str, list[str]) -> base_launcher.Launcher
+    """
+    Create a MaterialEditor compatible with the specified workspace.
+    MaterialEditor is only officially supported on the Windows Platform.
+    :param workspace: lumberyard workspace to use
+    :param launcher_platform: the platform to target for a launcher (i.e. 'windows_dedicated' for DedicatedWinLauncher)
+    :param args: List of arguments to pass to the launcher's 'args' argument during construction
+    :return: MaterialEditor instance
+    """
+    launcher_class = ly_test_tools.LAUNCHERS.get(launcher_platform)
+    if not launcher_class:
+        log.warning(f"Using default MaterialEditor launcher for '{ly_test_tools.HOST_OS_MATERIAL_EDITOR}' "
+                    f"as no option is available for '{launcher_platform}'")
+        launcher_class = ly_test_tools.LAUNCHERS.get(ly_test_tools.HOST_OS_MATERIAL_EDITOR)
+    return launcher_class(workspace, args)
+
+
 def create_generic_launcher(workspace, launcher_platform, exe_file_name, args=None):
     # type: (workspace_manager.AbstractWorkspaceManager, str, str, list[str]) -> base_launcher.Launcher
     """

--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/linux/launcher.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/linux/launcher.py
@@ -251,3 +251,17 @@ class LinuxGenericLauncher(LinuxLauncher):
         assert self.workspace.project is not None, (
             'Project cannot be NoneType - please specify a project name string.')
         return self.expected_executable_path
+
+
+class LinuxMaterialEditor(LinuxLauncher):
+
+    def __init__(self, build, args=None):
+        super(LinuxMaterialEditor, self).__init__(build, args)
+
+    def binary_path(self):
+        """
+        Return full path to the MaterialEditor for this build's configuration and project
+        :return: full path to MaterialEditor
+        """
+        assert self.workspace.project is not None
+        return os.path.join(self.workspace.paths.build_directory(), "MaterialEditor")

--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/win/launcher.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/win/launcher.py
@@ -250,3 +250,20 @@ class WinGenericLauncher(WinLauncher):
         assert self.workspace.project is not None, (
             'Project cannot be NoneType - please specify a project name string.')
         return self.expected_executable_path
+
+
+class WinMaterialEditor(WinLauncher):
+
+    def __init__(self, build, args=None):
+        super(WinMaterialEditor, self).__init__(build, args)
+        self.args.append('--regset="/Amazon/Settings/EnableSourceControl=false"')
+        self.args.append('--regset="/Amazon/AWS/Preferences/AWSAttributionConsentShown=true"')
+        self.args.append('--regset="/Amazon/AWS/Preferences/AWSAttributionEnabled=false"')
+
+    def binary_path(self):
+        """
+        Return full path to the MaterialEditor for this build's configuration and project
+        :return: full path to MaterialEditor
+        """
+        assert self.workspace.project is not None
+        return os.path.join(self.workspace.paths.build_directory(), "MaterialEditor.exe")

--- a/Tools/LyTestTools/ly_test_tools/o3de/multi_test_framework.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/multi_test_framework.py
@@ -1,0 +1,556 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+# Simplified O3DE test-writing utilities.
+#
+# Supports different options for running tests using this framework ("instance" refers to the executable under test).
+#
+# SingleTest: A single test that runs 1 test in 1 instance.
+# SharedTest: Multiple tests that run multiple tests in multiple instances.
+# BatchedTest: Multiple tests that run 1 instance with multiple tests in that 1 instance.
+# ParallelTest: Multiple tests that run multiple instances with 1 test in each instance.
+
+from __future__ import annotations
+__test__ = False  # Avoid pytest collection & warnings since this module is for test functions, but not a test itself.
+
+import abc
+import json
+import inspect
+import re
+import warnings
+
+import pytest
+import _pytest.python
+import _pytest.outcomes
+from _pytest.skipping import pytest_runtest_setup as skipping_pytest_runtest_setup
+
+import ly_test_tools.environment.process_utils as process_utils
+import ly_test_tools.o3de.editor_test_utils as editor_utils
+from ly_test_tools._internal.managers.workspace import AbstractWorkspaceManager
+from ly_test_tools.o3de.asset_processor import AssetProcessor
+
+
+class AbstractTestBase(abc.ABC):
+    """
+    Abstract base Test class
+    """
+    # Maximum time for run, in seconds.
+    timeout = 180
+    # Test file that this test will run.
+    test_module = None
+    # Attach debugger when running the test, useful for debugging crashes. This should never be True on production.
+    # It's also recommended to switch to SingleTest for debugging in isolation.
+    attach_debugger = False
+    # Wait until a debugger is attached at the startup of the test, this is another way of debugging.
+    wait_for_debugger = False
+
+
+class SingleTest(AbstractTestBase):
+    """
+    Test that will be run alone in one instance, with no parallel or serially batched instances.
+    This should only be used if SharedTest, ParallelTest, or BatchedTest cannot be utilized for the test steps.
+    It may also be used for debugging test issues in isolation.
+    """
+    def __init__(self):
+        # Extra cmdline arguments to supply to the instance for the test.
+        self.extra_cmdline_args = []
+        # Whether to use null renderer, this will override use_null_renderer for the BaseTestSuite if not None.
+        self.use_null_renderer = None
+
+    def setup(self, **args):
+        """
+        User-overrideable setup function, which will run before the test
+        """
+        pass
+
+    def wrap_run(self, **args):
+        """
+        User-overrideable wrapper function, which will run before and after test.
+        Any code before the 'yield' statement will run before the test. With code after yield run after the test.
+        """
+        yield
+
+    def teardown(self, **args):
+        """
+        User-overrideable teardown function, which will run after the test
+        """
+        pass
+
+
+class SharedTest(AbstractTestBase):
+    """
+    Can be one of two different test types:
+    1. Test that will be run in parallel with tests in multiple instances.
+    2. Test that will be run as serially batched with other tests in a single instance.
+
+    Minimizes total test run duration by reducing repeated overhead from starting the instance.
+    Does not support per test setup/teardown to avoid creating race conditions.
+    """
+    # Specifies if the test can be batched in the same instance.
+    is_batchable = True
+    # Specifies if the test can be run in multiple instances in parallel.
+    is_parallelizable = True
+
+
+class ParallelTest(SharedTest):
+    """Test that will be run in parallel with tests in multiple instances."""
+    is_batchable = False
+    is_parallelizable = True
+
+
+class BatchedTest(SharedTest):
+    """Test that will be run as serially batched with other tests in a single instance."""
+    is_batchable = True
+    is_parallelizable = False
+
+
+class AbstractTestSuite(object):
+    """
+    Main object used to run the tests.
+    The new test suite class you create for your tests should inherit from this base AbstractTestSuite class.
+    """
+    # When this object is inherited, add any custom attributes as needed.
+    # Test class to use for single test collection
+    single_test_class = SingleTest
+    # Test class to use for shared test collection
+    shared_test_class = SharedTest
+    # The number of instances to run in parallel for this test suite.
+    num_parallel_instances = 8
+
+    @classmethod
+    def get_instance_log_str(cls):
+        # type () -> str
+        """
+        Checks if a given instance's log attribute exists and returns it.
+        :return: Either the object attribute matching "instance_log_attribute_name" or None.
+        """
+        log = getattr(cls, "instance_log_attribute_name", None)
+        if log:
+            return log
+        else:
+            return "-- No instance (executable or app under test) log found --"
+
+    @classmethod
+    def get_output_str(cls):
+        # type () -> str
+        """
+        Checks if the output attribute exists and returns it.
+        :return: Output string from running a test, or a no output message.
+        """
+        output = getattr(cls, "output", None)
+        if output:
+            return output
+        else:
+            return "-- No output --"
+
+    @classmethod
+    def get_number_parallel_instances(cls):
+        """Function to calculate number of instances to run in parallel, this can be overridden by the user."""
+        return cls.num_parallel_instances
+
+    class TestData:
+        __test__ = False  # Avoid pytest collection & warnings since "test" is in the class name.
+
+        def __init__(self):
+            self.results = {}  # Dict of str(test_spec.__name__) -> Result
+            self.asset_processor = None
+
+    @pytest.fixture(scope="class")
+    def collected_test_data(self, request: _pytest.fixtures.FixtureRequest) -> AbstractTestSuite.TestData:
+        """
+        Yields a per-testsuite structure to store the data of each test result and an AssetProcessor object that will be
+        re-used on the whole suite
+        :request: The Pytest request object
+        :yield: The TestData object
+        """
+        yield from self._collected_test_data(request)
+
+    def _collected_test_data(self, request: _pytest.fixtures.FixtureRequest) -> AbstractTestSuite.TestData:
+        """
+        A wrapper function for unit testing of this file to call directly. Do not use in production.
+        """
+        test_data = self.TestData()
+        yield test_data
+        if test_data.asset_processor:
+            test_data.asset_processor.stop(1)
+            test_data.asset_processor.teardown()
+            test_data.asset_processor = None
+            editor_utils.kill_all_ly_processes(include_asset_processor=True)
+        else:
+            editor_utils.kill_all_ly_processes(include_asset_processor=False)
+
+    class Runner:
+        def __init__(self, name, func, tests):
+            self.name = name
+            self.func = func
+            self.tests = tests
+            self.run_pytestfunc = None
+            self.result_pytestfuncs = []
+
+    # TODO: A custom class to use these functions to collect and run tests goes here (RFC will be written).
+    # Editor tests use ly_test_tools.o3de.editor_test.EditorTestSuite.EditorTestClass
+    # MaterialEditor tests use ly_test_tools.o3de.material_editor_test.MaterialEditorTestSuite.MaterialEditorTestClass
+
+    @classmethod
+    def get_single_tests(cls) -> list[single_test_class]:
+        """
+        Grabs all of the single_test_class subclassed tests from the AbstractTestSuite class.
+        Usage example:
+           class MyTestSuite(AbstractTestSuite):
+               class MyFirstTest(SingleTest):
+                   from . import script_to_be_run_as_single_test as test_module
+        :return: The list of single tests
+        """
+        single_tests = [
+            c[1] for c in cls.__dict__.items() if inspect.isclass(c[1]) and issubclass(c[1], cls.single_test_class)]
+        return single_tests
+
+    @classmethod
+    def get_shared_tests(cls) -> list[shared_test_class]:
+        """
+        Grabs all of the shared_test_class from the AbstractTestSuite
+        Usage example:
+           class MyTestSuite(AbstractTestSuite):
+               class MyFirstTest(SharedTest):
+                   from . import test_script_to_be_run_1 as test_module
+               class MyFirstTest(SharedTest):
+                   from . import test_script_to_be_run_2 as test_module
+        :return: The list of shared tests
+        """
+        shared_tests = [
+            c[1] for c in cls.__dict__.items() if inspect.isclass(c[1]) and issubclass(c[1], cls.shared_test_class)]
+        return shared_tests
+
+    @classmethod
+    def get_session_shared_tests(cls, session: _pytest.main.Session) -> list[shared_test_class]:
+        """
+        Filters and returns all of the shared tests in a given session.
+        :session: The test session
+        :return: The list of tests
+        """
+        shared_tests = cls.get_shared_tests()
+        return cls.filter_session_shared_tests(session, shared_tests)
+
+    @staticmethod
+    def filter_session_shared_tests(session_items: list[_pytest.python.Function(shared_test_class)],
+                                    shared_tests: list[shared_test_class]) -> list[shared_test_class]:
+        """
+        Retrieve the test sub-set that was collected this can be less than the original set if were overridden via -k
+        argument or similar
+        :session_items: The tests in a session to run
+        :shared_tests: All of the shared tests
+        :return: The list of filtered tests
+        """
+
+        def will_run(item):
+            try:
+                skipping_pytest_runtest_setup(item)
+                return True
+            except (Warning, Exception, _pytest.outcomes.OutcomeException) as ex:
+                # intentionally broad to avoid events other than system interrupts
+                warnings.warn(f"Test deselected from execution queue due to {ex}")
+                return False
+
+        session_items_by_name = {item.originalname: item for item in session_items}
+        selected_shared_tests = [test for test in shared_tests if test.__name__ in session_items_by_name.keys() and
+                                 will_run(session_items_by_name[test.__name__])]
+        return selected_shared_tests
+
+    @staticmethod
+    def filter_shared_tests(shared_tests: list[shared_test_class],
+                            is_batchable: bool = False,
+                            is_parallelizable: bool = False) -> list[shared_test_class]:
+        """
+        Filters and returns all tests based off of if they are batched and/or parallel
+        :shared_tests: All shared tests
+        :is_batchable: Filter to batched tests
+        :is_parallelizable: Filter to parallel tests
+        :return: The list of filtered tests
+        """
+        return [
+            t for t in shared_tests if (
+                    getattr(t, "is_batchable", None) is is_batchable
+                    and
+                    getattr(t, "is_parallelizable", None) is is_parallelizable
+            )
+        ]
+
+    def _prepare_asset_processor(self,
+                                 workspace: AbstractWorkspaceManager,
+                                 collected_test_data: AbstractTestSuite.TestData) -> None:
+        """
+        Prepares the asset processor for the test depending on whether or not the process is open and if the current
+        test owns it.
+        :workspace: The workspace object in case an AssetProcessor object needs to be created
+        :collected_test_data: The test data from calling collected_test_data()
+        :return: None
+        """
+        try:
+            # Start-up an asset processor if we are not running one
+            # If another AP process exist, don't kill it, as we don't own it
+            if collected_test_data.asset_processor is None:
+                if not process_utils.process_exists("AssetProcessor", ignore_extensions=True):
+                    editor_utils.kill_all_ly_processes(include_asset_processor=True)
+                    collected_test_data.asset_processor = AssetProcessor(workspace)
+                    collected_test_data.asset_processor.start()
+                else:
+                    editor_utils.kill_all_ly_processes(include_asset_processor=False)
+            else:
+                # Make sure the asset processor from before wasn't closed by accident
+                collected_test_data.asset_processor.start()
+        except Exception as ex:
+            collected_test_data.asset_processor = None
+            raise ex
+
+    @staticmethod
+    def _get_results_using_output(test_spec_list: list[AbstractTestBase],
+                                  output: str,
+                                  test_log_content: str) -> dict[any, [Result.Unknown, Result.Pass, Result.Fail]]:
+        """
+        Utility function for parsing the output information from the test. It deserializes the JSON content printed in
+        the output for every test and returns that information.
+        :test_spec_list: The list of tests inheriting from AbstractTestBase
+        :output: The output str to parse results from
+        :test_log_content: The contents of the test log as a string
+        :return: A dict of the tests and their respective Result objects
+        """
+        results = {}
+        pattern = re.compile(r"JSON_START\((.+?)\)JSON_END")
+        out_matches = pattern.finditer(output)
+        found_jsons = {}
+        for m in out_matches:
+            try:
+                elem = json.loads(m.groups()[0])
+                found_jsons[elem["name"]] = elem
+            except Exception:  # Intentionally broad to avoid failing if the output data is corrupt
+                continue
+
+        # Try to find the element in the log, this is used for cutting the log contents later
+        log_matches = pattern.finditer(test_log_content)
+        for m in log_matches:
+            try:
+                elem = json.loads(m.groups()[0])
+                if elem["name"] in found_jsons:
+                    found_jsons[elem["name"]]["log_match"] = m
+            except Exception:  # Intentionally broad, to avoid failing if the log data is corrupt
+                continue
+
+        log_start = 0
+        for test_spec in test_spec_list:
+            name = editor_utils.get_module_filename(test_spec.test_module)
+            if name not in found_jsons.keys():
+                results[test_spec.__name__] = Result.Unknown(
+                    test_spec, output,
+                    f"Found no test run information on stdout for {name} in the test log",
+                    test_log_content)
+            else:
+                result = None
+                json_result = found_jsons[name]
+                json_output = json_result["output"]
+
+                # Cut the editor log so it only has the output for this run
+                if "log_match" in json_result:
+                    m = json_result["log_match"]
+                    end = m.end() if test_spec != test_spec_list[-1] else -1
+                else:
+                    end = -1
+                cur_log = test_log_content[log_start: end]
+                log_start = end
+
+                if json_result["success"]:
+                    result = Result.Pass(test_spec, json_output, cur_log)
+                else:
+                    result = Result.Fail(test_spec, json_output, cur_log)
+                results[test_spec.__name__] = result
+
+        return results
+
+    @staticmethod
+    def _report_result(name: str, result: Result) -> None:
+        """
+        Fails the test if the test result is not a PASS, specifying the information
+        :name: Name of the test
+        :result: The Result object which denotes if the test passed or not
+        :return: None
+        """
+        if isinstance(result, Result.Pass):
+            output_str = f"Test {name}:\n{str(result)}"
+            print(output_str)
+        else:
+            error_str = f"Test {name}:\n{str(result)}"
+            pytest.fail(error_str)
+
+    def _setup_test_run(self,
+                        workspace: AbstractWorkspaceManager,
+                        collected_test_data: AbstractTestSuite.TestData) -> None:
+        """
+        Sets up a test run by preparing the Asset Processor and killing all other O3DE processes relevant to tests.
+        :workspace: The test Workspace object
+        :collected_test_data: The TestData from calling collected_test_data()
+        :return: None
+        """
+        self._prepare_asset_processor(workspace, collected_test_data)
+        editor_utils.kill_all_ly_processes(include_asset_processor=False)
+
+
+class Result(object):
+
+    class UnknownResultException(Exception):
+        """Indicates that an unknown result was found during the tests."""
+
+    class Pass(object):
+
+        def __init__(self, test_spec: type(AbstractTestBase), output: str, test_instance_log: str):
+            """
+            Represents a test success.
+            :test_spec: The test class of the test.
+            :output: The test output.
+            :test_instance_log: The instance (executable or app under test) log's output.
+            """
+            self.test_spec = test_spec
+            self.output = output
+            self.test_instance_log = test_instance_log
+
+        def __str__(self):
+            output = (
+                f"Test Passed\n"
+                f"------------\n"
+                f"|  Output  |\n"
+                f"------------\n"
+                f"{AbstractTestSuite.get_output_str()}\n"
+            )
+            return output
+
+    class Fail(object):
+
+        def __init__(self, test_spec: type(AbstractTestBase), output: str, test_instance_log: str):
+            """
+            Represents a normal test failure.
+            :test_spec: The test class of the test.
+            :output: The test output.
+            :test_instance_log: The instance (executable or app under test) log's output.
+            """
+            self.test_spec = test_spec
+            self.output = output
+            self.test_instance_log = test_instance_log
+
+        def __str__(self):
+            output = (
+                f"Test FAILED\n"
+                f"------------\n"
+                f"|  Output  |\n"
+                f"------------\n"
+                f"{AbstractTestSuite.get_output_str()}\n"
+                f"--------------\n"
+                f"| Log |\n"
+                f"--------------\n"
+                f"{AbstractTestSuite.get_instance_log_str()}\n"
+            )
+            return output
+
+    class Crash(object):
+
+        def __init__(self,
+                     test_spec: type(AbstractTestBase),
+                     output: str,
+                     ret_code: int,
+                     stacktrace: str,
+                     test_instance_log: str or None):
+            """
+            Represents a test which failed with an unexpected crash.
+            :test_spec: The test class of the test.
+            :output: The test output.
+            :ret_code: The test's return code.
+            :stacktrace: The test's stacktrace if available.
+            :test_instance_log: The instance (executable or app under test) log's output.
+            """
+            self.output = output
+            self.test_spec = test_spec
+            self.ret_code = ret_code
+            self.stacktrace = stacktrace
+            self.test_instance_log = test_instance_log
+
+        def __str__(self):
+            stacktrace_str = "-- No stacktrace data found --" if not self.stacktrace else self.stacktrace
+            output = (
+                f"Test CRASHED, return code {hex(self.ret_code)}\n"
+                f"---------------\n"
+                f"|  Stacktrace |\n"
+                f"---------------\n"
+                f"{stacktrace_str}"
+                f"------------\n"
+                f"|  Output  |\n"
+                f"------------\n"
+                f"{AbstractTestSuite.get_output_str()}\n"
+                f"--------------\n"
+                f"| Log |\n"
+                f"--------------\n"
+                f"{AbstractTestSuite.get_instance_log_str()}\n"
+            )
+            return output
+
+    class Timeout(object):
+
+        def __init__(self, test_spec: type(AbstractTestBase), output: str, time_secs: float, test_instance_log: str):
+            """
+            Represents a test which failed due to freezing, hanging, or executing slowly.
+            :test_spec: The test class of the test.
+            :output: The test output.
+            :time_secs: The timeout duration in seconds.
+            :test_instance_log: The instance (executable or app under test) log's output.
+            :return: The Timeout object.
+            """
+            self.output = output
+            self.test_spec = test_spec
+            self.time_secs = time_secs
+            self.test_instance_log = test_instance_log
+
+        def __str__(self):
+            output = (
+                f"Test ABORTED after not completing within {self.time_secs} seconds\n"
+                f"------------\n"
+                f"|  Output  |\n"
+                f"------------\n"
+                f"{AbstractTestSuite.get_output_str()}\n"
+                f"--------------\n"
+                f"| Log |\n"
+                f"--------------\n"
+                f"{AbstractTestSuite.get_instance_log_str()}\n"
+            )
+            return output
+
+    class Unknown(object):
+
+        def __init__(self,
+                     test_spec: type(AbstractTestBase or SingleTest or SharedTest or Result),
+                     output: str = None,
+                     extra_info: str = None,
+                     test_instance_log: str = None):
+            """
+            Represents a failure that the test framework cannot classify.
+            :test_spec: The test class of the test.
+            :output: The test output.
+            :extra_info: Any extra information as a string.
+            :test_instance_log: The instance (executable or app under test) log's output.
+            """
+            self.output = output
+            self.test_spec = test_spec
+            self.test_instance_log = test_instance_log
+            self.extra_info = extra_info
+
+        def __str__(self):
+            output = (
+                f"Indeterminate test result interpreted as failure, possible cause: {self.extra_info}\n"
+                f"------------\n"
+                f"|  Output  |\n"
+                f"------------\n"
+                f"{AbstractTestSuite.get_output_str()}\n"
+                f"--------------\n"
+                f"| Log |\n"
+                f"--------------\n"
+                f"{AbstractTestSuite.get_instance_log_str()}\n"
+            )
+            return output

--- a/Tools/LyTestTools/tests/unit/test_editor_test_utils.py
+++ b/Tools/LyTestTools/tests/unit/test_editor_test_utils.py
@@ -129,7 +129,7 @@ class TestEditorTestUtils(unittest.TestCase):
         mock_log = 'mock log info'
 
         with mock.patch('builtins.open', mock.mock_open(read_data=mock_log)) as mock_file:
-            assert f'[{mock_logname}]  {mock_log}' == editor_test_utils.retrieve_editor_log_content(0, mock_logname, mock_workspace)
+            assert f'[{mock_logname}]  {mock_log}' == editor_test_utils.retrieve_test_log_content(0, mock_logname, mock_workspace)
 
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
     @mock.patch('ly_test_tools.environment.waiter.wait_for', mock.MagicMock())
@@ -139,7 +139,7 @@ class TestEditorTestUtils(unittest.TestCase):
         mock_workspace = mock.MagicMock()
         expected = f"-- Error reading {mock_logname}"
 
-        assert expected in editor_test_utils.retrieve_editor_log_content(0, mock_logname, mock_workspace)
+        assert expected in editor_test_utils.retrieve_test_log_content(0, mock_logname, mock_workspace)
 
     def test_RetrieveLastRunTestIndexFromOutput_SecondTestFailed_Returns0(self):
         mock_test = mock.MagicMock()

--- a/Tools/LyTestTools/tests/unit/test_o3de_editor_test.py
+++ b/Tools/LyTestTools/tests/unit/test_o3de_editor_test.py
@@ -462,7 +462,7 @@ class TestUtils(unittest.TestCase):
     def test_SetupEditorTest_ValidArgs_CallsCorrectly(self, mock_prepare_ap, mock_kill_processes):
         mock_test_suite = editor_test.EditorTestSuite()
         mock_editor = mock.MagicMock()
-        mock_test_suite._setup_editor_test(mock_editor, mock.MagicMock(), mock.MagicMock())
+        mock_test_suite._setup_test_run(mock_editor, mock.MagicMock(), mock.MagicMock())
 
         assert mock_editor.configure_settings.called
         assert mock_prepare_ap.called
@@ -573,7 +573,7 @@ class TestUtils(unittest.TestCase):
 class TestRunningTests(unittest.TestCase):
 
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
-    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
+    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_test_log_content')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_testcase_module_filepath')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
@@ -598,7 +598,7 @@ class TestRunningTests(unittest.TestCase):
 
 
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
-    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
+    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_test_log_content')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_testcase_module_filepath')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
@@ -624,7 +624,7 @@ class TestRunningTests(unittest.TestCase):
 
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_crash_output')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
-    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
+    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_test_log_content')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_testcase_module_filepath')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
@@ -652,7 +652,7 @@ class TestRunningTests(unittest.TestCase):
         assert mock_workspace.artifact_manager.save_artifact.call_count == 3
 
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
-    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
+    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_test_log_content')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_testcase_module_filepath')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
@@ -735,7 +735,7 @@ class TestRunningTests(unittest.TestCase):
 
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_crash_output')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
-    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
+    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_test_log_content')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_testcase_module_filepath')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
@@ -773,7 +773,7 @@ class TestRunningTests(unittest.TestCase):
 
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_crash_output')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
-    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
+    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_test_log_content')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_testcase_module_filepath')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
@@ -812,7 +812,7 @@ class TestRunningTests(unittest.TestCase):
         assert results[mock_test_spec_2.__name__].extra_info, "Extra info missing from Unknown failure"
 
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
-    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
+    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_test_log_content')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_testcase_module_filepath')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
@@ -848,7 +848,7 @@ class TestRunningTests(unittest.TestCase):
 
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._report_result')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._exec_editor_test')
-    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_editor_test')
+    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_test_run')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.save_failed_asset_joblogs', mock.MagicMock())
     def test_RunSingleTest_ValidTest_ReportsResults(self, mock_setup_test, mock_exec_editor_test, mock_report_result):
         mock_test_suite = ly_test_tools.o3de.editor_test.EditorTestSuite()
@@ -867,7 +867,7 @@ class TestRunningTests(unittest.TestCase):
         mock_report_result.assert_called_with(mock_test_name, mock_result)
 
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._exec_editor_multitest')
-    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_editor_test')
+    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_test_run')
     def test_RunBatchedTests_ValidTests_CallsCorrectly(self, mock_setup_test, mock_exec_multitest):
         mock_test_suite = ly_test_tools.o3de.editor_test.EditorTestSuite()
         mock_test_data = mock.MagicMock()
@@ -881,7 +881,7 @@ class TestRunningTests(unittest.TestCase):
 
     @mock.patch('threading.Thread')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_number_parallel_editors')
-    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_editor_test')
+    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_test_run')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.save_failed_asset_joblogs', mock.MagicMock())
     def test_RunParallelTests_TwoTestsAndEditors_TwoThreads(self, mock_setup_test, mock_get_num_editors, mock_thread):
         mock_test_suite = ly_test_tools.o3de.editor_test.EditorTestSuite()
@@ -898,7 +898,7 @@ class TestRunningTests(unittest.TestCase):
 
     @mock.patch('threading.Thread')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_number_parallel_editors')
-    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_editor_test')
+    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_test_run')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.save_failed_asset_joblogs', mock.MagicMock())
     def test_RunParallelTests_TenTestsAndTwoEditors_TenThreads(self, mock_setup_test, mock_get_num_editors, mock_thread):
         mock_test_suite = ly_test_tools.o3de.editor_test.EditorTestSuite()
@@ -917,7 +917,7 @@ class TestRunningTests(unittest.TestCase):
 
     @mock.patch('threading.Thread')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_number_parallel_editors')
-    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_editor_test')
+    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_test_run')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.save_failed_asset_joblogs', mock.MagicMock())
     def test_RunParallelTests_TenTestsAndThreeEditors_TenThreads(self, mock_setup_test, mock_get_num_editors,
                                                                  mock_thread):
@@ -937,7 +937,7 @@ class TestRunningTests(unittest.TestCase):
 
     @mock.patch('threading.Thread')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_number_parallel_editors')
-    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_editor_test')
+    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_test_run')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.save_failed_asset_joblogs', mock.MagicMock())
     def test_RunParallelBatchedTests_TwoTestsAndEditors_TwoThreads(self, mock_setup_test, mock_get_num_editors,
                                                                    mock_thread):
@@ -955,7 +955,7 @@ class TestRunningTests(unittest.TestCase):
 
     @mock.patch('threading.Thread')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_number_parallel_editors')
-    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_editor_test')
+    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_test_run')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.save_failed_asset_joblogs', mock.MagicMock())
     def test_RunParallelBatchedTests_TenTestsAndTwoEditors_2Threads(self, mock_setup_test, mock_get_num_editors,
                                                                       mock_thread):
@@ -975,7 +975,7 @@ class TestRunningTests(unittest.TestCase):
 
     @mock.patch('threading.Thread')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_number_parallel_editors')
-    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_editor_test')
+    @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._setup_test_run')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.save_failed_asset_joblogs', mock.MagicMock())
     def test_RunParallelBatchedTests_TenTestsAndThreeEditors_ThreeThreads(self, mock_setup_test, mock_get_num_editors,
                                                                         mock_thread):


### PR DESCRIPTION
- As work on this has progressed it has become apparent that not all of the classes and functions in this code are easy to convert or have new classes inherit from.
- A new RFC will be written to cover the remainder of the work, which in my opinion is re-factor work. I have spent weeks on this, trying to hone it to be a clean refactor as well as support MaterialEditor. In the RFC I'll be writing, we need to work as a team with the architectural notes I'll be putting together for this framework to explain how this code runs exactly. The TLDR is, most of the run code is placed into the `pytest.Class` object and trying to de-couple code from it runs into problems with fixture call order. It's because it does custom collection with the fixtures and that makes debugging their call order non-trivial as well as pushes the work outside of the scope of this effort (in my opinion). We've waited long enough for this support and its better to have it sooner rather than later (plus I'm losing my sanity).  For this reason, the new RFC is needed as I cannot take it upon solely myself to overhaul and re-factor the original `EditorTestClass` object - we need to tackle this one as a team, with some meetings to go over our plan for how to address it.
- With this in mind, the `EditorTestClass` object was kept as part of the Editor tests and mostly copied for the new `MaterialEditorTestClass` object. The new RFC that will be written will address this issue, and we will need full team feedback + support to make this happen before we get into the re-factor.
- Anything else that could be moved was moved into the new `AbstractTestSuite` class so `EditorTestSuite` and `MaterialEditorTestSuite` inherit from that class. Also the `Result` class was moved into the `multi_test_framework.py` module and imports into the new `editor_test.py` and `material_editor.py` modules.
- There is one remaining issue with how I am gathering the logs, but all of the tests should pass even with that issue present. This bug manifests itself in this way in the log output (will have it fixed in next PR update):
```
Test AtomEditorComponents_ExposureControlAdded:
Test Passed
------------
|  Output  |
------------
-- No output --
```
- Some sample run logs below.
- Command used: `C:\git\o3de\python\runtime\python-3.7.12-rev2-windows\python\python.exe -m pytest -vv -s --build-directory="C:\git\o3de\build\bin\profile" C:\git\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Null_Render_Component_01.py `
```
==== 9 passed in 48.64s ====
```
- Command used: `C:\git\o3de\python\runtime\python-3.7.12-rev2-windows\python\python.exe -m pytest -vv -s --build-directory="C:\git\o3de\build\bin\profile" C:\git\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_GPU.py -k AtomGPU_LightComponent_AreaLightScreenshotsMatchGoldenImages_DX12`
```
=== 1 passed, 5 deselected in 91.57s (0:01:31) ====
```
- Command used (this one is the most problematic so far): `C:\git\o3de\python\runtime\python-3.7.12-rev2-windows\python\python.exe -m pytest -vv -s --build-directory="C:\git\o3de\build\bin\profile" C:\git\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Null_Render_MaterialEditor.py -k MaterialEditor_Atom_LaunchMaterialEditor`
```
=== 1 failed, 1 passed in 45.43s ===
```