### PR TITLE
Hiding spawner nodes when prefab system is enabled

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Scripting/RandomTimedSpawnerComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/RandomTimedSpawnerComponent.cpp
@@ -9,6 +9,8 @@
 
 #include <AzCore/RTTI/BehaviorContext.h>
 
+#include <AzFramework/API/ApplicationAPI.h>
+
 #include <LmbrCentral/Shape/ShapeComponentBus.h>
 #include <LmbrCentral/Scripting/SpawnerComponentBus.h>
 
@@ -30,29 +32,34 @@ namespace LmbrCentral
                 ;
         }
 
-        if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        bool usePrefabSystem = false;
+        AzFramework::ApplicationRequests::Bus::BroadcastResult(usePrefabSystem, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
+        if (!usePrefabSystem)
         {
-            behaviorContext->EBus<RandomTimedSpawnerComponentRequestBus>("RandomTimedSpawnerRequestBus")
+            if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext
+                    ->EBus<RandomTimedSpawnerComponentRequestBus>("RandomTimedSpawnerRequestBus")
 
-                ->Event("Enable", &RandomTimedSpawnerComponentRequestBus::Events::Enable)
-                ->Event("Disable", &RandomTimedSpawnerComponentRequestBus::Events::Disable)
-                ->Event("Toggle", &RandomTimedSpawnerComponentRequestBus::Events::Toggle)
-                ->Event("IsEnabled", &RandomTimedSpawnerComponentRequestBus::Events::IsEnabled)
+                    ->Event("Enable", &RandomTimedSpawnerComponentRequestBus::Events::Enable)
+                    ->Event("Disable", &RandomTimedSpawnerComponentRequestBus::Events::Disable)
+                    ->Event("Toggle", &RandomTimedSpawnerComponentRequestBus::Events::Toggle)
+                    ->Event("IsEnabled", &RandomTimedSpawnerComponentRequestBus::Events::IsEnabled)
 
-                ->Event("SetRandomDistribution", &RandomTimedSpawnerComponentRequestBus::Events::SetRandomDistribution)
-                ->Event("GetRandomDistribution", &RandomTimedSpawnerComponentRequestBus::Events::GetRandomDistribution)
-                ->VirtualProperty("RandomDistribution", "GetRandomDistribution", "SetRandomDistribution")
+                    ->Event("SetRandomDistribution", &RandomTimedSpawnerComponentRequestBus::Events::SetRandomDistribution)
+                    ->Event("GetRandomDistribution", &RandomTimedSpawnerComponentRequestBus::Events::GetRandomDistribution)
+                    ->VirtualProperty("RandomDistribution", "GetRandomDistribution", "SetRandomDistribution")
 
-                ->Event("SetSpawnDelay", &RandomTimedSpawnerComponentRequestBus::Events::SetSpawnDelay)
-                ->Event("GetSpawnDelay", &RandomTimedSpawnerComponentRequestBus::Events::GetSpawnDelay)
-                ->VirtualProperty("SpawnDelay", "GetSpawnDelay", "SetSpawnDelay")
+                    ->Event("SetSpawnDelay", &RandomTimedSpawnerComponentRequestBus::Events::SetSpawnDelay)
+                    ->Event("GetSpawnDelay", &RandomTimedSpawnerComponentRequestBus::Events::GetSpawnDelay)
+                    ->VirtualProperty("SpawnDelay", "GetSpawnDelay", "SetSpawnDelay")
 
-                ->Event("SetSpawnDelayVariation", &RandomTimedSpawnerComponentRequestBus::Events::SetSpawnDelayVariation)
-                ->Event("GetSpawnDelayVariation", &RandomTimedSpawnerComponentRequestBus::Events::GetSpawnDelayVariation)
-                ->VirtualProperty("SpawnDelayVariation", "GetSpawnDelayVariation", "SetSpawnDelayVariation")
-                ;
+                    ->Event("SetSpawnDelayVariation", &RandomTimedSpawnerComponentRequestBus::Events::SetSpawnDelayVariation)
+                    ->Event("GetSpawnDelayVariation", &RandomTimedSpawnerComponentRequestBus::Events::GetSpawnDelayVariation)
+                    ->VirtualProperty("SpawnDelayVariation", "GetSpawnDelayVariation", "SetSpawnDelayVariation");
 
-            behaviorContext->Class<RandomTimedSpawnerComponent>()->RequestBus("RandomTimedSpawnerRequestBus");
+                behaviorContext->Class<RandomTimedSpawnerComponent>()->RequestBus("RandomTimedSpawnerRequestBus");
+            }
         }
     }
 

