### PR TITLE
removing Report.info from get_property_tree in editor_entity_utils.py

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_entity_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_entity_utils.py
@@ -75,7 +75,6 @@ class EditorComponent:
             build_prop_tree_outcome.IsSuccess()
         ), f"Failure: Could not build property tree editor of component: '{self.get_component_name()}'"
         prop_tree = build_prop_tree_outcome.GetValue()
-        Report.info(prop_tree.build_paths_list())
         self.property_tree_editor = prop_tree
         return self.property_tree_editor
 


### PR DESCRIPTION
prefabs introduced a change that is force resetting property tree editor for every set property call. Because get_property_tree has a Report.info dumping the property paths every time this is called it ends up spamming the log with property tree paths every time a property is set.
the forced reset of PTE is occurring for all components not just prefabs.

this removes the Report.info line which is spamming the test logs.

if there is need of the property paths information you can call get_property_type_visibility() on your component object and get a dictionary where key is property path

Signed-off-by: Scott Murray <scottmur@amazon.com>