### PR TITLE
Asset Processor - Fixed issue with AP waiting forever for builder registration

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.h
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.h
@@ -114,7 +114,7 @@ Q_SIGNALS:
 
 public Q_SLOTS:
     void ReadyToQuit(QObject* source);
-    void QuitRequested();
+    virtual void QuitRequested();
     void ObjectDestroyed(QObject* source);
     void Restart();
 

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -1524,8 +1524,8 @@ bool ApplicationManagerBase::Activate()
     // Start up a thread which will request a builder to start to handle the registration of gems/builders
     // Builder info will be sent back to the AP via the network connection, start up will wait for the info before continuing
     // See ApplicationManagerBase::InitConnectionManager BuilderRegistrationRequest for the resume point here
-    // Note that we can't wait here because the message comes back as a network message, which requires the main thread to process it
-    // Since we can't wait here, this also means the thread object will go out of scope, so we have to detach it before exiting
+    // Waiting here is not possible because the message comes back as a network message, which requires the main thread to process it
+    // Since execution has to continue, this also means the thread object will go out of scope, so it must be detached before exiting.
     AZStd::thread_desc desc;
     desc.m_name = "Builder Component Registration";
     AZStd::thread builderRegistrationThread(

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -210,7 +210,7 @@ void ApplicationManagerBase::InitAssetProcessorManager()
     if (commandLine->HasSwitch(Command_reprocessFileList.m_switch))
     {
         m_reprocessFileList = commandLine->GetSwitchValue(Command_reprocessFileList.m_switch, 0).c_str();
-    }    
+    }
 
     m_fileDependencyScanPattern = "*";
 
@@ -1230,7 +1230,7 @@ void ApplicationManagerBase::CheckForIdle()
         {
             return;
         }
