### PR TITLE
Streamer throughput optimizations

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/IStreamer.h
+++ b/Code/Framework/AzCore/AzCore/IO/IStreamer.h
@@ -266,9 +266,7 @@ namespace AZ::IO
         //
 
         //! Sets a callback function that will trigger when the provided request completes. The callback will be triggered
-        //! from within the Streamer's stack on a different thread. While in the callback function Streamer can't continue
-        //! processing requests so it's recommended to keep the callback short, for instance by setting an atomic value
-        //! to be picked up by another thread like the main thread or to queue a job (function) to complete the work.
+        //! from within TaskExecutor on a different thread than the caller thread.
         //! Note avoid storing a copy of the owning FileRequestPtr in a lambda provided as the callback. This will result in
         //! the same request storing a copy of itself indirectly, which means the reference counter can never reach zero due
         //! to the circular dependency and results in a resource leak.

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/BlockCache.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/BlockCache.cpp
@@ -114,12 +114,12 @@ namespace AZ::IO
         {
             m_onlyEpilogWrites = true;
         }
+        m_recentlyUsed = RecentlyUsedBlockIndex(m_numBlocks);
 
         m_cache = reinterpret_cast<u8*>(AZ::AllocatorInstance<AZ::SystemAllocator>::Get().Allocate(
             m_cacheSize, alignment, 0, "AZ::IO::Streamer BlockCache", __FILE__, __LINE__));
         m_cachedPaths = AZStd::unique_ptr<RequestPath[]>(new RequestPath[m_numBlocks]);
         m_cachedOffsets = AZStd::unique_ptr<u64[]>(new u64[m_numBlocks]);
-        m_blockLastTouched = AZStd::unique_ptr<TimePoint[]>(new TimePoint[m_numBlocks]);
         m_inFlightRequests = AZStd::unique_ptr<FileRequest*[]>(new FileRequest*[m_numBlocks]);
 
         ResetCache();
@@ -369,6 +369,7 @@ namespace AZ::IO
             if (m_cachedPaths[i] == filePath)
             {
                 ResetCacheEntry(i);
+                m_recentlyUsed.Flush(i);
             }
         }
     }
@@ -376,6 +377,7 @@ namespace AZ::IO
     void BlockCache::FlushEntireCache()
     {
         ResetCache();
+        m_recentlyUsed.FlushAll();
     }
 
     void BlockCache::CollectStatistics(AZStd::vector<Statistic>& statistics) const
@@ -431,7 +433,7 @@ namespace AZ::IO
     {
         if (!IsCacheBlockInFlight(cacheBlock))
         {
-            TouchBlock(cacheBlock);
+            m_recentlyUsed.Touch(cacheBlock);
             memcpy(section.m_output, GetCacheBlockData(cacheBlock) + section.m_blockOffset, section.m_copySize);
             return CacheResult::ReadFromCache;
         }
@@ -545,12 +547,13 @@ namespace AZ::IO
 
         if (requestWasSuccessful)
         {
-            TouchBlock(cacheBlockIndex);
+            m_recentlyUsed.Touch(cacheBlockIndex);
             m_inFlightRequests[cacheBlockIndex] = nullptr;
         }
         else
         {
             ResetCacheEntry(cacheBlockIndex);
+            m_recentlyUsed.Flush(cacheBlockIndex);
         }
         AZ_Assert(m_numInFlightRequests > 0, "Clearing out an in-flight request, but there shouldn't be any in flight according to records.");
         m_numInFlightRequests--;
@@ -685,34 +688,17 @@ namespace AZ::IO
         return m_cache + (index * m_blockSize);
     }
 
-    void BlockCache::TouchBlock(u32 index)
-    {
-        AZ_Assert(index < m_numBlocks, "Index for touch a cache entry in the BlockCache is out of bounds.");
-        m_blockLastTouched[index] = AZStd::chrono::steady_clock::now();
-    }
-
     u32 BlockCache::RecycleOldestBlock(const RequestPath& filePath, u64 offset)
     {
         AZ_Assert((offset & (m_blockSize - 1)) == 0, "The offset used to recycle a block cache needs to be a multiple of the block size.");
 
-        // Find the oldest cache block.
-        TimePoint oldest = m_blockLastTouched[0];
-        u32 oldestIndex = 0;
-        for (u32 i = 1; i < m_numBlocks; ++i)
-        {
-            if (m_blockLastTouched[i] < oldest && !m_inFlightRequests[i])
-            {
-                oldest = m_blockLastTouched[i];
-                oldestIndex = i;
-            }
-        }
-
+        u32 oldestIndex = m_recentlyUsed.GetLeastRecentlyUsed();
         if (!IsCacheBlockInFlight(oldestIndex))
         {
             // Recycle the block.
             m_cachedPaths[oldestIndex] = filePath;
             m_cachedOffsets[oldestIndex] = offset;
-            TouchBlock(oldestIndex);
+            m_recentlyUsed.TouchLeastRecentlyUsed();
             return oldestIndex;
         }
         else
@@ -747,7 +733,6 @@ namespace AZ::IO
 
         m_cachedPaths[index].Clear();
         m_cachedOffsets[index] = 0;
-        m_blockLastTouched[index] = TimePoint::min();
         m_inFlightRequests[index] = nullptr;
     }
 

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/BlockCache.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/BlockCache.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/IO/Streamer/RecentlyUsedIndex.h>
 #include <AzCore/IO/Streamer/Statistics.h>
 #include <AzCore/IO/Streamer/StreamerConfiguration.h>
 #include <AzCore/IO/Streamer/StreamStackEntry.h>
@@ -61,6 +62,8 @@ namespace AZ::IO
         : public StreamStackEntry
     {
     public:
+        using RecentlyUsedBlockIndex = RecentlyUsedIndex<u32>;
+
         BlockCache(u64 cacheSize, u32 blockSize, u32 alignment, bool onlyEpilogWrites);
         BlockCache(BlockCache&& rhs) = delete;
         BlockCache(const BlockCache& rhs) = delete;
@@ -126,7 +129,6 @@ namespace AZ::IO
             u64 offset, u64 size, u8* buffer) const;
 
         u8* GetCacheBlockData(u32 index);
-        void TouchBlock(u32 index);
         AZ::u32 RecycleOldestBlock(const RequestPath& filePath, u64 offset);
         u32 FindInCache(const RequestPath& filePath, u64 offset) const;
         bool IsCacheBlockInFlight(u32 index) const;
@@ -143,6 +145,8 @@ namespace AZ::IO
         AZ::Statistics::RunningStatistic m_hitRateStat;
         AZ::Statistics::RunningStatistic m_cacheableStat;
 
+        RecentlyUsedBlockIndex m_recentlyUsed;
+
         u8* m_cache;
         u64 m_cacheSize;
         u32 m_blockSize;
@@ -153,8 +157,6 @@ namespace AZ::IO
         AZStd::unique_ptr<RequestPath[]> m_cachedPaths; // Array of m_numBlocks size.
         //! The offset into the file the cache blocks starts at.
         AZStd::unique_ptr<u64[]> m_cachedOffsets; // Array of m_numBlocks size.
-        //! The last time the cache block was read from.
-        AZStd::unique_ptr<TimePoint[]> m_blockLastTouched; // Array of m_numBlocks size.
         //! The file request that's currently read data into the cache block. If null, the block has been read.
         AZStd::unique_ptr<FileRequest*[]> m_inFlightRequests; // Array of m_numbBlocks size.
 

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.cpp
@@ -6,7 +6,6 @@
  *
  */
 
-#include <limits>
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/IO/Streamer/RequestPath.h>
 #include <AzCore/IO/Streamer/FileRequest.h>
@@ -418,9 +417,10 @@ namespace AZ::IO
         if (parent)
         {
             m_parent = parent;
-            AZ_Assert(parent->m_dependencies < std::numeric_limits<decltype(parent->m_dependencies)>::max(),
+            AZ_Assert(
+                parent->m_dependencies < GetMaxNumDependencies(),
                 "A file request dependency was added, but the parent can't have any more dependencies.");
-            ++parent->m_dependencies;
+            parent->m_dependencies++;
         }
     }
 

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.cpp
@@ -405,7 +405,7 @@ namespace AZ::IO
     void FileRequest::Reset()
     {
         m_command = AZStd::monostate{};
-        m_onCompletion = &OnCompletionPlaceholder;
+        m_onCompletion = nullptr;
         m_estimatedCompletion = AZStd::chrono::steady_clock::time_point();
         m_parent = nullptr;
         m_status = IStreamerTypes::RequestStatus::Pending;

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.h
@@ -351,8 +351,6 @@ namespace AZ::IO
         void Reset();
         void SetOptionalParent(FileRequest* parent);
 
-        inline static void OnCompletionPlaceholder(const FileRequest& /*request*/) {}
-
         //! Command and parameters for the request.
         CommandVariant m_command;
 

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.h
@@ -380,7 +380,7 @@ namespace AZ::IO
         AZStd::atomic<IStreamerTypes::RequestStatus> m_status{ IStreamerTypes::RequestStatus::Pending };
 
         //! The number of dependent file request that need to complete before this one is done.
-        u16 m_dependencies{ 0 };
+        AZStd::atomic<u16> m_dependencies{ 0 };
 
         //! Internal request. If this is true the request is created inside the streaming stack and never
         //! leaves it. If true it will automatically be maintained by the scheduler, if false than it's

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.inl
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.inl
@@ -42,6 +42,7 @@ namespace AZ::IO
     {
         // Leave a bit of room for requests that don't check the available space for dependencies
         // because they only add a small (usually one or two) number of dependencies.
-        return AZStd::numeric_limits<typename decltype(m_dependencies)::value_type>::max() - 255;
+        return AZStd::numeric_limits<decltype(m_dependencies.load())>::max() - 255;
+        // Android has a non-conforming version of std::atomic so using value_type doesn't work.
     }
 } // namespace AZ::IO

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.inl
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.inl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <limits>
+#include <AzCore/std/limits.h>
 
 namespace AZ::IO
 {
@@ -42,6 +42,6 @@ namespace AZ::IO
     {
         // Leave a bit of room for requests that don't check the available space for dependencies
         // because they only add a small (usually one or two) number of dependencies.
-        return std::numeric_limits<decltype(m_dependencies)>::max() - 255;
+        return AZStd::numeric_limits<typename decltype(m_dependencies)::value_type>::max() - 255;
     }
 } // namespace AZ::IO

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/ReadSplitter.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/ReadSplitter.cpp
@@ -196,7 +196,8 @@ namespace AZ::IO
 
         while (pending.m_readSize > 0)
         {
-            if (pending.m_request->GetNumDependencies() >= FileRequest::GetMaxNumDependencies())
+            // - 1 because there needs to be room to attach the wait.
+            if (pending.m_request->GetNumDependencies() >= FileRequest::GetMaxNumDependencies() - 1)
             {
                 // Add a wait to make sure the read request isn't completed if all sub-reads completed before
                 // the ReadSplitter has had a chance to add new sub-reads to complete the read.

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/RecentlyUsedIndex.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/RecentlyUsedIndex.h
@@ -47,8 +47,11 @@ namespace AZ::IO
         void GetIndicesInOrder(const AZStd::function<void(T)>& callback) const;
 
     private:
-        AZStd::unique_ptr<T[]> m_indices_previous;
-        AZStd::unique_ptr<T[]> m_indices_next;
+        template<bool CheckFront, bool CheckBack>
+        void Remove(T index);
+
+        AZStd::unique_ptr<T[]> m_indicesPrevious;
+        AZStd::unique_ptr<T[]> m_indicesNext;
         T m_size{ 0 };
         T m_front{ InvalidIndex };
         T m_back{ InvalidIndex };

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/RecentlyUsedIndex.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/RecentlyUsedIndex.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/functional.h>
+#include <AzCore/std/numeric.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/std/typetraits/is_integral.h>
+
+namespace AZ::IO
+{
+    //! Uses an optimized double linked list to keep track of the most and least recently used index.
+    template<typename T>
+    class RecentlyUsedIndex
+    {
+        static_assert(
+            AZStd::is_integral_v<T> && AZStd::is_unsigned_v<T>,
+            "Recently Used Index only supports unsigned integers as they need to represent an index.");
+
+    public:
+        static constexpr T InvalidIndex = AZStd::numeric_limits<T>::max();
+
+        RecentlyUsedIndex() = default;
+        explicit RecentlyUsedIndex(T size);
+
+        //! Pushes the index to end of the list, making it the most recently used.
+        void Touch(T index);
+        //! Pushes the index to the start of the list, making it the least recently used.
+        void Flush(T index);
+
+        //! Flush all indices, returning the cache to it's initial state.
+        void FlushAll();
+
+        //! Touches the least recently used index. This has better performance than using Touch with
+        //! the least recently used index.
+        T TouchLeastRecentlyUsed();
+
+        T GetLeastRecentlyUsed() const;
+        T GetMostRecentlyUsed() const;
+
+        void GetIndicesInOrder(const AZStd::function<void(T)>& callback) const;
+
+    private:
+        AZStd::unique_ptr<T[]> m_indices_previous;
+        AZStd::unique_ptr<T[]> m_indices_next;
+        T m_size{ 0 };
+        T m_front{ InvalidIndex };
+        T m_back{ InvalidIndex };
+    };
+} // namespace AZ::IO
+
+#include <AzCore/IO/Streamer/RecentlyUsedIndex.inl>

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/RecentlyUsedIndex.inl
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/RecentlyUsedIndex.inl
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+namespace AZ::IO
+{
+    template<typename T>
+    RecentlyUsedIndex<T>::RecentlyUsedIndex(T size)
+        : m_indices_previous(AZStd::make_unique<T[]>(size))
+        , m_indices_next(AZStd::make_unique<T[]>(size))
+        , m_size(size)
+        , m_front(0)
+        , m_back(size - 1)
+    {
+        AZ_Assert(size > 2, "At least 2 entries are needed in order to have a separate front and back.");
+        AZ_Assert(size < AZStd::numeric_limits<T>::max() - 1, "Size too large for Recently Used Index with the provided type.");
+
+        FlushAll();
+    }
+
+    template<typename T>
+    void RecentlyUsedIndex<T>::Touch(T index)
+    {
+        if (index != m_back)
+        {
+            AZ_Assert(index < m_size, "Index out of bounds while calling Touch in Recently Used Index.");
+
+            // Remove the index from its current spot and fix m_front if needed.
+            T previous = m_indices_previous[index];
+            T next = m_indices_next[index];
+            if (previous != InvalidIndex)
+            {
+                m_indices_next[previous] = next;
+            }
+            else
+            {
+                m_front = next; // This index was at the front, so the front needs to be reset.
+            }
+
+            if (next != InvalidIndex)
+            {
+                m_indices_previous[next] = previous;
+            }
+
+            // Reset indices.
+            m_indices_previous[index] = m_back;
+            m_indices_next[index] = InvalidIndex;
+
+            // Insert at the back.
+            m_indices_next[m_back] = index;
+            m_back = index;
+        }
+    }
+
+    template<typename T>
+    void RecentlyUsedIndex<T>::Flush(T index)
+    {
+        if (index != m_front)
+        {
+            AZ_Assert(index < m_size, "Index out of bounds while calling Flush in Recently Used Index.");
+
+            T previous = m_indices_previous[index];
+            T next = m_indices_next[index];
+            if (previous != InvalidIndex)
+            {
+                m_indices_next[previous] = next;
+            }
+
+            if (next != InvalidIndex)
+            {
+                m_indices_previous[next] = previous;
+            }
+            else
+            {
+                m_back = previous; // This index was at the front, so the front needs to be reset.
+            }
+
+            // Reset indices.
+            m_indices_previous[index] = InvalidIndex;
+            m_indices_next[index] = m_front;
+
+            // Insert at the front.
+            m_indices_previous[m_front] = index;
+            m_front = index;
+        }
+    }
+
+    template<typename T>
+    void RecentlyUsedIndex<T>::FlushAll()
+    {
+        m_indices_previous[0] = InvalidIndex;
+        for (T i = 1; i < m_size; ++i)
+        {
+            m_indices_previous[i] = i - 1;
+        }
+
+        for (T i = 0; i < m_size - 1; ++i)
+        {
+            m_indices_next[i] = i + 1;
+        }
+        m_indices_next[m_size - 1] = InvalidIndex;
+    }
+
+    template<typename T>
+    T RecentlyUsedIndex<T>::TouchLeastRecentlyUsed()
+    {
+        AZ_Assert(m_size > 0, "Least recently used index is begin touched in Recently Used Index before being initialized with a size.");
+
+        // Very similar to Touch and Flush, but some work and checks can be avoided as it's known that it's the front being moved to the back.
+        T next = m_indices_next[m_front];
+        m_indices_next[m_back] = m_front;
+        m_indices_previous[next] = InvalidIndex;
+
+        m_indices_previous[m_front] = m_back;
+        m_indices_next[m_front] = InvalidIndex;
+
+        m_back = m_front;
+        m_front = next;
+
+        return m_back;
+    }
+
+    template<typename T>
+    T RecentlyUsedIndex<T>::GetLeastRecentlyUsed() const
+    {
+        return m_front;
+    }
+
+    template<typename T>
+    T RecentlyUsedIndex<T>::GetMostRecentlyUsed() const
+    {
+        return m_back;
+    }
+
+    template<typename T>
+    void RecentlyUsedIndex<T>::GetIndicesInOrder(const AZStd::function<void(T)>& callback) const
+    {
+        T current = m_front;
+        for (T i = 0; i < m_size; ++i)
+        {
+            callback(current);
+            current = m_indices_next[current];
+        }
+        AZ_Assert(current == InvalidIndex, "The double linked list in Recently Used Index has become corrupted.");
+    }
+} // namespace AZ::IO

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/RequestPath.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/RequestPath.cpp
@@ -37,12 +37,12 @@ namespace AZ
 
         bool RequestPath::operator==(const RequestPath& rhs) const
         {
-            return m_absolutePathHash != rhs.m_absolutePathHash ? false : (m_path == rhs.m_path);
+            return m_absolutePathHash == rhs.m_absolutePathHash && m_path == rhs.m_path;
         }
 
         bool RequestPath::operator!=(const RequestPath& rhs) const
         {
-            return m_absolutePathHash != rhs.m_absolutePathHash ? true : (m_path != rhs.m_path);
+            return !operator==(rhs);
         }
 
         bool RequestPath::IsValid() const

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/RequestPath.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/RequestPath.h
@@ -29,7 +29,7 @@ namespace AZ
             RequestPath(RequestPath&& rhs) = default;
             // Allow path views to be cast to a request path.
             RequestPath(AZ::IO::PathView path);
-            
+
             RequestPath& operator=(const RequestPath& rhs) = default;
             RequestPath& operator=(RequestPath&& rhs) = default;
             RequestPath& operator=(AZ::IO::PathView path);

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/RequestPath.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/RequestPath.h
@@ -29,7 +29,7 @@ namespace AZ
             RequestPath(RequestPath&& rhs) = default;
             // Allow path views to be cast to a request path.
             RequestPath(AZ::IO::PathView path);
-
+            
             RequestPath& operator=(const RequestPath& rhs) = default;
             RequestPath& operator=(RequestPath&& rhs) = default;
             RequestPath& operator=(AZ::IO::PathView path);
@@ -47,14 +47,13 @@ namespace AZ
             size_t GetHash() const;
 
         private:
-            constexpr static const size_t s_invalidPathHash = std::numeric_limits<size_t>::max();
-            constexpr static const size_t s_emptyPathHash = std::numeric_limits<size_t>::min();
-
+            constexpr static const size_t InvalidPathHash = std::numeric_limits<size_t>::max();
+            
             void ResolvePath() const;
             size_t FindAliasOffset(AZStd::string_view path) const;
 
             mutable FixedMaxPath m_path;
-            mutable size_t m_absolutePathHash = s_emptyPathHash;
+            mutable size_t m_absolutePathHash = InvalidPathHash;
             mutable size_t m_relativePathOffset = 0;
         };
     } // namespace IO

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/Scheduler.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/Scheduler.cpp
@@ -37,7 +37,13 @@ namespace AZ::IO
         m_threadData.m_streamStack = AZStd::move(streamStack);
     }
 
