### PR TITLE
Material Component: More explicit menu option names and links to open files in material editor

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -115,7 +115,6 @@ namespace AZ
                 // Add material functors that are in the top-level functors list. Other functors are also added per-property-group elsewhere.
                 AddEditorMaterialFunctors(m_editData.m_materialTypeSourceData.m_materialFunctorSourceData, AZ::RPI::MaterialNameContext{});
 
-
                 Populate();
                 LoadOverridesFromEntity();
                 return true;
@@ -457,7 +456,7 @@ namespace AZ
 
                         // This first converts to an acceptable runtime type in case the value came from script
                         const auto propertyIndex = m_materialInstance->FindPropertyIndex(property.GetId());
-                        if (!propertyIndex.IsNull())
+                        if (propertyIndex.IsValid())
                         {
                             const auto runtimeValue = AtomToolsFramework::ConvertToRuntimeType(editValue);
                             if (runtimeValue.IsValid())
@@ -638,7 +637,7 @@ namespace AZ
                 }
 
                 const auto propertyIndex = m_materialInstance->FindPropertyIndex(property.GetId());
-                if (!propertyIndex.IsNull())
+                if (propertyIndex.IsValid())
                 {
                     m_dirtyPropertyFlags.set(propertyIndex.GetIndex());
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -35,6 +35,7 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnin
 #include <QLabel>
 #include <QMenu>
 #include <QToolButton>
+#include <QToolTip>
 #include <QWidget>
 AZ_POP_DISABLE_WARNING
 
@@ -239,35 +240,35 @@ namespace AZ
                 if (!m_editData.m_materialSourcePath.empty())
                 {
                     // Inserting links that will be used to open the material/type in the material editor
-                    const auto& materialSourceRelativePath = GetRelativePath(m_editData.m_materialSourcePath);
+                    const auto& materialSourceFileName = GetFileName(m_editData.m_materialSourcePath);
                     if (IsSourceMaterial(m_editData.m_materialSourcePath))
                     {
                         materialInfo += tr("<tr><td><b>Material Source&emsp;</b></td><td><a href=\"%1\">%2</a></td></tr>")
                                             .arg(m_editData.m_materialSourcePath.c_str())
-                                            .arg(materialSourceRelativePath.c_str());
+                                            .arg(materialSourceFileName.c_str());
                     }
                     else
                     {
                         // Materials that come from other sources like FBX files will not have the link
                         materialInfo += tr("<tr><td><b>Material Source&emsp;</b></td><td>%1</td></tr>")
-                                            .arg(materialSourceRelativePath.c_str());
+                                            .arg(materialSourceFileName.c_str());
                     }
                 }
                 if (IsSourceMaterial(m_editData.m_materialParentSourcePath))
                 {
                     // Inserting links that will be used to open the material/type in the material editor
-                    const auto& materialParentSourceRelativePath = GetRelativePath(m_editData.m_materialParentSourcePath);
+                    const auto& materialParentSourceFileName = GetFileName(m_editData.m_materialParentSourcePath);
                     materialInfo += tr("<tr><td><b>Material Parent&emsp;</b></td><td><a href=\"%1\">%2</a></td></tr>")
                                         .arg(m_editData.m_materialParentSourcePath.c_str())
-                                        .arg(materialParentSourceRelativePath.c_str());
+                                        .arg(materialParentSourceFileName.c_str());
                 }
                 if (!m_editData.m_materialTypeSourcePath.empty())
                 {
                     // Inserting links that will be used to open the material/type in the material editor
-                    const auto& materialTypeSourceRelativePath = GetRelativePath(m_editData.m_materialTypeSourcePath);
+                    const auto& materialTypeSourceFileName = GetFileName(m_editData.m_materialTypeSourcePath);
                     materialInfo += tr("<tr><td><b>Material Type&emsp;</b></td><td><a href=\"%1\">%2</a></td></tr>")
                                         .arg(m_editData.m_materialTypeSourcePath.c_str())
-                                        .arg(materialTypeSourceRelativePath.c_str());
+                                        .arg(materialTypeSourceFileName.c_str());
                 }
                 materialInfo += tr("</table>");
 
@@ -277,6 +278,9 @@ namespace AZ
                 connect(m_overviewText, &QLabel::linkActivated, this, [](const QString& link) {
                     EditorMaterialSystemComponentRequestBus::Broadcast(
                         &EditorMaterialSystemComponentRequestBus::Events::OpenMaterialEditor, link.toUtf8().constData());
+                });
+                connect(m_overviewText, &QLabel::linkHovered, this, [](const QString& link) {
+                    QToolTip::showText(QCursor::pos(), link);
                 });
 
                 // Update the overview image with the last rendered preview of the primary entity's material.
@@ -682,6 +686,13 @@ namespace AZ
                 return relativePath;
             }
 
