### PR TITLE
Add undo/redo functionality to folder renames in Audio Controls Editor

### DIFF
--- a/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorUndo.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorUndo.cpp
@@ -223,6 +223,41 @@ namespace AudioControls
     }
 
     //-------------------------------------------------------------------------------------------//
+    CUndoFolderRename::CUndoFolderRename(QStandardItem* pItem)
+        : IUndoFolderOperation(pItem)
+    {
+    }
+
+    //-------------------------------------------------------------------------------------------//
+    void CUndoFolderRename::Undo([[maybe_unused]] bool bUndo)
+    {
+        SwapNames();
+    }
+
+    //-------------------------------------------------------------------------------------------//
+    void CUndoFolderRename::Redo()
+    {
+        SwapNames();
+    }
+
+    //-------------------------------------------------------------------------------------------//
+    void CUndoFolderRename::SwapNames()
+    {
+        CUndoSuspend suspendUndo;
+        QATLTreeModel* pTree = CAudioControlsEditorPlugin::GetControlsTree();
+        if (pTree)
+        {
+            QStandardItem* pItem = GetItem(pTree, m_path);
+            if (pItem)
+            {
+                QString oldName = pItem->text();
+                pItem->setText(m_sName);
+                m_sName = oldName;
+            }
+        }
+    }
+
+    //-------------------------------------------------------------------------------------------//
     CUndoControlModified::CUndoControlModified(CID id)
         : m_id(id)
     {
@@ -379,4 +414,5 @@ namespace AudioControls
             Copy(pTree->invisibleRootItem(), m_original.invisibleRootItem());
         }
     }
+
 } // namespace AudioControls

--- a/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorUndo.h
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorUndo.h
@@ -17,6 +17,7 @@
 
 #include <QATLControlsTreeModel.h>
 #include <Undo/IUndoObject.h>
+#include <Util/UndoUtil.h>
 
 #include <QAbstractItemModel>
 #include <QString>
@@ -107,6 +108,21 @@ namespace AudioControls
     };
 
     //-------------------------------------------------------------------------------------------//
+    class CUndoFolderRename
+        : public IUndoFolderOperation
+    {
+    public:
+        explicit CUndoFolderRename(QStandardItem* pItem);
+    protected:
+        int GetSize() override { return sizeof(*this); }
+
+        void Undo(bool bUndo) override;
+        void Redo() override;
+
+        void SwapNames();
+    };
+
+    //-------------------------------------------------------------------------------------------//
     class CUndoControlModified
         : public IUndoObject
     {
@@ -145,4 +161,5 @@ namespace AudioControls
 
         bool bModifiedInitialised;
     };
+
 } //namespace AudioControls

--- a/Gems/AudioSystem/Code/Source/Editor/QAudioControlTreeWidget.h
+++ b/Gems/AudioSystem/Code/Source/Editor/QAudioControlTreeWidget.h
@@ -49,6 +49,8 @@ public:
     explicit QAudioControlSortProxy(QObject* pParent = 0);
     bool setData(const QModelIndex& index, const QVariant& value, int role /* = Qt::EditRole */) override;
 
+    QStandardItem* GetStandardItemFromIndex(const QModelIndex& index);
+
 protected:
     bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 };


### PR DESCRIPTION
- Renaming folders in the ATL controls panel of the audio controls
  editor weren't added to the undo stack.
- This adds undo functionality whenever the user changes the name.

closes #6880
