### PR TITLE
[Terrain] Fix and re-enable Terrain physics python test

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
@@ -33,10 +33,10 @@ def Terrain_SupportsPhysics():
     Test Steps:
      1) Load the base level
      2) Create 2 test entities, one parent at 512.0, 512.0, 50.0 and one child at the default position and add the required components
-     2a) Create a ball at 600.0, 600.0, 46.0 - This position is not too high over the heightfield so will collide in a reasonable time
+     2a) Create a ball at 600.0, 600.0, 46.0 - This position intersects the terrain
      3) Start the Tracer to catch any errors and warnings
      4) Change the Axis Aligned Box Shape dimensions
-     5) Set the Vegetation Shape reference to TestEntity1
+     5) Set the Reference Shape to TestEntity1
      6) Set the FastNoise gradient frequency to 0.01
      7) Set the Gradient List to TestEntity2
      8) Set the PhysX Collider to Sphere mode
@@ -79,7 +79,8 @@ def Terrain_SupportsPhysics():
     height_provider_entity = hydra.Entity("TestEntity2")
     height_provider_entity.create_entity(azmath.Vector3(0.0, 0.0, 0.0), entity2_components_to_add,terrain_spawner_entity.id)
     Report.result(Tests.create_height_provider_entity, height_provider_entity.id.IsValid())
-    # 2a) Create a ball at 600.0, 600.0, 46.0 - This position is not too high over the heightfield so will collide in a reasonable time
+    # 2a) Create a ball at 600.0, 600.0, 46.0 - The ball is created as a collider, but without a Rigid Body, so it will stay in place.
+    # This location is chosen because the ball should intersect the terrain.
     ball = hydra.Entity("Ball")
     ball.create_entity(azmath.Vector3(600.0, 600.0, 46.0), ball_components_to_add)
     Report.result(Tests.create_test_ball, ball.id.IsValid())
@@ -94,7 +95,7 @@ def Terrain_SupportsPhysics():
         box_shape_dimensions = hydra.get_component_property_value(terrain_spawner_entity.components[0], "Axis Aligned Box Shape|Box Configuration|Dimensions")
         Report.result(Tests.box_dimensions_changed, box_dimensions == box_shape_dimensions)
         
-        # 5) Set the Vegetaion Shape reference to TestEntity1
+        # 5) Set the Refreence Shape to TestEntity1
         height_provider_entity.get_set_test(0, "Configuration|Shape Entity Id", terrain_spawner_entity.id)
         entityId = hydra.get_component_property_value(height_provider_entity.components[0], "Configuration|Shape Entity Id")
         Report.result(Tests.shape_changed, entityId == terrain_spawner_entity.id)
@@ -125,7 +126,7 @@ def Terrain_SupportsPhysics():
 
         general.idle_wait_frames(1)
 
-        # 10) Enter game mode and test if the ball hits the heightfield within 3 seconds
+        # 10) Enter game mode and test if the ball detects the heightfield collision within 3 seconds
         TIMEOUT = 3.0
 
         class Collider:

