### PR TITLE
[Terrain] First pass of async terrain physics

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/TerrainPhysicsCollider_ChangesSizeWithAxisAlignedBoxShapeChanges.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/TerrainPhysicsCollider_ChangesSizeWithAxisAlignedBoxShapeChanges.py
@@ -63,6 +63,10 @@ def TerrainPhysicsCollider_ChangesSizeWithAxisAlignedBoxShapeChanges():
     # 1) Load the level
     hydra.open_base_level()
 
+    #1a) Load the level components
+    hydra.add_level_component("Terrain World")
+    hydra.add_level_component("Terrain World Renderer")
+
     # 2) Create test entity
     test_entity = EditorEntity.create_editor_entity_at(azmath.Vector3(0.0, 0.0, 0.0), "TestEntity")
     Report.result(Tests.create_test_entity, test_entity.id.IsValid())

--- a/Code/Framework/AzFramework/AzFramework/Physics/HeightfieldProviderBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/HeightfieldProviderBus.h
@@ -13,6 +13,7 @@
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Math/Aabb.h>
 #include <AzFramework/Physics/Material.h>
+#include <AzCore/EBus/EBusSharedDispatchTraits.h>
 
 namespace Physics
 {
@@ -49,10 +50,13 @@ namespace Physics
     using UpdateHeightfieldSampleFunction = AZStd::function<void(int32_t, int32_t, const Physics::HeightMaterialPoint&)>;
 
     //! An interface to provide heightfield values.
-    class HeightfieldProviderRequests
-        : public AZ::ComponentBus
+    //! This EBus supports multiple concurrent requests from different threads.
+    class HeightfieldProviderRequests : public AZ::EBusSharedDispatchTraits<HeightfieldProviderRequests>
     {
     public:
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+        typedef AZ::EntityId BusIdType;
+
         static void Reflect(AZ::ReflectContext* context);
 
         //! Returns the distance between each height in the map.
@@ -126,10 +130,7 @@ namespace Physics
             Settings = (1 << 0),
             HeightData = (1 << 1),
             SurfaceData = (1 << 2),
-            DestroyBegin = (1 << 3),
-            DestroyEnd = (1 << 4),
-            CreateEnd = (1 << 5),
-            SurfaceMapping = (1 << 6)
+            SurfaceMapping = (1 << 3)
         };
 
         //! Called whenever the heightfield data changes.

--- a/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.cpp
@@ -395,7 +395,15 @@ namespace Physics
 
     void HeightfieldShapeConfiguration::SetNumColumnVertices(int32_t numColumns)
     {
+        AZ_Assert(
+            (numColumns == 0) || (numColumns >= 2),
+            "A non-empty heightfield must have at least 2 column vertices to define 1 square. Num columns provided: %d", numColumns);
         m_numColumns = numColumns;
+
+        if (m_numColumns < 2)
+        {
+            m_numColumns = 0;
+        }
     }
 
     int32_t HeightfieldShapeConfiguration::GetNumRowVertices() const
@@ -405,7 +413,15 @@ namespace Physics
 
     void HeightfieldShapeConfiguration::SetNumRowVertices(int32_t numRows)
     {
+        AZ_Assert(
+            (numRows == 0) || (numRows >= 2),
+            "A non-empty heightfield must have at least 2 row vertices to define 1 square. Num rows provided: %d", numRows);
         m_numRows = numRows;
+
+        if (m_numRows < 2)
+        {
+            m_numRows = 0;
+        }
     }
 
     int32_t HeightfieldShapeConfiguration::GetNumColumnSquares() const

--- a/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
@@ -103,7 +103,7 @@ namespace AzFramework
             //! maximum number of cores / job threads on the current PC. It's a symbolic number,
             //! not a literal one, since the maximum number of available jobs will change from
             //! machine to machine.
-            static constexpr int32_t NumJobsMax = -1;
+            static constexpr int32_t UseMaxJobs = -1;
 
             //! This constant is used with m_desiredNumberOfJobs to set the default number of jobs
             //! for splitting up async terrain requests. By default, we use a single job so that the

--- a/Gems/PhysX/Code/Include/PhysX/SystemComponentBus.h
+++ b/Gems/PhysX/Code/Include/PhysX/SystemComponentBus.h
@@ -44,6 +44,8 @@ namespace PhysX
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
 
+        using MutexType = AZStd::recursive_mutex;
+
         virtual ~SystemRequests() = default;
 
         /// Creates a new convex mesh.

--- a/Gems/PhysX/Code/Mocks/PhysX/MockPhysXHeightfieldProviderComponent.h
+++ b/Gems/PhysX/Code/Mocks/PhysX/MockPhysXHeightfieldProviderComponent.h
@@ -67,7 +67,6 @@ namespace UnitTest
         MOCK_CONST_METHOD0(GetMaterialList, AZStd::vector<Physics::MaterialId>());
         MOCK_CONST_METHOD0(GetHeights, AZStd::vector<float>());
         MOCK_CONST_METHOD1(UpdateHeights, AZStd::vector<float>(const AZ::Aabb& dirtyRegion));
-        MOCK_CONST_METHOD1(UpdateHeightsAndMaterials, AZStd::vector<Physics::HeightMaterialPoint>(const AZ::Aabb& dirtyRegion));
         MOCK_CONST_METHOD0(GetHeightfieldAabb, AZ::Aabb());
         MOCK_CONST_METHOD0(GetHeightfieldMinHeight, float());
         MOCK_CONST_METHOD0(GetHeightfieldMaxHeight, float());

--- a/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.cpp
@@ -116,9 +116,9 @@ namespace PhysX
         // - Offset:  There shouldn't be a need to offset the data, since the heightfield provider is giving a physics representation
         // - IsTrigger:  PhysX heightfields don't support acting as triggers
         // - MaterialSelection:  The heightfield provider provides per-vertex material selection
-        m_colliderConfig.SetPropertyVisibility(Physics::ColliderConfiguration::Offset, false);
-        m_colliderConfig.SetPropertyVisibility(Physics::ColliderConfiguration::IsTrigger, false);
-        m_colliderConfig.SetPropertyVisibility(Physics::ColliderConfiguration::MaterialSelection, false);
+        m_colliderConfig->SetPropertyVisibility(Physics::ColliderConfiguration::Offset, false);
+        m_colliderConfig->SetPropertyVisibility(Physics::ColliderConfiguration::IsTrigger, false);
+        m_colliderConfig->SetPropertyVisibility(Physics::ColliderConfiguration::MaterialSelection, false);
     }
 
     EditorHeightfieldColliderComponent ::~EditorHeightfieldColliderComponent()

--- a/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.cpp
@@ -13,7 +13,6 @@
 #include <AzCore/Math/Color.h>
 #include <AzCore/Math/MathStringConversions.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
-#include <AzCore/std/utility/as_const.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
 #include <AzFramework/Physics/Configuration/StaticRigidBodyConfiguration.h>
 #include <AzFramework/Physics/MaterialBus.h>
@@ -44,7 +43,6 @@ namespace PhysX
                 ->Version(1)
                 ->Field("ColliderConfiguration", &EditorHeightfieldColliderComponent::m_colliderConfig)
                 ->Field("DebugDrawSettings", &EditorHeightfieldColliderComponent::m_colliderDebugDraw)
-                ->Field("ShapeConfig", &EditorHeightfieldColliderComponent::m_shapeConfig)
                 ;
 
             if (auto editContext = serializeContext->GetEditContext())
