### PR TITLE
EMotion FX: Unassigning the actor re-parents the entity to root level

### DIFF
--- a/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
@@ -310,11 +310,12 @@ namespace EMotionFX
         {
             if (targetEntityId.IsValid() && targetEntityId != GetEntityId())
             {
+                m_attachmentTargetEntityId = targetEntityId;
+
                 ActorComponentNotificationBus::Handler::BusDisconnect();
                 ActorComponentNotificationBus::Handler::BusConnect(targetEntityId);
 
                 AZ::TransformNotificationBus::MultiHandler::BusConnect(targetEntityId);
-                m_attachmentTargetEntityId = targetEntityId;
 
                 // There's no guarantee that we will receive a on transform change call for the target entity because of the entity activate order.
                 // Enforce a transform query on target to get the correct initial transform.
@@ -332,10 +333,16 @@ namespace EMotionFX
         //////////////////////////////////////////////////////////////////////////
         void ActorComponent::DetachFromEntity()
         {
-            if (m_attachmentTargetActor)
+            if (!m_actorInstance)
             {
-                m_attachmentTargetActor->RemoveAttachment(m_actorInstance.get());
-                AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetParent, AZ::EntityId());
+                return;
+            }
+
+            ActorInstance* attachedTo = m_actorInstance->GetAttachedTo();
+            if (attachedTo)
+            {
+                attachedTo->RemoveAttachment(m_actorInstance.get());
+                AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetParent, m_attachmentPreviousParent);
                 AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetLocalTM, AZ::Transform::CreateIdentity());
 
                 AZ::TransformNotificationBus::MultiHandler::BusDisconnect(m_attachmentTargetEntityId);
@@ -466,6 +473,9 @@ namespace EMotionFX
                 }
             }
 
