### PR TITLE
Skip Terrain_SupportsPhysics test until it can be made more stable.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Terrain/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/TestSuite_Main.py
@@ -18,6 +18,7 @@ class TestAutomation(EditorTestSuite):
     class test_AxisAlignedBoxShape_ConfigurationWorks(EditorSharedTest):
         from .EditorScripts import TerrainPhysicsCollider_ChangesSizeWithAxisAlignedBoxShapeChanges as test_module
 
+    @pytest.mark.skip(reason="GHI #9850: Test Periodically Fails")
     class test_Terrain_SupportsPhysics(EditorSharedTest):
         from .EditorScripts import Terrain_SupportsPhysics as test_module
 


### PR DESCRIPTION
The Terrain_SupportsPhysics test intermittently fails because it creates a sphere that starts with penetrating the heightfield, and relies on waiting a certain amount of time to detect a collision. If the heightfield takes too long to initialize, the test can fail because the sphere won't detect the collision. Disabling the test until it can be improved and be made deterministic.


Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>