### PR TITLE
chore(AZCore): standardized string formatting

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Aabb.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Aabb.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Math/MathStringConversions.h>
 #include <AzCore/Math/Aabb.h>
 
 #include <AzCore/Math/Obb.h>
@@ -14,67 +15,72 @@
 
 namespace AZ
 {
-    //Script Wrappers for Axis Aligned Bounding Box
-    void AabbDefaultConstructor(AZ::Aabb* thisPtr)
-    {
-        new (thisPtr) AZ::Aabb(AZ::Aabb::CreateNull());
-    }
 
-
-    void AabbSetGeneric(Aabb* thisPtr, ScriptDataContext& dc)
-    {
-        if (dc.GetNumArguments() == 2 && dc.IsClass<Vector3>(0) && dc.IsClass<Vector3>(1))
+    namespace Internal {
+        //Script Wrappers for Axis Aligned Bounding Box
+        void AabbDefaultConstructor(AZ::Aabb* thisPtr)
         {
-            Vector3 min, max;
-            dc.ReadArg<Vector3>(0, min);
-            dc.ReadArg<Vector3>(1, max);
-            thisPtr->Set(min, max);
+            new (thisPtr) AZ::Aabb(AZ::Aabb::CreateNull());
         }
-        else
+
+
+        void AabbSetGeneric(Aabb* thisPtr, ScriptDataContext& dc)
         {
-            AZ_Error("Script", false, "ScriptAabb Set only supports two arguments: Vector3 min, Vector3 max");
-        }
-    }
-
-
-    void AabbGetAsSphereMultipleReturn(const Aabb* thisPtr, ScriptDataContext& dc)
-    {
-        Vector3 center;
-        float radius;
-        thisPtr->GetAsSphere(center, radius);
-        dc.PushResult(center);
-        dc.PushResult(radius);
-    }
-
-
-    void AabbContainsGeneric(const Aabb* thisPtr, ScriptDataContext& dc)
-    {
-        if (dc.GetNumArguments() == 1)
-        {
-            if (dc.IsClass<Vector3>(0))
+            if (dc.GetNumArguments() == 2 && dc.IsClass<Vector3>(0) && dc.IsClass<Vector3>(1))
             {
-                Vector3 v = Vector3::CreateZero();
-                dc.ReadArg<Vector3>(0, v);
-                dc.PushResult<bool>(thisPtr->Contains(v));
+                Vector3 min, max;
+                dc.ReadArg<Vector3>(0, min);
+                dc.ReadArg<Vector3>(1, max);
+                thisPtr->Set(min, max);
             }
-            else if (dc.IsClass<Aabb>(0))
+            else
             {
-                Aabb aabb = Aabb::CreateNull();
-                dc.ReadArg<Aabb>(0, aabb);
-                dc.PushResult<bool>(thisPtr->Contains(aabb));
+                AZ_Error("Script", false, "ScriptAabb Set only supports two arguments: Vector3 min, Vector3 max");
             }
         }
 
-        if (dc.GetNumResults() == 0)
+
+        void AabbGetAsSphereMultipleReturn(const Aabb* thisPtr, ScriptDataContext& dc)
         {
-            AZ_Error("Script", false, "ScriptAabb Contains expects one argument: Either Vector3 or Aabb");
+            Vector3 center;
+            float radius;
+            thisPtr->GetAsSphere(center, radius);
+            dc.PushResult(center);
+            dc.PushResult(radius);
         }
-    }
 
 
-    AZStd::string AabbToString(const Aabb& aabb)
-    {
-        return AZStd::string::format("Min %s Max %s", Vector3ToString(aabb.GetMin()).c_str(), Vector3ToString(aabb.GetMax()).c_str());
+        void AabbContainsGeneric(const Aabb* thisPtr, ScriptDataContext& dc)
+        {
+            if (dc.GetNumArguments() == 1)
+            {
+                if (dc.IsClass<Vector3>(0))
+                {
+                    Vector3 v = Vector3::CreateZero();
+                    dc.ReadArg<Vector3>(0, v);
+                    dc.PushResult<bool>(thisPtr->Contains(v));
+                }
+                else if (dc.IsClass<Aabb>(0))
+                {
+                    Aabb aabb = Aabb::CreateNull();
+                    dc.ReadArg<Aabb>(0, aabb);
+                    dc.PushResult<bool>(thisPtr->Contains(aabb));
+                }
+            }
+
+            if (dc.GetNumResults() == 0)
+            {
+                AZ_Error("Script", false, "ScriptAabb Contains expects one argument: Either Vector3 or Aabb");
+            }
+        }
+
+
+        AZStd::string AAbbToString(const Aabb& aabb)
+        {
+            return AZStd::string::format("Min %s Max %s", 
+                AZStd::to_string(aabb.GetMin(), AZStd::MathStringFormat::Vector3ScriptFormat).c_str(), 
+                AZStd::to_string(aabb.GetMax(), AZStd::MathStringFormat::Vector3ScriptFormat).c_str());
+        }
     }
 
 
@@ -96,10 +102,10 @@ namespace AZ
                 ->Attribute(AZ::Script::Attributes::Module, "math")
                 ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::ListOnly)
                 ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
-                ->Attribute(AZ::Script::Attributes::GenericConstructorOverride, &AabbDefaultConstructor)
+                ->Attribute(AZ::Script::Attributes::GenericConstructorOverride, &Internal::AabbDefaultConstructor)
                 ->Property("min", &Aabb::GetMin, &Aabb::SetMin)
                 ->Property("max", &Aabb::GetMax, &Aabb::SetMax)
-                ->Method("ToString", &AabbToString)
+                ->Method("ToString", &Internal::AAbbToString)
                 ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::ToString)
                 ->Method("CreateNull", &Aabb::CreateNull)
                 ->Method("IsValid", &Aabb::IsValid)
