### PR TITLE
Change OnPreparingSpawnable notification to be specific to tools

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/InMemorySpawnableAssetContainer.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/InMemorySpawnableAssetContainer.cpp
@@ -13,7 +13,6 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzFramework/Spawnable/InMemorySpawnableAssetContainer.h>
 #include <AzFramework/Spawnable/Spawnable.h>
-#include <AzFramework/Spawnable/SpawnableAssetBus.h>
 #include <AzFramework/Spawnable/SpawnableAssetUtils.h>
 
 namespace AzFramework
@@ -77,8 +76,6 @@ namespace AzFramework
             {
                 auto spawnable = azrtti_cast<Spawnable*>(assetData);
 
-                SpawnableAssetEventsBus::Broadcast(&SpawnableAssetEvents::OnPreparingSpawnable,
-                    *spawnable, assetInfo.m_relativePath);
                 spawnables.push_back(AZStd::make_pair<Spawnable*, const AZStd::string&>(spawnable, assetInfo.m_relativePath));
 
                 if (assetInfo.m_relativePath == rootProductId)

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableAssetBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableAssetBus.h
@@ -32,12 +32,6 @@ namespace AzFramework
         //!     an asset for loading.
         virtual void OnResolveAliases(
             Spawnable::EntityAliasVisitor& aliases, const SpawnableMetaData& metadata, const Spawnable::EntityList& entities) = 0;
-
-        //! Notification to allow systems to access a spawnable before it's been modified, for example, by aliasing
-        //! @param spawnable the spawnable that is being prepared
-        //! @param assetHint the spawnable asset name
-        virtual void OnPreparingSpawnable(
-            [[maybe_unused]] const Spawnable& spawnable, [[maybe_unused]] const AZStd::string& assetHint) {}
     };
 
     using SpawnableAssetEventsBus = AZ::EBus<SpawnableAssetEvents>;

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableAssetHandler.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableAssetHandler.cpp
@@ -12,7 +12,6 @@
 #include <AzCore/std/sort.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableAssetHandler.h>
-#include <AzFramework/Spawnable/SpawnableAssetBus.h>
 #include <AzFramework/Spawnable/SpawnableAssetUtils.h>
 
 namespace AzFramework
@@ -55,7 +54,6 @@ namespace AzFramework
         AZ::ObjectStream::FilterDescriptor filter(assetLoadFilterCB);
         if (AZ::Utils::LoadObjectFromStreamInPlace(*stream, *spawnable, nullptr /*SerializeContext*/, filter))
         {
-            SpawnableAssetEventsBus::Broadcast(&SpawnableAssetEventsBus::Events::OnPreparingSpawnable, *spawnable, asset.GetHint());
             SpawnableAssetUtils::ResolveEntityAliases(spawnable, asset.GetHint(), stream->GetStreamingDeadline(), stream->GetStreamingPriority(), assetLoadFilterCB);
             return AZ::Data::AssetHandler::LoadResult::LoadComplete;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabInMemorySpawnableConverter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabInMemorySpawnableConverter.cpp
@@ -15,6 +15,7 @@
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 #include <AzToolsFramework/Prefab/Spawnable/PrefabConverterStackProfileNames.h>
 #include <AzToolsFramework/Prefab/Spawnable/PrefabInMemorySpawnableConverter.h>
+#include <AzToolsFramework/Prefab/Spawnable/PrefabToInMemorySpawnableNotificationBus.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableAssetBus.h>
 
@@ -101,6 +102,14 @@ namespace AzToolsFramework::Prefab::PrefabConversionUtils
             info.m_relativePath = product.GetId();
             AZ::Data::AssetData* assetData = product.ReleaseAsset().release();
             assetDataInfoContainer.emplace_back(AZStd::make_pair<AZ::Data::AssetData*, AZ::Data::AssetInfo>(assetData, info));
+
+            if (info.m_assetType == azrtti_typeid<AzFramework::Spawnable>())
+            {
+                auto spawnable = azrtti_cast<AzFramework::Spawnable*>(assetData);
+
+                PrefabToInMemorySpawnableNotificationBus::Broadcast(&PrefabToInMemorySpawnableNotifications::OnPreparingInMemorySpawnableFromPrefab,
+                    *spawnable, info.m_relativePath);
+            }
         }
 
         return m_assetContainer.CreateInMemorySpawnableAsset(assetDataInfoContainer, loadReferencedAssets, spawnableName);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabToInMemorySpawnableNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabToInMemorySpawnableNotificationBus.h
@@ -18,6 +18,12 @@ namespace AzToolsFramework::Prefab
         : public AZ::EBusTraits
     {
     public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        //////////////////////////////////////////////////////////////////////////
+
         //! Notification to allow systems to access a spawnable before it's been modified, for example, by aliasing
         //! @param spawnable the spawnable that is being prepared
         //! @param assetHint the spawnable asset name

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabToInMemorySpawnableNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabToInMemorySpawnableNotificationBus.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <AzFramework/Entity/EntityContext.h>
+
+namespace AzToolsFramework::Prefab
+{
+    //! This EBus is used to send notifications during the conversion of a prefab template to an in-memory spawnable
+    class PrefabToInMemorySpawnableNotifications
+        : public AZ::EBusTraits
+    {
+    public:
+        //! Notification to allow systems to access a spawnable before it's been modified, for example, by aliasing
+        //! @param spawnable the spawnable that is being prepared
+        //! @param assetHint the spawnable asset name
+        virtual void OnPreparingInMemorySpawnableFromPrefab(
+            [[maybe_unused]] const AzFramework::Spawnable& spawnable, [[maybe_unused]] const AZStd::string& assetHint) {}
+
+    protected:
+        ~PrefabToInMemorySpawnableNotifications() = default;
+    };
+
+    using PrefabToInMemorySpawnableNotificationBus = AZ::EBus<PrefabToInMemorySpawnableNotifications>;
+
+} // namespace AzToolsFramework::Prefab

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -759,6 +759,7 @@ set(FILES
     Prefab/Spawnable/PrefabDocument.h
     Prefab/Spawnable/PrefabDocument.inl
     Prefab/Spawnable/PrefabDocument.cpp
+    Prefab/Spawnable/PrefabToInMemorySpawnableNotificationBus.h
     Prefab/Spawnable/ProcesedObjectStore.h
     Prefab/Spawnable/ProcesedObjectStore.cpp
     Prefab/Spawnable/PrefabProcessor.h


### PR DESCRIPTION
The "OnPreparingSpawnable" notification was a generic notification that was being called on every spawnable load. This PR replaces this notification with a more specific one that is only called on the tools side when a prefab template is to be processed and converted into an in-memory spawnable. This is used in editor networking code so that unchanged spawnables can be sent to the server and have their aliases resolved there instead of resolving them first on the client, which may have different alias resolving logic.

Signed-off-by: abrmich <abrmich@amazon.com>