### PR TITLE
Added missing macro AZ_RELEASE_BUILD on release configuration.

### DIFF
--- a/Code/Framework/AzCore/AzCore/PlatformDef.h
+++ b/Code/Framework/AzCore/AzCore/PlatformDef.h
@@ -209,6 +209,10 @@
 #   define AZ_PROFILE_BUILD
 #endif
 
+#if !defined(AZ_RELEASE_BUILD) && defined(_RELEASE)
+#   define AZ_RELEASE_BUILD
+#endif
+
 // note that many include ONLY PlatformDef.h and not base.h, so flags such as below need to be here.
 // AZ_ENABLE_DEBUG_TOOLS - turns on and off interaction with the debugger.
 // Things like being able to check whether the current process is being debugged, to issue a "debug break" command, etc.

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
@@ -90,7 +90,7 @@ namespace AZ::DocumentPropertyEditor
                 Dom::Utils::ComparisonParameters comparisonParameters;
                 // Because callbacks are often dynamically generated as opaque attributes, only do type-level comparison when validating patches
                 comparisonParameters.m_treatOpaqueValuesOfSameTypeAsEqual = true;
-                const bool valuesMatch = Dom::Utils::DeepCompareIsEqual(actualContents, m_cachedContents, comparisonParameters);
+                [[maybe_unused]] const bool valuesMatch = Dom::Utils::DeepCompareIsEqual(actualContents, m_cachedContents, comparisonParameters);
                 AZ_Warning("DPE", valuesMatch, "DocumentAdapter::NotifyContentsChanged: DOM patches applied, but the new model contents don't match the result of GenerateContents");
             }
         }

--- a/Gems/Multiplayer/Code/Source/Components/LocalPredictionPlayerInputComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/LocalPredictionPlayerInputComponent.cpp
@@ -223,6 +223,7 @@ namespace Multiplayer
                 }
                 else
                 {
+#ifndef AZ_RELEASE_BUILD
                     if (cl_EnableDesyncDebugging && cl_DesyncDebugging_AuditInputs)
                     {
                         // Add to Audit Trail here (server)
@@ -234,6 +235,7 @@ namespace Multiplayer
                                 AZStd::move(inputLogs));
                         }
                     }
+#endif
                     AZLOG(NET_Prediction, "Processed InputId=%u", aznumeric_cast<uint32_t>(input.GetClientInputId()));
                 }
             }
@@ -380,6 +382,7 @@ namespace Multiplayer
         // If this correction is for a move outside our input history window, just start replaying from the oldest move we have available
         const uint32_t startReplayIndex = (inputHistorySize > historicalDelta) ? (inputHistorySize - historicalDelta) : 0;
 
+#ifndef AZ_RELEASE_BUILD
         if (cl_EnableDesyncDebugging)
         {
             int32_t inputFrameId = 0;
@@ -390,7 +393,6 @@ namespace Multiplayer
 
             AZLOG_WARN("** Autonomous Desync - Correcting clientInputId=%d from host frame=%d", aznumeric_cast<int32_t>(inputId), inputFrameId);
 
-#ifndef AZ_RELEASE_BUILD
             auto iter = m_predictiveStateHistory.find(inputId);
             if (iter != m_predictiveStateHistory.end())
             {
@@ -411,8 +413,8 @@ namespace Multiplayer
             {
                 AZLOG_INFO("Received correction that is too old to diff, increase cl_PredictiveStateHistorySize");
             }
-#endif
         }
+#endif
 
         const double clientInputRateSec = AZ::TimeMsToSecondsDouble(cl_InputRateMs);
         for (uint32_t replayIndex = startReplayIndex; replayIndex < inputHistorySize; ++replayIndex)

--- a/cmake/Platform/Common/Configurations_common.cmake
+++ b/cmake/Platform/Common/Configurations_common.cmake
@@ -30,13 +30,13 @@ ly_append_configurations_options(
         _HAS_EXCEPTIONS=0
     DEFINES_DEBUG
         _DEBUG            # TODO: this should be able to removed since it gets added automatically by some compilation flags
-        AZ_DEBUG_BUILD=1
+        AZ_DEBUG_BUILD
         AZ_ENABLE_TRACING
         AZ_ENABLE_DEBUG_TOOLS
         AZ_BUILD_CONFIGURATION_TYPE="${LY_BUILD_CONFIGURATION_TYPE_DEBUG}"
     DEFINES_PROFILE
         _PROFILE
-        AZ_PROFILE_BUILD=1
+        AZ_PROFILE_BUILD
         NDEBUG
         AZ_ENABLE_TRACING
         AZ_ENABLE_DEBUG_TOOLS
@@ -44,7 +44,7 @@ ly_append_configurations_options(
     DEFINES_RELEASE
         _RELEASE
         RELEASE
-        AZ_RELEASE_BUILD=1
+        AZ_RELEASE_BUILD
         NDEBUG
         AZ_BUILD_CONFIGURATION_TYPE="${LY_BUILD_CONFIGURATION_TYPE_RELEASE}"
 )

--- a/cmake/Platform/Common/Configurations_common.cmake
+++ b/cmake/Platform/Common/Configurations_common.cmake
@@ -44,6 +44,7 @@ ly_append_configurations_options(
     DEFINES_RELEASE
         _RELEASE
         RELEASE
+        AZ_RELEASE_BUILD=1
         NDEBUG
         AZ_BUILD_CONFIGURATION_TYPE="${LY_BUILD_CONFIGURATION_TYPE_RELEASE}"
 )


### PR DESCRIPTION
`AZ_DEBUG_BUILD` and `AZ_PROFILE_BUILD` already exist, but `AZ_RELEASE_BUILD` was missing and there is code using it, which was a bug.

Fixed Multiplayer gem cvars only defined when it's not release configuration.

Signed-off-by: moraaar <moraaar@amazon.com>