### PR TITLE
Prevent Linux crash (NPE) when switching to a multi-view viewport

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineState.cpp
@@ -27,16 +27,28 @@ namespace AZ
 
         PipelineLayout* PipelineState::GetPipelineLayout() const
         {
+            if (m_pipeline == nullptr)
+            {
+                return nullptr;
+            }
             return m_pipeline->GetPipelineLayout();
         }
 
         Pipeline* PipelineState::GetPipeline() const
         {
+            if (m_pipeline == nullptr)
+            {
+                return nullptr;
+            }
             return m_pipeline.get();
         }
 
         PipelineLibrary* PipelineState::GetPipelineLibrary() const
         {
+            if (m_pipeline == nullptr)
+            {
+                return nullptr;
+            }
             return m_pipeline->GetPipelineLibrary();
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineState.cpp
@@ -27,7 +27,7 @@ namespace AZ
 
         PipelineLayout* PipelineState::GetPipelineLayout() const
         {
-            if (m_pipeline == nullptr)
+            if (!m_pipeline)
             {
                 return nullptr;
             }
@@ -36,16 +36,12 @@ namespace AZ
 
         Pipeline* PipelineState::GetPipeline() const
         {
-            if (m_pipeline == nullptr)
-            {
-                return nullptr;
-            }
             return m_pipeline.get();
         }
 
         PipelineLibrary* PipelineState::GetPipelineLibrary() const
         {
-            if (m_pipeline == nullptr)
+            if (!m_pipeline)
             {
                 return nullptr;
             }


### PR DESCRIPTION
This a patch fix to prevent a NPE on Linux when switching viewports. It appears that there is a latent Job (RHI::FrameScheduler)  that still executes after a ```PipelineState::ShutdownInternal``` is called. This fix prevents access to the null pointer so that the job can terminate gracefully.

However, after switching viewport layouts, the window is not sized properly. (Created https://github.com/o3de/o3de/issues/9725 )

closing #9107

Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>