-    Scheduler::~Scheduler() = default;
+    Scheduler::~Scheduler()
+    {
+        if (m_isRunning)
+        {
+            Stop();
+        }
+    }
 
     void Scheduler::Start(const AZStd::thread_desc& threadDesc)
     {
@@ -244,20 +250,23 @@ namespace AZ::IO
             }
 
 #if AZ_STREAMER_ADD_EXTRA_PROFILING_INFO
-            m_stackStatus = StreamStackEntry::Status{};
-            m_threadData.m_streamStack->UpdateStatus(m_stackStatus);
-            if (m_stackStatus.m_isIdle)
+            if (m_processingSize > 0)
             {
-                auto duration = AZStd::chrono::steady_clock::now() - m_processingStartTime;
-                auto durationSec = AZStd::chrono::duration_cast<AZStd::chrono::duration<double>>(duration);
-                m_processingSpeedStat.PushEntry(m_processingSize / durationSec.count());
-                m_processingSize = 0;
+                m_stackStatus = StreamStackEntry::Status{};
+                m_threadData.m_streamStack->UpdateStatus(m_stackStatus);
+                if (m_stackStatus.m_isIdle)
+                {
+                    auto duration = AZStd::chrono::steady_clock::now() - m_processingStartTime;
+                    auto durationSec = AZStd::chrono::duration_cast<AZStd::chrono::duration<double>>(duration);
+                    m_processingSpeedStat.PushEntry(m_processingSize / durationSec.count());
+                    m_processingSize = 0;
+                }
             }
 #endif
         }
 
-        // Make sure all requests in the stack are cleared out. This dangling async processes or async processes crashing as assigned
-        // such as memory buffers are no longer available.
+        // Make sure all requests in the stack are cleared out. This prevents dangling async processes or async processes crashing due to
+        // memory buffers not being available among others.
         Thread_ProcessTillIdle();
     }
 
