### PR TITLE
Small changes to fix Android build and deploy on Mac

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Mac/Vulkan_Traits_Mac.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Mac/Vulkan_Traits_Mac.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#define AZ_TRAIT_ATOM_SHADERBUILDER_DXC "Builders/DirectXShaderCompilerAz/bin/dxc"
+#define AZ_TRAIT_ATOM_SHADERBUILDER_DXC "Builders/DirectXShaderCompiler/bin/dxc"
 #define AZ_TRAIT_ATOM_VULKAN_DISABLE_DUAL_SOURCE_BLENDING 0
 #define AZ_TRAIT_ATOM_VULKAN_DLL ""
 #define AZ_TRAIT_ATOM_VULKAN_DLL_1 ""

--- a/cmake/Tools/Platform/Android/android_deployment.py
+++ b/cmake/Tools/Platform/Android/android_deployment.py
@@ -183,7 +183,7 @@ class AndroidDeployment(object):
         logging.debug(f"adb command: {subprocess.list2cmdline(call_arguments)}")
 
         try:
-            output = subprocess.check_output(call_arguments,
+            output = subprocess.check_output(subprocess.list2cmdline(call_arguments),
                                              shell=True,
                                              stderr=subprocess.PIPE).decode(common.DEFAULT_TEXT_READ_ENCODING,
                                                                                common.ENCODING_ERROR_HANDLINGS)


### PR DESCRIPTION
The DX Shader Compiler has no "Az" at the end anymore.
The subprocess command in python, when using 'shell' has to be concatentated as the shell only views the first argument as all the arguments.

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>