--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
@@ -24,24 +24,24 @@ class Tests:
 def Terrain_SupportsPhysics():
     """
     Summary:
-    Test aspects of the TerrainHeightGradientList through the BehaviorContext and the Property Tree.
+    General validation that terrain physics heightfields work within the context of the PhysX integration.
 
-    Test Steps:
     Expected Behavior:
-    The Editor is stable there are no warnings or errors.
+    The terrain system is initialized, gets a hilly physics heightfield generated, and detects a collision between a sphere and a hill
+    in a timely fashion without errors or warnings.
 
     Test Steps:
      1) Load the base level
      2) Create 2 test entities, one parent at 512.0, 512.0, 50.0 and one child at the default position and add the required components
-     2a) Create a ball at 600.0, 600.0, 46.0 - This position intersects the terrain
+     2a) Create a ball at 600.0, 600.0, 46.0 - This position intersects the terrain when it has hills generated correctly.
      3) Start the Tracer to catch any errors and warnings
      4) Change the Axis Aligned Box Shape dimensions
      5) Set the Reference Shape to TestEntity1
      6) Set the FastNoise gradient frequency to 0.01
      7) Set the Gradient List to TestEntity2
      8) Set the PhysX Collider to Sphere mode
-     9) Disable and Enable the Terrain Gradient List so that it is recognised
-     10) Enter game mode and test if the ball hits the heightfield within 3 seconds
+     9) Set the Rigid Body to start with no gravity enabled, so that it sits in place, intersecting the expected terrain
+     10) Enter game mode and test if the ball detects the heightfield intersection within 3 seconds
      11) Verify there are no errors and warnings in the logs
 
 
@@ -72,15 +72,15 @@ def Terrain_SupportsPhysics():
     # 2) Create 2 test entities, one parent at 512.0, 512.0, 50.0 and one child at the default position and add the required components
     entity1_components_to_add = ["Axis Aligned Box Shape", "Terrain Layer Spawner", "Terrain Height Gradient List", "Terrain Physics Heightfield Collider", "PhysX Heightfield Collider"]
     entity2_components_to_add = ["Shape Reference", "Gradient Transform Modifier", "FastNoise Gradient"]
-    ball_components_to_add = ["Sphere Shape", "PhysX Collider"]
+    ball_components_to_add = ["Sphere Shape", "PhysX Collider", "PhysX Rigid Body"]
     terrain_spawner_entity = hydra.Entity("TestEntity1")
     terrain_spawner_entity.create_entity(azmath.Vector3(512.0, 512.0, 50.0), entity1_components_to_add)
     Report.result(Tests.create_terrain_spawner_entity, terrain_spawner_entity.id.IsValid())
     height_provider_entity = hydra.Entity("TestEntity2")
     height_provider_entity.create_entity(azmath.Vector3(0.0, 0.0, 0.0), entity2_components_to_add,terrain_spawner_entity.id)
     Report.result(Tests.create_height_provider_entity, height_provider_entity.id.IsValid())
-    # 2a) Create a ball at 600.0, 600.0, 46.0 - The ball is created as a collider, but without a Rigid Body, so it will stay in place.
-    # This location is chosen because the ball should intersect the terrain.
+    # 2a) Create a ball at 600.0, 600.0, 46.0 - The ball is created as a collider with a Rigid Body, but at rest and without gravity,
+    # so that it will stay in place. This specific location is chosen because the ball should intersect the terrain.
     ball = hydra.Entity("Ball")
     ball.create_entity(azmath.Vector3(600.0, 600.0, 46.0), ball_components_to_add)
     Report.result(Tests.create_test_ball, ball.id.IsValid())
@@ -112,15 +112,18 @@ def Terrain_SupportsPhysics():
         checkID = propertyTree.get_container_item("Configuration|Gradient Entities", 0)
         Report.result(Tests.entity_added, checkID.GetValue() == height_provider_entity.id)
 
+        # 7a) Disable and Enable the Terrain Height Gradient List so that the change to the container is recognized
+        editor.EditorComponentAPIBus(bus.Broadcast, 'EnableComponents', [terrain_spawner_entity.components[2]])
+        PrefabUtils.wait_for_propagation()
+        
         # 8) Set the PhysX Collider to Sphere mode
         shape = 0
         hydra.get_set_test(ball, 1, "Shape Configuration|Shape", shape)
         setShape = hydra.get_component_property_value(ball.components[1], "Shape Configuration|Shape")
         Report.result(Tests.shape_set, shape == setShape)
 
-        # 9) Disable and Enable the Terrain Gradient List so that it is recognised
-        editor.EditorComponentAPIBus(bus.Broadcast, 'EnableComponents', [terrain_spawner_entity.components[2]])
-        PrefabUtils.wait_for_propagation()
+        # 9) Set the PhysX Rigid Body to not use gravity
+        hydra.get_set_test(ball, 2, "Configuration|Gravity enabled", False)
 
         general.enter_game_mode()
 
@@ -138,7 +141,7 @@ def Terrain_SupportsPhysics():
         def on_collision_begin(args):
             other_id = args[0]
             if other_id.Equal(terrain_id):
-                Report.info("Touched ground")
+                Report.info("Ball intersected with heightfield")
                 Collider.touched_ground = True
 
         handler = azlmbr.physics.CollisionNotificationBusHandler()

--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
@@ -72,7 +72,7 @@ def Terrain_SupportsPhysics():
     # 2) Create 2 test entities, one parent at 512.0, 512.0, 50.0 and one child at the default position and add the required components
     entity1_components_to_add = ["Axis Aligned Box Shape", "Terrain Layer Spawner", "Terrain Height Gradient List", "Terrain Physics Heightfield Collider", "PhysX Heightfield Collider"]
     entity2_components_to_add = ["Shape Reference", "Gradient Transform Modifier", "FastNoise Gradient"]
-    ball_components_to_add = ["Sphere Shape", "PhysX Collider", "PhysX Rigid Body"]
+    ball_components_to_add = ["Sphere Shape", "PhysX Collider"]
     terrain_spawner_entity = hydra.Entity("TestEntity1")
     terrain_spawner_entity.create_entity(azmath.Vector3(512.0, 512.0, 50.0), entity1_components_to_add)
     Report.result(Tests.create_terrain_spawner_entity, terrain_spawner_entity.id.IsValid())
@@ -95,7 +95,7 @@ def Terrain_SupportsPhysics():
         box_shape_dimensions = hydra.get_component_property_value(terrain_spawner_entity.components[0], "Axis Aligned Box Shape|Box Configuration|Dimensions")
         Report.result(Tests.box_dimensions_changed, box_dimensions == box_shape_dimensions)
         
-        # 5) Set the Refreence Shape to TestEntity1
+        # 5) Set the Reference Shape to TestEntity1
         height_provider_entity.get_set_test(0, "Configuration|Shape Entity Id", terrain_spawner_entity.id)
         entityId = hydra.get_component_property_value(height_provider_entity.components[0], "Configuration|Shape Entity Id")
         Report.result(Tests.shape_changed, entityId == terrain_spawner_entity.id)

--- a/AutomatedTesting/Gem/PythonTests/Terrain/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/TestSuite_Main.py
@@ -18,7 +18,6 @@ class TestAutomation(EditorTestSuite):
     class test_AxisAlignedBoxShape_ConfigurationWorks(EditorSharedTest):
         from .EditorScripts import TerrainPhysicsCollider_ChangesSizeWithAxisAlignedBoxShapeChanges as test_module
 
-    @pytest.mark.skip(reason="GHI #9850: Test Periodically Fails")
     class test_Terrain_SupportsPhysics(EditorSharedTest):
         from .EditorScripts import Terrain_SupportsPhysics as test_module
 

--- a/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
@@ -503,8 +503,14 @@ namespace Terrain
                 TerrainDataRequests::TerrainDataMask::Heights | TerrainDataRequests::TerrainDataMask::SurfaceData),
             perPositionCallback, AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT, params);
 
-        // Wait for the query to complete.
-        wait.acquire();
+        // If a jobContext was successfully created, wait for the query to complete.
+        // (If the call to UpdateHeightsAndMaterials was made on a thread, and the TerrainSystem is currently shutting down on a different
+        // thread, it's possible that the TerrainDataRequest bus won't have a listener at the moment we call it, which is why we need
+        // to validate that the jobContext was returned successfully)
+        if (jobContext)
+        {
+            wait.acquire();
+        }
     }
 
     void TerrainPhysicsColliderComponent::UpdateConfiguration(const TerrainPhysicsColliderConfig& newConfiguration)


### PR DESCRIPTION
The Terrain_SupportsPhysics test intermittently failed, which caused the test to get disabled. This PR re-enables a fixed version of the test.
1. The test was creating a sphere and a heightfield and waiting for a collision. However, the starting point of the sphere was intersecting the heightfield, so if the sphere fell faster than the heightfield initialized, it could end up below the heightfield without a collision. The fix is to disable gravity on the sphere, so it is guaranteed to collide once the heightfield finishes initializing.
2. The test exposed a subtle race condition in the new async terrain physics code where it could deadlock if the terrain system was shutting down in the middle of a terrain physics update. The fix is to verify that the terrain async system call actually started before blocking to wait on completion.