@@ -442,8 +451,11 @@ namespace AZ::IO
         {
             m_stackStatus = StreamStackEntry::Status{};
             m_threadData.m_streamStack->UpdateStatus(m_stackStatus);
-            if (m_stackStatus.m_isIdle)
+            if (m_stackStatus.m_isIdle && m_context.GetOutstandingTaskCount() == 0)
             {
+                // Clean up the last requests as there can be requests that have been completed
+                // on another thread, but haven't been completed yet.
+                m_context.FinalizeCompletedRequests();
                 return;
             }
 

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StorageDrive.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StorageDrive.cpp
@@ -40,8 +40,8 @@ namespace AZ::IO
 
     StorageDrive::StorageDrive(u32 maxFileHandles)
         : StreamStackEntry("Storage drive (generic)")
+        , m_recentlyUsed(maxFileHandles)
     {
-        m_fileLastUsed.resize(maxFileHandles, AZStd::chrono::steady_clock::time_point::min());
         m_filePaths.resize(maxFileHandles);
         m_fileHandles.resize(maxFileHandles);
 
@@ -163,7 +163,7 @@ namespace AZ::IO
         StreamStackEntry::UpdateCompletionEstimates(now, internalPending, pendingBegin, pendingEnd);
 
         const RequestPath* activeFile = nullptr;
-        if (m_activeCacheSlot != s_fileNotFound)
+        if (m_activeCacheSlot != InvalidFileIndex)
         {
             activeFile = &m_filePaths[m_activeCacheSlot];
         }
@@ -229,7 +229,7 @@ namespace AZ::IO
         {
             if (activeFile && activeFile != targetFile)
             {
-                if (FindFileInCache(*targetFile) == s_fileNotFound)
+                if (FindFileInCache(*targetFile) == InvalidFileIndex)
                 {
                     AZStd::chrono::microseconds fileOpenCloseTimeAverage = AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(m_fileOpenCloseTimeAverage.CalculateAverage());
                     startTime += fileOpenCloseTimeAverage;
@@ -260,29 +260,19 @@ namespace AZ::IO
         SystemFile* file = nullptr;
 
         // If the file is already open, use that file handle and update it's last touched time.
-        size_t cacheIndex = FindFileInCache(data->m_path);
-        if (cacheIndex != s_fileNotFound)
+        u32 cacheIndex = FindFileInCache(data->m_path);
+        if (cacheIndex != InvalidFileIndex)
         {
             file = m_fileHandles[cacheIndex].get();
-            m_fileLastUsed[cacheIndex] = AZStd::chrono::steady_clock::now();
+            m_recentlyUsed.Touch(cacheIndex);
         }
 
         // If the file is not open, eject the entry from the cache that hasn't been used for the longest time
         // and open the file for reading.
         if (!file)
         {
-            AZStd::chrono::steady_clock::time_point oldest = m_fileLastUsed[0];
-            cacheIndex = 0;
-            size_t numFiles = m_filePaths.size();
-            for (size_t i = 1; i < numFiles; ++i)
-            {
-                if (m_fileLastUsed[i] < oldest)
-                {
-                    oldest = m_fileLastUsed[i];
-                    cacheIndex = i;
-                }
-            }
-
+            cacheIndex = m_recentlyUsed.TouchLeastRecentlyUsed();
+            
             TIMED_AVERAGE_WINDOW_SCOPE(m_fileOpenCloseTimeAverage);
             AZStd::unique_ptr<SystemFile> newFile = AZStd::make_unique<SystemFile>();
             bool isOpen = newFile->Open(data->m_path.GetAbsolutePathCStr(), SystemFile::OpenMode::SF_OPEN_READ_ONLY);
@@ -294,7 +284,6 @@ namespace AZ::IO
             }
 
             file = newFile.get();
-            m_fileLastUsed[cacheIndex] = AZStd::chrono::steady_clock::now();
             m_fileHandles[cacheIndex] = AZStd::move(newFile);
             m_filePaths[cacheIndex] = data->m_path;
         }
@@ -343,8 +332,8 @@ namespace AZ::IO
         TIMED_AVERAGE_WINDOW_SCOPE(m_getFileExistsTimeAverage);
 
         auto& fileExists = AZStd::get<Requests::FileExistsCheckData>(request->GetCommand());
-        size_t cacheIndex = FindFileInCache(fileExists.m_path);
-        if (cacheIndex != s_fileNotFound)
+        u32 cacheIndex = FindFileInCache(fileExists.m_path);
+        if (cacheIndex != InvalidFileIndex)
         {
             fileExists.m_found = true;
         }
@@ -362,8 +351,8 @@ namespace AZ::IO
 
         auto& command = AZStd::get<Requests::FileMetaDataRetrievalData>(request->GetCommand());
         // If the file is already open, use the file handle which usually is cheaper than asking for the file by name.
-        size_t cacheIndex = FindFileInCache(command.m_path);
-        if (cacheIndex != s_fileNotFound)
+        u32 cacheIndex = FindFileInCache(command.m_path);
+        if (cacheIndex != InvalidFileIndex)
         {
             AZ_Assert(m_fileHandles[cacheIndex],
                 "File path '%s' doesn't have an associated file handle.", m_filePaths[cacheIndex].GetRelativePathCStr());
@@ -392,10 +381,10 @@ namespace AZ::IO
 
     void StorageDrive::FlushCache(const RequestPath& filePath)
     {
-        size_t cacheIndex = FindFileInCache(filePath);
-        if (cacheIndex != s_fileNotFound)
+        u32 cacheIndex = FindFileInCache(filePath);
+        if (cacheIndex != InvalidFileIndex)
         {
-            m_fileLastUsed[cacheIndex] = AZStd::chrono::steady_clock::time_point();
+            m_recentlyUsed.Flush(cacheIndex);
             m_fileHandles[cacheIndex].reset();
             m_filePaths[cacheIndex].Clear();
         }
@@ -406,23 +395,23 @@ namespace AZ::IO
         size_t numFiles = m_filePaths.size();
         for (size_t i = 0; i < numFiles; ++i)
         {
-            m_fileLastUsed[i] = AZStd::chrono::steady_clock::time_point();
             m_fileHandles[i].reset();
             m_filePaths[i].Clear();
         }
+        m_recentlyUsed.FlushAll();
     }
 
-    size_t StorageDrive::FindFileInCache(const RequestPath& filePath) const
+    u32 StorageDrive::FindFileInCache(const RequestPath& filePath) const
     {
         size_t numFiles = m_filePaths.size();
         for (size_t i = 0; i < numFiles; ++i)
         {
             if (m_filePaths[i] == filePath)
             {
-                return i;
+                return aznumeric_caster(i);
             }
         }
-        return s_fileNotFound;
+        return InvalidFileIndex;
     }
 
     void StorageDrive::CollectStatistics(AZStd::vector<Statistic>& statistics) const

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StorageDrive.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StorageDrive.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/IO/Streamer/RecentlyUsedIndex.h>
 #include <AzCore/IO/Streamer/RequestPath.h>
 #include <AzCore/IO/Streamer/Statistics.h>
 #include <AzCore/IO/Streamer/StreamerConfiguration.h>
@@ -64,10 +65,12 @@ namespace AZ::IO
         void CollectStatistics(AZStd::vector<Statistic>& statistics) const override;
 
     protected:
+        using RecentlyUsedFileIndex = RecentlyUsedIndex<u32>;
         static const AZStd::chrono::microseconds s_averageSeekTime;
         static constexpr s32 s_maxRequests = 1;
+        static constexpr u32 InvalidFileIndex = AZStd::numeric_limits<u32>::max();
 
-        size_t FindFileInCache(const RequestPath& filePath) const;
+        u32 FindFileInCache(const RequestPath& filePath) const;
         void ReadFile(FileRequest* request);
         void CancelRequest(FileRequest* cancelRequest, FileRequestPtr& target);
         void FileExistsRequest(FileRequest* request);
@@ -88,8 +91,7 @@ namespace AZ::IO
         //! File requests that are queued for processing.
         AZStd::deque<FileRequest*> m_pendingRequests;
 
-        //! The last time a file handle was used to access a file. The handle is stored in m_fileHandles.
-        AZStd::vector<AZStd::chrono::steady_clock::time_point> m_fileLastUsed;
+        RecentlyUsedFileIndex m_recentlyUsed;
         //! The file path to the file handle. The handle is stored in m_fileHandles.
         AZStd::vector<RequestPath> m_filePaths;
         //! A list of file handles that's being cached in case they're needed again in the future.
@@ -98,6 +100,6 @@ namespace AZ::IO
         //! The offset into the file that's cached by the active cache slot.
         u64 m_activeOffset = 0;
         //! The index into m_fileHandles for the file that's currently being read.
-        size_t m_activeCacheSlot = s_fileNotFound;
+        u32 m_activeCacheSlot = InvalidFileIndex;
     };
 } // namespace AZ::IO

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerComponent.cpp
@@ -181,6 +181,7 @@ namespace AZ
 
     void StreamerComponent::GetDependentServices([[maybe_unused]] ComponentDescriptor::DependencyArrayType& dependent)
     {
+        dependent.push_back(AZ_CRC_CE("TaskExecutorService"));
     }
 
     //=========================================================================

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerComponent.cpp
@@ -179,9 +179,9 @@ namespace AZ
         incompatible.push_back(AZ_CRC_CE("DataStreamingService"));
     }
 
-    void StreamerComponent::GetDependentServices([[maybe_unused]] ComponentDescriptor::DependencyArrayType& dependent)
+    void StreamerComponent::GetRequiredServices( ComponentDescriptor::DependencyArrayType& required)
     {
-        dependent.push_back(AZ_CRC_CE("TaskExecutorService"));
+        required.push_back(AZ_CRC_CE("TaskExecutorService"));
     }
 
     //=========================================================================

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerComponent.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerComponent.h
@@ -42,7 +42,7 @@ namespace AZ
 
         static void GetProvidedServices(ComponentDescriptor::DependencyArrayType& provided);
         static void GetIncompatibleServices(ComponentDescriptor::DependencyArrayType& incompatible);
-        static void GetDependentServices(ComponentDescriptor::DependencyArrayType& dependent);
+        static void GetRequiredServices(ComponentDescriptor::DependencyArrayType& required);
         static void Reflect(ReflectContext* reflection);
 
         static AZStd::unique_ptr<AZ::IO::Scheduler> CreateSimpleStreamerStack();

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerContext.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerContext.cpp
@@ -265,7 +265,7 @@ namespace AZ
                         if (top->m_onCompletion)
                         {
                             m_outstandingTaskCount++;
-                            TaskToken completionTask = task.AddTask(
+                            task.AddTask(
                                 m_taskDescriptor,
                                 [this, top]()
                                 {

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerContext.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerContext.cpp
@@ -174,7 +174,7 @@ namespace AZ
 #if AZ_STREAMER_ADD_EXTRA_PROFILING_INFO
             auto now = AZStd::chrono::steady_clock::now();
 #endif
-            TaskGraph task;
+            TaskGraph task("FinalizeCompletedRequests");
                             
             bool hasCompletedRequests = false;
             while (true)

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerContext.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerContext.cpp
@@ -11,6 +11,8 @@
 #include <AzCore/IO/Streamer/FileRequest.h>
 #include <AzCore/IO/Streamer/StreamerContext.h>
 #include <AzCore/IO/Streamer/StreamStackEntry.h>
+#include <AzCore/Task/TaskExecutor.h>
+#include <AzCore/Task/TaskGraph.h>
 
 namespace AZ
 {
@@ -23,7 +25,12 @@ namespace AZ
         static constexpr const char* MissedDeadlinesName = "Missed deadlines";
 #endif // AZ_STREAMER_ADD_EXTRA_PROFILING_INFO
 
-        StreamerContext::StreamerContext() = default;
+        StreamerContext::StreamerContext()
+            : m_taskExecutor(AZ::TaskExecutor::Instance())
+        {
+            m_taskDescriptor.taskName = "Completion callback";
+            m_taskDescriptor.taskGroup = "AZ::IO:Streamer";     
+        }
 
         StreamerContext::~StreamerContext()
         {
@@ -162,6 +169,8 @@ namespace AZ
 #if AZ_STREAMER_ADD_EXTRA_PROFILING_INFO
             auto now = AZStd::chrono::steady_clock::now();
 #endif
+            TaskGraph task;
+                            
             bool hasCompletedRequests = false;
             while (true)
             {
@@ -172,7 +181,7 @@ namespace AZ
                 }
                 if (completed.empty())
                 {
-                    return hasCompletedRequests;
+                    break;
                 }
 
                 hasCompletedRequests = true;
@@ -219,51 +228,70 @@ namespace AZ
                     FileRequest* parent = top->m_parent;
                     bool isInternal = top->m_usage == FileRequest::Usage::Internal;
 
+                    if (isInternal)
                     {
-#if AZ_STREAMER_ADD_EXTRA_PROFILING_INFO
-                        if (isInternal)
                         {
+#if AZ_STREAMER_ADD_EXTRA_PROFILING_INFO
                             TIMED_AVERAGE_WINDOW_SCOPE(m_internalCompletionTimeAverage);
+#endif
                             AZ_PROFILE_SCOPE(AzCore, "Completion callback internal");
                             top->m_onCompletion(*top);
                             AZ_PROFILE_INTERVAL_END(AzCore, top);
                         }
-                        else
+                        if (parent)
                         {
-                            TIMED_AVERAGE_WINDOW_SCOPE(m_externalCompletionTimeAverage);
-                            AZ_PROFILE_SCOPE(AzCore, "Completion callback external");
-                            top->m_onCompletion(*top);
-                            AZ_PROFILE_INTERVAL_END(AzCore, top);
+                            AZ_Assert(
+                                parent->m_dependencies > 0,
+                                "A file request with a parent has completed, but the request wasn't registered as a dependency with "
+                                "the parent.");
+                            --parent->m_dependencies;
+
+                            parent->SetStatus(status);
+                            if (parent->m_dependencies == 0)
+                            {
+                                completed.push(parent);
+                            }
                         }
-#else
-                        AZ_PROFILE_SCOPE(AzCore,
-                            isInternal ? "Completion callback internal" : "Completion callback external");
-                        top->m_onCompletion(*top);
-                        AZ_PROFILE_INTERVAL_END(AzCore, top);
-#endif
-                    }
 
-                    if (parent)
-                    {
-                        AZ_Assert(parent->m_dependencies > 0,
-                            "A file request with a parent has completed, but the request wasn't registered as a dependency with the parent.");
-                        --parent->m_dependencies;
-
-                        parent->SetStatus(status);
-                        if (parent->m_dependencies == 0)
-                        {
-                            completed.push(parent);
-                        }
-                    }
-
-                    if (isInternal)
-                    {
                         RecycleRequest(top);
+                    }
+                    else
+                    {
+                        task.AddTask(
+                            m_taskDescriptor,
+                            [this, top]()
+                            {
+                                top->m_onCompletion(*top);
+                                FileRequest* parent = top->m_parent;
+                                // For external requests the only parent is the reference holder. It's not needed to wake up the
+                                // scheduler because it would only do a bunch of work to collect a few additional internal requests
+                                // that would also be picked up by any regular iteration of the scheduler. Not waking up the scheduler
+                                // in this case will not prevent any important requests from completing.
+                                if (parent)
+                                {
+                                    AZ_Assert(
+                                        parent->m_dependencies > 0,
+                                        "A file request with a parent has completed, but the request wasn't registered as a dependency "
+                                        "with the "
+                                        "parent.");
+                                    --parent->m_dependencies;
+
+                                    parent->SetStatus(top->GetStatus());
+                                    if (parent->m_dependencies == 0)
+                                    {
+                                        MarkRequestAsCompleted(parent);
+                                    }
+                                }
+                            });
+                        AZ_PROFILE_INTERVAL_END(AzCore, top);
                     }
 
                     completed.pop();
                 }
             }
+
+            task.Detach();
+            task.SubmitOnExecutor(m_taskExecutor);
             return hasCompletedRequests;
         }
 
@@ -309,12 +337,6 @@ namespace AZ
                 ContextName, "Internal callback duration", m_internalCompletionTimeAverage.CalculateAverage(),
                 m_internalCompletionTimeAverage.GetMinimum(), m_internalCompletionTimeAverage.GetMaximum(),
                 "The average amount of time in microseconds spend on processing internal callbacks."));
-            statistics.push_back(Statistic::CreateTimeRange(
-                ContextName, "External callback duration", m_externalCompletionTimeAverage.CalculateAverage(),
-                m_externalCompletionTimeAverage.GetMinimum(), m_externalCompletionTimeAverage.GetMaximum(),
-                "The average amount of time in microseconds spend on processing external callbacks. If this takes up a long time there may "
-                "be a callback on a request that should be handed off to another thread. While the callback is processing Streamer can not "
-                "schedule or process any other requests."));
 #endif // AZ_STREAMER_ADD_EXTRA_PROFILNG_INFO
             statistics.push_back(Statistic::CreateInteger(
                 ContextName, "Total requests", aznumeric_caster(m_pendingIdCounter), "The total number of requests Streamer has processed.",

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerContext.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerContext.h
@@ -15,6 +15,12 @@
 #include <AzCore/std/containers/deque.h>
 #include <AzCore/std/containers/queue.h>
 #include <AzCore/std/containers/vector.h>
+#include <AzCore/Task/TaskDescriptor.h>
+
+namespace AZ
+{
+    class TaskExecutor;
+}
 
 namespace AZ::IO
 {
@@ -23,7 +29,7 @@ namespace AZ::IO
 
     using FileRequestPtr = AZStd::intrusive_ptr<ExternalFileRequest>;
 
-    class StreamerContext
+    class StreamerContext final
     {
     public:
         using PreparedQueue = AZStd::deque<FileRequest*>;
@@ -127,12 +133,13 @@ namespace AZ::IO
 
         //! The average amount of time spend on completing internal completion callbacks.
         TimedAverageWindow<s_statisticsWindowSize> m_internalCompletionTimeAverage;
-        //! The average amount of time spend on completing external completion callbacks.
-        TimedAverageWindow<s_statisticsWindowSize> m_externalCompletionTimeAverage;
 #endif // AZ_STREAMER_ADD_EXTRA_PROFILING_INFO
 
         //! Platform-specific synchronization object used to suspend the Streamer thread and wake it up to resume procesing.
         AZ::Platform::StreamerContextThreadSync m_threadSync;
+
+        AZ::TaskExecutor& m_taskExecutor;
+        AZ::TaskDescriptor m_taskDescriptor;    
 
         size_t m_pendingIdCounter{ 0 };
     };

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerContext.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerContext.h
@@ -15,6 +15,7 @@
 #include <AzCore/std/containers/deque.h>
 #include <AzCore/std/containers/queue.h>
 #include <AzCore/std/containers/vector.h>
+#include <AzCore/std/parallel/atomic.h>
 #include <AzCore/Task/TaskDescriptor.h>
 
 namespace AZ
@@ -83,6 +84,9 @@ namespace AZ::IO
         //! Adds an old external request to the recycle bin so it can be reused later.
         void RecycleRequest(ExternalFileRequest* request);
 
+        //! Returns the number of tasks that are haven't completed processing yet. These are commonly tasks that have a callback
+        //! that's still being processed.
+        size_t GetOutstandingTaskCount() const;
         //! Does the FinalizeRequest callback where appropriate and does some bookkeeping to finalize requests.
         //! @return True if any requests were finalized, otherwise false.
         bool FinalizeCompletedRequests();
@@ -138,6 +142,7 @@ namespace AZ::IO
         //! Platform-specific synchronization object used to suspend the Streamer thread and wake it up to resume procesing.
         AZ::Platform::StreamerContextThreadSync m_threadSync;
 
+        AZStd::atomic<size_t> m_outstandingTaskCount{ 0 };
         AZ::TaskExecutor& m_taskExecutor;
         AZ::TaskDescriptor m_taskDescriptor;    
 

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
@@ -28,6 +28,8 @@ namespace AZ
     class TaskExecutor;
     class TaskGraph;
 
+    inline constexpr uint32_t TaskExecutorServiceCrc = AZ_CRC_CE("TaskExecutorService");
+
     class TaskGraphActiveInterface
     {
     public:

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraphSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraphSystemComponent.cpp
@@ -28,8 +28,6 @@ AZ_CVAR(uint32_t, cl_taskGraphThreadsNumReserved, 2, nullptr, AZ::ConsoleFunctor
 AZ_CVAR(uint32_t, cl_taskGraphThreadsMinNumber, 2, nullptr, AZ::ConsoleFunctorFlags::Null, "TaskGraph minimum number of worker threads to create after scaling the number of hw threads");
 AZ_CVAR(uint32_t, cl_taskGraphThreadsMaxNumber, 0, nullptr, AZ::ConsoleFunctorFlags::Null, "TaskGraph maximum number of worker threads to create after scaling the number of hw threads (0 indicates uncapped)");
 
-static constexpr uint32_t TaskExecutorServiceCrc = AZ_CRC_CE("TaskExecutorService");
-
 namespace AZ
 {
     void TaskGraphSystemComponent::Activate()

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -193,6 +193,8 @@ set(FILES
     IO/Streamer/FullFileDecompressor.cpp
     IO/Streamer/ReadSplitter.h
     IO/Streamer/ReadSplitter.cpp
+    IO/Streamer/RecentlyUsedIndex.h
+    IO/Streamer/RecentlyUsedIndex.inl
     IO/Streamer/RequestPath.h
     IO/Streamer/RequestPath.cpp
     IO/Streamer/Scheduler.h

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.cpp
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.cpp
@@ -247,7 +247,7 @@ namespace AZ::IO
     {
         bool hasFinalizedReads = FinalizeReads();
 
-        TaskGraph readTasks;
+        TaskGraph readTasks("ExecuteRequests");
 
         // Queue as many read requests as possible in order to maximize throughput.
         while (!m_pendingReadRequests.empty())
@@ -1008,7 +1008,7 @@ namespace AZ::IO
     {
         AZ_PROFILE_FUNCTION(AzCore);
 
-        TaskGraph readTasks;
+        TaskGraph readTasks("FinalizeReadRequests");
 
         bool hasWorked = false;
         for (size_t readSlot = 0; readSlot < m_readSlots_active.size(); ++readSlot)
@@ -1047,7 +1047,7 @@ namespace AZ::IO
                             hasWorked = true;
                             constexpr bool encounteredError = true;
                             constexpr bool isCanceled = false;
-                            FinalizeSingleRequest(status, readSlot, bytesTransferred, false, encounteredError, readTasks);
+                            FinalizeSingleRequest(status, readSlot, bytesTransferred, isCanceled, encounteredError, readTasks);
                         }
                     }
                 }
@@ -1075,7 +1075,7 @@ namespace AZ::IO
 
             m_activeReads_ByteCount = 0;
         }
-        
+
         FileReadInformation& fileReadInfo = m_readSlots_readInfo[readSlot];
 
         auto readCommand = AZStd::get_if<Requests::ReadData>(&fileReadInfo.m_request->GetCommand());

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.cpp
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.cpp
@@ -13,6 +13,8 @@
 #include <AzCore/IO/Streamer/FileRequest.h>
 #include <AzCore/IO/Streamer/StreamerContext.h>
 #include <AzCore/IO/Streamer/StorageDrive_Windows.h>
+#include <AzCore/Task/TaskExecutor.h>
+#include <AzCore/Task/TaskGraph.h>
 #include <AzCore/std/typetraits/decay.h>
 #include <AzCore/std/typetraits/is_unsigned.h>
 #include <AzCore/StringFunc/StringFunc.h>
@@ -66,6 +68,7 @@ namespace AZ::IO
     StorageDriveWin::StorageDriveWin(const AZStd::vector<AZStd::string_view>& drivePaths, u32 maxFileHandles, u32 maxMetaDataCacheEntries,
         size_t physicalSectorSize, size_t logicalSectorSize, u32 ioChannelCount, s32 overCommit, ConstructionOptions options)
         : m_metaDataCache_recentlyUsed(maxMetaDataCacheEntries)
+        , m_taskExecutor(AZ::TaskExecutor::Instance())
         , m_maxFileHandles(maxFileHandles)
         , m_physicalSectorSize(physicalSectorSize)
         , m_logicalSectorSize(logicalSectorSize)
@@ -149,6 +152,10 @@ namespace AZ::IO
 
         m_metaDataCache_paths.resize(maxMetaDataCacheEntries);
         m_metaDataCache_fileSize.resize(maxMetaDataCacheEntries);
+
+        // Initialize read request task descriptor
+        m_readTaskDescriptor.taskName = "WinAPI ReadFile";
+        m_readTaskDescriptor.taskGroup = "AZ::IO:Streamer";         
     }
 
     StorageDriveWin::~StorageDriveWin()
@@ -241,11 +248,13 @@ namespace AZ::IO
         bool hasFinalizedReads = FinalizeReads();
         bool hasWorked = false;
 
+        TaskGraph readTasks;
+
         // Queue as many read requests as possible in order to maximize throughput.
         while (!m_pendingReadRequests.empty())
         {
             FileRequest* request = m_pendingReadRequests.front();
-            if (ReadRequest(request))
+            if (ReadRequest(request, readTasks))
             {
                 m_pendingReadRequests.pop_front();
                 hasWorked = true;
@@ -256,6 +265,11 @@ namespace AZ::IO
             }
         }
 
+        if (hasWorked && !readTasks.IsEmpty())
+        {
+            readTasks.Detach();
+            readTasks.SubmitOnExecutor(m_taskExecutor);
+        }
         // Pick up one other synchronous request if no read requests were issued.
         if (!hasWorked && !m_pendingRequests.empty())
         {
@@ -524,7 +538,7 @@ namespace AZ::IO
         return OpenFileResult::FileOpened;
     }
 
-    bool StorageDriveWin::ReadRequest(FileRequest* request)
+    bool StorageDriveWin::ReadRequest(FileRequest* request, TaskGraph& tasks)
     {
         AZ_PROFILE_SCOPE(AzCore, "StorageDriveWin::ReadRequest %s", m_name.c_str());
 
@@ -536,7 +550,7 @@ namespace AZ::IO
             m_fileCache_activeReads.resize(m_maxFileHandles, 0);
 
             m_readSlots_readInfo.resize(m_ioChannelCount);
-            m_readSlots_statusInfo.resize(m_ioChannelCount);
+            m_readSlots_statusInfo = AZStd::make_unique<FileReadStatus[]>(m_ioChannelCount);
             m_readSlots_active.resize(m_ioChannelCount);
 
             m_cachesInitialized = true;
@@ -550,10 +564,10 @@ namespace AZ::IO
         size_t readSlot = FindAvailableReadSlot();
         AZ_Assert(readSlot != InvalidReadSlotIndex, "Active read slot count indicates there's a read slot available, but no read slot was found.");
 
-        return ReadRequest(request, readSlot);
+        return ReadRequest(request, readSlot, tasks);
     }
 
-    bool StorageDriveWin::ReadRequest(FileRequest* request, size_t readSlot)
+    bool StorageDriveWin::ReadRequest(FileRequest* request, size_t readSlot, [[maybe_unused]]TaskGraph& tasks)
     {
         AZ_PROFILE_SCOPE(AzCore, "StorageDriveWin::ReadRequest %s", m_name.c_str());
 
@@ -674,33 +688,36 @@ namespace AZ::IO
         overlapped->hEvent = m_context->GetStreamerThreadSynchronizer().CreateEventHandle();
         readStatus.m_fileHandleIndex = fileCacheSlot;
 
-        bool result = false;
         {
             AZ_PROFILE_SCOPE(AzCore, "StorageDriveWin::ReadRequest ::ReadFile");
-            result = ::ReadFile(file, output, readSize, nullptr, overlapped);
-        }
-
-        if (!result)
-        {
-            DWORD error = ::GetLastError();
-            if (error != ERROR_IO_PENDING)
-            {
-                AZ_Warning("StorageDriveWin", false, "::ReadFile failed with error: %u\n", error);
-
-                m_context->GetStreamerThreadSynchronizer().DestroyEventHandle(overlapped->hEvent);
-
-                // Finish the request since this drive opened the file handle but the read failed.
-                request->SetStatus(IStreamerTypes::RequestStatus::Failed);
-                m_context->MarkRequestAsCompleted(request);
-                readInfo.Clear();
-                return true;
-            }
-        }
-        else
-        {
-            // If this scope is reached, it means that ::ReadFile processed the read synchronously.  This can happen if
-            // the OS already had the file in the cache.  The OVERLAPPED struct will still be filled out so we proceed as
-            // if the read was fully asynchronous.
+            tasks.AddTask(
+                m_readTaskDescriptor,
+                [this, file, output, readSize, overlapped, state = &readStatus.m_requestState]()
+                {
+                    AZ_PROFILE_SCOPE(AzCore, "::ReadFile WinAPI.");
+                    if (!::ReadFile(file, output, readSize, nullptr, overlapped))
+                    {
+                        DWORD error = ::GetLastError();
+                        if (error == ERROR_IO_PENDING)
+                        {
+                            *state = FileReadStatus::RequestState::SuccessfullyStarted;
+                            // The scheduler thread will be woken up by the OS when the read completes.
+                        }
+                        else
+                        {
+                            *state = FileReadStatus::RequestState::Error;
+                            m_context->WakeUpSchedulingThread();
+                        }
+                    }
+                    else
+                    {
+                        // If this scope is reached, it means that ::ReadFile processed the read synchronously.  This can happen if
+                        // the OS already had the file in the cache. The OVERLAPPED struct will still be filled out so we proceed as
+                        // if the read was fully asynchronous.
+                        *state = FileReadStatus::RequestState::SuccessfullyStarted;
+                        m_context->WakeUpSchedulingThread();
+                    }
+                });
         }
 
         auto now = AZStd::chrono::steady_clock::now();
@@ -977,6 +994,8 @@ namespace AZ::IO
     {
         AZ_PROFILE_FUNCTION(AzCore);
 
+        TaskGraph readTasks;
+
         bool hasWorked = false;
         for (size_t readSlot = 0; readSlot < m_readSlots_active.size(); ++readSlot)
         {
@@ -984,34 +1003,55 @@ namespace AZ::IO
             {
                 FileReadStatus& status = m_readSlots_statusInfo[readSlot];
 
-                if (HasOverlappedIoCompleted(&status.m_overlapped))
+                if (status.m_requestState != FileReadStatus::RequestState::NotStarted)
                 {
-                    DWORD bytesTransferred = 0;
-                    BOOL result = ::GetOverlappedResult(m_fileCache_handles[status.m_fileHandleIndex],
-                        &status.m_overlapped, &bytesTransferred, FALSE);
-                    DWORD error = ::GetLastError();
-
-                    if (result || error == ERROR_OPERATION_ABORTED)
+                    if (status.m_requestState == FileReadStatus::RequestState::Error)
                     {
-                        hasWorked = true;
-                        constexpr bool encounteredError = false;
-                        FinalizeSingleRequest(status, readSlot, bytesTransferred, error == ERROR_OPERATION_ABORTED, encounteredError);
-                    }
-                    else if (error != ERROR_IO_PENDING && error != ERROR_IO_INCOMPLETE)
-                    {
-                        AZ_Error("StorageDriveWin", false, "Async file read operation completed with extended error code %u\n", error);
+                        AZ_Error("StorageDriveWin", false, "Async file read operation failed to queue a read request with the OS.\n");
                         hasWorked = true;
                         constexpr bool encounteredError = true;
-                        FinalizeSingleRequest(status, readSlot, bytesTransferred, false, encounteredError);
+                        constexpr bool isCanceled = false;
+                        FinalizeSingleRequest(status, readSlot, 0, isCanceled, encounteredError, readTasks);
+                        status.m_requestState = FileReadStatus::RequestState::NotStarted;
+                    }
+                    else if (HasOverlappedIoCompleted(&status.m_overlapped))
+                    {
+                        DWORD bytesTransferred = 0;
+                        BOOL result = ::GetOverlappedResult(
+                            m_fileCache_handles[status.m_fileHandleIndex], &status.m_overlapped, &bytesTransferred, FALSE);
+                        DWORD error = ::GetLastError();
+
+                        if (result || error == ERROR_OPERATION_ABORTED)
+                        {
+                            hasWorked = true;
+                            constexpr bool encounteredError = false;
+                            FinalizeSingleRequest(
+                                status, readSlot, bytesTransferred, error == ERROR_OPERATION_ABORTED, encounteredError, readTasks);
+                        }
+                        else if (error != ERROR_IO_PENDING && error != ERROR_IO_INCOMPLETE)
+                        {
+                            AZ_Error("StorageDriveWin", false, "Async file read operation completed with extended error code %u\n", error);
+                            hasWorked = true;
+                            constexpr bool encounteredError = true;
+                            constexpr bool isCanceled = false;
+                            FinalizeSingleRequest(status, readSlot, bytesTransferred, false, encounteredError, readTasks);
+                        }
+                        status.m_requestState = FileReadStatus::RequestState::NotStarted;
                     }
                 }
             }
         }
+
+        if (hasWorked && !readTasks.IsEmpty())
+        {
+            readTasks.Detach();
+            readTasks.SubmitOnExecutor(m_taskExecutor);
+        }
         return hasWorked;
     }
 
-    void StorageDriveWin::FinalizeSingleRequest(FileReadStatus& status, size_t readSlot, DWORD numBytesTransferred,
-        bool isCanceled, bool encounteredError)
+    void StorageDriveWin::FinalizeSingleRequest(
+        FileReadStatus& status, size_t readSlot, DWORD numBytesTransferred, bool isCanceled, bool encounteredError, TaskGraph& readTasks)
     {
         m_activeReads_ByteCount += numBytesTransferred;
         if (--m_activeReads_Count == 0)
@@ -1057,7 +1097,7 @@ namespace AZ::IO
         if (!m_pendingReadRequests.empty())
         {
             FileRequest* request = m_pendingReadRequests.front();
-            if (ReadRequest(request, readSlot))
+            if (ReadRequest(request, readSlot, readTasks))
             {
                 m_pendingReadRequests.pop_front();
             }

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.cpp
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.cpp
@@ -246,7 +246,6 @@ namespace AZ::IO
     bool StorageDriveWin::ExecuteRequests()
     {
         bool hasFinalizedReads = FinalizeReads();
-        bool hasWorked = false;
 
         TaskGraph readTasks;
 
@@ -257,7 +256,6 @@ namespace AZ::IO
             if (ReadRequest(request, readTasks))
             {
                 m_pendingReadRequests.pop_front();
-                hasWorked = true;
             }
             else
             {
@@ -265,41 +263,51 @@ namespace AZ::IO
             }
         }
 
-        if (hasWorked && !readTasks.IsEmpty())
+        if (!readTasks.IsEmpty())
         {
             readTasks.Detach();
             readTasks.SubmitOnExecutor(m_taskExecutor);
-        }
-        // Pick up one other synchronous request if no read requests were issued.
-        if (!hasWorked && !m_pendingRequests.empty())
-        {
-            FileRequest* request = m_pendingRequests.front();
-            hasWorked = AZStd::visit(
-                [this, request](auto&& args)
-                {
-                    using Command = AZStd::decay_t<decltype(args)>;
-                    if constexpr (AZStd::is_same_v<Command, Requests::FileExistsCheckData>)
-                    {
-                        FileExistsRequest(request);
-                        m_pendingRequests.pop_front();
-                        return true;
-                    }
-                    else if constexpr (AZStd::is_same_v<Command, Requests::FileMetaDataRetrievalData>)
-                    {
-                        FileMetaDataRetrievalRequest(request);
-                        m_pendingRequests.pop_front();
-                        return true;
-                    }
-                    else
-                    {
-                        AZ_Assert(false, "A request was added to StorageDriveWin's pending queue that isn't supported.");
-                        return false;
-                    }
-                },
-                request->GetCommand());
-        }
 
-        return StreamStackEntry::ExecuteRequests() || hasFinalizedReads || hasWorked;
+            StreamStackEntry::ExecuteRequests();
+            return true;
+        }
+        else
+        {
+            // Pick up one other synchronous request if no read requests were issued.
+            if (!m_pendingRequests.empty())
+            {
+                FileRequest* request = m_pendingRequests.front();
+                bool hasWorked = AZStd::visit(
+                    [this, request](auto&& args)
+                    {
+                        using Command = AZStd::decay_t<decltype(args)>;
+                        if constexpr (AZStd::is_same_v<Command, Requests::FileExistsCheckData>)
+                        {
+                            FileExistsRequest(request);
+                            m_pendingRequests.pop_front();
+                            return true;
+                        }
+                        else if constexpr (AZStd::is_same_v<Command, Requests::FileMetaDataRetrievalData>)
+                        {
+                            FileMetaDataRetrievalRequest(request);
+                            m_pendingRequests.pop_front();
+                            return true;
+                        }
+                        else
+                        {
+                            AZ_Assert(false, "A request was added to StorageDriveWin's pending queue that isn't supported.");
+                            return false;
+                        }
+                    },
+                    request->GetCommand());
+
+                return StreamStackEntry::ExecuteRequests() || hasFinalizedReads || hasWorked;
+            }
+            else
+            {
+                return StreamStackEntry::ExecuteRequests() || hasFinalizedReads;
+            }
+        }
     }
 
     void StorageDriveWin::UpdateStatus(Status& status) const

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.cpp
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.cpp
@@ -65,7 +65,8 @@ namespace AZ::IO
     //
     StorageDriveWin::StorageDriveWin(const AZStd::vector<AZStd::string_view>& drivePaths, u32 maxFileHandles, u32 maxMetaDataCacheEntries,
         size_t physicalSectorSize, size_t logicalSectorSize, u32 ioChannelCount, s32 overCommit, ConstructionOptions options)
-        : m_maxFileHandles(maxFileHandles)
+        : m_metaDataCache_recentlyUsed(maxMetaDataCacheEntries)
+        , m_maxFileHandles(maxFileHandles)
         , m_physicalSectorSize(physicalSectorSize)
         , m_logicalSectorSize(logicalSectorSize)
         , m_ioChannelCount(ioChannelCount)
@@ -146,8 +147,6 @@ namespace AZ::IO
         m_readSizeAverage.PushEntry(1);
         m_readTimeAverage.PushEntry(AZStd::chrono::microseconds(1));
 
-        AZ_Assert(IStreamerTypes::IsPowerOf2(maxMetaDataCacheEntries),
-            "StorageDriveWin requires a power-of-2 for maxMetaDataCacheEntries. Received %zu", maxMetaDataCacheEntries);
         m_metaDataCache_paths.resize(maxMetaDataCacheEntries);
         m_metaDataCache_fileSize.resize(maxMetaDataCacheEntries);
     }
@@ -445,17 +444,18 @@ namespace AZ::IO
             aznumeric_cast<s32>(m_pendingRequests.size()) - m_activeReads_Count;
     }
 
-    auto StorageDriveWin::OpenFile(HANDLE& fileHandle, size_t& cacheSlot, FileRequest* request, const Requests::ReadData& data) -> OpenFileResult
+    auto StorageDriveWin::OpenFile(HANDLE& fileHandle, u32& cacheSlot, FileRequest* request, const Requests::ReadData& data) -> OpenFileResult
     {
         HANDLE file = INVALID_HANDLE_VALUE;
 
         // If the file is already opened for use, use that file handle and update it's last touched time.
-        size_t cacheIndex = FindInFileHandleCache(data.m_path);
+        u32 cacheIndex = FindInFileHandleCache(data.m_path);
         if (cacheIndex != InvalidFileCacheIndex)
         {
             file = m_fileCache_handles[cacheIndex];
             AZ_Assert(file != INVALID_HANDLE_VALUE, "Found the file '%s' in cache, but file handle is invalid.\n",
                 data.m_path.GetRelativePath());
+            m_fileCache_recentlyUsed.Touch(cacheIndex);
         }
         else
         {
@@ -496,7 +496,7 @@ namespace AZ::IO
                     return OpenFileResult::RequestForwarded;
                 }
 
-                // Remove any alertable IO completion notifications that could be queued by the IO Manager.
+                // Remove any alert-able IO completion notifications that could be queued by the IO Manager.
                 if (!::SetFileCompletionNotificationModes(file, FILE_SKIP_SET_EVENT_ON_HANDLE | FILE_SKIP_COMPLETION_PORT_ON_SUCCESS))
                 {
                     AZ_Warning("StorageDriveWin", false, "Failed to remove alertable IO completion notifications. (Error: %u)\n", ::GetLastError());
@@ -508,6 +508,8 @@ namespace AZ::IO
                 }
             }
 
+            m_fileCache_recentlyUsed.TouchLeastRecentlyUsed();
+
             // Fill the cache entry with data about the new file.
             m_fileCache_handles[cacheIndex] = file;
             m_fileCache_activeReads[cacheIndex] = 0;
@@ -517,8 +519,6 @@ namespace AZ::IO
         AZ_Assert(file != INVALID_HANDLE_VALUE, "While searching for file '%s' in StorageDeviceWin::OpenFile failed to detect a problem.",
             data.m_path.GetRelativePath());
 
-        // Set the current request and update timestamp, regardless of cache hit or miss.
-        m_fileCache_lastTimeUsed[cacheIndex] = AZStd::chrono::steady_clock::now();
         fileHandle = file;
         cacheSlot = cacheIndex;
         return OpenFileResult::FileOpened;
@@ -530,7 +530,7 @@ namespace AZ::IO
 
         if (!m_cachesInitialized)
         {
-            m_fileCache_lastTimeUsed.resize(m_maxFileHandles, AZStd::chrono::steady_clock::time_point::min());
+            m_fileCache_recentlyUsed = RecentlyUsedFileIndex(m_maxFileHandles);
             m_fileCache_paths.resize(m_maxFileHandles);
             m_fileCache_handles.resize(m_maxFileHandles, INVALID_HANDLE_VALUE);
             m_fileCache_activeReads.resize(m_maxFileHandles, 0);
@@ -567,7 +567,7 @@ namespace AZ::IO
         AZ_Assert(data, "Read request in StorageDriveWin doesn't contain read data.");
 
         HANDLE file = INVALID_HANDLE_VALUE;
-        size_t fileCacheSlot = InvalidFileCacheIndex;
+        u32 fileCacheSlot = InvalidFileCacheIndex;
         switch (OpenFile(file, fileCacheSlot, request, *data))
         {
         case OpenFileResult::FileOpened:
@@ -800,7 +800,7 @@ namespace AZ::IO
             "FileExistsRequest was queued on a StorageDriveWin that doesn't service files on the given path '%s'.",
             fileExists.m_path.GetRelativePath());
 
-        size_t cacheIndex = FindInFileHandleCache(fileExists.m_path);
+        u32 cacheIndex = FindInFileHandleCache(fileExists.m_path);
         if (cacheIndex != InvalidFileCacheIndex)
         {
             fileExists.m_found = true;
@@ -815,6 +815,7 @@ namespace AZ::IO
             fileExists.m_found = true;
             request->SetStatus(IStreamerTypes::RequestStatus::Completed);
             m_context->MarkRequestAsCompleted(request);
+            m_metaDataCache_recentlyUsed.Touch(cacheIndex);
             return;
         }
 
@@ -830,7 +831,7 @@ namespace AZ::IO
                 fileSize.LowPart = attributes.nFileSizeLow;
                 fileSize.HighPart = attributes.nFileSizeHigh;
 
-                cacheIndex = GetNextMetaDataCacheSlot();
+                cacheIndex = m_metaDataCache_recentlyUsed.TouchLeastRecentlyUsed();
                 m_metaDataCache_paths[cacheIndex] = fileExists.m_path;
                 m_metaDataCache_fileSize[cacheIndex] = aznumeric_caster(fileSize.QuadPart);
                 fileExists.m_found = true;
@@ -852,13 +853,14 @@ namespace AZ::IO
             m_name.c_str(), command.m_path.GetRelativePath());
         TIMED_AVERAGE_WINDOW_SCOPE(m_getFileMetaDataRetrievalTimeAverage);
 
-        size_t cacheIndex = FindInMetaDataCache(command.m_path);
+        u32 cacheIndex = FindInMetaDataCache(command.m_path);
         if (cacheIndex != InvalidMetaDataCacheIndex)
         {
             command.m_fileSize = m_metaDataCache_fileSize[cacheIndex];
             command.m_found = true;
             request->SetStatus(IStreamerTypes::RequestStatus::Completed);
             m_context->MarkRequestAsCompleted(request);
+            m_metaDataCache_recentlyUsed.Touch(cacheIndex);
             return;
         }
 
@@ -896,7 +898,7 @@ namespace AZ::IO
         command.m_fileSize = aznumeric_caster(fileSize.QuadPart);
         command.m_found = true;
 
-        cacheIndex = GetNextMetaDataCacheSlot();
+        cacheIndex = m_metaDataCache_recentlyUsed.TouchLeastRecentlyUsed();
 
         m_metaDataCache_paths[cacheIndex] = command.m_path;
         m_metaDataCache_fileSize[cacheIndex] = aznumeric_caster(fileSize.QuadPart);
@@ -909,26 +911,35 @@ namespace AZ::IO
     {
         if (m_cachesInitialized)
         {
-            size_t cacheIndex = FindInFileHandleCache(filePath);
-            if (cacheIndex != InvalidFileCacheIndex)
+            // Clear file handle from cache.
             {
-                if (m_fileCache_handles[cacheIndex] != INVALID_HANDLE_VALUE)
+                u32 cacheIndex = FindInFileHandleCache(filePath);
+                if (cacheIndex != InvalidFileCacheIndex)
                 {
-                    AZ_Assert(m_fileCache_activeReads[cacheIndex] == 0, "Flushing '%s' but it has %u active reads\n",
-                        filePath.GetRelativePath(), m_fileCache_activeReads[cacheIndex]);
-                    ::CloseHandle(m_fileCache_handles[cacheIndex]);
-                    m_fileCache_handles[cacheIndex] = INVALID_HANDLE_VALUE;
+                    if (m_fileCache_handles[cacheIndex] != INVALID_HANDLE_VALUE)
+                    {
+                        AZ_Assert(
+                            m_fileCache_activeReads[cacheIndex] == 0, "Flushing '%s' but it has %u active reads\n",
+                            filePath.GetRelativePath(), m_fileCache_activeReads[cacheIndex]);
+                        ::CloseHandle(m_fileCache_handles[cacheIndex]);
+                        m_fileCache_handles[cacheIndex] = INVALID_HANDLE_VALUE;
+                        m_fileCache_recentlyUsed.Flush(cacheIndex);
+                    }
+                    m_fileCache_activeReads[cacheIndex] = 0;
+                    m_fileCache_recentlyUsed.Flush(cacheIndex);
+                    m_fileCache_paths[cacheIndex].Clear();
                 }
-                m_fileCache_activeReads[cacheIndex] = 0;
-                m_fileCache_lastTimeUsed[cacheIndex] = AZStd::chrono::steady_clock::time_point();
-                m_fileCache_paths[cacheIndex].Clear();
             }
 
-            cacheIndex = FindInMetaDataCache(filePath);
-            if (cacheIndex != InvalidMetaDataCacheIndex)
+            // Clear file meta data from cache.
             {
-                m_metaDataCache_paths[cacheIndex].Clear();
-                m_metaDataCache_fileSize[cacheIndex] = 0;
+                u32 cacheIndex = FindInMetaDataCache(filePath);
+                if (cacheIndex != InvalidMetaDataCacheIndex)
+                {
+                    m_metaDataCache_paths[cacheIndex].Clear();
+                    m_metaDataCache_fileSize[cacheIndex] = 0;
+                    m_metaDataCache_recentlyUsed.Flush(cacheIndex);
+                }
             }
         }
     }
@@ -948,15 +959,15 @@ namespace AZ::IO
                     m_fileCache_handles[cacheIndex] = INVALID_HANDLE_VALUE;
                 }
                 m_fileCache_activeReads[cacheIndex] = 0;
-                m_fileCache_lastTimeUsed[cacheIndex] = AZStd::chrono::steady_clock::time_point();
                 m_fileCache_paths[cacheIndex].Clear();
             }
+            m_fileCache_recentlyUsed.FlushAll();
 
             // Clear meta data cache
+            m_metaDataCache_recentlyUsed.FlushAll();
             auto metaDataCacheSize = m_metaDataCache_paths.size();
             m_metaDataCache_paths.clear();
             m_metaDataCache_fileSize.clear();
-            m_metaDataCache_front = 0;
             m_metaDataCache_paths.resize(metaDataCacheSize);
             m_metaDataCache_fileSize.resize(metaDataCacheSize);
         }
@@ -1053,36 +1064,29 @@ namespace AZ::IO
         }
     }
 
-    size_t StorageDriveWin::FindInFileHandleCache(const RequestPath& filePath) const
+    u32 StorageDriveWin::FindInFileHandleCache(const RequestPath& filePath) const
     {
         size_t numFiles = m_fileCache_paths.size();
         for (size_t i = 0; i < numFiles; ++i)
         {
             if (m_fileCache_paths[i] == filePath)
             {
-                return i;
+                return aznumeric_caster(i);
             }
         }
         return InvalidFileCacheIndex;
     }
 
-    size_t StorageDriveWin::FindAvailableFileHandleCacheIndex() const
+    u32 StorageDriveWin::FindAvailableFileHandleCacheIndex()
     {
         AZ_Assert(m_cachesInitialized, "Using file cache before it has been (lazily) initialized\n");
 
-        // This needs to look for files with no active reads, and the oldest file among those.
-        size_t cacheIndex = InvalidFileCacheIndex;
-        AZStd::chrono::steady_clock::time_point oldest = AZStd::chrono::steady_clock::time_point::max();
-        for (size_t index = 0; index < m_maxFileHandles; ++index)
+        u32 cacheIndex = m_fileCache_recentlyUsed.GetLeastRecentlyUsed();
+        if (m_fileCache_activeReads[cacheIndex] == 0)
         {
-            if (m_fileCache_activeReads[index] == 0 && m_fileCache_lastTimeUsed[index] < oldest)
-            {
-                oldest = m_fileCache_lastTimeUsed[index];
-                cacheIndex = index;
-            }
+            return cacheIndex;
         }
-
-        return cacheIndex;
+        return InvalidFileCacheIndex;
     }
 
     size_t StorageDriveWin::FindAvailableReadSlot()
@@ -1097,23 +1101,17 @@ namespace AZ::IO
         return InvalidReadSlotIndex;
     }
 
