### PR TITLE
Fixing the lack of a dot at the end of SpawnedEntitiesList parameter tooltip

### DIFF
--- a/AutomatedTesting/Levels/Navigation/NavigationSample/city_generator.scriptcanvas
+++ b/AutomatedTesting/Levels/Navigation/NavigationSample/city_generator.scriptcanvas
@@ -2472,7 +2472,7 @@
                                                     }
                                                 ],
                                                 "slotName": "SpawnedEntitiesList",
-                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first",
+                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first.",
                                                 "DisplayDataType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"

--- a/AutomatedTesting/ScriptCanvas/ScriptCanvas_SpawnEntityWithPhysComponents.scriptcanvas
+++ b/AutomatedTesting/ScriptCanvas/ScriptCanvas_SpawnEntityWithPhysComponents.scriptcanvas
@@ -250,7 +250,7 @@
                                                     }
                                                 ],
                                                 "slotName": "SpawnedEntitiesList",
-                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first",
+                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first.",
                                                 "DisplayDataType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"

--- a/AutomatedTesting/ScriptCanvas/Spawnables/DespawnOnEntityDeactivate.scriptcanvas
+++ b/AutomatedTesting/ScriptCanvas/Spawnables/DespawnOnEntityDeactivate.scriptcanvas
@@ -607,7 +607,7 @@
                                                     }
                                                 ],
                                                 "slotName": "SpawnedEntitiesList",
-                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first",
+                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first.",
                                                 "DisplayDataType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"

--- a/AutomatedTesting/ScriptCanvas/Spawnables/MultipleSpawnsFromSingleTicket.scriptcanvas
+++ b/AutomatedTesting/ScriptCanvas/Spawnables/MultipleSpawnsFromSingleTicket.scriptcanvas
@@ -297,7 +297,7 @@
                                                     }
                                                 ],
                                                 "slotName": "SpawnedEntitiesList",
-                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first",
+                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first.",
                                                 "DisplayDataType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"
@@ -792,7 +792,7 @@
                                                     }
                                                 ],
                                                 "slotName": "SpawnedEntitiesList",
-                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first",
+                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first.",
                                                 "DisplayDataType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"
@@ -2442,7 +2442,7 @@
                                                     }
                                                 ],
                                                 "slotName": "SpawnedEntitiesList",
-                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first",
+                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first.",
                                                 "DisplayDataType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"

--- a/AutomatedTesting/ScriptCanvas/Spawnables/NestedSpawnerSpawner.scriptcanvas
+++ b/AutomatedTesting/ScriptCanvas/Spawnables/NestedSpawnerSpawner.scriptcanvas
@@ -218,7 +218,7 @@
                                                     }
                                                 ],
                                                 "slotName": "SpawnedEntitiesList",
-                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first",
+                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first.",
                                                 "DisplayDataType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"

--- a/AutomatedTesting/ScriptCanvas/Spawnables/SimpleNestedSpawn.scriptcanvas
+++ b/AutomatedTesting/ScriptCanvas/Spawnables/SimpleNestedSpawn.scriptcanvas
@@ -515,7 +515,7 @@
                                                     }
                                                 ],
                                                 "slotName": "SpawnedEntitiesList",
-                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first",
+                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first.",
                                                 "DisplayDataType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"

--- a/AutomatedTesting/ScriptCanvas/Spawnables/SimpleSpawnDespawn.scriptcanvas
+++ b/AutomatedTesting/ScriptCanvas/Spawnables/SimpleSpawnDespawn.scriptcanvas
@@ -322,7 +322,7 @@
                                                     }
                                                 ],
                                                 "slotName": "SpawnedEntitiesList",
-                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first",
+                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first.",
                                                 "DisplayDataType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"

--- a/AutomatedTesting/ScriptCanvas/Spawnables/SimpleSpawnNoDespawn.scriptcanvas
+++ b/AutomatedTesting/ScriptCanvas/Spawnables/SimpleSpawnNoDespawn.scriptcanvas
@@ -520,7 +520,7 @@
                                                     }
                                                 ],
                                                 "slotName": "SpawnedEntitiesList",
-                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first",
+                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first.",
                                                 "DisplayDataType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/SpawnNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/SpawnNodeable.ScriptCanvasNodeable.xml
@@ -22,7 +22,7 @@
 
     <Output Name="On Spawn Completed" Description="Called when spawning entities is completed.">
         <Parameter Name="SpawnTicketOut" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance of the spawn result."/>
-        <Parameter Name="SpawnedEntitiesList" Type="AZStd::vector&lt;Data::EntityIDType&gt;" Description="List of spawned entities sorted by hierarchy with the root being first"/>
+        <Parameter Name="SpawnedEntitiesList" Type="AZStd::vector&lt;Data::EntityIDType&gt;" Description="List of spawned entities sorted by hierarchy with the root being first."/>
     </Output>/>
   </Class>
 </ScriptCanvas>


### PR DESCRIPTION
Signed-off-by: Bartosz Cwiek [100559077+LB-BartoszCwiek@users.noreply.github.com](mailto:100559077+LB-BartoszCwiek@users.noreply.github.com)

Adding the missing dot at the end of the SpawnedEntitiesList parameter tooltip. Fixing the tooltip in existing AutomatedTesting .scriptcanvas files.

Before changes:
![image](https://user-images.githubusercontent.com/100559077/171610282-f81ac83d-c98d-43bc-ae66-90cc23f64401.png)

After changes:
![image](https://user-images.githubusercontent.com/100559077/171620388-3a305aa1-7461-4467-823d-ed1e95e96a08.png)

