### PR TITLE
Allow read+write of binary file

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/FileIO.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/FileIO.cpp
@@ -246,6 +246,10 @@ namespace AZ::IO
             }
             if (AnyFlag(mode & OpenMode::ModeBinary))
             {
+                if (AnyFlag(mode & OpenMode::ModeRead))
+                {
+                    return "wb+";
+                }
                 return "wb";
             }
             if (AnyFlag(mode & OpenMode::ModeText))


### PR DESCRIPTION
Fix `GetStringModeFromOpenMode(OpenMode::ModeBinary | OpenMode::ModeWrite | OpenMode::ModeRead)`