### PR TITLE
Fix assert when creating an in-memory spawnable

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/InMemorySpawnableAssetContainer.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/InMemorySpawnableAssetContainer.cpp
@@ -89,7 +89,19 @@ namespace AzFramework
 
             AZ::Data::AssetCatalogRequestBus::Broadcast(
                 &AZ::Data::AssetCatalogRequestBus::Events::RegisterAsset, assetInfo.m_assetId, assetInfo);
-            spawnableAssetData.m_assets.emplace_back(assetInfo.m_assetId, assetData, AZ::Data::AssetLoadBehavior::Default);
+
+            // The asset Id may not already be set in the asset data in which case we will pass it to the asset creation.
+            // For example, spawnable asset data is serialized and sent to the server, but the asset Id is not included
+            // in the serialization
+            if (assetData->GetId().IsValid())
+            {
+                AZ_Assert(assetData->GetId() == assetInfo.m_assetId, "Asset data already has an asset Id but it's different from the Id set in the corresponding assetInfo.");
+                spawnableAssetData.m_assets.emplace_back(assetData, AZ::Data::AssetLoadBehavior::Default);
+            }
+            else
+            {
+                spawnableAssetData.m_assets.emplace_back(assetInfo.m_assetId, assetData, AZ::Data::AssetLoadBehavior::Default);
+            }
 
             // Ensure the product asset is registered with the AssetManager
             // Hold on to the returned asset to keep ref count alive until we assign it the latest data


### PR DESCRIPTION
When spawnable data is generated via prefab processing for editor game mode, the asset data already has an asset Id assigned. However, when creating an in-memory spawnable from serialized spawnable asset data (network server), the asset Id of the asset data is not assigned because asset Ids don't get serialized. 

If an asset is being created from asset data that has a valid asset Id but an asset Id is also passed to the constructor, an assert happens.

This PR adds a check to determine which is the appropriate constructor to call to avoid the assert.

Signed-off-by: abrmich <abrmich@amazon.com>