### PR TITLE
fix issue with ray intersections against quads being dependent on qua…

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/IntersectSegment.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/IntersectSegment.cpp
@@ -1043,11 +1043,12 @@ namespace AZ
         Vector3 E = rayDir.Cross(QA);
         float dnAbs = 0.0f;
 
-        if (dn < -EPSILON) // vertices have counter-clock wise winding when looking at the quad from rayOrigin
+        const float triNLength = triN.GetLength();
+        if (dn < -EPSILON * triNLength) // vertices have counter-clock wise winding when looking at the quad from rayOrigin
         {
             dnAbs = -dn;
         }
-        else if (dn > EPSILON)
+        else if (dn > EPSILON * triNLength)
         {
             E = -E;
             dnAbs = dn;

--- a/Code/Framework/AzCore/Tests/Math/IntersectionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/IntersectionTests.cpp
@@ -1092,6 +1092,19 @@ namespace UnitTest
         EXPECT_EQ(hit, 0);
     }
 
+    TEST(MATH_Intersection, RaySmallQuad)
+    {
+        Vector3 rayOrigin = AZ::Vector3::CreateAxisX(-10.0f);
+        Vector3 rayDir = AZ::Vector3::CreateAxisX();
+        Vector3 vertexA(0.0f, -0.001f, 0.001f);
+        Vector3 vertexB(0.0f, 0.001f, 0.001f);
+        Vector3 vertexC(0.0f, 0.001f, -0.001f);
+        Vector3 vertexD(0.0f, -0.001f, -0.001f);
+        float t = 0.0f;
+        int hit = Intersect::IntersectRayQuad(rayOrigin, rayDir, vertexA, vertexB, vertexC, vertexD, t);
+        EXPECT_EQ(hit, 1);
+    }
+
     class MATH_IntersectRayBoxTest
         : public AllocatorsFixture
     {


### PR DESCRIPTION
…d size

Signed-off-by: greerdv <greerdv@amazon.com>

Without this change, manipulators which use the quad billboard view can become unpickable when close to the camera

https://user-images.githubusercontent.com/82226198/170082508-45a6d59d-9c17-4ff7-92be-e1121fb85b8e.mp4

After the change, they can still be picked when close to the camera

https://user-images.githubusercontent.com/82226198/170082580-4b860662-3333-4c71-8ba2-dfdccc103220.mp4