--- a/Gems/LmbrCentral/Code/Source/Scripting/SpawnerComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/SpawnerComponent.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/std/sort.h>
 #include <AzCore/Asset/AssetManager.h>
 
+#include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/Entity/GameEntityContextBus.h>
 #include <AzFramework/Entity/SliceGameEntityOwnershipServiceBus.h>
 
@@ -129,35 +130,38 @@ namespace LmbrCentral
                 ->Field("DestroyOnDeactivate", &SpawnerComponent::m_destroyOnDeactivate)
                 ;
         }
- 
-        AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context);
-        if (behaviorContext)
+
+        bool usePrefabSystem = false;
+        AzFramework::ApplicationRequests::Bus::BroadcastResult(usePrefabSystem, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
+        if (!usePrefabSystem)
         {
-            behaviorContext->EBus<SpawnerComponentRequestBus>("SpawnerComponentRequestBus")
-                ->Event("Spawn", &SpawnerComponentRequestBus::Events::Spawn)
-                ->Event("SpawnRelative", &SpawnerComponentRequestBus::Events::SpawnRelative)
-                ->Event("SpawnAbsolute", &SpawnerComponentRequestBus::Events::SpawnAbsolute)
-                ->Event("DestroySpawnedSlice", &SpawnerComponentRequestBus::Events::DestroySpawnedSlice)
-                ->Event("DestroyAllSpawnedSlices", &SpawnerComponentRequestBus::Events::DestroyAllSpawnedSlices)
-                ->Event("GetCurrentlySpawnedSlices", &SpawnerComponentRequestBus::Events::GetCurrentlySpawnedSlices)
-                ->Event("HasAnyCurrentlySpawnedSlices", &SpawnerComponentRequestBus::Events::HasAnyCurrentlySpawnedSlices)
-                ->Event("GetCurrentEntitiesFromSpawnedSlice", &SpawnerComponentRequestBus::Events::GetCurrentEntitiesFromSpawnedSlice)
-                ->Event("GetAllCurrentlySpawnedEntities", &SpawnerComponentRequestBus::Events::GetAllCurrentlySpawnedEntities)
-                ->Event("SetDynamicSlice", &SpawnerComponentRequestBus::Events::SetDynamicSliceByAssetId)
-                ->Event("IsReadyToSpawn", &SpawnerComponentRequestBus::Events::IsReadyToSpawn)
-                ;
+            AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context);
+            if (behaviorContext)
+            {
+                behaviorContext->EBus<SpawnerComponentRequestBus>("SpawnerComponentRequestBus")
+                    ->Event("Spawn", &SpawnerComponentRequestBus::Events::Spawn)
+                    ->Event("SpawnRelative", &SpawnerComponentRequestBus::Events::SpawnRelative)
+                    ->Event("SpawnAbsolute", &SpawnerComponentRequestBus::Events::SpawnAbsolute)
+                    ->Event("DestroySpawnedSlice", &SpawnerComponentRequestBus::Events::DestroySpawnedSlice)
+                    ->Event("DestroyAllSpawnedSlices", &SpawnerComponentRequestBus::Events::DestroyAllSpawnedSlices)
+                    ->Event("GetCurrentlySpawnedSlices", &SpawnerComponentRequestBus::Events::GetCurrentlySpawnedSlices)
+                    ->Event("HasAnyCurrentlySpawnedSlices", &SpawnerComponentRequestBus::Events::HasAnyCurrentlySpawnedSlices)
+                    ->Event("GetCurrentEntitiesFromSpawnedSlice", &SpawnerComponentRequestBus::Events::GetCurrentEntitiesFromSpawnedSlice)
+                    ->Event("GetAllCurrentlySpawnedEntities", &SpawnerComponentRequestBus::Events::GetAllCurrentlySpawnedEntities)
+                    ->Event("SetDynamicSlice", &SpawnerComponentRequestBus::Events::SetDynamicSliceByAssetId)
+                    ->Event("IsReadyToSpawn", &SpawnerComponentRequestBus::Events::IsReadyToSpawn);
 
-            behaviorContext->EBus<SpawnerComponentNotificationBus>("SpawnerComponentNotificationBus")
-                ->Handler<BehaviorSpawnerComponentNotificationBusHandler>()
-                ;
+                behaviorContext->EBus<SpawnerComponentNotificationBus>("SpawnerComponentNotificationBus")
+                    ->Handler<BehaviorSpawnerComponentNotificationBusHandler>();
 
-            behaviorContext->Constant("SpawnerComponentTypeId", BehaviorConstant(SpawnerComponentTypeId));
+                behaviorContext->Constant("SpawnerComponentTypeId", BehaviorConstant(SpawnerComponentTypeId));
 
-            behaviorContext->Class<SpawnerConfig>()
-                //->Property("sliceAsset", BehaviorValueProperty(&SpawnerConfig::m_sliceAsset))
-                ->Property("spawnOnActivate", BehaviorValueProperty(&SpawnerConfig::m_spawnOnActivate))
-                ->Property("destroyOnDeactivate", BehaviorValueProperty(&SpawnerConfig::m_destroyOnDeactivate))
-                ;
+                behaviorContext
+                    ->Class<SpawnerConfig>()
+                    //->Property("sliceAsset", BehaviorValueProperty(&SpawnerConfig::m_sliceAsset))
+                    ->Property("spawnOnActivate", BehaviorValueProperty(&SpawnerConfig::m_spawnOnActivate))
+                    ->Property("destroyOnDeactivate", BehaviorValueProperty(&SpawnerConfig::m_destroyOnDeactivate));
+            }
         }
     }
 

