### PR TITLE
Prevent AssetBrowserTableModel assertion at Editor startup

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableModel.cpp
@@ -55,6 +55,11 @@ namespace AzToolsFramework
             return createIndex(m_rowMap[sourceIndex], sourceIndex.column());
         }
 
+        bool AssetBrowserTableModel::filterAcceptsRow(int source_row, [[maybe_unused]] const QModelIndex& source_parent) const
+        {
+            return m_indexMap.contains(source_row);
+        }
+
         QVariant AssetBrowserTableModel::headerData(int section, Qt::Orientation orientation, int role) const
         {
             if (role == Qt::DisplayRole && orientation == Qt::Horizontal)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableModel.h
@@ -44,6 +44,7 @@ namespace AzToolsFramework
             int rowCount(const QModelIndex& parent = QModelIndex()) const override;
 
         protected:
+            bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
             QVariant headerData(int section, Qt::Orientation orientation, int role /* = Qt::DisplayRole */) const override;
             void timerEvent(QTimerEvent* event) override;
             ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Resolves assertion encountered during Editor startup in debug mode which was introduced by the changes in PR #9564. This issue is only seen in debug mode and does not appear to cause any issues otherwise.

Prior to PR #9564, there was rapid rebuilding of the Asset Browser's search result table model during Editor startup. Stopping the repeated rebuilds resulted in an empty `QPersistentModelIndex` map in the custom `AssetBrowserTableModel` when the editor finished loading. In turn, this resulted in us tripping [this assert](https://code.woboq.org/qt5/qtbase/src/corelib/itemmodels/qabstractitemmodel.cpp.html#2722) in `QAbstractItemModel::beginInsertRows` as signals made their way up from the base `AssetBrowserModel`.

This [Qt documentation](https://doc.qt.io/qt-5/qtwidgets-itemviews-customsortfiltermodel-example.html) mentions that custom filter models may need to override `QSortFilterProxyModel::filterAcceptsRow` in order to filter out items not included in the model. In this case, overriding filterAcceptsRow does just that but mainly for the purpose of preventing unwanted rows from attempting to insert themselves in the model before the model technically exists, resulting in an assertion.

Testing done:
- Ran AzToolsFramework.Tests & python tests
- Verified no assertion when building debug mode
- Manually verified Asset Browser search results table behavior is unchanged

Signed-off-by: amzn-tmryan <104796591+amzn-tmryan@users.noreply.github.com>