@@ -103,7 +101,7 @@ namespace PhysX
         , m_onMaterialLibraryChangedEventHandler(
               [this](const AZ::Data::AssetId& defaultMaterialLibrary)
               {
-                  m_colliderConfig.m_materialSelection.OnMaterialLibraryChanged(defaultMaterialLibrary);
+                  m_colliderConfig->m_materialSelection.OnMaterialLibraryChanged(defaultMaterialLibrary);
                   Physics::ColliderComponentEventBus::Event(GetEntityId(), &Physics::ColliderComponentEvents::OnColliderChanged);
 
                   AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
@@ -117,27 +115,29 @@ namespace PhysX
 
     EditorHeightfieldColliderComponent ::~EditorHeightfieldColliderComponent()
     {
-        ClearHeightfield();
     }
 
     // AZ::Component
     void EditorHeightfieldColliderComponent::Activate()
     {
-        AzToolsFramework::Components::EditorComponentBase::Activate();
-
         // Heightfields don't support the following:
         // - Offset:  There shouldn't be a need to offset the data, since the heightfield provider is giving a physics representation
         // - IsTrigger:  PhysX heightfields don't support acting as triggers
         // - MaterialSelection:  The heightfield provider provides per-vertex material selection
-        m_colliderConfig.SetPropertyVisibility(Physics::ColliderConfiguration::Offset, false);
-        m_colliderConfig.SetPropertyVisibility(Physics::ColliderConfiguration::IsTrigger, false);
-        m_colliderConfig.SetPropertyVisibility(Physics::ColliderConfiguration::MaterialSelection, false);
+        m_colliderConfig->SetPropertyVisibility(Physics::ColliderConfiguration::Offset, false);
+        m_colliderConfig->SetPropertyVisibility(Physics::ColliderConfiguration::IsTrigger, false);
+        m_colliderConfig->SetPropertyVisibility(Physics::ColliderConfiguration::MaterialSelection, false);
 
-        m_sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-        if (m_sceneInterface)
+        AzPhysics::SceneHandle sceneHandle = AzPhysics::InvalidSceneHandle;
+        if (auto sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
         {
-            m_attachedSceneHandle = m_sceneInterface->GetSceneHandle(AzPhysics::EditorPhysicsSceneName);
+            sceneHandle = sceneInterface->GetSceneHandle(AzPhysics::EditorPhysicsSceneName);
         }
+
+        m_heightfieldCollider = AZStd::make_unique<HeightfieldCollider>(
+            GetEntityId(), GetEntity()->GetName(), sceneHandle, m_colliderConfig, m_shapeConfig);
+
+        AzToolsFramework::Components::EditorComponentBase::Activate();
 
         const AZ::EntityId entityId = GetEntityId();
 
@@ -147,198 +147,26 @@ namespace PhysX
         m_colliderDebugDraw.Connect(entityId);
         m_colliderDebugDraw.SetDisplayCallback(this);
 
-        Physics::HeightfieldProviderNotificationBus::Handler::BusConnect(entityId);
-        PhysX::ColliderShapeRequestBus::Handler::BusConnect(entityId);
-        AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusConnect(entityId);
     }
 
     void EditorHeightfieldColliderComponent::Deactivate()
     {
-        AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusDisconnect();
-        PhysX::ColliderShapeRequestBus::Handler::BusDisconnect();
-        Physics::HeightfieldProviderNotificationBus::Handler::BusDisconnect();
-
         m_colliderDebugDraw.Disconnect();
         AzToolsFramework::EntitySelectionEvents::Bus::Handler::BusDisconnect();
         AzToolsFramework::Components::EditorComponentBase::Deactivate();
 
-        ClearHeightfield();
+        m_heightfieldCollider.reset();
     }
 
     void EditorHeightfieldColliderComponent::BuildGameEntity(AZ::Entity* gameEntity)
     {
         auto* heightfieldColliderComponent = gameEntity->CreateComponent<HeightfieldColliderComponent>();
-
-        // Create an empty shapeConfig for initializing the component's ShapeConfiguration.
-        // The actual shapeConfig for the component will get filled out at runtime as everything initializes,
-        // so the values set here during initialization don't matter.
-        AZStd::shared_ptr<Physics::HeightfieldShapeConfiguration> shapeConfig{ aznew Physics::HeightfieldShapeConfiguration() };
-
-        heightfieldColliderComponent->SetShapeConfiguration(
-            { AZStd::make_shared<Physics::ColliderConfiguration>(m_colliderConfig), shapeConfig });
-    }
-
-    void EditorHeightfieldColliderComponent::OnHeightfieldDataChanged(const AZ::Aabb& dirtyRegion, 
-        const Physics::HeightfieldProviderNotifications::HeightfieldChangeMask changeMask)
-    {
-        RefreshHeightfield(changeMask, dirtyRegion);
-    }
-
-    void EditorHeightfieldColliderComponent::ClearHeightfield()
-    {
-        // There are two references to the heightfield data, we need to clear both to make the heightfield clear out and deallocate:
-        // - The simulated body has a pointer to the shape, which has a GeometryHolder, which has the Heightfield inside it
-        // - The shape config is also holding onto a pointer to the Heightfield
-
-        // We remove the simulated body first, since we don't want the heightfield to exist any more.
-        if (m_sceneInterface && m_staticRigidBodyHandle != AzPhysics::InvalidSimulatedBodyHandle)
-        {
-            m_sceneInterface->RemoveSimulatedBody(m_attachedSceneHandle, m_staticRigidBodyHandle);
-        }
-
-        // Now we can safely clear out the cached heightfield pointer.
-        m_shapeConfig->SetCachedNativeHeightfield(nullptr);
-    }
-
-    void EditorHeightfieldColliderComponent::InitStaticRigidBody()
-    {
-        const AZ::Transform baseTransform = GetWorldTM();
-        AzPhysics::StaticRigidBodyConfiguration configuration;
-        configuration.m_orientation = baseTransform.GetRotation();
-        configuration.m_position = baseTransform.GetTranslation();
-        configuration.m_entityId = GetEntityId();
-        configuration.m_debugName = GetEntity()->GetName();
-
-        // Get the transform from the HeightfieldProvider.  Because rotation and scale can indirectly affect how the heightfield itself
-        // is computed and the size of the heightfield, it's possible that the HeightfieldProvider will provide a different transform
-        // back to us than the one that's directly on that entity.
-        AZ::Transform transform = AZ::Transform::CreateIdentity();
-        Physics::HeightfieldProviderRequestsBus::EventResult(
-            transform, GetEntityId(), &Physics::HeightfieldProviderRequestsBus::Events::GetHeightfieldTransform);
-
-        // Because the heightfield's transform may not match the entity's transform, use the heightfield transform
-        // to generate an offset rotation/position from the entity's transform for the collider configuration.
-        m_colliderConfig.m_rotation = transform.GetRotation() * baseTransform.GetRotation().GetInverseFull();
-        m_colliderConfig.m_position =
-            m_colliderConfig.m_rotation.TransformVector(transform.GetTranslation() - baseTransform.GetTranslation());
-
-        // Update material selection from the mapping
-        Utils::SetMaterialsFromHeightfieldProvider(GetEntityId(), m_colliderConfig.m_materialSelection);
-
-        AzPhysics::ShapeColliderPairList colliderShapePairs;
-        colliderShapePairs.emplace_back(AZStd::make_shared<Physics::ColliderConfiguration>(m_colliderConfig), m_shapeConfig);
-        configuration.m_colliderAndShapeData = colliderShapePairs;
-
-        if (m_sceneInterface)
-        {
-            m_staticRigidBodyHandle = m_sceneInterface->AddSimulatedBody(m_attachedSceneHandle, &configuration);
-        }
-    }
-
-    void EditorHeightfieldColliderComponent::InitHeightfieldShapeConfiguration()
-    {
-        *m_shapeConfig = Utils::CreateHeightfieldShapeConfiguration(GetEntityId());
-    }
-
-    void EditorHeightfieldColliderComponent::RefreshHeightfield(
-        const Physics::HeightfieldProviderNotifications::HeightfieldChangeMask changeMask,
-        const AZ::Aabb& dirtyRegion)
-    {
-        using Physics::HeightfieldProviderNotifications;
-
-        if (HeightfieldChangeMask::DestroyBegin == (changeMask & HeightfieldChangeMask::DestroyBegin) ||
-            HeightfieldChangeMask::DestroyEnd == (changeMask & HeightfieldChangeMask::DestroyEnd))
-        {
-            // Clear the entire terrain if destroying
-            ClearHeightfield();
-            Physics::ColliderComponentEventBus::Event(GetEntityId(), &Physics::ColliderComponentEvents::OnColliderChanged);
-            return;
-        }
-
-        // If the change is only about heightfield materials mapping, we can simply update material selection in the heightfield shape
-        if (changeMask == HeightfieldChangeMask::SurfaceMapping)
-        {
-            Physics::MaterialSelection updatedMaterialSelection;
-            Utils::SetMaterialsFromHeightfieldProvider(GetEntityId(), updatedMaterialSelection);
-
-            // Make sure the number of slots is the same.
-            // Otherwise the heightfield needs to be rebuilt to support updated indices.
-            if (updatedMaterialSelection.GetMaterialIdsAssignedToSlots().size()
-                == m_colliderConfig.m_materialSelection.GetMaterialIdsAssignedToSlots().size())
-            {
-                UpdateHeightfieldMaterialSelection(updatedMaterialSelection);
-                return;
-            }
-        }
-
-        AZ::Aabb heightfieldAabb = GetColliderShapeAabb();
-        AZ::Aabb requestRegion = dirtyRegion;
-
-        if (!requestRegion.IsValid())
-        {
-            requestRegion = heightfieldAabb;
-        }
-
-        // Early out if the updated region is outside of the heightfield Aabb
-        if (heightfieldAabb.Disjoint(requestRegion))
-        {
-            return;
-        }
-
-        // Clamp requested region to the entire heightfield AABB
-        requestRegion.Clamp(heightfieldAabb);
-
-        // if dirty region invalid, recreate the entire heightfield, otherwise request samples
-        bool shouldRecreateHeightfield = (m_shapeConfig == nullptr) ||
-            (HeightfieldChangeMask::CreateEnd == (changeMask & HeightfieldChangeMask::CreateEnd));
-
-        // Check if dirtyRegion covers the entire terrain
-        shouldRecreateHeightfield = shouldRecreateHeightfield || (requestRegion == heightfieldAabb);
-
-        // Check if base configuration parameters have changed
-        if (!shouldRecreateHeightfield)
-        {
-            Physics::HeightfieldShapeConfiguration baseConfiguration = Utils::CreateBaseHeightfieldShapeConfiguration(GetEntityId());
-            shouldRecreateHeightfield = shouldRecreateHeightfield || (baseConfiguration.GetNumRowVertices() != m_shapeConfig->GetNumRowVertices());
-            shouldRecreateHeightfield = shouldRecreateHeightfield || (baseConfiguration.GetNumColumnVertices() != m_shapeConfig->GetNumColumnVertices());
-            shouldRecreateHeightfield = shouldRecreateHeightfield || (baseConfiguration.GetMinHeightBounds() != m_shapeConfig->GetMinHeightBounds());
-            shouldRecreateHeightfield = shouldRecreateHeightfield || (baseConfiguration.GetMaxHeightBounds() != m_shapeConfig->GetMaxHeightBounds());
-        }
-
-        if (shouldRecreateHeightfield)
-        {
-            ClearHeightfield();
-            InitHeightfieldShapeConfiguration();
-
-            if (!m_shapeConfig->GetSamples().empty())
-            {
-                InitStaticRigidBody();
-            }
-        }
-        else
-        {
-            // Update m_shapeConfig
-            Physics::HeightfieldProviderRequestsBus::Event(GetEntityId(),
-                &Physics::HeightfieldProviderRequestsBus::Events::UpdateHeightsAndMaterials,
-                [this](int32_t row, int32_t col, const Physics::HeightMaterialPoint& point)
-                {
-                    m_shapeConfig->ModifySample(row, col, point);
-                },
-                requestRegion);
-
-            if (!m_shapeConfig->GetSamples().empty())
-            {
-                ClearHeightfield();
-                InitStaticRigidBody();
-            }
-        }
-
-        Physics::ColliderComponentEventBus::Event(GetEntityId(), &Physics::ColliderComponentEvents::OnColliderChanged);
+        heightfieldColliderComponent->SetColliderConfiguration(*m_colliderConfig);
     }
 
     AZ::u32 EditorHeightfieldColliderComponent::OnConfigurationChanged()
     {
-        RefreshHeightfield(Physics::HeightfieldProviderNotifications::HeightfieldChangeMask::Settings);
+        m_heightfieldCollider->RefreshHeightfield(Physics::HeightfieldProviderNotifications::HeightfieldChangeMask::Settings);
         return AZ::Edit::PropertyRefreshLevels::None;
     }
 
@@ -369,7 +197,7 @@ namespace PhysX
     void EditorHeightfieldColliderComponent::Display(const AzFramework::ViewportInfo& viewportInfo,
         AzFramework::DebugDisplayRequests& debugDisplay) const
     {
-        const AzPhysics::SimulatedBody* simulatedBody = GetSimulatedBody();
+        const AzPhysics::SimulatedBody* simulatedBody = m_heightfieldCollider->GetSimulatedBody();
         if (!simulatedBody)
         {
             return;
@@ -404,131 +232,6 @@ namespace PhysX
                 debugDisplay.DrawWireBox(boundsAabb.GetMin(), boundsAabb.GetMax());
             }
         }
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    void EditorHeightfieldColliderComponent::EnablePhysics()
-    {
-        if (!IsPhysicsEnabled() && m_sceneInterface)
-        {
-            m_sceneInterface->EnableSimulationOfBody(m_attachedSceneHandle, m_staticRigidBodyHandle);
-        }
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    void EditorHeightfieldColliderComponent::DisablePhysics()
-    {
-        if (m_sceneInterface)
-        {
-            m_sceneInterface->DisableSimulationOfBody(m_attachedSceneHandle, m_staticRigidBodyHandle);
-        }
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    bool EditorHeightfieldColliderComponent::IsPhysicsEnabled() const
-    {
-        if (m_sceneInterface && m_staticRigidBodyHandle != AzPhysics::InvalidSimulatedBodyHandle)
-        {
-            if (auto* body = m_sceneInterface->GetSimulatedBodyFromHandle(m_attachedSceneHandle, m_staticRigidBodyHandle))
-            {
-                return body->m_simulating;
-            }
-        }
-        return false;
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    AzPhysics::SimulatedBodyHandle EditorHeightfieldColliderComponent::GetSimulatedBodyHandle() const
-    {
-        return m_staticRigidBodyHandle;
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    AzPhysics::SimulatedBody* EditorHeightfieldColliderComponent::GetSimulatedBody()
-    {
-        return const_cast<AzPhysics::SimulatedBody*>(AZStd::as_const(*this).GetSimulatedBody());
-    }
-
-    const AzPhysics::SimulatedBody* EditorHeightfieldColliderComponent::GetSimulatedBody() const
-    {
-        if (m_sceneInterface && m_staticRigidBodyHandle != AzPhysics::InvalidSimulatedBodyHandle)
-        {
-            if (auto* body = m_sceneInterface->GetSimulatedBodyFromHandle(m_attachedSceneHandle, m_staticRigidBodyHandle))
-            {
-                return body;
-            }
-        }
-        return nullptr;
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    AzPhysics::SceneQueryHit EditorHeightfieldColliderComponent::RayCast(const AzPhysics::RayCastRequest& request)
-    {
-        if (m_sceneInterface && m_staticRigidBodyHandle != AzPhysics::InvalidSimulatedBodyHandle)
-        {
-            if (auto* body = m_sceneInterface->GetSimulatedBodyFromHandle(m_attachedSceneHandle, m_staticRigidBodyHandle))
-            {
-                return body->RayCast(request);
-            }
-        }
-        return AzPhysics::SceneQueryHit();
-    }
-
-    // ColliderShapeRequestBus
-    AZ::Aabb EditorHeightfieldColliderComponent::GetColliderShapeAabb()
-    {
-        // Get the Collider AABB directly from the heightfield provider.
-        AZ::Aabb colliderAabb = AZ::Aabb::CreateNull();
-        Physics::HeightfieldProviderRequestsBus::EventResult(
-            colliderAabb, GetEntityId(), &Physics::HeightfieldProviderRequestsBus::Events::GetHeightfieldAabb);
-
-        return colliderAabb;
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    AZ::Aabb EditorHeightfieldColliderComponent::GetAabb() const
-    {
-        // On the SimulatedBodyComponentRequestsBus, get the AABB from the simulated body instead of the collider.
-        if (m_sceneInterface && m_staticRigidBodyHandle != AzPhysics::InvalidSimulatedBodyHandle)
-        {
-            if (auto* body = m_sceneInterface->GetSimulatedBodyFromHandle(m_attachedSceneHandle, m_staticRigidBodyHandle))
-            {
-                return body->GetAabb();
-            }
-        }
-        return AZ::Aabb::CreateNull();
-    }
-
-    void EditorHeightfieldColliderComponent::UpdateHeightfieldMaterialSelection(const Physics::MaterialSelection& updatedMaterialSelection)
-    {
-        AzPhysics::SimulatedBody* simulatedBody = m_sceneInterface->GetSimulatedBodyFromHandle(m_attachedSceneHandle, m_staticRigidBodyHandle);
-        if (!simulatedBody)
-        {
-            return;
-        }
-
-        AzPhysics::StaticRigidBody* rigidBody = azdynamic_cast<AzPhysics::StaticRigidBody*>(simulatedBody);
-
-        if (rigidBody->GetShapeCount() != 1)
-        {
-            AZ_Error("UpdateHeightfieldMaterialSelection",
-                rigidBody->GetShapeCount() == 1, "Heightfield collider should have only 1 shape. Count: %d", rigidBody->GetShapeCount());
-            return;
-        }
-
-        AZStd::shared_ptr<Physics::Shape> shape = rigidBody->GetShape(0);
-        PhysX::Shape* physxShape = azdynamic_cast<PhysX::Shape*>(shape.get());
-
-        AZStd::vector<AZStd::shared_ptr<Physics::Material>> materials;
-
-        Physics::PhysicsMaterialRequestBus::Broadcast(
-            &Physics::PhysicsMaterialRequestBus::Events::GetMaterials,
-            updatedMaterialSelection,
-            materials);
-
-        physxShape->SetMaterials(materials);
-
-        m_colliderConfig.m_materialSelection = updatedMaterialSelection;
     }
 
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.h
@@ -12,12 +12,10 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <Editor/DebugDraw.h>
 
-#include <AzFramework/Physics/Components/SimulatedBodyComponentBus.h>
-#include <AzFramework/Physics/HeightfieldProviderBus.h>
 #include <AzFramework/Physics/PhysicsScene.h>
 #include <AzFramework/Physics/Shape.h>
 
-#include <PhysX/ColliderShapeBus.h>
+#include <Source/HeightfieldCollider.h>
 
 namespace PhysX
 {
@@ -26,9 +24,6 @@ namespace PhysX
         : public AzToolsFramework::Components::EditorComponentBase
         , protected AzToolsFramework::EntitySelectionEvents::Bus::Handler
         , protected DebugDraw::DisplayCallback
-        , protected AzPhysics::SimulatedBodyComponentRequestsBus::Handler
-        , protected PhysX::ColliderShapeRequestBus::Handler
-        , protected Physics::HeightfieldProviderNotificationBus::Handler
     {
     public:
         AZ_EDITOR_COMPONENT(
@@ -60,53 +55,20 @@ namespace PhysX
         void Display(const AzFramework::ViewportInfo& viewportInfo,
             AzFramework::DebugDisplayRequests& debugDisplay) const;
 
-        // ColliderShapeRequestBus
-        AZ::Aabb GetColliderShapeAabb() override;
-        bool IsTrigger() override
-        {
-            // PhysX Heightfields don't support triggers.
-            return false;
-        }
-
-        // AzPhysics::SimulatedBodyComponentRequestsBus::Handler overrides ...
-        void EnablePhysics() override;
-        void DisablePhysics() override;
-        bool IsPhysicsEnabled() const override;
-        AZ::Aabb GetAabb() const override;
-        AzPhysics::SimulatedBody* GetSimulatedBody() override;
-        AzPhysics::SimulatedBodyHandle GetSimulatedBodyHandle() const override;
-        AzPhysics::SceneQueryHit RayCast(const AzPhysics::RayCastRequest& request) override;
-
-        const AzPhysics::SimulatedBody* GetSimulatedBody() const;
-
-        // Physics::HeightfieldProviderNotificationBus
-        void OnHeightfieldDataChanged(const AZ::Aabb& dirtyRegion, 
-            Physics::HeightfieldProviderNotifications::HeightfieldChangeMask changeMask) override;
-
     private:
         AZ::u32 OnConfigurationChanged();
 
-        void ClearHeightfield();
-        void InitHeightfieldShapeConfiguration();
-        void InitStaticRigidBody();
-        void RefreshHeightfield(
-            Physics::HeightfieldProviderNotifications::HeightfieldChangeMask changeMask,
-            const AZ::Aabb& dirtyRegion = AZ::Aabb::CreateNull());
-
-        void UpdateHeightfieldMaterialSelection(const Physics::MaterialSelection& updatedMaterialSelection);
-
         DebugDraw::Collider m_colliderDebugDraw; //!< Handles drawing the collider
-        AzPhysics::SceneInterface* m_sceneInterface{ nullptr };
 
         AzPhysics::SystemEvents::OnConfigurationChangedEvent::Handler m_physXConfigChangedHandler;
         AzPhysics::SystemEvents::OnMaterialLibraryChangedEvent::Handler m_onMaterialLibraryChangedEventHandler;
 
-        Physics::ColliderConfiguration m_colliderConfig; //!< Stores collision layers, whether the collider is a trigger, etc.
-        AZStd::shared_ptr<Physics::HeightfieldShapeConfiguration> m_shapeConfig{ new Physics::HeightfieldShapeConfiguration() };
-
-        AzPhysics::SimulatedBodyHandle m_staticRigidBodyHandle =
-            AzPhysics::InvalidSimulatedBodyHandle; //!< Handle to the body in the editor physics scene if there is no rigid body component.
-        AzPhysics::SceneHandle m_attachedSceneHandle = AzPhysics::InvalidSceneHandle;
+        //! Stores collision layers, whether the collider is a trigger, etc.
+        AZStd::shared_ptr<Physics::ColliderConfiguration> m_colliderConfig{ aznew Physics::ColliderConfiguration()  };
+        //! Stores all of the cached information for the heightfield shape.
+        AZStd::shared_ptr<Physics::HeightfieldShapeConfiguration> m_shapeConfig{ aznew Physics::HeightfieldShapeConfiguration() };
+        //! Contains all of the runtime logic for creating / updating / destroying the heightfield collider.
+        AZStd::unique_ptr<HeightfieldCollider> m_heightfieldCollider;
     };
 
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/HeightfieldCollider.cpp
+++ b/Gems/PhysX/Code/Source/HeightfieldCollider.cpp
@@ -255,7 +255,9 @@ namespace PhysX
         {
             *m_shapeConfig = Utils::CreateBaseHeightfieldShapeConfiguration(m_entityId);
             size_t numSamples = m_shapeConfig->GetNumRowVertices() * m_shapeConfig->GetNumColumnVertices();
-            if (numSamples > 0)
+
+            // A heightfield needs to be at least a 1 x 1 square.
+            if ((m_shapeConfig->GetNumRowSquares() > 0) && (m_shapeConfig->GetNumColumnSquares() > 0))
             {
                 AZStd::vector<Physics::HeightMaterialPoint> samples(numSamples);
                 m_shapeConfig->SetSamples(AZStd::move(samples));
@@ -263,7 +265,7 @@ namespace PhysX
         }
 
         // If our new size is "none", we're done.
-        if (m_shapeConfig->GetSamples().empty())
+        if ((m_shapeConfig->GetNumRowSquares() == 0) || (m_shapeConfig->GetNumColumnSquares() == 0))
         {
             return;
         }

--- a/Gems/PhysX/Code/Source/HeightfieldCollider.cpp
+++ b/Gems/PhysX/Code/Source/HeightfieldCollider.cpp
@@ -1,0 +1,469 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Component/TransformBus.h>
+#include <AzCore/Console/IConsole.h>
+#include <AzCore/Jobs/JobFunction.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/std/utility/as_const.h>
+#include <AzFramework/Physics/Configuration/StaticRigidBodyConfiguration.h>
+#include <AzFramework/Physics/ColliderComponentBus.h>
+#include <AzFramework/Physics/MaterialBus.h>
+#include <AzFramework/Physics/SimulatedBodies/StaticRigidBody.h>
+#include <AzFramework/Physics/Shape.h>
+#include <AzFramework/Physics/SystemBus.h>
+#include <Source/HeightfieldCollider.h>
+#include <System/PhysXSystem.h>
+#include <Source/RigidBodyStatic.h>
+#include <Source/Shape.h>
+#include <Source/Utils.h>
+
+
+namespace PhysX
+{
+    AZ_CVAR(float, physx_heightfieldColliderUpdateRegionSize, 128.0f, nullptr,
+        AZ::ConsoleFunctorFlags::Null,
+        "Size of a heightfield collider update region in meters, used for partitioning updates for faster cancellation.");
+
+    // The HeightfieldUpdateJobContext is an extremely simplified way to manage the background update jobs.
+    // On any heightfield change, the collider code will cancel any update job that's currently running, wait for it
+    // to complete, and then start a new update job.
+    // Also, on HeightfieldCollider destruction, any running jobs will get canceled and block on completion.
+    // Eventually, this could get migrated to a more complex system that allows for overlapping jobs, or potentially using a queue
+    // of regions to update in a currently-running job.
+    void HeightfieldCollider::HeightfieldUpdateJobContext::Cancel()
+    {
+        m_isCanceled = true;
+    }
+
+    bool HeightfieldCollider::HeightfieldUpdateJobContext::IsCanceled() const
+    {
+        return m_isCanceled;
+    }
+
+    void HeightfieldCollider::HeightfieldUpdateJobContext::OnJobStart()
+    {
+        // When the update job starts, track that it has started and that we shouldn't cancel anything yet.
+        AZStd::unique_lock<AZStd::mutex> lock(m_jobsRunningNotificationMutex);
+        m_isCanceled = false;
+        m_numRunningJobs++;
+    }
+
+    void HeightfieldCollider::HeightfieldUpdateJobContext::OnJobComplete()
+    {
+        // On completion, track that the job has finished, and notify any listneers that it's done.
+        {
+            AZStd::unique_lock<AZStd::mutex> lock(m_jobsRunningNotificationMutex);
+            m_numRunningJobs--;
+        }
+        m_jobsRunning.notify_all();
+    }
+
+    void HeightfieldCollider::HeightfieldUpdateJobContext::BlockUntilComplete()
+    {
+        // Block until the update job completes (or don't block at all if the job never ran)
+        AZStd::unique_lock<AZStd::mutex> lock(m_jobsRunningNotificationMutex);
+        m_jobsRunning.wait(
+            lock,
+            [this]
+            {
+                return m_numRunningJobs <= 0;
+            });
+    }
+
+    HeightfieldCollider::HeightfieldCollider(
+        AZ::EntityId entityId,
+        const AZStd::string& entityName,
+        AzPhysics::SceneHandle sceneHandle,
+        AZStd::shared_ptr<Physics::ColliderConfiguration> colliderConfig,
+        AZStd::shared_ptr<Physics::HeightfieldShapeConfiguration> shapeConfig)
+        : m_entityId(entityId)
+        , m_entityName(entityName)
+        , m_colliderConfig(colliderConfig)
+        , m_shapeConfig(shapeConfig)
+        , m_attachedSceneHandle(sceneHandle)
+    {
+        m_jobContext = AZStd::make_unique<HeightfieldUpdateJobContext>(AZ::JobContext::GetGlobalContext()->GetJobManager());
+
+        PhysX::ColliderShapeRequestBus::Handler::BusConnect(entityId);
+        Physics::HeightfieldProviderNotificationBus::Handler::BusConnect(entityId);
+        AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusConnect(entityId);
+    }
+
+    HeightfieldCollider::~HeightfieldCollider()
+    {
+        AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusDisconnect();
+        Physics::HeightfieldProviderNotificationBus::Handler::BusDisconnect();
+        PhysX::ColliderShapeRequestBus::Handler::BusDisconnect();
+
+        // Make sure any heightfield collider jobs that are running finish up before we destroy ourselves.
+        m_jobContext->Cancel();
+        m_jobContext->BlockUntilComplete();
+
+        ClearHeightfield();
+
+        m_jobContext.reset();
+    }
+
+    // ColliderShapeRequestBus
+    AZ::Aabb HeightfieldCollider::GetColliderShapeAabb()
+    {
+        // Get the Collider AABB directly from the heightfield provider.
+        AZ::Aabb colliderAabb = AZ::Aabb::CreateNull();
+        Physics::HeightfieldProviderRequestsBus::EventResult(
+            colliderAabb, m_entityId, &Physics::HeightfieldProviderRequestsBus::Events::GetHeightfieldAabb);
+
+        return colliderAabb;
+    }
+
+    // Physics::HeightfieldProviderNotificationBus
+    void HeightfieldCollider::OnHeightfieldDataChanged(
+        const AZ::Aabb& dirtyRegion, const Physics::HeightfieldProviderNotifications::HeightfieldChangeMask changeMask)
+    {
+        RefreshHeightfield(changeMask, dirtyRegion);
+    }
+
+    void HeightfieldCollider::ClearHeightfield()
+    {
+        // There are two references to the heightfield data, we need to clear both to make the heightfield clear out and deallocate:
+        // - The simulated body has a pointer to the shape, which has a GeometryHolder, which has the Heightfield inside it
+        // - The shape config is also holding onto a pointer to the Heightfield
+
+        // We remove the simulated body first, since we don't want the heightfield to exist any more.
+        if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+            sceneInterface && m_staticRigidBodyHandle != AzPhysics::InvalidSimulatedBodyHandle)
+        {
+            sceneInterface->RemoveSimulatedBody(m_attachedSceneHandle, m_staticRigidBodyHandle);
+        }
+
+        // Now we can safely clear out the cached heightfield pointer.
+        m_shapeConfig->SetCachedNativeHeightfield(nullptr);
+    }
+
+    void HeightfieldCollider::InitStaticRigidBody(const AZ::Transform& baseTransform)
+    {
+        // Set the rigid body's position and orientation to match the entity's position and orientation.
+        AzPhysics::StaticRigidBodyConfiguration configuration;
+        configuration.m_orientation = baseTransform.GetRotation();
+        configuration.m_position = baseTransform.GetTranslation();
+        configuration.m_entityId = m_entityId;
+        configuration.m_debugName = m_entityName;
+
+        AzPhysics::ShapeColliderPairList colliderShapePairs{ AzPhysics::ShapeColliderPair(m_colliderConfig, m_shapeConfig) };
+        configuration.m_colliderAndShapeData = colliderShapePairs;
+
+        // Get the transform from the HeightfieldProvider.  Because rotation and scale can indirectly affect how the heightfield itself
+        // is computed and the size of the heightfield, and the heightfield might snap or clamp to grids, it's possible that the
+        // HeightfieldProvider will provide a different transform back to us than the one that's directly on that entity.
+        AZ::Transform transform = AZ::Transform::CreateIdentity();
+        Physics::HeightfieldProviderRequestsBus::EventResult(
+            transform, m_entityId, &Physics::HeightfieldProviderRequestsBus::Events::GetHeightfieldTransform);
+
+        // Because the heightfield's transform may not match the entity's transform, use the heightfield transform
+        // to generate an offset rotation/position from the entity's transform for the collider configuration.
+        m_colliderConfig->m_rotation = transform.GetRotation() * baseTransform.GetRotation().GetInverseFull();
+        m_colliderConfig->m_position =
+            m_colliderConfig->m_rotation.TransformVector(transform.GetTranslation() - baseTransform.GetTranslation());
+
+        // Update material selection from the mapping
+        Utils::SetMaterialsFromHeightfieldProvider(m_entityId, m_colliderConfig->m_materialSelection);
+
+        // Create a new simulated body in the world from the given collision / shape configuration.
+        if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
+        {
+            m_staticRigidBodyHandle = sceneInterface->AddSimulatedBody(m_attachedSceneHandle, &configuration);
+        }
+    }
+
+    void HeightfieldCollider::RefreshHeightfield(
+        const Physics::HeightfieldProviderNotifications::HeightfieldChangeMask changeMask,
+        const AZ::Aabb& dirtyRegion)
+    {
+        using Physics::HeightfieldProviderNotifications;
+
+        // If the change is only about heightfield materials mapping, we can simply update material selection in the heightfield shape
+        if (changeMask == Physics::HeightfieldProviderNotifications::HeightfieldChangeMask::SurfaceMapping)
+        {
+            Physics::MaterialSelection updatedMaterialSelection;
+            Utils::SetMaterialsFromHeightfieldProvider(m_entityId, updatedMaterialSelection);
+
+            // Make sure the number of slots is the same.
+            // Otherwise the heightfield needs to be rebuilt to support updated indices.
+            if (updatedMaterialSelection.GetMaterialIdsAssignedToSlots().size() ==
+                m_colliderConfig->m_materialSelection.GetMaterialIdsAssignedToSlots().size())
+            {
+                UpdateHeightfieldMaterialSelection(updatedMaterialSelection);
+                return;
+            }
+        }
+
+        AZ::Aabb heightfieldAabb = GetColliderShapeAabb();
+        AZ::Aabb requestRegion = dirtyRegion;
+
+        if (!requestRegion.IsValid())
+        {
+            requestRegion = heightfieldAabb;
+        }
+
+        // Early out if the updated region is outside of the heightfield Aabb
+        if (heightfieldAabb.IsValid() && heightfieldAabb.Disjoint(requestRegion))
+        {
+            return;
+        }
+
+        // Clamp requested region to the heightfield AABB so that it only references the area we need to update.
+        requestRegion.Clamp(heightfieldAabb);
+
+        // There are two refresh possibilities - resizing the area or updating the data.
+        // Resize: we need to cancel any running job, wait for it to finish, resize the area, and kick it off again.
+        //   PhysX heightfields need to have a static number of points, so a resize requires a complete rebuild of the heightfield.
+        // Update: technically, we could get more clever with updates, and just perform in-place modifications to the PhysX heightfield
+        //   data, and potentially even keep the same job running with just a modified list of update regions. But for now, we're
+        //   keeping it simple and just cancel and re-runn the job on any update change, same as with resizing.
+
+        // If we don't have a shape configuration yet, we need to recreate the entire heightfield.
+        bool shouldRecreateHeightfield = (m_shapeConfig == nullptr);
+
+        // If the dirty region exactly matches the existing heightfield size, we could either recreate it or update it in place.
+        // For now, we'll choose to recreate it.
+        shouldRecreateHeightfield = shouldRecreateHeightfield || (requestRegion == heightfieldAabb);
+
+        // Check if base configuration parameters have changed. If any of the sizes have changed, we'll recreate the entire heightfield.
+        if (!shouldRecreateHeightfield)
+        {
+            Physics::HeightfieldShapeConfiguration baseConfiguration = Utils::CreateBaseHeightfieldShapeConfiguration(m_entityId);
+            shouldRecreateHeightfield = shouldRecreateHeightfield || (baseConfiguration.GetNumRowVertices() != m_shapeConfig->GetNumRowVertices());
+            shouldRecreateHeightfield = shouldRecreateHeightfield || (baseConfiguration.GetNumColumnVertices() != m_shapeConfig->GetNumColumnVertices());
+            shouldRecreateHeightfield = shouldRecreateHeightfield || (baseConfiguration.GetMinHeightBounds() != m_shapeConfig->GetMinHeightBounds());
+            shouldRecreateHeightfield = shouldRecreateHeightfield || (baseConfiguration.GetMaxHeightBounds() != m_shapeConfig->GetMaxHeightBounds());
+        }
+
+        // If any jobs are running, stop them and wait for them to complete.
+        m_jobContext->Cancel();
+        m_jobContext->BlockUntilComplete();
+
+        // Destroy the existing heightfield. This will completely remove it from the world.
+        ClearHeightfield();
+
+        // If our heightfield has changed size, recreate the configuration and initialize it.
+        if (shouldRecreateHeightfield)
+        {
+            *m_shapeConfig = Utils::CreateBaseHeightfieldShapeConfiguration(m_entityId);
+            size_t numSamples = m_shapeConfig->GetNumRowVertices() * m_shapeConfig->GetNumColumnVertices();
+            if (numSamples > 0)
+            {
+                AZStd::vector<Physics::HeightMaterialPoint> samples(numSamples);
+                m_shapeConfig->SetSamples(AZStd::move(samples));
+            }
+        }
+
+        // If our new size is "none", we're done.
+        if (m_shapeConfig->GetSamples().empty())
+        {
+            return;
+        }
+
+        // Fetch our entity transform on the main thread, because transforms can't be safely requested from a job thread.
+        // This will be used to create our new heightfield at the end of the job.
+        AZ::Transform baseTransform = AZ::Transform::CreateIdentity();
+        AZ::TransformBus::EventResult(baseTransform, m_entityId, &AZ::TransformInterface::GetWorldTM);
+
+        // Get the number of meters to subdivide our update region into. We process the region as subdivided regions
+        // so that cancellation requests can be detected and processed more quickly. If we just processed a single full dirty region,
+        // regardless of size, there would be a lot more work that needs to complete before we could cancel a job.
+        const float regionDivider = physx_heightfieldColliderUpdateRegionSize;
+
+        auto jobLambda = [this, baseTransform, regionDivider, requestRegion]() -> void
+        {
+            // For each sub-region in our dirty region, get the updated height and material data for the heightfield.
+            for (float y = requestRegion.GetMin().GetY(); y <= requestRegion.GetMax().GetY(); y += regionDivider)
+            {
+                for (float x = requestRegion.GetMin().GetX(); x <= requestRegion.GetMax().GetX(); x += regionDivider)
+                {
+                    // On each sub-region, if a cancellation has been requested, early-out.
+                    if (m_jobContext->IsCanceled())
+                    {
+                        break;
+                    }
+
+                    // Create the sub-region to process.
+                    const float xMax = AZStd::min(x + regionDivider, requestRegion.GetMax().GetX());
+                    const float yMax = AZStd::min(y + regionDivider, requestRegion.GetMax().GetY());
+
+                    AZ::Aabb subRegion;
+                    subRegion.Set(
+                        AZ::Vector3(x, y, requestRegion.GetMin().GetZ()),
+                        AZ::Vector3(xMax, yMax, requestRegion.GetMax().GetZ()));
+
+                    // Update the shape configuration with the new height and material data for the heightfield.
+                    // This makes the assumption that the shape configuration already has been created with the correct number
+                    // of samples.
+                    Physics::HeightfieldProviderRequestsBus::Event(
+                        m_entityId, &Physics::HeightfieldProviderRequestsBus::Events::UpdateHeightsAndMaterials,
+                        [this](int32_t row, int32_t col, const Physics::HeightMaterialPoint& point)
+                        {
+                            m_shapeConfig->ModifySample(row, col, point);
+                        },
+                        subRegion);
+                }
+            }
+
+            // If the job hasn't been canceled, use the updated shape configuration to create a new heightfield in the world
+            // and notify any listeners that the collider has changed.
+            if (!m_jobContext->IsCanceled())
+            {
+                InitStaticRigidBody(baseTransform);
+                Physics::ColliderComponentEventBus::Event(m_entityId, &Physics::ColliderComponentEvents::OnColliderChanged);
+            }
+
+            // Notify the job context that the job is completed, so that anything blocking on job completion knows it can proceed.
+            m_jobContext->OnJobComplete();
+        };
+
+        // Kick off the job to update the heightfield configuration and create the heightfield.
+        constexpr bool autoDelete = true;
+        auto* runningJob = AZ::CreateJobFunction(jobLambda, autoDelete, m_jobContext.get());
+        m_jobContext->OnJobStart();
+        runningJob->Start();
+    }
+
+    void HeightfieldCollider::UpdateHeightfieldMaterialSelection(const Physics::MaterialSelection& updatedMaterialSelection)
+    {
+        auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+        AzPhysics::SimulatedBody* simulatedBody =
+            sceneInterface->GetSimulatedBodyFromHandle(m_attachedSceneHandle, m_staticRigidBodyHandle);
+        if (!simulatedBody)
+        {
+            return;
+        }
+
+        AzPhysics::StaticRigidBody* rigidBody = azdynamic_cast<AzPhysics::StaticRigidBody*>(simulatedBody);
+
+        if (rigidBody->GetShapeCount() != 1)
+        {
+            AZ_Error(
+                "UpdateHeightfieldMaterialSelection", rigidBody->GetShapeCount() == 1,
+                "Heightfield collider should have only 1 shape. Count: %d", rigidBody->GetShapeCount());
+            return;
+        }
+
+        AZStd::shared_ptr<Physics::Shape> shape = rigidBody->GetShape(0);
+        PhysX::Shape* physxShape = azdynamic_cast<PhysX::Shape*>(shape.get());
+
+        AZStd::vector<AZStd::shared_ptr<Physics::Material>> materials;
+
+        Physics::PhysicsMaterialRequestBus::Broadcast(
+            &Physics::PhysicsMaterialRequestBus::Events::GetMaterials, updatedMaterialSelection, materials);
+
+        physxShape->SetMaterials(materials);
+
+        m_colliderConfig->m_materialSelection = updatedMaterialSelection;
+    }
+
+    // SimulatedBodyComponentRequestsBus
+    void HeightfieldCollider::EnablePhysics()
+    {
+        if (IsPhysicsEnabled())
+        {
+            return;
+        }
+        if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
+        {
+            sceneInterface->EnableSimulationOfBody(m_attachedSceneHandle, m_staticRigidBodyHandle);
+        }
+    }
+
+    // SimulatedBodyComponentRequestsBus
+    void HeightfieldCollider::DisablePhysics()
+    {
+        if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
+        {
+            sceneInterface->DisableSimulationOfBody(m_attachedSceneHandle, m_staticRigidBodyHandle);
+        }
+    }
+
+    // SimulatedBodyComponentRequestsBus
+    bool HeightfieldCollider::IsPhysicsEnabled() const
+    {
+        if (m_staticRigidBodyHandle != AzPhysics::InvalidSimulatedBodyHandle)
+        {
+            if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+                sceneInterface != nullptr && sceneInterface->IsEnabled(m_attachedSceneHandle)) // check if the scene is enabled
+            {
+                if (AzPhysics::SimulatedBody* body =
+                        sceneInterface->GetSimulatedBodyFromHandle(m_attachedSceneHandle, m_staticRigidBodyHandle))
+                {
+                    return body->m_simulating;
+                }
+            }
+        }
+        return false;
+    }
+
+    // SimulatedBodyComponentRequestsBus
+    AzPhysics::SimulatedBodyHandle HeightfieldCollider::GetSimulatedBodyHandle() const
+    {
+        // If there are any jobs running, wait for them to complete before returning the simulated body.
+        m_jobContext->BlockUntilComplete();
+        return m_staticRigidBodyHandle;
+    }
+
+    // SimulatedBodyComponentRequestsBus
+    AzPhysics::SimulatedBody* HeightfieldCollider::GetSimulatedBody()
+    {
+        return const_cast<AzPhysics::SimulatedBody*>(AZStd::as_const(*this).GetSimulatedBody());
+    }
+
+    const AzPhysics::SimulatedBody* HeightfieldCollider::GetSimulatedBody() const
+    {
+        // If there are any jobs running, wait for them to complete before returning the simulated body.
+        m_jobContext->BlockUntilComplete();
+        if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
+        {
+            return sceneInterface->GetSimulatedBodyFromHandle(m_attachedSceneHandle, m_staticRigidBodyHandle);
+        }
+        return nullptr;
+    }
+
+    // SimulatedBodyComponentRequestsBus
+    AzPhysics::SceneQueryHit HeightfieldCollider::RayCast(const AzPhysics::RayCastRequest& request)
+    {
+        if (auto* body = azdynamic_cast<PhysX::StaticRigidBody*>(GetSimulatedBody()))
+        {
+            return body->RayCast(request);
+        }
+        return AzPhysics::SceneQueryHit();
+    }
+
+    // SimulatedBodyComponentRequestsBus
+    AZ::Aabb HeightfieldCollider::GetAabb() const
+    {
+        // On the SimulatedBodyComponentRequestsBus, get the AABB from the simulated body instead of the collider.
+        if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
+        {
+            if (AzPhysics::SimulatedBody* body = sceneInterface->GetSimulatedBodyFromHandle(m_attachedSceneHandle, m_staticRigidBodyHandle))
+            {
+                return body->GetAabb();
+            }
+        }
+        return AZ::Aabb::CreateNull();
+    }
+
+    AZStd::shared_ptr<Physics::Shape> HeightfieldCollider::GetHeightfieldShape()
+    {
+        if (auto* body = azdynamic_cast<PhysX::StaticRigidBody*>(GetSimulatedBody()))
+        {
+            // Heightfields should only have one shape
+            AZ_Assert(body->GetShapeCount() == 1, "Heightfield rigid body has the wrong number of shapes:  %zu", body->GetShapeCount());
+            return body->GetShape(0);
+        }
+
+        return {};
+    }
+
+} // namespace PhysX

--- a/Gems/PhysX/Code/Source/HeightfieldCollider.h
+++ b/Gems/PhysX/Code/Source/HeightfieldCollider.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Jobs/Job.h>
+#include <AzCore/std/parallel/condition_variable.h>
+
+#include <AzFramework/Physics/Components/SimulatedBodyComponentBus.h>
+#include <AzFramework/Physics/HeightfieldProviderBus.h>
+#include <AzFramework/Physics/PhysicsScene.h>
+#include <AzFramework/Physics/Shape.h>
+
+#include <PhysX/ColliderShapeBus.h>
+
+namespace PhysX
+{
+    //! PhysX Heightfield Collider base class.
+    //! This contains all the logic shared between the Editor Heightfield Collider Component and the Heightfield Collider Component
+    //! to create, update, and destroy the heightfield collider at runtime.
+    class HeightfieldCollider
+        : protected AzPhysics::SimulatedBodyComponentRequestsBus::Handler
+        , protected Physics::HeightfieldProviderNotificationBus::Handler
+        , protected PhysX::ColliderShapeRequestBus::Handler
+    {
+    public:
+        HeightfieldCollider() = default;
+        ~HeightfieldCollider();
+
+        //! Create a HeightfieldCollider that operates on the given set of data.
+        //! @param entityId The entity Id for the entity that contains this heightfield collider
+        //! @param entityName The enntity name for the entity that contains this heightfield collider (for debug purposes)
+        //! @param sceneHandler The physics scene to create the collider in (Editor or runtime)
+        //! @param colliderConfig The collider configuration to use. Some of its data will get modified based on the heightfield data.
+        //! @param shapeConfig The shape configuration to use. All of its data will get modified based on the heightfield data.
+        HeightfieldCollider(
+            AZ::EntityId entityId,
+            const AZStd::string& entityName,
+            AzPhysics::SceneHandle sceneHandle, 
+            AZStd::shared_ptr<Physics::ColliderConfiguration> colliderConfig,
+            AZStd::shared_ptr<Physics::HeightfieldShapeConfiguration> shapeConfig);
+
+        //! Get the currently-spawned heightfield shape.
+        //! @return Pointer to the heightfield shape.
+        AZStd::shared_ptr<Physics::Shape> GetHeightfieldShape();
+
+        //! Notify the heightfield that it may need to refresh some or all of its data.
+        //! @param changeMask The types of data changes causing the notification.
+        //! @param dirtyRegion The area affected by the notification, or a Null Aabb if everything is affected.
+        void RefreshHeightfield(
+            Physics::HeightfieldProviderNotifications::HeightfieldChangeMask changeMask,
+            const AZ::Aabb& dirtyRegion = AZ::Aabb::CreateNull());
+
+        //! Get a pointer to the currently-spawned simulated body.
+        //! @return Pointer to the simulated body.
+        const AzPhysics::SimulatedBody* GetSimulatedBody() const;
+
+        // AzPhysics::SimulatedBodyComponentRequestsBus::Handler overrides ...
+        void EnablePhysics() override;
+        void DisablePhysics() override;
+        bool IsPhysicsEnabled() const override;
+        AZ::Aabb GetAabb() const override;
+        AzPhysics::SimulatedBody* GetSimulatedBody() override;
+        AzPhysics::SimulatedBodyHandle GetSimulatedBodyHandle() const override;
+        AzPhysics::SceneQueryHit RayCast(const AzPhysics::RayCastRequest& request) override;
+
+    protected:
+        // Physics::HeightfieldProviderNotificationBus::Handler overrides ...
+        void OnHeightfieldDataChanged(
+            const AZ::Aabb& dirtyRegion, Physics::HeightfieldProviderNotifications::HeightfieldChangeMask changeMask) override;
+
+        // ColliderShapeRequestBus
+        AZ::Aabb GetColliderShapeAabb() override;
+        bool IsTrigger() override
+        {
+            // PhysX Heightfields don't support triggers.
+            return false;
+        }
+
+        void ClearHeightfield();
+        void InitStaticRigidBody(const AZ::Transform& baseTransform);
+
+        void UpdateHeightfieldMaterialSelection(const Physics::MaterialSelection& updatedMaterialSelection);
+
+    private:
+        //! Helper class to manage the spawned physics update jobs.
+        class HeightfieldUpdateJobContext : public AZ::JobContext
+        {
+        public:
+            HeightfieldUpdateJobContext(AZ::JobManager& jobManager)
+                : JobContext(jobManager)
+            {
+            }
+
+            //! Cancel any running jobs
+            void Cancel();
+
+            //! Check to see if the jobs should be canceled.
+            bool IsCanceled() const;
+
+            //! Track all jobs that are being started.
+            void OnJobStart();
+
+            //! Track all jobs that have been completed.
+            void OnJobComplete();
+
+            //! Block until all jobs have been completed.
+            void BlockUntilComplete();
+
+        private:
+            //! Track the number of currently-running jobs. (This will currently either be 0 or 1, but may get more complicated someday)
+            int m_numRunningJobs = 0;
+            //! Mutex to protect the job-running state
+            AZStd::mutex m_jobsRunningNotificationMutex;
+            //! Notification mechanism for knowing when the jobs have stopped running.
+            //! This uses a condition_variable instead of a semaphore so that there doesn't need to be an equal number of job starts
+            //! vs "block on complete" calls.
+            AZStd::condition_variable m_jobsRunning;
+
+            //! Track whether or not the currently-running jobs should be canceled.
+            AZStd::atomic_bool m_isCanceled = false;
+        };
+
+        //! Stores collision layers, whether the collider is a trigger, etc.
+        AZStd::shared_ptr<Physics::ColliderConfiguration> m_colliderConfig;
+
+        //! Stores all of the cached information for the heightfield shape.
+        AZStd::shared_ptr<Physics::HeightfieldShapeConfiguration> m_shapeConfig;
+
+        //! Handle to the body in the provided physics scene.
+        AzPhysics::SimulatedBodyHandle m_staticRigidBodyHandle = AzPhysics::InvalidSimulatedBodyHandle; 
+
+        //! Handle to the provided physics scene.
+        AzPhysics::SceneHandle m_attachedSceneHandle = AzPhysics::InvalidSceneHandle;
+
+        //! Job context for managing the collider update jobs that get spawned.
+        AZStd::unique_ptr<HeightfieldUpdateJobContext> m_jobContext;
+
+        //! Cached entity ID for the entity this collider is attached to.
+        AZ::EntityId m_entityId;
+
+        //! Cached entity name for the entity this collider is attached to.
+        AZStd::string m_entityName;
+    };
+
+} // namespace PhysX

--- a/Gems/PhysX/Code/Source/HeightfieldColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/HeightfieldColliderComponent.cpp
@@ -33,7 +33,7 @@ namespace PhysX
         {
             serializeContext->Class<HeightfieldColliderComponent, AZ::Component>()
                 ->Version(1)
-                ->Field("ShapeConfig", &HeightfieldColliderComponent::m_shapeConfig)
+                ->Field("ColliderConfiguration", &HeightfieldColliderComponent::m_colliderConfig)
                 ;
         }
     }
@@ -60,105 +60,31 @@ namespace PhysX
 
     HeightfieldColliderComponent::~HeightfieldColliderComponent()
     {
-        ClearHeightfield();
     }
 
     void HeightfieldColliderComponent::Activate()
     {
         const AZ::EntityId entityId = GetEntityId();
 
-        Physics::HeightfieldProviderNotificationBus::Handler::BusConnect(entityId);
+        AzPhysics::SceneHandle sceneHandle = AzPhysics::InvalidSceneHandle;
+        Physics::DefaultWorldBus::BroadcastResult(sceneHandle, &Physics::DefaultWorldRequests::GetDefaultSceneHandle);
+
+        m_heightfieldCollider =
+            AZStd::make_unique<HeightfieldCollider>(GetEntityId(), GetEntity()->GetName(), sceneHandle, m_colliderConfig, m_shapeConfig);
+
         ColliderComponentRequestBus::Handler::BusConnect(entityId);
-        ColliderShapeRequestBus::Handler::BusConnect(entityId);
         Physics::CollisionFilteringRequestBus::Handler::BusConnect(entityId);
-        AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusConnect(entityId);
     }
 
     void HeightfieldColliderComponent::Deactivate()
     {
-        AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusDisconnect();
         Physics::CollisionFilteringRequestBus::Handler::BusDisconnect();
-        ColliderShapeRequestBus::Handler::BusDisconnect();
         ColliderComponentRequestBus::Handler::BusDisconnect();
-        Physics::HeightfieldProviderNotificationBus::Handler::BusDisconnect();
 
-        ClearHeightfield();
+        m_heightfieldCollider.reset();
     }
 
-    void HeightfieldColliderComponent::OnHeightfieldDataChanged(const AZ::Aabb& dirtyRegion, 
-        const Physics::HeightfieldProviderNotifications::HeightfieldChangeMask changeMask)
-    {
-        RefreshHeightfield(changeMask, dirtyRegion);
-    }
-
-    void HeightfieldColliderComponent::ClearHeightfield()
-    {
-        // There are two references to the heightfield data, we need to clear both to make the heightfield clear out and deallocate:
-        // - The simulated body has a pointer to the shape, which has a GeometryHolder, which has the Heightfield inside it
-        // - The shape config is also holding onto a pointer to the Heightfield
-
-        // We remove the simulated body first, since we don't want the heightfield to exist any more.
-        if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-            sceneInterface && m_staticRigidBodyHandle != AzPhysics::InvalidSimulatedBodyHandle)
-        {
-            sceneInterface->RemoveSimulatedBody(m_attachedSceneHandle, m_staticRigidBodyHandle);
-        }
-
-        // Now we can safely clear out the cached heightfield pointer.
-        Physics::HeightfieldShapeConfiguration& configuration = static_cast<Physics::HeightfieldShapeConfiguration&>(*m_shapeConfig.second);
-        configuration.SetCachedNativeHeightfield(nullptr);
-    }
-
-    void HeightfieldColliderComponent::InitStaticRigidBody()
-    {
-        AZ::Transform transform = AZ::Transform::CreateIdentity();
-        AZ::TransformBus::EventResult(transform, GetEntityId(), &AZ::TransformInterface::GetWorldTM);
-
-        AzPhysics::StaticRigidBodyConfiguration configuration;
-        configuration.m_orientation = transform.GetRotation();
-        configuration.m_position = transform.GetTranslation();
-        configuration.m_entityId = GetEntityId();
-        configuration.m_debugName = GetEntity()->GetName();
-        configuration.m_colliderAndShapeData = GetShapeConfigurations();
-
-        if (m_attachedSceneHandle == AzPhysics::InvalidSceneHandle)
-        {
-            Physics::DefaultWorldBus::BroadcastResult(m_attachedSceneHandle, &Physics::DefaultWorldRequests::GetDefaultSceneHandle);
-        }
-        if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
-        {
-            m_staticRigidBodyHandle = sceneInterface->AddSimulatedBody(m_attachedSceneHandle, &configuration);
-        }
-    }
-
-    void HeightfieldColliderComponent::InitHeightfieldShapeConfiguration()
-    {
-        Physics::HeightfieldShapeConfiguration& configuration = static_cast<Physics::HeightfieldShapeConfiguration&>(*m_shapeConfig.second);
-
-        configuration = Utils::CreateHeightfieldShapeConfiguration(GetEntityId());
-
-        // Update material selection from the mapping
-        Physics::ColliderConfiguration* colliderConfig = m_shapeConfig.first.get();
-        Utils::SetMaterialsFromHeightfieldProvider(GetEntityId(), colliderConfig->m_materialSelection);
-    }
-
-    void HeightfieldColliderComponent::RefreshHeightfield( 
-        [[maybe_unused]] const Physics::HeightfieldProviderNotifications::HeightfieldChangeMask changeMask,
-        [[maybe_unused]] const AZ::Aabb& dirtyRegion)
-    {
-        ClearHeightfield();
-        InitHeightfieldShapeConfiguration();
-
-        Physics::HeightfieldShapeConfiguration& configuration = static_cast<Physics::HeightfieldShapeConfiguration&>(*m_shapeConfig.second);
-        if (!configuration.GetSamples().empty())
-        {
-            InitStaticRigidBody();
-        }
-
-        Physics::ColliderComponentEventBus::Event(GetEntityId(), &Physics::ColliderComponentEvents::OnColliderChanged);
-    }
-
-    void HeightfieldColliderComponent::SetShapeConfiguration(const AzPhysics::ShapeColliderPair& shapeConfig)
+    void HeightfieldColliderComponent::SetColliderConfiguration(const Physics::ColliderConfiguration& colliderConfig)
     {
         if (GetEntity()->GetState() == AZ::Entity::State::Active)
         {
@@ -167,123 +93,25 @@ namespace PhysX
                 GetEntity()->GetName().c_str());
             return;
         }
-        m_shapeConfig = shapeConfig;
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    void HeightfieldColliderComponent::EnablePhysics()
-    {
-        if (IsPhysicsEnabled())
-        {
-            return;
-        }
-        if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
-        {
-            sceneInterface->EnableSimulationOfBody(m_attachedSceneHandle, m_staticRigidBodyHandle);
-        }
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    void HeightfieldColliderComponent::DisablePhysics()
-    {
-        if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
-        {
-            sceneInterface->DisableSimulationOfBody(m_attachedSceneHandle, m_staticRigidBodyHandle);
-        }
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    bool HeightfieldColliderComponent::IsPhysicsEnabled() const
-    {
-        if (m_staticRigidBodyHandle != AzPhysics::InvalidSimulatedBodyHandle)
-        {
-            if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-                sceneInterface != nullptr && sceneInterface->IsEnabled(m_attachedSceneHandle)) // check if the scene is enabled
-            {
-                if (AzPhysics::SimulatedBody* body =
-                        sceneInterface->GetSimulatedBodyFromHandle(m_attachedSceneHandle, m_staticRigidBodyHandle))
-                {
-                    return body->m_simulating;
-                }
-            }
-        }
-        return false;
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    AzPhysics::SimulatedBodyHandle HeightfieldColliderComponent::GetSimulatedBodyHandle() const
-    {
-        return m_staticRigidBodyHandle;
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    AzPhysics::SimulatedBody* HeightfieldColliderComponent::GetSimulatedBody()
-    {
-        if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
-        {
-            return sceneInterface->GetSimulatedBodyFromHandle(m_attachedSceneHandle, m_staticRigidBodyHandle);
-        }
-        return nullptr;
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    AzPhysics::SceneQueryHit HeightfieldColliderComponent::RayCast(const AzPhysics::RayCastRequest& request)
-    {
-        if (auto* body = azdynamic_cast<PhysX::StaticRigidBody*>(GetSimulatedBody()))
-        {
-            return body->RayCast(request);
-        }
-        return AzPhysics::SceneQueryHit();
+        *m_colliderConfig = colliderConfig;
     }
 
     // ColliderComponentRequestBus
     AzPhysics::ShapeColliderPairList HeightfieldColliderComponent::GetShapeConfigurations()
     {
-        AzPhysics::ShapeColliderPairList shapeConfigurationList({ m_shapeConfig });
+        AzPhysics::ShapeColliderPairList shapeConfigurationList({ AzPhysics::ShapeColliderPair(m_colliderConfig, m_shapeConfig) });
         return shapeConfigurationList;
     }
 
     AZStd::shared_ptr<Physics::Shape> HeightfieldColliderComponent::GetHeightfieldShape()
     {
-        if (auto* body = azdynamic_cast<PhysX::StaticRigidBody*>(GetSimulatedBody()))
-        {
-            // Heightfields should only have one shape
-            AZ_Assert(body->GetShapeCount() == 1, "Heightfield rigid body has the wrong number of shapes:  %zu", body->GetShapeCount());
-            return body->GetShape(0);
-        }
-
-        return {};
+        return m_heightfieldCollider->GetHeightfieldShape();
     }
 
     // ColliderComponentRequestBus
     AZStd::vector<AZStd::shared_ptr<Physics::Shape>> HeightfieldColliderComponent::GetShapes()
     {
         return { GetHeightfieldShape() };
-    }
-
-    // PhysX::ColliderShapeBus
-    AZ::Aabb HeightfieldColliderComponent::GetColliderShapeAabb()
-    {
-        // Get the Collider AABB directly from the heightfield provider.
-        AZ::Aabb colliderAabb = AZ::Aabb::CreateNull();
-        Physics::HeightfieldProviderRequestsBus::EventResult(
-            colliderAabb, GetEntityId(), &Physics::HeightfieldProviderRequestsBus::Events::GetHeightfieldAabb);
-
-        return colliderAabb;
-    }
-
-    // SimulatedBodyComponentRequestsBus
-    AZ::Aabb HeightfieldColliderComponent::GetAabb() const
-    {
-        // On the SimulatedBodyComponentRequestsBus, get the AABB from the simulated body instead of the collider.
-        if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
-        {
-            if (AzPhysics::SimulatedBody* body = sceneInterface->GetSimulatedBodyFromHandle(m_attachedSceneHandle, m_staticRigidBodyHandle))
-            {
-                return body->GetAabb();
-            }
-        }
-        return AZ::Aabb::CreateNull();
     }
 
     // CollisionFilteringRequestBus

--- a/Gems/PhysX/Code/Source/HeightfieldColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/HeightfieldColliderComponent.cpp
@@ -32,7 +32,7 @@ namespace PhysX
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<HeightfieldColliderComponent, AZ::Component>()
-                ->Version(1)
+                ->Version(2)
                 ->Field("ColliderConfiguration", &HeightfieldColliderComponent::m_colliderConfig)
                 ;
         }

--- a/Gems/PhysX/Code/Source/HeightfieldColliderComponent.h
+++ b/Gems/PhysX/Code/Source/HeightfieldColliderComponent.h
@@ -17,6 +17,8 @@
 #include <PhysX/ColliderComponentBus.h>
 #include <PhysX/ColliderShapeBus.h>
 
+#include <Source/HeightfieldCollider.h>
+
 namespace AzPhysics
 {
     struct SimulatedBody;
@@ -35,10 +37,7 @@ namespace PhysX
     class HeightfieldColliderComponent
         : public AZ::Component
         , public ColliderComponentRequestBus::Handler
-        , public AzPhysics::SimulatedBodyComponentRequestsBus::Handler
-        , protected PhysX::ColliderShapeRequestBus::Handler
         , protected Physics::CollisionFilteringRequestBus::Handler
-        , protected Physics::HeightfieldProviderNotificationBus::Handler
     {
     public:
         using Configuration = Physics::HeightfieldShapeConfiguration;
@@ -55,20 +54,12 @@ namespace PhysX
         void Activate() override;
         void Deactivate() override;
 
-        void SetShapeConfiguration(const AzPhysics::ShapeColliderPair& shapeConfig);
+        void SetColliderConfiguration(const Physics::ColliderConfiguration& colliderConfig);
 
     protected:
         // ColliderComponentRequestBus
         AzPhysics::ShapeColliderPairList GetShapeConfigurations() override;
         AZStd::vector<AZStd::shared_ptr<Physics::Shape>> GetShapes() override;
-
-        // ColliderShapeRequestBus
-        AZ::Aabb GetColliderShapeAabb() override;
-        bool IsTrigger() override
-        {
-            // PhysX Heightfields don't support triggers.
-            return false;
-        }
 
         // CollisionFilteringRequestBus
         void SetCollisionLayer(const AZStd::string& layerName, AZ::Crc32 filterTag) override;
@@ -77,30 +68,14 @@ namespace PhysX
         AZStd::string GetCollisionGroupName() override;
         void ToggleCollisionLayer(const AZStd::string& layerName, AZ::Crc32 filterTag, bool enabled) override;
 
-        // SimulatedBodyComponentRequestsBus
-        void EnablePhysics() override;
-        void DisablePhysics() override;
-        bool IsPhysicsEnabled() const override;
-        AZ::Aabb GetAabb() const override;
-        AzPhysics::SimulatedBodyHandle GetSimulatedBodyHandle() const override;
-        AzPhysics::SimulatedBody* GetSimulatedBody() override;
-        AzPhysics::SceneQueryHit RayCast(const AzPhysics::RayCastRequest& request) override;
-
-        // HeightfieldProviderNotificationBus
-        void OnHeightfieldDataChanged(const AZ::Aabb& dirtyRegion, 
-            Physics::HeightfieldProviderNotifications::HeightfieldChangeMask changeMask) override;
-
     private:
         AZStd::shared_ptr<Physics::Shape> GetHeightfieldShape();
 
-        void ClearHeightfield();
-        void InitHeightfieldShapeConfiguration();
-        void InitStaticRigidBody();
-        void RefreshHeightfield(Physics::HeightfieldProviderNotifications::HeightfieldChangeMask changeMask,
-            const AZ::Aabb& dirtyRegion = AZ::Aabb::CreateNull());
-
-        AzPhysics::ShapeColliderPair m_shapeConfig;
-        AzPhysics::SimulatedBodyHandle m_staticRigidBodyHandle = AzPhysics::InvalidSimulatedBodyHandle;
-        AzPhysics::SceneHandle m_attachedSceneHandle = AzPhysics::InvalidSceneHandle;
+        //! Stores collision layers, whether the collider is a trigger, etc.
+        AZStd::shared_ptr<Physics::ColliderConfiguration> m_colliderConfig{ aznew Physics::ColliderConfiguration() };
+        //! Stores all of the cached information for the heightfield shape.
+        AZStd::shared_ptr<Physics::HeightfieldShapeConfiguration> m_shapeConfig{ aznew Physics::HeightfieldShapeConfiguration() };
+        //! Contains all of the runtime logic for creating / updating / destroying the heightfield collider.
+        AZStd::unique_ptr<HeightfieldCollider> m_heightfieldCollider;
     };
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/Utils.cpp
+++ b/Gems/PhysX/Code/Source/Utils.cpp
@@ -1581,8 +1581,12 @@ namespace PhysX
             Physics::HeightfieldProviderRequestsBus::Event(
                 entityId, &Physics::HeightfieldProviderRequestsBus::Events::GetHeightfieldGridSize, numColumns, numRows);
 
-            configuration.SetNumRowVertices(numRows);
-            configuration.SetNumColumnVertices(numColumns);
+            // The heightfield needs to be at least 2 x 2 vertices to define a single heightfield square.
+            if ((numRows >= 2) && (numColumns >= 2))
+            {
+                configuration.SetNumRowVertices(numRows);
+                configuration.SetNumColumnVertices(numColumns);
+            }
 
             float minHeightBounds = 0.0f;
             float maxHeightBounds = 0.0f;

--- a/Gems/PhysX/Code/Tests/EditorHeightfieldColliderComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/EditorHeightfieldColliderComponentTests.cpp
@@ -90,6 +90,20 @@ namespace PhysXEditorTests
                     y = 3.0f;
                 });
         ON_CALL(mockShapeRequests, GetMaterialList).WillByDefault(Return(GetMaterialList()));
+
+        ON_CALL(mockShapeRequests, UpdateHeightsAndMaterials)
+            .WillByDefault(
+                [](const Physics::UpdateHeightfieldSampleFunction& updateHeightsMaterialsCallback, [[maybe_unused]]const AZ::Aabb& regionIn)
+                {
+                    auto samples = GetSamples();
+                    for (int32_t row = 0; row < 3; row++)
+                    {
+                        for (int32_t col = 0; col < 3; col++)
+                        {
+                            updateHeightsMaterialsCallback(row, col, samples[(row * 3) + col]);
+                        }
+                    }
+                });
     }
 
     EntityPtr TestCreateActiveGameEntityFromEditorEntity(AZ::Entity* editorEntity)
@@ -118,7 +132,7 @@ namespace PhysXEditorTests
             // the corresponding game entity.
             Physics::HeightfieldProviderNotificationBus::Broadcast(
                 &Physics::HeightfieldProviderNotificationBus::Events::OnHeightfieldDataChanged, AZ::Aabb::CreateNull(),
-                Physics::HeightfieldProviderNotifications::HeightfieldChangeMask::CreateEnd);
+                Physics::HeightfieldProviderNotifications::HeightfieldChangeMask::Settings);
 
             m_gameEntity = TestCreateActiveGameEntityFromEditorEntity(m_editorEntity.get());
             m_gameMockShapeRequests = AZStd::make_unique<NiceMock<UnitTest::MockPhysXHeightfieldProvider>>(m_gameEntity->GetId());
@@ -128,7 +142,7 @@ namespace PhysXEditorTests
             // Send the notification a second time so that the game entity gets refreshed as well.
             Physics::HeightfieldProviderNotificationBus::Broadcast(
                 &Physics::HeightfieldProviderNotificationBus::Events::OnHeightfieldDataChanged, AZ::Aabb::CreateNull(),
-                Physics::HeightfieldProviderNotifications::HeightfieldChangeMask::CreateEnd);
+                Physics::HeightfieldProviderNotifications::HeightfieldChangeMask::Settings);
         }
 
         void TearDown() override

--- a/Gems/PhysX/Code/physx_files.cmake
+++ b/Gems/PhysX/Code/physx_files.cmake
@@ -35,6 +35,8 @@ set(FILES
     Source/MeshColliderComponent.h
     Source/BoxColliderComponent.h
     Source/BoxColliderComponent.cpp
+    Source/HeightfieldCollider.h
+    Source/HeightfieldCollider.cpp
     Source/HeightfieldColliderComponent.h
     Source/HeightfieldColliderComponent.cpp
     Source/SphereColliderComponent.h

--- a/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
@@ -13,10 +13,13 @@
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Casting/lossy_cast.h>
+#include <AzCore/Console/Console.h>
 #include <AzCore/Debug/Profiler.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/parallel/binary_semaphore.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
 
 #include <AzFramework/Physics/Material.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
@@ -27,6 +30,11 @@ AZ_DECLARE_BUDGET(Terrain);
 
 namespace Terrain
 {
+    AZ_CVAR(int32_t, cl_terrainPhysicsColliderMaxJobs, AzFramework::Terrain::QueryAsyncParams::UseMaxJobs, nullptr,
+        AZ::ConsoleFunctorFlags::Null,
+        "The maximum number of jobs to use when updating a Terrain Physics Collider (-1 will use all available cores).");
+
+
     Physics::HeightfieldProviderNotifications::HeightfieldChangeMask TerrainToPhysicsHeightfieldChangeMask(AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask mask)
     {
         using AzFramework::Terrain::TerrainDataNotifications;
@@ -199,8 +207,9 @@ namespace Terrain
         m_terrainDataActive = true;
 
         // The terrain system has finished creating itself, so we should now have data for creating a heightfield.
+        // Notify this as a 'settings' change because the heightfield has changed activation status.
         NotifyListenersOfHeightfieldDataChange(
-            Physics::HeightfieldProviderNotifications::HeightfieldChangeMask::CreateEnd, AZ::Aabb::CreateNull());
+            Physics::HeightfieldProviderNotifications::HeightfieldChangeMask::Settings, AZ::Aabb::CreateNull());
     }
 
     void TerrainPhysicsColliderComponent::OnTerrainDataDestroyBegin()
@@ -209,8 +218,9 @@ namespace Terrain
 
         // The terrain system is starting to destroy itself, so notify listeners of a change since the heightfield
         // will no longer have any valid data.
+        // Notify this as a 'settings' change because the heightfield has changed activation status.
         NotifyListenersOfHeightfieldDataChange(
-            Physics::HeightfieldProviderNotifications::HeightfieldChangeMask::DestroyBegin, AZ::Aabb::CreateNull());
+            Physics::HeightfieldProviderNotifications::HeightfieldChangeMask::Settings, AZ::Aabb::CreateNull());
     }
 
     void TerrainPhysicsColliderComponent::OnTerrainDataChanged(
@@ -218,8 +228,8 @@ namespace Terrain
     {
         if (m_terrainDataActive)
         {
-            Physics::HeightfieldProviderNotifications::HeightfieldChangeMask physicsMask
-                = TerrainToPhysicsHeightfieldChangeMask(dataChangedMask);
+            Physics::HeightfieldProviderNotifications::HeightfieldChangeMask physicsMask =
+                TerrainToPhysicsHeightfieldChangeMask(dataChangedMask);
 
             NotifyListenersOfHeightfieldDataChange(physicsMask, dirtyRegion);
         }
@@ -227,6 +237,13 @@ namespace Terrain
 
     void TerrainPhysicsColliderComponent::CalculateHeightfieldRegion()
     {
+        if (!m_terrainDataActive)
+        {
+            AZStd::unique_lock lock(m_stateMutex);
+            m_heightfieldRegion = AzFramework::Terrain::TerrainQueryRegion();
+            return;
+        }
+
         AZ::Aabb heightfieldBox = AZ::Aabb::CreateNull();
 
         LmbrCentral::ShapeComponentRequestsBus::EventResult(
@@ -240,28 +257,45 @@ namespace Terrain
         // The "+ 1.0" at the end is because we need to be sure to include the end points. (ex: start=1, end=4 should have 4 points)
         AZ::Vector2 numPoints = (constrictedAlignedEndPoint - constrictedAlignedStartPoint) / gridResolution + AZ::Vector2(1.0f);
 
-        m_heightfieldRegion.m_startPoint =
-            AZ::Vector3(constrictedAlignedStartPoint.GetX(), constrictedAlignedStartPoint.GetY(), heightfieldBox.GetMin().GetZ());
-        m_heightfieldRegion.m_stepSize = gridResolution;
-        m_heightfieldRegion.m_numPointsX = aznumeric_cast<size_t>(numPoints.GetX());
-        m_heightfieldRegion.m_numPointsY = aznumeric_cast<size_t>(numPoints.GetY());
+        {
+            AZStd::unique_lock lock(m_stateMutex);
+            m_heightfieldRegion.m_startPoint =
+                AZ::Vector3(constrictedAlignedStartPoint.GetX(), constrictedAlignedStartPoint.GetY(), heightfieldBox.GetMin().GetZ());
+            m_heightfieldRegion.m_stepSize = gridResolution;
+            m_heightfieldRegion.m_numPointsX = aznumeric_cast<size_t>(numPoints.GetX());
+            m_heightfieldRegion.m_numPointsY = aznumeric_cast<size_t>(numPoints.GetY());
+        }
     }
 
     AZ::Aabb TerrainPhysicsColliderComponent::GetHeightfieldAabb() const
     {
+        if (!m_terrainDataActive)
+        {
+            return AZ::Aabb::CreateNull();
+        }
+
         AZ::Aabb heightfieldBox = AZ::Aabb::CreateNull();
         LmbrCentral::ShapeComponentRequestsBus::EventResult(
             heightfieldBox, GetEntityId(), &LmbrCentral::ShapeComponentRequestsBus::Events::GetEncompassingAabb);
 
-
-        AZ::Vector3 endPoint = m_heightfieldRegion.m_startPoint +
-            AZ::Vector3(m_heightfieldRegion.m_stepSize.GetX() * (m_heightfieldRegion.m_numPointsX - 1),
-                        m_heightfieldRegion.m_stepSize.GetY() * (m_heightfieldRegion.m_numPointsY - 1), heightfieldBox.GetZExtent());
-        return AZ::Aabb::CreateFromMinMax(m_heightfieldRegion.m_startPoint, endPoint);
+        {
+            AZStd::shared_lock lock(m_stateMutex);
+            AZ::Vector3 endPoint = m_heightfieldRegion.m_startPoint +
+                AZ::Vector3(m_heightfieldRegion.m_stepSize.GetX() * (m_heightfieldRegion.m_numPointsX - 1),
+                            m_heightfieldRegion.m_stepSize.GetY() * (m_heightfieldRegion.m_numPointsY - 1), heightfieldBox.GetZExtent());
+            return AZ::Aabb::CreateFromMinMax(m_heightfieldRegion.m_startPoint, endPoint);
+        }
     }
 
     void TerrainPhysicsColliderComponent::GetHeightfieldHeightBounds(float& minHeightBounds, float& maxHeightBounds) const
     {
+        if (!m_terrainDataActive)
+        {
+            minHeightBounds = 0.0f;
+            maxHeightBounds = 0.0f;
+            return;
+        }
+
         const AZ::Aabb heightfieldAabb = GetHeightfieldAabb();
 
         // Because our terrain heights are relative to the center of the bounding box, the min and max allowable heights are also
@@ -298,8 +332,16 @@ namespace Terrain
     {
         AZ_PROFILE_FUNCTION(Terrain);
 
+        AzFramework::Terrain::TerrainQueryRegion queryRegion;
+
+        {
+            AZStd::shared_lock lock(m_stateMutex);
+            queryRegion = m_heightfieldRegion;
+        }
+
+
         heights.clear();
-        heights.reserve(m_heightfieldRegion.m_numPointsX * m_heightfieldRegion.m_numPointsY);
+        heights.reserve(queryRegion.m_numPointsX * queryRegion.m_numPointsY);
 
         AZ::Aabb worldSize = GetHeightfieldAabb();
         const float worldCenterZ = worldSize.GetCenter().GetZ();
@@ -312,7 +354,7 @@ namespace Terrain
 
         // We can use the "EXACT" sampler here because our query points are guaranteed to be aligned with terrain grid points.
         AzFramework::Terrain::TerrainDataRequestBus::Broadcast(
-            &AzFramework::Terrain::TerrainDataRequests::QueryRegion, m_heightfieldRegion,
+            &AzFramework::Terrain::TerrainDataRequests::QueryRegion, queryRegion,
             AzFramework::Terrain::TerrainDataRequests::TerrainDataMask::Heights,
             perPositionHeightCallback, AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT);
     }
@@ -330,6 +372,8 @@ namespace Terrain
 
     Physics::MaterialId TerrainPhysicsColliderComponent::FindMaterialIdForSurfaceTag(const SurfaceData::SurfaceTag tag) const
     {
+        AZStd::shared_lock lock(m_stateMutex);
+
         uint8_t index = 0;
 
         for (auto& mapping : m_configuration.m_surfaceMaterialMappings)
@@ -371,15 +415,29 @@ namespace Terrain
 
         const AZ::Vector2 gridResolution = GetHeightfieldGridSpacing();
 
-        AZ::Vector2 heightfieldStartGridPoint = AZ::Vector2(m_heightfieldRegion.m_startPoint) / m_heightfieldRegion.m_stepSize;
+        TerrainQueryRegion queryRegion;
+        size_t xOffset, yOffset;
 
-        AZ::Vector2 contractedAlignedStartGridPoint = (AZ::Vector2(region.GetMin()) / gridResolution).GetCeil();
-        AZ::Vector2 contractedAlignedEndGridPoint = (AZ::Vector2(region.GetMax()) / gridResolution).GetFloor();
+        {
+            AZStd::shared_lock lock(m_stateMutex);
 
-        AZ::Vector2 contractedAlignedStartPoint = contractedAlignedStartGridPoint * gridResolution;
+            AZ::Vector2 heightfieldStartGridPoint = AZ::Vector2(m_heightfieldRegion.m_startPoint) / m_heightfieldRegion.m_stepSize;
 
-        size_t xOffset = aznumeric_cast<size_t>(contractedAlignedStartGridPoint.GetX() - heightfieldStartGridPoint.GetX());
-        size_t yOffset = aznumeric_cast<size_t>(contractedAlignedStartGridPoint.GetY() - heightfieldStartGridPoint.GetY());
+            AZ::Vector2 contractedAlignedStartGridPoint = (AZ::Vector2(region.GetMin()) / gridResolution).GetCeil();
+            AZ::Vector2 contractedAlignedEndGridPoint = (AZ::Vector2(region.GetMax()) / gridResolution).GetFloor();
+
+            AZ::Vector2 contractedAlignedStartPoint = contractedAlignedStartGridPoint * gridResolution;
+
+            xOffset = aznumeric_cast<size_t>(contractedAlignedStartGridPoint.GetX() - heightfieldStartGridPoint.GetX());
+            yOffset = aznumeric_cast<size_t>(contractedAlignedStartGridPoint.GetY() - heightfieldStartGridPoint.GetY());
+
+            // The "+ 1.0" at the end is because we need to be sure to include the end points. (ex: start=1, end=4 should have 4 points)
+            AZ::Vector2 numPoints = contractedAlignedEndGridPoint - contractedAlignedStartGridPoint + AZ::Vector2(1.0f);
+            const size_t numPointsX = AZStd::min(aznumeric_cast<size_t>(numPoints.GetX()), m_heightfieldRegion.m_numPointsX);
+            const size_t numPointsY = AZStd::min(aznumeric_cast<size_t>(numPoints.GetY()),  m_heightfieldRegion.m_numPointsY);
+
+            queryRegion = TerrainQueryRegion(contractedAlignedStartPoint, numPointsX, numPointsY, gridResolution);
+        }
 
         const float worldCenterZ = worldSize.GetCenter().GetZ();
         const float worldHeightBoundsMin = worldSize.GetMin().GetZ();
@@ -422,24 +480,39 @@ namespace Terrain
             updateHeightsMaterialsCallback(row, column, point);
         };
 
-        // The "+ 1.0" at the end is because we need to be sure to include the end points. (ex: start=1, end=4 should have 4 points)
-        AZ::Vector2 numPoints = contractedAlignedEndGridPoint - contractedAlignedStartGridPoint + AZ::Vector2(1.0f);
-        const size_t numPointsX = AZStd::min(aznumeric_cast<size_t>(numPoints.GetX()), m_heightfieldRegion.m_numPointsX);
-        const size_t numPointsY = AZStd::min(aznumeric_cast<size_t>(numPoints.GetY()),  m_heightfieldRegion.m_numPointsY);
-        TerrainQueryRegion queryRegion(contractedAlignedStartPoint, numPointsX, numPointsY, gridResolution);
+        // Create an async query to update all of the height and material data so that we can spread the computation across
+        // multiple threads, but block on completion so that we can guarantee the updates have completed by the time we leave
+        // this method.
+
+        AZStd::shared_ptr<AzFramework::Terrain::TerrainJobContext> jobContext;
+
+        AZStd::binary_semaphore wait;
+        auto params = AZStd::make_shared<AzFramework::Terrain::QueryAsyncParams>();
+        params->m_desiredNumberOfJobs = cl_terrainPhysicsColliderMaxJobs;
+        params->m_completionCallback =
+            [&wait]([[maybe_unused]] AZStd::shared_ptr<AzFramework::Terrain::TerrainJobContext> context)
+        {
+            // Notify the main test thread that the query has completed.
+            wait.release();
+        };
 
         // We can use the "EXACT" sampler here because our query points are guaranteed to be aligned with terrain grid points.
-        TerrainDataRequestBus::Broadcast(
-            &TerrainDataRequests::QueryRegion,
-            queryRegion,
-            static_cast<TerrainDataRequests::TerrainDataMask>(TerrainDataRequests::TerrainDataMask::Heights | TerrainDataRequests::TerrainDataMask::SurfaceData),
-            perPositionCallback,
-            TerrainDataRequests::Sampler::EXACT);
+        AzFramework::Terrain::TerrainDataRequestBus::BroadcastResult(
+            jobContext, &AzFramework::Terrain::TerrainDataRequests::QueryRegionAsync, queryRegion,
+            static_cast<TerrainDataRequests::TerrainDataMask>(
+                TerrainDataRequests::TerrainDataMask::Heights | TerrainDataRequests::TerrainDataMask::SurfaceData),
+            perPositionCallback, AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT, params);
+
+        // Wait for the query to complete.
+        wait.acquire();
     }
 
     void TerrainPhysicsColliderComponent::UpdateConfiguration(const TerrainPhysicsColliderConfig& newConfiguration)
     {
-        m_configuration = newConfiguration;
+        {
+            AZStd::unique_lock lock(m_stateMutex);
+            m_configuration = newConfiguration;
+        }
 
         NotifyListenersOfHeightfieldDataChange(
             Physics::HeightfieldProviderNotifications::HeightfieldChangeMask::SurfaceMapping, AZ::Aabb::CreateNull());
@@ -447,6 +520,11 @@ namespace Terrain
 
     AZ::Vector2 TerrainPhysicsColliderComponent::GetHeightfieldGridSpacing() const
     {
+        if (!m_terrainDataActive)
+        {
+            return AZ::Vector2(0.0f);
+        }
+
         float gridResolution = 1.0f;
         AzFramework::Terrain::TerrainDataRequestBus::BroadcastResult(
             gridResolution, &AzFramework::Terrain::TerrainDataRequests::GetTerrainHeightQueryResolution);
@@ -456,22 +534,27 @@ namespace Terrain
 
     void TerrainPhysicsColliderComponent::GetHeightfieldGridSize(int32_t& numColumns, int32_t& numRows) const
     {
+        AZStd::shared_lock lock(m_stateMutex);
         numColumns = aznumeric_cast<int32_t>(m_heightfieldRegion.m_numPointsX);
         numRows = aznumeric_cast<int32_t>(m_heightfieldRegion.m_numPointsY);
     }
 
     int32_t TerrainPhysicsColliderComponent::GetHeightfieldGridColumns() const
     {
+        AZStd::shared_lock lock(m_stateMutex);
         return aznumeric_cast<int32_t>(m_heightfieldRegion.m_numPointsX);
     }
 
     int32_t TerrainPhysicsColliderComponent::GetHeightfieldGridRows() const
     {
+        AZStd::shared_lock lock(m_stateMutex);
         return aznumeric_cast<int32_t>(m_heightfieldRegion.m_numPointsY);
     }
 
     AZStd::vector<Physics::MaterialId> TerrainPhysicsColliderComponent::GetMaterialList() const
     {
+        AZStd::shared_lock lock(m_stateMutex);
+
         AZStd::vector<Physics::MaterialId> materialList;
 
         // Ensure the list contains the default material as the first entry.

--- a/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.h
@@ -125,7 +125,10 @@ namespace Terrain
 
     private:
         TerrainPhysicsColliderConfig m_configuration;
-        bool m_terrainDataActive = false;
+        AZStd::atomic_bool m_terrainDataActive = false;
         AzFramework::Terrain::TerrainQueryRegion m_heightfieldRegion;
+
+        // Protect state reads from happening in parallel with state writes.
+        mutable AZStd::shared_mutex m_stateMutex;
     };
 }

--- a/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainPhysicsColliderComponent.cpp
+++ b/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainPhysicsColliderComponent.cpp
@@ -116,6 +116,8 @@ namespace Terrain
     {
         AzToolsFramework::Components::EditorComponentBase::Deactivate();
         m_component.Deactivate();
+        // remove the entity association, in case the parent component is being removed, otherwise the component will be reactivated
+        m_component.SetEntity(nullptr);
     }
 
     void EditorTerrainPhysicsColliderComponent::BuildGameEntity(AZ::Entity* gameEntity)

--- a/Gems/Terrain/Code/Tests/TerrainPhysicsColliderTests.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainPhysicsColliderTests.cpp
@@ -252,6 +252,23 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderGetHeightsRetu
                 []([[maybe_unused]]float x, [[maybe_unused]]float y){ return 0.0f; });
         }
     );
+    ON_CALL(terrainListener, QueryRegionAsync)
+        .WillByDefault(
+            [this](
+                const AzFramework::Terrain::TerrainQueryRegion& queryRegion,
+                [[maybe_unused]] AzFramework::Terrain::TerrainDataRequests::TerrainDataMask requestedData,
+                AzFramework::Terrain::SurfacePointRegionFillCallback perPositionCallback,
+                [[maybe_unused]] AzFramework::Terrain::TerrainDataRequests::Sampler sampleFilter,
+                AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> params)
+                -> AZStd::shared_ptr<AzFramework::Terrain::TerrainJobContext>
+            {
+                ProcessRegionLoop(
+                    queryRegion, perPositionCallback, nullptr,
+                    []([[maybe_unused]] float x, [[maybe_unused]] float y){ return 0.0f; });
+
+                params->m_completionCallback(nullptr);
+                return nullptr;
+            });
 
     ActivateEntity(m_entity.get());
 
@@ -296,6 +313,23 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderReturnsRelativ
                 [mockHeight]([[maybe_unused]]float x, [[maybe_unused]]float y){ return mockHeight; });
         }
     );
+    ON_CALL(terrainListener, QueryRegionAsync)
+        .WillByDefault(
+            [this, mockHeight](
+                const AzFramework::Terrain::TerrainQueryRegion& queryRegion,
+                [[maybe_unused]] AzFramework::Terrain::TerrainDataRequests::TerrainDataMask requestedData,
+                AzFramework::Terrain::SurfacePointRegionFillCallback perPositionCallback,
+                [[maybe_unused]] AzFramework::Terrain::TerrainDataRequests::Sampler sampleFilter,
+                AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> params)
+                -> AZStd::shared_ptr<AzFramework::Terrain::TerrainJobContext>
+            {
+                ProcessRegionLoop(
+                    queryRegion, perPositionCallback, nullptr,
+                    [mockHeight]([[maybe_unused]] float x, [[maybe_unused]] float y){ return mockHeight; });
+
+                params->m_completionCallback(nullptr);
+                return nullptr;
+            });
 
     // Just return the bounds as setup. This is equivalent to the box being at the origin.
     NiceMock<UnitTest::MockShapeComponentRequests> boxShape(m_entity->GetId());
@@ -421,6 +455,23 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderGetHeightsAndM
                 [mockHeight]([[maybe_unused]]float x, [[maybe_unused]]float y){ return mockHeight; });
         }
     );
