### PR TITLE
Use sanitized name in skin weight data

### DIFF
--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.cpp
@@ -97,6 +97,8 @@ namespace AZ
                         }
                         Pending pending;
                         pending.m_bone = bone;
+                        pending.m_sanitizedName = bone->mName.C_Str();
+                        RenamedNodesMap::SanitizeNodeName(pending.m_sanitizedName, context.m_scene.GetGraph(), context.m_currentGraphPosition);
                         pending.m_numVertices = static_cast<unsigned int>(totalVertices);
                         pending.m_skinWeightData = skinWeightData;
                         pending.m_vertOffset = vertexCount;
@@ -126,9 +128,7 @@ namespace AZ
                 for (auto& it : m_pendingSkinWeights)
                 {
                     it.m_skinWeightData->ResizeContainerSpace(it.m_numVertices);
-
-                    AZStd::string boneName = it.m_bone->mName.C_Str();
-                    int boneId = it.m_skinWeightData->GetBoneId(boneName);
+                    int boneId = it.m_skinWeightData->GetBoneId(it.m_sanitizedName);
 
                     for(unsigned weight = 0; weight < it.m_bone->mNumWeights; ++weight)
                     {

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.h
@@ -51,6 +51,7 @@ namespace AZ
                 struct Pending
                 {
                     const aiBone* m_bone = nullptr;
+                    AZStd::string m_sanitizedName;
                     unsigned m_numVertices = 0;
                     unsigned m_vertOffset = 0;
                     AZStd::shared_ptr<SceneData::GraphData::SkinWeightData> m_skinWeightData;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/69218254/171344922-bd61fcc0-26cb-491f-9dff-8678708fe066.png)

Fixed an issue that causes the skin mesh render only part of the mesh. The root cause is when sanitize name process actually change the bone name (e.g bone.001 -> bone_001), the skin weight data now will stores the sanitized name.

Signed-off-by: rhhong <rhhong@amazon.com>