-    size_t StorageDriveWin::FindInMetaDataCache(const RequestPath& filePath) const
+    u32 StorageDriveWin::FindInMetaDataCache(const RequestPath& filePath) const
     {
         size_t numFiles = m_metaDataCache_paths.size();
         for (size_t i = 0; i < numFiles; ++i)
         {
             if (m_metaDataCache_paths[i] == filePath)
             {
-                return i;
+                return aznumeric_caster(i);
             }
         }
         return InvalidMetaDataCacheIndex;
-    }
-
-    size_t StorageDriveWin::GetNextMetaDataCacheSlot()
-    {
-        m_metaDataCache_front = (m_metaDataCache_front + 1) & (m_metaDataCache_paths.size() - 1);
-        return m_metaDataCache_front;
     }
 
     bool StorageDriveWin::IsServicedByThisDrive(AZ::IO::PathView filePath) const

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.h
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.h
@@ -102,9 +102,9 @@ namespace AZ::IO
         using RecentlyUsedMetaIndex = RecentlyUsedIndex<u32>;
         static const AZStd::chrono::microseconds s_averageSeekTime;
 
-        inline static constexpr u32 InvalidFileCacheIndex = std::numeric_limits<u32>::max();
-        inline static constexpr size_t InvalidReadSlotIndex = std::numeric_limits<size_t>::max();
-        inline static constexpr u32 InvalidMetaDataCacheIndex = std::numeric_limits<u32>::max();
+        inline static constexpr u32 InvalidFileCacheIndex = AZStd::numeric_limits<u32>::max();
+        inline static constexpr size_t InvalidReadSlotIndex = AZStd::numeric_limits<size_t>::max();
+        inline static constexpr u32 InvalidMetaDataCacheIndex = AZStd::numeric_limits<u32>::max();
 
         struct FileReadStatus
         {

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.h
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Task/TaskDescriptor.h>
 #include <AzCore/PlatformIncl.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/IO/Streamer/RecentlyUsedIndex.h>
@@ -18,9 +19,16 @@
 #include <AzCore/std/containers/deque.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/chrono/chrono.h>
+#include <AzCore/std/parallel/atomic.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/string/string_view.h>
 #include <AzCore/Statistics/RunningStatistic.h>
+
+namespace AZ
+{
+    class TaskExecutor;
+    class TaskGraph;
+}
 
 namespace AZ::IO::Requests
 {
@@ -100,8 +108,15 @@ namespace AZ::IO
 
         struct FileReadStatus
         {
+            enum class RequestState : u8
+            {
+                NotStarted,
+                SuccessfullyStarted,
+                Error
+            };
             OVERLAPPED m_overlapped{};
             u32 m_fileHandleIndex{ InvalidFileCacheIndex };
+            AZStd::atomic<RequestState> m_requestState{ RequestState::NotStarted };
         };
 
         struct FileReadInformation
@@ -123,8 +138,8 @@ namespace AZ::IO
         };
 
         OpenFileResult OpenFile(HANDLE& fileHandle, u32& cacheSlot, FileRequest* request, const Requests::ReadData& data);
-        bool ReadRequest(FileRequest* request);
-        bool ReadRequest(FileRequest* request, size_t readSlot);
+        bool ReadRequest(FileRequest* request, TaskGraph& tasks);
+        bool ReadRequest(FileRequest* request, size_t readSlot, TaskGraph& tasks);
         bool CancelRequest(FileRequest* cancelRequest, FileRequestPtr& target);
         void FileExistsRequest(FileRequest* request);
         void FileMetaDataRetrievalRequest(FileRequest* request);
@@ -144,8 +159,13 @@ namespace AZ::IO
         void FlushEntireCache();
 
         bool FinalizeReads();
-        void FinalizeSingleRequest(FileReadStatus& status, size_t readSlot, DWORD numBytesTransferred,
-            bool isCanceled, bool encounteredError);
+        void FinalizeSingleRequest(
+            FileReadStatus& status,
+            size_t readSlot,
+            DWORD numBytesTransferred,
+            bool isCanceled,
+            bool encounteredError,
+            TaskGraph& readTasks);
 
         void Report(const Requests::ReportData& data) const;
 
@@ -165,7 +185,7 @@ namespace AZ::IO
         AZStd::deque<FileRequest*> m_pendingRequests;
 
         AZStd::vector<FileReadInformation> m_readSlots_readInfo;
-        AZStd::vector<FileReadStatus> m_readSlots_statusInfo;
+        AZStd::unique_ptr<FileReadStatus[]> m_readSlots_statusInfo;
         AZStd::vector<bool> m_readSlots_active;
 
         RecentlyUsedFileIndex m_fileCache_recentlyUsed;
@@ -178,6 +198,9 @@ namespace AZ::IO
         AZStd::vector<u64> m_metaDataCache_fileSize;
 
         AZStd::vector<AZStd::string> m_drivePaths;
+
+        AZ::TaskDescriptor m_readTaskDescriptor;
+        AZ::TaskExecutor& m_taskExecutor;
 
         size_t m_activeReads_ByteCount{ 0 };
 

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.h
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/PlatformIncl.h>
 #include <AzCore/IO/Path/Path.h>
+#include <AzCore/IO/Streamer/RecentlyUsedIndex.h>
 #include <AzCore/IO/Streamer/RequestPath.h>
 #include <AzCore/IO/Streamer/Statistics.h>
 #include <AzCore/IO/Streamer/StreamerConfiguration.h>
@@ -89,16 +90,18 @@ namespace AZ::IO
         void CollectStatistics(AZStd::vector<Statistic>& statistics) const override;
 
     protected:
+        using RecentlyUsedFileIndex = RecentlyUsedIndex<u32>;
+        using RecentlyUsedMetaIndex = RecentlyUsedIndex<u32>;
         static const AZStd::chrono::microseconds s_averageSeekTime;
 
-        inline static constexpr size_t InvalidFileCacheIndex = std::numeric_limits<size_t>::max();
+        inline static constexpr u32 InvalidFileCacheIndex = std::numeric_limits<u32>::max();
         inline static constexpr size_t InvalidReadSlotIndex = std::numeric_limits<size_t>::max();
-        inline static constexpr size_t InvalidMetaDataCacheIndex = std::numeric_limits<size_t>::max();
+        inline static constexpr u32 InvalidMetaDataCacheIndex = std::numeric_limits<u32>::max();
 
         struct FileReadStatus
         {
             OVERLAPPED m_overlapped{};
-            size_t m_fileHandleIndex{ InvalidFileCacheIndex };
+            u32 m_fileHandleIndex{ InvalidFileCacheIndex };
         };
 
         struct FileReadInformation
@@ -119,17 +122,16 @@ namespace AZ::IO
             CacheFull
         };
 