+    ON_CALL(terrainListener, QueryRegionAsync)
+        .WillByDefault(
+            [this, mockHeight, &surfaceTags](
+                const AzFramework::Terrain::TerrainQueryRegion& queryRegion,
+                [[maybe_unused]] AzFramework::Terrain::TerrainDataRequests::TerrainDataMask requestedData,
+                AzFramework::Terrain::SurfacePointRegionFillCallback perPositionCallback,
+                [[maybe_unused]] AzFramework::Terrain::TerrainDataRequests::Sampler sampleFilter,
+                AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> params)
+                -> AZStd::shared_ptr<AzFramework::Terrain::TerrainJobContext>
+            {
+                ProcessRegionLoop(
+                    queryRegion, perPositionCallback, &surfaceTags,
+                    [mockHeight]([[maybe_unused]] float x, [[maybe_unused]] float y){ return mockHeight; });
+
+                params->m_completionCallback(nullptr);
+                return nullptr;
+            });
 
     ActivateEntity(m_entity.get());
 
@@ -501,6 +552,23 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderDefaultMateria
             [mockHeight]([[maybe_unused]]float x, [[maybe_unused]]float y){ return mockHeight; });
     }
     );
+    ON_CALL(terrainListener, QueryRegionAsync)
+        .WillByDefault(
+            [this, mockHeight, &surfaceTags](
+                const AzFramework::Terrain::TerrainQueryRegion& queryRegion,
+                [[maybe_unused]] AzFramework::Terrain::TerrainDataRequests::TerrainDataMask requestedData,
+                AzFramework::Terrain::SurfacePointRegionFillCallback perPositionCallback,
+                [[maybe_unused]] AzFramework::Terrain::TerrainDataRequests::Sampler sampleFilter,
+                AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> params)
+                -> AZStd::shared_ptr<AzFramework::Terrain::TerrainJobContext>
+            {
+                ProcessRegionLoop(
+                    queryRegion, perPositionCallback, &surfaceTags,
+                    [mockHeight]([[maybe_unused]] float x, [[maybe_unused]] float y){ return mockHeight; });
+
+                params->m_completionCallback(nullptr);
+                return nullptr;
+            });
 
     ActivateEntity(m_entity.get());
 