@@ -111,17 +117,17 @@ namespace AZ
                 ->Method("GetExtents", &Aabb::GetExtents)
                 ->Method("GetCenter", &Aabb::GetCenter)
                 ->Method("Set", &Aabb::Set)
-                ->Attribute(AZ::Script::Attributes::MethodOverride, &AabbSetGeneric)
+                ->Attribute(AZ::Script::Attributes::MethodOverride, &Internal::AabbSetGeneric)
                 ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::ListOnly)
                 ->Method("CreateFromObb", &Aabb::CreateFromObb)
                 ->Method("GetXExtent", &Aabb::GetXExtent)
                 ->Method("GetYExtent", &Aabb::GetYExtent)
                 ->Method("GetZExtent", &Aabb::GetZExtent)
                 ->Method("GetAsSphere", &Aabb::GetAsSphere, nullptr, "() -> Vector3(center) and float(radius)")
-                ->Attribute(AZ::Script::Attributes::MethodOverride, &AabbGetAsSphereMultipleReturn)
+                ->Attribute(AZ::Script::Attributes::MethodOverride, &Internal::AabbGetAsSphereMultipleReturn)
                 ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::ListOnly)
                 ->Method<bool (Aabb::*)(const Aabb&) const>("Contains", &Aabb::Contains, nullptr, "const Vector3& or const Aabb&")
-                ->Attribute(AZ::Script::Attributes::MethodOverride, &AabbContainsGeneric)
+                ->Attribute(AZ::Script::Attributes::MethodOverride, &Internal::AabbContainsGeneric)
                 ->Method<bool (Aabb::*)(const Vector3&) const>("ContainsVector3", &Aabb::Contains, nullptr, "const Vector3&")
                 ->Attribute(AZ::Script::Attributes::Ignore, 0) // ignore for script since we already got the generic contains above
                 ->Method("Overlaps", &Aabb::Overlaps)

--- a/Code/Framework/AzCore/AzCore/Math/Color.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Color.cpp
@@ -6,6 +6,8 @@
  *
  */
 
+#include <AzCore/Math/MathStringConversions.h>
+#include "AzCore/std/string/conversions.h"
 #include "Color.h"
 #include <AzCore/Math/MathScriptHelpers.h>
 
@@ -217,7 +219,7 @@ namespace AZ
 
         AZStd::string ColorToString(const Color& c)
         {
-            return AZStd::string::format("(r=%.7f,g=%.7f,b=%.7f,a=%.7f)", static_cast<float>(c.GetR()), static_cast<float>(c.GetG()), static_cast<float>(c.GetB()), static_cast<float>(c.GetA()));
+            return AZStd::to_string(c, AZStd::MathStringFormat::ColorScriptFormat);
         }
     }
 

--- a/Code/Framework/AzCore/AzCore/Math/MathScriptHelpers.h
+++ b/Code/Framework/AzCore/AzCore/Math/MathScriptHelpers.h
@@ -22,8 +22,14 @@ namespace AZ
     class Quaternion;
     class Transform;
 
+    // O3DE_DEPRECATION_NOTICE(GHI-XX)
+    //! @deprecated replace with AZStd::to_string(v, MathStringFormat::Vector3ScriptFormat)
     AZStd::string Vector3ToString(const Vector3& v);
+    // O3DE_DEPRECATION_NOTICE(GHI-XX)
+    //! @deprecated replace with AZStd::to_string(v, MathStringFormat::Vector4ScriptFormat)
     AZStd::string Vector4ToString(const Vector4& v);
+    // O3DE_DEPRECATION_NOTICE(GHI-XX)
+    //! @deprecated replace with AZStd::to_string(v, MathStringFormat::QuaternionScriptFormat)
     AZStd::string QuaternionToString(const Quaternion& v);
     AZStd::string TransformToString(const Transform& t);
 

