### PR TITLE
Add better guardrails for test level clean up for editor tests

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
@@ -21,6 +21,11 @@ class TestAutomationNoAutoTestMode(EditorTestSuite):
     # interact with modal dialogs
     global_extra_cmdline_args = []
 
+    # Helper for test level cleanup
+    def cleanup_test_level(self, workspace):
+        file_system.delete([os.path.join(workspace.paths.engine_root(), "AutomatedTesting", "Levels", "tmp_level")],
+                           True, True)
+
     class test_AssetPicker_UI_UX(EditorSharedTest):
         from .EditorScripts import AssetPicker_UI_UX as test_module
 
@@ -34,10 +39,14 @@ class TestAutomationNoAutoTestMode(EditorTestSuite):
         from .EditorScripts import EditorWorkflow_ChildEntityTransform_Persists_After_ParentEntityTransform as test_module
 
     class test_BasicEditorWorkflows_LevelEntityComponentCRUD(EditorSingleTest):
-        # Custom teardown to remove level created during test
+
+        # Custom setup and teardown to remove level created during test
+        def setup(self, request, workspace, editor, editor_test_results, launcher_platform):
+            TestAutomationNoAutoTestMode.cleanup_test_level(self, workspace)
+
         def teardown(self, request, workspace, editor, editor_test_results, launcher_platform):
-            file_system.delete([os.path.join(workspace.paths.engine_root(), "AutomatedTesting", "Levels", "tmp_level")],
-                               True, True)
+            TestAutomationNoAutoTestMode.cleanup_test_level(self, workspace)
+
         from .EditorScripts import BasicEditorWorkflows_LevelEntityComponentCRUD as test_module
 
     @pytest.mark.REQUIRES_gpu
@@ -46,9 +55,12 @@ class TestAutomationNoAutoTestMode(EditorTestSuite):
         use_null_renderer = False
 
         # Custom teardown to remove level created during test
+        def setup(self, request, workspace, editor, editor_test_results, launcher_platform):
+            TestAutomationNoAutoTestMode.cleanup_test_level(self, workspace)
+
         def teardown(self, request, workspace, editor, editor_test_results, launcher_platform):
-            file_system.delete([os.path.join(workspace.paths.engine_root(), "AutomatedTesting", "Levels", "tmp_level")],
-                               True, True)
+            TestAutomationNoAutoTestMode.cleanup_test_level(self, workspace)
+
         from .EditorScripts import BasicEditorWorkflows_LevelEntityComponentCRUD as test_module
 
     class test_InputBindings_Add_Remove_Input_Events(EditorSharedTest):


### PR DESCRIPTION
These 2 editor automation tests delete the tmp_level during teardown but they can also run into a scenario where the tmp_level is still present during setup due to a previous crash or as a remnant of some other test suite run. In such cases, these 2 tests timeout and fail.  So, I added an additional guardrail to remove the tmp_level from disk if it exists before the test is begun.

Signed-off-by: srikappa-amzn <82230713+srikappa-amzn@users.noreply.github.com>