### PR TITLE
#9804 Fixed incorrect properties display when the component is blocked from activating due to unresolved dependencies

### DIFF
--- a/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.cpp
@@ -113,6 +113,14 @@ namespace PhysX
     {
         // By default, disable heightfield collider debug drawing. This doesn't need to be viewed in the common case.
         m_colliderDebugDraw.SetDisplayFlag(false);
+
+        // Heightfields don't support the following:
+        // - Offset:  There shouldn't be a need to offset the data, since the heightfield provider is giving a physics representation
+        // - IsTrigger:  PhysX heightfields don't support acting as triggers
+        // - MaterialSelection:  The heightfield provider provides per-vertex material selection
+        m_colliderConfig.SetPropertyVisibility(Physics::ColliderConfiguration::Offset, false);
+        m_colliderConfig.SetPropertyVisibility(Physics::ColliderConfiguration::IsTrigger, false);
+        m_colliderConfig.SetPropertyVisibility(Physics::ColliderConfiguration::MaterialSelection, false);
     }
 
     EditorHeightfieldColliderComponent ::~EditorHeightfieldColliderComponent()
@@ -124,14 +132,6 @@ namespace PhysX
     void EditorHeightfieldColliderComponent::Activate()
     {
         AzToolsFramework::Components::EditorComponentBase::Activate();
-
-        // Heightfields don't support the following:
-        // - Offset:  There shouldn't be a need to offset the data, since the heightfield provider is giving a physics representation
-        // - IsTrigger:  PhysX heightfields don't support acting as triggers
-        // - MaterialSelection:  The heightfield provider provides per-vertex material selection
-        m_colliderConfig.SetPropertyVisibility(Physics::ColliderConfiguration::Offset, false);
-        m_colliderConfig.SetPropertyVisibility(Physics::ColliderConfiguration::IsTrigger, false);
-        m_colliderConfig.SetPropertyVisibility(Physics::ColliderConfiguration::MaterialSelection, false);
 
         m_sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         if (m_sceneInterface)


### PR DESCRIPTION
#9804  Fixed incorrect properties display when the component is blocked from activating due to unresolved dependencies

Signed-off-by: Sergey Pereslavtsev <pereslav@amazon.com>