### PR TITLE
[Terrain] Terrain no longer renders where terrain doesn't exist

### DIFF
--- a/Gems/Terrain/Assets/Shaders/Terrain/SceneSrg.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/SceneSrg.azsli
@@ -14,10 +14,10 @@ partial ShaderResourceGroup SceneSrg
 {
     struct TerrainWorldData
     {
-        float3 m_min;
-        float m_padding1;
-        float3 m_max;
-        float m_padding2;
+        float m_zMin;
+        float m_zMax;
+        float m_zExtents;
+        float m_padding;
     };
 
     TerrainWorldData m_terrainWorldData;

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainCommon.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainCommon.azsli
@@ -105,7 +105,7 @@ void CalculateTerrainPosition(
     out float3 worldPosition, out float4 position, out float2 cullDistance, out float3 normal)
 {
     float2 worldXyPosition = GetWorldXYPosition(ObjectSrg::m_patchData, input.m_xyPosition);
-    if (IsVertexOutsideOfTerrainBounds(worldXyPosition, worldData.m_min.xy, worldData.m_max.xy))
+    if (input.m_zPosition == 1.0 || IsVertexOutsideOfTerrainBounds(worldXyPosition, worldData.m_min.xy, worldData.m_max.xy))
     {
         // Output a NaN to remove this vertex.
         position = 1.0 / 0.0;

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainCommon.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainCommon.azsli
@@ -95,25 +95,19 @@ float2 GetWorldXYPosition(in ObjectSrg::PatchData patchData, in float2 vertexPos
     return float2(patchData.m_xyTranslation + vertexPosition * patchData.m_xyScale);
 }
 
-bool IsVertexOutsideOfTerrainBounds(float2 position, float2 minBounds, float2 maxBounds)
-{
-    return (any(position < minBounds) || any(position > maxBounds));
-}
-
 void CalculateTerrainPosition(
     in SceneSrg::TerrainWorldData worldData, in ObjectSrg::PatchData patchData, in VertexInput input,
     out float3 worldPosition, out float4 position, out float2 cullDistance, out float3 normal)
 {
     float2 worldXyPosition = GetWorldXYPosition(ObjectSrg::m_patchData, input.m_xyPosition);
-    if (input.m_zPosition == 1.0 || IsVertexOutsideOfTerrainBounds(worldXyPosition, worldData.m_min.xy, worldData.m_max.xy))
+    if (input.m_zPosition == 1.0)
     {
-        // Output a NaN to remove this vertex.
+        // 1.0 means there is no height data at this vertex, so output a NaN to remove this vertex.
         position = 1.0 / 0.0;
         return;
     }
 
-    float heightScale = worldData.m_max.z - worldData.m_min.z;
-    float height = worldData.m_min.z + input.m_zPosition * heightScale;
+    float height = worldData.m_zMin + input.m_zPosition * worldData.m_zExtents;
 
     worldPosition = float3(GetWorldXYPosition(patchData, input.m_xyPosition), height);
     cullDistance = TerrainSrg::CalculateCullDistance(patchData.m_lodLevel, worldPosition);
@@ -125,7 +119,7 @@ void CalculateTerrainPosition(
         const float quadDiagonal = quadSize * sqrt(2.0);
         float clodPadding = quadDiagonal * 2; // pad enough to handle a diagonal on the quad from the next lod (which will be 2x the size).
         float clodBlend = saturate((cullDistance.y - clodPadding) * TerrainSrg::m_meshData.m_rcpClodDistance * patchData.m_rcpLodLevel);
-        float lodHeight = worldData.m_min.z + input.m_lodZPosition * heightScale;
+        float lodHeight = worldData.m_zMin + input.m_lodZPosition * worldData.m_zExtents;
         worldPosition.z = lerp(lodHeight, height, clodBlend);
 
         normal = float3(lerp(input.m_lodXYNormal, input.m_xyNormal, clodBlend), 0.0);

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
@@ -34,11 +34,6 @@ namespace Terrain
         [[maybe_unused]] const char* TerrainFPName = "TerrainFeatureProcessor";
     }
 
-    namespace SceneSrgInputs
-    {
-        static const char* const TerrainWorldData("m_terrainWorldData");
-    }
-
     namespace TerrainSrgInputs
     {
         static const char* const Textures("m_textures");
@@ -68,9 +63,6 @@ namespace Terrain
 
         auto sceneSrgLayout = AZ::RPI::RPISystemInterface::Get()->GetSceneSrgLayout();
         
-        m_worldDataIndex = sceneSrgLayout->FindShaderInputConstantIndex(AZ::Name(SceneSrgInputs::TerrainWorldData));
-        AZ_Error(TerrainFPName, m_worldDataIndex.IsValid(), "Failed to find scene srg input constant %s.", SceneSrgInputs::TerrainWorldData);
-
         // Load the terrain material asynchronously
         const AZStd::string materialFilePath = "Materials/Terrain/DefaultPbrTerrain.azmaterial";
         m_materialAssetLoader = AZStd::make_unique<AZ::RPI::AssetUtils::AsyncAssetLoader>();
@@ -352,8 +344,9 @@ namespace Terrain
             m_terrainBoundsNeedUpdate = false;
 
             WorldShaderData worldData;
-            m_terrainBounds.GetMin().StoreToFloat3(worldData.m_min.data());
-            m_terrainBounds.GetMax().StoreToFloat3(worldData.m_max.data());
+            worldData.m_zMin = m_terrainBounds.GetMin().GetZ();
+            worldData.m_zMax = m_terrainBounds.GetMax().GetZ();
+            worldData.m_zExtents = m_terrainBounds.GetZExtent();
 
             auto sceneSrg = GetParentScene()->GetShaderResourceGroup();
             sceneSrg->SetConstant(m_worldDataIndex, worldData);

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
@@ -113,7 +113,7 @@ namespace Terrain
 
     void TerrainFeatureProcessor::OnTerrainDataDestroyBegin()
     {
-        m_terrainBounds = AZ::Aabb::CreateNull();
+        m_zBounds = AZ::Vector2::CreateZero();
         m_dirtyRegion = AZ::Aabb::CreateNull();
     }
     
@@ -140,10 +140,16 @@ namespace Terrain
         AzFramework::Terrain::TerrainDataRequestBus::BroadcastResult(
             queryResolution, &AzFramework::Terrain::TerrainDataRequests::GetTerrainHeightQueryResolution);
 
-        if (m_terrainBounds != worldBounds || m_sampleSpacing != queryResolution)
+        AZ::Vector2 worldZBounds = AZ::Vector2
+        (
+            worldBounds.GetMin().GetZ(),
+            worldBounds.GetMax().GetZ()
+        );
+
+        if (m_zBounds != worldZBounds || m_sampleSpacing != queryResolution)
         {
             m_terrainBoundsNeedUpdate = true;
-            m_terrainBounds = worldBounds;
+            m_zBounds = worldZBounds;
             m_sampleSpacing = queryResolution;
         }
     }
@@ -286,7 +292,7 @@ namespace Terrain
     {
         AZ_PROFILE_FUNCTION(AzRender);
         
-        if (!m_terrainBounds.IsValid())
+        if (m_zBounds.IsZero())
         {
             return;
         }
@@ -344,9 +350,9 @@ namespace Terrain
             m_terrainBoundsNeedUpdate = false;
 
             WorldShaderData worldData;
-            worldData.m_zMin = m_terrainBounds.GetMin().GetZ();
-            worldData.m_zMax = m_terrainBounds.GetMax().GetZ();
-            worldData.m_zExtents = m_terrainBounds.GetZExtent();
+            worldData.m_zMin = m_zBounds.GetX();
+            worldData.m_zMax = m_zBounds.GetY();
+            worldData.m_zExtents = worldData.m_zMax - worldData.m_zMin;
 
             auto sceneSrg = GetParentScene()->GetShaderResourceGroup();
             sceneSrg->SetConstant(m_worldDataIndex, worldData);

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.h
@@ -109,7 +109,7 @@ namespace Terrain
 
         AZ::RHI::ShaderInputNameIndex m_worldDataIndex = "m_terrainWorldData";
 
-        AZ::Aabb m_terrainBounds{ AZ::Aabb::CreateNull() };
+        AZ::Vector2 m_zBounds{ AZ::Vector2::CreateZero() };
         AZ::Aabb m_dirtyRegion{ AZ::Aabb::CreateNull() };
         
         float m_sampleSpacing{ 0.0f };

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.h
@@ -65,10 +65,10 @@ namespace Terrain
         
         struct WorldShaderData
         {
-            AZStd::array<float, 3> m_min{ 0.0f, 0.0f, 0.0f };
-            float padding1{ 0.0f };
-            AZStd::array<float, 3> m_max{ 0.0f, 0.0f, 0.0f };
-            float padding2{ 0.0f };
+            float m_zMin;
+            float m_zMax;
+            float m_zExtents;
+            float m_padding;
         };
 
         // AZ::RPI::MaterialReloadNotificationBus::Handler overrides...
@@ -107,7 +107,7 @@ namespace Terrain
 
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_terrainSrg;
 
-        AZ::RHI::ShaderInputConstantIndex m_worldDataIndex;
+        AZ::RHI::ShaderInputNameIndex m_worldDataIndex = "m_terrainWorldData";
 
         AZ::Aabb m_terrainBounds{ AZ::Aabb::CreateNull() };
         AZ::Aabb m_dirtyRegion{ AZ::Aabb::CreateNull() };

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -363,9 +363,9 @@ namespace Terrain
 
                 for (auto& sector : sectorStack.m_sectors)
                 {
-                    if (viewVector.Dot(viewPosition - sector.m_aabb.GetCenter()) < -radius || // Cheap check to eliminate sectors behind camera
-                        viewFrustum.IntersectAabb(sector.m_aabb) == AZ::IntersectResult::Exterior || // Check against frustum
-                        !sector.m_aabb.Overlaps(m_worldBounds)) // Check against world bounds
+                    if (!sector.m_hasData || // No terrain areas exist in this sector or it's all empty.
+                        viewVector.Dot(viewPosition - sector.m_aabb.GetCenter()) < -radius || // Cheap check to eliminate sectors behind camera
+                        viewFrustum.IntersectAabb(sector.m_aabb) == AZ::IntersectResult::Exterior) // Check against frustum
                     {
                         continue;
                     }
@@ -492,15 +492,9 @@ namespace Terrain
             float queryResolution = 1.0f;
             AzFramework::Terrain::TerrainDataRequestBus::BroadcastResult(
                 queryResolution, &AzFramework::Terrain::TerrainDataRequests::GetTerrainHeightQueryResolution);
-            // Currently query resolution is multidimensional but the rendering system only supports this changing in one dimension.
 
-            // Sectors need to be rebuilt if the world bounds change in the x/y, or the sample spacing changes.
-            m_rebuildSectors = m_rebuildSectors ||
-                m_worldBounds.GetMin().GetX() != worldBounds.GetMin().GetX() ||
-                m_worldBounds.GetMin().GetY() != worldBounds.GetMin().GetY() ||
-                m_worldBounds.GetMax().GetX() != worldBounds.GetMax().GetX() ||
-                m_worldBounds.GetMax().GetY() != worldBounds.GetMax().GetY() ||
-                m_sampleSpacing != queryResolution;
+            // Sectors need to be rebuilt if the sample spacing changes.
+            m_rebuildSectors = m_rebuildSectors || (m_sampleSpacing != queryResolution);
 
             m_worldBounds = worldBounds;
             m_sampleSpacing = queryResolution;
@@ -591,13 +585,15 @@ namespace Terrain
         sector.m_normalsBuffer->UpdateData(normals.data(), normals.size_bytes(), 0);
     }
 
-    void TerrainMeshManager::UpdateSectorLodBuffers(StackSectorData& sector, const AZStd::span<const HeightDataType> heights, const AZStd::span<const NormalDataType> normals)
+    void TerrainMeshManager::UpdateSectorLodBuffers(StackSectorData& sector,
+        const AZStd::span<const HeightDataType> originalHeights, const AZStd::span<const NormalDataType> originalNormals,
+        const AZStd::span<const HeightDataType> lodHeights, const AZStd::span<const NormalDataType> lodNormals)
     {
         // Store the height and normal information for the next lod level in each vertex for continuous LOD.
-        AZStd::vector<HeightDataType> lodHeights;
-        AZStd::vector<NormalDataType> lodNormals;
-        lodHeights.resize_no_construct(GridVerts1D * GridVerts1D);
-        lodNormals.resize_no_construct(GridVerts1D * GridVerts1D);
+        AZStd::vector<HeightDataType> clodHeights;
+        AZStd::vector<NormalDataType> clodNormals;
+        clodHeights.resize_no_construct(GridVerts1D * GridVerts1D);
+        clodNormals.resize_no_construct(GridVerts1D * GridVerts1D);
 
         constexpr uint32_t LodGridVerts1D = (GridVerts1D >> 1) + 1;
 
@@ -619,15 +615,23 @@ namespace Terrain
                     // y position is between two vertices in the column
                     lodIndex2 += LodGridVerts1D;
                 }
-                lodHeights[index] = (heights[lodIndex1] + heights[lodIndex2]) / 2;
-                lodNormals[index].first = (normals[lodIndex1].first + normals[lodIndex2].first) / 2;
-                lodNormals[index].second = (normals[lodIndex1].second + normals[lodIndex2].second) / 2;
+
+                if (lodHeights[lodIndex1] == 0xFFFF || lodHeights[lodIndex2] == 0xFFFF)
+                {
+                    clodHeights[index] = originalHeights[index];
+                    clodNormals[index] = originalNormals[index];
+                }
+                else
+                {
+                    clodHeights[index] = (lodHeights[lodIndex1] + lodHeights[lodIndex2]) / 2;
+                    clodNormals[index].first = (lodNormals[lodIndex1].first + lodNormals[lodIndex2].first) / 2;
+                    clodNormals[index].second = (lodNormals[lodIndex1].second + lodNormals[lodIndex2].second) / 2;
+                }
             }
         }
 
-        sector.m_lodHeightsBuffer->UpdateData(lodHeights.data(), lodHeights.size() * sizeof(HeightDataType), 0);
-        sector.m_lodNormalsBuffer->UpdateData(lodNormals.data(), lodNormals.size() * sizeof(NormalDataType), 0);
-
+        sector.m_lodHeightsBuffer->UpdateData(clodHeights.data(), clodHeights.size() * sizeof(HeightDataType), 0);
+        sector.m_lodNormalsBuffer->UpdateData(clodNormals.data(), clodNormals.size() * sizeof(NormalDataType), 0);
     }
 
     void TerrainMeshManager::InitializeCommonSectorData()
@@ -670,7 +674,7 @@ namespace Terrain
         m_raytracingIndexBuffer = CreateMeshBufferInstance(AZ::RHI::Format::R32_UINT, rayTracingIndicesCount, raytracingIndices.data(), "TerrainRaytracingIndices");
     }
 
-    void TerrainMeshManager::GatherMeshData(SectorDataRequest request, AZStd::vector<HeightDataType>& meshHeights, AZStd::vector<NormalDataType>& meshNormals, AZ::Aabb& meshAabb)
+    void TerrainMeshManager::GatherMeshData(SectorDataRequest request, AZStd::vector<HeightDataType>& meshHeights, AZStd::vector<NormalDataType>& meshNormals, AZ::Aabb& meshAabb, bool& terrainExistsAnywhere)
     {
         const AZ::Vector2 stepSize(request.m_vertexSpacing);
 
@@ -685,11 +689,12 @@ namespace Terrain
         meshHeights.resize_no_construct(outputSamplesCount);
         meshNormals.resize_no_construct(outputSamplesCount);
 
-        auto perPositionCallback = [this, &heights, querySamplesX]
+        auto perPositionCallback = [this, &heights, querySamplesX, &terrainExistsAnywhere]
         (size_t xIndex, size_t yIndex, const AzFramework::SurfaceData::SurfacePoint& surfacePoint, [[maybe_unused]] bool terrainExists)
         {
             const float height = surfacePoint.m_position.GetZ() - m_worldBounds.GetMin().GetZ();
-            heights.at(yIndex * querySamplesX + xIndex) = height;
+            heights.at(yIndex * querySamplesX + xIndex) = terrainExists ? height : -1.0f; // store terrain doesn't exist as a -1.0
+            terrainExistsAnywhere = terrainExistsAnywhere || terrainExists;
         };
 
         AzFramework::Terrain::TerrainQueryRegion queryRegion(
@@ -705,9 +710,9 @@ namespace Terrain
         const float rcpWorldZ = 1.0f / m_worldBounds.GetExtents().GetZ();
         const float vertexSpacing2 = request.m_vertexSpacing * 2.0f;
 
-        // initialize min/max heights to the first height
-        float minHeight = heights.at(querySamplesX + 1);
-        float maxHeight = minHeight;
+        // initialize min/max heights to the max/min possible values so they're immediately updated when a valid point is found.
+        float minHeight = m_worldBounds.GetExtents().GetZ();
+        float maxHeight = 0.0;
 
         // float versions of int max to make sure a int->float conversion doesn't happen at each loop iteration.
         constexpr float maxUint15 = float(AZStd::numeric_limits<uint16_t>::max() / 2);
@@ -724,6 +729,13 @@ namespace Terrain
                 const uint16_t coord = y * request.m_samplesX + x;
 
                 const float height = heights.at(queryCoord);
+                if (height < 0.0)
+                {
+                    // Terrain doesn't exist at this point
+                    meshHeights.at(coord) = 0xFFFF;
+                    continue;
+                }
+
                 const float clampedHeight = AZ::GetClamp(height * rcpWorldZ, 0.0f, 1.0f);
 
                 // For continuous LOD, it needs to be possible to create a height that's exactly in between any other height, so scale to 15 bits
@@ -740,14 +752,41 @@ namespace Terrain
                     maxHeight = height;
                 }
 
+                auto getSlope = [&](float height1, float height2)
+                {
+                    if (height1 < 0.0f)
+                    {
+                        if (height2 >= 0.0f)
+                        {
+                            return (height - height2) / request.m_vertexSpacing;
+                        }
+                        else
+                        {
+                            // Assume no slope if the left and right vertices both don't exist.
+                            return 0.0f;
+                        }
+                    }
+                    else
+                    {
+                        if (height2 < 0.0f)
+                        {
+                            return (height1 - height) / request.m_vertexSpacing;
+                        }
+                        else
+                        {
+                            return (height1 - height2) / vertexSpacing2;
+                        }
+                    }
+                };
+
                 const float leftHeight = heights.at(queryCoord - 1);
                 const float rightHeight = heights.at(queryCoord + 1);
-                const float xSlope = (leftHeight - rightHeight) / vertexSpacing2;
+                const float xSlope = getSlope(leftHeight, rightHeight);
                 const float normalX = xSlope / sqrt(xSlope * xSlope + 1); // sin(arctan(xSlope)
 
                 const float upHeight = heights.at(queryCoord - querySamplesX);
                 const float downHeight = heights.at(queryCoord + querySamplesX);
-                const float ySlope = (upHeight - downHeight) / vertexSpacing2;
+                const float ySlope = getSlope(upHeight, downHeight);
                 const float normalY = ySlope / sqrt(ySlope * ySlope + 1); // sin(arctan(ySlope)
 
                 meshNormals.at(coord) =
@@ -775,6 +814,9 @@ namespace Terrain
 
             const auto jobLambda = [this, sector, gridMeters]() -> void
             {
+                AZStd::vector<HeightDataType> meshHeights;
+                AZStd::vector<NormalDataType> meshNormals;
+
                 {
                     SectorDataRequest request;
                     request.m_samplesX = GridVerts1D;
@@ -782,13 +824,11 @@ namespace Terrain
                     request.m_worldStartPosition = AZ::Vector2(sector->m_worldX * gridMeters, sector->m_worldY * gridMeters);
                     request.m_vertexSpacing = gridMeters / GridSize;
 
-                    AZStd::vector<HeightDataType> meshHeights;
-                    AZStd::vector<NormalDataType> meshNormals;
-                    GatherMeshData(request, meshHeights, meshNormals, sector->m_aabb);
+                    GatherMeshData(request, meshHeights, meshNormals, sector->m_aabb, sector->m_hasData);
                     UpdateSectorBuffers(*sector, meshHeights, meshNormals);
                 }
 
-                if (m_config.m_clodEnabled)
+                if (m_config.m_clodEnabled && sector->m_hasData)
                 {
                     SectorDataRequest request;
                     uint16_t gridSizeNextLod = (GridSize >> 1);
@@ -797,11 +837,12 @@ namespace Terrain
                     request.m_worldStartPosition = AZ::Vector2(sector->m_worldX * gridMeters, sector->m_worldY * gridMeters);
                     request.m_vertexSpacing = gridMeters / gridSizeNextLod;
 
-                    AZ::Aabb dummyAabb = AZ::Aabb::CreateNull(); // don't update the sector aabb based on only the clod vertices.
+                    AZ::Aabb dummyAabb = AZ::Aabb::CreateNull(); // Don't update the sector aabb based on only the clod vertices.
+                    bool dummyTerrainExists = false; // Terrain must have data, no need to check again.
                     AZStd::vector<HeightDataType> meshLodHeights;
                     AZStd::vector<NormalDataType> meshLodNormals;
-                    GatherMeshData(request, meshLodHeights, meshLodNormals, dummyAabb);
-                    UpdateSectorLodBuffers(*sector, meshLodHeights, meshLodNormals);
+                    GatherMeshData(request, meshLodHeights, meshLodNormals, dummyAabb, dummyTerrainExists);
+                    UpdateSectorLodBuffers(*sector, meshHeights, meshNormals, meshLodHeights, meshLodNormals);
                 }
             };
 
@@ -826,6 +867,11 @@ namespace Terrain
                 executeGroupJob->SetDependent(&jobCompletion);
                 executeGroupJob->Start();
             }
+            else
+            {
+                sector->m_hasData = false;
+            }
+
         }
         jobCompletion.StartAndWaitForCompletion();
 
