### PR TITLE
Fixed typo in the Container type tooltip

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Dialogs/ContainerWizard/ContainerTypeLineEdit.ui
+++ b/Gems/ScriptCanvas/Code/Editor/View/Dialogs/ContainerWizard/ContainerTypeLineEdit.ui
@@ -68,7 +68,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Specifies the type of Container to Create.</string>
+         <string>Specifies the type of Container to create.</string>
         </property>
         <property name="text">
          <string>Key Type</string>


### PR DESCRIPTION
Signed-off-by: LB-BartoszCwiek <v-bartosz.cwiek@lionbridge.com>

Fixed typo in the Container type tooltip.

Before changes:
![image](https://user-images.githubusercontent.com/100559077/172379088-de5a42c2-8958-4c56-b430-95517e4e78b2.png)

After changes:
![image](https://user-images.githubusercontent.com/100559077/172379219-50047377-0e63-4b5e-98dd-e35b19d52479.png)
