### PR TITLE
Fix TargetJoinThread attempting to Join on itself

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/TargetManagement/TargetManagementComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/TargetManagement/TargetManagementComponent.cpp
@@ -299,6 +299,7 @@ namespace AzFramework
         if (target_autoconnect && !m_isTargetHost && !m_targetJoinThread->IsRunning() &&
             m_networkInterface->GetConnectionSet().GetActiveConnectionCount() == 0)
         {
+            m_targetJoinThread->Join();
             m_targetJoinThread->Start();
         }
 #endif
@@ -761,7 +762,6 @@ namespace AzFramework
         if (networkInterface && networkInterface->GetConnectionSet().GetActiveConnectionCount() > 0)
         {
             Stop();
-            Join();
         }
     }
 }   // namespace AzFramework


### PR DESCRIPTION
TargetJoinThread failed to Join since it was attempting to on itself. A thread joining on itself is normally a deadlock scenario but O3DE guards against this and fails silently. This led to the assert seen in https://github.com/o3de/o3de/issues/9612 which further caused AP to disconnect/crash.

This change moves the Join to a more appropriate spot.

Tested per the linked issue by opening the Lua IDE from Editor, closing the Lua IDE and confirming no assert occurred and AP did not disconnect/crash.

Signed-off-by: puvvadar <puvvadar@amazon.com>