### PR TITLE
Fix crash when binding swapchain to imported texture attachment

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
@@ -84,7 +84,7 @@ namespace AZ
             // display mapper parameters.
             if (m_swapChainAttachmentBinding && m_swapChainAttachmentBinding->GetAttachment())
             {
-                m_displayBufferFormat = m_swapChainAttachmentBinding->GetAttachment()->GetTransientImageDescriptor().m_imageDescriptor.m_format;
+                m_displayBufferFormat = m_swapChainAttachmentBinding->GetAttachment()->m_descriptor.m_image.m_format;
             }
 
             if (m_displayBufferFormat != RHI::Format::Unknown)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationTransformPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationTransformPass.cpp
@@ -44,7 +44,7 @@ namespace AZ
             RHI::Format swapChainFormat = RHI::Format::Unknown;
             if (m_swapChainAttachmentBinding && m_swapChainAttachmentBinding->GetAttachment())
             {
-                swapChainFormat = m_swapChainAttachmentBinding->GetAttachment()->GetTransientImageDescriptor().m_imageDescriptor.m_format;
+                swapChainFormat = m_swapChainAttachmentBinding->GetAttachment()->m_descriptor.m_image.m_format;
             }
 
             // Update the children passes


### PR DESCRIPTION
This fix was suggested on Discord, to fix a crash occurring when you try to redirect the final pass from the swapchain to a texture for example.