### PR TITLE
Enabled Debug Output in AP-GUI

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -477,10 +477,12 @@ void MainWindow::Activate()
     // Tools tab:
     connect(ui->fullScanButton, &QPushButton::clicked, this, &MainWindow::OnRescanButtonClicked);
 
-    settings.beginGroup("Options");
+    settings.beginGroup("Options"); //GetBuilderDebugFlag
     bool zeroAnalysisModeFromSettings = settings.value("EnableZeroAnalysis", QVariant(true)).toBool();
+    bool enableBuilderDebugFlag = settings.value("EnableBuilderDebugFlag", QVariant(false)).toBool();
     settings.endGroup();
 
+    // zero analysis flag
     QObject::connect(ui->modtimeSkippingCheckBox, &QCheckBox::stateChanged, this,
         [this](int newCheckState)
     {
@@ -494,6 +496,21 @@ void MainWindow::Activate()
 
     m_guiApplicationManager->GetAssetProcessorManager()->SetEnableModtimeSkippingFeature(zeroAnalysisModeFromSettings);
     ui->modtimeSkippingCheckBox->setCheckState(zeroAnalysisModeFromSettings ? Qt::Checked : Qt::Unchecked);
+
+    // output debug flag
+    QObject::connect(ui->debugOutputCheckBox, &QCheckBox::stateChanged, this,
+        [this](int newCheckState)
+        {
+            bool newOption = newCheckState == Qt::Checked ? true : false;
+            m_guiApplicationManager->GetAssetProcessorManager()->SetBuilderDebugFlag(newOption);
+            QSettings settingsInCallback;
+            settingsInCallback.beginGroup("Options");
+            settingsInCallback.setValue("EnableBuilderDebugFlag", QVariant(newOption));
+            settingsInCallback.endGroup();
+        });
+
+    m_guiApplicationManager->GetAssetProcessorManager()->SetBuilderDebugFlag(enableBuilderDebugFlag);
+    ui->debugOutputCheckBox->setCheckState(enableBuilderDebugFlag ? Qt::Checked : Qt::Unchecked);
 }
 
 void MainWindow::BuilderTabSelectionChanged(const QItemSelection& selected, const QItemSelection& /*deselected*/)

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -477,7 +477,7 @@ void MainWindow::Activate()
     // Tools tab:
     connect(ui->fullScanButton, &QPushButton::clicked, this, &MainWindow::OnRescanButtonClicked);
 
-    settings.beginGroup("Options"); //GetBuilderDebugFlag
+    settings.beginGroup("Options");
     bool zeroAnalysisModeFromSettings = settings.value("EnableZeroAnalysis", QVariant(true)).toBool();
     bool enableBuilderDebugFlag = settings.value("EnableBuilderDebugFlag", QVariant(false)).toBool();
     settings.endGroup();

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -567,125 +567,125 @@
          <property name="childrenCollapsible">
           <bool>false</bool>
          </property>
-          <widget class="QWidget" name="AssetDetailsLeftLayout">
-              <layout class="QVBoxLayout" name="assetDetailsVerticalLayout1">
-                <item>
-                  <widget class="AzQtComponents::FilteredSearchWidget" name="assetDataFilteredSearchWidget" native="true">
-                    <property name="sizePolicy">
-                      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                      </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                      <size>
-                        <width>0</width>
-                        <height>24</height>
-                      </size>
-                    </property>
-                    <property name="placeholderText" stdset="0">
-                      <string>Search for assets by name or ID</string>
-                    </property>
-                  </widget>
-                </item>
-                <item>
-                  <widget class="QTabWidget" name="assetsTabWidget">
-                    <property name="currentIndex">
-                      <number>0</number>
-                    </property>
-                    <widget class="QWidget" name="SourceAssetsTab">
-                      <attribute name="title">
-                        <string>Source Assets</string>
-                      </attribute>
-                      <layout class="QVBoxLayout" name="SourceAssetsVerticalLayout" stretch="0">
-                        <item>
-                          <widget class="QTreeView" name="SourceAssetsTreeView">
-                            <property name="editTriggers">
-                              <set>QAbstractItemView::NoEditTriggers</set>
-                            </property>
-                            <property name="sortingEnabled">
-                              <bool>true</bool>
-                            </property>
-                            <attribute name="headerDefaultSectionSize">
-                              <number>300</number>
-                            </attribute>
-                          </widget>
-                        </item>
-                      </layout>
-                    </widget>
-                    <widget class="QWidget" name="ProductAssetsTab">
-                      <attribute name="title">
-                        <string>Product Assets</string>
-                      </attribute>
-                      <layout class="QVBoxLayout" name="ProductAssetsVerticalLayout" stretch="0">
-                        <item>
-                          <widget class="QTreeView" name="ProductAssetsTreeView">
-                            <property name="sortingEnabled">
-                              <bool>true</bool>
-                            </property>
-                            <attribute name="headerDefaultSectionSize">
-                              <number>300</number>
-                            </attribute>
-                          </widget>
-                        </item>
-                      </layout>
-                    </widget>
-                  </widget>
-                </item>
+         <widget class="QWidget" name="AssetDetailsLeftLayout">
+          <layout class="QVBoxLayout" name="assetDetailsVerticalLayout1">
+           <item>
+            <widget class="AzQtComponents::FilteredSearchWidget" name="assetDataFilteredSearchWidget" native="true">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>24</height>
+              </size>
+             </property>
+             <property name="placeholderText" stdset="0">
+              <string>Search for assets by name or ID</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTabWidget" name="assetsTabWidget">
+             <property name="currentIndex">
+              <number>0</number>
+             </property>
+             <widget class="QWidget" name="SourceAssetsTab">
+              <attribute name="title">
+               <string>Source Assets</string>
+              </attribute>
+              <layout class="QVBoxLayout" name="SourceAssetsVerticalLayout" stretch="0">
+               <item>
+                <widget class="QTreeView" name="SourceAssetsTreeView">
+                 <property name="editTriggers">
+                  <set>QAbstractItemView::NoEditTriggers</set>
+                 </property>
+                 <property name="sortingEnabled">
+                  <bool>true</bool>
+                 </property>
+                 <attribute name="headerDefaultSectionSize">
+                  <number>300</number>
+                 </attribute>
+                </widget>
+               </item>
               </layout>
-          </widget>
-          <widget class="QWidget" name="AssetDetailsRightLayout">
-            <layout class="QVBoxLayout" name="assetDetailsVerticalLayout2">
-              <item>
-                <widget class="AssetProcessor::SourceAssetDetailsPanel" name="sourceAssetDetailsPanel"/>
-              </item>
-              <item>
-                <widget class="AssetProcessor::ProductAssetDetailsPanel" name="productAssetDetailsPanel">
-                  <property name="visible">
-                    <bool>false</bool>
-                  </property>
+             </widget>
+             <widget class="QWidget" name="ProductAssetsTab">
+              <attribute name="title">
+               <string>Product Assets</string>
+              </attribute>
+              <layout class="QVBoxLayout" name="ProductAssetsVerticalLayout" stretch="0">
+               <item>
+                <widget class="QTreeView" name="ProductAssetsTreeView">
+                 <property name="sortingEnabled">
+                  <bool>true</bool>
+                 </property>
+                 <attribute name="headerDefaultSectionSize">
+                  <number>300</number>
+                 </attribute>
                 </widget>
-              </item>
-              <item>
-                <widget class="QListWidget" name="missingDependencyScanResults">
-                  <property name="sizePolicy">
-                    <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                    </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                    <size>
-                      <width>0</width>
-                      <height>0</height>
-                    </size>
-                  </property>
-                  <property name="maximumSize">
-                    <size>
-                      <width>16777215</width>
-                      <height>72</height>
-                    </size>
-                  </property>
-                  <property name="editTriggers">
-                    <set>QAbstractItemView::NoEditTriggers</set>
-                  </property>
-                  <property name="tabKeyNavigation">
-                    <bool>true</bool>
-                  </property>
-                  <property name="showDropIndicator" stdset="0">
-                    <bool>false</bool>
-                  </property>
-                  <property name="defaultDropAction">
-                    <enum>Qt::IgnoreAction</enum>
-                  </property>
-                  <property name="alternatingRowColors">
-                    <bool>true</bool>
-                  </property>
-                </widget>
-              </item>
-            </layout>
-          </widget>
-
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="AssetDetailsRightLayout">
+          <layout class="QVBoxLayout" name="assetDetailsVerticalLayout2">
+           <item>
+            <widget class="AssetProcessor::SourceAssetDetailsPanel" name="sourceAssetDetailsPanel"/>
+           </item>
+           <item>
+            <widget class="AssetProcessor::ProductAssetDetailsPanel" name="productAssetDetailsPanel">
+             <property name="visible">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QListWidget" name="missingDependencyScanResults">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>72</height>
+              </size>
+             </property>
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="tabKeyNavigation">
+              <bool>true</bool>
+             </property>
+             <property name="showDropIndicator" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="defaultDropAction">
+              <enum>Qt::IgnoreAction</enum>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+			
         </widget>
         <widget class="QWidget" name="LogDialog">
          <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -1289,6 +1289,65 @@
              <widget class="QLabel" name="modtimeSkippingDescription">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This mode completes the startup scan faster by skipping some steps to check if your assets have been modified.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="scaledContents">
+               <bool>false</bool>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="gapSpacer1">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>16</width>
+              <height>16</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="debugOutputCheckBox">
+            <property name="styleSheet">
+             <string notr="true">font: 12pt;</string>
+            </property>
+            <property name="text">
+             <string>Debug Output</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <spacer name="indentSpacer1">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLabel" name="debugOutputCheckBoxDescription">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled, builders that support it will output debug information as product assets.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="scaledContents">
                <bool>false</bool>


### PR DESCRIPTION
* the "debug output" flag can be set inside the AP-GUI now so that users can see debug output while the AP-GUI tool is running


![debugoutput](https://user-images.githubusercontent.com/23512001/171294082-2d26717e-69f2-4f82-b62a-1141d0811864.png)
>