### PR TITLE
bugfix(Whitebox): better handle updating material for whitebox mesh (GHI-9442)

### DIFF
--- a/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.cpp
+++ b/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.cpp
@@ -262,8 +262,6 @@ namespace WhiteBox
         m_meshFeatureProcessor->SetTransform(m_meshHandle, worldFromLocal);
     }
 
-
-
     void AtomRenderMesh::UpdateMaterial(const WhiteBoxMaterial& material)
     {
         if (m_meshFeatureProcessor)
@@ -271,6 +269,8 @@ namespace WhiteBox
             auto& materialAssignment = m_materialMap[AZ::Render::DefaultMaterialAssignmentId];
             materialAssignment.m_propertyOverrides[AZ::Name("baseColor.color")] = AZ::Color(material.m_tint);
             materialAssignment.m_propertyOverrides[AZ::Name("baseColor.useTexture")] = material.m_useTexture;
+            // if ApplyProperties fails, defer updating the material assignment map 
+            // on the next tick, and try applying properties again
             if (materialAssignment.ApplyProperties())
             {
                 if (AZ::TickBus::Handler::BusIsConnected())
@@ -286,9 +286,10 @@ namespace WhiteBox
         }
     }
 
-    void AtomRenderMesh::OnTick([[maybe_unused]]float deltaTime, [[maybe_unused]]AZ::ScriptTimePoint time) {
+    void AtomRenderMesh::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    {
         auto& materialAssignment = m_materialMap[AZ::Render::DefaultMaterialAssignmentId];
-        if (materialAssignment.ApplyProperties()) 
+        if (materialAssignment.ApplyProperties())
         {
             m_meshFeatureProcessor->SetMaterialAssignmentMap(m_meshHandle, m_materialMap);
             AZ::TickBus::Handler::BusDisconnect();

--- a/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.h
+++ b/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.h
@@ -51,7 +51,7 @@ namespace WhiteBox
         bool IsVisible() const override;
         void SetVisiblity(bool visibility) override;
 
-        // AZ::TickBus overrides...
+        // AZ::TickBus overrides ...
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
 
     private:

--- a/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.h
+++ b/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <AzCore/Component/TickBus.h>
+
 #include <Rendering/Atom/WhiteBoxAttributeBuffer.h>
 #include <Rendering/Atom/WhiteBoxBuffer.h>
 #include <Rendering/WhiteBoxRenderData.h>
@@ -33,7 +35,7 @@ namespace WhiteBox
     class AtomRenderMesh
         : public RenderMeshInterface
         , private AZ::Render::MeshHandleStateRequestBus::Handler
-
+        , private AZ::TickBus::Handler
     {
     public:
         AZ_RTTI(AtomRenderMesh, "{1F48D2F5-037C-400B-977C-7C0C9A34B84C}", RenderMeshInterface);
@@ -48,6 +50,9 @@ namespace WhiteBox
         void UpdateMaterial(const WhiteBoxMaterial& material) override;
         bool IsVisible() const override;
         void SetVisiblity(bool visibility) override;
+
+        // AZ::TickBus overrides...
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
 
     private:
         //! Creates an attribute buffer in the slot dictated by AttributeTypeT.


### PR DESCRIPTION
looks like ApplyProperties is failing so the mesh will disappear. this is a continuation of the previous fix. 

https://user-images.githubusercontent.com/854359/169208246-afa59133-2f41-41a7-b16c-2c6d7326cc42.mp4

ref: https://github.com/o3de/o3de/pull/9442#event-6617921824