--- a/Code/Framework/AzCore/AzCore/Math/MathStringConversions.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MathStringConversions.cpp
@@ -19,55 +19,63 @@
 
 namespace AZStd
 {
-    void to_string(string& str, const AZ::Vector2& value)
+    void to_string(string& str, const AZ::Vector2& value, const char* format)
     {
-        str = AZStd::string::format("%.8f,%.8f", 
-            static_cast<float>(value.GetX()), 
+        str = AZStd::string::format(format,
+            static_cast<float>(value.GetX()),
             static_cast<float>(value.GetY()));
     }
 
-    void to_string(string& str, const AZ::Vector3& value)
+    void to_string(string& str, const AZ::Vector3& value, const char* format)
     {
-        str = AZStd::string::format("%.8f,%.8f,%.8f", 
-            static_cast<float>(value.GetX()), 
-            static_cast<float>(value.GetY()), 
+        str = AZStd::string::format(format,
+            static_cast<float>(value.GetX()),
+            static_cast<float>(value.GetY()),
             static_cast<float>(value.GetZ()));
     }
 
-    void to_string(string& str, const AZ::Vector4& value)
+    void to_string(string& str, const AZ::Vector4& value, const char* format)
     {
-        str = AZStd::string::format("%.8f,%.8f,%.8f,%.8f", 
-            static_cast<float>(value.GetX()), 
-            static_cast<float>(value.GetY()), 
-            static_cast<float>(value.GetZ()), 
-            static_cast<float>(value.GetW()));
-    }
-    
-    void to_string(string& str, const AZ::Quaternion& value)
-    {
-        str = AZStd::string::format("%.8f,%.8f,%.8f,%.8f",
+        str = AZStd::string::format(format,
             static_cast<float>(value.GetX()),
             static_cast<float>(value.GetY()),
             static_cast<float>(value.GetZ()),
             static_cast<float>(value.GetW()));
     }
 
-    void to_string(string& str, const AZ::Matrix3x3& value)
+    void to_string(string& str, const AZ::Quaternion& value, const char* format)
     {
-        str = AZStd::string::format(
-            "%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f",
+        str = AZStd::string::format(format,
+            static_cast<float>(value.GetX()),
+            static_cast<float>(value.GetY()),
+            static_cast<float>(value.GetZ()),
+            static_cast<float>(value.GetW()));
+    }
+
+    void to_string(string& str, const AZ::Matrix3x3& value, const char* format)
+    {
+        str = AZStd::string::format(format, 
             static_cast<float>(value(0, 0)), static_cast<float>(value(1, 0)), static_cast<float>(value(2, 0)),
             static_cast<float>(value(0, 1)), static_cast<float>(value(1, 1)), static_cast<float>(value(2, 1)),
             static_cast<float>(value(0, 2)), static_cast<float>(value(1, 2)), static_cast<float>(value(2, 2)));
     }
 
-    void to_string(string& str, const AZ::Matrix4x4& value)
+    void to_string(string& str, const AZ::Matrix4x4& value, const char* format)
     {
-        str = AZStd::string::format("%.8f,%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f,%.8f", 
+        str = AZStd::string::format(format, 
             static_cast<float>(value(0, 0)), static_cast<float>(value(1, 0)), static_cast<float>(value(2, 0)), static_cast<float>(value(3, 0)),
             static_cast<float>(value(0, 1)), static_cast<float>(value(1, 1)), static_cast<float>(value(2, 1)), static_cast<float>(value(3, 1)),
             static_cast<float>(value(0, 2)), static_cast<float>(value(1, 2)), static_cast<float>(value(2, 2)), static_cast<float>(value(3, 2)),
             static_cast<float>(value(0, 3)), static_cast<float>(value(1, 3)), static_cast<float>(value(2, 3)), static_cast<float>(value(3, 3)));
+    }
+
+    void to_string(string& str, const AZ::Matrix3x4& value, const char* format)
+    {
+        str = AZStd::string::format(format, 
+            static_cast<float>(value(0, 0)), static_cast<float>(value(1, 0)), static_cast<float>(value(2, 0)),
+            static_cast<float>(value(0, 1)), static_cast<float>(value(1, 1)), static_cast<float>(value(2, 1)), 
+            static_cast<float>(value(0, 2)), static_cast<float>(value(1, 2)), static_cast<float>(value(2, 2)), 
+            static_cast<float>(value(0, 3)), static_cast<float>(value(1, 3)), static_cast<float>(value(2, 3)));
     }
 
     void to_string(string& str, const AZ::Transform& value)
@@ -90,8 +98,9 @@ namespace AZStd
             static_cast<float>(value.GetMax().GetY()), static_cast<float>(value.GetMax().GetZ()));
     }
 
-    void to_string(string& str, const AZ::Color& color)
+    void to_string(string& str, const AZ::Color& color, const char* format)
     {
-        str = AZStd::string::format("R:%d, G:%d, B:%d A:%d", color.GetR8(), color.GetG8(), color.GetB8(), color.GetA8());
+        str = AZStd::string::format(format, color.GetR8(), color.GetG8(), color.GetB8(), color.GetA8());
     }
-}
+
+} // namespace AZStd

--- a/Code/Framework/AzCore/AzCore/Math/MathStringConversions.h
+++ b/Code/Framework/AzCore/AzCore/Math/MathStringConversions.h
@@ -30,29 +30,29 @@ namespace AZStd
 {
     namespace MathStringFormat
     {
-        static const char* Vector2DefaultFormat = "%.8f,%.8f";
-        static const char* Vector2ScriptFormat = "(x=%.7f,y=%.7f)";
+        inline constexpr const char* Vector2DefaultFormat = "%.8f,%.8f";
+        inline constexpr const char* Vector2ScriptFormat = "(x=%.7f,y=%.7f)";
 
-        static const char* Vector3DefaultFormat = "%.8f,%.8f,%.8f";
-        static const char* Vector3ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f)";
+        inline constexpr const char* Vector3DefaultFormat = "%.8f,%.8f,%.8f";
+        inline constexpr const char* Vector3ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f)";
         
-        static const char* Vector4DefaultFormat = "%.8f,%.8f,%.8f,%.8f";
-        static const char* Vector4ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f,w=%.7f)";
+        inline constexpr const char* Vector4DefaultFormat = "%.8f,%.8f,%.8f,%.8f";
+        inline constexpr const char* Vector4ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f,w=%.7f)";
         
