### PR TITLE
chore: add CreatePoints with span for aabb

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Aabb.h
+++ b/Code/Framework/AzCore/AzCore/Math/Aabb.h
@@ -43,10 +43,10 @@ namespace AZ
         static Aabb CreateCenterRadius(const Vector3& center, float radius);
 
         //! Creates an AABB which contains the specified points.
-        static Aabb CreatePoints(const Vector3* pts, size_t numPts);
+        static Aabb CreatePoints(const Vector3* points, size_t pointCount);
 
         //! Creates an AABB which contains the specified points.
-        static Aabb CreatePoints(const AZStd::span<Vector3>& points);
+        static Aabb CreatePoints(AZStd::span<const Vector3> points);
 
         //! Creates an AABB which contains the specified OBB.
         static Aabb CreateFromObb(const Obb& obb);

--- a/Code/Framework/AzCore/AzCore/Math/Aabb.h
+++ b/Code/Framework/AzCore/AzCore/Math/Aabb.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <AzCore/std/containers/span.h>
 #include <AzCore/base.h>
 #include <AzCore/Math/Vector3.h>
 
@@ -43,6 +44,9 @@ namespace AZ
 
         //! Creates an AABB which contains the specified points.
         static Aabb CreatePoints(const Vector3* pts, size_t numPts);
+
+        //! Creates an AABB which contains the specified points.
+        static Aabb CreatePoints(const AZStd::span<Vector3>& points);
 
         //! Creates an AABB which contains the specified OBB.
         static Aabb CreateFromObb(const Obb& obb);

--- a/Code/Framework/AzCore/AzCore/Math/Aabb.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Aabb.inl
@@ -59,17 +59,25 @@ namespace AZ
         return CreateCenterHalfExtents(center, Vector3(radius));
     }
 
-
     AZ_MATH_INLINE Aabb Aabb::CreatePoints(const Vector3* pts, size_t numPts)
     {
-        Aabb aabb = Aabb::CreateFromPoint(pts[0]);
-        for (size_t i = 1; i < numPts; ++i)
+        Aabb aabb = Aabb::CreateNull();
+        for (size_t i = 0; i < numPts; ++i)
         {
             aabb.AddPoint(pts[i]);
         }
         return aabb;
     }
 
+    AZ_MATH_INLINE Aabb Aabb::CreatePoints(const AZStd::span<Vector3>& points)
+    {
+        Aabb aabb = Aabb::CreateNull();
+        for (const auto& point : points)
+        {
+            aabb.AddPoint(point);
+        }
+        return aabb;
+    }
 
     AZ_MATH_INLINE const Vector3& Aabb::GetMin() const
     {

--- a/Code/Framework/AzCore/AzCore/Math/Aabb.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Aabb.inl
@@ -59,17 +59,17 @@ namespace AZ
         return CreateCenterHalfExtents(center, Vector3(radius));
     }
 
-    AZ_MATH_INLINE Aabb Aabb::CreatePoints(const Vector3* pts, size_t numPts)
+    AZ_MATH_INLINE Aabb Aabb::CreatePoints(const Vector3* points, size_t pointCount)
     {
         Aabb aabb = Aabb::CreateNull();
-        for (size_t i = 0; i < numPts; ++i)
+        for (size_t i = 0; i < pointCount; ++i)
         {
-            aabb.AddPoint(pts[i]);
+            aabb.AddPoint(points[i]);
         }
         return aabb;
     }
 
-    AZ_MATH_INLINE Aabb Aabb::CreatePoints(const AZStd::span<Vector3>& points)
+    AZ_MATH_INLINE Aabb Aabb::CreatePoints(AZStd::span<const Vector3> points)
     {
         Aabb aabb = Aabb::CreateNull();
         for (const auto& point : points)

--- a/Code/Framework/AzCore/Tests/Math/AabbTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/AabbTests.cpp
@@ -87,9 +87,7 @@ namespace UnitTest
 
     TEST(MATH_Aabb, TestCreatePointsEmpty)
     {
-        const int numPoints = 0;
-        Vector3 points[numPoints] = {};
-        Aabb aabb = Aabb::CreatePoints(points, numPoints);
+        Aabb aabb = Aabb::CreatePoints(nullptr, 0);
         EXPECT_FALSE(aabb.IsValid());
     }
 

--- a/Code/Framework/AzCore/Tests/Math/AabbTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/AabbTests.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/std/containers/span.h>
 #include <AzCore/Math/Aabb.h>
 #include <AzCore/Math/Obb.h>
 #include <AzCore/Math/Vector3.h>
@@ -69,6 +70,34 @@ namespace UnitTest
         Aabb aabb = Aabb::CreatePoints(points, numPoints);
         EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-10.0f)));
         EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(10.0f)));
+    }
+
+    TEST(MATH_Aabb, TestCreatePointsSlice)
+    {
+        Vector3 points[] =
+        { 
+            Vector3(10.0f, 0.0f, -10.0f),
+            Vector3(-10.0f, 10.0f, 0.0f),
+            Vector3(0.0f, -10.0f, 10.0f)
+        };
+        Aabb aabb = Aabb::CreatePoints(points);
+        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-10.0f)));
+        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(10.0f)));
+    }
+
+    TEST(MATH_Aabb, TestCreatePointsEmpty)
+    {
+        const int numPoints = 0;
+        Vector3 points[numPoints] = {};
+        Aabb aabb = Aabb::CreatePoints(points, numPoints);
+        EXPECT_FALSE(aabb.IsValid());
+    }
+
+    TEST(MATH_Aabb, TestCreatePointsEmptySlice)
+    {
+        AZStd::span<Vector3> points = {};
+        Aabb aabb = Aabb::CreatePoints(points);
+        EXPECT_FALSE(aabb.IsValid());
     }
 
     TEST(MATH_Aabb, TestCreateFromObb)


### PR DESCRIPTION
small update to Aabb with span to avoid passing raw pointers and also fixed a crash when passing in points where the numPts is zero.  

Signed-off-by: Michael Pollind <mpollind@gmail.com>