### PR TITLE
{ly97798} fix to handle mixed path slashes for ACS

### DIFF
--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
@@ -818,6 +818,7 @@ namespace AssetProcessor
         for (AssetBuilderSDK::JobProduct& product : jobResponse.m_outputProducts)
         {
             // Try to handle Absolute paths within the temp folder
+            AzFramework::StringFunc::Path::Normalize(product.m_productFileName);
             if (!AzFramework::StringFunc::Replace(product.m_productFileName, normalizedTempFolderPath.c_str(), s_tempString))
             {
                 // From CopyCompiledAssets:
@@ -836,7 +837,6 @@ namespace AssetProcessor
                     AzFramework::StringFunc::Path::Normalize(sourceFile);
                     AzFramework::StringFunc::Path::StripFullName(sourceFile);
 
-                    AzFramework::StringFunc::Path::Normalize(product.m_productFileName);
                     size_t sourcePathPos = product.m_productFileName.find(sourceFile.c_str());
                     if(sourcePathPos != AZStd::string::npos)
                     {
@@ -845,7 +845,9 @@ namespace AssetProcessor
                     }
                     else
                     {
-                        AZ_Warning(AssetBuilderSDK::WarningWindow, false, "Failed to find source path %s or temp path %s in non relative path in %s", sourceFile.c_str(), normalizedTempFolderPath.c_str(), product.m_productFileName.c_str());
+                        AZ_Warning(AssetBuilderSDK::WarningWindow, false,
+                            "Failed to find source path %s or temp path %s in non relative path in %s",
+                            sourceFile.c_str(), normalizedTempFolderPath.c_str(), product.m_productFileName.c_str());
                     }
                 }
             }
@@ -909,8 +911,8 @@ namespace AssetProcessor
 
             if(jobLogResponse.m_jobLog.find("No log file found") != AZStd::string::npos)
             {
-                AZ_TracePrintf(AssetProcessor::DebugChannel, "Unable to find job log from the server. This could happen if you are trying to use the server cache with a copy job,\
-please check the assetprocessorplatformconfig.ini file and ensure that server cache is disabled for the job.\n");
+                AZ_TracePrintf(AssetProcessor::DebugChannel, "Unable to find job log from the server. This could happen if you are trying to use the server cache with a copy job, "
+                    "please check the assetprocessorplatformconfig.ini file and ensure that server cache is disabled for the job.\n");
             }
 
             return false;
@@ -920,9 +922,9 @@ please check the assetprocessorplatformconfig.ini file and ensure that server ca
         AZ_TracePrintf(AssetProcessor::DebugChannel, "------------SERVER BEGIN----------\n");
         AzToolsFramework::Logging::LogLine::ParseLog(jobLogResponse.m_jobLog.c_str(), jobLogResponse.m_jobLog.size(),
             [&jobLogTraceListener](AzToolsFramework::Logging::LogLine& line)
-        {
-            jobLogTraceListener.AppendLog(line);
-        });
+            {
+                jobLogTraceListener.AppendLog(line);
+            });
         AZ_TracePrintf(AssetProcessor::DebugChannel, "------------SERVER END----------\n");
         return true;
     }

--- a/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.h
+++ b/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.h
@@ -9,6 +9,9 @@
 #pragma once
 
 #include <utilities/AssetUtilEBusHelper.h>