-         
+
         if (shouldExit)
         {
             // If everything else is done, and it was requested to scan for missing product dependencies, perform that scan now.
@@ -1521,6 +1521,11 @@ bool ApplicationManagerBase::Activate()
     AssetProcessor::AssetProcessorStatusEntry entry(AssetProcessor::AssetProcessorStatus::Initializing_Builders, 0, QString());
     Q_EMIT AssetProcessorStatusChanged(entry);
 
+    // Start up a thread which will request a builder to start to handle the registration of gems/builders
+    // Builder info will be sent back to the AP via the network connection, start up will wait for the info before continuing
+    // See ApplicationManagerBase::InitConnectionManager BuilderRegistrationRequest for the resume point here
+    // Note that we can't wait here because the message comes back as a network message, which requires the main thread to process it
+    // Since we can't wait here, this also means the thread object will go out of scope, so we have to detach it before exiting
     AZStd::thread_desc desc;
     desc.m_name = "Builder Component Registration";
     AZStd::thread builderRegistrationThread(
@@ -1529,6 +1534,12 @@ bool ApplicationManagerBase::Activate()
         {
             AssetProcessor::BuilderRef builder;
             AssetProcessor::BuilderManagerBus::BroadcastResult(builder, &AssetProcessor::BuilderManagerBus::Events::GetBuilder, true);
+
+            if (!builder)
+            {
+                AZ_Error("ApplicationManagerBase", false, "AssetBuilder process failed to start.  Builder registration cannot complete.  Shutting down.");
+                AssetProcessor::MessageInfoBus::Broadcast(&AssetProcessor::MessageInfoBus::Events::OnBuilderRegistrationFailure);
+            }
         });
 
     builderRegistrationThread.detach();
@@ -1581,7 +1592,7 @@ static void HandleConditionalRetry(const AssetProcessor::BuilderRunJobOutcome& r
 {
     // If a lost connection occured or the process was terminated before a response can be read, and there is another retry to get the
     // response from a Builder, then handle the logic to log and sleep before attempting the retry of the job
-    if ((result == AssetProcessor::BuilderRunJobOutcome::LostConnection || 
+    if ((result == AssetProcessor::BuilderRunJobOutcome::LostConnection ||
          result == AssetProcessor::BuilderRunJobOutcome::ProcessTerminated ) && (retryCount <= AssetProcessor::RetriesForJobLostConnection))
     {
         const int delay = 1 << (retryCount-1);
@@ -1599,7 +1610,7 @@ static void HandleConditionalRetry(const AssetProcessor::BuilderRunJobOutcome& r
                             builderRef->GetUuid().ToString<AZStd::string>().c_str(),
                             retryCount+1,
                             delay);
-        } 
+        }
         else
         {
             AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Lost connection to builder %s. Retrying (Attempt %d  with %d second delay)",
@@ -1659,7 +1670,7 @@ void ApplicationManagerBase::RegisterBuilderInformation(const AssetBuilderSDK::A
 
                     HandleConditionalRetry(result, retryCount, builderRef);
 
-                } while ((result == AssetProcessor::BuilderRunJobOutcome::LostConnection || 
+                } while ((result == AssetProcessor::BuilderRunJobOutcome::LostConnection ||
                           result == AssetProcessor::BuilderRunJobOutcome::ProcessTerminated) &&
                           retryCount <= AssetProcessor::RetriesForJobLostConnection);
             }
@@ -1696,9 +1707,9 @@ void ApplicationManagerBase::RegisterBuilderInformation(const AssetBuilderSDK::A
                     retryCount++;
                     result = builderRef->RunJob<AssetBuilder::ProcessJobNetRequest, AssetBuilder::ProcessJobNetResponse>(
                         request, response, s_MaximumProcessJobsTimeSeconds, "process", "", &jobCancelListener, request.m_tempDirPath);
-                    
+
                     HandleConditionalRetry(result, retryCount, builderRef);
-                    
+
                 } while ((result == AssetProcessor::BuilderRunJobOutcome::LostConnection ||
                           result == AssetProcessor::BuilderRunJobOutcome::ProcessTerminated) &&
                           retryCount <= AssetProcessor::RetriesForJobLostConnection);
@@ -1932,6 +1943,11 @@ void ApplicationManagerBase::RemoveOldTempFolders()
 void ApplicationManagerBase::ConnectivityStateChanged(const AzToolsFramework::SourceControlState /*newState*/)
 {
     Q_EMIT SourceControlReady();
+}
+
+void ApplicationManagerBase::OnBuilderRegistrationFailure()
+{
+    QMetaObject::invokeMethod(this, "QuitRequested");
 }
 
 void ApplicationManagerBase::OnAssetProcessorManagerIdleState(bool isIdle)

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.h
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.h
@@ -58,6 +58,7 @@ class ApplicationManagerBase
     , protected AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler
     , public AssetProcessor::DiskSpaceInfoBus::Handler
     , protected AzToolsFramework::SourceControlNotificationBus::Handler
+    , public AssetProcessor::MessageInfoBus::Handler
 {
     Q_OBJECT
 public:
@@ -108,6 +109,9 @@ public:
 
     //! AzFramework::SourceControlNotificationBus::Handler
     void ConnectivityStateChanged(const AzToolsFramework::SourceControlState newState) override;
+
+    //! MessageInfoBus::Handler
+    void OnBuilderRegistrationFailure() override;
 
     void RemoveOldTempFolders();
 

--- a/Code/Tools/AssetProcessor/native/utilities/AssetUtilEBusHelper.h
+++ b/Code/Tools/AssetProcessor/native/utilities/AssetUtilEBusHelper.h
@@ -124,6 +124,8 @@ namespace AssetProcessor
         virtual void OnAssetFailed(const AZStd::string& /*sourceFileName*/) {}
         // Notifies listener about a general error
         virtual void OnErrorMessage([[maybe_unused]] const char* error) {}
+        // Notifies listener about a builder registration failure
+        virtual void OnBuilderRegistrationFailure() {};
     };
 
     using MessageInfoBus = AZ::EBus<MessageInfoBusTraits>;
@@ -265,5 +267,4 @@ namespace AssetProcessor
     };
 
     using  AssetServerInfoBus = AZ::EBus<AssetServerInfoBusTraits>;
-
 } // namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.h
+++ b/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.h
@@ -19,7 +19,6 @@ namespace AssetProcessor
 
 class BatchApplicationManager
     : public ApplicationManagerBase
-    , public AssetProcessor::MessageInfoBus::Handler
 {
     Q_OBJECT
 public:

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
@@ -29,7 +29,7 @@ namespace AssetProcessor
     //! Amount of time in seconds to wait for a builder to start up and connect
     // sometimes, builders take a long time to start because of things like virus scanners scanning each
     // builder DLL, so we give them a large margin.
-    static const int s_StartupConnectionWaitTimeS = 300;
+    static const int s_StartupConnectionWaitTimeS = 900;
 
     static const int s_MillisecondsInASecond = 1000;
 

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
@@ -26,11 +26,6 @@ namespace AssetProcessor
     //! Time in milliseconds to wait after each message pump cycle
     static const int s_IdleBuilderPumpingDelayMS = 100;
 
-    //! Amount of time in seconds to wait for a builder to start up and connect
-    // sometimes, builders take a long time to start because of things like virus scanners scanning each
-    // builder DLL, so we give them a large margin.
-    static const int s_StartupConnectionWaitTimeS = 900;
-
     static const int s_MillisecondsInASecond = 1000;
 
     static const char* s_buildersFolderName = "Builders";
@@ -42,6 +37,15 @@ namespace AssetProcessor
 
     bool Builder::WaitForConnection()
     {
+        if (m_startupWaitTimeS == 0)
+        {
+            const auto* settingsRegistry = AZ::SettingsRegistry::Get();
+            if (settingsRegistry)
+            {
+                settingsRegistry->Get(m_startupWaitTimeS, "/Amazon/AssetProcessor/Settings/BuilderManager/StartupTimeoutSeconds");
+            }
+        }
+
         if (m_connectionId == 0)
         {
             bool result = false;
@@ -55,7 +59,7 @@ namespace AssetProcessor
 
                 PumpCommunicator();
 
-                if (ticker.elapsed() > s_StartupConnectionWaitTimeS * s_MillisecondsInASecond
+                if (ticker.elapsed() > m_startupWaitTimeS * s_MillisecondsInASecond
                     || m_quitListener.WasQuitRequested()
                     || !IsRunning())
                 {
@@ -83,7 +87,7 @@ namespace AssetProcessor
             }
             else
             {
-                AZ_Error("Builder", false, "AssetBuilder failed to connect within %d seconds", s_StartupConnectionWaitTimeS);
+                AZ_Error("Builder", false, "AssetBuilder failed to connect within %d seconds", m_startupWaitTimeS);
             }
 
             return false;

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.h
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.h
@@ -134,6 +134,9 @@ namespace AssetProcessor
         AZStd::unique_ptr<ProcessCommunicatorTracePrinter> m_tracePrinter = nullptr;
 
         const AssetUtilities::QuitListener& m_quitListener;
+
+        //! Time to wait in seconds for a builder to startup before timing out.
+        AZ::s64 m_startupWaitTimeS = 0;
     };
 
     //! Scoped reference to a builder. Destructor returns the builder to the free builders pool
@@ -154,7 +157,7 @@ namespace AssetProcessor
         const Builder* operator->() const;
 
         explicit operator bool() const;
-    
+
         void release();
 
     private:

--- a/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
@@ -706,6 +706,13 @@ void GUIApplicationManager::ShowTrayIconErrorMessage(QString msg)
     }
 }
 
+void GUIApplicationManager::QuitRequested()
+{
+    m_startupErrorCollector = nullptr;
+
+    ApplicationManagerBase::QuitRequested();
+}
+
 void GUIApplicationManager::ShowTrayIconMessage(QString msg)
 {
     if (m_trayIcon && m_mainWindow && !m_mainWindow->isVisible())

--- a/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.h
+++ b/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.h
@@ -48,7 +48,6 @@ struct ErrorCollector
 
 class GUIApplicationManager
     : public ApplicationManagerBase
-    , public AssetProcessor::MessageInfoBus::Handler
 {
     Q_OBJECT
 public:
@@ -92,6 +91,7 @@ protected Q_SLOTS:
     void ShowMessageBox(QString title, QString msg, bool isCritical);
     void ShowTrayIconMessage(QString msg);
     void ShowTrayIconErrorMessage(QString msg);
+    void QuitRequested() override;
 
 private:
     bool Restart();

--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -34,6 +34,10 @@
                     // individual job took.
                     "MaxIndividualStats" : 4
                 },
+                "BuilderManager": {
+                    // Number of seconds to wait for AssetBuilder process to start before terminating the process
+                    "StartupTimeoutSeconds" : 900
+                },
                 "Platform pc": {
                     "tags": "tools,renderer,dx12,vulkan,null"
                 },


### PR DESCRIPTION
If the builder takes too long, the BuilderManager will timeout the process and terminate it.  
AP will now react to a builder failure by printing an error message and shutting down. 
Additionally, timeout was increased 3x from 5 minutes to 15 minutes as this situation was encountered when CPU was under heavy load.
Also fixed issue with StartupErrorCollector crashing on shutdown when QuitRequested is called

Fix was tested manually by lowering timeout to 1 second.