### PR TITLE
[Terrain] Macro materials can cover very large world areas

### DIFF
--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroHelpers.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroHelpers.azsli
@@ -9,28 +9,39 @@
 
 #include <Atom/RPI/TangentSpace.azsli>
 
+static const uint InvalidMacroMaterialRef = 0x0000FFFF;
+
 void SampleMacroTexture(float2 worldPosition, float2 positionDdx, float2 positionDdy, out float3 macroColor, inout float3 macroNormal)
 {
     macroColor = TerrainMaterialSrg::m_baseColor.rgb;
 
     // ------- Macro Data -------
     uint2 macroGridResolution = TerrainSrg::GetMacroGridResolution();
-    float macroTileSize = TerrainSrg::m_macroMaterialGrid.m_tileSize;
-    float2 macroGridOffset = TerrainSrg::m_macroMaterialGrid.m_offset;
+    float macroTileSize = TerrainSrg::m_macroMaterialGridInfo.m_tileSize;
+    float2 macroGridOffset = TerrainSrg::m_macroMaterialGridInfo.m_offset;
     uint2 macroGridPosition = (worldPosition - macroGridOffset) / macroTileSize;
 
     uint macroTileIndex = macroGridResolution.x * macroGridPosition.y + macroGridPosition.x;
     static const uint NumMacroMaterialsPerTile = 4;
-    macroTileIndex *= NumMacroMaterialsPerTile;
 
+    TerrainSrg::MacroMaterialRefs refs = TerrainSrg::m_macroMaterialGridRefs[macroTileIndex];
+    uint materialIndices[4] = 
+    {
+        refs.m_index12 & 0x0000FFFF,
+        refs.m_index12 >> 16,
+        refs.m_index34 & 0x0000FFFF,
+        refs.m_index34 >> 16,
+    };
+    
     for (uint i = 0; i < NumMacroMaterialsPerTile; ++i)
     {
-        TerrainSrg::MacroMaterialData macroMaterialData = TerrainSrg::m_macroMaterialData[macroTileIndex + i];
-        if ((macroMaterialData.m_flags & 1) == 0)
+        uint ref = materialIndices[i];
+        if (ref == 0xFFFF)
         {
             break; // No more macro materials for this tile
         }
 
+        TerrainSrg::MacroMaterialData macroMaterialData = TerrainSrg::m_macroMaterialData[ref];
         if (any(worldPosition < macroMaterialData.m_boundsMin) || any (worldPosition > macroMaterialData.m_boundsMax))
         {
             continue; // Macro material exists for this tile but is out of the bounds of this particular position
@@ -54,8 +65,8 @@ void SampleMacroTexture(float2 worldPosition, float2 positionDdx, float2 positio
 
         if (macroMaterialData.m_normalMapId != 0xFFFF)
         {
-            bool flipX = macroMaterialData.m_flags & 2;
-            bool flipY = macroMaterialData.m_flags & 4;
+            bool flipX = macroMaterialData.m_flags & 1;
+            bool flipY = macroMaterialData.m_flags & 2;
             float factor = macroMaterialData.m_normalFactor;
 
             // Because of lacking derivatives in compute shader, manually sample and convert

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroHelpers.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroHelpers.azsli
@@ -27,16 +27,16 @@ void SampleMacroTexture(float2 worldPosition, float2 positionDdx, float2 positio
     TerrainSrg::MacroMaterialRefs refs = TerrainSrg::m_macroMaterialGridRefs[macroTileIndex];
     uint materialIndices[4] = 
     {
-        refs.m_index12 & 0x0000FFFF,
-        refs.m_index12 >> 16,
-        refs.m_index34 & 0x0000FFFF,
-        refs.m_index34 >> 16,
+        refs.m_index01 & 0x0000FFFF,
+        refs.m_index01 >> 16,
+        refs.m_index23 & 0x0000FFFF,
+        refs.m_index23 >> 16,
     };
     
     for (uint i = 0; i < NumMacroMaterialsPerTile; ++i)
     {
         uint ref = materialIndices[i];
-        if (ref == 0xFFFF)
+        if (ref == InvalidMacroMaterialRef)
         {
             break; // No more macro materials for this tile
         }

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainSrg.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainSrg.azsli
@@ -83,11 +83,17 @@ ShaderResourceGroup TerrainSrg : SRG_Terrain
         float2 m_boundsMax;
     };
 
-    struct MacroMaterialGrid
+    struct MacroMaterialGridInfo
     {
         uint m_resolution; // How many x/y tiles in grid. x & y stored in 16 bits each. Total number of entries in m_macroMaterialData will be x * y
         float m_tileSize; // Size of a tile in meters.
         float2 m_offset; // x/y offset of min x/y corner of grid.
+    };
+
+    struct MacroMaterialRefs
+    {
+        uint m_index12;
+        uint m_index34;
     };
 
     struct ClipmapData
@@ -201,14 +207,15 @@ ShaderResourceGroup TerrainSrg : SRG_Terrain
     StructuredBuffer<DetailMaterialData> m_detailMaterialData;
 
     StructuredBuffer<MacroMaterialData> m_macroMaterialData;
-    MacroMaterialGrid m_macroMaterialGrid;
+    StructuredBuffer<MacroMaterialRefs> m_macroMaterialGridRefs;
+    MacroMaterialGridInfo m_macroMaterialGridInfo;
     
     Texture2D m_textures[]; // bindless array of all textures for detail and macro materials
     float m_detailMaterialIdScale;
 
     uint2 GetMacroGridResolution()
     {
-        return uint2(m_macroMaterialGrid.m_resolution >> 16, m_macroMaterialGrid.m_resolution & 0xFFFF);
+        return uint2(m_macroMaterialGridInfo.m_resolution >> 16, m_macroMaterialGridInfo.m_resolution & 0xFFFF);
     }
     
     float2 CalculateCullDistance(uint lodLevel, float3 worldPosition)

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainSrg.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainSrg.azsli
@@ -92,8 +92,8 @@ ShaderResourceGroup TerrainSrg : SRG_Terrain
 
     struct MacroMaterialRefs
     {
-        uint m_index12;
-        uint m_index34;
+        uint m_index01;
+        uint m_index23;
     };
 
     struct ClipmapData

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.cpp
@@ -335,10 +335,9 @@ namespace Terrain
         for (++shaderDataIdx; shaderDataIdx < MacroMaterialsPerTile; ++shaderDataIdx)
         {
             materialRefs.at(shaderDataIdx - 1) = materialRefs.at(shaderDataIdx);
-            materialRefs.at(shaderDataIdx - 1) = materialRefs.at(shaderDataIdx);
         }
         // Disable the last entry.
-        materialRefs.at(shaderDataIdx - 1) = InvalidMacroMaterialRef;
+        materialRefs.at(MacroMaterialsPerTile - 1) = InvalidMacroMaterialRef;
     }
 
     template<typename Callback>

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.cpp
@@ -18,7 +18,7 @@ namespace Terrain
     namespace TerrainSrgInputs
     {
         static const char* const MacroMaterialData("m_macroMaterialData");
-        static const char* const MacroMaterialGrid("m_macroMaterialGrid");
+        static const char* const MacroMaterialGridRefs("m_macroMaterialGridRefs");
     }
     
     void TerrainMacroMaterialManager::Initialize(
@@ -51,10 +51,11 @@ namespace Terrain
     {
         m_isInitialized = false;
 
-        m_macroMaterialDataBuffer = {};
+        m_materialDataBuffer = {};
+        m_materialRefGridDataBuffer = {};
 
-        m_macroMaterialShaderData.clear();
-        m_macroMaterialEntities.clear();
+        m_materialShaderData.Clear();
+        m_materialRefGridShaderData.clear();
 
         RemoveAllImages();
         m_macroMaterials.clear();
@@ -73,22 +74,24 @@ namespace Terrain
     bool TerrainMacroMaterialManager::UpdateSrgIndices(AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>& terrainSrg)
     {
         const AZ::RHI::ShaderResourceGroupLayout* terrainSrgLayout = terrainSrg->GetLayout();
-            
-        m_macroMaterialGridIndex = terrainSrgLayout->FindShaderInputConstantIndex(AZ::Name(TerrainSrgInputs::MacroMaterialGrid));
-        AZ_Error(TerrainMacroMaterialManagerName, m_macroMaterialGridIndex.IsValid(), "Failed to find terrain srg input constant %s.", TerrainSrgInputs::MacroMaterialGrid);
         
         AZ::Render::GpuBufferHandler::Descriptor desc;
+        desc.m_srgLayout = terrainSrgLayout;
 
         // Set up the gpu buffer for macro material data
         desc.m_bufferName = "Macro Material Data";
         desc.m_bufferSrgName = TerrainSrgInputs::MacroMaterialData;
         desc.m_elementSize = sizeof(MacroMaterialShaderData);
-        desc.m_srgLayout = terrainSrgLayout;
-        m_macroMaterialDataBuffer = AZ::Render::GpuBufferHandler(desc);
+        m_materialDataBuffer = AZ::Render::GpuBufferHandler(desc);
+
+        desc.m_bufferName = "Macro Material Ref Grid";
+        desc.m_bufferSrgName = TerrainSrgInputs::MacroMaterialGridRefs;
+        desc.m_elementSize = sizeof(MacroMaterialRefs);
+        m_materialRefGridDataBuffer = AZ::Render::GpuBufferHandler(desc);
 
         m_bufferNeedsUpdate = true;
 
-        return m_macroMaterialDataBuffer.IsValid() && m_macroMaterialGridIndex.IsValid();
+        return m_materialDataBuffer.IsValid() && m_materialRefGridDataBuffer.IsValid();
     }
 
     void TerrainMacroMaterialManager::OnTerrainDataChanged(const AZ::Aabb& dirtyRegion [[maybe_unused]], TerrainDataChangedMask dataChangedMask)
@@ -122,6 +125,8 @@ namespace Terrain
             "OnTerrainMacroMaterialCreated called for a macro material that already exists. This indicates that either the bus is incorrectly sending out "
             "OnCreated announcements for existing materials, or the terrain feature processor isn't properly cleaning up macro materials.");
 
+        AZ_Assert(m_materialShaderData.GetSize() < AZStd::numeric_limits<uint16_t>::max(), "No more room for terrain macro materials.")
+
         MacroMaterial& macroMaterial = m_macroMaterials[entityId];
         macroMaterial.m_data = newMaterialData;
         if (newMaterialData.m_colorImage)
@@ -133,18 +138,20 @@ namespace Terrain
             macroMaterial.m_normalIndex = m_bindlessImageHandler->AppendBindlessImage(newMaterialData.m_normalImage->GetImageView());
         }
 
+        macroMaterial.m_materialRef = aznumeric_cast<uint16_t>(m_materialShaderData.Reserve());
+        UpdateMacroMaterialShaderEntry(m_materialShaderData.GetElement(macroMaterial.m_materialRef), macroMaterial);
+
         ForMacroMaterialsInBounds(newMaterialData.m_bounds,
-            [&](uint16_t idx, [[maybe_unused]] const AZ::Vector2& corner)
+            [&](uint32_t idx, [[maybe_unused]] const AZ::Vector2& corner)
             {
-                for (uint16_t offset = 0; offset < MacroMaterialsPerTile; ++offset)
+                MacroMaterialRefs& materialRefList = m_materialRefGridShaderData.at(idx);
+                for (uint8_t offset = 0; offset < MacroMaterialsPerTile; ++offset)
                 {
-                    MacroMaterialShaderData& macroMaterialShaderData = m_macroMaterialShaderData.at(idx + offset);
-                    if ((macroMaterialShaderData.m_flags & MacroMaterialShaderFlags::IsUsed) == 0)
+                    if (materialRefList.at(offset) == InvalidMacroMaterialRef)
                     {
-                        UpdateMacroMaterialShaderEntry(idx + offset, macroMaterial);
+                        materialRefList.at(offset) = macroMaterial.m_materialRef;
                         break;
                     }
-                    AZ_Assert(m_macroMaterialEntities.at(idx + offset) != entityId, "Found existing macro material tile for what should be a completely new macro material.");
                 }
             }
         );
@@ -198,21 +205,8 @@ namespace Terrain
         {
             UpdateImageIndex(macroMaterial.m_normalIndex, newMaterialData.m_normalImage);
         }
-        
-        ForMacroMaterialsInBounds(newMaterialData.m_bounds,
-            [&](uint16_t idx, [[maybe_unused]] const AZ::Vector2& corner)
-            {
-                for (uint16_t offset = 0; offset < MacroMaterialsPerTile; ++offset)
-                {
-                    if (m_macroMaterialEntities.at(idx + offset) == entityId)
-                    {
-                        UpdateMacroMaterialShaderEntry(idx + offset, macroMaterial);
-                        break;
-                    }
-                }
-            }
-        );
-        
+
+        UpdateMacroMaterialShaderEntry(m_materialShaderData.GetElement(macroMaterial.m_materialRef), macroMaterial);
         m_bufferNeedsUpdate = true;
     }
     
@@ -234,39 +228,40 @@ namespace Terrain
         MacroMaterial& macroMaterial = m_macroMaterials[entityId];
         macroMaterial.m_data.m_bounds = newRegion;
 
+        UpdateMacroMaterialShaderEntry(m_materialShaderData.GetElement(macroMaterial.m_materialRef), macroMaterial);
+
         AZ::Aabb changedRegion = oldRegion;
         changedRegion.AddAabb(newRegion);
 
         ForMacroMaterialsInBounds(changedRegion,
-            [&](uint16_t idx, const AZ::Vector2& corner)
+            [&](uint32_t idx, const AZ::Vector2& corner)
             {
                 AZ::Aabb tileAabb = AZ::Aabb::CreateFromMinMaxValues(
                     corner.GetX(), corner.GetY(), m_terrainBounds.GetMin().GetZ(),
                     corner.GetX() + MacroMaterialGridSize, corner.GetY() + MacroMaterialGridSize, m_terrainBounds.GetMax().GetZ());
 
                 bool overlapsNew = tileAabb.Overlaps(newRegion);
-                uint16_t end = idx + MacroMaterialsPerTile;
 
-                for (; idx < end; ++idx)
+                MacroMaterialRefs& materialRefList = m_materialRefGridShaderData.at(idx);
+                for (uint16_t refIdx = 0; refIdx < MacroMaterialsPerTile; ++refIdx)
                 {
-                    if (m_macroMaterialEntities.at(idx) == entityId)
+
+                    if (materialRefList.at(refIdx) == macroMaterial.m_materialRef)
                     {
-                        if (overlapsNew)
+                        if (!overlapsNew)
                         {
-                            // Update the macro material entry from this tile.
-                            UpdateMacroMaterialShaderEntry(idx, macroMaterial);
-                        }
-                        else
-                        {
-                            // Remove the macro material entry from this tile.
-                            RemoveMacroMaterialShaderEntry(idx);
+                            // Remove material from region it no longer overlaps
+                            RemoveMacroMaterialShaderEntry(refIdx, materialRefList);
                         }
                         break;
                     }
-                    else if (overlapsNew && (m_macroMaterialShaderData.at(idx).m_flags & MacroMaterialShaderFlags::IsUsed) == 0)
+                    else if (materialRefList.at(refIdx) == InvalidMacroMaterialRef)
                     {
-                        // Add a macro material entry from this tile. (!overlapsOld && overlapsNew)
-                        UpdateMacroMaterialShaderEntry(idx, macroMaterial);
+                        if (overlapsNew)
+                        {
+                            // Add material to region that it now overlaps but used to not.
+                            materialRefList.at(refIdx) = macroMaterial.m_materialRef;
+                        }
                         break;
                     }
                 }
@@ -293,15 +288,15 @@ namespace Terrain
         const MacroMaterial& macroMaterial = m_macroMaterials[entityId];
         
         ForMacroMaterialsInBounds(macroMaterial.m_data.m_bounds,
-            [&](uint16_t idx, [[maybe_unused]] const AZ::Vector2& corner)
+            [&](uint32_t idx, [[maybe_unused]] const AZ::Vector2& corner)
             {
-                uint16_t end = idx + MacroMaterialsPerTile;
-
-                for (; idx < end; ++idx)
+                MacroMaterialRefs& materialRefList = m_materialRefGridShaderData.at(idx);
+                for (uint16_t refIdx = 0; refIdx < MacroMaterialsPerTile; ++refIdx)
                 {
-                    if (m_macroMaterialEntities.at(idx) == entityId)
+                    if (materialRefList.at(refIdx) == macroMaterial.m_materialRef)
                     {
-                        RemoveMacroMaterialShaderEntry(idx);
+                        RemoveMacroMaterialShaderEntry(refIdx, materialRefList);
+                        break;
                     }
                 }
             }
@@ -315,18 +310,14 @@ namespace Terrain
         {
             m_bindlessImageHandler->RemoveBindlessImage(macroMaterial.m_normalIndex);
         }
-
+        m_materialShaderData.Release(macroMaterial.m_materialRef);
         m_macroMaterials.erase(entityId);
         m_bufferNeedsUpdate = true;
     }
     
-    void TerrainMacroMaterialManager::UpdateMacroMaterialShaderEntry(uint16_t shaderDataIdx, const MacroMaterial& macroMaterial)
+    void TerrainMacroMaterialManager::UpdateMacroMaterialShaderEntry(MacroMaterialShaderData& macroMaterialShaderData, const MacroMaterial& macroMaterial)
     {
-        m_macroMaterialEntities.at(shaderDataIdx) = macroMaterial.m_data.m_entityId;
-        MacroMaterialShaderData& macroMaterialShaderData = m_macroMaterialShaderData.at(shaderDataIdx);
-
         macroMaterialShaderData.m_flags = (MacroMaterialShaderFlags)(
-            MacroMaterialShaderFlags::IsUsed |
             (macroMaterial.m_data.m_normalFlipX ? MacroMaterialShaderFlags::FlipMacroNormalX : 0) |
             (macroMaterial.m_data.m_normalFlipY ? MacroMaterialShaderFlags::FlipMacroNormalY : 0)
         );
@@ -338,17 +329,16 @@ namespace Terrain
         macroMaterialShaderData.m_normalMapId = macroMaterial.m_normalIndex;
     }
 
-    void TerrainMacroMaterialManager::RemoveMacroMaterialShaderEntry(uint16_t shaderDataIdx)
+    void TerrainMacroMaterialManager::RemoveMacroMaterialShaderEntry(uint16_t shaderDataIdx, MacroMaterialRefs& materialRefs)
     {
         // Remove the macro material entry from this tile by copying the remaining entries on top.
-        for (++shaderDataIdx; shaderDataIdx % MacroMaterialsPerTile != 0; ++shaderDataIdx)
+        for (++shaderDataIdx; shaderDataIdx < MacroMaterialsPerTile; ++shaderDataIdx)
         {
-            m_macroMaterialEntities.at(shaderDataIdx - 1) = m_macroMaterialEntities.at(shaderDataIdx);
-            m_macroMaterialShaderData.at(shaderDataIdx - 1) = m_macroMaterialShaderData.at(shaderDataIdx);
+            materialRefs.at(shaderDataIdx - 1) = materialRefs.at(shaderDataIdx);
+            materialRefs.at(shaderDataIdx - 1) = materialRefs.at(shaderDataIdx);
         }
         // Disable the last entry.
-        m_macroMaterialEntities.at(shaderDataIdx - 1) = AZ::EntityId();
-        m_macroMaterialShaderData.at(shaderDataIdx - 1).m_flags = MacroMaterialShaderFlags(0);
+        materialRefs.at(shaderDataIdx - 1) = InvalidMacroMaterialRef;
     }
 
     template<typename Callback>
@@ -374,7 +364,7 @@ namespace Terrain
         {
             for (uint16_t x = xStartIdx; x < xEndIdx; ++x)
             {
-                uint16_t idx = (y * m_tilesX + x) * MacroMaterialsPerTile;
+                uint32_t idx = (y * m_tilesX + x);
                 const AZ::Vector2 corner = gridCorner + AZ::Vector2(x * MacroMaterialGridSize, y * MacroMaterialGridSize);
                 callback(idx, corner);
             }
@@ -392,16 +382,19 @@ namespace Terrain
 
             RemoveAllImages();
             m_macroMaterials.clear();
-
-            m_macroMaterialShaderData.clear();
-            m_macroMaterialEntities.clear();
+            m_materialShaderData.Clear();
+            m_materialRefGridShaderData.clear();
             
             m_tilesX = aznumeric_cast<uint16_t>(m_terrainBounds.GetXExtent() / MacroMaterialGridSize) + 1;
             m_tilesY = aznumeric_cast<uint16_t>(m_terrainBounds.GetYExtent() / MacroMaterialGridSize) + 1;
-            const uint32_t macroMaterialTileCount = m_tilesX * m_tilesY * MacroMaterialsPerTile;
+            const uint32_t macroMaterialTileCount = m_tilesX * m_tilesY;
             
-            m_macroMaterialShaderData.resize(macroMaterialTileCount);
-            m_macroMaterialEntities.resize(macroMaterialTileCount);
+            m_materialRefGridShaderData.resize(macroMaterialTileCount);
+            MacroMaterialRefs defaultRefs =
+            {
+                InvalidMacroMaterialRef, InvalidMacroMaterialRef, InvalidMacroMaterialRef, InvalidMacroMaterialRef
+            };
+            AZStd::fill(m_materialRefGridShaderData.begin(), m_materialRefGridShaderData.end(), defaultRefs);
 
             TerrainMacroMaterialRequestBus::EnumerateHandlers(
                 [&](TerrainMacroMaterialRequests* handler)
@@ -417,7 +410,8 @@ namespace Terrain
         if (m_bufferNeedsUpdate)
         {
             m_bufferNeedsUpdate = false;
-            m_macroMaterialDataBuffer.UpdateBuffer(m_macroMaterialShaderData.data(), aznumeric_cast<uint32_t>(m_macroMaterialShaderData.size()));
+            m_materialDataBuffer.UpdateBuffer(m_materialShaderData.GetRawData(), aznumeric_cast<uint32_t>(m_materialShaderData.GetSize()));
+            m_materialRefGridDataBuffer.UpdateBuffer(m_materialRefGridShaderData.data(), aznumeric_cast<uint32_t>(m_materialRefGridShaderData.size()));
 
             MacroMaterialGridShaderData macroMaterialGridShaderData;
             macroMaterialGridShaderData.m_offset = { m_terrainBounds.GetMin().GetX(), m_terrainBounds.GetMin().GetY() };
@@ -426,7 +420,8 @@ namespace Terrain
 
             if (terrainSrg)
             {   
-                m_macroMaterialDataBuffer.UpdateSrg(terrainSrg.get());
+                m_materialDataBuffer.UpdateSrg(terrainSrg.get());
+                m_materialRefGridDataBuffer.UpdateSrg(terrainSrg.get());
                 terrainSrg->SetConstant(m_macroMaterialGridIndex, macroMaterialGridShaderData);
             }
         }


### PR DESCRIPTION
Macro material information is stored in a grid across the terrain, with each tile in the grid supporting up to 4 macro materials and covering 64m x 64m. Previously the total number of indexable macro materials was limited to a uint16, which means it would break with worlds larger than 8km x 8km. Also each tile stored the full macro material for every entry at 32 bytes per entry / 128bytes per tile.

This change makes it so the total number of tiles is limited to uint32, which should be more than large enough for any amount of terrain with the current terrain system. This change also adds a level of indirection, so the macro materials themselves are stored in a separate buffer, and the tiles just reference that buffer with 16 bit indices. This means the 4 macro materials per tile only cost 2 bytes each / 8 bytes per tile.