-        static const char* QuaternionDefaultFormat = "%.8f,%.8f,%.8f,%.8f";
-        static const char* QuaternionScriptFormat = "(x=%.7f,y=%.7f,z=%.7f,w=%.7f)";
+        inline constexpr const char* QuaternionDefaultFormat = "%.8f,%.8f,%.8f,%.8f";
+        inline constexpr const char* QuaternionScriptFormat = "(x=%.7f,y=%.7f,z=%.7f,w=%.7f)";
 
-        static const char* Matrix3x3DefaultFormat = "%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f";
-        static const char* Matrix3x3ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f),(x=%.7f,y=%.7f,z=%.7f),(x=%.7f,y=%.7f,z=%.7f)";
+        inline constexpr const char* Matrix3x3DefaultFormat = "%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f";
+        inline constexpr const char* Matrix3x3ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f),(x=%.7f,y=%.7f,z=%.7f),(x=%.7f,y=%.7f,z=%.7f)";
         
-        static const char* Matrix4x4DefaultFormat = "%.8f,%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f,%.8f";
-        static const char* Matrix4x4ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f,w=%.7f),(x=%.7f,y=%.7f,z=%.7f,w=%.7f),(x=%.7f,y=%.7f,z=%.7f,w=%.7f)";
+        inline constexpr const char* Matrix4x4DefaultFormat = "%.8f,%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f,%.8f";
+        inline constexpr const char* Matrix4x4ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f,w=%.7f),(x=%.7f,y=%.7f,z=%.7f,w=%.7f),(x=%.7f,y=%.7f,z=%.7f,w=%.7f)";
 
-        static const char* Matrix3x4DefaultFormat = "%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f";
-        static const char* Matrix3x4ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f),(x=%.7f,y=%.7f,z=%.7f),(x=%.7f,y=%.7f,z=%.7f)";
+        inline constexpr const char* Matrix3x4DefaultFormat = "%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f";
+        inline constexpr const char* Matrix3x4ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f),(x=%.7f,y=%.7f,z=%.7f),(x=%.7f,y=%.7f,z=%.7f)";
 
-        static const char* ColorDefaultFormat = "R:%d, G:%d, B:%d A:%d";
-        static const char* ColorScriptFormat = "(r=%.7f,g=%.7f,b=%.7f,a=%.7f)";
+        inline constexpr const char* ColorDefaultFormat = "R:%d, G:%d, B:%d A:%d";
+        inline constexpr const char* ColorScriptFormat = "(r=%.7f,g=%.7f,b=%.7f,a=%.7f)";
     }; // namespace MathStringFormat
 
     //! Prints a Vector2 with precision to 8 decimal places.

--- a/Code/Framework/AzCore/AzCore/Math/MathStringConversions.h
+++ b/Code/Framework/AzCore/AzCore/Math/MathStringConversions.h
@@ -17,6 +17,7 @@ namespace AZ
     class Aabb;
     class Color;
     class Matrix3x3;
+    class Matrix3x4;
     class Matrix4x4;
     class Quaternion;
     class Transform;
@@ -27,23 +28,53 @@ namespace AZ
 
 namespace AZStd
 {
+    namespace MathStringFormat
+    {
+        static const char* Vector2DefaultFormat = "%.8f,%.8f";
+        static const char* Vector2ScriptFormat = "(x=%.7f,y=%.7f)";
+
+        static const char* Vector3DefaultFormat = "%.8f,%.8f,%.8f";
+        static const char* Vector3ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f)";
+        
+        static const char* Vector4DefaultFormat = "%.8f,%.8f,%.8f,%.8f";
+        static const char* Vector4ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f,w=%.7f)";
+        
+        static const char* QuaternionDefaultFormat = "%.8f,%.8f,%.8f,%.8f";
+        static const char* QuaternionScriptFormat = "(x=%.7f,y=%.7f,z=%.7f,w=%.7f)";
+
+        static const char* Matrix3x3DefaultFormat = "%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f";
+        static const char* Matrix3x3ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f),(x=%.7f,y=%.7f,z=%.7f),(x=%.7f,y=%.7f,z=%.7f)";
+        
+        static const char* Matrix4x4DefaultFormat = "%.8f,%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f,%.8f";
+        static const char* Matrix4x4ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f,w=%.7f),(x=%.7f,y=%.7f,z=%.7f,w=%.7f),(x=%.7f,y=%.7f,z=%.7f,w=%.7f)";
+
+        static const char* Matrix3x4DefaultFormat = "%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f\n%.8f,%.8f,%.8f";
+        static const char* Matrix3x4ScriptFormat = "(x=%.7f,y=%.7f,z=%.7f),(x=%.7f,y=%.7f,z=%.7f),(x=%.7f,y=%.7f,z=%.7f)";
+
+        static const char* ColorDefaultFormat = "R:%d, G:%d, B:%d A:%d";
+        static const char* ColorScriptFormat = "(r=%.7f,g=%.7f,b=%.7f,a=%.7f)";
+    }; // namespace MathStringFormat
+
     //! Prints a Vector2 with precision to 8 decimal places.
