### PR TITLE
[Terrain] Tube Shape / Shape Falloff Fixes

### DIFF
--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ShapeAreaFalloffGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ShapeAreaFalloffGradientComponent.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Component/Component.h>
+#include <AzCore/Component/EntityBus.h>
 #include <AzCore/std/parallel/shared_mutex.h>
 #include <GradientSignal/Ebuses/GradientRequestBus.h>
 #include <GradientSignal/Ebuses/ShapeAreaFalloffGradientRequestBus.h>
@@ -48,6 +49,7 @@ namespace GradientSignal
         , private GradientRequestBus::Handler
         , private ShapeAreaFalloffGradientRequestBus::Handler
         , private LmbrCentral::ShapeComponentNotificationsBus::Handler
+        , private AZ::EntityBus::Handler
     {
     public:
         template<typename, typename> friend class LmbrCentral::EditorWrappedComponentBase;
@@ -74,6 +76,11 @@ namespace GradientSignal
         void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
 
     protected:
+        ////////////////////////////////////////////////////////////////////////
+        // EntityEvents
+        void OnEntityActivated(const AZ::EntityId& entityId) override;
+        void OnEntityDeactivated(const AZ::EntityId& entityId) override;
+
         ////////////////////////////////////////////////////////////////////////
         // LmbrCentral::ShapeComponentNotificationsBus
         void OnShapeChanged(LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons reasons) override;

--- a/Gems/GradientSignal/Code/Source/Components/ShapeAreaFalloffGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ShapeAreaFalloffGradientComponent.cpp
@@ -136,6 +136,7 @@ namespace GradientSignal
         // Make sure we're notified whenever the shape changes, so that we can re-cache its center point.
         if (m_configuration.m_shapeEntityId.IsValid())
         {
+            AZ::EntityBus::Handler::BusConnect(m_configuration.m_shapeEntityId);
             LmbrCentral::ShapeComponentNotificationsBus::Handler::BusConnect(m_configuration.m_shapeEntityId);
         }
 
@@ -154,6 +155,7 @@ namespace GradientSignal
         LmbrCentral::ShapeComponentNotificationsBus::Handler::BusDisconnect();
         m_dependencyMonitor.Reset();
         ShapeAreaFalloffGradientRequestBus::Handler::BusDisconnect();
+        AZ::EntityBus::Handler::BusDisconnect();
     }
 
     bool ShapeAreaFalloffGradientComponent::ReadInConfig(const AZ::ComponentConfig* baseConfig)
@@ -268,9 +270,11 @@ namespace GradientSignal
 
             m_configuration.m_shapeEntityId = entityId;
 
+            AZ::EntityBus::Handler::BusDisconnect();
             LmbrCentral::ShapeComponentNotificationsBus::Handler::BusDisconnect();
             if (m_configuration.m_shapeEntityId.IsValid())
             {
+                AZ::EntityBus::Handler::BusConnect(m_configuration.m_shapeEntityId);
                 LmbrCentral::ShapeComponentNotificationsBus::Handler::BusConnect(m_configuration.m_shapeEntityId);
             }
         }
@@ -333,6 +337,16 @@ namespace GradientSignal
     
     void ShapeAreaFalloffGradientComponent::OnShapeChanged(
         [[maybe_unused]] LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons reasons)
+    {
+        CacheShapeBounds();
+    }
+
+    void ShapeAreaFalloffGradientComponent::OnEntityActivated([[maybe_unused]] const AZ::EntityId& entityId)
+    {
+        CacheShapeBounds();
+    }
+
+    void ShapeAreaFalloffGradientComponent::OnEntityDeactivated([[maybe_unused]] const AZ::EntityId& entityId)
     {
         CacheShapeBounds();
     }

--- a/Gems/LmbrCentral/Code/Source/Shape/TubeShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/TubeShape.cpp
@@ -274,7 +274,7 @@ namespace LmbrCentral
         return (m_spline->GetPosition(address) - localPoint).GetLengthSq() < (radiusSq + variableRadiusSq) * scale;
     }
 