@@ -843,7 +889,8 @@ namespace Terrain
         AZStd::vector<HeightDataType> meshHeights;
         AZStd::vector<NormalDataType> meshNormals;
         AZ::Aabb outAabb;
-        GatherMeshData(request, meshHeights, meshNormals, outAabb);
+        bool terrainExistsAnywhere = false;
+        GatherMeshData(request, meshHeights, meshNormals, outAabb, terrainExistsAnywhere);
 
         struct Position
         {

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.h
@@ -139,6 +139,8 @@ namespace Terrain
 
             // Hold reference to the draw srgs so they don't get released.
             AZStd::fixed_vector<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, AZ::RHI::DrawPacketBuilder::DrawItemCountMax> m_perDrawSrgs;
+
+            bool m_hasData = false;
         };
 
         struct StackData
@@ -216,8 +218,10 @@ namespace Terrain
         void InitializeCommonSectorData();
         AZ::Data::Instance<AZ::RPI::Buffer> CreateMeshBufferInstance(AZ::RHI::Format format, uint64_t elementCount, const void* initialData = nullptr, const char* name = nullptr);
         void UpdateSectorBuffers(StackSectorData& sector, const AZStd::span<const HeightDataType> heights, const AZStd::span<const NormalDataType> normals);
-        void UpdateSectorLodBuffers(StackSectorData& sector, const AZStd::span<const HeightDataType> heights, const AZStd::span<const NormalDataType> normals);
-        void GatherMeshData(SectorDataRequest request, AZStd::vector<HeightDataType>& meshHeights, AZStd::vector<NormalDataType>& meshNormals, AZ::Aabb& meshAabb);
+        void UpdateSectorLodBuffers(StackSectorData& sector,
+            const AZStd::span<const HeightDataType> originalHeights, const AZStd::span<const NormalDataType> originalNormals,
+            const AZStd::span<const HeightDataType> lodHeights, const AZStd::span<const NormalDataType> lodNormals);
+        void GatherMeshData(SectorDataRequest request, AZStd::vector<HeightDataType>& meshHeights, AZStd::vector<NormalDataType>& meshNormals, AZ::Aabb& meshAabb, bool& terrainExistsAnywhere);
 
         void CheckStacksForUpdate(AZ::Vector3 newPosition);
         void ProcessSectorUpdates(AZStd::span<SectorUpdateContext> sectorUpdates);

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -151,6 +151,18 @@ void TerrainSystem::SetTerrainAabb(const AZ::Aabb& worldBounds)
     m_terrainSettingsDirty = true;
 }
 