-    void to_string(string& str, const AZ::Vector2& value);
+    void to_string(string& str, const AZ::Vector2& value, const char* format = MathStringFormat::Vector2DefaultFormat);
 
     //! Prints a Vector3 with precision to 8 decimal places.
-    void to_string(string& str, const AZ::Vector3& value);
+    void to_string(string& str, const AZ::Vector3& value, const char* format = MathStringFormat::Vector3DefaultFormat);
 
     //! Prints a Vector4 with precision to 8 decimal places.
-    void to_string(string& str, const AZ::Vector4& value);
+    void to_string(string& str, const AZ::Vector4& value, const char* format = MathStringFormat::Vector4DefaultFormat);
 
     //! Prints a Quaternion with precision to 8 decimal places.
-    void to_string(string& str, const AZ::Quaternion& value);
+    void to_string(string& str, const AZ::Quaternion& value, const char* format = MathStringFormat::QuaternionDefaultFormat);
 
     //! Prints a 3x3 matrix in row major order over three lines with precision to 8 decimal places.
-    void to_string(string& str, const AZ::Matrix3x3& value);
+    void to_string(string& str, const AZ::Matrix3x3& value, const char* format = MathStringFormat::Matrix3x3DefaultFormat);
 
     //! Prints a 4x4 matrix in row major order over four lines with precision to 8 decimal places.
-    void to_string(string& str, const AZ::Matrix4x4& value);
+    void to_string(string& str, const AZ::Matrix4x4& value, const char* format = MathStringFormat::Matrix4x4DefaultFormat);
+
+    //! Prints a 3x4 matrix in row major order over four lines with precision to 8 decimal places.
+    void to_string(string& str, const AZ::Matrix3x4& value, const char* format = MathStringFormat::Matrix3x4ScriptFormat);
 
     //! Prints a transform as a 3x4 matrix in row major order over four lines with precision to 8 decimal places.
     void to_string(string& str, const AZ::Transform& value);
@@ -52,47 +83,54 @@ namespace AZStd
     void to_string(string& str, const AZ::Aabb& value);
 
     //! Prints a Color as four unsigned ints representing RGBA.
-    void to_string(string& str, const AZ::Color& value);
+    void to_string(string& str, const AZ::Color& value, const char* format = MathStringFormat::ColorDefaultFormat);
 
-    inline AZStd::string to_string(const AZ::Vector2& val)
+    inline AZStd::string to_string(const AZ::Vector2& val, const char* format = MathStringFormat::Vector2DefaultFormat)
     {
         AZStd::string str;
-        to_string(str, val);
+        to_string(str, val, format);
         return str;
     }
 
-    inline AZStd::string to_string(const AZ::Vector3& val)
+    inline AZStd::string to_string(const AZ::Vector3& val, const char* format = MathStringFormat::Vector3DefaultFormat)
     {
         AZStd::string str;
-        to_string(str, val);
+        to_string(str, val, format);
         return str;
     }
 
-    inline AZStd::string to_string(const AZ::Vector4& val)
+    inline AZStd::string to_string(const AZ::Vector4& val, const char* format = MathStringFormat::Vector4DefaultFormat)
     {
         AZStd::string str;
-        to_string(str, val);
+        to_string(str, val, format);
         return str;
     }
 
-    inline AZStd::string to_string(const AZ::Quaternion& val)
+    inline AZStd::string to_string(const AZ::Quaternion& val, const char* format = MathStringFormat::QuaternionDefaultFormat)
     {
         AZStd::string str;
-        to_string(str, val);
+        to_string(str, val, format);
         return str;
     }
 
-    inline AZStd::string to_string(const AZ::Matrix3x3& val)
+    inline AZStd::string to_string(const AZ::Matrix3x3& val, const char* format = MathStringFormat::Matrix3x3DefaultFormat)
     {
         AZStd::string str;
-        to_string(str, val);
+        to_string(str, val, format);
         return str;
     }
 
-    inline AZStd::string to_string(const AZ::Matrix4x4& val)
+    inline AZStd::string to_string(const AZ::Matrix4x4& val, const char* format = MathStringFormat::Matrix4x4DefaultFormat)
     {
         AZStd::string str;
-        to_string(str, val);
+        to_string(str, val, format);
+        return str;
+    }
+    
+    inline AZStd::string to_string(const AZ::Matrix3x4& val, const char* format = MathStringFormat::Matrix3x4DefaultFormat)
+    {
+        AZStd::string str;
+        to_string(str, val, format);
         return str;
     }
     inline AZStd::string to_string(const AZ::Transform& val)
