### PR TITLE
Ly test tools unittest fix creating files

### DIFF
--- a/Tools/LyTestTools/tests/unit/test_fixtures.py
+++ b/Tools/LyTestTools/tests/unit/test_fixtures.py
@@ -187,13 +187,6 @@ class TestFixtures(object):
         retval = mock.MagicMock()
         mock_create.return_value = retval
         mock_workspace = mock.MagicMock()
-        mock_workspace.paths.waf.return_value = "dummy"
-        mock_workspace.paths.autoexec_file.return_value = "dummy2"
-        file_handler = mock.mock_open()
-
-        with mock.patch('ly_test_tools._internal.pytest_plugin.test_tools_fixtures.open', file_handler, create=True):
-            with open(mock_workspace.paths.autoexec_file(), 'w') as autoexec_file:
-                autoexec_file.write('map ' + 'level')
 
         under_test = test_tools_fixtures._launcher(mock.MagicMock(), mock_workspace, 'windows', 'level')
 
@@ -208,9 +201,6 @@ class TestFixtures(object):
         mock_create.return_value = retval
         mock_request = mock.MagicMock()
         mock_workspace = mock.MagicMock()
-        mock_workspace.paths.waf.return_value = "dummy"
-        mock_workspace.paths.autoexec_file.return_value = "dummy2"
-        file_handler = mock.mock_open()
 
         def _fail_finalizer():
             assert False, "teardown should have been added to finalizer"
@@ -221,10 +211,6 @@ class TestFixtures(object):
 
         _finalizer = _fail_finalizer
         mock_request.addfinalizer = _capture_finalizer
-
-        with mock.patch('ly_test_tools._internal.pytest_plugin.test_tools_fixtures.open', file_handler, create=True):
-            with open(mock_workspace.paths.autoexec_file(), 'w') as autoexec_file:
-                autoexec_file.write('map ' + 'level')
 
         under_test = test_tools_fixtures._launcher(mock_request, mock_workspace, 'windows', 'level')
 

--- a/Tools/LyTestTools/tests/unit/test_py_logging_util.py
+++ b/Tools/LyTestTools/tests/unit/test_py_logging_util.py
@@ -48,11 +48,11 @@ class TestTerminateLogging(object):
         mock_removeHandler.assert_has_calls(calls)
 
 
+@mock.patch("logging.FileHandler", mock.MagicMock())
 class TestInitializeLogging(object):
 
     @mock.patch("logging.getLogger", scope='function')
     @mock.patch("logging.StreamHandler", mock.MagicMock())
-    @mock.patch("logging.FileHandler", mock.MagicMock())
     def test_InitializeLogging_AddHandlerCalled_CalledThrice(self, mock_get_logger):
         dummy_log_path = "dummy_log_path"
         dummy_info_path = "dummy_info_path"
@@ -65,7 +65,6 @@ class TestInitializeLogging(object):
         py_logging_util.terminate_logging()
 
     @mock.patch("logging.getLogger", scope='function')
-    @mock.patch("logging.FileHandler", mock.MagicMock())
     def test_InitializeLogging_CheckLoggerCalled_LoggerCalledOnce(self, mock_get_logger):
         dummy_log_path = "dummy_path"
         dummy_info_path = "dummy_path"
@@ -73,7 +72,6 @@ class TestInitializeLogging(object):
         mock_get_logger.assert_called_once()
 
     @mock.patch("logging.getLogger", scope='function')
-    @mock.patch("logging.FileHandler", mock.MagicMock())
     def test_InitializeLogging_SetLogLevelValidArgs_ValidArgsPassed(self, mock_get_logger):
         dummy_log_path = "dummy_path"
         dummy_info_path = "dummy_path"
@@ -81,7 +79,6 @@ class TestInitializeLogging(object):
         py_logging_util.initialize_logging(dummy_info_path, dummy_log_path)
         mock_setLevel.assert_called_with(10)  # logging.DEBUG = 10
 
-    @mock.patch("logging.FileHandler", mock.MagicMock())
     def test_InitializeLogging_CheckHandlerInitialized_HandlerNotNone(self):
         dummy_log_path = "dummy_path"
         dummy_info_path = "dummy_path"
@@ -91,14 +88,14 @@ class TestInitializeLogging(object):
         assert py_logging_util._stream_handler is not None
 
     @mock.patch("logging.StreamHandler.setFormatter", scope='function')
