### PR TITLE
bugfix: fix spline types for SplineComponent for linux (GHI-9904)

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.cpp
@@ -15,14 +15,14 @@
 
 namespace LmbrCentral
 {
-    using SplineComboBoxVec = AZStd::vector<AZStd::pair<size_t, AZStd::string>>;
+    using SplineComboBoxVec = AZStd::vector<AZ::Edit::EnumConstant<size_t>>;
     static SplineComboBoxVec PopulateSplineTypeList()
     {
         return SplineComboBoxVec
         {
-            AZStd::make_pair(AZ::LinearSpline::RTTI_Type().GetHash(), "Linear"),
-            AZStd::make_pair(AZ::BezierSpline::RTTI_Type().GetHash(), "Bezier"),
-            AZStd::make_pair(AZ::CatmullRomSpline::RTTI_Type().GetHash(), "Catmull-Rom")
+            { AZ::LinearSpline::RTTI_Type().GetHash(), "Linear" },
+            { AZ::BezierSpline::RTTI_Type().GetHash(), "Bezier" },
+            { AZ::CatmullRomSpline::RTTI_Type().GetHash(), "Catmull-Rom" }
         };
     }
 


### PR DESCRIPTION
seem PropertyEnumComboBoxCtrl.hxx its unable to fetch the EnumType from `AZStd::vector<AZStd::pair<ValueType, AZStd::string>`. Might make sense to write some test cases that that cover this case because this problems seems platform specific between linux and windows. This does address the serialization problem when I switched to `AZ::Edit::EnumConstant` since the other code path is marked as deprecated?


ref: https://github.com/o3de/o3de/issues/9904

Signed-off-by: Michael Pollind <mpollind@gmail.com>