+#include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Interface/Interface.h>
+#include <gmock/gmock.h>
 
 namespace UnitTests
 {
@@ -34,5 +37,46 @@ namespace UnitTests
         QString m_jobDependencyFilePath;
         AZStd::vector<AZ::u32> m_subIdDependencies;
         int m_createJobsCount = 0;
+    };
+
+    class MockComponentApplication
+        : public AZ::ComponentApplicationBus::Handler
+    {
+    public:
+        MockComponentApplication()
+        {
+            AZ::ComponentApplicationBus::Handler::BusConnect();
+            AZ::Interface<AZ::ComponentApplicationRequests>::Register(this);
+        }
+
+        ~MockComponentApplication()
+        {
+            AZ::Interface<AZ::ComponentApplicationRequests>::Unregister(this);
+            AZ::ComponentApplicationBus::Handler::BusDisconnect();
+        }
+
+    public:
+        MOCK_METHOD1(FindEntity, AZ::Entity* (const AZ::EntityId&));
+        MOCK_METHOD1(AddEntity, bool(AZ::Entity*));
+        MOCK_METHOD0(Destroy, void());
+        MOCK_METHOD1(RegisterComponentDescriptor, void(const AZ::ComponentDescriptor*));
+        MOCK_METHOD1(UnregisterComponentDescriptor, void(const AZ::ComponentDescriptor*));
+        MOCK_METHOD1(RegisterEntityAddedEventHandler, void(AZ::EntityAddedEvent::Handler&));
+        MOCK_METHOD1(RegisterEntityRemovedEventHandler, void(AZ::EntityRemovedEvent::Handler&));
+        MOCK_METHOD1(RegisterEntityActivatedEventHandler, void(AZ::EntityActivatedEvent::Handler&));
+        MOCK_METHOD1(RegisterEntityDeactivatedEventHandler, void(AZ::EntityDeactivatedEvent::Handler&));
+        MOCK_METHOD1(SignalEntityActivated, void(AZ::Entity*));
+        MOCK_METHOD1(SignalEntityDeactivated, void(AZ::Entity*));
+        MOCK_METHOD1(RemoveEntity, bool(AZ::Entity*));
+        MOCK_METHOD1(DeleteEntity, bool(const AZ::EntityId&));
+        MOCK_METHOD1(GetEntityName, AZStd::string(const AZ::EntityId&));
+        MOCK_METHOD1(EnumerateEntities, void(const ComponentApplicationRequests::EntityCallback&));
+        MOCK_METHOD0(GetApplication, AZ::ComponentApplication* ());
+        MOCK_METHOD0(GetSerializeContext, AZ::SerializeContext* ());
+        MOCK_METHOD0(GetJsonRegistrationContext, AZ::JsonRegistrationContext* ());
+        MOCK_METHOD0(GetBehaviorContext, AZ::BehaviorContext* ());
+        MOCK_CONST_METHOD0(GetEngineRoot, const char* ());
+        MOCK_CONST_METHOD0(GetExecutableFolder, const char* ());
+        MOCK_CONST_METHOD1(QueryApplicationType, void(AZ::ApplicationTypeQuery&));
     };
 }

--- a/Code/Tools/AssetProcessor/native/tests/resourcecompiler/RCJobTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/resourcecompiler/RCJobTest.cpp
@@ -7,7 +7,9 @@
  */
 
 #include <native/tests/AssetProcessorTest.h>
+#include <native/tests/UnitTestUtilities.h>
 #include <native/resourcecompiler/rcjob.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace UnitTests
 {
@@ -53,7 +55,7 @@ namespace UnitTests
             m_data.reset(new StaticData());
             m_data->tempDirPath = QDir(m_data->m_tempDir.path());
             m_data->m_absolutePathToTempInputFolder = m_data->tempDirPath.absoluteFilePath("InputFolder").toUtf8().constData();
-            // note that the case of OutputFolder is intentionally upper/lower case becuase
+            // note that the case of OutputFolder is intentionally upper/lower case because
             // while files inside the output folder should be lowercased, the path to there should not be lowercased by RCJob.
             m_data->m_absolutePathToTempOutputFolder = m_data->tempDirPath.absoluteFilePath("OutputFolder").toUtf8().constData();
             m_data->tempDirPath.mkpath(QString::fromUtf8(m_data->m_absolutePathToTempInputFolder.c_str()));
@@ -280,5 +282,60 @@ namespace UnitTests
         EXPECT_STREQ(normalizedStopPath.toUtf8().constData(), m_data->m_notifyTracker.m_capturedStopPaths[0].c_str());
     }
 
