### PR TITLE
Material: Fix Compile() when NeedsCompile() = false

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -340,7 +340,12 @@ namespace AZ
         {
             AZ_PROFILE_FUNCTION(RPI);
 
-            if (NeedsCompile() && CanCompile())
+            if (!NeedsCompile())
+            {
+                return true;
+            }
+
+            if (CanCompile())
             {
                 // On some platforms, PipelineStateObjects must be pre-compiled and shipped with the game; they cannot be compiled at runtime. So at some
                 // point the material system needs to be smart about when it allows PSO changes and when it doesn't. There is a task scheduled to

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialTests.cpp
@@ -354,7 +354,7 @@ namespace UnitTest
         EXPECT_FALSE(material->SetPropertyValue<float>(material->FindPropertyIndex(Name{ "MyFloat" }), 2.5f));
         
         ProcessQueuedSrgCompilations(m_testMaterialShaderAsset, m_testMaterialSrgLayout->GetName());
-        EXPECT_FALSE(material->Compile());
+        EXPECT_TRUE(material->Compile());
 
         // Make sure the SRG is still tainted, because the SetPropertyValue() functions weren't processed
         EXPECT_EQ(srgData.GetConstant<float>(srgData.FindShaderInputConstantIndex(Name{ "m_float" })), 0.0f);


### PR DESCRIPTION
When a material property is updated on a material that doesn't have this property (which of course is a mistake), the material becomes stuck and cannot compile. 

As `Material::CanCompile` will return false (because its srg will not be queued for compilation), the material will simply try to compile every tick forever.

A simple fix is to check if the material compilation is required.