### PR TITLE
Fix for UI Editor freezing/crashing the Editor in Linux after closing and opening 3 times

### DIFF
--- a/Gems/LyShine/Code/Editor/EditorWindow.cpp
+++ b/Gems/LyShine/Code/Editor/EditorWindow.cpp
@@ -2195,10 +2195,16 @@ void EditorWindow::closeEvent(QCloseEvent* closeEvent)
     // Save the current window state
     SaveEditorWindowSettings();
 
-    // Instead of closing this window, replicate the action of unchecking UI Editor from the Editor toolbar by
-    // hiding the parent view pane instead
+#if defined(AZ_PLATFORM_LINUX)
+    // Work-around for issue on Linux where closing (and destroying) the window an re-opening causes the Editor
+    // to hang or crash. So instead of closing this window, replicate the action of unchecking UI Editor from the
+    //  Editor toolbar by hiding the parent view pane instead
     nativeParentWidget()->hide();
     closeEvent->ignore();
+#else
+    QMainWindow::closeEvent(closeEvent);
+#endif
+
 }
 
 void EditorWindow::dragEnterEvent(QDragEnterEvent* event)


### PR DESCRIPTION
On Linux, if you open and close the UI Editor, the 3rd attempt (usually) will cause the entire editor to either freeze of crash. This seems related to something on Linux/Qt that is not being cleaned up when the UI Editor widget is destroyed and then re-created. If you go through to show and close the UI Editor through the action menu, this does not occur, because the handler for that action does not destroy the window (It does close the parent view pane)

This is a topical fix to prevent the UI Editor from crashing on Linux, but forcing the 'close' event to behave similarly to the behavior of closing through the action menu always. Will create a GHI backlog issue to investigate the root cause of this.