@@ -583,6 +651,23 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderDefaultMateria
             [mockHeight]([[maybe_unused]]float x, [[maybe_unused]]float y){ return mockHeight; });
     }
     );
+    ON_CALL(terrainListener, QueryRegionAsync)
+        .WillByDefault(
+            [this, mockHeight, &surfaceTags](
+                const AzFramework::Terrain::TerrainQueryRegion& queryRegion,
+                [[maybe_unused]] AzFramework::Terrain::TerrainDataRequests::TerrainDataMask requestedData,
+                AzFramework::Terrain::SurfacePointRegionFillCallback perPositionCallback,
+                [[maybe_unused]] AzFramework::Terrain::TerrainDataRequests::Sampler sampleFilter,
+                AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> params)
+                -> AZStd::shared_ptr<AzFramework::Terrain::TerrainJobContext>
+            {
+                ProcessRegionLoop(
+                    queryRegion, perPositionCallback, &surfaceTags,
+                    [mockHeight]([[maybe_unused]] float x, [[maybe_unused]] float y){ return mockHeight; });
+
+                params->m_completionCallback(nullptr);
+                return nullptr;
+            });
 
     ActivateEntity(m_entity.get());
 
@@ -658,6 +743,23 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderRequestSubpart
             [](float x, float y){ return x + y; });
     }
     );
