### PR TITLE
VS2022 Compile fixes.

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/ranges/ranges.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/ranges.h
@@ -1112,14 +1112,14 @@ namespace AZStd::ranges
 
         template <class Derived = D>
         constexpr auto data() ->
-            enable_if_t<contiguous_iterator<iterator_t<Derived>>, decltype(to_address(ranges::begin(static_cast<Derived&>(*this))))>
+            enable_if_t<contiguous_iterator<iterator_t<Derived>>, decltype(AZStd::to_address(ranges::begin(static_cast<Derived&>(*this))))>
         {
             return to_address(ranges::begin(derived()));
         }
         template <class Derived = D>
         constexpr auto data() const ->
             enable_if_t<range<const Derived> && contiguous_iterator<iterator_t<const Derived>>,
-            decltype(to_address(ranges::begin(static_cast<const Derived&>(*this))))>
+            decltype(AZStd::to_address(ranges::begin(static_cast<const Derived&>(*this))))>
         {
             return to_address(ranges::begin(derived()));
         }

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshOptimizerComponent.cpp
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshOptimizerComponent.cpp
@@ -535,7 +535,7 @@ namespace AZ::SceneGenerationComponents
             // the views provided by SceneAPI do not have a size() method, so compute it
             const size_t layerCount = AZStd::distance(dataView.begin(), dataView.end());
             AZStd::vector<ResultingLayerType*> layers(layerCount);
-            AZStd::generate(layers.begin(), layers.end(), [&meshBuilder, vertexCount]
+            AZStd::generate(layers.begin(), layers.end(), [&meshBuilder = meshBuilder, vertexCount = vertexCount]
             {
                 return meshBuilder.AddLayer<ResultingLayerType>(vertexCount);
             });


### PR DESCRIPTION
For some reason the `to_address` call in the AZStd::ranges::view_interface to avoid a incomplete base class error.

The MeshOptimizerComponent VS2022 was having issues capturing a captured variable into inner lambda.

Both of these issues I attribute for VS2022 compiler bugs.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>