-        OpenFileResult OpenFile(HANDLE& fileHandle, size_t& cacheSlot, FileRequest* request, const Requests::ReadData& data);
+        OpenFileResult OpenFile(HANDLE& fileHandle, u32& cacheSlot, FileRequest* request, const Requests::ReadData& data);
         bool ReadRequest(FileRequest* request);
         bool ReadRequest(FileRequest* request, size_t readSlot);
         bool CancelRequest(FileRequest* cancelRequest, FileRequestPtr& target);
         void FileExistsRequest(FileRequest* request);
         void FileMetaDataRetrievalRequest(FileRequest* request);
-        size_t FindInFileHandleCache(const RequestPath& filePath) const;
-        size_t FindAvailableFileHandleCacheIndex() const;
+        u32 FindInFileHandleCache(const RequestPath& filePath) const;
+        u32 FindAvailableFileHandleCacheIndex();
         size_t FindAvailableReadSlot();
-        size_t FindInMetaDataCache(const RequestPath& filePath) const;
-        size_t GetNextMetaDataCacheSlot();
+        u32 FindInMetaDataCache(const RequestPath& filePath) const;
         bool IsServicedByThisDrive(AZ::IO::PathView filePath) const;
 
         void EstimateCompletionTimeForRequest(FileRequest* request, AZStd::chrono::steady_clock::time_point& startTime,
@@ -166,11 +168,12 @@ namespace AZ::IO
         AZStd::vector<FileReadStatus> m_readSlots_statusInfo;
         AZStd::vector<bool> m_readSlots_active;
 
-        AZStd::vector<AZStd::chrono::steady_clock::time_point> m_fileCache_lastTimeUsed;
+        RecentlyUsedFileIndex m_fileCache_recentlyUsed;
         AZStd::vector<RequestPath> m_fileCache_paths;
         AZStd::vector<HANDLE> m_fileCache_handles;
         AZStd::vector<u16> m_fileCache_activeReads;
 
+        RecentlyUsedMetaIndex m_metaDataCache_recentlyUsed;
         AZStd::vector<RequestPath> m_metaDataCache_paths;
         AZStd::vector<u64> m_metaDataCache_fileSize;
 
@@ -180,9 +183,8 @@ namespace AZ::IO
 
         size_t m_physicalSectorSize{ 0 };
         size_t m_logicalSectorSize{ 0 };
-        size_t m_activeCacheSlot{ InvalidFileCacheIndex };
-        size_t m_metaDataCache_front{ 0 };
         u64 m_activeOffset{ 0 };
+        u32 m_activeCacheSlot{ InvalidFileCacheIndex };
         u32 m_maxFileHandles{ 1 };
         u32 m_ioChannelCount{ 1 };
         s32 m_overCommit{ 0 };

--- a/Code/Framework/AzCore/Tests/Asset/BaseAssetManagerTest.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/BaseAssetManagerTest.cpp
@@ -77,6 +77,9 @@ namespace UnitTest
         m_jobContext = aznew AZ::JobContext(*m_jobManager);
         AZ::JobContext::SetGlobalContext(m_jobContext);
 
+        m_taskExecutor = aznew TaskExecutor();
+        TaskExecutor::SetInstance(m_taskExecutor);
+
         m_prevFileIO = IO::FileIOBase::GetInstance();
         IO::FileIOBase::SetInstance(&m_fileIO);
 
@@ -106,6 +109,9 @@ namespace UnitTest
         m_assetsWritten.shrink_to_fit();
 
         IO::FileIOBase::SetInstance(m_prevFileIO);
+
+        TaskExecutor::SetInstance(nullptr);
+        delete m_taskExecutor;
 
         AZ::JobContext::SetGlobalContext(nullptr);
         delete m_jobContext;

--- a/Code/Framework/AzCore/Tests/Asset/BaseAssetManagerTest.h
+++ b/Code/Framework/AzCore/Tests/Asset/BaseAssetManagerTest.h
@@ -14,6 +14,7 @@
 #include <AzCore/Jobs/JobContext.h>
 #include <AzCore/Serialization/ObjectStream.h>
 #include <AzCore/Serialization/Utils.h>
+#include <AzCore/Task/TaskExecutor.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AZTestShared/Utils/Utils.h>
 #include <Tests/FileIOBaseTestTypes.h>
@@ -85,6 +86,7 @@ namespace UnitTest
         IO::IStreamer* m_streamer{ nullptr };
         TestFileIOBase m_fileIO;
         AZStd::vector<AZStd::string> m_assetsWritten;
+        TaskExecutor* m_taskExecutor{ nullptr };
     };
 
     

--- a/Code/Framework/AzCore/Tests/AssetJsonSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/AssetJsonSerializerTests.cpp
@@ -17,6 +17,7 @@
 #include <AzCore/Jobs/JobContext.h>
 #include <AzCore/Memory/PoolAllocator.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <Tests/Serialization/Json/JsonSerializerConformityTests.h>
 
 namespace JsonSerializationTests
@@ -266,6 +267,7 @@ namespace JsonSerializationTests
         {
             systemComponents.push_back(AZ::AssetManagerComponent::CreateDescriptor());
             systemComponents.push_back(AZ::JobManagerComponent::CreateDescriptor());
+            systemComponents.push_back(AZ::TaskGraphSystemComponent::CreateDescriptor());
             systemComponents.push_back(AZ::StreamerComponent::CreateDescriptor());
         }
 

--- a/Code/Framework/AzCore/Tests/Components.cpp
+++ b/Code/Framework/AzCore/Tests/Components.cpp
@@ -23,6 +23,7 @@
 #include <AzCore/IO/SystemFile.h>
 
 #include <AzCore/Memory/AllocationRecords.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <AzCore/UnitTest/TestTypes.h>
 
 #include <AzCore/std/parallel/containers/concurrent_unordered_set.h>
@@ -50,6 +51,7 @@ TEST(ComponentApplication, Test)
     Entity* systemEntity = app.Create(appDesc);
 
     systemEntity->CreateComponent<MemoryComponent>();
+    systemEntity->CreateComponent<TaskGraphSystemComponent>();
     systemEntity->CreateComponent<StreamerComponent>();
     systemEntity->CreateComponent(AZ::Uuid("{CAE3A025-FAC9-4537-B39E-0A800A2326DF}")); // JobManager component
     systemEntity->CreateComponent(AZ::Uuid("{D5A73BCC-0098-4d1e-8FE4-C86101E374AC}")); // AssetDatabase component

--- a/Code/Framework/AzCore/Tests/Platform/Windows/Tests/IO/Streamer/StorageDriveTests_Windows.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Windows/Tests/IO/Streamer/StorageDriveTests_Windows.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/IO/Streamer/StorageDrive_Windows.h>
 #include <AzCore/IO/Streamer/Streamer.h>
 #include <AzCore/IO/SystemFile.h>
+#include <AzCore/Task/TaskExecutor.h>
 #include <AzCore/std/parallel/binary_semaphore.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/StringFunc/StringFunc.h>
@@ -19,7 +20,7 @@
 
 namespace AZ::IO
 {
-    constexpr AZ::u32 TestMaxFileHandles = 1;
+    constexpr AZ::u32 TestMaxFileHandles = 4;
     constexpr AZ::u32 TestMaxMetaDataEntries = 16;
     constexpr size_t TestPhysicalSectorSize = 4_kib;
     constexpr size_t TestLogicalSectorSize = 512;
@@ -123,6 +124,7 @@ namespace AZ::IO
         AZStd::vector<AZStd::unique_ptr<char[]>> m_dummyBuffers;
         StreamerTraceBusDetector m_traceDetector;
         StorageDriveWin::ConstructionOptions m_configurationOptions;
+        TaskExecutor m_taskExecutor;
 
         // Methods...
         Streamer_StorageDriveWindowsTestFixture()
@@ -157,6 +159,7 @@ namespace AZ::IO
 
         void SetUp() override
         {
+            TaskExecutor::SetInstance(&m_taskExecutor);
             m_dummyRequestPath = RequestPath(AZ::IO::PathView(m_dummyFilepath));
 
             SetupStorageDrive(TestOverCommit);
@@ -171,6 +174,7 @@ namespace AZ::IO
             RemoveDummyFiles();
             m_dummyBuffers.clear();
             m_dummyBuffers.shrink_to_fit();
+            TaskExecutor::SetInstance(nullptr);
         }
 
         // Create a file filled with a single character.
@@ -920,6 +924,7 @@ namespace AZ::IO
 
         void SetUp() override
         {
+            Streamer_StorageDriveWindowsTestFixture::SetUp();
             SetupStorageDrive(TestOverCommit);
         }
 

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -64,6 +64,7 @@
 
 #include <AzCore/RTTI/AttributeReader.h>
 #include <AzCore/std/string/conversions.h>
+#include <AzCore/Task/TaskExecutor.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AZTestShared/Utils/Utils.h>
 
@@ -1300,6 +1301,9 @@ namespace UnitTest
             AZ::AllocatorInstance<AZ::PoolAllocator>::Create();
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Create();
 
+            m_taskExecutor = AZStd::make_unique<AZ::TaskExecutor>();
+            AZ::TaskExecutor::SetInstance(m_taskExecutor.get());
+
             m_streamer = AZStd::make_unique<IO::Streamer>(AZStd::thread_desc{}, AZ::StreamerComponent::CreateStreamerStack());
             Interface<IO::IStreamer>::Register(m_streamer.get());
         }
@@ -1310,6 +1314,9 @@ namespace UnitTest
 
             Interface<IO::IStreamer>::Unregister(m_streamer.get());
             m_streamer.reset();
+
+            AZ::TaskExecutor::SetInstance(nullptr);
+            m_taskExecutor.reset();
 
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Destroy();
             AZ::AllocatorInstance<AZ::PoolAllocator>::Destroy();
@@ -1348,6 +1355,7 @@ namespace UnitTest
 
     protected:
         AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
+        AZStd::unique_ptr<AZ::TaskExecutor> m_taskExecutor;
         AZStd::unique_ptr<AZ::IO::Streamer> m_streamer;
     };
 
@@ -3416,6 +3424,9 @@ TEST_F(SerializeBasicTest, BasicTypeTest_Succeed)
             AllocatorInstance<PoolAllocator>::Create();
             AllocatorInstance<ThreadPoolAllocator>::Create();
 
+            m_taskExecutor = aznew AZ::TaskExecutor();
+            AZ::TaskExecutor::SetInstance(m_taskExecutor);
+
             m_prevFileIO = IO::FileIOBase::GetInstance();
             IO::FileIOBase::SetInstance(&m_fileIO);
             m_streamer = aznew IO::Streamer(AZStd::thread_desc{}, StreamerComponent::CreateStreamerStack());
@@ -3448,6 +3459,9 @@ TEST_F(SerializeBasicTest, BasicTypeTest_Succeed)
             Interface<IO::IStreamer>::Unregister(m_streamer);
             delete m_streamer;
 
+            AZ::TaskExecutor::SetInstance(nullptr);
+            delete m_taskExecutor;
+
             IO::FileIOBase::SetInstance(m_prevFileIO);
             AllocatorInstance<ThreadPoolAllocator>::Destroy();
             AllocatorInstance<PoolAllocator>::Destroy();