-    float TubeShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
+    float TubeShape::DistanceFromPoint(const AZ::Vector3& point)
     {
         AZStd::shared_lock lock(m_mutex);
         AZ::Transform worldFromLocalNormalized = m_currentTransform;
@@ -286,7 +286,14 @@ namespace LmbrCentral
         const float variableRadius =
             m_variableRadius.GetElementInterpolated(splineQueryResult.m_splineAddress, Lerpf);
 
-        return powf((sqrtf(splineQueryResult.m_distanceSq) - (m_radius + variableRadius)) * uniformScale, 2.0f);
+        // Make sure the distance is clamped to 0 for all points that exist within the tube.
+        return AZStd::max(0.0f, (sqrtf(splineQueryResult.m_distanceSq) - (m_radius + variableRadius)) * uniformScale);
+    }
+
+    float TubeShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
+    {
+        float distance = DistanceFromPoint(point);
+        return powf(distance, 2.0f);
     }
 
     bool TubeShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)

--- a/Gems/LmbrCentral/Code/Source/Shape/TubeShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/TubeShape.h
@@ -43,6 +43,7 @@ namespace LmbrCentral
         AZ::Aabb GetEncompassingAabb() override;
         void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override;
         bool IsPointInside(const AZ::Vector3& point)  override;
+        float DistanceFromPoint(const AZ::Vector3& point) override;
         float DistanceSquaredFromPoint(const AZ::Vector3& point) override;
         bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) override;
 

--- a/Gems/LmbrCentral/Code/Tests/TubeShapeTest.cpp
+++ b/Gems/LmbrCentral/Code/Tests/TubeShapeTest.cpp
@@ -340,6 +340,32 @@ namespace UnitTest
         EXPECT_NEAR(distance, 1.0f, 1e-2f);
     }
 
+    // distance scaled - along length
+    TEST_F(TubeShapeTest, DistanceFromPointInsideTubeIsZero)
+    {
+        AZ::Entity entity;
+        CreateTube(
+            AZ::Transform::CreateTranslation(AZ::Vector3(37.0f, 36.0f, 39.0f)) *
+            AZ::Transform::CreateUniformScale(2.0f), 1.5f, entity);
+
+        LmbrCentral::TubeShapeComponentRequestsBus::Event(
+            entity.GetId(), &LmbrCentral::TubeShapeComponentRequestsBus::Events::SetVariableRadius, 0, 1.0f);
+        LmbrCentral::TubeShapeComponentRequestsBus::Event(
+            entity.GetId(), &LmbrCentral::TubeShapeComponentRequestsBus::Events::SetVariableRadius, 1, 0.2f);
+        LmbrCentral::TubeShapeComponentRequestsBus::Event(
+            entity.GetId(), &LmbrCentral::TubeShapeComponentRequestsBus::Events::SetVariableRadius, 2, 0.5f);
+        LmbrCentral::TubeShapeComponentRequestsBus::Event(
+            entity.GetId(), &LmbrCentral::TubeShapeComponentRequestsBus::Events::SetVariableRadius, 3, 2.0f);
+
+        // The 3rd vertex located at (43, 36, 39) has a radius of 2 * (1.5 + 2), so a point that's 5 up on the y axis should
+        // still be located inside the tube and have a distance of 0.
+        float distance;
+        LmbrCentral::ShapeComponentRequestsBus::EventResult(
+            distance, entity.GetId(), &LmbrCentral::ShapeComponentRequests::DistanceFromPoint, AZ::Vector3(43.0f, 41.0f, 39.0f));
+
+        EXPECT_NEAR(distance, 0.0f, 1e-2f);
+    }
+
     TEST_F(TubeShapeTest, RadiiCannotBeNegativeFromVariableChange)
     {
         AZ::Entity entity;


### PR DESCRIPTION
While trying to use the Tube Shape with the Shape Falloff component with terrain, I discovered two separate bugs, fixed here:
1. The tube shape was returning non-zero DistanceFromPoint() values for points inside the tube.
2. The Shape Falloff component wasn't always refreshing correctly on shape component changes.

Before:
(bug 1) The interior of the tube in the shape falloff is hollow instead of solid.
(bug 2) The shape falloff only shows up while editing, but disappears again when not editing.
https://user-images.githubusercontent.com/82224783/173136816-b3890d90-c2c2-41c6-85e6-078232ca159c.mp4

After:
(bugs are fixed)
![image](https://user-images.githubusercontent.com/82224783/173137372-a248d04b-57b4-40fb-8e6c-4dc8018d796d.png)

