### PR TITLE
Motion Matching: Adding transformer interface and a min-max scaler used for feature normalization

### DIFF
--- a/Gems/MotionMatching/Code/Source/FeatureMatrixMinMaxScaler.cpp
+++ b/Gems/MotionMatching/Code/Source/FeatureMatrixMinMaxScaler.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Allocators.h>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <FeatureMatrixMinMaxScaler.h>
+
+namespace EMotionFX::MotionMatching
+{
+    AZ_CLASS_ALLOCATOR_IMPL(MinMaxScaler, MotionMatchAllocator, 0)
+
+    bool MinMaxScaler::Fit(const FeatureMatrix& in, const Settings& settings)
+    {
+        const FeatureMatrix::Index numRows = in.rows();
+        const FeatureMatrix::Index numColumns = in.cols();
+
+        m_clip = settings.m_clip;
+        m_featureMin = settings.m_featureMin;
+        m_featureMax = settings.m_featureMax;
+        m_featureRange = settings.m_featureMax - settings.m_featureMin;
+        AZ_Assert(m_featureRange > s_epsilon, "Feature range too small. This will lead to divisions by infinity.");
+        m_dataMin.clear();
+        m_dataMin.resize(numColumns, std::numeric_limits<float>::max());
+        m_dataMax.clear();
+        m_dataMax.resize(numColumns, -std::numeric_limits<float>::max());
+
+        for (FeatureMatrix::Index row = 0; row < numRows; ++row)
+        {
+            for (FeatureMatrix::Index column = 0; column < numColumns; ++column)
+            {
+                m_dataMin[column] = AZStd::min(m_dataMin[column], in(row, column));
+                m_dataMax[column] = AZStd::max(m_dataMax[column], in(row, column));
+            }
+        }
+
+        m_dataRange.clear();
+        m_dataRange.resize(numColumns);
+        for (FeatureMatrix::Index column = 0; column < numColumns; ++column)
+        {
+            const float columnMin = m_dataMin[column];
+            const float columnMax = m_dataMax[column];
+            const float range = columnMax - columnMin;
+            m_dataRange[column] = range;
+        }
+
+        return true;
+    }
+
+    //-------------------------------------------------------------------------
+
+    float MinMaxScaler::Transform(float value, FeatureMatrix::Index column) const
+    {
+        const float& min = m_dataMin[column];
+        const float& range = m_dataRange[column];
+
+        float result = value;
+        if (range > s_epsilon)
+        {
+            const float normalizedValue = (value - min) / (range);
+            const float scaled = normalizedValue * m_featureRange + m_featureMin;
+
+            result = scaled;
+        }
+
+        if (m_clip)
+        {
+            result = AZ::GetClamp(result, m_featureMin, m_featureMax);
+        }
+
+        return result;
+    }
+
+    AZ::Vector2 MinMaxScaler::Transform(const AZ::Vector2& value, FeatureMatrix::Index column) const
+    {
+        return AZ::Vector2(
+            Transform(value.GetX(), column + 0),
+            Transform(value.GetY(), column + 1));
+    }
+
+    AZ::Vector3 MinMaxScaler::Transform(const AZ::Vector3& value, FeatureMatrix::Index column) const
+    {
+        return AZ::Vector3(
+            Transform(value.GetX(), column + 0),
+            Transform(value.GetY(), column + 1),
+            Transform(value.GetZ(), column + 2));
+    }
+
+    void MinMaxScaler::Transform(AZStd::span<float> data) const
+    {
+        const size_t numValues = data.size();
+        AZ_Assert(numValues == m_dataMin.size(), "Input data needs to have the same number of elements.");
+        for (size_t i = 0; i < numValues; ++i)
+        {
+            data[i] = Transform(data[i], i);
+        }
+    }
+
+    FeatureMatrix MinMaxScaler::Transform(const FeatureMatrix& in) const
+    {
+        const FeatureMatrix::Index numRows = in.rows();
+        const FeatureMatrix::Index numColumns = in.cols();
+        FeatureMatrix result;
+        result.resize(numRows, numColumns);
+
+        for (FeatureMatrix::Index row = 0; row < numRows; ++row)
+        {
+            for (FeatureMatrix::Index column = 0; column < numColumns; ++column)
+            {
+                result(row, column) = Transform(in(row, column), column);
+            }
+        }
+
+        return result;
+    }
+
+    //-------------------------------------------------------------------------
+
+    FeatureMatrix MinMaxScaler::InverseTransform(const FeatureMatrix& in) const
+    {
+        const FeatureMatrix::Index numRows = in.rows();
+        const FeatureMatrix::Index numColumns = in.cols();
+        FeatureMatrix result;
+        result.resize(numRows, numColumns);
+
+        for (FeatureMatrix::Index row = 0; row < numRows; ++row)
+        {
+            for (FeatureMatrix::Index column = 0; column < numColumns; ++column)
+            {
+                result(row, column) = InverseTransform(in(row, column), column);
+            }
+        }
+
+        return result;
+    }
+
+    AZ::Vector2 MinMaxScaler::InverseTransform(const AZ::Vector2& value, FeatureMatrix::Index column) const
+    {
+        return AZ::Vector2(
+            InverseTransform(value.GetX(), column + 0),
+            InverseTransform(value.GetY(), column + 1));
+    }
+
+    AZ::Vector3 MinMaxScaler::InverseTransform(const AZ::Vector3& value, FeatureMatrix::Index column) const
+    {
+        return AZ::Vector3(
+            InverseTransform(value.GetX(), column + 0),
+            InverseTransform(value.GetY(), column + 1),
+            InverseTransform(value.GetZ(), column + 2));
+    }
+
+    float MinMaxScaler::InverseTransform(float value, FeatureMatrix::Index column) const
+    {
+        const float normalizedValue = (value - m_featureMin) / m_featureRange;
+        return normalizedValue * m_dataRange[column] + m_dataMin[column];
+    }
+
+    void MinMaxScaler::SaveMinMaxAsCsv(const AZStd::string& filename, const AZStd::vector<AZStd::string>& columnNames)
+    {
+        std::ofstream file(filename.c_str());
+
+        // Save column names in the first row
+        if (!columnNames.empty())
+        {
+            for (size_t i = 0; i < columnNames.size(); ++i)
+            {
+                if (i != 0)
+                {
+                    file << ",";
+                }
+
+                file << columnNames[i].c_str();
+            }
+            file << "\n";
+        }
+
+        for (size_t i = 0; i < m_dataMin.size(); ++i)
+        {
+            if (i != 0)
+            {
+                file << ",";
+            }
+
+            file << m_dataMin[i];
+        }
+
+        file << "\n";
+
+        for (size_t i = 0; i < m_dataMax.size(); ++i)
+        {
+            if (i != 0)
+            {
+                file << ",";
+            }
+
+            file << m_dataMax[i];
+        }
+
+        file << "\n";
+        file.close();
+    }
+} // namespace EMotionFX::MotionMatching

