### PR TITLE
Fix for crashes on Linux when actions related to deleting nodes are invoked in Script Canvas

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/Component.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/Component.cpp
@@ -23,7 +23,6 @@ namespace AZ
     Component::Component()
         : m_entity(nullptr)
         , m_id(InvalidComponentId)
-        , m_isDeleting(false)
     {
     }
 
@@ -33,7 +32,6 @@ namespace AZ
     //=========================================================================
     Component::~Component()
     {
-        m_isDeleting = true;
         if (m_entity)
         {
             m_entity->RemoveComponent(this);
@@ -46,30 +44,28 @@ namespace AZ
     //=========================================================================
     EntityId Component::GetEntityId() const
     {
-        if (!m_isDeleting)
+
+        if (m_entity)
         {
-            if (m_entity)
-            {
-                return m_entity->GetId();
-            }
-            else
-            {
-                AZ_Warning("System", false, "Can't get component (type: %s, addr: %p) entity ID as it is not attached to an entity yet!", RTTI_GetTypeName(), this);
-            }
+            return m_entity->GetId();
         }
+        else
+        {
+            AZ_Warning("System", false, "Can't get component (type: %s, addr: %p) entity ID as it is not attached to an entity yet!", RTTI_GetTypeName(), this);
+        }
+
         return EntityId();
     }
 
     NamedEntityId Component::GetNamedEntityId() const
     {
-        if (!m_isDeleting)
+
+        if (m_entity)
         {
-            if (m_entity)
-            {
-                return NamedEntityId(m_entity->GetId(), m_entity->GetName());
-            }
-            AZ_Warning("System", false, "Can't get component (type: %s, addr: %p) entity ID as it is not attached to an entity yet!", RTTI_GetTypeName(), this);
+            return NamedEntityId(m_entity->GetId(), m_entity->GetName());
         }
+        AZ_Warning("System", false, "Can't get component (type: %s, addr: %p) entity ID as it is not attached to an entity yet!", RTTI_GetTypeName(), this);
+
         return NamedEntityId();
     }
 

--- a/Code/Framework/AzCore/AzCore/Component/Component.h
+++ b/Code/Framework/AzCore/AzCore/Component/Component.h
@@ -238,7 +238,6 @@ namespace AZ
 
         Entity*     m_entity;       ///< Reference to the entity that owns the component. The value is null if the component is not attached to an entity.
         ComponentId m_id;           ///< A component ID that is unique for an entity. This component ID is not unique across all entities.
-        bool        m_isDeleting;   ///< Flag to prevent access to any member variables to the instance (possibly from other threads) while an instance is being deleted
     };
 
     /**

--- a/Gems/GraphCanvas/Code/Source/Components/SceneComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/SceneComponent.cpp
@@ -2941,12 +2941,6 @@ namespace GraphCanvas
             }
 
             SceneNotificationBus::Event(GetEntityId(), &SceneNotifications::PostDeletionEvent);
-
-#if defined (AZ_PLATFORM_LINUX)
-            // Work-around for a crash on Linux caused by the MainWindow::OnSystemTick not being handled before the ReflectedPropertyEditor's DoRefresh.
-            // This will force the pending actions that were setup by this call to occur before exiting this function. This issue only occurs on Linux.
-            AZ::SystemTickBus::Broadcast(&AZ::SystemTickBus::Events::OnSystemTick);
-#endif 
         }
     }
 

--- a/Gems/GraphCanvas/Code/Source/Components/SceneComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/SceneComponent.cpp
@@ -2941,6 +2941,12 @@ namespace GraphCanvas
             }
 
             SceneNotificationBus::Event(GetEntityId(), &SceneNotifications::PostDeletionEvent);
+
+#if defined (AZ_PLATFORM_LINUX)
+            // Work-around for a crash on Linux caused by the MainWindow::OnSystemTick not being handled before the ReflectedPropertyEditor's DoRefresh.
+            // This will force the pending actions that were setup by this call to occur before exiting this function. This issue only occurs on Linux.
+            AZ::SystemTickBus::Broadcast(&AZ::SystemTickBus::Events::OnSystemTick);
+#endif 
         }
     }
 

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -2051,6 +2051,12 @@ namespace ScriptCanvasEditor
     void EditorGraph::PostDeletionEvent()
     {
         GeneralRequestBus::Broadcast(&GeneralRequests::PostUndoPoint, GetScriptCanvasId());
+
+#if defined(AZ_PLATFORM_LINUX)
+        // Work-around for a crash on Linux caused by the MainWindow::OnSystemTick not being handled before the ReflectedPropertyEditor's DoRefresh.
+        // This will force a refresh selection on any post-deletion events so that the DoRefresh will not crash on deleted objects
+        UIRequestBus::Broadcast(&UIRequests::RefreshSelection);
+#endif
     }
 
     void EditorGraph::PostCreationEvent()

--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Bus/ScriptCanvasBus.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Bus/ScriptCanvasBus.h
@@ -41,6 +41,8 @@ namespace ScriptCanvasEditor
         virtual QMainWindow* GetMainWindow() = 0;
 
         virtual void OpenValidationPanel() = 0;
+
+        virtual void RefreshSelection() = 0;
     };
 
     using UIRequestBus = AZ::EBus<UIRequests>;

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
@@ -257,6 +257,7 @@ namespace ScriptCanvasEditor
         // UIRequestBus
         QMainWindow* GetMainWindow() override { return qobject_cast<QMainWindow*>(this); }
         void OpenValidationPanel() override;
+        void RefreshSelection() override;
         //
 
         // Undo Handlers
@@ -398,7 +399,6 @@ namespace ScriptCanvasEditor
 
         void SetDefaultLayout();
 
-        void RefreshSelection();
         void Clear();
 
         void OnTabCloseRequest(int index);


### PR DESCRIPTION
There are a few bugs logged ( https://github.com/o3de/o3de/issues/9335, https://github.com/o3de/o3de/issues/7579, https://github.com/o3de/o3de/issues/9335, https://github.com/o3de/o3de/issues/8016, https://github.com/o3de/o3de/issues/7849 ) that causes crashes in Script Canvas were all related to nodes being directly or indirectly deleted. 

This also undoes a previous fix attempt ( https://github.com/o3de/o3de/pull/9629 ) that instead tried to protect from accessing the nodes member variables in the middle of a deletion. (This partially fixed it in some situations, but the root cause was the timing issue that this change fixes), the description of the problem and a working solution was proposed in PR https://github.com/o3de/o3de/pull/9679 .  

But it seems all of the crashes can be prevented by applying the same fix at the base call to ```SceneComponent::Delete``` .

This change will:

1. Insert a force of MainWindow::OnSystemTick whenever entities are deleted
2. Rollback previous fix for crash that just tried to protect the object during deletion

Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>