@@ -109,10 +147,10 @@ namespace AZStd
         return str;
     }
 
-    inline AZStd::string to_string(const AZ::Color& val)
+    inline AZStd::string to_string(const AZ::Color& val, const char* format = MathStringFormat::ColorDefaultFormat)
     {
         AZStd::string str;
-        to_string(str, val);
+        to_string(str, val, format);
         return str;
     }
 } // namespace AZStd

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x3.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x3.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Math/MathStringConversions.h>
 #include <AzCore/Math/Matrix3x3.h>
 #include <AzCore/Math/MathScriptHelpers.h>
 
@@ -240,7 +241,7 @@ namespace AZ
 
         AZStd::string Matrix3x3ToString(const Matrix3x3& m)
         {
-            return AZStd::string::format("%s,%s,%s", Vector3ToString(m.GetBasisX()).c_str(), Vector3ToString(m.GetBasisY()).c_str(), Vector3ToString(m.GetBasisZ()).c_str());
+            return AZStd::to_string(m, AZStd::MathStringFormat::Matrix3x3ScriptFormat);
         }
     }
 

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x4.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x4.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Math/MathStringConversions.h>
 #include <AzCore/Math/Matrix3x4.h>
 #include <AzCore/Math/MathScriptHelpers.h>
 
@@ -230,9 +231,7 @@ namespace AZ
 
         AZStd::string Matrix3x4ToString(const Matrix3x4& t)
         {
-            return AZStd::string::format("%s,%s,%s,%s",
-                Vector3ToString(t.GetColumn(0)).c_str(), Vector3ToString(t.GetColumn(1)).c_str(),
-                Vector3ToString(t.GetColumn(2)).c_str(), Vector3ToString(t.GetColumn(3)).c_str());
+            return AZStd::to_string(t, AZStd::MathStringFormat::Matrix3x4ScriptFormat);
         }
     } // namespace Internal
 

--- a/Code/Framework/AzCore/AzCore/Math/Matrix4x4.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix4x4.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Math/MathStringConversions.h>
 #include <AzCore/Math/Matrix4x4.h>
 #include <AzCore/Math/MathScriptHelpers.h>
 
@@ -258,9 +259,7 @@ namespace AZ
 
         AZStd::string Matrix4x4ToString(const Matrix4x4& m)
         {
-            return AZStd::string::format("%s,%s,%s,%s",
-                Vector4ToString(m.GetColumn(0)).c_str(), Vector4ToString(m.GetColumn(1)).c_str(),
-                Vector4ToString(m.GetColumn(2)).c_str(), Vector4ToString(m.GetColumn(3)).c_str());
+            return AZStd::to_string(m, AZStd::MathStringFormat::Matrix4x4ScriptFormat);
         }
     }
 

--- a/Code/Framework/AzCore/AzCore/Math/Obb.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Obb.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Math/MathStringConversions.h>
 #include <AzCore/Math/Obb.h>
 #include <AzCore/Math/Aabb.h>
 #include <AzCore/Math/Transform.h>
@@ -42,10 +43,10 @@ namespace AZ
         AZStd::string ObbToString(const Obb& obb)
         {
             return AZStd::string::format("Position %s AxisX %s AxisY %s AxisZ %s halfLengthX=%.7f halfLengthY=%.7f halfLengthZ=%.7f",
-                Vector3ToString(obb.GetPosition()).c_str(),
-                Vector3ToString(obb.GetAxisX()).c_str(),
-                Vector3ToString(obb.GetAxisY()).c_str(),
-                Vector3ToString(obb.GetAxisZ()).c_str(),
+                AZStd::to_string(obb.GetPosition(), AZStd::MathStringFormat::Vector3ScriptFormat).c_str(),
+                AZStd::to_string(obb.GetAxisX(), AZStd::MathStringFormat::Vector3ScriptFormat).c_str(),
+                AZStd::to_string(obb.GetAxisY(), AZStd::MathStringFormat::Vector3ScriptFormat).c_str(),
+                AZStd::to_string(obb.GetAxisZ(), AZStd::MathStringFormat::Vector3ScriptFormat).c_str(),
                 obb.GetHalfLengthX(),
                 obb.GetHalfLengthY(),
                 obb.GetHalfLengthZ());

--- a/Code/Framework/AzCore/AzCore/Math/Plane.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Plane.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Math/MathStringConversions.h>
 #include <AzCore/Math/Plane.h>
 #include <AzCore/Math/MathScriptHelpers.h>
 
@@ -124,7 +125,7 @@ namespace AZ
 
         AZStd::string PlaneToString(const Plane& p)
         {
-            return AZStd::string::format("%s", Vector4ToString(p.GetPlaneEquationCoefficients()).c_str());
+            return AZStd::to_string(p.GetPlaneEquationCoefficients(), AZStd::MathStringFormat::Vector4ScriptFormat);
         }
     }
 

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Math/MathStringConversions.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Math/Matrix3x3.h>
 #include <AzCore/Math/MathUtils.h>
