### PR TITLE
ImageProcessing: expose some functions and allows in-memory processing

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingBus.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingBus.h
@@ -11,6 +11,7 @@
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <Atom/ImageProcessing/ImageObject.h>
+#include <Atom/ImageProcessing/ImageProcessingDefines.h>
 
 namespace AssetBuilderSDK
 {
@@ -76,6 +77,18 @@ namespace ImageProcessingAtom
 
         //! Return whether the specified preset requires an image to be square and a power of 2
         virtual bool IsPresetFormatSquarePow2(const AZStd::string& presetName, const AZStd::string& platformName) = 0;
+
+        virtual FileMask GetFileMask(AZStd::string_view imageFilePath) = 0;
+
+        virtual AZStd::vector<AZStd::string> GetFileMasksForPreset(const PresetName& presetName) = 0;
+
+        virtual AZStd::vector<PresetName> GetPresetsForFileMask(const FileMask& fileMask) = 0;
+
+        virtual PresetName GetDefaultPreset() = 0;
+
+        virtual PresetName GetDefaultAlphaPreset() = 0;
+
+        virtual bool IsValidPreset(PresetName presetName) = 0;
     };
 
     using ImageBuilderRequestBus = AZ::EBus<ImageBuilderRequests>;

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingBus.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingBus.h
@@ -65,6 +65,7 @@ namespace ImageProcessingAtom
             const AZ::Data::AssetId& sourceAssetId,
             const AZStd::string& sourceAssetName) = 0;
 
+        //! Convert an image and return its product instead ot saving it to the disk
         virtual IImageObjectPtr ConvertImageObjectInMemory(
             IImageObjectPtr imageObject,
             const AZStd::string& presetName,
@@ -78,16 +79,22 @@ namespace ImageProcessingAtom
         //! Return whether the specified preset requires an image to be square and a power of 2
         virtual bool IsPresetFormatSquarePow2(const AZStd::string& presetName, const AZStd::string& platformName) = 0;
 
+        //! Extract the file mask of a file path
         virtual FileMask GetFileMask(AZStd::string_view imageFilePath) = 0;
 
+        //! Return all file masks associated with this preset
         virtual AZStd::vector<AZStd::string> GetFileMasksForPreset(const PresetName& presetName) = 0;
 
+        //! Return all preset names associated with this file mask
         virtual AZStd::vector<PresetName> GetPresetsForFileMask(const FileMask& fileMask) = 0;
 
+        //! Return the default opaque preset name
         virtual PresetName GetDefaultPreset() = 0;
 
+        //! Return the default alpha preset name
         virtual PresetName GetDefaultAlphaPreset() = 0;
 
+        //! Return true if the preset name is valid
         virtual bool IsValidPreset(PresetName presetName) = 0;
     };
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingBus.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingBus.h
@@ -64,6 +64,13 @@ namespace ImageProcessingAtom
             const AZ::Data::AssetId& sourceAssetId,
             const AZStd::string& sourceAssetName) = 0;
 
+        virtual IImageObjectPtr ConvertImageObjectInMemory(
+            IImageObjectPtr imageObject,
+            const AZStd::string& presetName,
+            const AZStd::string& platformName,
+            const AZ::Data::AssetId& sourceAssetId,
+            const AZStd::string& sourceAssetName) = 0;
+
         //! Return whether the specified platform is supported by the image builder
         virtual bool DoesSupportPlatform(const AZStd::string& platformId) = 0;
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
@@ -623,7 +623,9 @@ namespace ImageProcessingAtom
         if (auto it = m_presetFilterMap.find(fileMask); it != m_presetFilterMap.end())
         {
             for (const PresetName& presetName : it->second)
+            {
                 presets.push_back(presetName);
+            }
         }
 
         return presets;

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
@@ -587,7 +587,7 @@ namespace ImageProcessingAtom
         metafilePath = AZStd::string();
     }
 
-    AZStd::string GetFileMask(AZStd::string_view imageFilePath)
+    AZStd::string BuilderSettingManager::GetFileMask(AZStd::string_view imageFilePath) const
     {
         //get file name
         AZStd::string fileName;
@@ -603,6 +603,30 @@ namespace ImageProcessingAtom
         }
 
         return AZStd::string();
+    }
+
+    PresetName BuilderSettingManager::GetDefaultPreset() const
+    {
+        return m_defaultPreset;
+    }
+
+    PresetName BuilderSettingManager::GetDefaultAlphaPreset() const
+    {
+        return m_defaultPresetAlpha;
+    }
+
+    AZStd::vector<PresetName> BuilderSettingManager::GetPresetsForFileMask(const FileMask& fileMask) const
+    {
+        AZStd::vector<PresetName> presets;
+
+        AZStd::lock_guard<AZStd::recursive_mutex> lock(m_presetMapLock);
+        if (auto it = m_presetFilterMap.find(fileMask); it != m_presetFilterMap.end())
+        {
+            for (const PresetName& presetName : it->second)
+                presets.push_back(presetName);
+        }
+
+        return presets;
     }
 
     bool BuilderSettingManager::IsValidPreset(PresetName presetName) const

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.h
@@ -102,14 +102,19 @@ namespace ImageProcessingAtom
         //! Otherwise, the preset's file path can be retrieved in GetPreset() function
         AZStd::vector<AZStd::string> GetPossiblePresetPaths(const PresetName& presetName) const;
 
+        //! Extract the file mask of a file path
         AZStd::string GetFileMask(AZStd::string_view imageFilePath) const;
 
+        //! Return the default opaque preset name
         PresetName GetDefaultPreset() const;
 
+        //! Return the default alpha preset name
         PresetName GetDefaultAlphaPreset() const;
 
