### PR TITLE
Animation Editor: Centralized save dirty file callbacks and made them persistent

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/FileManager.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/FileManager.cpp
@@ -637,6 +637,86 @@ namespace EMStudio
         return filename;
     }
 
+    void FileManager::SaveAnimGraph(const char* filename, size_t animGraphIndex, MCore::CommandGroup* commandGroup)
+    {
+        const AZStd::string command = AZStd::string::format("SaveAnimGraph -index %zu -filename \"%s\"", animGraphIndex, filename);
+
+        if (!commandGroup)
+        {
+            AZStd::string result;
+            if (!EMStudio::GetCommandManager()->ExecuteCommand(command, result))
+            {
+                GetNotificationWindowManager()->CreateNotificationWindow(NotificationWindow::TYPE_ERROR,
+                    AZStd::string::format("AnimGraph <font color=red>failed</font> to save<br/><br/>%s", result.c_str()).c_str());
+            }
+            else
+            {
+                GetNotificationWindowManager()->CreateNotificationWindow(NotificationWindow::TYPE_SUCCESS,
+                    "AnimGraph <font color=green>successfully</font> saved");
+            }
+        }
+        else
+        {
+            commandGroup->AddCommandString(command);
+        }
+    }
+
+    void FileManager::SaveAnimGraph(QWidget* parent, EMotionFX::AnimGraph* animGraph, MCore::CommandGroup* commandGroup)
+    {
+        const size_t animGraphIndex = EMotionFX::GetAnimGraphManager().FindAnimGraphIndex(animGraph);
+        if (animGraphIndex == InvalidIndex)
+        {
+            return;
+        }
+
+        AZStd::string filename = animGraph->GetFileName();
+        if (filename.empty())
+        {
+            filename = SaveAnimGraphFileDialog(parent);
+            if (filename.empty())
+            {
+                return;
+            }
+        }
+
+        SaveAnimGraph(filename.c_str(), animGraphIndex, commandGroup);
+    }
+
+    void FileManager::SaveAnimGraphAs(QWidget* parent, EMotionFX::AnimGraph* animGraph, const EMotionFX::AnimGraph* focusedAnimGraph, MCore::CommandGroup* commandGroup)
+    {
+        const AZStd::string filename = SaveAnimGraphFileDialog(parent);
+        if (filename.empty())
+        {
+            return;
+        }
+
+        AZStd::string assetFilename = filename;
+        RelocateToAssetCacheFolder(assetFilename);
+        AZStd::string sourceFilename = filename;
+        RelocateToAssetSourceFolder(sourceFilename);
+
+        // Are we about to overwrite an already opened anim graph?
+        const EMotionFX::AnimGraph* sourceAnimGraph = EMotionFX::GetAnimGraphManager().FindAnimGraphByFileName(sourceFilename.c_str(), /*isTool*/ true);
+        const EMotionFX::AnimGraph* cacheAnimGraph = EMotionFX::GetAnimGraphManager().FindAnimGraphByFileName(assetFilename.c_str(), /*isTool*/ true);
+        if (QFile::exists(sourceFilename.c_str()) &&
+            (sourceAnimGraph || cacheAnimGraph) &&
+            (sourceAnimGraph != focusedAnimGraph && cacheAnimGraph != focusedAnimGraph))
+        {
+            QMessageBox::warning(parent, "Cannot overwrite anim graph", "Anim graph is already opened and cannot be overwritten.", QMessageBox::Ok);
+            return;
+        }
+
+        const size_t animGraphIndex = EMotionFX::GetAnimGraphManager().FindAnimGraphIndex(animGraph);
+        if (animGraphIndex == InvalidIndex)
+        {
+            MCore::LogError("Cannot save anim graph. Anim graph index invalid.");
+            return;
+        }
+
+        SaveAnimGraph(filename.c_str(), animGraphIndex, commandGroup);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
 
     // load a node map file
     AZStd::string FileManager::LoadNodeMapFileDialog(QWidget* parent)

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/FileManager.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/FileManager.h
@@ -97,6 +97,9 @@ namespace EMStudio
         // anim graph files
         AZStd::string LoadAnimGraphFileDialog(QWidget* parent);
         AZStd::string SaveAnimGraphFileDialog(QWidget* parent);
+        void SaveAnimGraph(const char* filename, size_t animGraphIndex, MCore::CommandGroup* commandGroup = nullptr);
+        void SaveAnimGraph(QWidget* parent, EMotionFX::AnimGraph* animGraph, MCore::CommandGroup* commandGroup = nullptr);
+        void SaveAnimGraphAs(QWidget* parent, EMotionFX::AnimGraph* animGraph, const EMotionFX::AnimGraph* focusedAnimGraph, MCore::CommandGroup* commandGroup = nullptr);
 
         // game controller preset files
         AZStd::string LoadControllerPresetFileDialog(QWidget* parent, const char* defaultFolder);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.h
@@ -61,7 +61,6 @@ namespace EMStudio
     class BlendGraphViewWidget;
     class AnimGraphPlugin;
     class TimeViewPlugin;
-    class SaveDirtyAnimGraphFilesCallback;
     class NavigationHistory;
 
     // our anim graph event handler
@@ -130,10 +129,6 @@ namespace EMStudio
         void SetActiveAnimGraph(EMotionFX::AnimGraph* animGraph);
         EMotionFX::AnimGraph* GetActiveAnimGraph()           { return m_activeAnimGraph; }
 
-        void SaveAnimGraph(const char* filename, size_t animGraphIndex, MCore::CommandGroup* commandGroup = nullptr);
-        void SaveAnimGraph(EMotionFX::AnimGraph* animGraph, MCore::CommandGroup* commandGroup = nullptr);
-        void SaveAnimGraphAs(EMotionFX::AnimGraph* animGraph, MCore::CommandGroup* commandGroup = nullptr);
-        int SaveDirtyAnimGraph(EMotionFX::AnimGraph* animGraph, MCore::CommandGroup* commandGroup, bool askBeforeSaving, bool showCancelButton = true);
         int OnSaveDirtyAnimGraphs();
 
         PluginOptions* GetOptions() override { return &m_options; }
@@ -265,8 +260,6 @@ namespace EMStudio
         NodeGroupWindow*                            m_nodeGroupWindow;
         BlendGraphViewWidget*                       m_viewWidget;
         NavigationHistory*                          m_navigationHistory;
-
-        SaveDirtyAnimGraphFilesCallback*            m_dirtyFilesCallback;
 
         QDockWidget*                                m_nodePaletteDock;
         QDockWidget*                                m_parameterDock;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.h
@@ -28,17 +28,12 @@
 #include <QDialog>
 #endif
 
-
 namespace EMStudio
 {
-    // forward declarations
-    class SaveDirtyMotionSetFilesCallback;
-
-
     class MotionSetsWindowPlugin
         : public EMStudio::DockWidgetPlugin
     {
-        Q_OBJECT
+        Q_OBJECT // AUTOMOC
         MCORE_MEMORYOBJECTCATEGORY(MotionSetsWindowPlugin, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_STANDARDPLUGINS);
 
     public:
@@ -67,7 +62,6 @@ namespace EMStudio
         EMotionFX::MotionSet* GetSelectedSet() const;
 
         void SetSelectedSet(EMotionFX::MotionSet* motionSet);
-        int SaveDirtyMotionSet(EMotionFX::MotionSet* motionSet, MCore::CommandGroup* commandGroup, bool askBeforeSaving, bool showCancelButton = true);
 
         MotionSetManagementWindow*  GetManagementWindow()                                                       { return m_motionSetManagementWindow; }
         MotionSetWindow*            GetMotionSetWindow()                                                        { return m_motionSetWindow; }
@@ -97,7 +91,5 @@ namespace EMStudio
         MysticQt::DialogStack*                  m_dialogStack;
 
         EMotionFX::MotionSet*                   m_selectedSet;
-
-        SaveDirtyMotionSetFilesCallback*        m_dirtyFilesCallback;
     };
 } // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionWindow/MotionWindowPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionWindow/MotionWindowPlugin.h
@@ -82,7 +82,6 @@ namespace EMStudio
         MCORE_INLINE const char* GetDefaultNodeSelectionLabelText()                                 { return "Click to select node"; }
 
         int OnSaveDirtyMotions();
-        int SaveDirtyMotion(EMotionFX::Motion* motion, MCore::CommandGroup* commandGroup, bool askBeforeSaving, bool showCancelButton = true);
 
         void PlayMotions(const AZStd::vector<EMotionFX::Motion*>& motions);
         void PlayMotion(EMotionFX::Motion* motion);
@@ -115,8 +114,6 @@ namespace EMStudio
 
         MotionListWindow*                               m_motionListWindow;
         MotionPropertiesWindow*                         m_motionPropertiesWindow;
-
-        SaveDirtyMotionFilesCallback*                   m_dirtyFilesCallback;
 
         QAction*                                        m_addMotionsAction;
         QAction*                                        m_saveAction;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/ActorsWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/ActorsWindow.cpp
@@ -22,7 +22,7 @@
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QToolBar>
-
+#include <Editor/SaveDirtyFilesCallbacks.h>
 
 namespace EMStudio
 {
@@ -275,7 +275,7 @@ namespace EMStudio
         // Ask the user if he wants to save the actor in case it got modified and is about to be removed.
         for (EMotionFX::Actor* actor : toBeRemovedActors)
         {
-            m_plugin->SaveDirtyActor(actor, &commandGroup, true, false);
+            SaveDirtyActorFilesCallback::SaveDirtyActor(actor, &commandGroup, true, false);
         }
 
         AZStd::string result;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/SceneManagerPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/SceneManagerPlugin.cpp
@@ -23,52 +23,6 @@
 
 namespace EMStudio
 {
-    void SaveDirtyActorFilesCallback::GetDirtyFileNames(AZStd::vector<AZStd::string>* outFileNames, AZStd::vector<ObjectPointer>* outObjects)
-    {
-        const size_t numLeaderActors = EMotionFX::GetActorManager().GetNumActors();
-        for (size_t i = 0; i < numLeaderActors; ++i)
-        {
-            EMotionFX::Actor* actor = EMotionFX::GetActorManager().GetActor(i);
-
-            // return in case we found a dirty file
-            if (actor->GetDirtyFlag() && actor->GetIsUsedForVisualization() == false)
-            {
-                // add the filename to the dirty filenames array
-                outFileNames->push_back(actor->GetFileName());
-
-                // add the link to the actual object
-                ObjectPointer objPointer;
-                objPointer.m_actor = actor;
-                outObjects->push_back(objPointer);
-            }
-        }
-    }
-
-
-    int SaveDirtyActorFilesCallback::SaveDirtyFiles(const AZStd::vector<AZStd::string>& filenamesToSave, const AZStd::vector<ObjectPointer>& objects, MCore::CommandGroup* commandGroup)
-    {
-        MCORE_UNUSED(filenamesToSave);
-
-        for (const ObjectPointer& objPointer : objects)
-        {
-            // get the current object pointer and skip directly if the type check fails
-            if (objPointer.m_actor == nullptr)
-            {
-                continue;
-            }
-
-            EMotionFX::Actor* actor = objPointer.m_actor;
-            if (m_plugin->SaveDirtyActor(actor, commandGroup, false) == DirtyFileManager::CANCELED)
-            {
-                return DirtyFileManager::CANCELED;
-            }
-        }
-
-        return DirtyFileManager::FINISHED;
-    }
-
-
-    // constructor
     SceneManagerPlugin::SceneManagerPlugin()
         : EMStudio::DockWidgetPlugin()
     {
@@ -85,95 +39,8 @@ namespace EMStudio
         m_adjustActorCallback                = nullptr;
         m_actorSetCollisionMeshesCallback    = nullptr;
         m_adjustActorInstanceCallback        = nullptr;
-        m_dirtyFilesCallback                 = nullptr;
-            }
-
-
-    // save dirty actor
-    int SceneManagerPlugin::SaveDirtyActor(EMotionFX::Actor* actor, [[maybe_unused]] MCore::CommandGroup* commandGroup, bool askBeforeSaving, bool showCancelButton)
-    {
-        // only process changed files
-        if (actor->GetDirtyFlag() == false)
-        {
-            return DirtyFileManager::NOFILESTOSAVE;
-        }
-
-        // and files that really represent an actor that we take serious in emstudio :)
-        if (actor->GetIsUsedForVisualization())
-        {
-            return DirtyFileManager::NOFILESTOSAVE;
-        }
-
-        if (askBeforeSaving)
-        {
-            EMStudio::GetApp()->setOverrideCursor(QCursor(Qt::ArrowCursor));
-
-            QMessageBox msgBox(GetMainWindow());
-            AZStd::string text;
-            AZStd::string filename = actor->GetFileNameString();
-            AZStd::string extension;
-            AzFramework::StringFunc::Path::GetExtension(filename.c_str(), extension, false /* include dot */);
-
-            if (filename.empty() == false && extension.empty() == false)
-            {
-                text = AZStd::string::format("Save changes to '%s'?", actor->GetFileName());
-            }
-            else if (actor->GetNameString().empty() == false)
-            {
-                text = AZStd::string::format("Save changes to the actor named '%s'?", actor->GetName());
-            }
-            else
-            {
-                text = "Save changes to untitled actor?";
-            }
-
-            msgBox.setText(text.c_str());
-            msgBox.setWindowTitle("Save Changes");
-
-            if (showCancelButton)
-            {
-                msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
-            }
-            else
-            {
-                msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard);
-            }
-
-            msgBox.setDefaultButton(QMessageBox::Save);
-            msgBox.setIcon(QMessageBox::Question);
-
-
-            int messageBoxResult = msgBox.exec();
-            switch (messageBoxResult)
-            {
-            case QMessageBox::Save:
-            {
-                GetMainWindow()->GetFileManager()->SaveActor(actor);
-                break;
-            }
-            case QMessageBox::Discard:
-            {
-                EMStudio::GetApp()->restoreOverrideCursor();
-                return DirtyFileManager::FINISHED;
-            }
-            case QMessageBox::Cancel:
-            {
-                EMStudio::GetApp()->restoreOverrideCursor();
-                return DirtyFileManager::CANCELED;
-            }
-            }
-        }
-        else
-        {
-            // save without asking first
-            GetMainWindow()->GetFileManager()->SaveActor(actor);
-        }
-
-        return DirtyFileManager::FINISHED;
     }
 
-
-    // destructor
     SceneManagerPlugin::~SceneManagerPlugin()
     {
         // unregister the command callbacks and get rid of the memory
@@ -201,9 +68,6 @@ namespace EMStudio
         delete m_actorSetCollisionMeshesCallback;
         delete m_adjustActorInstanceCallback;
         delete m_scaleActorDataCallback;
-
-        GetMainWindow()->GetDirtyFileManager()->RemoveCallback(m_dirtyFilesCallback, false);
-        delete m_dirtyFilesCallback;
     }
 
     // init after the parent dock window has been created
@@ -260,10 +124,6 @@ namespace EMStudio
 
         // reinit the dialog
         ReInit();
-
-        // initialize the dirty files callback
-        m_dirtyFilesCallback = new SaveDirtyActorFilesCallback(this);
-        GetMainWindow()->GetDirtyFileManager()->AddCallback(m_dirtyFilesCallback);
 
         return true;
     }

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/SceneManagerPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/SceneManagerPlugin.h
@@ -24,39 +24,6 @@ QT_FORWARD_DECLARE_CLASS(QPushButton)
 
 namespace EMStudio
 {
-    class SaveDirtyActorFilesCallback
-        : public SaveDirtyFilesCallback
-    {
-        MCORE_MEMORYOBJECTCATEGORY(SaveDirtyActorFilesCallback, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_STANDARDPLUGINS)
-
-    public:
-        enum
-        {
-            TYPE_ID = 0x00000001
-        };
-
-    public:
-        SaveDirtyActorFilesCallback(SceneManagerPlugin* plugin)
-            : SaveDirtyFilesCallback()  { m_plugin = plugin; }
-        ~SaveDirtyActorFilesCallback()                                                      {}
-
-        uint32 GetType() const override                                                     { return TYPE_ID; }
-        uint32 GetPriority() const override                                                 { return 4; }
-        bool GetIsPostProcessed() const override                                            { return false; }
-        const char* GetExtension() const override                                           { return "actor"; }
-        const char* GetFileType() const override                                            { return "actor"; }
-        const AZ::Uuid GetFileRttiType() const override
-        {
-            return azrtti_typeid<EMotionFX::Actor>();
-        }
-
-        void GetDirtyFileNames(AZStd::vector<AZStd::string>* outFileNames, AZStd::vector<ObjectPointer>* outObjects) override;
-        int SaveDirtyFiles(const AZStd::vector<AZStd::string>& filenamesToSave, const AZStd::vector<ObjectPointer>& objects, MCore::CommandGroup* commandGroup) override;
-
-    private:
-        SceneManagerPlugin* m_plugin;
-    };
-
     class SceneManagerPlugin
         : public EMStudio::DockWidgetPlugin
     {
@@ -84,8 +51,6 @@ namespace EMStudio
         EMStudioPlugin* Clone() const override { return new SceneManagerPlugin(); }
         void UpdateInterface();
         void ReInit();
-
-        int SaveDirtyActor(EMotionFX::Actor* actor, MCore::CommandGroup* commandGroup, bool askBeforeSaving, bool showCancelButton = true);
 
     public slots:
         void WindowReInit(bool visible);
@@ -116,9 +81,6 @@ namespace EMStudio
         CommandActorSetCollisionMeshesCallback* m_actorSetCollisionMeshesCallback;
         CommandAdjustActorInstanceCallback*     m_adjustActorInstanceCallback;
         CommandScaleActorDataCallback*          m_scaleActorDataCallback;
-
-        SaveDirtyActorFilesCallback*            m_dirtyFilesCallback;
-
         ActorsWindow*                           m_actorsWindow;
         ActorPropertiesWindow*                  m_actorPropsWindow;
     };

--- a/Gems/EMotionFX/Code/Source/Editor/SaveDirtyFilesCallbacks.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/SaveDirtyFilesCallbacks.cpp
@@ -1,0 +1,580 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <EMotionFX/Source/ActorManager.h>
+#include <EMotionFX/Source/AnimGraphManager.h>
+#include <EMotionFX/Source/MotionManager.h>
+#include <EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/EMStudioManager.h>
+#include <EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/FileManager.h>
+#include <EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.h>
+#include <Editor/SaveDirtyFilesCallbacks.h>
+#include <QApplication>
+#include <QMessageBox>
+
+namespace EMStudio
+{
+    void SaveDirtyActorFilesCallback::GetDirtyFileNames(
+        AZStd::vector<AZStd::string>* outFileNames, AZStd::vector<ObjectPointer>* outObjects)
+    {
+        const size_t numLeaderActors = EMotionFX::GetActorManager().GetNumActors();
+        for (size_t i = 0; i < numLeaderActors; ++i)
+        {
+            EMotionFX::Actor* actor = EMotionFX::GetActorManager().GetActor(i);
+
+            if (actor->GetDirtyFlag() &&
+                !actor->GetIsUsedForVisualization())
+            {
+                outFileNames->push_back(actor->GetFileName());
+
+                ObjectPointer objPointer;
+                objPointer.m_actor = actor;
+                outObjects->push_back(objPointer);
+            }
+        }
+    }
+
+    int SaveDirtyActorFilesCallback::SaveDirtyFiles(
+        [[maybe_unused]] const AZStd::vector<AZStd::string>& filenamesToSave,
+        const AZStd::vector<ObjectPointer>& objects,
+        MCore::CommandGroup* commandGroup)
+    {
+        for (const ObjectPointer& objPointer : objects)
+        {
+            if (!objPointer.m_actor)
+            {
+                continue;
+            }
+
+            EMotionFX::Actor* actor = objPointer.m_actor;
+            if (SaveDirtyActor(actor, commandGroup, false) == DirtyFileManager::CANCELED)
+            {
+                return DirtyFileManager::CANCELED;
+            }
+        }
+
+        return DirtyFileManager::FINISHED;
+    }
+
+    int SaveDirtyActorFilesCallback::SaveDirtyActor(
+        EMotionFX::Actor* actor, [[maybe_unused]] MCore::CommandGroup* commandGroup, bool askBeforeSaving, bool showCancelButton)
+    {
+        // only process changed files
+        if (!actor->GetDirtyFlag())
+        {
+            return DirtyFileManager::NOFILESTOSAVE;
+        }
+
+        // and files that really represent an actor that we take serious in emstudio :)
+        if (actor->GetIsUsedForVisualization())
+        {
+            return DirtyFileManager::NOFILESTOSAVE;
+        }
+
+        if (askBeforeSaving)
+        {
+            EMStudio::GetApp()->setOverrideCursor(QCursor(Qt::ArrowCursor));
+
+            QMessageBox msgBox(GetMainWindow());
+            AZStd::string text;
+            AZStd::string filename = actor->GetFileNameString();
+            AZStd::string extension;
+            AzFramework::StringFunc::Path::GetExtension(filename.c_str(), extension, false /* include dot */);
+
+            if (!filename.empty() &&
+                !extension.empty())
+            {
+                text = AZStd::string::format("Save changes to '%s'?", actor->GetFileName());
+            }
+            else if (!actor->GetNameString().empty())
+            {
+                text = AZStd::string::format("Save changes to the actor named '%s'?", actor->GetName());
+            }
+            else
+            {
+                text = "Save changes to untitled actor?";
+            }
+
+            msgBox.setText(text.c_str());
+            msgBox.setWindowTitle("Save Changes");
+
+            if (showCancelButton)
+            {
+                msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+            }
+            else
+            {
+                msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard);
+            }
+
+            msgBox.setDefaultButton(QMessageBox::Save);
+            msgBox.setIcon(QMessageBox::Question);
+
+            int messageBoxResult = msgBox.exec();
+            switch (messageBoxResult)
+            {
+            case QMessageBox::Save:
+                {
+                    GetMainWindow()->GetFileManager()->SaveActor(actor);
+                    break;
+                }
+            case QMessageBox::Discard:
+                {
+                    EMStudio::GetApp()->restoreOverrideCursor();
+                    return DirtyFileManager::FINISHED;
+                }
+            case QMessageBox::Cancel:
+                {
+                    EMStudio::GetApp()->restoreOverrideCursor();
+                    return DirtyFileManager::CANCELED;
+                }
+            }
+        }
+        else
+        {
+            // save without asking first
+            GetMainWindow()->GetFileManager()->SaveActor(actor);
+        }
+
+        return DirtyFileManager::FINISHED;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    void SaveDirtyMotionFilesCallback::GetDirtyFileNames(
+        AZStd::vector<AZStd::string>* outFileNames, AZStd::vector<ObjectPointer>* outObjects)
+    {
+        const size_t numMotions = EMotionFX::GetMotionManager().GetNumMotions();
+        for (size_t i = 0; i < numMotions; ++i)
+        {
+            EMotionFX::Motion* motion = EMotionFX::GetMotionManager().GetMotion(i);
+
+            if (motion->GetIsOwnedByRuntime())
+            {
+                continue;
+            }
+
+            if (motion->GetDirtyFlag())
+            {
+                outFileNames->push_back(motion->GetFileName());
+
+                ObjectPointer objPointer;
+                objPointer.m_motion = motion;
+                outObjects->push_back(objPointer);
+            }
+        }
+    }
+
+    int SaveDirtyMotionFilesCallback::SaveDirtyFiles(
+        [[maybe_unused]] const AZStd::vector<AZStd::string>& filenamesToSave,
+        const AZStd::vector<ObjectPointer>& objects,
+        MCore::CommandGroup* commandGroup)
+    {
+        for (const ObjectPointer& objPointer : objects)
+        {
+            if (!objPointer.m_motion)
+            {
+                continue;
+            }
+
+            EMotionFX::Motion* motion = objPointer.m_motion;
+            if (SaveDirtyMotion(motion, commandGroup, false) == DirtyFileManager::CANCELED)
+            {
+                return DirtyFileManager::CANCELED;
+            }
+        }
+
+        return DirtyFileManager::FINISHED;
+    }
+
+    int SaveDirtyMotionFilesCallback::SaveDirtyMotion(
+        EMotionFX::Motion* motion, [[maybe_unused]] MCore::CommandGroup* commandGroup, bool askBeforeSaving, bool showCancelButton)
+    {
+        // only process changed files
+        if (!motion->GetDirtyFlag())
+        {
+            return DirtyFileManager::NOFILESTOSAVE;
+        }
+
+        if (askBeforeSaving)
+        {
+            EMStudio::GetApp()->setOverrideCursor(QCursor(Qt::ArrowCursor));
+
+            QMessageBox msgBox(GetMainWindow());
+            AZStd::string text;
+
+            if (!motion->GetFileNameString().empty())
+            {
+                text = AZStd::string::format("Save changes to '%s'?", motion->GetFileName());
+            }
+            else if (!motion->GetNameString().empty())
+            {
+                text = AZStd::string::format("Save changes to the motion named '%s'?", motion->GetName());
+            }
+            else
+            {
+                text = "Save changes to untitled motion?";
+            }
+
+            msgBox.setText(text.c_str());
+            msgBox.setWindowTitle("Save Changes");
+
+            if (showCancelButton)
+            {
+                msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+            }
+            else
+            {
+                msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard);
+            }
+
+            msgBox.setDefaultButton(QMessageBox::Save);
+            msgBox.setIcon(QMessageBox::Question);
+
+            int messageBoxResult = msgBox.exec();
+            switch (messageBoxResult)
+            {
+            case QMessageBox::Save:
+                {
+                    GetMainWindow()->GetFileManager()->SaveMotion(motion->GetID());
+                    break;
+                }
+            case QMessageBox::Discard:
+                {
+                    EMStudio::GetApp()->restoreOverrideCursor();
+                    return DirtyFileManager::FINISHED;
+                }
+            case QMessageBox::Cancel:
+                {
+                    EMStudio::GetApp()->restoreOverrideCursor();
+                    return DirtyFileManager::CANCELED;
+                }
+            }
+        }
+        else
+        {
+            // save without asking first
+            GetMainWindow()->GetFileManager()->SaveMotion(motion->GetID());
+        }
+
+        return DirtyFileManager::FINISHED;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    void SaveDirtyMotionSetFilesCallback::GetDirtyFileNames(
+        AZStd::vector<AZStd::string>* outFileNames, AZStd::vector<ObjectPointer>* outObjects)
+    {
+        const size_t numMotionSets = EMotionFX::GetMotionManager().GetNumMotionSets();
+        for (size_t i = 0; i < numMotionSets; ++i)
+        {
+            EMotionFX::MotionSet* motionSet = EMotionFX::GetMotionManager().GetMotionSet(i);
+
+            if (motionSet->GetIsOwnedByRuntime())
+            {
+                continue;
+            }
+
+            // only save root motion sets
+            if (motionSet->GetParentSet())
+            {
+                continue;
+            }
+
+            if (motionSet->GetDirtyFlag())
+            {
+                outFileNames->push_back(motionSet->GetFilename());
+
+                ObjectPointer objPointer;
+                objPointer.m_motionSet = motionSet;
+                outObjects->push_back(objPointer);
+            }
+        }
+    }
+
+    int SaveDirtyMotionSetFilesCallback::SaveDirtyFiles(
+        [[maybe_unused]] const AZStd::vector<AZStd::string>& filenamesToSave,
+        const AZStd::vector<ObjectPointer>& objects,
+        MCore::CommandGroup* commandGroup)
+    {
+        for (const ObjectPointer& objPointer : objects)
+        {
+            if (!objPointer.m_motionSet)
+            {
+                continue;
+            }
+
+            EMotionFX::MotionSet* motionSet = objPointer.m_motionSet;
+            if (SaveDirtyMotionSet(motionSet, commandGroup, false) == DirtyFileManager::CANCELED)
+            {
+                return DirtyFileManager::CANCELED;
+            }
+        }
+
+        return DirtyFileManager::FINISHED;
+    }
+
+    int SaveDirtyMotionSetFilesCallback::SaveDirtyMotionSet(
+        EMotionFX::MotionSet* motionSet, MCore::CommandGroup* commandGroup, bool askBeforeSaving, bool showCancelButton)
+    {
+        // only save root motion sets
+        if (motionSet->GetParentSet())
+        {
+            return DirtyFileManager::NOFILESTOSAVE;
+        }
+
+        // only process changed files
+        if (!motionSet->GetDirtyFlag())
+        {
+            return DirtyFileManager::NOFILESTOSAVE;
+        }
+
+        if (askBeforeSaving)
+        {
+            EMStudio::GetApp()->setOverrideCursor(QCursor(Qt::ArrowCursor));
+
+            QMessageBox msgBox(GetMainWindow());
+            AZStd::string text;
+            const AZStd::string& filename = motionSet->GetFilenameString();
+            AZStd::string extension;
+            AzFramework::StringFunc::Path::GetExtension(filename.c_str(), extension, false /* include dot */);
+
+            if (!filename.empty() && !extension.empty())
+            {
+                text = AZStd::string::format("Save changes to '%s'?", motionSet->GetFilename());
+            }
+            else if (!motionSet->GetNameString().empty())
+            {
+                text = AZStd::string::format("Save changes to the motion set named '%s'?", motionSet->GetName());
+            }
+            else
+            {
+                text = "Save changes to untitled motion set?";
+            }
+
+            msgBox.setText(text.c_str());
+            msgBox.setWindowTitle("Save Changes");
+
+            if (showCancelButton)
+            {
+                msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+            }
+            else
+            {
+                msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard);
+            }
+
+            msgBox.setDefaultButton(QMessageBox::Save);
+            msgBox.setIcon(QMessageBox::Question);
+
+            int messageBoxResult = msgBox.exec();
+            switch (messageBoxResult)
+            {
+            case QMessageBox::Save:
+                {
+                    GetMainWindow()->GetFileManager()->SaveMotionSet(GetMainWindow(), motionSet, commandGroup);
+                    break;
+                }
+            case QMessageBox::Discard:
+                {
+                    EMStudio::GetApp()->restoreOverrideCursor();
+                    return DirtyFileManager::FINISHED;
+                }
+            case QMessageBox::Cancel:
+                {
+                    EMStudio::GetApp()->restoreOverrideCursor();
+                    return DirtyFileManager::CANCELED;
+                }
+            }
+        }
+        else
+        {
+            // save without asking first
+            GetMainWindow()->GetFileManager()->SaveMotionSet(GetMainWindow(), motionSet, commandGroup);
+        }
+
+        return DirtyFileManager::FINISHED;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    void SaveDirtyAnimGraphFilesCallback::GetDirtyFileNames(
+        AZStd::vector<AZStd::string>* outFileNames, AZStd::vector<ObjectPointer>* outObjects)
+    {
+        const size_t numAnimGraphs = EMotionFX::GetAnimGraphManager().GetNumAnimGraphs();
+        for (size_t i = 0; i < numAnimGraphs; ++i)
+        {
+            EMotionFX::AnimGraph* animGraph = EMotionFX::GetAnimGraphManager().GetAnimGraph(i);
+
+            if (animGraph->GetIsOwnedByRuntime())
+            {
+                continue;
+            }
+
+            if (animGraph->GetDirtyFlag())
+            {
+                outFileNames->push_back(animGraph->GetFileName());
+
+                ObjectPointer objPointer;
+                objPointer.m_animGraph = animGraph;
+                outObjects->push_back(objPointer);
+            }
+        }
+    }
+
+    int SaveDirtyAnimGraphFilesCallback::SaveDirtyFiles(
+        [[maybe_unused]] const AZStd::vector<AZStd::string>& filenamesToSave,
+        const AZStd::vector<ObjectPointer>& objects,
+        MCore::CommandGroup* commandGroup)
+    {
+        for (const ObjectPointer& objPointer : objects)
+        {
+            if (!objPointer.m_animGraph)
+            {
+                continue;
+            }
+
+            EMotionFX::AnimGraph* animGraph = objPointer.m_animGraph;
+            if (SaveDirtyAnimGraph(animGraph, commandGroup, false) == DirtyFileManager::CANCELED)
+            {
+                return DirtyFileManager::CANCELED;
+            }
+        }
+
+        return DirtyFileManager::FINISHED;
+    }
+
+    int SaveDirtyAnimGraphFilesCallback::SaveDirtyAnimGraph(
+        EMotionFX::AnimGraph* animGraph, MCore::CommandGroup* commandGroup, bool askBeforeSaving, bool showCancelButton)
+    {
+        if (!animGraph)
+        {
+            return QMessageBox::Discard;
+        }
+
+        // only process changed files
+        if (!animGraph->GetDirtyFlag())
+        {
+            return DirtyFileManager::NOFILESTOSAVE;
+        }
+
+        if (askBeforeSaving)
+        {
+            EMStudio::GetApp()->setOverrideCursor(QCursor(Qt::ArrowCursor));
+
+            QMessageBox msgBox(GetMainWindow());
+            AZStd::string text;
+
+            if (!animGraph->GetFileNameString().empty())
+            {
+                text = AZStd::string::format("Save changes to '%s'?", animGraph->GetFileName());
+            }
+            else
+            {
+                text = "Save changes to untitled anim graph?";
+            }
+
+            msgBox.setText(text.c_str());
+            msgBox.setWindowTitle("Save Changes");
+
+            if (showCancelButton)
+            {
+                msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+            }
+            else
+            {
+                msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard);
+            }
+
+            msgBox.setDefaultButton(QMessageBox::Save);
+            msgBox.setIcon(QMessageBox::Question);
+
+            int messageBoxResult = msgBox.exec();
+            switch (messageBoxResult)
+            {
+            case QMessageBox::Save:
+                {
+                    GetMainWindow()->GetFileManager()->SaveAnimGraph(GetMainWindow(), animGraph, commandGroup);
+                    break;
+                }
+            case QMessageBox::Discard:
+                {
+                    EMStudio::GetApp()->restoreOverrideCursor();
+                    return DirtyFileManager::FINISHED;
+                }
+            case QMessageBox::Cancel:
+                {
+                    EMStudio::GetApp()->restoreOverrideCursor();
+                    return DirtyFileManager::CANCELED;
+                }
+            }
+        }
+        else
+        {
+            // save without asking first
+            GetMainWindow()->GetFileManager()->SaveAnimGraph(GetMainWindow(), animGraph, commandGroup);
+        }
+
+        return DirtyFileManager::FINISHED;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    void SaveDirtyWorkspaceCallback::GetDirtyFileNames(AZStd::vector<AZStd::string>* outFileNames, AZStd::vector<ObjectPointer>* outObjects)
+    {
+        Workspace* workspace = GetManager()->GetWorkspace();
+        if (workspace->GetDirtyFlag())
+        {
+            // add the filename to the dirty filenames array
+            outFileNames->push_back(workspace->GetFilename());
+
+            // add the link to the actual object
+            ObjectPointer objPointer;
+            objPointer.m_workspace = workspace;
+            outObjects->push_back(objPointer);
+        }
+    }
+
+    int SaveDirtyWorkspaceCallback::SaveDirtyFiles(
+        [[maybe_unused]] const AZStd::vector<AZStd::string>& filenamesToSave,
+        const AZStd::vector<ObjectPointer>& objects,
+        MCore::CommandGroup* commandGroup)
+    {
+        for (const ObjectPointer& objPointer : objects)
+        {
+            if (!objPointer.m_workspace)
+            {
+                continue;
+            }
+
+            Workspace* workspace = objPointer.m_workspace;
+
+            // has the workspace been saved already or is it a new one?
+            if (workspace->GetFilenameString().empty())
+            {
+                // open up save as dialog so that we can choose a filename
+                const AZStd::string filename = GetMainWindow()->GetFileManager()->SaveWorkspaceFileDialog(GetMainWindow());
+                if (filename.empty())
+                {
+                    return DirtyFileManager::CANCELED;
+                }
+
+                // save the workspace using the newly selected filename
+                AZStd::string command = AZStd::string::format("SaveWorkspace -filename \"%s\"", filename.c_str());
+                commandGroup->AddCommandString(command);
+            }
+            else
+            {
+                // save workspace using its filename
+                AZStd::string command = AZStd::string::format("SaveWorkspace -filename \"%s\"", workspace->GetFilename());
+                commandGroup->AddCommandString(command);
+            }
+        }
+
+        return DirtyFileManager::FINISHED;
+    }
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/Source/Editor/SaveDirtyFilesCallbacks.h
+++ b/Gems/EMotionFX/Code/Source/Editor/SaveDirtyFilesCallbacks.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/SaveChangedFilesManager.h>
+
+namespace EMStudio
+{
+    class SaveDirtyActorFilesCallback
+        : public SaveDirtyFilesCallback
+    {
+        MCORE_MEMORYOBJECTCATEGORY(SaveDirtyActorFilesCallback, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_EMSTUDIOSDK)
+
+    public:
+        enum
+        {
+            TYPE_ID = 0x00000001
+        };
+
+    public:
+        SaveDirtyActorFilesCallback() = default;
+        ~SaveDirtyActorFilesCallback() = default;
+
+        uint32 GetType() const override { return TYPE_ID; }
+        uint32 GetPriority() const override { return 4; }
+        bool GetIsPostProcessed() const override { return false; }
+
+        const char* GetExtension() const override { return "actor"; }
+        const char* GetFileType() const override { return "actor"; }
+        const AZ::Uuid GetFileRttiType() const override { return azrtti_typeid<EMotionFX::Actor>(); }
+
+        void GetDirtyFileNames(AZStd::vector<AZStd::string>* outFileNames, AZStd::vector<ObjectPointer>* outObjects) override;
+        int SaveDirtyFiles(const AZStd::vector<AZStd::string>& filenamesToSave, const AZStd::vector<ObjectPointer>& objects, MCore::CommandGroup* commandGroup) override;
+
+        static int SaveDirtyActor(EMotionFX::Actor* actor, MCore::CommandGroup* commandGroup, bool askBeforeSaving, bool showCancelButton = true);
+    };
+
+    class SaveDirtyMotionFilesCallback
+        : public SaveDirtyFilesCallback
+    {
+        MCORE_MEMORYOBJECTCATEGORY(SaveDirtyMotionFilesCallback, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_EMSTUDIOSDK)
+
+    public:
+        SaveDirtyMotionFilesCallback() = default;
+        virtual ~SaveDirtyMotionFilesCallback() = default;
+
+        enum
+        {
+            TYPE_ID = 0x00000002
+        };
+        uint32 GetType() const override { return TYPE_ID; }
+        uint32 GetPriority() const override { return 3; }
+        bool GetIsPostProcessed() const override { return false; }
+
+        const char* GetExtension() const override { return "motion"; }
+        const char* GetFileType() const override { return "motion"; }
+        const AZ::Uuid GetFileRttiType() const override { return azrtti_typeid<EMotionFX::Motion>(); }
+
+        void GetDirtyFileNames(AZStd::vector<AZStd::string>* outFileNames, AZStd::vector<ObjectPointer>* outObjects) override;
+        int SaveDirtyFiles(const AZStd::vector<AZStd::string>& filenamesToSave, const AZStd::vector<ObjectPointer>& objects, MCore::CommandGroup* commandGroup) override;
+
+        static int SaveDirtyMotion(EMotionFX::Motion* motion, [[maybe_unused]] MCore::CommandGroup* commandGroup, bool askBeforeSaving, bool showCancelButton = true);
+    };
+
+    class SaveDirtyMotionSetFilesCallback
+        : public SaveDirtyFilesCallback
+    {
+        MCORE_MEMORYOBJECTCATEGORY(SaveDirtyMotionSetFilesCallback, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_EMSTUDIOSDK)
+
+    public:
+        SaveDirtyMotionSetFilesCallback() = default;
+        virtual ~SaveDirtyMotionSetFilesCallback() = default;
+
+        enum
+        {
+            TYPE_ID = 0x00000003
+        };
+        uint32 GetType() const override { return TYPE_ID; }
+        uint32 GetPriority() const override { return 2; }
+        bool GetIsPostProcessed() const override { return false; }
+
+        const char* GetExtension() const override { return "motionset"; }
+        const char* GetFileType() const override { return "motion set"; }
+        const AZ::Uuid GetFileRttiType() const override { return azrtti_typeid<EMotionFX::MotionSet>(); }
+
+        void GetDirtyFileNames(AZStd::vector<AZStd::string>* outFileNames, AZStd::vector<ObjectPointer>* outObjects) override;
+        int SaveDirtyFiles(const AZStd::vector<AZStd::string>& filenamesToSave, const AZStd::vector<ObjectPointer>& objects, MCore::CommandGroup* commandGroup) override;
+
+        static int SaveDirtyMotionSet(EMotionFX::MotionSet* motionSet, MCore::CommandGroup* commandGroup, bool askBeforeSaving, bool showCancelButton = true);
+    };
+
+    class SaveDirtyAnimGraphFilesCallback
+        : public SaveDirtyFilesCallback
+    {
+        MCORE_MEMORYOBJECTCATEGORY(SaveDirtyFilesCallback, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_EMSTUDIOSDK)
+
+    public:
+        SaveDirtyAnimGraphFilesCallback() = default;
+        ~SaveDirtyAnimGraphFilesCallback() = default;
+
+        enum
+        {
+            TYPE_ID = 0x00000004
+        };
+        uint32 GetType() const override { return TYPE_ID; }
+        uint32 GetPriority() const override { return 1; }
+        bool GetIsPostProcessed() const override { return false; }
+
+        const char* GetExtension() const override { return "animgraph"; }
+        const char* GetFileType() const override { return "anim graph"; }
+        const AZ::Uuid GetFileRttiType() const override { return azrtti_typeid<EMotionFX::AnimGraph>(); }
+
+        void GetDirtyFileNames(AZStd::vector<AZStd::string>* outFileNames, AZStd::vector<ObjectPointer>* outObjects) override;
+        int SaveDirtyFiles(const AZStd::vector<AZStd::string>& filenamesToSave, const AZStd::vector<ObjectPointer>& objects, MCore::CommandGroup* commandGroup) override;
+
+        int SaveDirtyAnimGraph(EMotionFX::AnimGraph* animGraph, MCore::CommandGroup* commandGroup, bool askBeforeSaving, bool showCancelButton = true);
+    };
+
+    class SaveDirtyWorkspaceCallback
+        : public SaveDirtyFilesCallback
+    {
+        MCORE_MEMORYOBJECTCATEGORY(SaveDirtyWorkspaceCallback, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_EMSTUDIOSDK)
+
+    public:
+        SaveDirtyWorkspaceCallback() = default;
+        ~SaveDirtyWorkspaceCallback() = default;
+
+        enum
+        {
+            TYPE_ID = 0x00000005
+        };
+        uint32 GetType() const override { return TYPE_ID; }
+        uint32 GetPriority() const override { return 0; }
+        bool GetIsPostProcessed() const override { return false; }
+
+        const char* GetExtension() const override { return "emfxworkspace"; }
+        const char* GetFileType() const override { return "workspace"; }
+        const AZ::Uuid GetFileRttiType() const override { return azrtti_typeid<EMStudio::Workspace>(); }
+
+        void GetDirtyFileNames(AZStd::vector<AZStd::string>* outFileNames, AZStd::vector<ObjectPointer>* outObjects) override;
+        int SaveDirtyFiles(const AZStd::vector<AZStd::string>& filenamesToSave, const AZStd::vector<ObjectPointer>& objects, MCore::CommandGroup* commandGroup) override;
+    };
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/emotionfx_editor_files.cmake
+++ b/Gems/EMotionFX/Code/emotionfx_editor_files.cmake
@@ -51,6 +51,8 @@ set(FILES
     Source/Editor/QtMetaTypes.h
     Source/Editor/ReselectingTreeView.cpp
     Source/Editor/ReselectingTreeView.h
+    Source/Editor/SaveDirtyFilesCallbacks.h
+    Source/Editor/SaveDirtyFilesCallbacks.cpp
     Source/Editor/SelectionProxyModel.h
     Source/Editor/SelectionProxyModel.cpp
     Source/Editor/SimulatedObjectBus.h


### PR DESCRIPTION
* Added save dirty file callbacks at a centralized place.
* Added save anim graph helpers to the file manager
* Removed the save dirty file callbacks from the plugins and register them from a centralized place
* Save dirty file callbacks still working with plugins not being present in the layout (now persistent).