@@ -152,6 +153,11 @@ namespace AZ
                 AZ_Error("Script", false, "Quaternion.Set only supports Set(number), Set(number, number, number, number), Set(Vector3, number)");
             }
         }
+        
+        AZStd::string QuaternionToString(const Quaternion& transform)
+        {
+            return AZStd::to_string(transform, AZStd::MathStringFormat::QuaternionScriptFormat);
+        }
     }
 
 
@@ -182,7 +188,7 @@ namespace AZ
                 Property("w", &Quaternion::GetW, &Quaternion::SetW)->
                 Method<Quaternion(Quaternion::*)() const>("Unary", &Quaternion::operator-)->
                     Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::Unary)->
-                Method("ToString", &QuaternionToString)->
+                Method("ToString", &Internal::QuaternionToString)->
                     Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::ToString)->
                 Method<Quaternion(Quaternion::*)(float) const>("MultiplyFloat", &Quaternion::operator*)->
                     Attribute(AZ::Script::Attributes::MethodOverride, &Internal::QuaternionMultiplyGeneric)->

--- a/Code/Framework/AzCore/AzCore/Math/Transform.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Transform.cpp
@@ -6,6 +6,8 @@
  *
  */
 
+#include "AzCore/std/string/conversions.h"
+#include <AzCore/Math/MathStringConversions.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Math/Matrix3x3.h>
@@ -140,6 +142,14 @@ namespace AZ
                 , Vector4(v10, v11, v12, v13)
                 , Vector4(v20, v21, v22, v23)));
         }
+
+        AZStd::string TransformToString(const Transform& transform)
+        {
+             return AZStd::string::format("%s,%s,%s,%s",
+                AZStd::to_string(transform.GetBasisX(), AZStd::MathStringFormat::Vector3ScriptFormat).c_str(), AZStd::to_string(transform.GetBasisY(), AZStd::MathStringFormat::Vector3ScriptFormat).c_str(),
+                AZStd::to_string(transform.GetBasisZ(), AZStd::MathStringFormat::Vector3ScriptFormat).c_str(), AZStd::to_string(transform.GetTranslation(), AZStd::MathStringFormat::Vector3ScriptFormat).c_str());
+        }
+
     } // namespace Internal
 
     const Transform g_transformIdentity = Transform::CreateIdentity();
@@ -303,7 +313,7 @@ namespace AZ
                 Method("GetBasisZ", &Transform::GetBasisZ)->
                 Property<const Vector3&(Transform::*)() const, void (Transform::*)(const Vector3&)>("translation", &Transform::GetTranslation, &Transform::SetTranslation)->
                 Property<const Quaternion&(Transform::*)() const, void (Transform::*)(const Quaternion&)>("rotation", &Transform::GetRotation, &Transform::SetRotation)->
-                Method("ToString", &TransformToString)->
+                Method("ToString", &Internal::TransformToString)->
                     Attribute(Script::Attributes::Operator, Script::Attributes::OperatorType::ToString)->
                 Method<Vector3(Transform::*)(const Vector3&) const>("Multiply", &Transform::TransformPoint)->
                     Attribute(Script::Attributes::MethodOverride, &Internal::TransformMultiplyGeneric)->

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Math/MathStringConversions.h>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Vector4.h>
@@ -76,7 +77,7 @@ namespace AZ
 
         AZStd::string Vector2ToString(const Vector2* thisPtr)
         {
-            return AZStd::string::format("(x=%.7f,y=%.7f)", static_cast<float>(thisPtr->GetX()), static_cast<float>(thisPtr->GetY()));
+            return AZStd::to_string(*thisPtr, AZStd::MathStringFormat::Vector2ScriptFormat);
         }
 
 

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Math/MathStringConversions.h>
 #include <AzCore/Math/Color.h>
 #include <AzCore/Math/MathScriptHelpers.h>
 #include <AzCore/Math/MathUtils.h>
@@ -179,6 +180,11 @@ namespace AZ
             dc.PushResult(v1);
             dc.PushResult(v2);
         }
+
+        AZStd::string Vector3ToString(const Vector3& v)
+        {
+            return AZStd::to_string(v, AZStd::MathStringFormat::Vector3ScriptFormat);
+        }
     }
 
     Vector3::Vector3(const Vector2& source)
@@ -217,7 +223,7 @@ namespace AZ
                 Property("z", &Vector3::GetZ, &Vector3::SetZ)->
                 Method<Vector3(Vector3::*)() const>("Unary", &Vector3::operator-)->
                     Attribute(Script::Attributes::Operator, Script::Attributes::OperatorType::Unary)->
-                Method("ToString",&Vector3ToString)->
+                Method("ToString",&Internal::Vector3ToString)->
                     Attribute(Script::Attributes::Operator, Script::Attributes::OperatorType::ToString)->
                 Method<Vector3(Vector3::*)(float) const>("MultiplyFloat",&Vector3::operator*)->
                     Attribute(Script::Attributes::MethodOverride, &Internal::Vector3MultiplyGeneric)->

