### PR TITLE
Fix crash accessing from deleted path

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -245,9 +245,9 @@ namespace O3DE::ProjectManager
 
                 if (!keepProject.contains(projectButtonsIter.key()))
                 {
+                    m_fileSystemWatcher->removePath(QDir::toNativeSeparators(projectButtonsIter.value()->GetProjectInfo().m_path + "/project.json"));
                     projectButtonsIter.value()->deleteLater();
                     projectButtonsIter = m_projectButtons.erase(projectButtonsIter);
-                    m_fileSystemWatcher->removePath(QDir::toNativeSeparators(projectButtonsIter.value()->GetProjectInfo().m_path + "/project.json"));
                 }
                 else
                 {


### PR DESCRIPTION
The QString and likely more, were being accessed after deletion.
Fixes #9707 

**Testing**
- Add, rename and remove projects

Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>