### PR TITLE
[Wwise] Fixes print formatting errors on Android/Linux

### DIFF
--- a/Gems/AudioEngineWwise/Code/Source/Engine/AudioSystemImpl_wwise.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/Engine/AudioSystemImpl_wwise.cpp
@@ -195,7 +195,8 @@ namespace Audio
         char* errorStr = nullptr;
         CONVERT_OSCHAR_TO_CHAR(in_pszError, errorStr);
         AZLOG_NOTICE(
-            "<Wwise> %s ErrorCode: %d PlayingID: %u GameObjID: %llu", errorStr, in_eErrorCode, in_playingID, in_gameObjID);
+            "<Wwise> %s ErrorCode: %d PlayingID: %u GameObjID: %llu", errorStr, in_eErrorCode, in_playingID,
+            static_cast<AZ::u64>(in_gameObjID));
     }
 #endif // WWISE_RELEASE
 
@@ -807,7 +808,7 @@ namespace Audio
                 {
                     AZ_Assert(sourceData, "SourceData not provided for source type!");
                     // format: "external/{collection_id}/{language_id}/{file_id}.wem"
-                    auto filePath = AZStd::string::format("%s" "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 ".wem",
+                    auto filePath = AZStd::string::format("%s/%llu/%llu/%llu.wem",
                         Audio::Wwise::ExternalSourcesPath,
                         sourceData->m_sourceInfo.m_collectionId,
                         sourceData->m_sourceInfo.m_languageId,
@@ -1485,7 +1486,7 @@ namespace Audio
         auto newObjectData = azcreate(SATLListenerData_wwise, (static_cast<AkGameObjectID>(listenerId)), Audio::AudioImplAllocator, "ATLListenerData_wwise-Default");
         if (newObjectData)
         {
-            auto listenerName = AZStd::string::format("DefaultAudioListener(%" PRIu64 ")", static_cast<AZ::u64>(newObjectData->nAKListenerObjectId));
+            auto listenerName = AZStd::string::format("DefaultAudioListener(%llu)", static_cast<AZ::u64>(newObjectData->nAKListenerObjectId));
             AKRESULT akResult = AK::SoundEngine::RegisterGameObj(newObjectData->nAKListenerObjectId, listenerName.c_str());
             if (IS_WWISE_OK(akResult))
             {
@@ -1514,7 +1515,7 @@ namespace Audio
         auto newObjectData = azcreate(SATLListenerData_wwise, (static_cast<AkGameObjectID>(listenerId)), Audio::AudioImplAllocator, "ATLListenerData_wwise");
         if (newObjectData)
         {
-            auto listenerName = AZStd::string::format("AudioListener(%" PRIu64 ")", static_cast<AZ::u64>(newObjectData->nAKListenerObjectId));
+            auto listenerName = AZStd::string::format("AudioListener(%llu)", static_cast<AZ::u64>(newObjectData->nAKListenerObjectId));
             AKRESULT akResult = AK::SoundEngine::RegisterGameObj(newObjectData->nAKListenerObjectId, listenerName.c_str());
             if (!IS_WWISE_OK(akResult))
             {
@@ -2098,7 +2099,8 @@ namespace Audio
             else
             {
                 AZLOG_WARN(
-                    "AK::SoundEngine::SetGameObjectAuxSendValues() on object %llu returned AKRESULT %u", implObjectData->nAKID, akResult);
+                    "AK::SoundEngine::SetGameObjectAuxSendValues() on object %llu returned AKRESULT %u",
+                    static_cast<AZ::u64>(implObjectData->nAKID), akResult);
             }
 
             implObjectData->bNeedsToUpdateEnvironments = false;

--- a/Gems/AudioEngineWwise/Code/Source/Engine/FileIOHandler_wwise.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/Engine/FileIOHandler_wwise.cpp
@@ -146,11 +146,11 @@ namespace Audio
         }
 
         AZ::u64 bytesRead = 0;
-        fileIO->Read(fileHandle, buffer, aznumeric_cast<AZ::u64>(transferInfo.uRequestedSize), &bytesRead);
+        fileIO->Read(fileHandle, buffer, aznumeric_cast<AZ::u64>(transferInfo.uRequestedSize), false, &bytesRead);
         const bool readOk = (bytesRead == aznumeric_cast<AZ::u64>(transferInfo.uRequestedSize));
 
-        AZ_Assert(readOk, 
-            "Number of bytes read (%" PRIu64 ") for read request doesn't match the requested size (%u).",
+        AZ_Assert(readOk,
+            "Number of bytes read (%llu) for read request doesn't match the requested size (%u).",
             bytesRead, transferInfo.uRequestedSize);
         return readOk ? AK_Success : AK_Fail;
     }
@@ -175,7 +175,7 @@ namespace Audio
         const bool writeOk = (bytesWritten == aznumeric_cast<AZ::u64>(transferInfo.uRequestedSize));
 
         AZ_Error("Wwise", writeOk,
-                "Number of bytes written (%" PRIu64 ") for write request doesn't match the requested size (%u).",
+                "Number of bytes written (%llu) for write request doesn't match the requested size (%u).",
                 bytesWritten, transferInfo.uRequestedSize);
         return writeOk ? AK_Success : AK_Fail;
     }
@@ -200,7 +200,7 @@ namespace Audio
         AK_CHAR_TO_UTF16(deviceDesc.szDeviceName, "IO::IArchive", AZ_ARRAY_SIZE(deviceDesc.szDeviceName));
         deviceDesc.uStringSize = aznumeric_cast<AkUInt32>(AKPLATFORM::AkUtf16StrLen(deviceDesc.szDeviceName));
     }
-    
+
     AkUInt32 CBlockingDevice_wwise::GetDeviceData()
     {
         return 1;
@@ -290,7 +290,7 @@ namespace Audio
         static_assert(AZ::IO::IStreamerTypes::s_priorityHighest == 255, "The priority range for AZ::IO::Streamer has changed, please update Wwise to match.");
         AZ::u16 wwisePriority = aznumeric_caster(heuristics.priority);
         AZ::u8 priority = aznumeric_caster(
-              (wwisePriority << 1) // 100 -> 200 
+              (wwisePriority << 1) // 100 -> 200
             + (wwisePriority >> 1) // 200 -> 250
             + (wwisePriority >> 4) // 250 -> 256
             - (wwisePriority >> 6));  // 256 -> 255


### PR DESCRIPTION
When formatting `AZ::u64` variables, use the `%llu` format rather than `PRIu64`.  In some places where 64-bit unsigned integer types have declarations from the Wwise SDK, they should be casted to the `AZ::u64` (`unsigned long long`) alias first for print, because they are likely typedefs of `unsigned long` on Android or Linux.