### PR TITLE
Revert "Prevent rapidly successive rebuilds of AssetBrowserTableModel Map (#9564)"

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableModel.cpp
@@ -24,12 +24,12 @@ namespace AzToolsFramework
             AZ_Assert(
                 m_filterModel,
                 "Error in AssetBrowserTableModel initialization, class expects source model to be an AssetBrowserFilterModel.");
-
             QSortFilterProxyModel::setSourceModel(sourceModel);
 
-            connect(m_filterModel, &QAbstractItemModel::rowsInserted, this, &AssetBrowserTableModel::StartUpdateModelMapTimer);
-            connect(m_filterModel, &QAbstractItemModel::rowsRemoved, this, &AssetBrowserTableModel::StartUpdateModelMapTimer);
-            connect(m_filterModel, &QAbstractItemModel::layoutChanged, this, &AssetBrowserTableModel::StartUpdateModelMapTimer);
+            connect(m_filterModel, &QAbstractItemModel::rowsInserted, this, &AssetBrowserTableModel::UpdateTableModelMaps);
+            connect(m_filterModel, &QAbstractItemModel::rowsRemoved, this, &AssetBrowserTableModel::UpdateTableModelMaps);
+            connect(m_filterModel, &QAbstractItemModel::layoutChanged, this, &AssetBrowserTableModel::UpdateTableModelMaps);
+            connect(m_filterModel, &AssetBrowserFilterModel::filterChanged, this, &AssetBrowserTableModel::beginResetModel);
             connect(m_filterModel, &AssetBrowserFilterModel::filterChanged, this, &AssetBrowserTableModel::UpdateTableModelMaps);
             connect(m_filterModel, &QAbstractItemModel::dataChanged, this, &AssetBrowserTableModel::SourceDataChanged);
         }
@@ -103,23 +103,6 @@ namespace AzToolsFramework
         int AssetBrowserTableModel::rowCount(const QModelIndex& parent) const
         {
             return !parent.isValid() ? m_indexMap.size() : 0;
-        }
-
-        void AssetBrowserTableModel::timerEvent([[maybe_unused]] QTimerEvent* event)
-        {
-            killTimer(m_updateModelMapTimerId);
-            m_updateModelMapTimerId = 0;
-            UpdateTableModelMaps();
-        }
-
-        void AssetBrowserTableModel::StartUpdateModelMapTimer()
-        {
-            constexpr int ModelRefreshWaitTimeMS = 250;
-            if (m_updateModelMapTimerId > 0)
-            {
-                killTimer(m_updateModelMapTimerId);
-            }
-            m_updateModelMapTimerId = startTimer(ModelRefreshWaitTimeMS);
         }
 
         int AssetBrowserTableModel::BuildTableModelMap(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableModel.h
@@ -10,7 +10,6 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/Asset/AssetCommon.h>
 #include <QSortFilterProxyModel>
-#include <QPersistentModelIndex>
 #include <QPointer>
 #endif
 #include <Editor/EditorSettingsAPIBus.h>
@@ -45,10 +44,8 @@ namespace AzToolsFramework
 
         protected:
             QVariant headerData(int section, Qt::Orientation orientation, int role /* = Qt::DisplayRole */) const override;
-            void timerEvent(QTimerEvent* event) override;
             ////////////////////////////////////////////////////////////////////
 
-            void StartUpdateModelMapTimer();
             AssetBrowserEntry* GetAssetEntry(QModelIndex index) const;
             int BuildTableModelMap(const QAbstractItemModel* model, const QModelIndex& parent = QModelIndex(), int row = 0);
 
@@ -57,13 +54,11 @@ namespace AzToolsFramework
 
         private slots:
             void SourceDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight);
-
         private:
             AZ::u64 m_numberOfItemsDisplayed = 50;
             int m_displayedItemsCounter = 0;
-            int m_updateModelMapTimerId = 0;
             QPointer<AssetBrowserFilterModel> m_filterModel;
-            QMap<int, QPersistentModelIndex> m_indexMap;
+            QMap<int, QModelIndex> m_indexMap;
             QMap<QModelIndex, int> m_rowMap;
         };
     } // namespace AssetBrowser


### PR DESCRIPTION
This reverts commit 3bd5cce8e872e0ea9381ef96a106d364749056a6.

Reverting because the change introduced an assert when the Editor is built and run in debug.
![image](https://user-images.githubusercontent.com/82231674/171498776-eade00ef-54b4-4c38-abd6-5cc4e169ca1e.png)