--- a/Gems/MotionMatching/Code/Source/FeatureMatrixMinMaxScaler.h
+++ b/Gems/MotionMatching/Code/Source/FeatureMatrixMinMaxScaler.h
@@ -13,6 +13,7 @@
 
 namespace EMotionFX::MotionMatching
 {
+    //! The min/max-scaler can be used to normalize the feature matrix, the query vector and other data.
     class MinMaxScaler
         : public FeatureMatrixTransformer
     {
@@ -22,17 +23,17 @@ namespace EMotionFX::MotionMatching
 
         MinMaxScaler() = default;
 
-        bool Fit(const FeatureMatrix& in, const Settings& settings = {}) override;
+        bool Fit(const FeatureMatrix& featureMatrix, const Settings& settings = {}) override;
 
         // Normalize and scale the values.
         float Transform(float value, FeatureMatrix::Index column) const override;
         AZ::Vector2 Transform(const AZ::Vector2& value, FeatureMatrix::Index column) const override;
         AZ::Vector3 Transform(const AZ::Vector3& value, FeatureMatrix::Index column) const override;
         void Transform(AZStd::span<float> data) const override;
-        FeatureMatrix Transform(const FeatureMatrix& in) const override;
+        FeatureMatrix Transform(const FeatureMatrix& featureMatrix) const override;
 
         // From normalized and scaled back to the original values.
-        FeatureMatrix InverseTransform(const FeatureMatrix& in) const override;
+        FeatureMatrix InverseTransform(const FeatureMatrix& featureMatrix) const override;
         AZ::Vector2 InverseTransform(const AZ::Vector2& value, FeatureMatrix::Index column) const override;
         AZ::Vector3 InverseTransform(const AZ::Vector3& value, FeatureMatrix::Index column) const override;
         float InverseTransform(float value, FeatureMatrix::Index column) const override;
@@ -42,12 +43,12 @@ namespace EMotionFX::MotionMatching
 
         static constexpr float s_epsilon = AZ::Constants::FloatEpsilon;
 
-        void SaveMinMaxAsCsv(const AZStd::string& filename, const AZStd::vector<AZStd::string>& columnNames = {});
+        void SaveMinMaxAsCsv(const char* filename, const AZStd::vector<AZStd::string>& columnNames = {});
 
     private:
         AZStd::vector<float> m_dataMin; //!< Minimum value per column seen in the given input feature matrix.
         AZStd::vector<float> m_dataMax; //!< Maximum value per column seen in the given input feature matrix.
-        AZStd::vector<float> m_dataRange;//!< Per column range (m_dataMax[col] - m_dataMin[col]) seen in the given input feature matrix.
+        AZStd::vector<float> m_dataRange; //!< Per column range (m_dataMax[col] - m_dataMin[col]) seen in the given input feature matrix.
 
         bool m_clip = false; //!< Clip transformed values out of feature range to provided feature range.
 

--- a/Gems/MotionMatching/Code/Source/FeatureMatrixMinMaxScaler.h
+++ b/Gems/MotionMatching/Code/Source/FeatureMatrixMinMaxScaler.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <FeatureMatrix.h>
+#include <FeatureMatrixTransformer.h>
+
+namespace EMotionFX::MotionMatching
+{
+    class MinMaxScaler
+        : public FeatureMatrixTransformer
+    {
+    public:
+        AZ_RTTI(MinMaxScaler, "{95D5BBA7-6144-4219-82F0-34C2DAB7DD3E}", FeatureMatrixTransformer);
+        AZ_CLASS_ALLOCATOR_DECL
+
+        MinMaxScaler() = default;
+
+        bool Fit(const FeatureMatrix& in, const Settings& settings = {}) override;
+
+        // Normalize and scale the values.
+        float Transform(float value, FeatureMatrix::Index column) const override;
+        AZ::Vector2 Transform(const AZ::Vector2& value, FeatureMatrix::Index column) const override;
+        AZ::Vector3 Transform(const AZ::Vector3& value, FeatureMatrix::Index column) const override;
+        void Transform(AZStd::span<float> data) const override;
+        FeatureMatrix Transform(const FeatureMatrix& in) const override;
+
+        // From normalized and scaled back to the original values.
+        FeatureMatrix InverseTransform(const FeatureMatrix& in) const override;
+        AZ::Vector2 InverseTransform(const AZ::Vector2& value, FeatureMatrix::Index column) const override;
+        AZ::Vector3 InverseTransform(const AZ::Vector3& value, FeatureMatrix::Index column) const override;
+        float InverseTransform(float value, FeatureMatrix::Index column) const override;
+
+        const AZStd::vector<float>& GetMin() const { return m_dataMin; }
+        const AZStd::vector<float>& GetMax() const { return m_dataMax; }
+
+        static constexpr float s_epsilon = AZ::Constants::FloatEpsilon;
+
+        void SaveMinMaxAsCsv(const AZStd::string& filename, const AZStd::vector<AZStd::string>& columnNames = {});
+
+    private:
+        AZStd::vector<float> m_dataMin; //!< Minimum value per column seen in the given input feature matrix.
+        AZStd::vector<float> m_dataMax; //!< Maximum value per column seen in the given input feature matrix.
+        AZStd::vector<float> m_dataRange;//!< Per column range (m_dataMax[col] - m_dataMin[col]) seen in the given input feature matrix.
+
+        bool m_clip = false; //!< Clip transformed values out of feature range to provided feature range.
+
+        //! Desired range of the transformed data.
+        float m_featureMin = 0.0f;
+        float m_featureMax = 1.0f;
+        float m_featureRange = 1.0f;
+    };
+} // namespace EMotionFX::MotionMatching

--- a/Gems/MotionMatching/Code/Source/FeatureMatrixTransformer.h
+++ b/Gems/MotionMatching/Code/Source/FeatureMatrixTransformer.h
@@ -14,11 +14,12 @@
 
 namespace EMotionFX::MotionMatching
 {
+    //! Transformers can be used to e.g. normalize or scale features in the feature matrix or the query vector.
     class FeatureMatrixTransformer
     {
     public:
         AZ_RTTI(Transformer, "{B19CDBB8-FA99-4CBD-86C1-640A3CC5988A}");
-        AZ_CLASS_ALLOCATOR(FeatureMatrixTransformer, MotionMatchAllocator, 0)
+        AZ_CLASS_ALLOCATOR(FeatureMatrixTransformer, MotionMatchAllocator, 0);
 
         virtual ~FeatureMatrixTransformer() = default;
 
@@ -34,7 +35,7 @@ namespace EMotionFX::MotionMatching
 
         //! Prepare the transformer.
         //! This might e.g. run some statistical analysis and cache values that will be needed for actually transforming the data.
-        virtual bool Fit(const FeatureMatrix& in, const Settings& settings = {}) = 0;
+        virtual bool Fit(const FeatureMatrix& featureMatrix, const Settings& settings) = 0;
 
         //! Copy and transform the input data.
         //! Note: Use the version that can batch transform the most data.

--- a/Gems/MotionMatching/Code/Source/FeatureMatrixTransformer.h
+++ b/Gems/MotionMatching/Code/Source/FeatureMatrixTransformer.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/containers/span.h>
+#include <Allocators.h>
+#include <FeatureMatrix.h>
+
+namespace EMotionFX::MotionMatching
+{
+    class FeatureMatrixTransformer
+    {
+    public:
+        AZ_RTTI(Transformer, "{B19CDBB8-FA99-4CBD-86C1-640A3CC5988A}");
+        AZ_CLASS_ALLOCATOR(FeatureMatrixTransformer, MotionMatchAllocator, 0)
+
+        virtual ~FeatureMatrixTransformer() = default;
+
+        struct Settings
+        {
+            float m_featureMin = 0.0f; //!< Minimum value after the transformation.
+            float m_featureMax = 1.0f; //!< Maximum value after the transformation.
+
+            //! Depending on the transformer to be used there might be some outliers from range [m_featureMin, m_featureMax].
+            //! Clips the values to range [m_featureMin, m_featureMax] in case true or keeps the data untouched in case of false.
+            bool m_clip = false;
+        };
+
+        //! Prepare the transformer.
+        //! This might e.g. run some statistical analysis and cache values that will be needed for actually transforming the data.
+        virtual bool Fit(const FeatureMatrix& in, const Settings& settings = {}) = 0;
+
+        //! Copy and transform the input data.
+        //! Note: Use the version that can batch transform the most data.
+        //!       Expect significant performance losses when calling the granular versions on lots of data points.
+        virtual float Transform(float value, FeatureMatrix::Index column) const = 0;
+        virtual AZ::Vector2 Transform(const AZ::Vector2& value, FeatureMatrix::Index column) const = 0;
+        virtual AZ::Vector3 Transform(const AZ::Vector3& value, FeatureMatrix::Index column) const = 0;
+        virtual void Transform(AZStd::span<float> data) const = 0;
+        virtual FeatureMatrix Transform(const FeatureMatrix& in) const = 0;
+
+        //! Input: Already transformed data, Output: Inverse transformed data (should match data before transform)
+        virtual float InverseTransform(float value, FeatureMatrix::Index column) const = 0;
+        virtual AZ::Vector2 InverseTransform(const AZ::Vector2& value, FeatureMatrix::Index column) const = 0;
+        virtual AZ::Vector3 InverseTransform(const AZ::Vector3& value, FeatureMatrix::Index column) const = 0;
+        virtual FeatureMatrix InverseTransform(const FeatureMatrix& in) const = 0;
+    };
+} // namespace EMotionFX::MotionMatching

--- a/Gems/MotionMatching/Code/Tests/MinMaxScalerTests.cpp
+++ b/Gems/MotionMatching/Code/Tests/MinMaxScalerTests.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Fixture.h>
+#include <FeatureMatrixMinMaxScaler.h>
+
+namespace EMotionFX::MotionMatching
+{
+    class MinMaxScalerFixture
+        : public Fixture
+    {
+    public:
+        void SetUp() override
+        {
+            Fixture::SetUp();
+
+            // Construct 3x3 matrix:
+            // 1 2 3
+            // 4 5 6
+            // 7 8 9
+            m_featureMatrix.resize(3, 3);
+
+            float counter = 1.0f;
+            for (size_t row = 0; row < 3; ++row)
+            {
+                for (size_t column = 0; column < 3; ++column)
+                {
+                    m_featureMatrix(row, column) = counter;
+                    counter++;
+                }
+            }
+        }
+
+        FeatureMatrix m_featureMatrix;
+    };
+
+    TEST_F(MinMaxScalerFixture, MinMaxValues)
+    {
+        FeatureMatrix m;
+        m.resize(3, 3);
+        m(0,0) = 0.0f;    m(0,1) =-1.0f;    m(0,2) = 9.0f;
+        m(1,0) = 0.5f;    m(1,1) = 5.0f;    m(1,2) = 6.0f;
+        m(2,0) = 7.0f;    m(2,1) = 0.1f;    m(2,2) = 3.0f;
+
+        MinMaxScaler minMaxScaler;
+        EXPECT_TRUE(minMaxScaler.Fit(m));
+
+        const AZStd::vector<float>& min = minMaxScaler.GetMin();
+        const AZStd::vector<float>& max = minMaxScaler.GetMax();
+        EXPECT_EQ(min[0], 0.0f); EXPECT_EQ(max[0], 7.0f);
+        EXPECT_EQ(min[1],-1.0f); EXPECT_EQ(max[1], 5.0f);
+        EXPECT_EQ(min[2], 3.0f); EXPECT_EQ(max[2], 9.0f);
+    }
+
+    TEST_F(MinMaxScalerFixture, Transform)
+    {
+        FeatureMatrix m;
+        m.resize(3, 4);
+        m(0,0) = 0.0f;    m(0,1) =-1.0f;    m(0,2) = 10.0f;    m(0, 3) = 3.0f;
+        m(1,0) = 0.5f;    m(1,1) = 1.0f;    m(1,2) =-10.0f;    m(1, 3) = 3.0f;
+        m(2,0) = 1.0f;    m(2,1) = 0.5f;    m(2,2) =-5.0f;     m(2, 3) = 3.0f;
+
+        MinMaxScaler minMaxScaler;
+        EXPECT_TRUE(minMaxScaler.Fit(m)); // default to normalization (feature range = [0, 1]
+        FeatureMatrix t = minMaxScaler.Transform(m);
+
+        EXPECT_EQ(t(0,0), 0.0f); EXPECT_EQ(t(0, 1), 0.0f); EXPECT_EQ(t(0, 2), 1.0f); EXPECT_EQ(t(0, 3), 3.0f);
+        EXPECT_EQ(t(1,0), 0.5f); EXPECT_EQ(t(1, 1), 1.0f); EXPECT_EQ(t(1, 2), 0.0f); EXPECT_EQ(t(1, 3), 3.0f);
+        EXPECT_EQ(t(2,0), 1.0f); EXPECT_EQ(t(2, 1), 0.75f);EXPECT_EQ(t(2, 2), 0.25f);EXPECT_EQ(t(1, 3), 3.0f);
+    }
+
+    TEST_F(MinMaxScalerFixture, SameValues)
+    {
+        FeatureMatrix m;
+        m.resize(3, 1);
+        m(0, 0) = 2.0f;
+        m(1, 0) = 2.0f;
+        m(2, 0) = 2.0f;
+
+        MinMaxScaler minMaxScaler;
+        EXPECT_TRUE(minMaxScaler.Fit(m));
+
+        EXPECT_EQ(minMaxScaler.GetMin()[0], 2.0f);
+        EXPECT_EQ(minMaxScaler.GetMax()[0], 2.0f);
+
+        EXPECT_EQ(minMaxScaler.Transform(2.0f, 0), 2.0f);
+        EXPECT_EQ(minMaxScaler.InverseTransform(2.0f, 0), 2.0f);
+
+        // Test out of data range.
+        // In case the feature was constant, it is expected to not transform the value.
+        EXPECT_EQ(minMaxScaler.Transform(0.0f, 0), 0.0f);
+        EXPECT_EQ(minMaxScaler.Transform(10.0f, 0), 10.0f);
+
+        // Test out of feature range.
+        // As the feature is constant, no matter what the input is, the constant feature should be returned.
+        EXPECT_EQ(minMaxScaler.InverseTransform(0.0f, 0), 2.0f);
+        EXPECT_EQ(minMaxScaler.InverseTransform(10.0f, 0), 2.0f);
+    }
+
+    TEST_F(MinMaxScalerFixture, SimpleRoundTrip)
+    {
+        FeatureMatrix m;
+        m.resize(2, 1);
+        m(0, 0) = -2.0f;
+        m(1, 0) = 2.0f; // range = 4.0
+
+        MinMaxScaler minMaxScaler;
+
+        FeatureMatrixTransformer::Settings fitSettings;
+        fitSettings.m_featureMin = -10.0f;
+        fitSettings.m_featureMax = 10.0f;
+        EXPECT_TRUE(minMaxScaler.Fit(m, fitSettings));
+
+        const float tVal = minMaxScaler.Transform(0.0f, 0);
+        EXPECT_EQ(tVal, 0.0f);
+
+        const float orgVal = minMaxScaler.InverseTransform(tVal, 0);
+        EXPECT_EQ(orgVal, 0.0f);
+    }
+} // EMotionFX::MotionMatching

--- a/Gems/MotionMatching/Code/motionmatching_files.cmake
+++ b/Gems/MotionMatching/Code/motionmatching_files.cmake
@@ -22,6 +22,9 @@ set(FILES
     Source/Feature.h
     Source/FeatureMatrix.cpp
     Source/FeatureMatrix.h
+    Source/FeatureMatrixMinMaxScaler.cpp
+    Source/FeatureMatrixMinMaxScaler.h
+    Source/FeatureMatrixTransformer.h
     Source/FeaturePosition.cpp
     Source/FeaturePosition.h
     Source/FeatureSchema.cpp

--- a/Gems/MotionMatching/Code/motionmatching_tests_files.cmake
+++ b/Gems/MotionMatching/Code/motionmatching_tests_files.cmake
@@ -10,5 +10,6 @@ set(FILES
     Tests/Fixture.h
     Tests/FeatureMatrixTests.cpp
     Tests/FeatureSchemaTests.cpp
+    Tests/MinMaxScalerTests.cpp
     Tests/MotionMatchingTest.cpp
 )


### PR DESCRIPTION
* Added base transformer interface used for scaling and normalizing the feature matrix and query vector.
* Each transformer needs to provide an inverse transform as well.
* Added a min-max scaler for normalizing data based on first gathering the min/max values per feature component and then normalizing the data using that range.
* The min/max scaler also provides a way to specify the feature min/max values in case other than normalized ranges are desired.
* Clipping: The min/max scaler provides clipping support to guarantee the data values are within the expected feature range.
* Added a basic set of automated tests (will add some more ones as next).