### PR TITLE
Fix mismatched `new[]` and `delete`

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -250,7 +250,7 @@ namespace AZ
 
             for (const VkDeviceQueueCreateInfo& queueInfo : queueCreationInfo)
             {
-                delete queueInfo.pQueuePriorities;
+                delete[] queueInfo.pQueuePriorities;
             }
 
             Instance& instance = Instance::GetInstance();


### PR DESCRIPTION
Signed-off-by: Chris Burel <burelc@amazon.com>