### PR TITLE
Fix component ScriptCanvas activation in AWS python tests

### DIFF
--- a/AutomatedTesting/Levels/AWS/ClientAuth/ClientAuth.prefab
+++ b/AutomatedTesting/Levels/AWS/ClientAuth/ClientAuth.prefab
@@ -20,7 +20,6 @@
                 "Id": 14126657869720434043,
                 "Child Entity Order": [
                     "Entity_[1176639161715]",
-                    "Entity_[2670735447885]",
                     "Entity_[2670735447885]"
                 ]
             },
@@ -575,15 +574,18 @@
                 "Component_[1921474395300693283]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 1921474395300693283,
-                    "m_name": "ConitoAnonymousAuthorization.scriptcanvas",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{C0B0CEBA-064E-580F-AD81-CFE8CE0D61B1}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{C0B0CEBA-064E-580F-AD81-CFE8CE0D61B1}",
+                            "path": "Levels/AWS/ClientAuth/ConitoAnonymousAuthorization.scriptcanvas"
+                        },
+                        "sourceName": "ConitoAnonymousAuthorization.scriptcanvas",
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{C0B0CEBA-064E-580F-AD81-CFE8CE0D61B1}",
+                                "path": "Levels/AWS/ClientAuth/ConitoAnonymousAuthorization.scriptcanvas"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{C0B0CEBA-064E-580F-AD81-CFE8CE0D61B1}"
                     }
                 },
                 "Component_[2312432053711106201]": {

--- a/AutomatedTesting/Levels/AWS/ClientAuthPasswordSignIn/ClientAuthPasswordSignIn.prefab
+++ b/AutomatedTesting/Levels/AWS/ClientAuthPasswordSignIn/ClientAuthPasswordSignIn.prefab
@@ -20,7 +20,6 @@
                 "Id": 14126657869720434043,
                 "Child Entity Order": [
                     "Entity_[1176639161715]",
-                    "Entity_[3263440934733]",
                     "Entity_[3263440934733]"
                 ]
             },
@@ -567,15 +566,18 @@
                 "Component_[14204408480276164321]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 14204408480276164321,
-                    "m_name": "PasswordSignIn.scriptcanvas",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{DA0FCA2B-66E4-575B-802E-BA93F35690C1}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{DA0FCA2B-66E4-575B-802E-BA93F35690C1}",
+                            "path": "Levels/AWS/ClientAuthPasswordSignIn/PasswordSignIn.scriptcanvas"
+                        },
+                        "sourceName": "PasswordSignIn.scriptcanvas",
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{DA0FCA2B-66E4-575B-802E-BA93F35690C1}",
+                                "path": "Levels/AWS/ClientAuthPasswordSignIn/PasswordSignIn.scriptcanvas"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{DA0FCA2B-66E4-575B-802E-BA93F35690C1}"
                     }
                 },
                 "Component_[15510129631063791276]": {

--- a/AutomatedTesting/Levels/AWS/ClientAuthPasswordSignUp/ClientAuthPasswordSignUp.prefab
+++ b/AutomatedTesting/Levels/AWS/ClientAuthPasswordSignUp/ClientAuthPasswordSignUp.prefab
@@ -20,7 +20,6 @@
                 "Id": 14126657869720434043,
                 "Child Entity Order": [
                     "Entity_[1176639161715]",
-                    "Entity_[3851851454285]",
                     "Entity_[3851851454285]"
                 ]
             },
@@ -555,15 +554,18 @@
                 "Component_[10199578265902796701]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 10199578265902796701,
-                    "m_name": "PasswordSignUp.scriptcanvas",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{367CEE66-3A7D-549E-BD69-C63612B3F12D}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{367CEE66-3A7D-549E-BD69-C63612B3F12D}",
+                            "path": "Levels/AWS/ClientAuthPasswordSignUp/PasswordSignUp.scriptcanvas"
+                        },
+                        "sourceName": "PasswordSignUp.scriptcanvas",
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{367CEE66-3A7D-549E-BD69-C63612B3F12D}",
+                                "path": "Levels/AWS/ClientAuthPasswordSignUp/PasswordSignUp.scriptcanvas"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{367CEE66-3A7D-549E-BD69-C63612B3F12D}"
                     }
                 },
                 "Component_[10665743855533689275]": {

--- a/AutomatedTesting/Levels/AWS/Core/Core.prefab
+++ b/AutomatedTesting/Levels/AWS/Core/Core.prefab
@@ -22,7 +22,6 @@
                     "Entity_[1176639161715]",
                     "Entity_[1386540226381]",
                     "Entity_[1390835193677]",
-                    "Entity_[1395130160973]",
                     "Entity_[1395130160973]"
                 ]
             },
