### PR TITLE
feature(Whitebox): add missing tooltips to WhiteBox when in Edit Mode (GHI-8652)

### DIFF
--- a/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponentMode.cpp
+++ b/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponentMode.cpp
@@ -479,6 +479,14 @@ namespace WhiteBox
         m_defaultModeButtonId = RegisterClusterButton(m_modeSelectionClusterId, "SketchMode");
         m_edgeRestoreModeButtonId = RegisterClusterButton(m_modeSelectionClusterId, "RestoreMode");
 
+        // set button tooltips
+        AzToolsFramework::ViewportUi::ViewportUiRequestBus::Event(
+            AzToolsFramework::ViewportUi::DefaultViewportId, &AzToolsFramework::ViewportUi::ViewportUiRequestBus::Events::SetClusterButtonTooltip, m_modeSelectionClusterId,
+            m_defaultModeButtonId, WhiteboxModeClusterDefaultTooltip);
+        AzToolsFramework::ViewportUi::ViewportUiRequestBus::Event(
+            AzToolsFramework::ViewportUi::DefaultViewportId, &AzToolsFramework::ViewportUi::ViewportUiRequestBus::Events::SetClusterButtonTooltip, m_modeSelectionClusterId,
+            m_edgeRestoreModeButtonId, WhiteboxModeClusterEdgeRestoreTooltip);
+
         auto onButtonClicked = [this](AzToolsFramework::ViewportUi::ButtonId buttonId)
         {
             if (buttonId == m_defaultModeButtonId)

--- a/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponentMode.h
+++ b/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponentMode.h
@@ -40,6 +40,9 @@ namespace WhiteBox
     public:
         AZ_CLASS_ALLOCATOR_DECL
 
+        constexpr static const char* const WhiteboxModeClusterEdgeRestoreTooltip = "Switch to Edge Restore mode";
+        constexpr static const char* const WhiteboxModeClusterDefaultTooltip = "Switch to Sketch mode";
+
         EditorWhiteBoxComponentMode(const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType);
         EditorWhiteBoxComponentMode(EditorWhiteBoxComponentMode&&) = delete;
         EditorWhiteBoxComponentMode& operator=(EditorWhiteBoxComponentMode&&) = delete;


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/8652

this adds the missing tooltips for whitebox in edit mode. 

Signed-off-by: Michael Pollind <mpollind@gmail.com>