### PR TITLE
Initial PR template for O3DE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,18 @@
+Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
+
+## What does this PR do?
+_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_
+
+## Related items
+_Please link any issues, RFCs or other items that are relevant to this PR_
+
+## How was this PR tested?
+_Please describe any testing performed_
+
+## Checklist
+_Put an `x` in the boxes that apply. You can update after the PR is created. Checklist helps maintainers understand scope of change but if you have questions please ask._
+
+- [ ] PR includes unit or automation tests. If not please consider adding these.
+- [ ] Has User facing changes. If so please consider adding screenshots and asking for SIG/ui-ux reviewers
+- [ ] Requires documentation. If so please consider adding links to documentation issues in o3de.org
+- [ ] Breaking change. If so please send out breaking change notification in advance.


### PR DESCRIPTION
Provide an initial PR template to encourage PR creators to provide information that helps maintainers review PRs

* GitHub best practice to have such a template.

GitHub docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository

Expectations of this PR:
* Gather feedback from community
* Will advertise in SIG-all
* Will bring to TSC for final approval prior to merge

Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>