+        //! Return all preset names associated with this file mask
         AZStd::vector<PresetName> GetPresetsForFileMask(const FileMask& fileMask) const;
 
+        //! Return true if the preset name is valid
         bool IsValidPreset(PresetName presetName) const;
 
         bool DoesSupportPlatform(AZStd::string_view platformId);

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.h
@@ -102,6 +102,14 @@ namespace ImageProcessingAtom
         //! Otherwise, the preset's file path can be retrieved in GetPreset() function
         AZStd::vector<AZStd::string> GetPossiblePresetPaths(const PresetName& presetName) const;
 
+        AZStd::string GetFileMask(AZStd::string_view imageFilePath) const;
+
+        PresetName GetDefaultPreset() const;
+
+        PresetName GetDefaultAlphaPreset() const;
+
+        AZStd::vector<PresetName> GetPresetsForFileMask(const FileMask& fileMask) const;
+
         bool IsValidPreset(PresetName presetName) const;
 
         bool DoesSupportPlatform(AZStd::string_view platformId);

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.cpp
@@ -255,6 +255,36 @@ namespace ImageProcessingAtom
         return info->bSquarePow2;
     }
 
+    FileMask BuilderPluginComponent::GetFileMask(AZStd::string_view imageFilePath)
+    {
+        return ImageProcessingAtom::BuilderSettingManager::Instance()->GetFileMask(imageFilePath);
+    }
+
+    AZStd::vector<AZStd::string> BuilderPluginComponent::GetFileMasksForPreset(const PresetName& presetName)
+    {
+        return ImageProcessingAtom::BuilderSettingManager::Instance()->GetFileMasksForPreset(presetName);
+    }
+
+    AZStd::vector<PresetName> BuilderPluginComponent::GetPresetsForFileMask(const FileMask& fileMask)
+    {
+        return ImageProcessingAtom::BuilderSettingManager::Instance()->GetPresetsForFileMask(fileMask);
+    }
+
+    PresetName BuilderPluginComponent::GetDefaultPreset()
+    {
+        return ImageProcessingAtom::BuilderSettingManager::Instance()->GetDefaultPreset();
+    }
+
+    PresetName BuilderPluginComponent::GetDefaultAlphaPreset()
+    {
+        return ImageProcessingAtom::BuilderSettingManager::Instance()->GetDefaultAlphaPreset();
+    }
+
+    bool BuilderPluginComponent::IsValidPreset(PresetName presetName)
+    {
+        return ImageProcessingAtom::BuilderSettingManager::Instance()->IsValidPreset(presetName);
+    }
+
     void ImageBuilderWorker::ShutDown()
     {
         // it is important to note that this will be called on a different thread than your process job thread

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.cpp
@@ -231,9 +231,13 @@ namespace ImageProcessingAtom
         process.ProcessAll();
         bool result = process.IsSucceed();
         if (result)
+        {
             return process.GetOutputImage();
+        }
         else
+        {
             return nullptr;
+        }
     }
 
     bool BuilderPluginComponent::DoesSupportPlatform(const AZStd::string& platformId)

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.h
@@ -90,6 +90,13 @@ namespace ImageProcessingAtom
             const AZStd::string& sourceAssetName) override;
         bool DoesSupportPlatform(const AZStd::string& platformId) override;
         bool IsPresetFormatSquarePow2(const AZStd::string& presetName, const AZStd::string& platformName) override;
+        FileMask GetFileMask(AZStd::string_view imageFilePath) override;
+        AZStd::vector<AZStd::string> GetFileMasksForPreset(const PresetName& presetName) override;
+        AZStd::vector<PresetName> GetPresetsForFileMask(const FileMask& fileMask) override;
+        PresetName GetDefaultPreset() override;
+        PresetName GetDefaultAlphaPreset() override;
+        bool IsValidPreset(PresetName presetName) override;
+
         ////////////////////////////////////////////////////////////////////////
 
     private:

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.h
@@ -82,6 +82,12 @@ namespace ImageProcessingAtom
             const AZStd::string& outputDir,
             const AZ::Data::AssetId& sourceAssetId,
             const AZStd::string& sourceAssetName) override;
+        IImageObjectPtr ConvertImageObjectInMemory(
+            IImageObjectPtr imageObject,
+            const AZStd::string& presetName,
+            const AZStd::string& platformName,
+            const AZ::Data::AssetId& sourceAssetId,
+            const AZStd::string& sourceAssetName) override;
         bool DoesSupportPlatform(const AZStd::string& platformId) override;
         bool IsPresetFormatSquarePow2(const AZStd::string& presetName, const AZStd::string& platformName) override;
         ////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
@@ -335,8 +335,8 @@ namespace ImageProcessingAtom
             ConvertPixelformat();
             break;
         case StepSaveToFile:
-            // save to file
-            if (!m_input->m_isPreview)
+            // save to file if required
+            if (!m_input->m_isPreview && m_input->m_shouldSaveFile)
             {
                 m_isSucceed = SaveOutput();
             }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.h
@@ -87,6 +87,9 @@ namespace ImageProcessingAtom
         AZ::Data::AssetId m_sourceAssetId;
         // List of output products for the job, appended to by the ImageConvertProcess
         AZStd::vector<AssetBuilderSDK::JobProduct>* m_jobProducts = nullptr;
+
+        // Should the step to save resulting file to disk be skipped. Disabling this can be useful for in-memory image processing.
+        bool m_shouldSaveFile = true;
     };
 
     /**


### PR DESCRIPTION
Currently, most of image processing is done inside the ImageProcessingAtom gem, and only a few functions are exposed.

It's interesting to expose some other functions to be able to do some image processing in memory, for example for a texture array  gem which only write one file for multiple images.