+            // Remember the parent entity before we re-parent (attach) it.
+            AZ::TransformBus::EventResult(m_attachmentPreviousParent, GetEntityId(), &AZ::TransformBus::Events::GetParentId);
+
             // Reattach all attachments
             for (AZ::EntityId& attachment : m_attachments)
             {
@@ -487,38 +497,53 @@ namespace EMotionFX
         void ActorComponent::CheckAttachToEntity()
         {
             // Attach to the target actor if we're both ready.
-            // Note that m_attachmentTargetActor will always be null if we're not configured to attach to anything.
-            if (m_actorInstance && m_attachmentTargetActor)
+            if (m_actorInstance)
             {
-                DetachFromEntity();
-
-                // Make sure we don't generate some circular loop by attaching to each other.
-                if (!m_attachmentTargetActor.get()->CheckIfCanHandleAttachment(m_actorInstance.get()))
+                if (m_attachmentTargetEntityId.IsValid())
                 {
-                    AZ_Error("EMotionFX", false, "You cannot attach to yourself or create circular dependencies!\n");
-                    return;
-                }
+                    // Create the attachment if the target instance is already created.
+                    // Otherwise, listen to the actor instance creation event.
+                    ActorInstance* targetActorInstance = nullptr;
+                    ActorComponentRequestBus::EventResult(targetActorInstance, m_attachmentTargetEntityId, &ActorComponentRequestBus::Events::GetActorInstance);
+                    if (targetActorInstance)
+                    {
+                        DetachFromEntity();
 
-                // Create the attachment.
-                AZ_Assert(m_configuration.m_attachmentType == AttachmentType::SkinAttachment, "Expected a skin attachment.");
-                Attachment* attachment = AttachmentSkin::Create(m_attachmentTargetActor.get(), m_actorInstance.get());
-                m_actorInstance->SetLocalSpaceTransform(Transform::CreateIdentity());
-                m_attachmentTargetActor->AddAttachment(attachment);
-                AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetParent, m_attachmentTargetActor->GetEntityId());
-                AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetLocalTM, AZ::Transform::CreateIdentity());
+                        // Make sure we don't generate some circular loop by attaching to each other.
+                        if (!targetActorInstance->CheckIfCanHandleAttachment(m_actorInstance.get()))
+                        {
+                            AZ_Error("EMotionFX", false, "You cannot attach to yourself or create circular dependencies!\n");
+                            return;
+                        }
+
+                        // Remember the parent entity before we re-parent (attach) it.
+                        AZ::TransformBus::EventResult(m_attachmentPreviousParent, GetEntityId(), &AZ::TransformBus::Events::GetParentId);
+
+                        // Create the attachment.
+                        AZ_Assert(m_configuration.m_attachmentType == AttachmentType::SkinAttachment, "Expected a skin attachment.");
+                        Attachment* attachment = AttachmentSkin::Create(targetActorInstance, m_actorInstance.get());
+                        m_actorInstance->SetLocalSpaceTransform(Transform::CreateIdentity());
+                        targetActorInstance->AddAttachment(attachment);
+                        AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetParent, targetActorInstance->GetEntityId());
+                        AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetLocalTM, AZ::Transform::CreateIdentity());
+                    }
+                }
+                else
+                {
+                    DetachFromEntity();
+                }
             }
         }
 
         //////////////////////////////////////////////////////////////////////////
         void ActorComponent::DestroyActor()
         {
+            DetachFromEntity();
+
             m_renderActorInstance.reset();
 
             if (m_actorInstance)
             {
-                DetachFromEntity();
-
-                m_attachmentTargetActor = nullptr;
 
                 ActorComponentNotificationBus::Event(
                     GetEntityId(),
@@ -605,8 +630,6 @@ namespace EMotionFX
             }
             else
             {
-                m_attachmentTargetActor.reset(actorInstance);
-
                 CheckAttachToEntity();
             }
         }
@@ -614,8 +637,6 @@ namespace EMotionFX
         void ActorComponent::OnActorInstanceDestroyed([[maybe_unused]] ActorInstance* actorInstance)
         {
             DetachFromEntity();
-
-            m_attachmentTargetActor = nullptr;
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
@@ -193,9 +193,8 @@ namespace EMotionFX
             void CheckAttachToEntity();
 
             Configuration                                   m_configuration;            ///< Component configuration.
-                                                                                        /// Live state
-            ActorAsset::ActorInstancePtr                    m_attachmentTargetActor;    ///< Target actor instance to attach to.
             AZ::EntityId                                    m_attachmentTargetEntityId; ///< Target actor entity ID
+            AZ::EntityId                                    m_attachmentPreviousParent; ///< The parent entity id before attaching to the attachment target.
             ActorAsset::ActorInstancePtr                    m_actorInstance;            ///< Live actor instance.
             AZStd::vector<AZ::EntityId>                     m_attachments;
 

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -301,6 +301,8 @@ namespace EMotionFX
         //////////////////////////////////////////////////////////////////////////
         void EditorActorComponent::DestroyActorInstance()
         {
+            DetachFromEntity();
+
             if (m_actorInstance)
             {
                 ActorComponentNotificationBus::Event(
@@ -979,6 +981,9 @@ namespace EMotionFX
                 }
             }
 
+            // Remember the parent entity before we re-parent (attach) it.
+            AZ::TransformBus::EventResult(m_attachmentPreviousParent, GetEntityId(), &AZ::TransformBus::Events::GetParentId);
+
             // Reattach all attachments
             for (AZ::EntityId& attachment : m_attachments)
             {
@@ -1052,8 +1057,8 @@ namespace EMotionFX
             if (attachedTo)
             {
                 attachedTo->RemoveAttachment(m_actorInstance.get());
+                AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetParent, m_attachmentPreviousParent);
             }
-            AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetParent, AZ::EntityId());
         }
 
         void EditorActorComponent::OnActorInstanceCreated(ActorInstance* actorInstance)
@@ -1083,6 +1088,9 @@ namespace EMotionFX
             {
                 return;
             }
+
+            // Remember the parent entity before we re-parent (attach) it.
+            AZ::TransformBus::EventResult(m_attachmentPreviousParent, GetEntityId(), &AZ::TransformBus::Events::GetParentId);
 
             DetachFromEntity();
             Attachment* attachmentSkin = AttachmentSkin::Create(targetActorInstance, m_actorInstance.get());

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
@@ -170,8 +170,10 @@ namespace EMotionFX
             bool                                m_renderBounds;             ///< Toggles rendering of the world bounding box.
             bool                                m_entityVisible;            ///< Entity visible from the EditorVisibilityNotificationBus
             SkinningMethod                      m_skinningMethod;           ///< The skinning method for this actor
+
             AttachmentType                      m_attachmentType;           ///< Attachment type.
             AZ::EntityId                        m_attachmentTarget;         ///< Target entity to attach to, if any.
+            AZ::EntityId                        m_attachmentPreviousParent; ///< The parent entity id before attaching to the attachment target.
             AZStd::string                       m_attachmentJointName;      ///< Joint name on target to which to attach (if ActorAttachment).
             size_t                              m_attachmentJointIndex;
             size_t                              m_lodLevel;


### PR DESCRIPTION
* Fixed a bug where the entity got reset to root level when unassigning the actor when using an attachment component.
* Removed attachment target actor variable that wasn't needed to be cached. (Fixed a crash)
* Code cleaning

Fixes #9550

https://user-images.githubusercontent.com/43751992/171650151-7ac1aa61-9ea8-4dae-b697-e0ad9a3e54b3.mp4

Signed-off-by: Benjamin Jillich <jillich@amazon.com>