### PR TITLE
Fix Crash in Script Canvas when creating a Variable Node and reverting back to reference in Linux

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -3177,6 +3177,12 @@ namespace ScriptCanvasEditor
             }
         }
 
+#if defined (AZ_PLATFORM_LINUX)
+        // Work-around for a crash on Linux caused by the MainWindow::OnSystemTick not being handled before the ReflectedPropertyEditor's DoRefresh.
+        // This will force the pending actions that were setup by this call to occur before exiting this function. This issue only occurs on Linux.
+        AZ::SystemTickBus::Broadcast(&AZ::SystemTickBus::Events::OnSystemTick);
+#endif // defined (AZ_PLATFORM_LINUX)
+
         return true;
     }
 


### PR DESCRIPTION
As described in https://github.com/o3de/o3de/issues/9335, when creating a variable node from a script canvas variable and then reverting it back to a reference causes a crash in Linux.

The root cause is that Script Canvas relies on the MainWindow::RefreshSelection() to be called before the ReflectedPropertyEditor::DoRefresh() is called. On non-linux systems, this is called in MainWindow::OnSystemTick(), and the tick gets processed before the DoRefresh() event. But on Linux, it does not (it may be queued up, but the tick doesnt get processed in time).

This is a safe work-around to prevent the crash. It is isolated to only the call to ```EditorGraph::ConvertVariableNodeToReference``` and only on Linux. The solution is to simply force the processing of queued tick events before leaving the function


Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>