### PR TITLE
Rename nightly weekly pipeline

### DIFF
--- a/scripts/build/Platform/Android/build_config.json
+++ b/scripts/build/Platform/Android/build_config.json
@@ -8,7 +8,7 @@
     }
   },
   "profile_pipe": {
-    "TAGS": [
+    "TAGS":[
       "default",
       "snapshot"
     ],
@@ -77,8 +77,6 @@
     "TAGS":[
         "default",
         "weekly-build-metrics",
-        "periodic-incremental-daily",
-        "periodic-clean-weekly-internal",
         "snapshot"
     ],
     "COMMAND":"../Windows/build_asset_windows.cmd",

--- a/scripts/build/Platform/Android/build_config.json
+++ b/scripts/build/Platform/Android/build_config.json
@@ -28,8 +28,8 @@
   },
   "debug": {
     "TAGS":[
-        "nightly-incremental",
-        "weekly-clean-internal",
+        "periodic-incremental-daily",
+        "periodic-clean-weekly-internal",
         "weekly-build-metrics"
     ],
     "COMMAND":"../Windows/build_ninja_windows.cmd",
@@ -59,8 +59,8 @@
   },
   "profile_nounity": {
     "TAGS":[
-        "nightly-incremental",
-        "weekly-clean-internal",
+        "periodic-incremental-daily",
+        "periodic-clean-weekly-internal",
         "weekly-build-metrics"
     ],
     "COMMAND":"../Windows/build_ninja_windows.cmd",
@@ -77,8 +77,8 @@
     "TAGS":[
         "default",
         "weekly-build-metrics",
-        "nightly-incremental",
-        "weekly-clean-internal",
+        "periodic-incremental-daily",
+        "periodic-clean-weekly-internal",
         "snapshot"
     ],
     "COMMAND":"../Windows/build_asset_windows.cmd",
@@ -96,8 +96,8 @@
   },
   "release": {
     "TAGS":[
-        "nightly-incremental",
-        "weekly-clean-internal",
+        "periodic-incremental-daily",
+        "periodic-clean-weekly-internal",
         "weekly-build-metrics"
     ],
     "COMMAND":"../Windows/build_ninja_windows.cmd",
@@ -112,8 +112,8 @@
   },
   "monolithic_release": {
     "TAGS":[
-        "nightly-incremental",
-        "weekly-clean-internal",
+        "periodic-incremental-daily",
+        "periodic-clean-weekly-internal",
         "weekly-build-metrics"
     ],
     "COMMAND":"../Windows/build_ninja_windows.cmd",

--- a/scripts/build/Platform/Android/pipeline.json
+++ b/scripts/build/Platform/Android/pipeline.json
@@ -12,10 +12,10 @@
         "daily-pipeline-metrics": {
             "CLEAN_WORKSPACE": true
         },
-        "weekly-clean": {
+        "periodic-clean-weekly": {
             "CLEAN_WORKSPACE": true
         },
-        "weekly-clean-internal": {
+        "periodic-clean-weekly-internal": {
             "CLEAN_WORKSPACE": true
         },
         "snapshot": {

--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -30,8 +30,8 @@
   },
   "debug": {
     "TAGS": [
-      "nightly-incremental",
-      "weekly-clean-internal",
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_linux.sh",
@@ -45,8 +45,8 @@
   },
   "profile": {
     "TAGS": [
-      "nightly-incremental",
-      "weekly-clean-internal",
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal",
       "daily-pipeline-metrics",
       "weekly-build-metrics"
     ],
@@ -61,8 +61,8 @@
   },
   "profile_gcc_nounity": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal"
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal"
     ],
     "COMMAND": "build_linux.sh",
     "PARAMETERS": {
@@ -106,8 +106,8 @@
   },
   "test_profile_gcc_nounity": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal"
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal"
     ],
     "COMMAND": "build_test_linux.sh",
     "PARAMETERS": {
@@ -139,8 +139,8 @@
   "asset_profile": {
     "TAGS": [
       "weekly-build-metrics",
-      "nightly-incremental",
-      "weekly-clean-internal"
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal"
     ],
     "COMMAND": "build_asset_linux.sh",
     "PARAMETERS": {
@@ -173,8 +173,8 @@
   },
   "awsi_test_profile_pipe": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal"
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal"
     ],
     "steps": [
       "awsi_deployment",
@@ -203,8 +203,8 @@
   },
   "periodic_test_profile": {
     "TAGS": [
-      "nightly-incremental",
-      "weekly-clean-internal",
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_test_linux.sh",
@@ -221,8 +221,8 @@
   },
   "sandbox_test_profile": {
     "TAGS": [
-      "nightly-incremental",
-      "weekly-clean-internal",
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "PIPELINE_ENV": {
@@ -242,8 +242,8 @@
   },
   "benchmark_test_profile": {
     "TAGS": [
-      "nightly-incremental",
-      "weekly-clean-internal",
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_test_linux.sh",
@@ -260,8 +260,8 @@
   },
   "release": {
     "TAGS": [
-      "nightly-incremental",
-      "weekly-clean-internal",
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_linux.sh",
@@ -275,8 +275,8 @@
   },
   "monolithic_release": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal",
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_linux.sh",
@@ -300,7 +300,7 @@
   },
   "installer_pipe": { 
     "TAGS": [
-      "weekly-clean-internal",
+      "periodic-clean-weekly-internal",
       "nightly-installer"
     ],
     "steps": [
@@ -324,8 +324,8 @@
   },
   "install_profile_pipe": {
     "TAGS": [
-      "nightly-incremental",
-      "weekly-clean-internal"
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal"
     ],
     "PIPELINE_ENV": {
       "PROJECT_REPOSITORY_NAME": "TestProject"

--- a/scripts/build/Platform/Linux/pipeline.json
+++ b/scripts/build/Platform/Linux/pipeline.json
@@ -10,10 +10,10 @@
         "daily-pipeline-metrics": {
             "CLEAN_WORKSPACE": true
         },
-        "weekly-clean": {
+        "periodic-clean-weekly": {
             "CLEAN_WORKSPACE": true
         },
-        "weekly-clean-internal": {
+        "periodic-clean-weekly-internal": {
             "CLEAN_WORKSPACE": true
         },
         "snapshot": {
@@ -22,7 +22,7 @@
         }
     },
     "PIPELINE_JENKINS_PARAMETERS": {
-        "nightly-incremental-internal": [
+        "periodic-incremental-daily-internal": [
             {
                 "parameter_name": "O3DE_AWS_DEPLOY_REGION",
                 "parameter_type": "string",
@@ -45,7 +45,7 @@
                 "description": "The commit ID for locking the version of CDK applications to deploy."
             }
         ],
-        "weekly-clean-internal": [
+        "periodic-clean-weekly-internal": [
             {
                 "parameter_name": "O3DE_AWS_DEPLOY_REGION",
                 "parameter_type": "string",

--- a/scripts/build/Platform/Mac/build_config.json
+++ b/scripts/build/Platform/Mac/build_config.json
@@ -9,8 +9,8 @@
   },
   "profile_pipe": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal"
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal"
     ],
     "steps": [
       "profile",
@@ -30,8 +30,8 @@
   },
   "debug": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal",
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_mac.sh",
@@ -59,8 +59,8 @@
   },
   "profile_nounity": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal",
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_mac.sh",
@@ -75,8 +75,8 @@
   "asset_profile": {
     "TAGS": [
       "weekly-build-metrics",
-      "nightly-incremental-internal",
-      "weekly-clean-internal"
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal"
     ],
     "COMMAND": "build_asset_mac.sh",
     "PARAMETERS": {
@@ -108,8 +108,8 @@
   },
   "periodic_test_profile": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal",
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_test_mac.sh",
@@ -125,8 +125,8 @@
   },
   "benchmark_test_profile": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal",
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_test_mac.sh",
@@ -142,8 +142,8 @@
   },
   "release": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal",
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_mac.sh",
@@ -157,8 +157,8 @@
   },
   "monolithic_release": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal",
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_mac.sh",
@@ -183,8 +183,8 @@
   },
   "install_profile_pipe": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal"
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal"
     ],
     "PIPELINE_ENV": {
       "PROJECT_REPOSITORY_NAME": "TestProject"

--- a/scripts/build/Platform/Mac/pipeline.json
+++ b/scripts/build/Platform/Mac/pipeline.json
@@ -10,10 +10,10 @@
         "daily-pipeline-metrics": {
             "CLEAN_WORKSPACE": true
         },
-        "weekly-clean": {
+        "periodic-clean-weekly": {
             "CLEAN_WORKSPACE": true
         },
-        "weekly-clean-internal": {
+        "periodic-clean-weekly-internal": {
             "CLEAN_WORKSPACE": true
         }
     }

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -18,8 +18,8 @@
   },
   "debug_pipe": {
     "TAGS": [
-      "nightly-incremental",
-      "weekly-clean-internal"
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal"
     ],
     "steps": [
       "debug",
@@ -121,8 +121,8 @@
   },
   "profile_nounity": {
     "TAGS": [
-      "nightly-incremental",
-      "weekly-clean-internal",
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_windows.cmd",
@@ -155,8 +155,8 @@
   },
   "test_gpu_profile": {
     "TAGS":[
-      "nightly-incremental-internal",
-      "weekly-clean-internal"
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal"
     ],
     "PIPELINE_ENV":{
       "NODE_LABEL":"windows-gpu"
@@ -178,8 +178,8 @@
   "asset_profile": {
     "TAGS": [
       "weekly-build-metrics",
-      "nightly-incremental",
-      "weekly-clean-internal"
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal"
     ],
     "COMMAND": "build_asset_windows.cmd",
     "PARAMETERS": {
@@ -196,8 +196,8 @@
   },
   "awsi_test_profile_pipe": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal"
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal"
     ],
     "steps": [
       "awsi_deployment",
@@ -227,8 +227,8 @@
   },
   "periodic_test_profile": {
     "TAGS": [
-        "nightly-incremental",
-        "weekly-clean-internal",
+        "periodic-incremental-daily",
+        "periodic-clean-weekly-internal",
         "weekly-build-metrics"
     ],
     "COMMAND": "build_test_windows.cmd",
@@ -246,8 +246,8 @@
   },
   "periodic_test_gpu_profile": {
     "TAGS": [
-        "nightly-incremental-internal",
-        "weekly-clean-internal",
+        "periodic-incremental-daily-internal",
+        "periodic-clean-weekly-internal",
         "weekly-build-metrics"
     ],
     "PIPELINE_ENV":{
@@ -268,8 +268,8 @@
   },
   "sandbox_test_profile": {
     "TAGS": [
-      "nightly-incremental",
-      "weekly-clean-internal",
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "PIPELINE_ENV": {
@@ -290,8 +290,8 @@
   },
   "benchmark_test_profile": {
     "TAGS": [
-      "nightly-incremental",
-      "weekly-clean-internal",
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_test_windows.cmd",
@@ -310,8 +310,8 @@
   "release": {
     "TAGS": [
       "default",
-      "nightly-incremental",
-      "weekly-clean-internal",
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics",
       "snapshot"
     ],
@@ -327,8 +327,8 @@
   },
   "monolithic_release": {
     "TAGS": [
-      "nightly-incremental",
-      "weekly-clean-internal",
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_windows.cmd",
@@ -354,7 +354,7 @@
   },
   "installer_pipe": { 
     "TAGS": [
-      "weekly-clean-internal",
+      "periodic-clean-weekly-internal",
       "nightly-installer"
     ],
     "steps": [
@@ -391,8 +391,8 @@
   },
   "install_profile_pipe": {
     "TAGS": [
-      "nightly-incremental",
-      "weekly-clean-internal"
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal"
     ],
     "PIPELINE_ENV": {
       "PROJECT_REPOSITORY_NAME": "TestProject"

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -177,9 +177,7 @@
   },
   "asset_profile": {
     "TAGS": [
-      "weekly-build-metrics",
-      "periodic-incremental-daily",
-      "periodic-clean-weekly-internal"
+      "weekly-build-metrics"
     ],
     "COMMAND": "build_asset_windows.cmd",
     "PARAMETERS": {
@@ -310,8 +308,6 @@
   "release": {
     "TAGS": [
       "default",
-      "periodic-incremental-daily",
-      "periodic-clean-weekly-internal",
       "weekly-build-metrics",
       "snapshot"
     ],

--- a/scripts/build/Platform/Windows/pipeline.json
+++ b/scripts/build/Platform/Windows/pipeline.json
@@ -10,10 +10,10 @@
         "daily-pipeline-metrics": {
             "CLEAN_WORKSPACE": true
         },
-        "weekly-clean": {
+        "periodic-clean-weekly": {
             "CLEAN_WORKSPACE": true
         },
-        "weekly-clean-internal": {
+        "periodic-clean-weekly-internal": {
             "CLEAN_WORKSPACE": true
         },
         "snapshot": {
@@ -22,7 +22,7 @@
         }
     },
     "PIPELINE_JENKINS_PARAMETERS": {
-        "nightly-incremental-internal": [
+        "periodic-incremental-daily-internal": [
             {
                 "parameter_name": "O3DE_AWS_DEPLOY_REGION",
                 "parameter_type": "string",
@@ -45,7 +45,7 @@
                 "description": "The commit ID for locking the version of CDK applications to deploy."
             }
         ],
-        "weekly-clean-internal": [
+        "periodic-clean-weekly-internal": [
             {
                 "parameter_name": "O3DE_AWS_DEPLOY_REGION",
                 "parameter_type": "string",

--- a/scripts/build/Platform/iOS/build_config.json
+++ b/scripts/build/Platform/iOS/build_config.json
@@ -19,8 +19,8 @@
   },
   "debug": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal",
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "../Mac/build_mac.sh",
@@ -35,8 +35,8 @@
   },
   "profile": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal",
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal",
       "daily-pipeline-metrics",
       "weekly-build-metrics"
     ],
@@ -52,8 +52,8 @@
   },
   "profile_nounity": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal",
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "../Mac/build_mac.sh",
@@ -68,8 +68,8 @@
   },
   "asset_profile": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal",
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "../Mac/build_asset_mac.sh",
@@ -86,8 +86,8 @@
   },
   "release": {
     "TAGS": [
-      "nightly-incremental-internal",
-      "weekly-clean-internal",
+      "periodic-incremental-daily-internal",
+      "periodic-clean-weekly-internal",
       "weekly-build-metrics"
     ],
     "COMMAND": "../Mac/build_mac.sh",

--- a/scripts/build/Platform/iOS/pipeline.json
+++ b/scripts/build/Platform/iOS/pipeline.json
@@ -10,10 +10,10 @@
         "daily-pipeline-metrics": {
             "CLEAN_WORKSPACE": true
         },
-        "weekly-clean": {
+        "periodic-clean-weekly": {
             "CLEAN_WORKSPACE": true
         },
-        "weekly-clean-internal": {
+        "periodic-clean-weekly-internal": {
             "CLEAN_WORKSPACE": true
         }
     }


### PR DESCRIPTION
Change nighty/weekly pipeline tag to periodic daily/weekly
Remove periodic build configurations that are also built in default pipeline

Signed-off-by: Shirang Jia <shiranj@amazon.com>