--- a/Gems/LyShine/Code/Source/UiSpawnerComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiSpawnerComponent.cpp
@@ -15,6 +15,8 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Asset/AssetManagerBus.h>
 
+#include <AzFramework/API/ApplicationAPI.h>
+
 #include <LyShine/Bus/UiGameEntityContextBus.h>
 #include <LyShine/Bus/UiElementBus.h>
 
@@ -88,18 +90,20 @@ void UiSpawnerComponent::Reflect(AZ::ReflectContext* context)
         }
     }
 
-    AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context);
-    if (behaviorContext)
+    bool usePrefabSystem = false;
+    AzFramework::ApplicationRequests::Bus::BroadcastResult(usePrefabSystem, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
+    if (!usePrefabSystem)
     {
-        behaviorContext->EBus<UiSpawnerBus>("UiSpawnerBus")
-            ->Event("Spawn", &UiSpawnerBus::Events::Spawn)
-            ->Event("SpawnRelative", &UiSpawnerBus::Events::SpawnRelative)
-            ->Event("SpawnAbsolute", &UiSpawnerBus::Events::SpawnViewport)
-        ;
+        AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context);
+        if (behaviorContext)
+        {
+            behaviorContext->EBus<UiSpawnerBus>("UiSpawnerBus")
+                ->Event("Spawn", &UiSpawnerBus::Events::Spawn)
+                ->Event("SpawnRelative", &UiSpawnerBus::Events::SpawnRelative)
+                ->Event("SpawnAbsolute", &UiSpawnerBus::Events::SpawnViewport);
 
-        behaviorContext->EBus<UiSpawnerNotificationBus>("UiSpawnerNotificationBus")
-            ->Handler<BehaviorUiSpawnerNotificationBusHandler>()
-        ;
+            behaviorContext->EBus<UiSpawnerNotificationBus>("UiSpawnerNotificationBus")->Handler<BehaviorUiSpawnerNotificationBusHandler>();
+        }
     }
 }
 


### PR DESCRIPTION
This change hides all slice-related spawn nodes in Script Canvas and Lua functions.

Signed-off-by: Mikhail Naumov <mnaumov@amazon.com>