@@ -577,15 +576,18 @@
                 "Component_[17553238493971510581]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 17553238493971510581,
-                    "m_name": "s3demo.scriptcanvas",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{D72821C5-1C31-5AE5-891D-30371C49B9E0}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{D72821C5-1C31-5AE5-891D-30371C49B9E0}",
+                            "path": "ScriptCanvas/s3demo.scriptcanvas"
+                        },
+                        "sourceName": "s3demo.scriptcanvas",
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{D72821C5-1C31-5AE5-891D-30371C49B9E0}",
+                                "path": "ScriptCanvas/s3demo.scriptcanvas"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{D72821C5-1C31-5AE5-891D-30371C49B9E0}"
                     }
                 },
                 "Component_[17621265899133139471]": {
@@ -653,15 +655,18 @@
                 "Component_[4890242568951925088]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 4890242568951925088,
-                    "m_name": "dynamodbdemo.scriptcanvas",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{004B97C6-75F3-5B95-ADA4-EBF751EEF697}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{004B97C6-75F3-5B95-ADA4-EBF751EEF697}",
+                            "path": "ScriptCanvas/dynamodbdemo.scriptcanvas"
+                        },
+                        "sourceName": "dynamodbdemo.scriptcanvas",
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{004B97C6-75F3-5B95-ADA4-EBF751EEF697}",
+                                "path": "ScriptCanvas/dynamodbdemo.scriptcanvas"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{004B97C6-75F3-5B95-ADA4-EBF751EEF697}"
                     }
                 },
                 "Component_[7140725680315799866]": {
@@ -737,15 +742,18 @@
                 "Component_[6251151424244415885]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 6251151424244415885,
-                    "m_name": "lambdademo.scriptcanvas",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{3DCA213D-534E-5C86-9308-2F7675A08029}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{3DCA213D-534E-5C86-9308-2F7675A08029}",
+                            "path": "ScriptCanvas/lambdademo.scriptcanvas"
+                        },
+                        "sourceName": "lambdademo.scriptcanvas",
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{3DCA213D-534E-5C86-9308-2F7675A08029}",
+                                "path": "ScriptCanvas/lambdademo.scriptcanvas"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{3DCA213D-534E-5C86-9308-2F7675A08029}"
                     }
                 },
                 "Component_[6526999075003995619]": {


### PR DESCRIPTION
Previously, AWSCore and AWSClientAuth python tests were failing on account of their ScriptCanvas components not activating when their respective levels were run. Disabling, then re-enabling the SC components fixed the problem.

NOTE: had to manually fix file paths in .prefab files due to https://github.com/o3de/o3de/issues/10070

### Testing

Python tests pass
```
// AWSCore tests
~\o3de>python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\AWS\core\test_aws_resource_interaction.py  --build-directory build\windows_vs2019\bin\profile
Pytest custom argument "--output-path" was not provided, defaulting Test Results output to: build\windows_vs2019\bin\profile\Testing\LyTestTools\pytest_results\2022-06-10T14-45-28-851301
================================================= test session starts =================================================
platform win32 -- Python 3.7.12, pytest-5.3.2, py-1.11.0, pluggy-0.13.1
rootdir: C:\Users\USER\source\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 2 items

AutomatedTesting\Gem\PythonTests\AWS\core\test_aws_resource_interaction.py ..                                    [100%]

============================================ 2 passed in 126.35s (0:02:06) ============================================


// AWSClientAuth tests
~\o3de>python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\AWS\client_auth\aws_client_auth_automation_test.py  --build-directory build\windows_vs2019\bin\profile
Pytest custom argument "--output-path" was not provided, defaulting Test Results output to: build\windows_vs2019\bin\profile\Testing\LyTestTools\pytest_results\2022-06-10T15-11-45-483200
================================================= test session starts =================================================
platform win32 -- Python 3.7.12, pytest-5.3.2, py-1.11.0, pluggy-0.13.1
rootdir: C:\Users\USER\source\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 3 items

AutomatedTesting\Gem\PythonTests\AWS\client_auth\aws_client_auth_automation_test.py ...                          [100%]

============================================ 3 passed in 204.80s (0:03:24) ============================================
```