### PR TITLE
Atom/antonmic/pass debug fix

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
@@ -109,18 +109,6 @@ namespace AZ
             // Returns the root of the pass tree hierarchy
             const Ptr<ParentPass>& GetRootPass() override;
 
-            // Calls Build() on passes queued in m_buildPassList
-            void BuildPasses();
-
-            // Calls Initialize() on passes queued in m_initializePassList
-            void InitializePasses();
-
-            // Validates Pass Hierarchy after building
-            void Validate();
-
-            // Removes queued passes in m_deletePassList from the hierarchy
-            void RemovePasses();
-
             // Functions for queuing passes in the lists below
             void QueueForBuild(Pass* pass) override;
             void QueueForRemoval(Pass* pass) override;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
@@ -144,9 +144,6 @@ namespace AZ
             // The root of the pass tree hierarchy
             Ptr<ParentPass> m_rootPass = nullptr;
 
-            // Whether the Pass System is currently hot reloading passes 
-            bool m_isHotReloading = false;
-
             // Name of the pass targeted for debugging
             AZ::Name m_targetedPassDebugName;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
@@ -200,13 +200,10 @@ namespace AZ
         {
             AZ_PROFILE_SCOPE(RPI, "PassSystem: ProcessQueuedChanges");
 
-            // Track whether pass hierarchy has changed or not this frame
-            bool change = false;
-
             // Process render pipelines
             for (RenderPipeline*& pipeline : m_renderPipelines)
             {
-                change = pipeline->m_passTree.ProcessQueuedChanges() || change;
+                pipeline->m_passTree.ProcessQueuedChanges();
             }
 
             // Erase any passes with pipelines from the passes without pipeline container
@@ -216,16 +213,7 @@ namespace AZ
                 });
 
             // Process passes that don't have a pipeline
-            change = m_passesWithoutPipeline.ProcessQueuedChanges() || change;
-
-            // If any changes to the hierarchy were made this frame
-            if (change)
-            {
-#if AZ_RPI_ENABLE_PASS_DEBUGGING
-                AZ_Printf("PassSystem", "\nFinished building passes:\n");
-                DebugPrintPassHierarchy();
-#endif
-            }
+            m_passesWithoutPipeline.ProcessQueuedChanges();
         }
 
         void PassSystem::FrameUpdate(RHI::FrameGraphBuilder& frameGraphBuilder)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassTree.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassTree.cpp
@@ -77,11 +77,8 @@ namespace AZ::RPI
         if (m_passesChangedThisFrame)
         {
 #if AZ_RPI_ENABLE_PASS_DEBUGGING
-            if (!m_isHotReloading)
-            {
-                AZ_Printf("PassSystem", "\nFinished building passes:\n");
-                DebugPrintPassHierarchy();
-            }
+            AZ_Printf("PassTree", "\nFinished building passes:\n");
+            m_rootPass->DebugPrint();
 #endif
         }
     }


### PR DESCRIPTION
Fixed compilation error in PassTree.cpp when AZ_RPI_ENABLE_PASS_DEBUGGING is enabled
Removed unused functionality out of PassSystem