### PR TITLE
Add prefab.editor.setreg for enabling in-memory spawnables related automated tests on editor console

### DIFF
--- a/Registry/prefab.editor.setreg
+++ b/Registry/prefab.editor.setreg
@@ -1,0 +1,21 @@
+{
+    "Amazon":
+    {
+        "Tools":
+        {
+            "Prefab":
+            {
+                "Processing":
+                {
+                    "Stack": {
+                        "IntegrationTests": 
+                        [
+                            { "$type": "AzToolsFramework::Prefab::PrefabConversionUtils::EditorInfoRemover" },
+                            { "$type": "AzToolsFramework::Prefab::PrefabConversionUtils::PrefabCatchmentProcessor" }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix bug #9016 by adding registry file `prefab.editor.setreg` in the Registry.

Verified by running the following command in editor's console:
```
pyRunFile <engine_path>\AutomatedTesting\Gem\PythonTests\largeworlds\dyn_veg\EditorScripts\ShapeIntersectionFilter_InstancesPlantInAssignedShape.py
```

Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>