+    TEST_F(RCJobTest, BeforeStoringJobResult_NonNormalPath_Succeeds)
+    {
+        auto serializeContext = AZStd::make_unique<AZ::SerializeContext>();
+        AssetBuilderSDK::ProcessJobResponse::Reflect(&*serializeContext);
+        AssetBuilderSDK::JobProduct::Reflect(&*serializeContext);
+        AzToolsFramework::AssetSystem::AssetJobLogResponse::Reflect(&*serializeContext);
+        AzFramework::AssetSystem::BaseAssetProcessorMessage::Reflect(&*serializeContext);
+
+        auto mockComponentApplication = NiceMock<::UnitTests::MockComponentApplication>();
+        ON_CALL(mockComponentApplication, GetSerializeContext()).WillByDefault(Return(serializeContext.get()));
+
+        AssetProcessor::RCJob rcJob;
+
+        BuilderParams builderParams(&rcJob);
+        builderParams.m_processJobRequest.m_tempDirPath = m_data->m_absolutePathToTempInputFolder.c_str(); // input working scratch space folder
+
+        AZStd::string backSlashedPath = builderParams.m_processJobRequest.m_tempDirPath;
+        AZStd::replace(backSlashedPath.begin(), backSlashedPath.end(), '/', '\\');
+
+        AZStd::string frontSlashedPath = builderParams.m_processJobRequest.m_tempDirPath;
+        AZStd::replace(frontSlashedPath.begin(), frontSlashedPath.end(), '\\', '/');
+
+        AZStd::string mixedSlashedPath = builderParams.m_processJobRequest.m_tempDirPath;
+        auto slashPos = mixedSlashedPath.find_first_of('\\');
+        if (slashPos == AZStd::string::npos)
+        {
+            slashPos = mixedSlashedPath.find_first_of('/');
+            ASSERT_TRUE(slashPos != AZStd::string::npos);
+            mixedSlashedPath.replace(slashPos, 1, 1, '\\');
+        }
+        else
+        {
+            mixedSlashedPath.replace(slashPos, 1, 1, '/');
+        }
+
+        AssetBuilderSDK::ProcessJobResponse jobResponse;
+        jobResponse.m_outputProducts.push_back({ (AZ::IO::Path(backSlashedPath) / "file1.txt").c_str() });
+        jobResponse.m_outputProducts.push_back({ (AZ::IO::Path(frontSlashedPath) / "file2.txt").c_str() });
+        jobResponse.m_outputProducts.push_back({ (AZ::IO::Path(mixedSlashedPath) / "file3.txt").c_str() });
+
+        auto outcome = RCJob::BeforeStoringJobResult(builderParams, jobResponse);
+
+        EXPECT_TRUE(outcome.IsSuccess());
+
+        AZStd::string responseFilePath;
+        AzFramework::StringFunc::Path::ConstructFull(builderParams.m_processJobRequest.m_tempDirPath.c_str(), AssetBuilderSDK::s_processJobResponseFileName, responseFilePath, true);
+        const auto* responseOnDisk = AZ::Utils::LoadObjectFromFile<AssetBuilderSDK::ProcessJobResponse>(responseFilePath);
+        ASSERT_TRUE(responseOnDisk);
+
+        EXPECT_STREQ(responseOnDisk->m_outputProducts[0].m_productFileName.c_str(), (AZ::IO::Path("%TEMP%") / "file1.txt").c_str());
+        EXPECT_STREQ(responseOnDisk->m_outputProducts[1].m_productFileName.c_str(), (AZ::IO::Path("%TEMP%") / "file2.txt").c_str());
+        EXPECT_STREQ(responseOnDisk->m_outputProducts[2].m_productFileName.c_str(), (AZ::IO::Path("%TEMP%") / "file3.txt").c_str());
+
+        delete responseOnDisk;
+    }
 
 } // end namespace UnitTests


### PR DESCRIPTION
* The Asset Cache Server was not handling mixed paths when packing up the product artifacts

Signed-off-by: Allen Jackson <23512001+jackalbe@users.noreply.github.com>