### PR TITLE
chore: minor improvement replace push_back with emplace_back EnumValues

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEnumComboBoxCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEnumComboBoxCtrl.hxx
@@ -150,12 +150,8 @@ namespace AzToolsFramework
                 {
                     for (const AZ::Edit::EnumConstant<ValueType>& constantValue : enumConstantValues)
                     {
-                        enumValues.push_back();
-                        auto& enumValue = enumValues.back();
-                        enumValue.first = constantValue.m_value;
-                        enumValue.second = constantValue.m_description;
+                        enumValues.emplace_back(constantValue.m_value, constantValue.m_description);
                     }
-
                     genericGUI->setElements(enumValues);
                 }
                 else
@@ -170,11 +166,7 @@ namespace AzToolsFramework
 
                             for (const auto& secondPair : attempt2)
                             {
-                                enumValues.push_back();
-                                auto& enumValue = enumValues.back();
-
-                                enumValue.first = secondPair.first;
-                                enumValue.second = secondPair.second;
+                                enumValues.emplace_back(secondPair.first, secondPair.second);
                             }
                         }
                         else


### PR DESCRIPTION
I noticed this when working on this PR: https://github.com/o3de/o3de/pull/9923. just a minor improvement shouldn't change this functionally. 


Signed-off-by: Michael Pollind <mpollind@gmail.com>