### PR TITLE
bugfix(Whitebox): Destroy Physics Collider when whitebox mesh is submitted (GHI-7819)

### DIFF
--- a/Gems/WhiteBox/Code/Source/Components/EditorWhiteBoxColliderComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/Components/EditorWhiteBoxColliderComponent.cpp
@@ -152,15 +152,17 @@ namespace WhiteBox
 
         if (m_sceneInterface)
         {
+            DestroyPhysics();
             m_rigidBodyHandle = m_sceneInterface->AddSimulatedBody(m_editorSceneHandle, &bodyConfiguration);
         }
     }
 
     void EditorWhiteBoxColliderComponent::DestroyPhysics()
     {
-        if (m_sceneInterface)
+        if (m_sceneInterface && m_rigidBodyHandle != AzPhysics::InvalidSimulatedBodyHandle)
         {
             m_sceneInterface->RemoveSimulatedBody(m_editorSceneHandle, m_rigidBodyHandle);
+            m_rigidBodyHandle = AzPhysics::InvalidSimulatedBodyHandle;
         }
     }
 


### PR DESCRIPTION
a new collider instance is created for every time the whitebox mesh is re-generated. This logic just ensure that the previous collider is removed when re-generating the new collider. 

ref: https://github.com/o3de/o3de/issues/7819
Signed-off-by: Michael Pollind <mpollind@gmail.com>