### PR TITLE
[EMotionFX] Fix crash from Inspector window when closing the EMotionFX editor

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/InspectorWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/InspectorWindow.cpp
@@ -18,6 +18,18 @@ namespace EMStudio
     InspectorWindow::~InspectorWindow()
     {
         InspectorRequestBus::Handler::BusDisconnect();
+
+        if (m_scrollArea)
+        {
+            m_scrollArea->takeWidget();
+
+            delete m_contentWidget;
+            m_contentWidget = nullptr;
+
+            delete m_noSelectionWidget;
+            m_noSelectionWidget = nullptr;
+        }
+
     }
 
     bool InspectorWindow::Init()
@@ -96,11 +108,11 @@ namespace EMStudio
         if (m_scrollArea->widget() != widget)
         {
             // Get back ownership of the cached widgets to avoid recreating it each time.
-            if (QWidget* oldWidget = m_scrollArea->takeWidget())
+            if (m_scrollArea->widget())
             {
-                oldWidget->hide();
-                oldWidget->deleteLater();
+                m_scrollArea->widget()->hide();
             }
+            m_scrollArea->takeWidget();
 
             // Set the no selection widget and destroy the previous one.
             m_scrollArea->setWidget(widget);


### PR DESCRIPTION
This fixes a crash introduced by
20873d8427f3f13ff53c6eab7140d4c1a7293726. The Inspector window reuses
the widgets it creates. It does this by calling `takeWidget()` paired
with `setWidget()` on its `QScrollArea`. Calling `takeWidget()` removes
the current widget's parent, and returns ownership back to the caller.
To ensure that both the content widget and the no selection widget are
both destroyed, the Inspector window now takes back ownership of
whatever widget is in the scroll area (which can only be one of the
content widget or the no selection widget), and then deletes both of
them.

Signed-off-by: Chris Burel <burelc@amazon.com>