+bool TerrainSystem::TerrainAreaExistsInBounds(const AZ::Aabb& bounds)
+{
+    for (const auto& area : m_registeredAreas)
+    {
+        if (area.second.m_areaBounds.Overlaps(bounds))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 void TerrainSystem::SetTerrainHeightQueryResolution(float queryResolution)
 {
     m_requestedSettings.m_heightQueryResolution = queryResolution;

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.h
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.h
@@ -65,6 +65,7 @@ namespace Terrain
         AZ::Aabb GetTerrainAabb() const override;
         void SetTerrainAabb(const AZ::Aabb& worldBounds) override;
 
+        bool TerrainAreaExistsInBounds(const AZ::Aabb& bounds) override;
 
         //! Returns terrains height in meters at location x,y.
         //! @terrainExistsPtr: Can be nullptr. If != nullptr then, if there's no terrain at location x,y or location x,y is inside a terrain

--- a/Gems/Terrain/Code/Tests/TerrainSystemTest.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainSystemTest.cpp
@@ -318,6 +318,13 @@ namespace UnitTest
                 }
             }
         }
+
+        // Bounds check for bounds that should and shouldn't have a terrain area inside
+        AZ::Aabb boundsCheckCollides = spawnerBox.GetTranslated(AZ::Vector3(5.0, 5.0, 5.0));
+        EXPECT_TRUE(terrainSystem->TerrainAreaExistsInBounds(boundsCheckCollides));
+
+        AZ::Aabb boundsCheckDoesNotCollide = spawnerBox.GetTranslated(AZ::Vector3(15.0, 15.0, 15.0));
+        EXPECT_FALSE(terrainSystem->TerrainAreaExistsInBounds(boundsCheckDoesNotCollide));
     }
 
     TEST_F(TerrainSystemTest, TerrainHeightQueriesWithExactSamplersIgnoreQueryGrid)


### PR DESCRIPTION
Place where terrain queries return "terrain doesn't exist" now results in an invalid vertex, destroying all triangles that touch that vertex. Surface normal and CLOD blending calculations take "null" vertices into account so they don't adversely impact those systems. This change also removes the use of terrain world xy bounds where it's no longer needed.