+            AZStd::string MaterialPropertyInspector::GetFileName(const AZStd::string& path) const
+            {
+                AZStd::string fileName;
+                AZ::StringFunc::Path::GetFullFileName(path.c_str(), fileName);
+                return fileName;
+            }
+
             bool MaterialPropertyInspector::IsSourceMaterial(const AZStd::string& path) const
             {
                 return !path.empty() && AZ::StringFunc::Path::IsExtension(path.c_str(), AZ::RPI::MaterialSourceData::Extension);
@@ -723,8 +734,8 @@ namespace AZ
 
                 if (IsSourceMaterial(m_editData.m_materialSourcePath))
                 {
-                    const auto& materialSourceRelativePath = GetRelativePath(m_editData.m_materialSourcePath);
-                    action = menu.addAction(tr("Save Over \"%1\"...").arg(materialSourceRelativePath.c_str()), [this] {
+                    const auto& materialSourceFileName = GetFileName(m_editData.m_materialSourcePath);
+                    action = menu.addAction(tr("Save Over \"%1\"...").arg(materialSourceFileName.c_str()), [this] {
                         SaveMaterial(m_editData.m_materialSourcePath);
                     });
                 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -682,7 +682,7 @@ namespace AZ
                 return relativePath;
             }
 
-            inline bool MaterialPropertyInspector::IsSourceMaterial(const AZStd::string& path) const
+            bool MaterialPropertyInspector::IsSourceMaterial(const AZStd::string& path) const
             {
                 return !path.empty() && AZ::StringFunc::Path::IsExtension(path.c_str(), AZ::RPI::MaterialSourceData::Extension);
             }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
@@ -70,12 +70,9 @@ namespace AZ
                 //! Builds all of the properties and generates the user interface for the inspector
                 void Populate();
 
-                bool SaveMaterial() const;
-                bool SaveMaterialToSource() const;
-                bool HasMaterialSource() const;
-                bool HasMaterialParentSource() const;
-                void OpenMaterialSourceInEditor() const;
-                void OpenMaterialParentSourceInEditor() const;
+                AZStd::string GetRelativePath(const AZStd::string& path) const;
+                bool IsSourceMaterial(const AZStd::string& path) const;
+                bool SaveMaterial(const AZStd::string& path) const;
                 void OpenMenu();
                 const EditorMaterialComponentUtil::MaterialEditData& GetEditData() const;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
@@ -71,6 +71,7 @@ namespace AZ
                 void Populate();
 
                 AZStd::string GetRelativePath(const AZStd::string& path) const;
+                AZStd::string GetFileName(const AZStd::string& path) const;
                 bool IsSourceMaterial(const AZStd::string& path) const;
                 bool SaveMaterial(const AZStd::string& path) const;
                 void OpenMenu();

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -293,7 +293,7 @@ namespace AZ
             AzToolsFramework::ViewPaneOptions inspectorOptions;
             inspectorOptions.canHaveMultipleInstances = true;
             inspectorOptions.preferedDockingArea = Qt::NoDockWidgetArea;
-            inspectorOptions.paneRect = QRect(50, 50, 400, 700);
+            inspectorOptions.paneRect = QRect(50, 50, 600, 1000);
             inspectorOptions.showInMenu = false;
             inspectorOptions.showOnToolsToolbar = false;
             AzToolsFramework::RegisterViewPane<AZ::Render::EditorMaterialComponentInspector::MaterialPropertyInspector>(


### PR DESCRIPTION
- Renamed save actions to clarify that “Save As” Is creating a new material from the settings in the inspector. “Save Over…” shows the name of the file that’s being overwritten in the menu option name.
- Removed the confusing “open” options from the material component inspector menu. Instead, any files that can be opened in the material editor now have links in the inspector heading. Clicking on any of the eligible material source files will open them in the material editor.
- This should address https://github.com/o3de/o3de/issues/9732 but is open to feedback for naming etc.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>
![image](https://user-images.githubusercontent.com/82461473/172743116-ba418a3e-c058-401a-8c52-e9f123fc8fea.png)
![image](https://user-images.githubusercontent.com/82461473/172743251-57c012c5-60fc-489c-aec9-ba3d38192625.png)
![image](https://user-images.githubusercontent.com/82461473/172743305-7f0eb410-d1b5-4582-8340-c65f23c08b67.png)