-    @mock.patch("logging.FileHandler", mock.MagicMock())
-    def test_InitializeLogging_CheckFormatting_HandlerFormattingIsCorrect(self,mock_stream_handler_formatter):
+    @mock.patch('logging.getLogger', mock.MagicMock())
+    def test_InitializeLogging_CheckFormatting_HandlerFormattingIsCorrect(self, mock_stream_handler_formatter):
         dummy_log_path = "dummy_path"
         dummy_info_path = "dummy_path"
         py_logging_util._stream_handler = None
         py_logging_util._info_file_handler = None
         py_logging_util._debug_file_handler = None
-        py_logging_util.initialize_logging(dummy_info_path,dummy_log_path)
+        py_logging_util.initialize_logging(dummy_info_path, dummy_log_path)
         #example of formatted string : 7024.00016785 - DEBUG - [MainThread] - ly_test_tools.launchers.platforms.win.launcher - Initialized Windows Launcher
         format_string = "%(relativeCreated)s - %(levelname)s - [%(threadName)s] - %(name)s - %(message)s"
         assert mock_stream_handler_formatter.call_args[0][0]._fmt == format_string

--- a/Tools/LyTestTools/tests/unit/test_py_logging_util.py
+++ b/Tools/LyTestTools/tests/unit/test_py_logging_util.py
@@ -50,7 +50,9 @@ class TestTerminateLogging(object):
 
 class TestInitializeLogging(object):
 
-    @mock.patch("logging.getLogger", scope='module')
+    @mock.patch("logging.getLogger", scope='function')
+    @mock.patch("logging.StreamHandler", mock.MagicMock())
+    @mock.patch("logging.FileHandler", mock.MagicMock())
     def test_InitializeLogging_AddHandlerCalled_CalledThrice(self, mock_get_logger):
         dummy_log_path = "dummy_log_path"
         dummy_info_path = "dummy_info_path"
@@ -62,15 +64,16 @@ class TestInitializeLogging(object):
         assert mock_add_handler.call_count == 3
         py_logging_util.terminate_logging()
 
-
-    @mock.patch("logging.getLogger", scope='module')
+    @mock.patch("logging.getLogger", scope='function')
+    @mock.patch("logging.FileHandler", mock.MagicMock())
     def test_InitializeLogging_CheckLoggerCalled_LoggerCalledOnce(self, mock_get_logger):
         dummy_log_path = "dummy_path"
         dummy_info_path = "dummy_path"
         py_logging_util.initialize_logging(dummy_info_path, dummy_log_path)
         mock_get_logger.assert_called_once()
 
-    @mock.patch("logging.getLogger", scope='module')
+    @mock.patch("logging.getLogger", scope='function')
+    @mock.patch("logging.FileHandler", mock.MagicMock())
     def test_InitializeLogging_SetLogLevelValidArgs_ValidArgsPassed(self, mock_get_logger):
         dummy_log_path = "dummy_path"
         dummy_info_path = "dummy_path"
@@ -78,6 +81,7 @@ class TestInitializeLogging(object):
         py_logging_util.initialize_logging(dummy_info_path, dummy_log_path)
         mock_setLevel.assert_called_with(10)  # logging.DEBUG = 10
 
+    @mock.patch("logging.FileHandler", mock.MagicMock())
     def test_InitializeLogging_CheckHandlerInitialized_HandlerNotNone(self):
         dummy_log_path = "dummy_path"
         dummy_info_path = "dummy_path"
@@ -86,7 +90,8 @@ class TestInitializeLogging(object):
         assert py_logging_util._info_file_handler is not None
         assert py_logging_util._stream_handler is not None
 
-    @mock.patch("logging.StreamHandler.setFormatter", scope='module')
+    @mock.patch("logging.StreamHandler.setFormatter", scope='function')
+    @mock.patch("logging.FileHandler", mock.MagicMock())
     def test_InitializeLogging_CheckFormatting_HandlerFormattingIsCorrect(self,mock_stream_handler_formatter):
         dummy_log_path = "dummy_path"
         dummy_info_path = "dummy_path"

--- a/Tools/LyTestTools/tests/unit/test_settings.py
+++ b/Tools/LyTestTools/tests/unit/test_settings.py
@@ -140,6 +140,7 @@ class TestReplaceLineInFile(unittest.TestCase):
     @mock.patch('os.path.isfile')
     @mock.patch('fileinput.input')
     @mock.patch('sys.stdout')
+    @mock.patch('builtins.open', mock.MagicMock())
     def test_ReplaceLineInFile_NoMatch_SettingAppended(self, mock_stdout, mock_input, mock_isfile):
         mock_isfile.return_value = True
         mock_input.return_value = MockDocumentInput(self.mock_file_content)


### PR DESCRIPTION
Fixes unit tests from creating files in various ways. Issues found were mostly non-mocked file handlers. Also found issues with tests setting logging values. Tested by running all LyTestTools unit tests.