@@ -3471,6 +3485,7 @@ TEST_F(SerializeBasicTest, BasicTypeTest_Succeed)
     protected:
         AZ::Test::ScopedAutoTempDirectory m_tempDirectory;
         AZ::IO::FileIOBase* m_prevFileIO{};
+        AZ::TaskExecutor* m_taskExecutor{};
         AZ::IO::Streamer* m_streamer{};
         TestFileIOBase m_fileIO;
         TestCloneAssetHandler m_testAssetHandlerAndCatalog;

--- a/Code/Framework/AzCore/Tests/Slice.cpp
+++ b/Code/Framework/AzCore/Tests/Slice.cpp
@@ -27,6 +27,7 @@
 #include <AzCore/Math/Sfmt.h>
 #include <AzCore/Memory/PoolAllocator.h>
 #include <AzCore/Slice/SliceMetadataInfoComponent.h>
+#include <AzCore/Task/TaskExecutor.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AZTestShared/Utils/Utils.h>
 
@@ -215,6 +216,9 @@ namespace UnitTest
             AZ::AllocatorInstance<AZ::PoolAllocator>::Create();
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Create();
 
+            m_taskExecutor = aznew AZ::TaskExecutor();
+            AZ::TaskExecutor::SetInstance(m_taskExecutor);
+
             m_serializeContext = aznew AZ::SerializeContext(true, true);
             m_sliceDescriptor = AZ::SliceComponent::CreateDescriptor();
 
@@ -250,6 +254,9 @@ namespace UnitTest
             delete m_streamer;
             AZ::IO::FileIOBase::SetInstance(m_prevFileIO);
 
+            AZ::TaskExecutor::SetInstance(nullptr);
+            delete m_taskExecutor;
+
             AZ::AllocatorInstance<AZ::PoolAllocator>::Destroy();
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Destroy();
 
@@ -257,6 +264,7 @@ namespace UnitTest
         }
 
         AZ::IO::FileIOBase* m_prevFileIO{ nullptr };
+        AZ::TaskExecutor* m_taskExecutor{ nullptr };
         AZ::IO::Streamer* m_streamer{ nullptr };
         TestFileIOBase m_fileIO;
         AZStd::unique_ptr<SliceTest_MockCatalog> m_catalog;

--- a/Code/Framework/AzCore/Tests/Streamer/FullDecompressorTests.cpp
+++ b/Code/Framework/AzCore/Tests/Streamer/FullDecompressorTests.cpp
@@ -16,6 +16,7 @@
 #include <AzCore/Memory/PoolAllocator.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/Task/TaskExecutor.h>
 #include <Tests/Streamer/StreamStackEntryConformityTests.h>
 #include <Tests/Streamer/StreamStackEntryMock.h>
 
@@ -72,6 +73,9 @@ namespace AZ::IO
 
             AllocatorInstance<PoolAllocator>::Create();
             AllocatorInstance<ThreadPoolAllocator>::Create();
+
+            m_taskExecutor = AZStd::make_unique<TaskExecutor>();
+            TaskExecutor::SetInstance(m_taskExecutor.get());
         }
 
         void TearDown() override
@@ -87,6 +91,9 @@ namespace AZ::IO
 
             delete m_context;
             m_context = nullptr;
+
+            TaskExecutor::SetInstance(nullptr);
+            m_taskExecutor.reset();
 
             AllocatorInstance<ThreadPoolAllocator>::Destroy();
             AllocatorInstance<PoolAllocator>::Destroy();
@@ -315,6 +322,7 @@ namespace AZ::IO
         StreamerContext* m_context;
         AZStd::shared_ptr<FullFileDecompressor> m_decompressor;
         AZStd::shared_ptr<StreamStackEntryMock> m_mock;
+        AZStd::unique_ptr<TaskExecutor> m_taskExecutor;
         u64 m_fakeFileLength{ 1 * 1024 * 1024 };
     };
 

--- a/Code/Framework/AzCore/Tests/Streamer/RecentlyUsedIndexTests.cpp
+++ b/Code/Framework/AzCore/Tests/Streamer/RecentlyUsedIndexTests.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/IO/Streamer/RecentlyUsedIndex.h>
+#include <AzCore/UnitTest/TestTypes.h>
+
+namespace AZ::IO
+{
+    class Streamer_RecentlyUsedIndexTest : public UnitTest::ScopedAllocatorSetupFixture
+    {
+    public:
+        using RUI = RecentlyUsedIndex<u8>;
+
+        template<size_t Size>
+        static void Validate(const RUI& rui, const u8 (&expectedValues)[Size])
+        {
+            u8 counter = 0;
+            auto callback = [&counter, &expectedValues](u8 value)
+            {
+                EXPECT_EQ(expectedValues[counter], value);
+                counter++;
+            };
+            rui.GetIndicesInOrder(callback);
+        }
+    };
+
+    TEST_F(Streamer_RecentlyUsedIndexTest, Constructor)
+    {
+        RUI rui{ 4 };
+        Validate(rui, { 0, 1, 2, 3 });
+    }
+
+    TEST_F(Streamer_RecentlyUsedIndexTest, GetLeastRecentlyUsed)
+    {
+        RUI rui{ 4 };
+        EXPECT_EQ(0, rui.GetLeastRecentlyUsed());
+    }
+
+    TEST_F(Streamer_RecentlyUsedIndexTest, GetMostRecentlyUsed)
+    {
+        RUI rui{ 4 };
+        EXPECT_EQ(3, rui.GetMostRecentlyUsed());
+    }
+
+    TEST_F(Streamer_RecentlyUsedIndexTest, Touch_Middle)
+    {
+        RUI rui{ 4 };
+        rui.Touch(2);
+        Validate(rui, { 0, 1, 3, 2 });
+        EXPECT_EQ(rui.GetLeastRecentlyUsed(), 0);
+        EXPECT_EQ(rui.GetMostRecentlyUsed(), 2);
+    }
+
+    TEST_F(Streamer_RecentlyUsedIndexTest, Touch_Front)
+    {
+        RUI rui{ 4 };
+        rui.Touch(0);
+        Validate(rui, { 1, 2, 3, 0 });
+        EXPECT_EQ(rui.GetLeastRecentlyUsed(), 1);
+        EXPECT_EQ(rui.GetMostRecentlyUsed(), 0);
+    }
+
+    TEST_F(Streamer_RecentlyUsedIndexTest, Touch_Back)
+    {
+        RUI rui{ 4 };
+        rui.Touch(3);
+        Validate(rui, { 0, 1, 2, 3 });
+        EXPECT_EQ(rui.GetLeastRecentlyUsed(), 0);
+        EXPECT_EQ(rui.GetMostRecentlyUsed(), 3);
+    }
+
+    TEST_F(Streamer_RecentlyUsedIndexTest, Flush_Middle)
+    {
+        RUI rui{ 4 };
+        rui.Flush(2);
+        Validate(rui, { 2, 0, 1, 3 });
+        EXPECT_EQ(rui.GetLeastRecentlyUsed(), 2);
+        EXPECT_EQ(rui.GetMostRecentlyUsed(), 3);
+    }
+
+    TEST_F(Streamer_RecentlyUsedIndexTest, Flush_Front)
+    {
+        RUI rui{ 4 };
+        rui.Flush(0);
+        Validate(rui, { 0, 1, 2, 3 });
+        EXPECT_EQ(rui.GetLeastRecentlyUsed(), 0);
+        EXPECT_EQ(rui.GetMostRecentlyUsed(), 3);
+    }
+
+    TEST_F(Streamer_RecentlyUsedIndexTest, Flush_Back)
+    {
+        RUI rui{ 4 };
+        rui.Flush(3);
+        Validate(rui, { 3, 0, 1, 2 });
+        EXPECT_EQ(rui.GetLeastRecentlyUsed(), 3);
+        EXPECT_EQ(rui.GetMostRecentlyUsed(), 2);
+    }
+
+    TEST_F(Streamer_RecentlyUsedIndexTest, TouchLeastRecentlyUsed)
+    {
+        RUI rui{ 4 };
+        rui.TouchLeastRecentlyUsed();
+        Validate(rui, { 1, 2, 3, 0 });
+        EXPECT_EQ(rui.GetLeastRecentlyUsed(), 1);
+        EXPECT_EQ(rui.GetMostRecentlyUsed(), 0);
+    }
+} // namespace AZ::IO

--- a/Code/Framework/AzCore/Tests/Streamer/StreamStackEntryConformityTests.h
+++ b/Code/Framework/AzCore/Tests/Streamer/StreamStackEntryConformityTests.h
@@ -15,6 +15,7 @@
 #include <AzCore/IO/Streamer/StreamStackEntry.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/Task/TaskExecutor.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzTest/AzTest.h>
 #include <Tests/Streamer/StreamStackEntryMock.h>
@@ -52,6 +53,8 @@ namespace AZ::IO
         void SetUp() override
         {
             UnitTest::AllocatorsFixture::SetUp();
+            m_taskExecutor = AZStd::make_unique<TaskExecutor>();
+            TaskExecutor::SetInstance(m_taskExecutor.get());
             m_description.SetUp();
 
             m_context = AZStd::make_unique<StreamerContext>();
@@ -62,6 +65,8 @@ namespace AZ::IO
             m_context.reset();
 
             m_description.TearDown();
+            TaskExecutor::SetInstance(nullptr);
+            m_taskExecutor.reset();
             UnitTest::AllocatorsFixture::TearDown();
         }
 
@@ -74,6 +79,7 @@ namespace AZ::IO
         }
 
         T m_description{};
+        AZStd::unique_ptr<TaskExecutor> m_taskExecutor;
         AZStd::unique_ptr<StreamerContext> m_context;
     };
 

--- a/Code/Framework/AzCore/Tests/StreamerTests.cpp
+++ b/Code/Framework/AzCore/Tests/StreamerTests.cpp
@@ -20,6 +20,7 @@
 #include <AzCore/std/parallel/thread.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/Task/TaskExecutor.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <AzTest/GemTestEnvironment.h>
 
 namespace AZ::IO
@@ -252,8 +253,6 @@ namespace AZ::IO
             AZ::AllocatorInstance<AZ::PoolAllocator>::Create();
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Create();
 
-            m_taskExecutor = AZStd::make_unique<TaskExecutor>();
-            TaskExecutor::SetInstance(m_taskExecutor.get());
 
             m_prevFileIO = FileIOBase::GetInstance();
             FileIOBase::SetInstance(&m_fileIO);
@@ -262,6 +261,7 @@ namespace AZ::IO
             AZ::ComponentApplication::Descriptor appDesc;
             appDesc.m_useExistingAllocator = true;
             auto m_systemEntity = m_application->Create(appDesc);
+            m_systemEntity->AddComponent(aznew AZ::TaskGraphSystemComponent());
             m_systemEntity->AddComponent(aznew AZ::StreamerComponent());
             m_systemEntity->Init();
             m_systemEntity->Activate();
@@ -278,9 +278,6 @@ namespace AZ::IO
             m_application = nullptr;
 
             FileIOBase::SetInstance(m_prevFileIO);
-
-            TaskExecutor::SetInstance(nullptr);
-            m_taskExecutor.reset();
 
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Destroy();
             AZ::AllocatorInstance<AZ::PoolAllocator>::Destroy();
@@ -369,7 +366,6 @@ namespace AZ::IO
         IStreamer* m_streamer{ nullptr };
         AZ::ComponentApplication* m_application{ nullptr };
         size_t m_testFileCount{ 0 };
-        AZStd::unique_ptr<TaskExecutor> m_taskExecutor;
     };
 
     template<typename TestTag>

--- a/Code/Framework/AzCore/Tests/StreamerTests.cpp
+++ b/Code/Framework/AzCore/Tests/StreamerTests.cpp
@@ -19,6 +19,7 @@
 #include <AzCore/std/parallel/binary_semaphore.h>
 #include <AzCore/std/parallel/thread.h>
 #include <AzCore/std/string/string.h>
+#include <AzCore/Task/TaskExecutor.h>
 #include <AzTest/GemTestEnvironment.h>
 
 namespace AZ::IO
@@ -251,6 +252,9 @@ namespace AZ::IO
             AZ::AllocatorInstance<AZ::PoolAllocator>::Create();
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Create();
 
+            m_taskExecutor = AZStd::make_unique<TaskExecutor>();
+            TaskExecutor::SetInstance(m_taskExecutor.get());
+
             m_prevFileIO = FileIOBase::GetInstance();
             FileIOBase::SetInstance(&m_fileIO);
 
@@ -274,6 +278,9 @@ namespace AZ::IO
             m_application = nullptr;
 
             FileIOBase::SetInstance(m_prevFileIO);
+
+            TaskExecutor::SetInstance(nullptr);
+            m_taskExecutor.reset();
 
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Destroy();
             AZ::AllocatorInstance<AZ::PoolAllocator>::Destroy();
@@ -362,6 +369,7 @@ namespace AZ::IO
         IStreamer* m_streamer{ nullptr };
         AZ::ComponentApplication* m_application{ nullptr };
         size_t m_testFileCount{ 0 };