--- a/Code/Framework/AzCore/AzCore/Math/Vector4.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector4.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Math/MathStringConversions.h>
 #include <AzCore/Math/Color.h>
 #include <AzCore/Math/MathScriptHelpers.h>
 #include <AzCore/Math/MathUtils.h>
@@ -197,6 +198,11 @@ namespace AZ
                 AZ_Error("Script", false, "Vector4.Set only supports Set(number,number,number,number), Set(number), Set(Vector3), Set(Vector3,float)");
             }
         }
+
+        AZStd::string Vector4ToString(const Vector4& v)
+        {
+            return AZStd::to_string(v, AZStd::MathStringFormat::Vector4ScriptFormat);
+        }
     }
 
 
@@ -227,7 +233,7 @@ namespace AZ
                 Property("w", &Vector4::GetW, &Vector4::SetW)->
                 Method<Vector4(Vector4::*)() const>("Unary", &Vector4::operator-)->
                     Attribute(Script::Attributes::Operator, Script::Attributes::OperatorType::Unary)->
-                Method("ToString", &Vector4ToString)->
+                Method("ToString", &Internal::Vector4ToString)->
                     Attribute(Script::Attributes::Operator, Script::Attributes::OperatorType::ToString)->
                 Method<Vector4(Vector4::*)(float) const>("MultiplyFloat", &Vector4::operator*)->
                     Attribute(Script::Attributes::MethodOverride, &Internal::Vector4MultiplyGeneric)->

--- a/Code/Framework/AzCore/Tests/Math/MathStringsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/MathStringsTests.cpp
@@ -37,6 +37,12 @@ namespace UnitTest
         EXPECT_EQ(AZStd::to_string(vec3), "1.00000000,1.00000000,1.00000000");
         EXPECT_EQ(AZStd::to_string(vec4), "1.00000000,1.00000000,1.00000000,1.00000000");
         EXPECT_EQ(AZStd::to_string(quat), "0.00000000,0.00000000,0.00000000,1.00000000");
+
+
+        EXPECT_EQ(AZStd::to_string(vec2, AZStd::MathStringFormat::Vector2ScriptFormat), "(x=1.0000000,y=1.0000000)");
+        EXPECT_EQ(AZStd::to_string(vec3, AZStd::MathStringFormat::Vector3ScriptFormat), "(x=1.0000000,y=1.0000000,z=1.0000000");
+        EXPECT_EQ(AZStd::to_string(vec4, AZStd::MathStringFormat::Vector4ScriptFormat), "(x=1.0000000,y=1.0000000,z=1.0000000,w=1.0000000)");
+        EXPECT_EQ(AZStd::to_string(quat, AZStd::MathStringFormat::QuaternionScriptFormat), "(x=0.0000000,y=0.0000000,z=0.0000000,w=1.0000000)");
     }
 
     TEST_F(MathStrings, TestMatrixStringConverters)
@@ -49,6 +55,8 @@ namespace UnitTest
         EXPECT_EQ(AZStd::to_string(mat44), "1.00000000,0.00000000,0.00000000,0.00000000\n0.00000000,1.00000000,0.00000000,0.00000000\n0.00000000,0.00000000,1.00000000,0.00000000\n0.00000000,0.00000000,0.00000000,1.00000000");
         EXPECT_EQ(AZStd::to_string(xform), "1.00000000,0.00000000,0.00000000\n0.00000000,1.00000000,0.00000000\n0.00000000,0.00000000,1.00000000\n0.00000000,0.00000000,0.00000000");
 
+        EXPECT_EQ(AZStd::to_string(mat33, AZStd::MathStringFormat::Matrix3x3ScriptFormat), "(x=1.0000000,y=0.0000000,z=0.0000000),(x=0.0000000,y=1.0000000,z=0.0000000),(x=0.0000000,y=0.0000000,z=1.0000000)");
+        EXPECT_EQ(AZStd::to_string(mat44, AZStd::MathStringFormat::Matrix4x4ScriptFormat), "(x=1.0000000,y=0.0000000,z=0.0000000,w=0.0000000),(x=0.0000000,y=1.0000000,z=0.0000000,w=0.0000000),(x=0.0000000,y=0.0000000,z=1.0000000,w=0.0000000),(x=0.0000000,y=0.0000000,z=0.0000000,w=1.0000000)");
     }
 
     TEST_F(MathStrings, TestAabbStringConverter)
@@ -60,5 +68,6 @@ namespace UnitTest
     TEST_F(MathStrings, TestColorStringConverter)
     {
         EXPECT_EQ(AZStd::to_string(AZ::Colors::Black), "R:0, G:0, B:0 A:255");
+        EXPECT_EQ(AZStd::to_string(AZ::Colors::Black,AZStd::MathStringFormat::ColorScriptFormat), "(r=0,g=0,b=0,a=255)");
     }
 }


### PR DESCRIPTION
This just standardizes how strings are formatted from AZMath. removes the math helpers and provides a standard interface for producing math strings of this type for ReflectContext and also keeps the original functionality. 

I still need to add more test cases. 