### PR TITLE
Fix for rapidly selecting and deleting a group of nodes in Script Canvas

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/Component.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/Component.cpp
@@ -48,8 +48,18 @@ namespace AZ
         {
             return m_entity->GetId();
         }
+        else if (m_id == InvalidComponentId)
+        {
+            AZ_Warning("System", false, "Can't get component (type: %s, addr: %p) entity ID as it is not attached to an entity yet!", RTTI_GetTypeName(), this);
+        }
+        else
+        {
+            // If m_entity is null but m_id is not equal to InvalidComponentId, then this object may have been deleted already.
+            // At this point RTTI_GetTypeName() on Linux causes a seg-fault. This is a work-around to prevent the crash and allow
+            // the call to partially warn about the detached entity and still return an Invalid EntityId()
+            AZ_Warning("System", false, "Can't get component (id: %ld) entity ID as it has detached its Entity.", m_id);
+        }
 
-        AZ_Warning("System", false, "Can't get component (type: %s, addr: %p) entity ID as it is not attached to an entity yet!", RTTI_GetTypeName(), this);
         return EntityId();
     }
 

--- a/Code/Framework/AzCore/AzCore/Component/Component.h
+++ b/Code/Framework/AzCore/AzCore/Component/Component.h
@@ -238,6 +238,7 @@ namespace AZ
 
         Entity*     m_entity;       ///< Reference to the entity that owns the component. The value is null if the component is not attached to an entity.
         ComponentId m_id;           ///< A component ID that is unique for an entity. This component ID is not unique across all entities.
+        bool        m_isDeleting;   ///< Flag to prevent access to any member variables to the instance (possibly from other threads) while an instance is being deleted
     };
 
     /**


### PR DESCRIPTION
Fixes an issue related to timing described in https://github.com/o3de/o3de/issues/7579 .

* When nodes are selected in Script Canvas, its components are created and displayed in the detail pane of the Script Canvas editor
* If you select a group of nodes, and then delete them AFTER the components are rendered in the node inspector, everything works as expected
* If you select the group of nodes but press the delete key very quickly, before the selected components are rendered (less than half a second), then a crash occurs because invalidating the windows checks against the component's entities but the component may have already been deleted

This does not address the root timing issue, but is a safe fix to protect against this race condition.

