### PR TITLE
Remove references to GFxFramework from PhysX and Blast gems

### DIFF
--- a/Gems/Blast/Code/CMakeLists.txt
+++ b/Gems/Blast/Code/CMakeLists.txt
@@ -82,7 +82,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                AZ::GFxFramework
                 AZ::SceneCore
                 AZ::SceneData
                 Legacy::Editor.Headers

--- a/Gems/PhysX/Code/CMakeLists.txt
+++ b/Gems/PhysX/Code/CMakeLists.txt
@@ -107,7 +107,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 AZ::AzCore
                 AZ::AzFramework
                 AZ::AzToolsFramework
-                AZ::GFxFramework
                 AZ::AssetBuilderSDK
                 AZ::SceneCore
                 AZ::SceneData

--- a/Gems/PhysX/Code/Source/Pipeline/MeshExporter.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshExporter.cpp
@@ -35,7 +35,6 @@
 #include <AzCore/XML/rapidxml.h>
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
-#include <GFxFramework/MaterialIO/Material.h>
 
 // A utility macro helping set/clear bits in a single line
 #define SET_BITS(flags, condition, bits) flags = (condition) ? ((flags) | (bits)) : ((flags) & ~(bits))


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>