+        AZStd::unique_ptr<TaskExecutor> m_taskExecutor;
     };
 
     template<typename TestTag>

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -242,6 +242,7 @@ set(FILES
     Streamer/IStreamerMock.h
     Streamer/IStreamerTypesMock.h
     Streamer/ReadSplitterTests.cpp
+    Streamer/RecentlyUsedIndexTests.cpp
     Streamer/SchedulerTests.cpp
     Streamer/StreamStackEntryConformityTests.h
     Streamer/StreamStackEntryMock.h

--- a/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
@@ -281,6 +281,7 @@ namespace AzFramework
             azrtti_typeid<AZ::UserSettingsComponent>(),
             azrtti_typeid<AZ::SliceComponent>(),
             azrtti_typeid<AZ::SliceSystemComponent>(),
+            azrtti_typeid<AZ::TaskGraphSystemComponent>(),
 
             azrtti_typeid<AzFramework::AssetCatalogComponent>(),
             azrtti_typeid<AzFramework::CustomAssetTypeComponent>(),

--- a/Code/Framework/AzFramework/AzFramework/IO/RemoteStorageDrive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/IO/RemoteStorageDrive.cpp
@@ -53,8 +53,8 @@ namespace AzFramework
 
     RemoteStorageDrive::RemoteStorageDrive(AZ::u32 maxFileHandles)
         : StreamStackEntry("Storage drive(VFS)")
+        , m_recentlyUsed(maxFileHandles)
     {
-        m_fileLastUsed.resize(maxFileHandles, AZStd::chrono::steady_clock::time_point::min());
         m_filePaths.resize(maxFileHandles);
         m_fileHandles.resize(maxFileHandles, AZ::IO::InvalidHandle);
 
@@ -260,7 +260,7 @@ namespace AzFramework
         {
             if (activeFile && activeFile != targetFile)
             {
-                if (FindFileInCache(*targetFile) == s_fileNotFound)
+                if (FindFileInCache(*targetFile) == InvalidFileIndex)
                 {
                     AZStd::chrono::microseconds fileOpenCloseTimeAverage = m_fileOpenCloseTimeAverage.CalculateAverage();
                     startTime += fileOpenCloseTimeAverage;
@@ -287,27 +287,17 @@ namespace AzFramework
         HandleType file = InvalidHandle;
 
         // If the file is already open, use that file handle and update it's last touched time.
-        size_t cacheIndex = FindFileInCache(data->m_path);
-        if (cacheIndex != s_fileNotFound)
+        AZ::u32 cacheIndex = FindFileInCache(data->m_path);
+        if (cacheIndex != InvalidFileIndex)
         {
             file = m_fileHandles[cacheIndex];
-            m_fileLastUsed[cacheIndex] = AZStd::chrono::steady_clock::now();
+            m_recentlyUsed.Touch(cacheIndex);
         }
 
         // If the file is not open, eject the oldest entry from the cache and open the file for reading.
         if (file == InvalidHandle)
         {
-            AZStd::chrono::steady_clock::time_point oldest = m_fileLastUsed[0];
-            cacheIndex = 0;
-            size_t numFiles = m_filePaths.size();
-            for (size_t i = 1; i < numFiles; ++i)
-            {
-                if (m_fileLastUsed[i] < oldest)
-                {
-                    oldest = m_fileLastUsed[i];
-                    cacheIndex = i;
-                }
-            }
+            cacheIndex = m_recentlyUsed.TouchLeastRecentlyUsed();
 
             TIMED_AVERAGE_WINDOW_SCOPE(m_fileOpenCloseTimeAverage);
             if (!m_fileIO.Open(data->m_path.GetRelativePathCStr(), OpenMode::ModeRead, file))
@@ -316,7 +306,6 @@ namespace AzFramework
                 return;
             }
 
-            m_fileLastUsed[cacheIndex] = AZStd::chrono::steady_clock::now();
             if (m_fileHandles[cacheIndex] != InvalidHandle)
             {
                 m_fileIO.Close(m_fileHandles[cacheIndex]);
@@ -405,8 +394,8 @@ namespace AzFramework
         TIMED_AVERAGE_WINDOW_SCOPE(m_getFileExistsTimeAverage);
 
         auto& fileExists = AZStd::get<Requests::FileExistsCheckData>(request->GetCommand());
-        size_t cacheIndex = FindFileInCache(fileExists.m_path);
-        if (cacheIndex != s_fileNotFound)
+        AZ::u32 cacheIndex = FindFileInCache(fileExists.m_path);
+        if (cacheIndex != InvalidFileIndex)
         {
             fileExists.m_found = true;
             m_context->MarkRequestAsCompleted(request);
@@ -439,8 +428,8 @@ namespace AzFramework
 
         auto& command = AZStd::get<Requests::FileMetaDataRetrievalData>(request->GetCommand());
         // If the file is already open, use the file handle which usually is cheaper than asking for the file by name.
-        size_t cacheIndex = FindFileInCache(command.m_path);
-        if (cacheIndex != s_fileNotFound)
+        AZ::u32 cacheIndex = FindFileInCache(command.m_path);
+        if (cacheIndex != InvalidFileIndex)
         {
             AZ_Assert(
                 m_fileHandles[cacheIndex] != InvalidHandle, "File path '%s' doesn't have an associated file handle.",
@@ -470,10 +459,10 @@ namespace AzFramework
     {
         using namespace AZ::IO;
 
-        size_t cacheIndex = FindFileInCache(filePath);
-        if (cacheIndex != s_fileNotFound)
+        AZ::u32 cacheIndex = FindFileInCache(filePath);
+        if (cacheIndex != InvalidFileIndex)
         {
-            m_fileLastUsed[cacheIndex] = AZStd::chrono::steady_clock::time_point();
+            m_recentlyUsed.Flush(cacheIndex);
             m_filePaths[cacheIndex].Clear();
             AZ_Assert(
                 m_fileHandles[cacheIndex] != AZ::IO::InvalidHandle, "File path '%s' doesn't have an associated file handle.",
@@ -488,7 +477,6 @@ namespace AzFramework
         size_t numFiles = m_filePaths.size();
         for (size_t i = 0; i < numFiles; ++i)
         {
-            m_fileLastUsed[i] = AZStd::chrono::steady_clock::time_point();
             m_filePaths[i].Clear();
             if (m_fileHandles[i] != AZ::IO::InvalidHandle)
             {
@@ -496,19 +484,20 @@ namespace AzFramework
                 m_fileHandles[i] = AZ::IO::InvalidHandle;
             }
         }
+        m_recentlyUsed.FlushAll();
     }
 
-    size_t RemoteStorageDrive::FindFileInCache(const AZ::IO::RequestPath& filePath) const
+    AZ::u32 RemoteStorageDrive::FindFileInCache(const AZ::IO::RequestPath& filePath) const
     {
         size_t numFiles = m_filePaths.size();
         for (size_t i = 0; i < numFiles; ++i)
         {
             if (m_filePaths[i] == filePath)
             {
-                return i;
+                return aznumeric_caster(i);
             }
         }
-        return AZ::IO::s_fileNotFound;
+        return InvalidFileIndex;
     }
 
     void RemoteStorageDrive::CollectStatistics(AZStd::vector<AZ::IO::Statistic>& statistics) const

--- a/Code/Framework/AzFramework/AzFramework/IO/RemoteStorageDrive.h
+++ b/Code/Framework/AzFramework/AzFramework/IO/RemoteStorageDrive.h
@@ -71,7 +71,7 @@ namespace AzFramework
         void FileExistsRequest(AZ::IO::FileRequest* request);
         void FileMetaDataRetrievalRequest(AZ::IO::FileRequest* request);
         AZ::u32 FindFileInCache(const AZ::IO::RequestPath& filePath) const;
-        void EstimateCompletionTimeForRequest(AZ::IO::FileRequest* request, AZStd::chrono::system_clock::time_point& startTime,
+        void EstimateCompletionTimeForRequest(AZ::IO::FileRequest* request, AZStd::chrono::steady_clock::time_point& startTime,
             const AZ::IO::RequestPath*& activeFile) const;
         void FlushCache(const AZ::IO::RequestPath& filePath);
         void FlushEntireCache();

--- a/Code/Framework/AzFramework/AzFramework/IO/RemoteStorageDrive.h
+++ b/Code/Framework/AzFramework/AzFramework/IO/RemoteStorageDrive.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/IO/Streamer/RecentlyUsedIndex.h>
 #include <AzCore/IO/Streamer/Statistics.h>
 #include <AzCore/IO/Streamer/StreamerConfiguration.h>
 #include <AzCore/IO/Streamer/StreamStackEntry.h>
@@ -61,14 +62,16 @@ namespace AzFramework
         void CollectStatistics(AZStd::vector<AZ::IO::Statistic>& statistics) const override;
 
     protected:
+        using RecentlyUsedFileIndex = AZ::IO::RecentlyUsedIndex<AZ::u32>;
+        static constexpr AZ::u32 InvalidFileIndex = AZStd::numeric_limits<AZ::u32>::max();
         static constexpr AZ::s32 s_maxRequests = 1;
 
         void ReadFile(AZ::IO::FileRequest* request);
         bool CancelRequest(AZ::IO::FileRequest* cancelRequest, AZ::IO::FileRequestPtr& target);
         void FileExistsRequest(AZ::IO::FileRequest* request);
         void FileMetaDataRetrievalRequest(AZ::IO::FileRequest* request);
-        size_t FindFileInCache(const AZ::IO::RequestPath& filePath) const;
-        void EstimateCompletionTimeForRequest(AZ::IO::FileRequest* request, AZStd::chrono::steady_clock::time_point& startTime,
+        AZ::u32 FindFileInCache(const AZ::IO::RequestPath& filePath) const;
+        void EstimateCompletionTimeForRequest(AZ::IO::FileRequest* request, AZStd::chrono::system_clock::time_point& startTime,
             const AZ::IO::RequestPath*& activeFile) const;
         void FlushCache(const AZ::IO::RequestPath& filePath);
         void FlushEntireCache();
@@ -82,7 +85,7 @@ namespace AzFramework
         AZ::IO::AverageWindow<AZ::u64, float, AZ::IO::s_statisticsWindowSize> m_readSizeAverage;
         AZStd::deque<AZ::IO::FileRequest*> m_pendingRequests;
 
-        AZStd::vector<AZStd::chrono::steady_clock::time_point> m_fileLastUsed;
+        RecentlyUsedFileIndex m_recentlyUsed;
         AZStd::vector<AZ::IO::RequestPath> m_filePaths;
         AZStd::vector<AZ::IO::HandleType> m_fileHandles;
 

--- a/Code/Framework/AzFramework/Tests/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/Tests/AssetCatalog.cpp
@@ -23,6 +23,7 @@
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/parallel/binary_semaphore.h>
+#include <AzCore/Task/TaskExecutor.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/UserSettings/UserSettingsComponent.h>
 #include <AzFramework/Asset/AssetCatalog.h>
@@ -1085,6 +1086,7 @@ namespace UnitTest
 
         AZ::IO::FileIOBase* m_prevFileIO{ nullptr };
         TestFileIOBase m_fileIO;
+        AZ::TaskExecutor* m_taskExecutor{ nullptr };
         AZ::IO::IStreamer* m_streamer{ nullptr };
         AzFramework::AssetCatalog* m_assetCatalog;
 
@@ -1097,6 +1099,9 @@ namespace UnitTest
 
             m_prevFileIO = AZ::IO::FileIOBase::GetInstance();
             AZ::IO::FileIOBase::SetInstance(&m_fileIO);
+
+            m_taskExecutor = aznew AZ::TaskExecutor();
+            AZ::TaskExecutor::SetInstance(m_taskExecutor);
 
             m_streamer = CreateStreamer();
             if (m_streamer)
@@ -1123,6 +1128,9 @@ namespace UnitTest
                 AZ::Interface<AZ::IO::IStreamer>::Unregister(m_streamer);
             }
             DestroyStreamer(m_streamer);
+
+            AZ::TaskExecutor::SetInstance(m_taskExecutor);
+            delete m_taskExecutor;
 
             AZ::IO::FileIOBase::SetInstance(m_prevFileIO);
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Destroy();

--- a/Code/Framework/AzFramework/Tests/Scene.cpp
+++ b/Code/Framework/AzFramework/Tests/Scene.cpp
@@ -15,6 +15,7 @@ AZ_PUSH_DISABLE_WARNING(, "-Wdelete-non-virtual-dtor")
 #include <AzCore/Component/Component.h>
 #include <AzFramework/Scene/SceneSystemComponent.h>
 #include <AzFramework/Scene/Scene.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <AzCore/Asset/AssetManagerComponent.h>
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/IO/Streamer/StreamerComponent.h>
@@ -110,6 +111,7 @@ namespace SceneUnitTest
             m_app.RegisterComponentDescriptor(AZ::SliceSystemComponent::CreateDescriptor());
             m_app.RegisterComponentDescriptor(AZ::AssetManagerComponent::CreateDescriptor());
             m_app.RegisterComponentDescriptor(AZ::JobManagerComponent::CreateDescriptor());
+            m_app.RegisterComponentDescriptor(AZ::TaskGraphSystemComponent::CreateDescriptor());
             m_app.RegisterComponentDescriptor(AZ::StreamerComponent::CreateDescriptor());
 
             AZ::ComponentApplication::Descriptor desc;
@@ -122,6 +124,7 @@ namespace SceneUnitTest
             m_systemEntity->CreateComponent<AZ::SliceSystemComponent>();
             m_systemEntity->CreateComponent<AZ::AssetManagerComponent>();
             m_systemEntity->CreateComponent<AZ::JobManagerComponent>();
+            m_systemEntity->CreateComponent<AZ::TaskGraphSystemComponent>();
             m_systemEntity->CreateComponent<AZ::StreamerComponent>();
             m_systemEntity->Activate();
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/main.cpp
@@ -15,6 +15,7 @@
 #include <AzCore/IO/Streamer/StreamerComponent.h>
 #include <AzCore/Jobs/JobManagerComponent.h>
 #include <AzCore/Memory/PoolAllocator.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <AzCore/UserSettings/UserSettingsComponent.h>
 
 #include <AzFramework/Asset/CustomAssetTypeComponent.h>
@@ -61,6 +62,7 @@ public:
 
         m_componentApp.RegisterComponentDescriptor(AZ::AssetManagerComponent::CreateDescriptor());
         m_componentApp.RegisterComponentDescriptor(AZ::JobManagerComponent::CreateDescriptor());
+        m_componentApp.RegisterComponentDescriptor(AZ::TaskGraphSystemComponent::CreateDescriptor());
         m_componentApp.RegisterComponentDescriptor(AZ::StreamerComponent::CreateDescriptor());
         m_componentApp.RegisterComponentDescriptor(AZ::UserSettingsComponent::CreateDescriptor());
         m_componentApp.RegisterComponentDescriptor(AzFramework::CustomAssetTypeComponent::CreateDescriptor());
@@ -68,6 +70,7 @@ public:
 
         m_systemEntity->CreateComponent<AZ::AssetManagerComponent>();
         m_systemEntity->CreateComponent<AZ::JobManagerComponent>();
+        m_systemEntity->CreateComponent<AZ::TaskGraphSystemComponent>();
         m_systemEntity->CreateComponent<AZ::StreamerComponent>();
         m_systemEntity->CreateComponent<AZ::UserSettingsComponent>();
         m_systemEntity->CreateComponent<AzFramework::CustomAssetTypeComponent>();
@@ -89,6 +92,7 @@ public:
         {
             m_systemEntity->FindComponent<AZ::AssetManagerComponent>(),
             m_systemEntity->FindComponent<AZ::JobManagerComponent>(),
+            m_systemEntity->FindComponent<AZ::TaskGraphSystemComponent>(),
             m_systemEntity->FindComponent<AZ::StreamerComponent>(),
             m_systemEntity->FindComponent<AZ::UserSettingsComponent>(),
             m_systemEntity->FindComponent<AzFramework::CustomAssetTypeComponent>(),
@@ -104,6 +108,7 @@ public:
         m_componentApp.UnregisterComponentDescriptor(AZ::AssetManagerComponent::CreateDescriptor());
         m_componentApp.UnregisterComponentDescriptor(AZ::JobManagerComponent::CreateDescriptor());
         m_componentApp.UnregisterComponentDescriptor(AZ::StreamerComponent::CreateDescriptor());
+        m_componentApp.UnregisterComponentDescriptor(AZ::TaskGraphSystemComponent::CreateDescriptor());
         m_componentApp.UnregisterComponentDescriptor(AZ::UserSettingsComponent::CreateDescriptor());
         m_componentApp.UnregisterComponentDescriptor(AzFramework::CustomAssetTypeComponent::CreateDescriptor());
         m_componentApp.UnregisterComponentDescriptor(AzToolsFramework::Components::PropertyManagerComponent::CreateDescriptor());

--- a/Code/Framework/AzTest/AzTest/GemTestEnvironment.cpp
+++ b/Code/Framework/AzTest/AzTest/GemTestEnvironment.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Jobs/JobManagerComponent.h>
 #include <AzCore/IO/Streamer/StreamerComponent.h>
 #include <AzCore/Memory/MemoryComponent.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 
 namespace AZ
 {
@@ -116,6 +117,7 @@ namespace AZ
             AddComponentIfNotPresent<AZ::MemoryComponent>(m_systemEntity);
             AddComponentIfNotPresent<AZ::AssetManagerComponent>(m_systemEntity);
             AddComponentIfNotPresent<AZ::JobManagerComponent>(m_systemEntity);
+            AddComponentIfNotPresent<AZ::TaskGraphSystemComponent>(m_systemEntity);
             AddComponentIfNotPresent<AZ::StreamerComponent>(m_systemEntity);
 
             m_systemEntity->Init();

--- a/Code/Framework/AzToolsFramework/Tests/Script/ScriptComponentTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Script/ScriptComponentTests.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Script/ScriptAsset.h>
 #include <AzCore/Script/ScriptSystemComponent.h>
 #include <AzCore/Script/ScriptContext.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzToolsFramework/ToolsComponents/ScriptEditorComponent.h>
 
@@ -46,6 +47,7 @@ namespace UnitTest
 
             systemEntity->CreateComponent<MemoryComponent>();
             systemEntity->CreateComponent(AZ::TypeId{ "{CAE3A025-FAC9-4537-B39E-0A800A2326DF}" }); // JobManager component
+            systemEntity->CreateComponent<TaskGraphSystemComponent>();
             systemEntity->CreateComponent<StreamerComponent>();
             systemEntity->CreateComponent<AssetManagerComponent>();
             systemEntity->CreateComponent(AZ::TypeId{ "{A316662A-6C3E-43E6-BC61-4B375D0D83B4}" }); // Usersettings component

--- a/Code/Framework/AzToolsFramework/Tests/SliceUpgradeTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/SliceUpgradeTests.cpp
@@ -21,6 +21,7 @@ AZ_PUSH_DISABLE_WARNING(,"-Wdelete-non-virtual-dtor")
 #include <AzCore/Slice/SliceComponent.h>
 #include <AzCore/Slice/SliceMetadataInfoComponent.h>
 #include <AzCore/Slice/SliceAssetHandler.h>
+#include <AzCore/Task/TaskExecutor.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 #include "SliceUpgradeTestsData.h"
 
@@ -107,6 +108,7 @@ namespace UnitTest
         AZStd::unique_ptr<AZ::ComponentDescriptor> m_sliceDescriptor;
         AZStd::unique_ptr<SliceUpgradeTest_MockCatalog> m_mockCatalog;
         AZStd::unique_ptr<AZ::IO::Streamer> m_streamer;
+        AZStd::unique_ptr<AZ::TaskExecutor> m_taskExecutor;
 
         AZStd::unique_ptr<AZ::SliceComponent> m_rootSliceComponent;
         AZStd::unordered_map<AZ::Data::AssetId, AZ::Data::Asset<AZ::SliceAsset>> m_sliceAssets;
@@ -117,6 +119,9 @@ namespace UnitTest
         {
             AZ::AllocatorInstance<AZ::PoolAllocator>::Create();
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Create();
+
+            m_taskExecutor = AZStd::make_unique<AZ::TaskExecutor>();
+            AZ::TaskExecutor::SetInstance(m_taskExecutor.get());
 
             m_streamer = AZStd::make_unique<AZ::IO::Streamer>(AZStd::thread_desc{}, AZ::StreamerComponent::CreateStreamerStack());
             AZ::Interface<AZ::IO::IStreamer>::Register(m_streamer.get());
@@ -159,6 +164,9 @@ namespace UnitTest
 
             AZ::Interface<AZ::IO::IStreamer>::Unregister(m_streamer.get());
             m_streamer.reset();
+
+            AZ::TaskExecutor::SetInstance(nullptr);
+            m_taskExecutor.reset();
 
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Destroy();
             AZ::AllocatorInstance<AZ::PoolAllocator>::Destroy();

--- a/Code/Tools/LuaIDE/Source/StandaloneToolsApplication.cpp
+++ b/Code/Tools/LuaIDE/Source/StandaloneToolsApplication.cpp
@@ -10,6 +10,7 @@
 
 #include <AzCore/IO/Streamer/StreamerComponent.h>
 #include <AzCore/Jobs/JobManagerComponent.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <AzCore/UserSettings/UserSettingsComponent.h>
 #include <AzCore/std/containers/array.h>
 #include <AzFramework/API/ApplicationAPI.h>
@@ -46,6 +47,7 @@ namespace StandaloneTools
         RegisterComponentDescriptor(AZ::UserSettingsComponent::CreateDescriptor());
 
         RegisterComponentDescriptor(AZ::JobManagerComponent::CreateDescriptor());
+        RegisterComponentDescriptor(AZ::TaskGraphSystemComponent::CreateDescriptor());
         RegisterComponentDescriptor(AZ::StreamerComponent::CreateDescriptor());
     }
 
@@ -59,6 +61,7 @@ namespace StandaloneTools
 
     void BaseApplication::CreateApplicationComponents()
     {
+        EnsureComponentCreated(AZ::TaskGraphSystemComponent::RTTI_Type());
         EnsureComponentCreated(AZ::StreamerComponent::RTTI_Type());
         EnsureComponentCreated(AZ::JobManagerComponent::RTTI_Type());
         EnsureComponentCreated(AzNetworking::NetworkingSystemComponent::RTTI_Type());

--- a/Gems/Atom/RPI/Code/Tests.Builders/BuilderTestFixture.cpp
+++ b/Gems/Atom/RPI/Code/Tests.Builders/BuilderTestFixture.cpp
@@ -87,6 +87,9 @@ namespace UnitTest
         AZ::AllocatorInstance<AZ::PoolAllocator>::Create();
         AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Create();
 
+        m_taskExecutor = AZStd::make_unique<AZ::TaskExecutor>();
+        AZ::TaskExecutor::SetInstance(m_taskExecutor.get());
+
         m_streamer = AZStd::make_unique<AZ::IO::Streamer>(AZStd::thread_desc{}, AZ::StreamerComponent::CreateStreamerStack());
         Interface<AZ::IO::IStreamer>::Register(m_streamer.get());
 
@@ -103,6 +106,9 @@ namespace UnitTest
 
         Interface<AZ::IO::IStreamer>::Unregister(m_streamer.get());
         m_streamer.reset();
+
+        AZ::TaskExecutor::SetInstance(nullptr);
+        m_taskExecutor.reset();
 
         AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Destroy();
         AZ::AllocatorInstance<AZ::PoolAllocator>::Destroy();

--- a/Gems/Atom/RPI/Code/Tests.Builders/BuilderTestFixture.h
+++ b/Gems/Atom/RPI/Code/Tests.Builders/BuilderTestFixture.h
@@ -14,6 +14,7 @@
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/Serialization/Json/JsonSystemComponent.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
+#include <AzCore/Task/TaskExecutor.h>
 #include <AzCore/UnitTest/TestTypes.h>
 
 #include <AzTest/AzTest.h>
@@ -66,6 +67,7 @@ namespace UnitTest
         // Required for json serializer
         AZStd::unique_ptr<AZ::JsonSystemComponent> m_jsonSystemComponent;
         AZStd::unique_ptr<AZ::JsonRegistrationContext> m_jsonRegistrationContext;
+        AZStd::unique_ptr<AZ::TaskExecutor> m_taskExecutor;
         AZStd::unique_ptr<AZ::IO::Streamer> m_streamer;
     };
 

--- a/Gems/EMotionFX/Code/Tests/ActorBuilderTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/ActorBuilderTests.cpp
@@ -38,6 +38,7 @@ namespace EMotionFX
         AZ::MemoryComponent,
         AZ::AssetManagerComponent,
         AZ::JobManagerComponent,
+        AZ::TaskGraphSystemComponent,
         AZ::StreamerComponent,
         AzToolsFramework::Components::PropertyManagerComponent,
         EMotionFX::Integration::SystemComponent,

--- a/Gems/EMotionFX/Code/Tests/EMotionFXBuilderFixture.h
+++ b/Gems/EMotionFX/Code/Tests/EMotionFXBuilderFixture.h
@@ -62,6 +62,7 @@ namespace EMotionFX
         AZ::MemoryComponent,
         AZ::AssetManagerComponent,
         AZ::JobManagerComponent,
+        AZ::TaskGraphSystemComponent,
         AZ::StreamerComponent,
         BuilderMockComponent
     >;

--- a/Gems/EMotionFX/Code/Tests/Editor/MotionSetLoadEscalation.cpp
+++ b/Gems/EMotionFX/Code/Tests/Editor/MotionSetLoadEscalation.cpp
@@ -56,6 +56,7 @@ namespace EMotionFX
             AZ::MemoryComponent,
             AZ::AssetManagerComponent,
             AZ::JobManagerComponent,
+            AZ::TaskGraphSystemComponent,
             AZ::StreamerComponent,
             AzFramework::AssetCatalogComponent,
             AzToolsFramework::Components::PropertyManagerComponent,

--- a/Gems/EMotionFX/Code/Tests/Integration/CanAddSimpleMotionComponent.cpp
+++ b/Gems/EMotionFX/Code/Tests/Integration/CanAddSimpleMotionComponent.cpp
@@ -28,6 +28,7 @@ namespace EMotionFX
         AZ::MemoryComponent,
         AZ::AssetManagerComponent,
         AZ::JobManagerComponent,
+        AZ::TaskGraphSystemComponent,
         AZ::StreamerComponent,
         AZ::UserSettingsComponent,
         AzToolsFramework::Components::PropertyManagerComponent,

--- a/Gems/EMotionFX/Code/Tests/Integration/CanDeleteJackEntity.cpp
+++ b/Gems/EMotionFX/Code/Tests/Integration/CanDeleteJackEntity.cpp
@@ -31,6 +31,7 @@ namespace EMotionFX
         AZ::MemoryComponent,
         AZ::AssetManagerComponent,
         AZ::JobManagerComponent,
+        AZ::TaskGraphSystemComponent,
         AZ::StreamerComponent,
         AZ::UserSettingsComponent,
         AzToolsFramework::Components::PropertyManagerComponent,

--- a/Gems/EMotionFX/Code/Tests/MetaDataRuleTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/MetaDataRuleTests.cpp
@@ -26,6 +26,7 @@ namespace EMotionFX
         AZ::MemoryComponent,
         AZ::AssetManagerComponent,
         AZ::JobManagerComponent,
+        AZ::TaskGraphSystemComponent,
         AZ::StreamerComponent,
         AzToolsFramework::Components::PropertyManagerComponent,
         EMotionFX::Integration::SystemComponent,

--- a/Gems/EMotionFX/Code/Tests/MorphTargetPipelineTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/MorphTargetPipelineTests.cpp
@@ -45,6 +45,7 @@ namespace EMotionFX
         AZ::MemoryComponent,
         AZ::AssetManagerComponent,
         AZ::JobManagerComponent,
+        AZ::TaskGraphSystemComponent,
         AZ::StreamerComponent,
         AzToolsFramework::Components::PropertyManagerComponent,
         EMotionFX::Integration::SystemComponent,

--- a/Gems/EMotionFX/Code/Tests/SimulatedObjectPipelineTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/SimulatedObjectPipelineTests.cpp
@@ -33,6 +33,7 @@ namespace EMotionFX
         AZ::MemoryComponent,
         AZ::AssetManagerComponent,
         AZ::JobManagerComponent,
+        AZ::TaskGraphSystemComponent,
         AZ::StreamerComponent,
         AzToolsFramework::Components::PropertyManagerComponent,
         EMotionFX::Integration::SystemComponent,

--- a/Gems/EMotionFX/Code/Tests/SystemComponentFixture.h
+++ b/Gems/EMotionFX/Code/Tests/SystemComponentFixture.h
@@ -21,6 +21,7 @@
 #include <AzCore/Module/Module.h>
 #include <AzCore/Module/ModuleManagerBus.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzCore/UserSettings/UserSettingsComponent.h>
 #include <AzFramework/Application/Application.h>
@@ -215,6 +216,7 @@ namespace EMotionFX
         AZ::MemoryComponent,
         AZ::AssetManagerComponent,
         AZ::JobManagerComponent,
+        AZ::TaskGraphSystemComponent,
         AZ::StreamerComponent,
         Physics::MaterialSystemComponent,
         EMotionFX::Integration::SystemComponent
@@ -226,6 +228,7 @@ namespace EMotionFX
         AZ::MemoryComponent,
         AZ::AssetManagerComponent,
         AZ::JobManagerComponent,
+        AZ::TaskGraphSystemComponent,
         AZ::StreamerComponent,
         AzFramework::AssetCatalogComponent,
         Physics::MaterialSystemComponent,

--- a/Gems/EMotionFX/Code/Tests/UI/UIFixture.h
+++ b/Gems/EMotionFX/Code/Tests/UI/UIFixture.h
@@ -63,6 +63,7 @@ namespace EMotionFX
         AZ::MemoryComponent,
         AZ::AssetManagerComponent,
         AZ::JobManagerComponent,
+        AZ::TaskGraphSystemComponent,
         AZ::StreamerComponent,
         AZ::UserSettingsComponent,
         Physics::MaterialSystemComponent,

--- a/Gems/GraphModel/Code/Tests/TestEnvironment.cpp
+++ b/Gems/GraphModel/Code/Tests/TestEnvironment.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <Tests/TestEnvironment.h>
 #include <Source/GraphModelSystemComponent.h>
 
@@ -209,6 +210,7 @@ namespace GraphModelIntegrationTest
         m_systemEntity->AddComponent(aznew AZ::MemoryComponent());
         m_systemEntity->AddComponent(aznew AZ::AssetManagerComponent());
         m_systemEntity->AddComponent(aznew AZ::JobManagerComponent());
+        m_systemEntity->AddComponent(aznew AZ::TaskGraphSystemComponent());
         m_systemEntity->AddComponent(aznew AZ::StreamerComponent());
         m_systemEntity->AddComponent(aznew GraphModel::GraphModelSystemComponent());
 

--- a/Gems/LmbrCentral/Code/Tests/SpawnerComponentTest.cpp
+++ b/Gems/LmbrCentral/Code/Tests/SpawnerComponentTest.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/Memory/MemoryComponent.h>
 #include <AzCore/Slice/SliceComponent.h>
 #include <AzCore/Slice/SliceSystemComponent.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <AzFramework/Application/Application.h>
 #include <AzFramework/Asset/AssetSystemComponent.h>
 #include <AzFramework/Components/TransformComponent.h>
@@ -90,6 +91,7 @@ class SpawnerApplication
         return AZ::ComponentTypeList{
             azrtti_typeid<AZ::MemoryComponent>(),
             azrtti_typeid<AZ::JobManagerComponent>(),
+            azrtti_typeid<AZ::TaskGraphSystemComponent>(),
             azrtti_typeid<AZ::StreamerComponent>(),
             azrtti_typeid<AZ::AssetManagerComponent>(),
             azrtti_typeid<AZ::SliceSystemComponent>(),

--- a/Gems/LyShine/Code/Tests/TextInputComponentTest.cpp
+++ b/Gems/LyShine/Code/Tests/TextInputComponentTest.cpp
@@ -23,6 +23,7 @@
 #include <AzCore/IO/Streamer/StreamerComponent.h>
 #include <AzCore/Jobs/JobManagerComponent.h>
 #include <AzCore/Slice/SliceSystemComponent.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 
 namespace UnitTest
 {
@@ -42,6 +43,7 @@ namespace UnitTest
                 azrtti_typeid<AZ::MemoryComponent>(),
                 azrtti_typeid<AZ::AssetManagerComponent>(),
                 azrtti_typeid<AZ::JobManagerComponent>(),
+                azrtti_typeid<AZ::TaskGraphSystemComponent>(),
                 azrtti_typeid<AZ::StreamerComponent>(),
                 azrtti_typeid<AZ::SliceSystemComponent>(),
                 azrtti_typeid<AzFramework::GameEntityContextComponent>(),

--- a/Gems/LyShine/Code/Tests/UiDynamicScrollBoxComponentTest.cpp
+++ b/Gems/LyShine/Code/Tests/UiDynamicScrollBoxComponentTest.cpp
@@ -24,6 +24,7 @@
 #include <AzCore/IO/Streamer/StreamerComponent.h>
 #include <AzCore/Jobs/JobManagerComponent.h>
 #include <AzCore/Slice/SliceSystemComponent.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 
 namespace UnitTest
 {
@@ -44,6 +45,7 @@ namespace UnitTest
                 azrtti_typeid<AZ::MemoryComponent>(),
                 azrtti_typeid<AZ::AssetManagerComponent>(),
                 azrtti_typeid<AZ::JobManagerComponent>(),
+                azrtti_typeid<AZ::TaskGraphSystemComponent>(),
                 azrtti_typeid<AZ::StreamerComponent>(),
                 azrtti_typeid<AZ::SliceSystemComponent>(),
                 azrtti_typeid<AzFramework::GameEntityContextComponent>(),

--- a/Gems/LyShine/Code/Tests/UiScrollBarComponentTest.cpp
+++ b/Gems/LyShine/Code/Tests/UiScrollBarComponentTest.cpp
@@ -23,6 +23,7 @@
 #include <AzCore/IO/Streamer/StreamerComponent.h>
 #include <AzCore/Jobs/JobManagerComponent.h>
 #include <AzCore/Slice/SliceSystemComponent.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 
 namespace UnitTest
 {
@@ -42,6 +43,7 @@ namespace UnitTest
                 azrtti_typeid<AZ::MemoryComponent>(),
                 azrtti_typeid<AZ::AssetManagerComponent>(),
                 azrtti_typeid<AZ::JobManagerComponent>(),
+                azrtti_typeid<AZ::TaskGraphSystemComponent>(),
                 azrtti_typeid<AZ::StreamerComponent>(),
                 azrtti_typeid<AZ::SliceSystemComponent>(),
                 azrtti_typeid<AzFramework::GameEntityContextComponent>(),

--- a/Gems/LyShine/Code/Tests/UiTooltipComponentTest.cpp
+++ b/Gems/LyShine/Code/Tests/UiTooltipComponentTest.cpp
@@ -24,6 +24,7 @@
 #include <AzCore/IO/Streamer/StreamerComponent.h>
 #include <AzCore/Jobs/JobManagerComponent.h>
 #include <AzCore/Slice/SliceSystemComponent.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <AzCore/UnitTest/Mocks/MockITime.h>
 
 namespace UnitTest
@@ -63,6 +64,7 @@ namespace UnitTest
                 azrtti_typeid<AZ::MemoryComponent>(),
                 azrtti_typeid<AZ::AssetManagerComponent>(),
                 azrtti_typeid<AZ::JobManagerComponent>(),
+                azrtti_typeid<AZ::TaskGraphSystemComponent>(),
                 azrtti_typeid<AZ::StreamerComponent>(),
                 azrtti_typeid<AZ::SliceSystemComponent>(),
                 azrtti_typeid<AzFramework::GameEntityContextComponent>(),

--- a/Gems/MotionMatching/Code/Tests/Fixture.h
+++ b/Gems/MotionMatching/Code/Tests/Fixture.h
@@ -16,6 +16,7 @@ namespace EMotionFX::MotionMatching
         AZ::MemoryComponent,
         AZ::AssetManagerComponent,
         AZ::JobManagerComponent,
+        AZ::TaskGraphSystemComponent,
         AZ::StreamerComponent,
         EMotionFX::Integration::SystemComponent,
         MotionMatchingSystemComponent

--- a/Gems/PhysX/Code/Tests/PhysXTestEnvironment.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXTestEnvironment.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/IO/Streamer/StreamerComponent.h>
 #include <AzCore/Jobs/JobManagerComponent.h>
 #include <AzCore/Memory/MemoryComponent.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <AzCore/UnitTest/UnitTest.h>
 #include <AzCore/Utils/Utils.h>
 
@@ -51,6 +52,7 @@ namespace PhysX
                 azrtti_typeid<AZ::MemoryComponent>(),
                 azrtti_typeid<AZ::AssetManagerComponent>(),
                 azrtti_typeid<AZ::JobManagerComponent>(),
+                azrtti_typeid<AZ::TaskGraphSystemComponent>(),
                 azrtti_typeid<AZ::StreamerComponent>(),
 
                 azrtti_typeid<AzFramework::AssetCatalogComponent>(),

--- a/Gems/ScriptEvents/Code/Tests/ScriptEventsTestApplication.h
+++ b/Gems/ScriptEvents/Code/Tests/ScriptEventsTestApplication.h
@@ -15,6 +15,7 @@
 #include <AzCore/Jobs/JobManagerComponent.h>
 #include <AzCore/IO/Streamer/StreamerComponent.h>
 #include <AzCore/Memory/MemoryComponent.h>
+#include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <AzFramework/Asset/AssetCatalogComponent.h>
 
 namespace ScriptEventsTests
@@ -34,6 +35,7 @@ namespace ScriptEventsTests
                     azrtti_typeid<AZ::MemoryComponent>(),
                     azrtti_typeid<AZ::AssetManagerComponent>(),
                     azrtti_typeid<AZ::JobManagerComponent>(),
+                    azrtti_typeid<AZ::TaskGraphSystemComponent>(),
                     azrtti_typeid<AZ::StreamerComponent>(),
                     azrtti_typeid<AzFramework::AssetCatalogComponent>(),
                 });


### PR DESCRIPTION
A set of optimizations aimed to reduce the latency between issuing a read request with AZ::IO::Streamer and it being queued with the OS. These optimizations improved performance on Windows for unarchived released builds from 490-498Mib/s to 515-525Mib/s. (Tests were done on an older SATA SSD that has a top speed of 533Mib/s according to benchmarks.) In DevMode (--cl_streamerDevMode=true) performance improved from 1.1-1.2GibS to 4.5-4.6Gib/s for files that were repeated read.

The following optimizations were made:
- The Windows Storage Drive in AZ::IO::Streamer now more aggressively queues async read requests. This reduced the gap between reads from an initial batch when no other reads are running.
- Resolving relative paths and aliases to absolute paths is now done when a RequestPath is constructed instead of using lazy initialization. Practically this means that AZ::IO::Streamer rarely has to resolve paths and the code calling into Streamer will instead resolve the path which distributes the cost.
- Completion callbacks for external requests to AZ::IO::Streamer are now ran in a TaskGraph. When finalizing requests all the external requests are being queued on a task graph for later execution. This has the added benefit that long running callbacks no longer negatively impact AZ::IO::Streamer. The downside is that cheap callbacks, those that would be faster than creating and queuing a task, are now going to be more expensive. On average though this is still a net gain.
- A default callback is no longer set on AZ::IO::Streamer requests. This prevents tasks being created for external requests that don't have a callback and instead the request and any dependencies can immediately be processed. This also slightly improved performance for internal requests.
- Used an optimized double linked list to speed up searching for available indices in AZ::IO::Streamer. Previously searching for an available slot for caches or file handles required keeping track of the time a slot was last used and searching the entire list to find the least recently used. The new approach maintains a double linked list to keep track of the least and most recently used slots. This makes finding a slot much faster, but does require a bit more work when having to touch a file.
- AZ::IO::Streamer now issues read requests through the task system. Issuing read request with the OS was taking up the majority of the read time (when no files needed to be opened). By moving the actual call to the OS to the task system the scheduler can work on the next request in the meantime and allows issuing read requests to the OS to overlap. In the test scenario this marginally improved the read speed of the drive, but closed gap between the overall throughput of Streamer and the drive to less than 1%. While the test scenario didn't provide a significant improvement, speeds running in developer mode (--cl_streamerDevMode=true) have more than quadrupled. It should be noted that in the test case the same few files get repeatedly read from the disk, which means in dev mode the Windows file cache is mostly used, but this doesn't translate to similar performance in real world scenarios as files are not frequently loaded within a time frame that the file cache would be beneficial (especially with the Asset Manager's aggressive caching of assets). It also doesn't perfectly demonstrates the ability of NVMe drives as the read request calls to the OS are much longer than normal due to copying from the cache. It does however show a significant improvement in handling fast reads, demonstrating a better chance of Streamer keeping up with faster drives.






