### PR TITLE
Set periodic PR build status to unstable on sucess

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -98,11 +98,11 @@ def IsPullRequest(branchName) {
 }
 
 def IsPeriodicPipeline(pipelineName) {
-    return pipelineName.pipelineName.startsWith('periodic-')
+    return pipelineName.startsWith('periodic-')
 }
 
 def IsJobEnabled(branchName, buildTypeMap, pipelineName, platformName) {
-    if (IsPullRequest(branchName)) {
+    if (IsPullRequest(branchName) && !IsPeriodicPipeline(pipelineName)) {
         return buildTypeMap.value.TAGS && buildTypeMap.value.TAGS.contains(pipelineName)
     }
     def job_list_override = params.JOB_LIST_OVERRIDE ? params.JOB_LIST_OVERRIDE.tokenize(',') : ''
@@ -938,7 +938,7 @@ try {
         }
         if("${currentBuild.currentResult}" == "SUCCESS" && IsPeriodicPipeline(pipelineName) && IsPullRequest(branchName)) {
             currentBuild.result = 'UNSTABLE'
-            currentBuild.result.color = 'BLUE'
+            currentBuild.description = 'Builds succeeded but regular PR run is required to merge the PR.'
         }
     }
 }

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -936,7 +936,7 @@ try {
         if (!someBuildHappened) {
             currentBuild.result = 'NOT_BUILT'
         }
-        if("${currentBuild.currentResult}" == "SUCCESS" IsPeriodicPipeline(pipelineName) && IsPullRequest(branchName)) {
+        if("${currentBuild.currentResult}" == "SUCCESS" && IsPeriodicPipeline(pipelineName) && IsPullRequest(branchName)) {
             currentBuild.result = 'UNSTABLE'
             currentBuild.result.color = 'BLUE'
         }

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -97,6 +97,10 @@ def IsPullRequest(branchName) {
     return branchName.startsWith('PR-')
 }
 
+def IsPeriodicPipeline(pipelineName) {
+    return pipelineName.pipelineName.startsWith('periodic-')
+}
+
 def IsJobEnabled(branchName, buildTypeMap, pipelineName, platformName) {
     if (IsPullRequest(branchName)) {
         return buildTypeMap.value.TAGS && buildTypeMap.value.TAGS.contains(pipelineName)
@@ -833,7 +837,7 @@ try {
                         pipelineConfig = LoadPipelineConfig(pipelineName, branchName)
 
                         // Add each platform as a parameter that the user can disable if needed
-                        if (!IsPullRequest(branchName)) {
+                        if (!IsPullRequest(branchName) || IsPeriodicPipeline(pipelineName)) {
                             pipelineParameters.add(stringParam(defaultValue: '', description: 'Filters and overrides the list of jobs to run for each of the below platforms (comma-separated). Can\'t be used during a pull request.', name: 'JOB_LIST_OVERRIDE'))
 
                             pipelineConfig.platforms.each { platform ->
@@ -889,11 +893,17 @@ try {
             }
         }
 
-        if(env.BUILD_NUMBER == '1' && !IsPullRequest(branchName)) {
+        if(env.BUILD_NUMBER == '1') {
             // Exit pipeline early on the intial build. This allows Jenkins to load the pipeline for the branch and enables users
             // to select build parameters on their first actual build. See https://issues.jenkins.io/browse/JENKINS-41929
-            currentBuild.result = 'SUCCESS'
-            return
+            if (!IsPullRequest(branchName)) {
+                currentBuild.result = 'SUCCESS'
+                return
+            }
+            else if (IsPeriodicPipeline(pipelineName)) {
+                currentBuild.result = 'NOT_BUILT'
+                return
+            }
         }
 
         def someBuildHappened = false
@@ -925,6 +935,10 @@ try {
         }
         if (!someBuildHappened) {
             currentBuild.result = 'NOT_BUILT'
+        }
+        if("${currentBuild.currentResult}" == "SUCCESS" IsPeriodicPipeline(pipelineName) && IsPullRequest(branchName)) {
+            currentBuild.result = 'UNSTABLE'
+            currentBuild.result.color = 'BLUE'
         }
     }
 }


### PR DESCRIPTION
In periodic multi-branch pipeline, PR builds always set PR status check "**continuous-integration/jenkins/pr-merge**", when people use JOB_LIST_OVERRIDE in periodic PR build to only build certain build configurations, we don't want the PR status check to be updated.

Signed-off-by: Shirang Jia <shiranj@amazon.com>