### PR TITLE
Disabling test_Multiplayer_AutoComponent_RPC because it periodically fails

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
@@ -33,6 +33,7 @@ class TestAutomation(EditorTestSuite):
         def setup(cls, instance, request, workspace, editor, editor_test_results, launcher_platform):
             save_multiplayer_level_cache_folder_artifact(workspace, "autocomponent_networkinput")
 
+    @pytest.mark.xfail(reason="GHI #9869: Test periodically fails")
     class test_Multiplayer_AutoComponent_RPC(EditorSingleTest):
         from .tests import Multiplayer_AutoComponent_RPC as test_module
 


### PR DESCRIPTION
GHI to fix the test: https://github.com/o3de/o3de/issues/9869

Signed-off-by: moraaar <moraaar@amazon.com>