+    ON_CALL(terrainListener, QueryRegionAsync)
+        .WillByDefault(
+            [this, &surfaceTags](
+                const AzFramework::Terrain::TerrainQueryRegion& queryRegion,
+                [[maybe_unused]] AzFramework::Terrain::TerrainDataRequests::TerrainDataMask requestedData,
+                AzFramework::Terrain::SurfacePointRegionFillCallback perPositionCallback,
+                [[maybe_unused]] AzFramework::Terrain::TerrainDataRequests::Sampler sampleFilter,
+                AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> params)
+                -> AZStd::shared_ptr<AzFramework::Terrain::TerrainJobContext>
+            {
+                ProcessRegionLoop(
+                    queryRegion, perPositionCallback, &surfaceTags,
+                    [](float x, float y){ return x + y; });
+
+                params->m_completionCallback(nullptr);
+                return nullptr;
+            });
 
     ActivateEntity(m_entity.get());
 

--- a/Gems/Terrain/Code/Tests/TerrainSystemBenchmarks.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainSystemBenchmarks.cpp
@@ -222,7 +222,7 @@ namespace UnitTest
 
                 AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> asyncParams
                     = AZStd::make_shared<AzFramework::Terrain::QueryAsyncParams>();
-                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::NumJobsMax;
+                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::UseMaxJobs;
                 asyncParams->m_completionCallback = completionCallback;
 
                 AZ::Vector2 stepSize = AZ::Vector2(queryResolution);
