### PR TITLE
Fixes mac deploying stale files and issuing warnings about info.plist

### DIFF
--- a/Code/Tools/AssetProcessor/Platform/Mac/assetprocessor_mac.cmake
+++ b/Code/Tools/AssetProcessor/Platform/Mac/assetprocessor_mac.cmake
@@ -13,4 +13,5 @@ set_target_properties(AssetProcessor PROPERTIES
     RESOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Platform/Mac/Images.xcassets
     XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME AssetProcessorAppIcon
     ENTITLEMENT_FILE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Platform/Mac/AssetProcessorEntitlements.plist
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.O3DE.AssetProcessor"
 )

--- a/Code/Tools/AssetProcessor/Platform/Mac/gui_info.plist
+++ b/Code/Tools/AssetProcessor/Platform/Mac/gui_info.plist
@@ -13,6 +13,6 @@
 	<key>CFBundleExecutable</key>
 	<string>AssetProcessor</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.Amazon.AssetProcessor</string>
+	<string>com.O3DE.AssetProcessor</string>
 </dict>
 </plist>

--- a/cmake/Platform/Mac/runtime_dependencies_mac.cmake.in
+++ b/cmake/Platform/Mac/runtime_dependencies_mac.cmake.in
@@ -44,7 +44,9 @@ function(ly_is_newer_than file1 file2 is_newer)
     if("${file1}" IS_NEWER_THAN "${file2}")
         file(TIMESTAMP "${file1}" file1_mod_time)
         file(TIMESTAMP "${file2}" file2_mod_time)
-        if (NOT file1_mod_time EQUAL file2_mod_time)
+        # note that the above modtimes will come thru in string format
+        # like "2022-06-09T14:21:30" - not as numbers, so use STREQUAL
+        if (NOT "${file1_mod_time}" STREQUAL "${file2_mod_time}")
             set(${is_newer} TRUE PARENT_SCOPE)
         endif()
     endif()


### PR DESCRIPTION
Issue:  New files would not get deployed into application bundles at
all, leading to stale files in the bundles after changes were made.

Issue: AssetProcessor had a warning stating that the Product
Bundle Identifier did not match what in the info.plist file.

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>