### PR TITLE
Explicltly call benchmark test in build config

### DIFF
--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -253,7 +253,7 @@
       "CMAKE_OPTIONS": "-G 'Ninja Multi-Config' -DLY_PARALLEL_LINK_JOBS=4",
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "TEST_SUITE_benchmark",
-      "CTEST_OPTIONS": "-L (^SUITE_benchmark$) --no-tests=error -T Test",
+      "CTEST_OPTIONS": "-L (SUITE_benchmark) -LE (REQUIRES_gpu) --no-tests=error -T Test",
       "TEST_METRICS": "True",
       "TEST_RESULTS": "True"
     }

--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -253,7 +253,7 @@
       "CMAKE_OPTIONS": "-G 'Ninja Multi-Config' -DLY_PARALLEL_LINK_JOBS=4",
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "TEST_SUITE_benchmark",
-      "CTEST_OPTIONS": "-L (SUITE_benchmark) --no-tests=error -T Test",
+      "CTEST_OPTIONS": "-L (^SUITE_benchmark$) --no-tests=error -T Test",
       "TEST_METRICS": "True",
       "TEST_RESULTS": "True"
     }

--- a/scripts/build/Platform/Mac/build_config.json
+++ b/scripts/build/Platform/Mac/build_config.json
@@ -136,7 +136,7 @@
       "CMAKE_OPTIONS": "-G Xcode",
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "TEST_SUITE_benchmark",
-      "CTEST_OPTIONS": "-L (SUITE_benchmark)",
+      "CTEST_OPTIONS": "-L (^SUITE_benchmark$)",
       "TEST_RESULTS": "False"
     }
   },

--- a/scripts/build/Platform/Mac/build_config.json
+++ b/scripts/build/Platform/Mac/build_config.json
@@ -136,7 +136,7 @@
       "CMAKE_OPTIONS": "-G Xcode",
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "TEST_SUITE_benchmark",
-      "CTEST_OPTIONS": "-L (^SUITE_benchmark$)",
+      "CTEST_OPTIONS": "-L (SUITE_benchmark) -LE (REQUIRES_gpu)",
       "TEST_RESULTS": "False"
     }
   },

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -322,7 +322,7 @@
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "TEST_SUITE_benchmark",
       "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo",
-      "CTEST_OPTIONS": "-L \"(^SUITE_benchmark$)\" -T Test --no-tests=error",
+      "CTEST_OPTIONS": "-L (SUITE_benchmark) -LE (REQUIRES_gpu) -T Test --no-tests=error",
       "TEST_METRICS": "True",
       "TEST_RESULTS": "True"
     }

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -322,7 +322,7 @@
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "TEST_SUITE_benchmark",
       "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo",
-      "CTEST_OPTIONS": "-L \"(SUITE_benchmark)\" -T Test --no-tests=error",
+      "CTEST_OPTIONS": "-L \"(^SUITE_benchmark$)\" -T Test --no-tests=error",
       "TEST_METRICS": "True",
       "TEST_RESULTS": "True"
     }


### PR DESCRIPTION
Puts in a exclude rule for GPU test in non-GPU benchmark jobs