@@ -306,7 +306,7 @@ namespace UnitTest
 
                 AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> asyncParams
                     = AZStd::make_shared<AzFramework::Terrain::QueryAsyncParams>();
-                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::NumJobsMax;
+                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::UseMaxJobs;
                 asyncParams->m_completionCallback = completionCallback;
                 AzFramework::Terrain::TerrainDataRequestBus::Broadcast(
                     &AzFramework::Terrain::TerrainDataRequests::QueryListAsync, inPositions,
@@ -413,7 +413,7 @@ namespace UnitTest
 
                 AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> asyncParams
                     = AZStd::make_shared<AzFramework::Terrain::QueryAsyncParams>();
-                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::NumJobsMax;
+                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::UseMaxJobs;
                 asyncParams->m_completionCallback = completionCallback;
 
                 AZ::Vector2 stepSize = AZ::Vector2(queryResolution);
@@ -491,7 +491,7 @@ namespace UnitTest
 
                 AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> asyncParams
                     = AZStd::make_shared<AzFramework::Terrain::QueryAsyncParams>();
-                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::NumJobsMax;
+                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::UseMaxJobs;
                 asyncParams->m_completionCallback = completionCallback;
                 AzFramework::Terrain::TerrainDataRequestBus::Broadcast(
                     &AzFramework::Terrain::TerrainDataRequests::QueryListAsync, inPositions,
@@ -596,7 +596,7 @@ namespace UnitTest
 
                 AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> asyncParams
                     = AZStd::make_shared<AzFramework::Terrain::QueryAsyncParams>();
-                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::NumJobsMax;
+                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::UseMaxJobs;
                 asyncParams->m_completionCallback = completionCallback;
 
                 AZ::Vector2 stepSize = AZ::Vector2(queryResolution);
@@ -674,7 +674,7 @@ namespace UnitTest
 
                 AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> asyncParams
                     = AZStd::make_shared<AzFramework::Terrain::QueryAsyncParams>();
-                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::NumJobsMax;
+                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::UseMaxJobs;
                 asyncParams->m_completionCallback = completionCallback;
                 AzFramework::Terrain::TerrainDataRequestBus::Broadcast(
                     &AzFramework::Terrain::TerrainDataRequests::QueryListAsync, inPositions,
@@ -780,7 +780,7 @@ namespace UnitTest
 
                 AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> asyncParams
                     = AZStd::make_shared<AzFramework::Terrain::QueryAsyncParams>();
-                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::NumJobsMax;
+                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::UseMaxJobs;
                 asyncParams->m_completionCallback = completionCallback;
 
                 AZ::Vector2 stepSize = AZ::Vector2(queryResolution);
@@ -858,7 +858,7 @@ namespace UnitTest
 
                 AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> asyncParams
                     = AZStd::make_shared<AzFramework::Terrain::QueryAsyncParams>();
-                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::NumJobsMax;
+                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::UseMaxJobs;
                 asyncParams->m_completionCallback = completionCallback;
                 AzFramework::Terrain::TerrainDataRequestBus::Broadcast(
                     &AzFramework::Terrain::TerrainDataRequests::QueryListAsync, inPositions,
@@ -1077,7 +1077,7 @@ namespace UnitTest
 
                 AZStd::shared_ptr<AzFramework::Terrain::QueryAsyncParams> asyncParams =
                     AZStd::make_shared<AzFramework::Terrain::QueryAsyncParams>();
-                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::NumJobsMax;
+                asyncParams->m_desiredNumberOfJobs = AzFramework::Terrain::QueryAsyncParams::UseMaxJobs;
                 asyncParams->m_completionCallback = completionCallback;
                 AzFramework::Terrain::TerrainDataRequestBus::Broadcast(
                     &AzFramework::Terrain::TerrainDataRequests::QueryListAsync, inPositions,


### PR DESCRIPTION
These changes make all terrain physics heightfield updates asynchronous, which makes the overall update time faster and keeps the editor more responsive.
The following changes were made to support this:
* Changed the HeightfieldProviderBus to support concurrent requests
* Removed the Create/Destroy flags from the Heightfield data updates. They didn't behave any different than Settings, and just added to the number of conditions and flags that needed to be checked, so they were consolidated down to just a "Settings" notification.
* Renamed "NumJobsMax" constant to "UseMaxJobs" for increased clarity.
* Added mutex to PhysXSystemBus so that it can be used from multiple threads, though not concurrently.
* Refactored all the duplicated HeightfieldCollider logic out of EditorHeightfieldColliderComponent / HeightfieldColliderComponent and moved into a new HeightfieldCollider class.
* Removed serialization of the shape config, since it only contained runtime data.
* Made the Heightfield Collider use an async job to update the heightfield shape configuration and spawn it. The job gets divided into subregions so that it can be canceled when changes occur. The subregion size is exposed as a CVar for tunability.
* Made the Terrain Physics Collider Component use the async queries to update the heightfield data. It still blocks on completion, but this lets it multithread the query while it processes. The number of threads is exposed as a CVar for tunability.

This code is likely to get iterated further, but as a first pass it's already made the Editor responsive at interactive framerates (4+ fps) when modifying a 4 km x 4 km terrain region that contains a single heightfield spanning the entire terrain.  (This previously took ~10 seconds per change)

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>