### PR TITLE
Material Component: Updated and renamed material and property override functions

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
@@ -284,7 +284,7 @@ def AtomEditorComponents_Material_AddedToEntity():
         # check override with ebus call
         Report.result(Tests.lod_material_set,
                       render.MaterialComponentRequestBus(
-                          bus.Event, "GetMaterialOverride", material_entity.id, assignment_id) == metal_gold.id)
+                          bus.Event, "GetMaterialAssetId", material_entity.id, assignment_id) == metal_gold.id)
 
         # 19. Clear the LOD Material override and confirm the active asset is the default value
         item[0].Clear()
@@ -304,16 +304,16 @@ def AtomEditorComponents_Material_AddedToEntity():
                 AtomComponentProperties.material('Material Asset')) == metal_gold.id)
 
         # 21. Clear the assignment of a default material using MaterialComponentRequestBus and confirm null asset
-        render.MaterialComponentRequestBus(bus.Event, "ClearDefaultMaterialOverride", material_entity.id)
+        render.MaterialComponentRequestBus(bus.Event, "ClearMaterialAssetIdOnDefaultSlot", material_entity.id)
         default_material_asset_id = render.MaterialComponentRequestBus(
-            bus.Event, "GetDefaultMaterialOverride", material_entity.id)
+            bus.Event, "GetMaterialAssetIdOnDefaultSlot", material_entity.id)
         Report.result(Tests.clear_default_material, default_material_asset_id == azlmbr.asset.AssetId())
 
         # 22. Set the Default Material asset using MaterialComponentRequestBus
         render.MaterialComponentRequestBus(
-            bus.Event, "SetDefaultMaterialOverride", material_entity.id, metal_gold.id)
+            bus.Event, "SetMaterialAssetIdOnDefaultSlot", material_entity.id, metal_gold.id)
         default_material_asset_id = render.MaterialComponentRequestBus(
-            bus.Event, "GetDefaultMaterialOverride", material_entity.id)
+            bus.Event, "GetMaterialAssetIdOnDefaultSlot", material_entity.id)
         Report.result(Tests.default_material, default_material_asset_id == metal_gold.id)
 
         # 23. Enter/Exit game mode.

--- a/Gems/Atom/Feature/Common/Assets/Scripts/material_find_overrides_demo.lua
+++ b/Gems/Atom/Feature/Common/Assets/Scripts/material_find_overrides_demo.lua
@@ -13,16 +13,6 @@ local FindMaterialAssignmentTest =
 {
     Properties = 
     {
-        Textures = 
-        {
-            "materials/presets/macbeth/05_blue_flower_srgb.tif.streamingimage",
-            "materials/presets/macbeth/06_bluish_green_srgb.tif.streamingimage",
-            "materials/presets/macbeth/09_moderate_red_srgb.tif.streamingimage",
-            "materials/presets/macbeth/11_yellow_green_srgb.tif.streamingimage",
-            "materials/presets/macbeth/12_orange_yellow_srgb.tif.streamingimage",
-            "materials/presets/macbeth/17_magenta_srgb.tif.streamingimage"
-        }, 
-        MaterialSlotFilter = ""
     }, 
 }
 
@@ -51,6 +41,17 @@ function FindMaterialAssignmentTest:OnActivate()
     self.colors = {}
     self.lerpDirs = {}
 
+    self.textures = 
+    {
+        "materials/presets/macbeth/05_blue_flower_srgb.tif.streamingimage",
+        "materials/presets/macbeth/06_bluish_green_srgb.tif.streamingimage",
+        "materials/presets/macbeth/09_moderate_red_srgb.tif.streamingimage",
+        "materials/presets/macbeth/11_yellow_green_srgb.tif.streamingimage",
+        "materials/presets/macbeth/12_orange_yellow_srgb.tif.streamingimage",
+        "materials/presets/macbeth/17_magenta_srgb.tif.streamingimage"
+    }
+    self.materialSlotFilter = ""
+
     self.tickBusHandler = TickBus.Connect(self);
 end
 
@@ -67,9 +68,9 @@ function FindMaterialAssignmentTest:UpdateColor(assignmentId, color)
 end
 
 function FindMaterialAssignmentTest:UpdateTexture(assignmentId)
-    if (#self.Properties.Textures > 0) then
+    if (#self.textures > 0) then
         local propertyName = "baseColor.textureMap"
-        local textureName = self.Properties.Textures[ math.random( #self.Properties.Textures ) ]
+        local textureName = self.textures[ math.random( #self.textures ) ]
         Debug.Log(textureName)
         local textureAssetId = AssetCatalogRequestBus.Broadcast.GetAssetIdByPath(textureName, Uuid(), false)
         MaterialComponentRequestBus.Event.SetPropertyValue(self.entityId, assignmentId, propertyName, textureAssetId);
@@ -134,9 +135,7 @@ end
 
 function FindMaterialAssignmentTest:OnTick(deltaTime, timePoint)
 
-
     if(nil == self.assignmentIds) then
-    
         local originalAssignments = MaterialComponentRequestBus.Event.GetDefautMaterialMap(self.entityId)
         if(nil == originalAssignments or #originalAssignments <= 1) then -- There is always 1 entry for the default assignment; a loaded model will have at least 2 assignments
             return
@@ -144,7 +143,7 @@ function FindMaterialAssignmentTest:OnTick(deltaTime, timePoint)
         
         self.assignmentIds =
         {
-            MaterialComponentRequestBus.Event.FindMaterialAssignmentId(self.entityId, -1, self.Properties.MaterialSlotFilter),
+            MaterialComponentRequestBus.Event.FindMaterialAssignmentId(self.entityId, -1, self.materialSlotFilter),
         }
     
         for index = 1, #self.assignmentIds do

--- a/Gems/Atom/Feature/Common/Assets/Scripts/material_find_overrides_demo.lua
+++ b/Gems/Atom/Feature/Common/Assets/Scripts/material_find_overrides_demo.lua
@@ -57,13 +57,13 @@ end
 function FindMaterialAssignmentTest:UpdateFactor(assignmentId)
     local propertyName = "baseColor.factor"
     local propertyValue = math.random()
-    MaterialComponentRequestBus.Event.SetPropertyOverride(self.entityId, assignmentId, propertyName, propertyValue);
+    MaterialComponentRequestBus.Event.SetPropertyValue(self.entityId, assignmentId, propertyName, propertyValue);
 end
 
 function FindMaterialAssignmentTest:UpdateColor(assignmentId, color)
     local propertyName = "baseColor.color"
     local propertyValue = color
-    MaterialComponentRequestBus.Event.SetPropertyOverride(self.entityId, assignmentId, propertyName, propertyValue);
+    MaterialComponentRequestBus.Event.SetPropertyValue(self.entityId, assignmentId, propertyName, propertyValue);
 end
 
 function FindMaterialAssignmentTest:UpdateTexture(assignmentId)
@@ -72,7 +72,7 @@ function FindMaterialAssignmentTest:UpdateTexture(assignmentId)
         local textureName = self.Properties.Textures[ math.random( #self.Properties.Textures ) ]
         Debug.Log(textureName)
         local textureAssetId = AssetCatalogRequestBus.Broadcast.GetAssetIdByPath(textureName, Uuid(), false)
-        MaterialComponentRequestBus.Event.SetPropertyOverride(self.entityId, assignmentId, propertyName, textureAssetId);
+        MaterialComponentRequestBus.Event.SetPropertyValue(self.entityId, assignmentId, propertyName, textureAssetId);
     end
 end
 
@@ -89,7 +89,7 @@ end
 
 function FindMaterialAssignmentTest:ClearProperties()
     Debug.Log("Clearing properties...")
-    MaterialComponentRequestBus.Event.ClearAllPropertyOverrides(self.entityId);
+    MaterialComponentRequestBus.Event.ClearAllPropertyValues(self.entityId);
 end
 
 function lerpColor(color, lerpDir, deltaTime)
@@ -137,7 +137,7 @@ function FindMaterialAssignmentTest:OnTick(deltaTime, timePoint)
 
     if(nil == self.assignmentIds) then
     
-        local originalAssignments = MaterialComponentRequestBus.Event.GetOriginalMaterialAssignments(self.entityId)
+        local originalAssignments = MaterialComponentRequestBus.Event.GetDefautMaterialMap(self.entityId)
         if(nil == originalAssignments or #originalAssignments <= 1) then -- There is always 1 entry for the default assignment; a loaded model will have at least 2 assignments
             return
         end

--- a/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.lua
+++ b/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.lua
@@ -13,15 +13,6 @@ local PropertyValueTest =
 {
     Properties = 
     {
-        Textures = 
-        {
-            "materials/presets/macbeth/05_blue_flower_srgb.tif.streamingimage",
-            "materials/presets/macbeth/06_bluish_green_srgb.tif.streamingimage",
-            "materials/presets/macbeth/09_moderate_red_srgb.tif.streamingimage",
-            "materials/presets/macbeth/11_yellow_green_srgb.tif.streamingimage",
-            "materials/presets/macbeth/12_orange_yellow_srgb.tif.streamingimage",
-            "materials/presets/macbeth/17_magenta_srgb.tif.streamingimage"
-        }, 
     }, 
 }
 
@@ -50,16 +41,16 @@ function PropertyValueTest:OnActivate()
     self.colors = {}
     self.lerpDirs = {}
 
-    self.originalAssignments = MaterialComponentRequestBus.Event.GetDefautMaterialMap(self.entityId);
-    self.assignmentIds = self.originalAssignments:GetKeys()
+    self.textures = 
+    {
+        "materials/presets/macbeth/05_blue_flower_srgb.tif.streamingimage",
+        "materials/presets/macbeth/06_bluish_green_srgb.tif.streamingimage",
+        "materials/presets/macbeth/09_moderate_red_srgb.tif.streamingimage",
+        "materials/presets/macbeth/11_yellow_green_srgb.tif.streamingimage",
+        "materials/presets/macbeth/12_orange_yellow_srgb.tif.streamingimage",
+        "materials/presets/macbeth/17_magenta_srgb.tif.streamingimage"
+    } 
 
-    for index = 1, self.assignmentIds:GetSize() do
-        local id = self.assignmentIds[index]
-        if (id ~= nil) then
-            self.colors[index] = randomColor()
-            self.lerpDirs[index] = randomDir()
-        end
-    end
     self.tickBusHandler = TickBus.Connect(self);
 end
 
@@ -76,9 +67,9 @@ function PropertyValueTest:UpdateColor(assignmentId, color)
 end
 
 function PropertyValueTest:UpdateTexture(assignmentId)
-    if (#self.Properties.Textures > 0) then
+    if (#self.textures > 0) then
         local propertyName = "baseColor.textureMap"
-        local textureName = self.Properties.Textures[ math.random( #self.Properties.Textures ) ]
+        local textureName = self.textures[ math.random( #self.textures ) ]
         Debug.Log(textureName)
         local textureAssetId = AssetCatalogRequestBus.Broadcast.GetAssetIdByPath(textureName, Uuid(), false)
         MaterialComponentRequestBus.Event.SetPropertyValue(self.entityId, assignmentId, propertyName, textureAssetId);
@@ -87,7 +78,7 @@ end
 
 function PropertyValueTest:UpdateProperties()
     Debug.Log("Overriding properties...")
-    for index = 1, self.assignmentIds:GetSize() do
+    for index = 1, #self.assignmentIds do
         local id = self.assignmentIds[index]
         if (id ~= nil) then
             self:UpdateFactor(id)
@@ -132,7 +123,7 @@ function lerpColor(color, lerpDir, deltaTime)
 end
 
 function PropertyValueTest:lerpColors(deltaTime)
-    for index = 1, self.assignmentIds:GetSize() do
+    for index = 1, #self.assignmentIds do
         local id = self.assignmentIds[index]
         if (id ~= nil) then
             lerpColor(self.colors[index], self.lerpDirs[index], deltaTime)
@@ -142,6 +133,24 @@ function PropertyValueTest:lerpColors(deltaTime)
 end
 
 function PropertyValueTest:OnTick(deltaTime, timePoint)
+
+    if(nil == self.assignmentIds) then
+        local originalAssignments = MaterialComponentRequestBus.Event.GetDefautMaterialMap(self.entityId)
+        if(nil == originalAssignments or #originalAssignments <= 1) then -- There is always 1 entry for the default assignment; a loaded model will have at least 2 assignments
+            return
+        end
+        
+        self.assignmentIds = originalAssignments:GetKeys()
+
+        for index = 1, #self.assignmentIds do
+            local id = self.assignmentIds[index]
+            if (id ~= nil) then
+                self.colors[index] = randomColor()
+                self.lerpDirs[index] = randomDir()
+            end
+        end
+    end
+
     self.timer = self.timer + deltaTime
     self.totalTime = self.totalTime + deltaTime
     self:lerpColors(deltaTime)

--- a/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.lua
+++ b/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.lua
@@ -9,7 +9,7 @@
 --
 ----------------------------------------------------------------------------------------------------
 
-local PropertyOverrideTest = 
+local PropertyValueTest = 
 {
     Properties = 
     {
@@ -42,7 +42,7 @@ function randomDir()
     return dir
 end
 
-function PropertyOverrideTest:OnActivate()
+function PropertyValueTest:OnActivate()
     self.timer = 0.0
     self.totalTime = 0.0
     self.totalTimeMax = 200.0
@@ -50,7 +50,7 @@ function PropertyOverrideTest:OnActivate()
     self.colors = {}
     self.lerpDirs = {}
 
-    self.originalAssignments = MaterialComponentRequestBus.Event.GetOriginalMaterialAssignments(self.entityId);
+    self.originalAssignments = MaterialComponentRequestBus.Event.GetDefautMaterialMap(self.entityId);
     self.assignmentIds = self.originalAssignments:GetKeys()
 
     for index = 1, self.assignmentIds:GetSize() do
@@ -63,29 +63,29 @@ function PropertyOverrideTest:OnActivate()
     self.tickBusHandler = TickBus.Connect(self);
 end
 
-function PropertyOverrideTest:UpdateFactor(assignmentId)
+function PropertyValueTest:UpdateFactor(assignmentId)
     local propertyName = "baseColor.factor"
     local propertyValue = math.random()
-    MaterialComponentRequestBus.Event.SetPropertyOverride(self.entityId, assignmentId, propertyName, propertyValue);
+    MaterialComponentRequestBus.Event.SetPropertyValue(self.entityId, assignmentId, propertyName, propertyValue);
 end
 
-function PropertyOverrideTest:UpdateColor(assignmentId, color)
+function PropertyValueTest:UpdateColor(assignmentId, color)
     local propertyName = "baseColor.color"
     local propertyValue = color
-    MaterialComponentRequestBus.Event.SetPropertyOverride(self.entityId, assignmentId, propertyName, propertyValue);
+    MaterialComponentRequestBus.Event.SetPropertyValue(self.entityId, assignmentId, propertyName, propertyValue);
 end
 
-function PropertyOverrideTest:UpdateTexture(assignmentId)
+function PropertyValueTest:UpdateTexture(assignmentId)
     if (#self.Properties.Textures > 0) then
         local propertyName = "baseColor.textureMap"
         local textureName = self.Properties.Textures[ math.random( #self.Properties.Textures ) ]
         Debug.Log(textureName)
         local textureAssetId = AssetCatalogRequestBus.Broadcast.GetAssetIdByPath(textureName, Uuid(), false)
-        MaterialComponentRequestBus.Event.SetPropertyOverride(self.entityId, assignmentId, propertyName, textureAssetId);
+        MaterialComponentRequestBus.Event.SetPropertyValue(self.entityId, assignmentId, propertyName, textureAssetId);
     end
 end
 
-function PropertyOverrideTest:UpdateProperties()
+function PropertyValueTest:UpdateProperties()
     Debug.Log("Overriding properties...")
     for index = 1, self.assignmentIds:GetSize() do
         local id = self.assignmentIds[index]
@@ -96,9 +96,9 @@ function PropertyOverrideTest:UpdateProperties()
     end
 end
 
-function PropertyOverrideTest:ClearProperties()
+function PropertyValueTest:ClearProperties()
     Debug.Log("Clearing properties...")
-    MaterialComponentRequestBus.Event.ClearAllPropertyOverrides(self.entityId);
+    MaterialComponentRequestBus.Event.ClearAllPropertyValues(self.entityId);
 end
 
 function lerpColor(color, lerpDir, deltaTime)
@@ -131,7 +131,7 @@ function lerpColor(color, lerpDir, deltaTime)
     end
 end
 
-function PropertyOverrideTest:lerpColors(deltaTime)
+function PropertyValueTest:lerpColors(deltaTime)
     for index = 1, self.assignmentIds:GetSize() do
         local id = self.assignmentIds[index]
         if (id ~= nil) then
@@ -141,7 +141,7 @@ function PropertyOverrideTest:lerpColors(deltaTime)
     end
 end
 
-function PropertyOverrideTest:OnTick(deltaTime, timePoint)
+function PropertyValueTest:OnTick(deltaTime, timePoint)
     self.timer = self.timer + deltaTime
     self.totalTime = self.totalTime + deltaTime
     self:lerpColors(deltaTime)
@@ -155,4 +155,4 @@ function PropertyOverrideTest:OnTick(deltaTime, timePoint)
     end
 end
 
-return PropertyOverrideTest
+return PropertyValueTest

--- a/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.py
+++ b/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.py
@@ -45,36 +45,36 @@ def assetIdToPath(assetId):
 # List all slot ids
 def getIds(entityId):
     print("Get material ids")
-    return azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'GetOriginalMaterialAssignments', entityId)
+    return azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'GetDefautMaterialMap', entityId)
 
 def printMaterials(entityId):
-    materials = azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'GetMaterialOverrides', entityId)
+    materials = azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'GetMaterialMap', entityId)
     print(f"Materials: {[(id.ToString(), override.ToString()) for id, override in materials.items()]}", sep='\n')
 
-def setMaterialOverrides(entityId, ids):
+def setMaterials(entityId, ids):
     print("Setting material overrides")
     for id in ids:
-        azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'SetMaterialOverride', entityId, id, getRandomMaterial())
+        azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'SetMaterialAssetId', entityId, id, getRandomMaterial())
 
 # Sets overrides of 3 types: float, color, and texture
-def setPropertyOverrides(entityId, ids):
+def setPropertyValues(entityId, ids):
     print("Setting property overrides")
     for id in ids:
         # factor override (float)
         factor = random.random()
         propertyName = Name("baseColor.factor")
-        azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'SetPropertyOverride', entityId, id, propertyName, factor)
+        azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'SetPropertyValue', entityId, id, propertyName, factor)
 
         # color override
         color = math.Color(random.random(), random.random(), random.random(), 1.0)
         propertyName = Name("baseColor.color")
-        azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'SetPropertyOverride', entityId, id, propertyName, color)
+        azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'SetPropertyValue', entityId, id, propertyName, color)
 
         # texture override
         texturePath = random.choice(textures)
         assetId = azlmbr.asset.AssetCatalogRequestBus(azlmbr.bus.Broadcast, 'GetAssetIdByPath', texturePath, math.Uuid(), False)
         propertyName = Name("baseColor.textureMap")
-        azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'SetPropertyOverride', entityId, id, propertyName, assetId)
+        azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'SetPropertyValue', entityId, id, propertyName, assetId)
 
 # Convert property value to string
 def propertyValueToString(value):
@@ -89,21 +89,21 @@ def propertyValueToString(value):
     return value
 
 # print all property overrides on a material component
-def printPropertyOverrides(entityId, ids):
+def printPropertyValues(entityId, ids):
     print("Property overrides:")
     for id in ids:
-        propertyOverrides = azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'GetPropertyOverrides', entityId, id)
+        propertyOverrides = azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'GetPropertyValues', entityId, id)
         print(f"{id.ToString(), [(name.ToString(), propertyValueToString(override)) for name, override in propertyOverrides.items()]}", sep='\n')
 
 # Clear property overrides for a single slot
-def clearPropertyOverrides(entityId, id):
+def clearPropertyValues(entityId, id):
     print(f"Clearing property overrides for slot <{id.ToString()}>")
-    azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'ClearPropertyOverrides', entityId, id)
+    azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'ClearPropertyValues', entityId, id)
 
 # Clear all property overrides for the material
-def clearAllPropertyOverrides(entityId):
+def clearAllPropertyValues(entityId):
     print("Clearing remaining property overrides")
-    azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'ClearAllPropertyOverrides', entityId)
+    azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'ClearAllPropertyValues', entityId)
 
 def run():
     searchFilter = azlmbr.entity.SearchFilter()
@@ -123,30 +123,30 @@ def run():
     printMaterials(entityId)
 
     # Set material overrides
-    setMaterialOverrides(entityId, ids)
+    setMaterials(entityId, ids)
 
     # Print current materials
     printMaterials(entityId)
 
     # Set property overrides
-    setPropertyOverrides(entityId, ids)
+    setPropertyValues(entityId, ids)
 
     # Print current property overrides
-    printPropertyOverrides(entityId, ids)
+    printPropertyValues(entityId, ids)
 
     # Clear property overrides for first slot
     for id in ids:
-        clearPropertyOverrides(entityId, id)
+        clearPropertyValues(entityId, id)
         break
 
     # Print current property overrides
-    printPropertyOverrides(entityId, ids)
+    printPropertyValues(entityId, ids)
 
     # Clear remaining property overrides
-    clearAllPropertyOverrides(entityId)
+    clearAllPropertyValues(entityId)
 
     # Print current property overrides
-    printPropertyOverrides(entityId, ids)
+    printPropertyValues(entityId, ids)
 
 if __name__ == "__main__":
     run()

--- a/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.py
+++ b/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.py
@@ -45,7 +45,7 @@ def assetIdToPath(assetId):
 # List all slot ids
 def getIds(entityId):
     print("Get material ids")
-    return azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'GetDefautMaterialMap', entityId)
+    return azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'GetDefautMaterialMap', entityId).keys()
 
 def printMaterials(entityId):
     materials = azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'GetMaterialMap', entityId)
@@ -62,18 +62,18 @@ def setPropertyValues(entityId, ids):
     for id in ids:
         # factor override (float)
         factor = random.random()
-        propertyName = Name("baseColor.factor")
+        propertyName = "baseColor.factor"
         azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'SetPropertyValue', entityId, id, propertyName, factor)
 
         # color override
         color = math.Color(random.random(), random.random(), random.random(), 1.0)
-        propertyName = Name("baseColor.color")
+        propertyName = "baseColor.color"
         azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'SetPropertyValue', entityId, id, propertyName, color)
 
         # texture override
         texturePath = random.choice(textures)
         assetId = azlmbr.asset.AssetCatalogRequestBus(azlmbr.bus.Broadcast, 'GetAssetIdByPath', texturePath, math.Uuid(), False)
-        propertyName = Name("baseColor.textureMap")
+        propertyName = "baseColor.textureMap"
         azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'SetPropertyValue', entityId, id, propertyName, assetId)
 
 # Convert property value to string
@@ -82,7 +82,15 @@ def propertyValueToString(value):
         return value
     if value.typename == 'Color':
         return 'Color(r={:.2f}, g={:.2f}, b={:.2f}, a={:.2f})'.format(value.r, value.g, value.b, value.a)
+    if value.typename == 'Vector4':
+        return 'Vector4(x={:.2f}, y={:.2f}, z={:.2f}, w={:.2f})'.format(value.x, value.y, value.z, value.w)
+    if value.typename == 'Vector3':
+        return 'Vector3(x={:.2f}, y={:.2f}, z={:.2f})'.format(value.x, value.y, value.z)
+    if value.typename == 'Vector2':
+        return 'Vector2(x={:.2f}, y={:.2f})'.format(value.x, value.y)
     if value.typename == 'ImageBinding':
+        return assetIdToPath(value.GetAssetId())
+    if value.typename == 'Asset':
         return assetIdToPath(value.GetAssetId())
     if value.typename == 'AssetId':
         return assetIdToPath(value)

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Material/MaterialAssignment.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Material/MaterialAssignment.h
@@ -74,13 +74,13 @@ namespace AZ
             const MaterialAssignmentMap& materials, const MaterialAssignmentId& id);
 
         //! Utility function for generating a set of available material assignments in a model
-        MaterialAssignmentMap GetMaterialAssignmentsFromModel(const Data::Asset<AZ::RPI::ModelAsset> modelAsset);
+        MaterialAssignmentMap GetDefautMaterialMapFromModelAsset(const Data::Asset<AZ::RPI::ModelAsset> modelAsset);
 
         //! Get material slot labels from a model
-        MaterialAssignmentLabelMap GetMaterialAssignmentSlotLabelsFromModel(const Data::Asset<AZ::RPI::ModelAsset> modelAsset);
+        MaterialAssignmentLabelMap GetMaterialSlotLabelsFromModelAsset(const Data::Asset<AZ::RPI::ModelAsset> modelAsset);
 
         //! Find an assignment id corresponding to the lod and label substring filters
-        MaterialAssignmentId FindMaterialAssignmentIdInModel(
+        MaterialAssignmentId GetMaterialSlotIdFromModelAsset(
             const Data::Asset<AZ::RPI::ModelAsset> modelAsset,
             const MaterialAssignmentLodIndex lodFilter,
             const AZStd::string& labelFilter);

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Material/MaterialAssignment.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Material/MaterialAssignment.h
@@ -60,6 +60,7 @@ namespace AZ
         };
 
         using MaterialAssignmentMap = AZStd::unordered_map<MaterialAssignmentId, MaterialAssignment>;
+        using MaterialAssignmentLabelMap = AZStd::unordered_map<MaterialAssignmentId, AZStd::string>;
         static const MaterialAssignment DefaultMaterialAssignment;
         static const MaterialAssignmentId DefaultMaterialAssignmentId;
         static const MaterialAssignmentMap DefaultMaterialAssignmentMap;
@@ -73,11 +74,16 @@ namespace AZ
             const MaterialAssignmentMap& materials, const MaterialAssignmentId& id);
 
         //! Utility function for generating a set of available material assignments in a model
-        MaterialAssignmentMap GetMaterialAssignmentsFromModel(Data::Instance<AZ::RPI::Model> model);
+        MaterialAssignmentMap GetMaterialAssignmentsFromModel(const Data::Asset<AZ::RPI::ModelAsset> modelAsset);
+
+        //! Get material slot labels from a model
+        MaterialAssignmentLabelMap GetMaterialAssignmentSlotLabelsFromModel(const Data::Asset<AZ::RPI::ModelAsset> modelAsset);
 
         //! Find an assignment id corresponding to the lod and label substring filters
         MaterialAssignmentId FindMaterialAssignmentIdInModel(
-            const Data::Instance<AZ::RPI::Model>& model, const MaterialAssignmentLodIndex lodFilter, const AZStd::string& labelFilter);
+            const Data::Asset<AZ::RPI::ModelAsset> modelAsset,
+            const MaterialAssignmentLodIndex lodFilter,
+            const AZStd::string& labelFilter);
 
         //! Special case handling to convert script values to supported types
         AZ::RPI::MaterialPropertyValue ConvertMaterialPropertyValueFromScript(

--- a/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
@@ -237,28 +237,26 @@ namespace AZ
             return DefaultMaterialAssignment;
         }
 
-        MaterialAssignmentMap GetMaterialAssignmentsFromModel(Data::Instance<AZ::RPI::Model> model)
+        MaterialAssignmentMap GetMaterialAssignmentsFromModel(const Data::Asset<AZ::RPI::ModelAsset> modelAsset)
         {
             MaterialAssignmentMap materials;
             materials[DefaultMaterialAssignmentId] = MaterialAssignment();
 
-            if (model)
+            if (modelAsset.IsReady())
             {
-                size_t lodIndex = 0;
-                for (const Data::Instance<AZ::RPI::ModelLod>& lod : model->GetLods())
+                MaterialAssignmentLodIndex lodIndex = 0;
+                for (const auto& lod : modelAsset->GetLodAssets())
                 {
-                    for (const AZ::RPI::ModelLod::Mesh& mesh : lod->GetMeshes())
+                    for (const auto& mesh : lod->GetMeshes())
                     {
-                        if (mesh.m_material)
-                        {
-                            const MaterialAssignmentId generalId =
-                                MaterialAssignmentId::CreateFromStableIdOnly(mesh.m_materialSlotStableId);
-                            materials[generalId] = MaterialAssignment(mesh.m_material->GetAsset(), mesh.m_material);
+                        const auto slotId = mesh.GetMaterialSlotId();
+                        const auto& slot = modelAsset->FindMaterialSlot(slotId);
 
-                            const MaterialAssignmentId specificId =
-                                MaterialAssignmentId::CreateFromLodAndStableId(lodIndex, mesh.m_materialSlotStableId);
-                            materials[specificId] = MaterialAssignment(mesh.m_material->GetAsset(), mesh.m_material);
-                        }
+                        const auto generalId = MaterialAssignmentId::CreateFromStableIdOnly(slotId);
+                        materials[generalId] = MaterialAssignment(slot.m_defaultMaterialAsset);
+
+                        const auto specificId = MaterialAssignmentId::CreateFromLodAndStableId(lodIndex, slotId);
+                        materials[specificId] = MaterialAssignment(slot.m_defaultMaterialAsset);
                     }
                     ++lodIndex;
                 }
@@ -267,37 +265,66 @@ namespace AZ
             return materials;
         }
 
+        MaterialAssignmentLabelMap GetMaterialAssignmentSlotLabelsFromModel(const Data::Asset<AZ::RPI::ModelAsset> modelAsset)
+        {
+            MaterialAssignmentLabelMap labels;
+            labels[DefaultMaterialAssignmentId] = "Default Material";
+
+                if (modelAsset.IsReady())
+            {
+                MaterialAssignmentLodIndex lodIndex = 0;
+                for (const auto& lod : modelAsset->GetLodAssets())
+                {
+                    for (const auto& mesh : lod->GetMeshes())
+                    {
+                        const auto slotId = mesh.GetMaterialSlotId();
+                        const auto& slot = modelAsset->FindMaterialSlot(slotId);
+
+                        const auto generalId = MaterialAssignmentId::CreateFromStableIdOnly(slotId);
+                        labels[generalId] = slot.m_displayName.GetStringView();
+
+                        const auto specificId = MaterialAssignmentId::CreateFromLodAndStableId(lodIndex, slotId);
+                        labels[specificId] = slot.m_displayName.GetStringView();
+                    }
+                    ++lodIndex;
+                }
+            }
+
+            return labels;
+        }
+
         MaterialAssignmentId FindMaterialAssignmentIdInLod(
-            const Data::Instance<AZ::RPI::Model>& model,
-            const Data::Instance<AZ::RPI::ModelLod>& lod,
+            const Data::Asset<AZ::RPI::ModelAsset> modelAsset,
+            const Data::Asset<AZ::RPI::ModelLodAsset>& lodAsset,
             const MaterialAssignmentLodIndex lodIndex,
             const AZStd::string& labelFilter)
         {
-            for (const AZ::RPI::ModelLod::Mesh& mesh : lod->GetMeshes())
+            for (const AZ::RPI::ModelLodAsset::Mesh& mesh : lodAsset->GetMeshes())
             {
-                const AZ::RPI::ModelMaterialSlot& slot = model->GetModelAsset()->FindMaterialSlot(mesh.m_materialSlotStableId);
+                const auto slotId = mesh.GetMaterialSlotId();
+                const auto& slot = modelAsset->FindMaterialSlot(slotId);
                 if (AZ::StringFunc::Contains(slot.m_displayName.GetCStr(), labelFilter, true))
                 {
-                    return MaterialAssignmentId::CreateFromLodAndStableId(lodIndex, mesh.m_materialSlotStableId);
+                    return MaterialAssignmentId::CreateFromLodAndStableId(lodIndex, slotId);
                 }
             }
             return MaterialAssignmentId();
         }
 
         MaterialAssignmentId FindMaterialAssignmentIdInModel(
-            const Data::Instance<AZ::RPI::Model>& model, const MaterialAssignmentLodIndex lodFilter, const AZStd::string& labelFilter)
+            const Data::Asset<AZ::RPI::ModelAsset> modelAsset, const MaterialAssignmentLodIndex lodFilter, const AZStd::string& labelFilter)
         {
-            if (model && !labelFilter.empty())
+            if (modelAsset.IsReady() && !labelFilter.empty())
             {
-                if (lodFilter < model->GetLodCount())
+                if (lodFilter < modelAsset->GetLodCount())
                 {
-                    return FindMaterialAssignmentIdInLod(model, model->GetLods()[lodFilter], lodFilter, labelFilter);
+                    return FindMaterialAssignmentIdInLod(modelAsset, modelAsset->GetLodAssets()[lodFilter], lodFilter, labelFilter);
                 }
 
-                for (size_t lodIndex = 0; lodIndex < model->GetLodCount(); ++lodIndex)
+                for (size_t lodIndex = 0; lodIndex < modelAsset->GetLodCount(); ++lodIndex)
                 {
                     const MaterialAssignmentId result =
-                        FindMaterialAssignmentIdInLod(model, model->GetLods()[lodIndex], MaterialAssignmentId::NonLodIndex, labelFilter);
+                        FindMaterialAssignmentIdInLod(modelAsset, modelAsset->GetLodAssets()[lodIndex], MaterialAssignmentId::NonLodIndex, labelFilter);
                     if (!result.IsDefault())
                     {
                         return result;

--- a/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
@@ -236,7 +236,7 @@ namespace AZ
             return DefaultMaterialAssignment;
         }
 
-        MaterialAssignmentMap GetMaterialAssignmentsFromModel(const Data::Asset<AZ::RPI::ModelAsset> modelAsset)
+        MaterialAssignmentMap GetDefautMaterialMapFromModelAsset(const Data::Asset<AZ::RPI::ModelAsset> modelAsset)
         {
             MaterialAssignmentMap materials;
             materials[DefaultMaterialAssignmentId] = MaterialAssignment();
@@ -264,12 +264,12 @@ namespace AZ
             return materials;
         }
 
-        MaterialAssignmentLabelMap GetMaterialAssignmentSlotLabelsFromModel(const Data::Asset<AZ::RPI::ModelAsset> modelAsset)
+        MaterialAssignmentLabelMap GetMaterialSlotLabelsFromModelAsset(const Data::Asset<AZ::RPI::ModelAsset> modelAsset)
         {
             MaterialAssignmentLabelMap labels;
             labels[DefaultMaterialAssignmentId] = "Default Material";
 
-                if (modelAsset.IsReady())
+            if (modelAsset.IsReady())
             {
                 MaterialAssignmentLodIndex lodIndex = 0;
                 for (const auto& lod : modelAsset->GetLodAssets())
@@ -292,7 +292,7 @@ namespace AZ
             return labels;
         }
 
-        MaterialAssignmentId FindMaterialAssignmentIdInLod(
+        MaterialAssignmentId GetMaterialSlotIdFromLodAsset(
             const Data::Asset<AZ::RPI::ModelAsset> modelAsset,
             const Data::Asset<AZ::RPI::ModelLodAsset>& lodAsset,
             const MaterialAssignmentLodIndex lodIndex,
@@ -310,20 +310,20 @@ namespace AZ
             return MaterialAssignmentId();
         }
 
-        MaterialAssignmentId FindMaterialAssignmentIdInModel(
+        MaterialAssignmentId GetMaterialSlotIdFromModelAsset(
             const Data::Asset<AZ::RPI::ModelAsset> modelAsset, const MaterialAssignmentLodIndex lodFilter, const AZStd::string& labelFilter)
         {
             if (modelAsset.IsReady() && !labelFilter.empty())
             {
                 if (lodFilter < modelAsset->GetLodCount())
                 {
-                    return FindMaterialAssignmentIdInLod(modelAsset, modelAsset->GetLodAssets()[lodFilter], lodFilter, labelFilter);
+                    return GetMaterialSlotIdFromLodAsset(modelAsset, modelAsset->GetLodAssets()[lodFilter], lodFilter, labelFilter);
                 }
 
                 for (size_t lodIndex = 0; lodIndex < modelAsset->GetLodCount(); ++lodIndex)
                 {
-                    const MaterialAssignmentId result =
-                        FindMaterialAssignmentIdInLod(modelAsset, modelAsset->GetLodAssets()[lodIndex], MaterialAssignmentId::NonLodIndex, labelFilter);
+                    const MaterialAssignmentId result = GetMaterialSlotIdFromLodAsset(
+                        modelAsset, modelAsset->GetLodAssets()[lodIndex], MaterialAssignmentId::NonLodIndex, labelFilter);
                     if (!result.IsDefault())
                     {
                         return result;

--- a/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
@@ -86,19 +86,18 @@ namespace AZ
         }
 
         MaterialAssignment::MaterialAssignment(const AZ::Data::AssetId& materialAssetId)
-            : m_materialAsset(materialAssetId, AZ::AzTypeInfo<AZ::RPI::MaterialAsset>::Uuid())
-            , m_materialInstance()
+            : MaterialAssignment(Data::Asset<RPI::MaterialAsset>(materialAssetId, AZ::AzTypeInfo<AZ::RPI::MaterialAsset>::Uuid()))
         {
         }
 
         MaterialAssignment::MaterialAssignment(const Data::Asset<RPI::MaterialAsset>& asset)
-            : m_materialAsset(asset)
-            , m_materialInstance()
+            : MaterialAssignment(asset, Data::Instance<RPI::Material>())
         {
         }
 
         MaterialAssignment::MaterialAssignment(const Data::Asset<RPI::MaterialAsset>& asset, const Data::Instance<RPI::Material>& instance)
-            : m_materialAsset(asset)
+            : m_defaultMaterialAsset(asset)
+            , m_materialAsset(asset)
             , m_materialInstance(instance)
         {
         }

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasViewportContent.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasViewportContent.cpp
@@ -69,7 +69,7 @@ namespace MaterialCanvas
             AZ::RPI::AssetUtils::GetAssetIdForProductPath("materialeditor/viewportmodels/plane_1x1.azmodel"));
 
         AZ::Render::MaterialComponentRequestBus::Event(
-            GetShadowCatcherEntityId(), &AZ::Render::MaterialComponentRequestBus::Events::SetMaterialOverride,
+            GetShadowCatcherEntityId(), &AZ::Render::MaterialComponentRequestBus::Events::SetMaterialAssetId,
             AZ::Render::DefaultMaterialAssignmentId,
             AZ::RPI::AssetUtils::GetAssetIdForProductPath("materials/special/shadowcatcher.azmaterial"));
 
@@ -160,7 +160,7 @@ namespace MaterialCanvas
                     viewportRequests->GetShadowCatcherEnabled());
 
                 AZ::Render::MaterialComponentRequestBus::Event(
-                    GetShadowCatcherEntityId(), &AZ::Render::MaterialComponentRequestBus::Events::SetPropertyOverride,
+                    GetShadowCatcherEntityId(), &AZ::Render::MaterialComponentRequestBus::Events::SetPropertyValue,
                     AZ::Render::DefaultMaterialAssignmentId, "settings.opacity", AZStd::any(lightingPreset.m_shadowCatcherOpacity));
 
                 AZ::Render::DisplayMapperComponentRequestBus::Event(

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorViewportContent.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorViewportContent.cpp
@@ -69,7 +69,7 @@ namespace MaterialEditor
             AZ::RPI::AssetUtils::GetAssetIdForProductPath("materialeditor/viewportmodels/plane_1x1.azmodel"));
 
         AZ::Render::MaterialComponentRequestBus::Event(
-            GetShadowCatcherEntityId(), &AZ::Render::MaterialComponentRequestBus::Events::SetMaterialOverride,
+            GetShadowCatcherEntityId(), &AZ::Render::MaterialComponentRequestBus::Events::SetMaterialAssetId,
             AZ::Render::DefaultMaterialAssignmentId,
             AZ::RPI::AssetUtils::GetAssetIdForProductPath("materials/special/shadowcatcher.azmaterial"));
 
@@ -131,7 +131,7 @@ namespace MaterialEditor
         materialAssignment.m_materialInstancePreCreated = true;
 
         AZ::Render::MaterialComponentRequestBus::Event(
-            GetObjectEntityId(), &AZ::Render::MaterialComponentRequestBus::Events::SetMaterialOverrides, materials);
+            GetObjectEntityId(), &AZ::Render::MaterialComponentRequestBus::Events::SetMaterialMap, materials);
     }
 
     void MaterialEditorViewportContent::OnViewportSettingsChanged()
@@ -170,7 +170,7 @@ namespace MaterialEditor
                     viewportRequests->GetShadowCatcherEnabled());
 
                 AZ::Render::MaterialComponentRequestBus::Event(
-                    GetShadowCatcherEntityId(), &AZ::Render::MaterialComponentRequestBus::Events::SetPropertyOverride,
+                    GetShadowCatcherEntityId(), &AZ::Render::MaterialComponentRequestBus::Events::SetPropertyValue,
                     AZ::Render::DefaultMaterialAssignmentId, "settings.opacity", AZStd::any(lightingPreset.m_shadowCatcherOpacity));
 
                 AZ::Render::DisplayMapperComponentRequestBus::Event(

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
@@ -196,7 +196,7 @@ namespace AZ
             //! Returns a map of all material slot labels.
             virtual MaterialAssignmentLabelMap GetMaterialLabels() const = 0;
 
-            //! Returns the available, overridable material slots and the default assigned materials
+            //! Returns the available material slots and default assigned materials
             virtual MaterialAssignmentMap GetDefautMaterialMap() const = 0;
 
             virtual AZStd::unordered_set<AZ::Name> GetModelUvNames() const = 0;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
@@ -15,132 +15,196 @@ namespace AZ
     namespace Render
     {
         //! MaterialComponentRequestBus provides an interface to request operations on a MaterialComponent
-        class MaterialComponentRequests
-            : public ComponentBus
+        class MaterialComponentRequests : public ComponentBus
         {
         public:
-            //! Get all material assignments that can be overridden
-            virtual MaterialAssignmentMap GetOriginalMaterialAssignments() const = 0;
-            //! Get material assignment id matching lod and label substring
-            virtual MaterialAssignmentId FindMaterialAssignmentId(const MaterialAssignmentLodIndex lod, const AZStd::string& label) const = 0;
-            //! Get the asset ID for the active material applied at a given slot. It will be the material override if one exists. Otherwise,
-            //! it will be the default material
-            virtual AZ::Data::AssetId GetActiveMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const = 0;
-            //! Get default material asset
+            //! Get a map representing the default layout and values for all material assignment slots on the source model or object
+            virtual MaterialAssignmentMap GetDefautMaterialMap() const = 0;
+
+            //! Search for a material assignment ID matching the lod and label parameters
+            //! @param lod Index of the LOD to be searched for the material assignment ID. -1 is used to search the default material and
+            //! model material slots.
+            //! @param label Substring used to look up a material assignment ID with a matching label.
+            //! @returns The corresponding material assignment ID is found, otherwise DefaultMaterialAssignmentId.
+            virtual MaterialAssignmentId FindMaterialAssignmentId(
+                const MaterialAssignmentLodIndex lod, const AZStd::string& label) const = 0;
+
+            //! Get the material asset associated with the source model or object prior to overrides being applied.
+            //! @param materialAssignmentId ID of material assignment slot for which the information is being requested.
+            //! @returns Default asset ID associated with the material assignment ID, otherwise an invalid asset ID.
             virtual AZ::Data::AssetId GetDefaultMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const = 0;
-            //! Get material slot label
-            virtual AZStd::string GetMaterialSlotLabel(const MaterialAssignmentId& materialAssignmentId) const = 0;
-            //! Set material overrides
-            virtual void SetMaterialOverrides(const MaterialAssignmentMap& materials) = 0;
-            //! Get material overrides
-            virtual const MaterialAssignmentMap& GetMaterialOverrides() const = 0;
-            //! Clear all material overrides
-            virtual void ClearAllMaterialOverrides() = 0;
-            //! Clear non-lod material overrides
-            virtual void ClearModelMaterialOverrides() = 0;
-            //! Clear lod material overrides
-            virtual void ClearLodMaterialOverrides() = 0;
-            //! Clear residual materials that don't correspond to the associated model
-            virtual void ClearIncompatibleMaterialOverrides() = 0;
-            //! Clear materials that reference missing assets
-            virtual void ClearInvalidMaterialOverrides() = 0;
-            //! Repair materials that reference missing assets by assigning the default asset
-            virtual void RepairInvalidMaterialOverrides() = 0;
-            //! Repair material property overrides that reference missing properties by auto-renaming them where possible
+
+            //! Get the material asset associated with the source model or object prior to overrides being applied.
+            //! @param materialAssignmentId ID of material assignment slot for which the information is being requested.
+            //! @returns String corresponding to the display name of the material slot.
+            virtual AZStd::string GetMaterialLabel(const MaterialAssignmentId& materialAssignmentId) const = 0;
+
+            //! Replaces all material and property overrides with whatever is contained in the provided map.
+            //! @param materials Map of material assignment data including materials, property overrides, and other parameters.
+            virtual void SetMaterialMap(const MaterialAssignmentMap& materials) = 0;
+
+            //! Returns all materials and properties used by the material component.
+            //! @returns Map of material assigned data including materials, property overrides, and other parameters.
+            virtual const MaterialAssignmentMap& GetMaterialMap() const = 0;
+
+            //! Clears all overridden materials and properties from the material component.
+            virtual void ClearMaterialMap() = 0;
+
+            //! Clears all overrides from the material component not associated with a specific LOD.
+            virtual void ClearMaterialsOnModelSlots() = 0;
+
+            //! Clears all overrides from the material component associated with a specific LOD.
+            virtual void ClearMaterialsOnLodSlots() = 0;
+
+            //! Clear all material overrides from the material component mapped to material assignment IDs that do not match the current
+            //! material layout. This is usually used for clearing materials leftover between model changes or moving the material component
+            //! from one entity to another.
+            virtual void ClearMaterialsOnInvalidSlots() = 0;
+
+            //! Clears all material overrides referencing material assets that cant' be located.
+            virtual void ClearMaterialsWithMissingAssets() = 0;
+
+            //! Updates all material overrides referencing material assets that can't be located to instead point to a default material
+            //! asset.
+            virtual void RepairMaterialsWithMissingAssets() = 0;
+
+            //! Remaps material property overrides that have been renamed since they were assigned.
             //! @return the number of properties that were updated
-            virtual uint32_t ApplyAutomaticPropertyUpdates() = 0;
-            //! Set default material override
-            virtual void SetDefaultMaterialOverride(const AZ::Data::AssetId& materialAssetId) = 0;
-            //! Get default material override
-            virtual const AZ::Data::AssetId GetDefaultMaterialOverride() const = 0;
-            //! Clear default material override
-            virtual void ClearDefaultMaterialOverride() = 0;
-            //! Set material override
-            virtual void SetMaterialOverride(const MaterialAssignmentId& materialAssignmentId, const AZ::Data::AssetId& materialAssetId) = 0;
-            //! Get material override
-            virtual AZ::Data::AssetId GetMaterialOverride(const MaterialAssignmentId& materialAssignmentId) const = 0;
-            //! Clear material override
-            virtual void ClearMaterialOverride(const MaterialAssignmentId& materialAssignmentId) = 0;
+            virtual uint32_t RepairMaterialsWithRenamedProperties() = 0;
+
+            //! Convenience function to set the overridden material asset on the default material slot.
+            //! @param materialAssetId Material asset that will be assigned to the default material slot.
+            virtual void SetMaterialAssetIdOnDefaultSlot(const AZ::Data::AssetId& materialAssetId) = 0;
+
+            //! Convenience function to get the current material asset on the default material slot.
+            virtual const AZ::Data::AssetId GetMaterialAssetIdOnDefaultSlot() const = 0;
+
+            //! Convenience function to clear be over written material has set on the default material slot.
+            virtual void ClearMaterialAssetIdOnDefaultSlot() = 0;
+
+            //! Assign a material asset to the slot corresponding to material assignment ID
+            //! @param materialAssignmentId ID of material slot that the material will be assigned to.
+            //! @param materialAssetId Material asset that will be assigned to the material slot.
+            virtual void SetMaterialAssetId(const MaterialAssignmentId& materialAssignmentId, const AZ::Data::AssetId& materialAssetId) = 0;
+
+            //! Retrieve the material asset associated with the material assignment ID
+            //! @param materialAssignmentId ID of material slot.
+            //! @returns The current material asset ID is found, otherwise invalid asset ID .
+            virtual AZ::Data::AssetId GetMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const = 0;
+
+            //! Removes the material asset associated with the material assignment ID
+            //! @param materialAssignmentId ID of material slot.
+            virtual void ClearMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) = 0;
+
+            //! Check if the material slot contains an explicit material asset override
+            //! @param materialAssignmentId ID of material slot.
+            //! @returns true if a valid material asset has been assigned. 
+            virtual bool IsMaterialAssetIdOverridden(const MaterialAssignmentId& materialAssignmentId) const = 0;
+
             //! Set a material property override value wrapped by an AZStd::any
-            virtual void SetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::any& value) = 0;
-            //! Get a material property override value wrapped by an AZStd::any
-            virtual AZStd::any GetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
-            //! Clear property override for a specific material assignment
-            virtual void ClearPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) = 0;
-            //! Clear property overrides for a specific material assignment
-            virtual void ClearPropertyOverrides(const MaterialAssignmentId& materialAssignmentId) = 0;
-            //! Clear all property overrides
-            virtual void ClearAllPropertyOverrides() = 0;
-            //! Set Property overrides for a specific material assignment
-            virtual void SetPropertyOverrides(
+            //! @param materialAssignmentId ID of material slot.
+            //! @param propertyName Name of the property being assigned.
+            //! @param value Value to be assigned to the specified property.
+            virtual void SetPropertyValue(
+                const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::any& value) = 0;
+
+            //! Get the current value of a material property wrapped by an AZStd::any
+            //! @param materialAssignmentId ID of material slot.
+            //! @param propertyName Name of the property being requested.
+            //! @returns Value of the property is located, otherwise an empty AZStd::any.
+            virtual AZStd::any GetPropertyValue(
+                const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
+
+            //! Clear any property override associated with the material assignment ID and property name.
+            //! @param materialAssignmentId ID of material slot.
+            //! @param propertyName Name of the property being cleared.
+            virtual void ClearPropertyValue(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) = 0;
+
+            //! Clear all property overrides associated with the material assignment ID.
+            //! @param materialAssignmentId ID of material slot.
+            virtual void ClearPropertyValues(const MaterialAssignmentId& materialAssignmentId) = 0;
+
+            //! Clear all property overrides for every material in the material component.
+            virtual void ClearAllPropertyValues() = 0;
+
+            //! Replaces all property overrides associated with the material assignment ID.
+            //! @param materialAssignmentId ID of material slot.
+            //! @param propertyOverrides Map of all property values being assigned.
+            virtual void SetPropertyValues(
                 const MaterialAssignmentId& materialAssignmentId, const MaterialPropertyOverrideMap& propertyOverrides) = 0;
-            //! Get Property overrides for a specific material assignment
-            virtual MaterialPropertyOverrideMap GetPropertyOverrides(const MaterialAssignmentId& materialAssignmentId) const = 0;
+
+            //! Retrieves a map of all property values associated with the material assignment ID.
+            //! @param materialAssignmentId ID of material slot.
+            //! @returns Map of all property values.
+            virtual MaterialPropertyOverrideMap GetPropertyValues(const MaterialAssignmentId& materialAssignmentId) const = 0;
+
             //! Set Model UV overrides for a specific material assignment
+            //! @param materialAssignmentId ID of material slot.
+            //! @param modelUvOverrides Map of remapped UV channels.
             virtual void SetModelUvOverrides(
                 const MaterialAssignmentId& materialAssignmentId, const AZ::RPI::MaterialModelUvOverrideMap& modelUvOverrides) = 0;
+
             //! Get Model UV overrides for a specific material assignment
+            //! @param materialAssignmentId ID of material slot.
+            //! @returns Map of remapped UV channels.
             virtual AZ::RPI::MaterialModelUvOverrideMap GetModelUvOverrides(const MaterialAssignmentId& materialAssignmentId) const = 0;
 
             //! Set material property override value with a specific type
             template<typename T>
-            void SetPropertyOverrideT(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const T& value)
+            void SetPropertyValueT(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const T& value)
             {
-                SetPropertyOverride(materialAssignmentId, propertyName, AZStd::any(value));
+                SetPropertyValue(materialAssignmentId, propertyName, AZStd::any(value));
             }
 
             //! Get material property override value with a specific type
             template<typename T>
-            T GetPropertyOverrideT(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
+            T GetPropertyValueT(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
             {
-                const AZStd::any& value = GetPropertyOverride(materialAssignmentId, propertyName);
+                const AZStd::any& value = GetPropertyValue(materialAssignmentId, propertyName);
                 return !value.empty() && value.is<T>() ? AZStd::any_cast<T>(value) : T{};
             }
         };
         using MaterialComponentRequestBus = EBus<MaterialComponentRequests>;
 
-        //! MaterialComponent can send out notifications on the MaterialComponentNotificationBus 
-        class MaterialComponentNotifications
-            : public ComponentBus
+        //! MaterialComponent can send out notifications on the MaterialComponentNotificationBus
+        class MaterialComponentNotifications : public ComponentBus
         {
         public:
-
-            //! This message is sent every time a material or property update affects UI.
+            //! This event is sent every time a material or property update affects UI.
             virtual void OnMaterialsEdited(){};
 
-            //! This message is sent whenever the default material slot configuration is updated in the material component.
+            //! This event is sent whenever the default material slot configuration is updated in the material component.
             virtual void OnMaterialSlotLayoutChanged(){};
 
-            //! This message is sent when one or more material property changes have been applied, at most once per frame.
+            //! This event is sent when one or more material property changes have been applied, at most once per frame.
             virtual void OnMaterialsUpdated([[maybe_unused]] const MaterialAssignmentMap& materials){};
 
-            //! This message is sent when the component has created the material instance to be used for rendering.
+            //! This event is sent when the component has created the material instance to be used for rendering.
             virtual void OnMaterialInstanceCreated([[maybe_unused]] const MaterialAssignment& materialAssignment){};
         };
         using MaterialComponentNotificationBus = EBus<MaterialComponentNotifications>;
 
-        //! Bus for retrieving information about materials embedded in or used by a source, like a model
-        class MaterialReceiverRequests
-            : public ComponentBus
+        //! Any component that wishes to interface with the material component must implement this bus. These functions provides the
+        //! material component with the layout, default materials, labels, and other information about all available material slots.
+        class MaterialReceiverRequests : public ComponentBus
         {
         public:
-            //! Get material assignment id matching lod and label substring
+            //! Search for a material assignment id matching lod and label substring
             virtual MaterialAssignmentId FindMaterialAssignmentId(
                 const MaterialAssignmentLodIndex lod, const AZStd::string& label) const = 0;
-                
+
             //! Returns a map of all material slot labels.
-            virtual MaterialAssignmentLabelMap GetMaterialAssignmentLabels() const = 0;
+            virtual MaterialAssignmentLabelMap GetMaterialLabels() const = 0;
 
             //! Returns the available, overridable material slots and the default assigned materials
-            virtual MaterialAssignmentMap GetMaterialAssignments() const = 0;
+            virtual MaterialAssignmentMap GetDefautMaterialMap() const = 0;
 
             virtual AZStd::unordered_set<AZ::Name> GetModelUvNames() const = 0;
         };
         using MaterialReceiverRequestBus = EBus<MaterialReceiverRequests>;
 
         //! Bus for notifying when materials embedded in or used by a source, like a model, change
-        class MaterialReceiverNotifications
-            : public ComponentBus
+        class MaterialReceiverNotifications : public ComponentBus
         {
         public:
             //! Notification that overridable material slots are available or have changed

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
@@ -106,13 +106,16 @@ namespace AZ
         public:
 
             //! This message is sent every time a material or property update affects UI.
-            virtual void OnMaterialsEdited() {}
+            virtual void OnMaterialsEdited(){};
+
+            //! This message is sent whenever the default material slot configuration is updated in the material component.
+            virtual void OnMaterialSlotLayoutChanged(){};
 
             //! This message is sent when one or more material property changes have been applied, at most once per frame.
-            virtual void OnMaterialsUpdated([[maybe_unused]] const MaterialAssignmentMap& materials) {}
+            virtual void OnMaterialsUpdated([[maybe_unused]] const MaterialAssignmentMap& materials){};
 
             //! This message is sent when the component has created the material instance to be used for rendering.
-            virtual void OnMaterialInstanceCreated([[maybe_unused]] const MaterialAssignment& materialAssignment) {}
+            virtual void OnMaterialInstanceCreated([[maybe_unused]] const MaterialAssignment& materialAssignment){};
         };
         using MaterialComponentNotificationBus = EBus<MaterialComponentNotifications>;
 
@@ -125,8 +128,8 @@ namespace AZ
             virtual MaterialAssignmentId FindMaterialAssignmentId(
                 const MaterialAssignmentLodIndex lod, const AZStd::string& label) const = 0;
                 
-            //! Returns the list of all ModelMaterialSlot's for the model, across all LODs.
-            virtual RPI::ModelMaterialSlotMap GetModelMaterialSlots() const = 0;
+            //! Returns a map of all material slot labels.
+            virtual MaterialAssignmentLabelMap GetMaterialAssignmentLabels() const = 0;
 
             //! Returns the available, overridable material slots and the default assigned materials
             virtual MaterialAssignmentMap GetMaterialAssignments() const = 0;
@@ -141,7 +144,7 @@ namespace AZ
         {
         public:
             //! Notification that overridable material slots are available or have changed
-            virtual void OnMaterialAssignmentsChanged() = 0;
+            virtual void OnMaterialAssignmentSlotsChanged(){};
         };
         using MaterialReceiverNotificationBus = EBus<MaterialReceiverNotifications>;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
@@ -143,7 +143,6 @@ namespace AZ
         void EditorMaterialComponent::Activate()
         {
             BaseClass::Activate();
-            MaterialReceiverNotificationBus::Handler::BusConnect(GetEntityId());
             MaterialComponentNotificationBus::Handler::BusConnect(GetEntityId());
             EditorMaterialSystemComponentNotificationBus::Handler::BusConnect();
             UpdateMaterialSlots();
@@ -152,7 +151,6 @@ namespace AZ
         void EditorMaterialComponent::Deactivate()
         {
             EditorMaterialSystemComponentNotificationBus::Handler::BusDisconnect();
-            MaterialReceiverNotificationBus::Handler::BusDisconnect();
             MaterialComponentNotificationBus::Handler::BusDisconnect();
             BaseClass::Deactivate();
         }
@@ -308,7 +306,7 @@ namespace AZ
             return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
         }
 
-        void EditorMaterialComponent::OnMaterialAssignmentsChanged()
+        void EditorMaterialComponent::OnMaterialSlotLayoutChanged()
         {
             UpdateMaterialSlots();
         }
@@ -320,11 +318,6 @@ namespace AZ
             m_materialSlots = {};
             m_materialSlotsByLod = {};
 
-            // Get current material assignments
-            MaterialAssignmentMap currentMaterials;
-            MaterialComponentRequestBus::EventResult(
-                currentMaterials, GetEntityId(), &MaterialComponentRequestBus::Events::GetMaterialOverrides);
-
             // Get the known material assignment slots from the associated model or other source
             MaterialAssignmentMap originalMaterials;
             MaterialComponentRequestBus::EventResult(
@@ -334,13 +327,7 @@ namespace AZ
             for (const auto& materialPair : originalMaterials)
             {
                 // Setup the material slot entry
-                EditorMaterialComponentSlot slot;
-                slot.m_entityId = GetEntityId();
-                slot.m_id = materialPair.first;
-
-                // if material is present in controller configuration, assign its data
-                const MaterialAssignment& materialFromController = GetMaterialAssignmentFromMap(currentMaterials, slot.m_id);
-                slot.m_materialAsset = materialFromController.m_materialAsset;
+                EditorMaterialComponentSlot slot(GetEntityId(), materialPair.first);
 
                 if (slot.m_id.IsDefault())
                 {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
@@ -97,7 +97,7 @@ namespace AZ
                             ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
                             ->Attribute(AZ::Edit::Attributes::ButtonText, GenerateMaterialsButtonText)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMaterialComponent::OpenMaterialExporterFromRPE)
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &EditorMaterialComponent::m_defaultMaterialSlot, "Default Material", "Materials assigned to this slot will be applied to the entire model unless specific model or LOD material overrides are set.")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &EditorMaterialComponent::m_defaultMaterialSlot, "Default Material", "Materials assigned to this slot will be applied to the entire model unless specific model or LOD materials are set.")
                             ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMaterialComponent::OnConfigurationChanged)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &EditorMaterialComponent::m_materialSlots, "Model Materials", "Materials assigned to these slots will be applied to every part of the model with same material slot name unless an overriding LOD material is specified.")
@@ -169,89 +169,89 @@ namespace AZ
 
             menu->addSeparator();
 
-            action = menu->addAction("Clear All Materials", [this, entityIdsToEdit]() {
-                AzToolsFramework::ScopedUndoBatch undoBatch("Clearing all materials.");
+            action = menu->addAction("Clear Materials", [this, entityIdsToEdit]() {
+                AzToolsFramework::ScopedUndoBatch undoBatch("Clear materials.");
                 m_materialSlotsByLodEnabled = false;
                 for (const AZ::EntityId& entityId : entityIdsToEdit)
                 {
                     AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
                         &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
-                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearAllMaterialOverrides);
+                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearMaterialMap);
                     MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
                 UpdateMaterialSlots();
             });
-            action->setToolTip("Clear all materials and properties then rebuild material slots from the associated model.");
+            action->setToolTip("Clears all material and property overrides.");
 
-            action = menu->addAction("Clear Model Materials", [this, entityIdsToEdit]() {
-                AzToolsFramework::ScopedUndoBatch undoBatch("Clearing model materials.");
+            action = menu->addAction("Clear Materials On Model Slots", [this, entityIdsToEdit]() {
+                AzToolsFramework::ScopedUndoBatch undoBatch("Clear materials on model slots.");
                 for (const AZ::EntityId& entityId : entityIdsToEdit)
                 {
                     AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
                         &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
-                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearModelMaterialOverrides);
+                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearMaterialsOnModelSlots);
                     MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
                 UpdateMaterialSlots();
             });
-            action->setToolTip("Clear model materials and properties then rebuild material slots from the associated model.");
+            action->setToolTip("Clears material and property overrides assigned to the Model Materials group.");
 
-            action = menu->addAction("Clear LOD Materials", [this, entityIdsToEdit]() {
-                AzToolsFramework::ScopedUndoBatch undoBatch("Clearing LOD materials.");
+            action = menu->addAction("Clear Materials On LOD Slots", [this, entityIdsToEdit]() {
+                AzToolsFramework::ScopedUndoBatch undoBatch("Clear materials on LOD slots.");
                 m_materialSlotsByLodEnabled = false;
                 for (const AZ::EntityId& entityId : entityIdsToEdit)
                 {
                     AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
                         &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
-                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearLodMaterialOverrides);
+                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearMaterialsOnLodSlots);
                     MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
                 UpdateMaterialSlots();
             });
-            action->setToolTip("Clear LOD materials and properties then rebuild material slots from the associated model.");
+            action->setToolTip("Clears material and property overrides assigned to the LOD Materials group.");
 
-            action = menu->addAction("Clear Incompatible Materials", [this, entityIdsToEdit]() {
-                AzToolsFramework::ScopedUndoBatch undoBatch("Clearing incompatible materials.");
+            action = menu->addAction("Clear Materials On Invalid Slots", [this, entityIdsToEdit]() {
+                AzToolsFramework::ScopedUndoBatch undoBatch("Clear materials on invalid slots.");
                 for (const AZ::EntityId& entityId : entityIdsToEdit)
                 {
                     AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
                         &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
                     MaterialComponentRequestBus::Event(
-                        entityId, &MaterialComponentRequestBus::Events::ClearIncompatibleMaterialOverrides);
+                        entityId, &MaterialComponentRequestBus::Events::ClearMaterialsOnInvalidSlots);
                     MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
                 UpdateMaterialSlots();
             });
-            action->setToolTip("Clear residual materials that don't correspond to the associated model.");
+            action->setToolTip("Clears residual or hidden material and property overrides assigned to slots that do not match the current layout.");
 
-            action = menu->addAction("Clear Invalid Materials", [this, entityIdsToEdit]() {
-                AzToolsFramework::ScopedUndoBatch undoBatch("Clearing invalid materials.");
+            action = menu->addAction("Clear Materials With Missing Assets", [this, entityIdsToEdit]() {
+                AzToolsFramework::ScopedUndoBatch undoBatch("Clear materials with missing assets.");
                 for (const AZ::EntityId& entityId : entityIdsToEdit)
                 {
                     AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
                         &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
-                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearInvalidMaterialOverrides);
+                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::ClearMaterialsWithMissingAssets);
                     MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
                 UpdateMaterialSlots();
             });
-            action->setToolTip("Clear materials that reference missing assets.");
+            action->setToolTip("Clears material overrides referencing missing assets.");
 
-            action = menu->addAction("Repair Invalid Materials", [this, entityIdsToEdit]() {
-                AzToolsFramework::ScopedUndoBatch undoBatch("Repairing invalid materials.");
+            action = menu->addAction("Repair Materials With Missing Assets", [this, entityIdsToEdit]() {
+                AzToolsFramework::ScopedUndoBatch undoBatch("Repair materials with missing assets.");
                 for (const AZ::EntityId& entityId : entityIdsToEdit)
                 {
                     AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
                         &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
-                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::RepairInvalidMaterialOverrides);
+                    MaterialComponentRequestBus::Event(entityId, &MaterialComponentRequestBus::Events::RepairMaterialsWithMissingAssets);
                     MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
                 UpdateMaterialSlots();
             });
-            action->setToolTip("Repair materials that reference missing assets by assigning the default asset.");
+            action->setToolTip("Removes references to any missing material assets.");
             
-            action = menu->addAction("Apply Automatic Property Updates", [this, entityIdsToEdit]() {
-                AzToolsFramework::ScopedUndoBatch undoBatch("Applying automatic property updates.");
+            action = menu->addAction("Repair Materials With Renamed Properties", [this, entityIdsToEdit]() {
+                AzToolsFramework::ScopedUndoBatch undoBatch("Repair materials with renamed properties.");
                 for (const AZ::EntityId& entityId : entityIdsToEdit)
                 {
                     AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
@@ -259,19 +259,19 @@ namespace AZ
 
                     uint32_t propertiesUpdated = 0;
                     MaterialComponentRequestBus::EventResult(
-                        propertiesUpdated, entityId, &MaterialComponentRequestBus::Events::ApplyAutomaticPropertyUpdates);
+                        propertiesUpdated, entityId, &MaterialComponentRequestBus::Events::RepairMaterialsWithRenamedProperties);
                     AZ_Printf("EditorMaterialComponent", "Updated %u property(s).", propertiesUpdated);
 
                     MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                 }
                 UpdateMaterialSlots();
             });
-            action->setToolTip("Repair material property overrides that reference missing properties by auto-renaming them where possible.");
+            action->setToolTip("Update material property overrides referencing names that have changed since they were set on the component.");
         }
 
         void EditorMaterialComponent::SetPrimaryAsset(const AZ::Data::AssetId& assetId)
         {
-            MaterialComponentRequestBus::Event(GetEntityId(), &MaterialComponentRequestBus::Events::SetDefaultMaterialOverride, assetId);
+            MaterialComponentRequestBus::Event(GetEntityId(), &MaterialComponentRequestBus::Events::SetMaterialAssetIdOnDefaultSlot, assetId);
 
             MaterialComponentNotificationBus::Event(GetEntityId(), &MaterialComponentNotifications::OnMaterialsEdited);
 
@@ -321,7 +321,7 @@ namespace AZ
             // Get the known material assignment slots from the associated model or other source
             MaterialAssignmentMap originalMaterials;
             MaterialComponentRequestBus::EventResult(
-                originalMaterials, GetEntityId(), &MaterialComponentRequestBus::Events::GetOriginalMaterialAssignments);
+                originalMaterials, GetEntityId(), &MaterialComponentRequestBus::Events::GetDefautMaterialMap);
                         
             // Generate the table of editable materials using the source data to define number of groups, elements, and initial values
             for (const auto& materialPair : originalMaterials)
@@ -377,7 +377,7 @@ namespace AZ
         {
             MaterialAssignmentMap originalMaterials;
             MaterialComponentRequestBus::EventResult(
-                originalMaterials, GetEntityId(), &MaterialComponentRequestBus::Events::GetOriginalMaterialAssignments);
+                originalMaterials, GetEntityId(), &MaterialComponentRequestBus::Events::GetDefautMaterialMap);
 
             // Generate a unique set of all material asset IDs that will be used for source data generation
             AZStd::unordered_map<AZ::Data::AssetId, AZStd::string> assetIdToSlotNameMap;
@@ -387,7 +387,7 @@ namespace AZ
                 if (originalAssetId.IsValid())
                 {
                     MaterialComponentRequestBus::EventResult(
-                        assetIdToSlotNameMap[originalAssetId], GetEntityId(), &MaterialComponentRequestBus::Events::GetMaterialSlotLabel,
+                        assetIdToSlotNameMap[originalAssetId], GetEntityId(), &MaterialComponentRequestBus::Events::GetMaterialLabel,
                         materialPair.first);
                 }
             }
@@ -431,7 +431,7 @@ namespace AZ
                                             &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
 
                                         MaterialComponentRequestBus::Event(
-                                            entityId, &MaterialComponentRequestBus::Events::SetMaterialOverride, materialPair.first,
+                                            entityId, &MaterialComponentRequestBus::Events::SetMaterialAssetId, materialPair.first,
                                             assetIdOutcome.GetValue());
                                     }
                                 }
@@ -453,7 +453,7 @@ namespace AZ
 
             if (!m_materialSlotsByLodEnabled)
             {
-                MaterialComponentRequestBus::Event(GetEntityId(), &MaterialComponentRequestBus::Events::ClearLodMaterialOverrides);
+                MaterialComponentRequestBus::Event(GetEntityId(), &MaterialComponentRequestBus::Events::ClearMaterialsOnLodSlots);
             }
 
             UpdateMaterialSlots();

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.h
@@ -22,7 +22,6 @@ namespace AZ
         //! In-editor material component for displaying and editing material assignments.
         class EditorMaterialComponent final
             : public EditorRenderComponentAdapter<MaterialComponentController, MaterialComponent, MaterialComponentConfig>
-            , public MaterialReceiverNotificationBus::Handler
             , public MaterialComponentNotificationBus::Handler
             , public EditorMaterialSystemComponentNotificationBus::Handler
         {
@@ -50,10 +49,8 @@ namespace AZ
 
             AZ::u32 OnConfigurationChanged() override;
 
-            //! MaterialReceiverNotificationBus::Handler overrides...
-            void OnMaterialAssignmentsChanged() override;
-
             //! MaterialComponentNotificationBus::Handler overrides...
+            void OnMaterialSlotLayoutChanged() override;
             void OnMaterialInstanceCreated(const MaterialAssignment& materialAssignment) override;
 
             //! EditorMaterialSystemComponentNotificationBus::Handler overrides...

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -218,7 +218,7 @@ namespace AZ
 
                 AZStd::string slotName;
                 MaterialComponentRequestBus::EventResult(
-                    slotName, m_primaryEntityId, &MaterialComponentRequestBus::Events::GetMaterialSlotLabel, m_materialAssignmentId);
+                    slotName, m_primaryEntityId, &MaterialComponentRequestBus::Events::GetMaterialLabel, m_materialAssignmentId);
 
                 QString materialInfo;
                 materialInfo += tr("<table>");
@@ -431,7 +431,7 @@ namespace AZ
 
                 m_editData.m_materialPropertyOverrideMap.clear();
                 MaterialComponentRequestBus::EventResult(
-                    m_editData.m_materialPropertyOverrideMap, m_primaryEntityId, &MaterialComponentRequestBus::Events::GetPropertyOverrides,
+                    m_editData.m_materialPropertyOverrideMap, m_primaryEntityId, &MaterialComponentRequestBus::Events::GetPropertyValues,
                     m_materialAssignmentId);
 
                 // Apply any automatic property renames so that the material inspector will be properly initialized with the right values
@@ -497,7 +497,7 @@ namespace AZ
                 for (const AZ::EntityId& entityId : m_entityIdsToEdit)
                 {
                     MaterialComponentRequestBus::Event(
-                        entityId, &MaterialComponentRequestBus::Events::SetPropertyOverride, m_materialAssignmentId,
+                        entityId, &MaterialComponentRequestBus::Events::SetPropertyValue, m_materialAssignmentId,
                         property.GetId().GetStringView(), property.GetValue());
                 }
 
@@ -753,7 +753,7 @@ namespace AZ
                         AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
                             &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
                         MaterialComponentRequestBus::Event(
-                            entityId, &MaterialComponentRequestBus::Events::SetPropertyOverrides, m_materialAssignmentId,
+                            entityId, &MaterialComponentRequestBus::Events::SetPropertyValues, m_materialAssignmentId,
                             m_editData.m_materialPropertyOverrideMap);
                         MaterialComponentNotificationBus::Event(entityId, &MaterialComponentNotifications::OnMaterialsEdited);
                     }
@@ -773,7 +773,7 @@ namespace AZ
             {
                 AZ::Data::AssetId materialAssetId = {};
                 MaterialComponentRequestBus::EventResult(
-                    materialAssetId, m_primaryEntityId, &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId, m_materialAssignmentId);
+                    materialAssetId, m_primaryEntityId, &MaterialComponentRequestBus::Events::GetMaterialAssetId, m_materialAssignmentId);
                 return materialAssetId;
             }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
@@ -141,10 +141,16 @@ namespace AZ
             : m_entityId(entityId)
             , m_id(materialAssignmentId)
         {
-            AZ::Data::AssetId assetId = {};
+            bool isOverridden = false;
             MaterialComponentRequestBus::EventResult(
-                assetId, m_entityId, &MaterialComponentRequestBus::Events::GetMaterialOverride, m_id);
-            m_materialAsset = AZ::Data::Asset<AZ::RPI::MaterialAsset>(assetId, AZ::AzTypeInfo<AZ::RPI::MaterialAsset>::Uuid());
+                isOverridden, m_entityId, &MaterialComponentRequestBus::Events::IsMaterialAssetIdOverridden, m_id);
+            if (isOverridden)
+            {
+                AZ::Data::AssetId assetId = {};
+                MaterialComponentRequestBus::EventResult(
+                    assetId, m_entityId, &MaterialComponentRequestBus::Events::GetMaterialAssetId, m_id);
+                m_materialAsset = AZ::Data::Asset<AZ::RPI::MaterialAsset>(assetId, AZ::AzTypeInfo<AZ::RPI::MaterialAsset>::Uuid());
+            }
         }
 
         AZStd::vector<char> EditorMaterialComponentSlot::GetPreviewPixmapData() const
@@ -178,7 +184,7 @@ namespace AZ
         {
             AZ::Data::AssetId assetId = {};
             MaterialComponentRequestBus::EventResult(
-                assetId, m_entityId, &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId, m_id);
+                assetId, m_entityId, &MaterialComponentRequestBus::Events::GetMaterialAssetId, m_id);
             return assetId;
         }
 
@@ -193,7 +199,7 @@ namespace AZ
         AZStd::string EditorMaterialComponentSlot::GetLabel() const
         {
             AZStd::string label;
-            MaterialComponentRequestBus::EventResult(label, m_entityId, &MaterialComponentRequestBus::Events::GetMaterialSlotLabel, m_id);
+            MaterialComponentRequestBus::EventResult(label, m_entityId, &MaterialComponentRequestBus::Events::GetMaterialLabel, m_id);
             return label;
         }
 
@@ -218,7 +224,7 @@ namespace AZ
         void EditorMaterialComponentSlot::Clear()
         {
             MaterialComponentRequestBus::Event(
-                m_entityId, &MaterialComponentRequestBus::Events::SetPropertyOverrides, m_id, MaterialPropertyOverrideMap());
+                m_entityId, &MaterialComponentRequestBus::Events::SetPropertyValues, m_id, MaterialPropertyOverrideMap());
             MaterialComponentRequestBus::Event(
                 m_entityId, &MaterialComponentRequestBus::Events::SetModelUvOverrides, m_id, AZ::RPI::MaterialModelUvOverrideMap());
             SetAsset({});
@@ -232,7 +238,7 @@ namespace AZ
         void EditorMaterialComponentSlot::ClearProperties()
         {
             MaterialComponentRequestBus::Event(
-                m_entityId, &MaterialComponentRequestBus::Events::SetPropertyOverrides, m_id, MaterialPropertyOverrideMap());
+                m_entityId, &MaterialComponentRequestBus::Events::SetPropertyValues, m_id, MaterialPropertyOverrideMap());
             MaterialComponentRequestBus::Event(
                 m_entityId, &MaterialComponentRequestBus::Events::SetModelUvOverrides, m_id, AZ::RPI::MaterialModelUvOverrideMap());
             OnDataChanged({ m_entityId }, false);
@@ -348,7 +354,7 @@ namespace AZ
                 for (const AZ::EntityId& entityId : entityIdsToEdit)
                 {
                     MaterialComponentRequestBus::Event(
-                        entityId, &MaterialComponentRequestBus::Events::SetPropertyOverrides, m_id, MaterialPropertyOverrideMap());
+                        entityId, &MaterialComponentRequestBus::Events::SetPropertyValues, m_id, MaterialPropertyOverrideMap());
                     MaterialComponentRequestBus::Event(
                         entityId, &MaterialComponentRequestBus::Events::SetModelUvOverrides, m_id,
                         AZ::RPI::MaterialModelUvOverrideMap());
@@ -361,7 +367,7 @@ namespace AZ
                 for (const AZ::EntityId& entityId : entityIdsToEdit)
                 {
                     MaterialComponentRequestBus::Event(
-                        entityId, &MaterialComponentRequestBus::Events::SetPropertyOverrides, m_id, MaterialPropertyOverrideMap());
+                        entityId, &MaterialComponentRequestBus::Events::SetPropertyValues, m_id, MaterialPropertyOverrideMap());
                     MaterialComponentRequestBus::Event(
                         entityId, &MaterialComponentRequestBus::Events::SetModelUvOverrides, m_id,
                         AZ::RPI::MaterialModelUvOverrideMap());
@@ -391,7 +397,7 @@ namespace AZ
                 if (updateAsset)
                 {
                     MaterialComponentRequestBus::Event(
-                        entityId, &MaterialComponentRequestBus::Events::SetMaterialOverride, m_id, m_materialAsset.GetId());
+                        entityId, &MaterialComponentRequestBus::Events::SetMaterialAssetId, m_id, m_materialAsset.GetId());
                 }
 
                 EditorMaterialSystemComponentRequestBus::Broadcast(

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
@@ -134,7 +134,18 @@ namespace AZ
                     ->Method("ExportMaterial", &EditorMaterialComponentSlot::ExportMaterial)
                     ;
             }
-        };
+        }
+
+        EditorMaterialComponentSlot::EditorMaterialComponentSlot(
+            const AZ::EntityId& entityId, const MaterialAssignmentId& materialAssignmentId)
+            : m_entityId(entityId)
+            , m_id(materialAssignmentId)
+        {
+            AZ::Data::AssetId assetId = {};
+            MaterialComponentRequestBus::EventResult(
+                assetId, m_entityId, &MaterialComponentRequestBus::Events::GetMaterialOverride, m_id);
+            m_materialAsset = AZ::Data::Asset<AZ::RPI::MaterialAsset>(assetId, AZ::AzTypeInfo<AZ::RPI::MaterialAsset>::Uuid());
+        }
 
         AZStd::vector<char> EditorMaterialComponentSlot::GetPreviewPixmapData() const
         {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
@@ -126,7 +126,7 @@ namespace AZ
                     ->Method("SetAssetId", &EditorMaterialComponentSlot::SetAssetId)
                     ->Method("Clear", &EditorMaterialComponentSlot::Clear)
                     ->Method("ClearMaterial", &EditorMaterialComponentSlot::ClearMaterial)
-                    ->Method("ClearProperties", &EditorMaterialComponentSlot::ClearProperties, "ClearOverrides") // deprecates ClearOverrides
+                    ->Method("ClearProperties", &EditorMaterialComponentSlot::ClearProperties)
                     ->Method("OpenMaterialExporter", &EditorMaterialComponentSlot::OpenMaterialExporter)
                     ->Method("OpenMaterialEditor", &EditorMaterialComponentSlot::OpenMaterialEditor)
                     ->Method("OpenMaterialInspector", &EditorMaterialComponentSlot::OpenMaterialInspector)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
@@ -32,6 +32,9 @@ namespace AZ
             static bool ConvertVersion(AZ::SerializeContext& context, AZ::SerializeContext::DataElementNode& classElement);
             static void Reflect(ReflectContext* context);
 
+            EditorMaterialComponentSlot() = default;
+            EditorMaterialComponentSlot(const AZ::EntityId& entityId, const MaterialAssignmentId& materialAssignmentId);
+
             //! Get cached preview image as a buffer to use as an RPE attribute
             //! If a cached image isn't avalible then a request will be made to render one
             AZStd::vector<char> GetPreviewPixmapData() const;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
@@ -196,7 +196,7 @@ namespace AZ
             {
                 AZ::Data::AssetId primaryMaterialAssetId = {};
                 MaterialComponentRequestBus::EventResult(
-                    primaryMaterialAssetId, primaryEntityId, &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId,
+                    primaryMaterialAssetId, primaryEntityId, &MaterialComponentRequestBus::Events::GetMaterialAssetId,
                     materialAssignmentId);
                 AZ::Data::AssetId primaryMaterialTypeAssetId = GetMaterialTypeAssetIdFromMaterialAssetId(primaryMaterialAssetId);
 
@@ -206,7 +206,7 @@ namespace AZ
                     {
                         AZ::Data::AssetId secondaryMaterialAssetId = {};
                         MaterialComponentRequestBus::EventResult(
-                            secondaryMaterialAssetId, secondaryEntityId, &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId,
+                            secondaryMaterialAssetId, secondaryEntityId, &MaterialComponentRequestBus::Events::GetMaterialAssetId,
                             materialAssignmentId);
                         AZ::Data::AssetId secondaryMaterialTypeAssetId = GetMaterialTypeAssetIdFromMaterialAssetId(secondaryMaterialAssetId);
                         return primaryMaterialTypeAssetId == secondaryMaterialTypeAssetId;
@@ -220,7 +220,7 @@ namespace AZ
             {
                 AZ::Data::AssetId primaryMaterialAssetId = {};
                 MaterialComponentRequestBus::EventResult(
-                    primaryMaterialAssetId, primaryEntityId, &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId,
+                    primaryMaterialAssetId, primaryEntityId, &MaterialComponentRequestBus::Events::GetMaterialAssetId,
                     materialAssignmentId);
 
                 return primaryMaterialAssetId.IsValid() && AZStd::all_of(
@@ -229,7 +229,7 @@ namespace AZ
                     {
                         AZ::Data::AssetId secondaryMaterialAssetId = {};
                         MaterialComponentRequestBus::EventResult(
-                            secondaryMaterialAssetId, secondaryEntityId, &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId,
+                            secondaryMaterialAssetId, secondaryEntityId, &MaterialComponentRequestBus::Events::GetMaterialAssetId,
                             materialAssignmentId);
                         return primaryMaterialAssetId == secondaryMaterialAssetId;
                     });
@@ -240,7 +240,7 @@ namespace AZ
             {
                 MaterialAssignmentMap primaryMaterialSlots;
                 MaterialComponentRequestBus::EventResult(
-                    primaryMaterialSlots, primaryEntityId, &MaterialComponentRequestBus::Events::GetOriginalMaterialAssignments);
+                    primaryMaterialSlots, primaryEntityId, &MaterialComponentRequestBus::Events::GetDefautMaterialMap);
 
                 return AZStd::all_of(
                     secondaryEntityIds.begin(), secondaryEntityIds.end(),
@@ -249,7 +249,7 @@ namespace AZ
                         MaterialAssignmentMap secondaryMaterialSlots;
                         MaterialComponentRequestBus::EventResult(
                             secondaryMaterialSlots, secondaryEntityId,
-                            &MaterialComponentRequestBus::Events::GetOriginalMaterialAssignments);
+                            &MaterialComponentRequestBus::Events::GetDefautMaterialMap);
 
                         if (primaryMaterialSlots.size() != secondaryMaterialSlots.size())
                         {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -176,7 +176,7 @@ namespace AZ
             {
                 AZ::Data::AssetId materialAssetId = {};
                 MaterialComponentRequestBus::EventResult(
-                    materialAssetId, entityId, &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId, materialAssignmentId);
+                    materialAssetId, entityId, &MaterialComponentRequestBus::Events::GetMaterialAssetId, materialAssignmentId);
                 if (!materialAssetId.IsValid())
                 {
                     return;
@@ -184,7 +184,7 @@ namespace AZ
 
                 AZ::Render::MaterialPropertyOverrideMap propertyOverrides;
                 AZ::Render::MaterialComponentRequestBus::EventResult(
-                    propertyOverrides, entityId, &AZ::Render::MaterialComponentRequestBus::Events::GetPropertyOverrides,
+                    propertyOverrides, entityId, &AZ::Render::MaterialComponentRequestBus::Events::GetPropertyValues,
                     materialAssignmentId);
 
                 AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -100,7 +100,7 @@ namespace AZ
             AZ::EntitySystemBus::Handler::BusConnect();
             EditorMaterialSystemComponentNotificationBus::Handler::BusConnect();
             EditorMaterialSystemComponentRequestBus::Handler::BusConnect();
-            MaterialReceiverNotificationBus::Router::BusRouterConnect();
+            MaterialComponentNotificationBus::Router::BusRouterConnect();
             AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler::BusConnect();
             AzToolsFramework::EditorMenuNotificationBus::Handler::BusConnect();
             AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
@@ -113,7 +113,7 @@ namespace AZ
             AZ::EntitySystemBus::Handler::BusDisconnect();
             EditorMaterialSystemComponentNotificationBus::Handler::BusDisconnect();
             EditorMaterialSystemComponentRequestBus::Handler::BusDisconnect();
-            MaterialReceiverNotificationBus::Router::BusRouterDisconnect();
+            MaterialComponentNotificationBus::Router::BusRouterDisconnect();
             AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler::BusDisconnect();
             AzToolsFramework::EditorMenuNotificationBus::Handler::BusDisconnect();
             AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect(); 
@@ -251,10 +251,10 @@ namespace AZ
             m_materialPreviews[entityId][materialAssignmentId] = pixmap;
         }
 
-        void EditorMaterialSystemComponent::OnMaterialAssignmentsChanged()
+        void EditorMaterialSystemComponent::OnMaterialSlotLayoutChanged()
         {
             // Deleting any preview saved for an entity whose material configuration is about to be invalidated
-            const AZ::EntityId entityId = *MaterialReceiverNotificationBus::GetCurrentBusId();
+            const AZ::EntityId entityId = *MaterialComponentNotificationBus::GetCurrentBusId();
             m_materialPreviews.erase(entityId);
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
@@ -30,7 +30,7 @@ namespace AZ
             , public AZ::EntitySystemBus::Handler
             , public EditorMaterialSystemComponentNotificationBus::Handler
             , public EditorMaterialSystemComponentRequestBus::Handler
-            , public MaterialReceiverNotificationBus::Router
+            , public MaterialComponentNotificationBus::Router
             , public AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler
             , public AzToolsFramework::EditorMenuNotificationBus::Handler
             , public AzToolsFramework::EditorEvents::Bus::Handler
@@ -69,8 +69,8 @@ namespace AZ
             void OnRenderMaterialPreviewComplete(
                 const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId, const QPixmap& pixmap) override;
 
-            //! MaterialReceiverNotificationBus::Router overrides...
-            void OnMaterialAssignmentsChanged() override;
+            //! MaterialComponentNotificationBus::Router overrides...
+            void OnMaterialSlotLayoutChanged() override;
 
             //! AssetBrowserInteractionNotificationBus::Handler overrides...
             AzToolsFramework::AssetBrowser::SourceFileDetails GetSourceFileDetails(const char* fullSourceFileName) override;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -36,55 +36,56 @@ namespace AZ
                     ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                     ->Attribute(AZ::Script::Attributes::Category, "render")
                     ->Attribute(AZ::Script::Attributes::Module, "render")
-                    ->Event("GetOriginalMaterialAssignments", &MaterialComponentRequestBus::Events::GetOriginalMaterialAssignments)
+                    ->Event("GetDefautMaterialMap", &MaterialComponentRequestBus::Events::GetDefautMaterialMap, "GetOriginalMaterialAssignments")
                     ->Event("FindMaterialAssignmentId", &MaterialComponentRequestBus::Events::FindMaterialAssignmentId)
-                    ->Event("GetActiveMaterialAssetId", &MaterialComponentRequestBus::Events::GetActiveMaterialAssetId)
+                    ->Event("GetActiveMaterialAssetId", &MaterialComponentRequestBus::Events::GetMaterialAssetId) // This function is now redundant but cannot be marked deprecated or removed in case it's still referenced in script
                     ->Event("GetDefaultMaterialAssetId", &MaterialComponentRequestBus::Events::GetDefaultMaterialAssetId)
-                    ->Event("GetMaterialSlotLabel", &MaterialComponentRequestBus::Events::GetMaterialSlotLabel)
-                    ->Event("SetMaterialOverrides", &MaterialComponentRequestBus::Events::SetMaterialOverrides)
-                    ->Event("GetMaterialOverrides", &MaterialComponentRequestBus::Events::GetMaterialOverrides)
-                    ->Event("ClearAllMaterialOverrides", &MaterialComponentRequestBus::Events::ClearAllMaterialOverrides)
-                    ->Event("SetDefaultMaterialOverride", &MaterialComponentRequestBus::Events::SetDefaultMaterialOverride)
-                    ->Event("GetDefaultMaterialOverride", &MaterialComponentRequestBus::Events::GetDefaultMaterialOverride)
-                    ->Event("ClearDefaultMaterialOverride", &MaterialComponentRequestBus::Events::ClearDefaultMaterialOverride)
-                    ->Event("ClearModelMaterialOverrides", &MaterialComponentRequestBus::Events::ClearModelMaterialOverrides)
-                    ->Event("ClearLodMaterialOverrides", &MaterialComponentRequestBus::Events::ClearLodMaterialOverrides)
-                    ->Event("ClearIncompatibleMaterialOverrides", &MaterialComponentRequestBus::Events::ClearIncompatibleMaterialOverrides)
-                    ->Event("ClearInvalidMaterialOverrides", &MaterialComponentRequestBus::Events::ClearInvalidMaterialOverrides)
-                    ->Event("RepairInvalidMaterialOverrides", &MaterialComponentRequestBus::Events::RepairInvalidMaterialOverrides)
-                    ->Event("ApplyAutomaticPropertyUpdates", &MaterialComponentRequestBus::Events::ApplyAutomaticPropertyUpdates)
-                    ->Event("SetMaterialOverride", &MaterialComponentRequestBus::Events::SetMaterialOverride)
-                    ->Event("GetMaterialOverride", &MaterialComponentRequestBus::Events::GetMaterialOverride)
-                    ->Event("ClearMaterialOverride", &MaterialComponentRequestBus::Events::ClearMaterialOverride)
-                    ->Event("SetPropertyOverride", &MaterialComponentRequestBus::Events::SetPropertyOverride)
-                    ->Event("SetPropertyOverrideBool", &MaterialComponentRequestBus::Events::SetPropertyOverrideT<bool>)
-                    ->Event("SetPropertyOverrideInt32", &MaterialComponentRequestBus::Events::SetPropertyOverrideT<int32_t>)
-                    ->Event("SetPropertyOverrideUInt32", &MaterialComponentRequestBus::Events::SetPropertyOverrideT<uint32_t>)
-                    ->Event("SetPropertyOverrideFloat", &MaterialComponentRequestBus::Events::SetPropertyOverrideT<float>)
-                    ->Event("SetPropertyOverrideVector2", &MaterialComponentRequestBus::Events::SetPropertyOverrideT<AZ::Vector2>)
-                    ->Event("SetPropertyOverrideVector3", &MaterialComponentRequestBus::Events::SetPropertyOverrideT<AZ::Vector3>)
-                    ->Event("SetPropertyOverrideVector4", &MaterialComponentRequestBus::Events::SetPropertyOverrideT<AZ::Vector4>)
-                    ->Event("SetPropertyOverrideColor", &MaterialComponentRequestBus::Events::SetPropertyOverrideT<AZ::Color>)
-                    ->Event("SetPropertyOverrideImage", &MaterialComponentRequestBus::Events::SetPropertyOverrideT<AZ::Data::AssetId>)
-                    ->Event("SetPropertyOverrideString", &MaterialComponentRequestBus::Events::SetPropertyOverrideT<AZStd::string>)
-                    ->Event("SetPropertyOverrideEnum", &MaterialComponentRequestBus::Events::SetPropertyOverrideT<uint32_t>)
-                    ->Event("GetPropertyOverride", &MaterialComponentRequestBus::Events::GetPropertyOverride)
-                    ->Event("GetPropertyOverrideBool", &MaterialComponentRequestBus::Events::GetPropertyOverrideT<bool>)
-                    ->Event("GetPropertyOverrideInt32", &MaterialComponentRequestBus::Events::GetPropertyOverrideT<int32_t>)
-                    ->Event("GetPropertyOverrideUInt32", &MaterialComponentRequestBus::Events::GetPropertyOverrideT<uint32_t>)
-                    ->Event("GetPropertyOverrideFloat", &MaterialComponentRequestBus::Events::GetPropertyOverrideT<float>)
-                    ->Event("GetPropertyOverrideVector2", &MaterialComponentRequestBus::Events::GetPropertyOverrideT<AZ::Vector2>)
-                    ->Event("GetPropertyOverrideVector3", &MaterialComponentRequestBus::Events::GetPropertyOverrideT<AZ::Vector3>)
-                    ->Event("GetPropertyOverrideVector4", &MaterialComponentRequestBus::Events::GetPropertyOverrideT<AZ::Vector4>)
-                    ->Event("GetPropertyOverrideColor", &MaterialComponentRequestBus::Events::GetPropertyOverrideT<AZ::Color>)
-                    ->Event("GetPropertyOverrideImage", &MaterialComponentRequestBus::Events::GetPropertyOverrideT<AZ::Data::AssetId>)
-                    ->Event("GetPropertyOverrideString", &MaterialComponentRequestBus::Events::GetPropertyOverrideT<AZStd::string>)
-                    ->Event("GetPropertyOverrideEnum", &MaterialComponentRequestBus::Events::GetPropertyOverrideT<uint32_t>)
-                    ->Event("ClearPropertyOverride", &MaterialComponentRequestBus::Events::ClearPropertyOverride)
-                    ->Event("ClearPropertyOverrides", &MaterialComponentRequestBus::Events::ClearPropertyOverrides)
-                    ->Event("ClearAllPropertyOverrides", &MaterialComponentRequestBus::Events::ClearAllPropertyOverrides)
-                    ->Event("SetPropertyOverrides", &MaterialComponentRequestBus::Events::SetPropertyOverrides)
-                    ->Event("GetPropertyOverrides", &MaterialComponentRequestBus::Events::GetPropertyOverrides)
+                    ->Event("GetMaterialLabel", &MaterialComponentRequestBus::Events::GetMaterialLabel, "GetMaterialSlotLabel")
+                    ->Event("SetMaterialMap", &MaterialComponentRequestBus::Events::SetMaterialMap, "SetMaterialOverrides")
+                    ->Event("GetMaterialMap", &MaterialComponentRequestBus::Events::GetMaterialMap, "GetMaterialOverrides")
+                    ->Event("ClearMaterialMap", &MaterialComponentRequestBus::Events::ClearMaterialMap, "ClearAllMaterialOverrides")
+                    ->Event("SetMaterialAssetIdOnDefaultSlot", &MaterialComponentRequestBus::Events::SetMaterialAssetIdOnDefaultSlot, "SetDefaultMaterialOverride")
+                    ->Event("GetMaterialAssetIdOnDefaultSlot", &MaterialComponentRequestBus::Events::GetMaterialAssetIdOnDefaultSlot, "GetDefaultMaterialOverride")
+                    ->Event("ClearMaterialAssetIdOnDefaultSlot", &MaterialComponentRequestBus::Events::ClearMaterialAssetIdOnDefaultSlot, "ClearDefaultMaterialOverride")
+                    ->Event("ClearMaterialsOnModelSlots", &MaterialComponentRequestBus::Events::ClearMaterialsOnModelSlots, "ClearModelMaterialOverrides")
+                    ->Event("ClearMaterialsOnLodSlots", &MaterialComponentRequestBus::Events::ClearMaterialsOnLodSlots, "ClearLodMaterialOverrides")
+                    ->Event("ClearMaterialsOnInvalidSlots", &MaterialComponentRequestBus::Events::ClearMaterialsOnInvalidSlots, "ClearIncompatibleMaterialOverrides")
+                    ->Event("ClearMaterialsWithMissingAssets", &MaterialComponentRequestBus::Events::ClearMaterialsWithMissingAssets, "ClearInvalidMaterialOverrides")
+                    ->Event("RepairMaterialsWithMissingAssets", &MaterialComponentRequestBus::Events::RepairMaterialsWithMissingAssets, "RepairInvalidMaterialOverrides")
+                    ->Event("RepairMaterialsWithRenamedProperties", &MaterialComponentRequestBus::Events::RepairMaterialsWithRenamedProperties, "ApplyAutomaticPropertyUpdates")
+                    ->Event("SetMaterialAssetId", &MaterialComponentRequestBus::Events::SetMaterialAssetId, "SetMaterialOverride")
+                    ->Event("GetMaterialAssetId", &MaterialComponentRequestBus::Events::GetMaterialAssetId, "GetMaterialOverride")
+                    ->Event("ClearMaterialAssetId", &MaterialComponentRequestBus::Events::ClearMaterialAssetId, "ClearMaterialOverride")
+                    ->Event("IsMaterialAssetIdOverridden", &MaterialComponentRequestBus::Events::IsMaterialAssetIdOverridden)
+                    ->Event("SetPropertyValue", &MaterialComponentRequestBus::Events::SetPropertyValue, "SetPropertyOverride")
+                    ->Event("SetPropertyValueBool", &MaterialComponentRequestBus::Events::SetPropertyValueT<bool>, "SetPropertyOverrideBool")
+                    ->Event("SetPropertyValueInt32", &MaterialComponentRequestBus::Events::SetPropertyValueT<int32_t>, "SetPropertyOverrideInt32")
+                    ->Event("SetPropertyValueUInt32", &MaterialComponentRequestBus::Events::SetPropertyValueT<uint32_t>, "SetPropertyOverrideUInt32")
+                    ->Event("SetPropertyValueFloat", &MaterialComponentRequestBus::Events::SetPropertyValueT<float>, "SetPropertyOverrideFloat")
+                    ->Event("SetPropertyValueVector2", &MaterialComponentRequestBus::Events::SetPropertyValueT<AZ::Vector2>, "SetPropertyOverrideVector2")
+                    ->Event("SetPropertyValueVector3", &MaterialComponentRequestBus::Events::SetPropertyValueT<AZ::Vector3>, "SetPropertyOverrideVector3")
+                    ->Event("SetPropertyValueVector4", &MaterialComponentRequestBus::Events::SetPropertyValueT<AZ::Vector4>, "SetPropertyOverrideVector4")
+                    ->Event("SetPropertyValueColor", &MaterialComponentRequestBus::Events::SetPropertyValueT<AZ::Color>, "SetPropertyOverrideColor")
+                    ->Event("SetPropertyValueImage", &MaterialComponentRequestBus::Events::SetPropertyValueT<AZ::Data::AssetId>, "SetPropertyOverrideImage")
+                    ->Event("SetPropertyValueString", &MaterialComponentRequestBus::Events::SetPropertyValueT<AZStd::string>, "SetPropertyOverrideString")
+                    ->Event("SetPropertyValueEnum", &MaterialComponentRequestBus::Events::SetPropertyValueT<uint32_t>, "SetPropertyOverrideEnum")
+                    ->Event("GetPropertyValue", &MaterialComponentRequestBus::Events::GetPropertyValue, "GetPropertyOverride")
+                    ->Event("GetPropertyValueBool", &MaterialComponentRequestBus::Events::GetPropertyValueT<bool>, "GetPropertyOverrideBool")
+                    ->Event("GetPropertyValueInt32", &MaterialComponentRequestBus::Events::GetPropertyValueT<int32_t>, "GetPropertyOverrideInt32")
+                    ->Event("GetPropertyValueUInt32", &MaterialComponentRequestBus::Events::GetPropertyValueT<uint32_t>, "GetPropertyOverrideUInt32")
+                    ->Event("GetPropertyValueFloat", &MaterialComponentRequestBus::Events::GetPropertyValueT<float>, "GetPropertyOverrideFloat")
+                    ->Event("GetPropertyValueVector2", &MaterialComponentRequestBus::Events::GetPropertyValueT<AZ::Vector2>, "GetPropertyOverrideVector2")
+                    ->Event("GetPropertyValueVector3", &MaterialComponentRequestBus::Events::GetPropertyValueT<AZ::Vector3>, "GetPropertyOverrideVector3")
+                    ->Event("GetPropertyValueVector4", &MaterialComponentRequestBus::Events::GetPropertyValueT<AZ::Vector4>, "GetPropertyOverrideVector4")
+                    ->Event("GetPropertyValueColor", &MaterialComponentRequestBus::Events::GetPropertyValueT<AZ::Color>, "GetPropertyOverrideColor")
+                    ->Event("GetPropertyValueImage", &MaterialComponentRequestBus::Events::GetPropertyValueT<AZ::Data::AssetId>, "GetPropertyOverrideImage")
+                    ->Event("GetPropertyValueString", &MaterialComponentRequestBus::Events::GetPropertyValueT<AZStd::string>, "GetPropertyOverrideString")
+                    ->Event("GetPropertyValueEnum", &MaterialComponentRequestBus::Events::GetPropertyValueT<uint32_t>, "GetPropertyOverrideEnum")
+                    ->Event("ClearPropertyValue", &MaterialComponentRequestBus::Events::ClearPropertyValue, "ClearPropertyValue")
+                    ->Event("ClearPropertyValues", &MaterialComponentRequestBus::Events::ClearPropertyValues, "ClearPropertyValues")
+                    ->Event("ClearAllPropertyValues", &MaterialComponentRequestBus::Events::ClearAllPropertyValues, "ClearAllPropertyValues")
+                    ->Event("SetPropertyValues", &MaterialComponentRequestBus::Events::SetPropertyValues, "SetPropertyOverrides")
+                    ->Event("GetPropertyValues", &MaterialComponentRequestBus::Events::GetPropertyValues, "GetPropertyOverrides")
                     ;
             }
         }
@@ -203,7 +204,7 @@ namespace AZ
             ReleaseMaterials();
 
             // Build tables of all referenced materials so that we can load and look up defaults
-            for (const auto& [materialAssignmentId, materialAssignment] : GetOriginalMaterialAssignments())
+            for (const auto& [materialAssignmentId, materialAssignment] : GetDefautMaterialMap())
             {
                 const auto& defaultMaterialAsset = materialAssignment.m_materialAsset;
                 m_uniqueMaterialMap[defaultMaterialAsset.GetId()] = defaultMaterialAsset;
@@ -301,11 +302,11 @@ namespace AZ
             }
         }
 
-        MaterialAssignmentMap MaterialComponentController::GetOriginalMaterialAssignments() const
+        MaterialAssignmentMap MaterialComponentController::GetDefautMaterialMap() const
         {
             MaterialAssignmentMap originalMaterials;
             MaterialReceiverRequestBus::EventResult(
-                originalMaterials, m_entityId, &MaterialReceiverRequestBus::Events::GetMaterialAssignments);
+                originalMaterials, m_entityId, &MaterialReceiverRequestBus::Events::GetDefautMaterialMap);
             return originalMaterials;
         }
 
@@ -318,47 +319,34 @@ namespace AZ
             return materialAssignmentId;
         }
 
-        AZ::Data::AssetId MaterialComponentController::GetActiveMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const
-        {
-            // If there is a material override return that asset ID
-            const auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
-            if (materialIt != m_configuration.m_materials.end() && materialIt->second.m_materialAsset.GetId().IsValid())
-            {
-                return materialIt->second.m_materialAsset.GetId();
-            }
-
-            // Otherwise return the cached default material asset ID
-            return GetDefaultMaterialAssetId(materialAssignmentId);
-        }
-
         AZ::Data::AssetId MaterialComponentController::GetDefaultMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const
         {
             auto materialIt = m_defaultMaterialMap.find(materialAssignmentId);
             return materialIt != m_defaultMaterialMap.end() ? materialIt->second.GetId() : AZ::Data::AssetId();
         }
 
-        AZStd::string MaterialComponentController::GetMaterialSlotLabel(const MaterialAssignmentId& materialAssignmentId) const
+        AZStd::string MaterialComponentController::GetMaterialLabel(const MaterialAssignmentId& materialAssignmentId) const
         {
             MaterialAssignmentLabelMap labels;
-            MaterialReceiverRequestBus::EventResult(labels, m_entityId, &MaterialReceiverRequestBus::Events::GetMaterialAssignmentLabels);
+            MaterialReceiverRequestBus::EventResult(labels, m_entityId, &MaterialReceiverRequestBus::Events::GetMaterialLabels);
 
             auto labelIt = labels.find(materialAssignmentId);
             return labelIt != labels.end() ? labelIt->second : "<unknown>";
         }
 
-        void MaterialComponentController::SetMaterialOverrides(const MaterialAssignmentMap& materials)
+        void MaterialComponentController::SetMaterialMap(const MaterialAssignmentMap& materials)
         {
             m_configuration.m_materials = materials;
             ConvertAssetsForSerialization();
             QueueLoadMaterials();
         }
 
-        const MaterialAssignmentMap& MaterialComponentController::GetMaterialOverrides() const
+        const MaterialAssignmentMap& MaterialComponentController::GetMaterialMap() const
         {
             return m_configuration.m_materials;
         }
 
-        void MaterialComponentController::ClearAllMaterialOverrides()
+        void MaterialComponentController::ClearMaterialMap()
         {
             if (!m_configuration.m_materials.empty())
             {
@@ -367,7 +355,7 @@ namespace AZ
             }
         }
 
-        void MaterialComponentController::ClearModelMaterialOverrides()
+        void MaterialComponentController::ClearMaterialsOnModelSlots()
         {
             const auto numErased = AZStd::erase_if(m_configuration.m_materials, [](const auto& materialPair) {
                 return materialPair.first.IsSlotIdOnly();
@@ -378,7 +366,7 @@ namespace AZ
             }
         }
 
-        void MaterialComponentController::ClearLodMaterialOverrides()
+        void MaterialComponentController::ClearMaterialsOnLodSlots()
         {
             const auto numErased = AZStd::erase_if(m_configuration.m_materials, [](const auto& materialPair) {
                 return materialPair.first.IsLodAndSlotId();
@@ -389,7 +377,7 @@ namespace AZ
             }
         }
 
-        void MaterialComponentController::ClearIncompatibleMaterialOverrides()
+        void MaterialComponentController::ClearMaterialsOnInvalidSlots()
         {
             const auto numErased = AZStd::erase_if(m_configuration.m_materials, [this](const auto& materialPair) {
                 return m_defaultMaterialMap.find(materialPair.first) == m_defaultMaterialMap.end();
@@ -400,7 +388,7 @@ namespace AZ
             }
         }
 
-        void MaterialComponentController::ClearInvalidMaterialOverrides()
+        void MaterialComponentController::ClearMaterialsWithMissingAssets()
         {
             const auto numErased = AZStd::erase_if(m_configuration.m_materials, [](const auto& materialPair) {
                 if (materialPair.second.m_materialAsset.GetId().IsValid())
@@ -419,7 +407,7 @@ namespace AZ
             }
         }
 
-        void MaterialComponentController::RepairInvalidMaterialOverrides()
+        void MaterialComponentController::RepairMaterialsWithMissingAssets()
         {
             for (auto& materialPair : m_configuration.m_materials)
             {
@@ -438,7 +426,7 @@ namespace AZ
             }
         }
         
-        uint32_t MaterialComponentController::ApplyAutomaticPropertyUpdates()
+        uint32_t MaterialComponentController::RepairMaterialsWithRenamedProperties()
         {
             uint32_t propertiesUpdated = 0;
 
@@ -471,22 +459,22 @@ namespace AZ
             return propertiesUpdated;
         }
 
-        void MaterialComponentController::SetDefaultMaterialOverride(const AZ::Data::AssetId& materialAssetId)
+        void MaterialComponentController::SetMaterialAssetIdOnDefaultSlot(const AZ::Data::AssetId& materialAssetId)
         {
-            SetMaterialOverride(DefaultMaterialAssignmentId, materialAssetId);
+            SetMaterialAssetId(DefaultMaterialAssignmentId, materialAssetId);
         }
 
-        const AZ::Data::AssetId MaterialComponentController::GetDefaultMaterialOverride() const
+        const AZ::Data::AssetId MaterialComponentController::GetMaterialAssetIdOnDefaultSlot() const
         {
-            return GetMaterialOverride(DefaultMaterialAssignmentId);
+            return GetMaterialAssetId(DefaultMaterialAssignmentId);
         }
 
-        void MaterialComponentController::ClearDefaultMaterialOverride()
+        void MaterialComponentController::ClearMaterialAssetIdOnDefaultSlot()
         {
-            ClearMaterialOverride(DefaultMaterialAssignmentId);
+            ClearMaterialAssetId(DefaultMaterialAssignmentId);
         }
 
-        void MaterialComponentController::SetMaterialOverride(
+        void MaterialComponentController::SetMaterialAssetId(
             const MaterialAssignmentId& materialAssignmentId, const AZ::Data::AssetId& materialAssetId)
         {
             auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
@@ -517,18 +505,31 @@ namespace AZ
             QueueLoadMaterials();
         }
 
-        AZ::Data::AssetId MaterialComponentController::GetMaterialOverride(const MaterialAssignmentId& materialAssignmentId) const
+        AZ::Data::AssetId MaterialComponentController::GetMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const
         {
-            auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
-            return materialIt != m_configuration.m_materials.end() ? materialIt->second.m_materialAsset.GetId() : AZ::Data::AssetId();
+            // If there is a material override return that asset ID
+            const auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
+            if (materialIt != m_configuration.m_materials.end() && materialIt->second.m_materialAsset.GetId().IsValid())
+            {
+                return materialIt->second.m_materialAsset.GetId();
+            }
+
+            // Otherwise return the cached default material asset ID
+            return GetDefaultMaterialAssetId(materialAssignmentId);
         }
 
-        void MaterialComponentController::ClearMaterialOverride(const MaterialAssignmentId& materialAssignmentId)
+        void MaterialComponentController::ClearMaterialAssetId(const MaterialAssignmentId& materialAssignmentId)
         {
-            SetMaterialOverride(materialAssignmentId, {});
+            SetMaterialAssetId(materialAssignmentId, {});
         }
 
-        void MaterialComponentController::SetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::any& value)
+        bool MaterialComponentController::IsMaterialAssetIdOverridden(const MaterialAssignmentId& materialAssignmentId) const
+        {
+            const auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
+            return materialIt != m_configuration.m_materials.end() && materialIt->second.m_materialAsset.GetId().IsValid();
+        }
+
+        void MaterialComponentController::SetPropertyValue(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::any& value)
         {
             auto& materialAssignment = m_configuration.m_materials[materialAssignmentId];
             const bool wasEmpty = materialAssignment.m_propertyOverrides.empty();
@@ -552,43 +553,56 @@ namespace AZ
             QueuePropertyChanges(materialAssignmentId);
         }
 
-        AZStd::any MaterialComponentController::GetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
+        AZStd::any MaterialComponentController::GetPropertyValue(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
         {
+            AZ::Data::Asset<AZ::RPI::MaterialAsset> materialAsset;
+
+            // First, check if there is an explicit property value override matching the name and material slot
             const auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
             if (materialIt != m_configuration.m_materials.end())
             {
+                // If there is an explicit property value override return it immediately
                 const auto propertyIt = materialIt->second.m_propertyOverrides.find(AZ::Name(propertyName));
-                if (propertyIt != materialIt->second.m_propertyOverrides.end())
+                if (propertyIt != materialIt->second.m_propertyOverrides.end() && !propertyIt->second.empty())
                 {
                     return propertyIt->second;
                 }
 
-                if (materialIt->second.m_materialAsset.IsReady())
+                // Otherwise, determine the highest priority material asset to pull property values from
+                materialAsset = materialIt->second.m_materialAsset;
+                if (!materialAsset.IsReady())
                 {
-                    const auto index =
-                        materialIt->second.m_materialAsset->GetMaterialPropertiesLayout()->FindPropertyIndex(AZ::Name(propertyName));
-                    if (index.IsValid())
-                    {
-                        return AZ::RPI::MaterialPropertyValue::ToAny(
-                            materialIt->second.m_materialAsset->GetPropertyValues()[index.GetIndex()]);
-                    }
+                    materialAsset = materialIt->second.m_defaultMaterialAsset;
                 }
             }
 
-            const auto defaultMaterialIt = m_defaultMaterialMap.find(materialAssignmentId);
-            if (defaultMaterialIt != m_defaultMaterialMap.end() && defaultMaterialIt->second.IsReady())
+            // No matching value or asset has been found, so check against the default material map
+            if (!materialAsset.IsReady())
             {
-                const auto index = defaultMaterialIt->second->GetMaterialPropertiesLayout()->FindPropertyIndex(AZ::Name(propertyName));
+                const auto defaultMaterialIt = m_defaultMaterialMap.find(materialAssignmentId);
+                if (defaultMaterialIt != m_defaultMaterialMap.end() && defaultMaterialIt->second.IsReady())
+                {
+                    materialAsset = defaultMaterialIt->second;
+                }
+            }
+
+            // If a valid, ready asset was identified, attempt to read the default property value from it.
+            if (materialAsset.IsReady())
+            {
+                const auto layout = materialAsset->GetMaterialPropertiesLayout();
+                const auto index = layout->FindPropertyIndex(AZ::Name(propertyName));
                 if (index.IsValid())
                 {
-                    return AZ::RPI::MaterialPropertyValue::ToAny(defaultMaterialIt->second->GetPropertyValues()[index.GetIndex()]);
+                    return AZ::RPI::MaterialPropertyValue::ToAny(materialAsset->GetPropertyValues()[index.GetIndex()]);
                 }
             }
 
             return {};
         }
 
-        void MaterialComponentController::ClearPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName)
+        void MaterialComponentController::ClearPropertyValue(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName)
         {
             auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
             if (materialIt == m_configuration.m_materials.end())
@@ -606,14 +620,15 @@ namespace AZ
             if (materialIt->second.m_propertyOverrides.empty())
             {
                 materialIt->second.RebuildInstance();
-                MaterialComponentNotificationBus::Event(m_entityId, &MaterialComponentNotifications::OnMaterialInstanceCreated, materialIt->second);
+                MaterialComponentNotificationBus::Event(
+                    m_entityId, &MaterialComponentNotifications::OnMaterialInstanceCreated, materialIt->second);
                 QueueMaterialUpdateNotification();
             }
 
             QueuePropertyChanges(materialAssignmentId);
         }
 
-        void MaterialComponentController::ClearPropertyOverrides(const MaterialAssignmentId& materialAssignmentId)
+        void MaterialComponentController::ClearPropertyValues(const MaterialAssignmentId& materialAssignmentId)
         {
             auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
             if (materialIt == m_configuration.m_materials.end())
@@ -625,12 +640,13 @@ namespace AZ
             {
                 materialIt->second.m_propertyOverrides = {};
                 materialIt->second.RebuildInstance();
-                MaterialComponentNotificationBus::Event(m_entityId, &MaterialComponentNotifications::OnMaterialInstanceCreated, materialIt->second);
+                MaterialComponentNotificationBus::Event(
+                    m_entityId, &MaterialComponentNotifications::OnMaterialInstanceCreated, materialIt->second);
                 QueueMaterialUpdateNotification();
             }
         }
 
-        void MaterialComponentController::ClearAllPropertyOverrides()
+        void MaterialComponentController::ClearAllPropertyValues()
         {
             for (auto& materialPair : m_configuration.m_materials)
             {
@@ -638,13 +654,14 @@ namespace AZ
                 {
                     materialPair.second.m_propertyOverrides = {};
                     materialPair.second.RebuildInstance();
-                    MaterialComponentNotificationBus::Event(m_entityId, &MaterialComponentNotifications::OnMaterialInstanceCreated, materialPair.second);
+                    MaterialComponentNotificationBus::Event(
+                        m_entityId, &MaterialComponentNotifications::OnMaterialInstanceCreated, materialPair.second);
                     QueueMaterialUpdateNotification();
                 }
             }
         }
 
-        void MaterialComponentController::SetPropertyOverrides(
+        void MaterialComponentController::SetPropertyValues(
             const MaterialAssignmentId& materialAssignmentId, const MaterialPropertyOverrideMap& propertyOverrides)
         {
             auto& materialAssignment = m_configuration.m_materials[materialAssignmentId];
@@ -667,11 +684,48 @@ namespace AZ
             QueuePropertyChanges(materialAssignmentId);
         }
 
-        MaterialPropertyOverrideMap MaterialComponentController::GetPropertyOverrides(
-            const MaterialAssignmentId& materialAssignmentId) const
+        MaterialPropertyOverrideMap MaterialComponentController::GetPropertyValues(const MaterialAssignmentId& materialAssignmentId) const
         {
+            MaterialPropertyOverrideMap properties;
+            AZ::Data::Asset<AZ::RPI::MaterialAsset> materialAsset;
+
             const auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
-            return materialIt != m_configuration.m_materials.end() ? materialIt->second.m_propertyOverrides : MaterialPropertyOverrideMap();
+            if (materialIt != m_configuration.m_materials.end())
+            {
+                // First, insert all the explicit material property overrides into the returned property map
+                properties.insert(materialIt->second.m_propertyOverrides.begin(), materialIt->second.m_propertyOverrides.end());
+
+                // Determine if there is an asset ready with additional values to populate the map
+                materialAsset = materialIt->second.m_materialAsset;
+                if (!materialAsset.IsReady())
+                {
+                    materialAsset = materialIt->second.m_defaultMaterialAsset;
+                }
+            }
+
+            // If no hacen has been identified, fall back to the default material mapping
+            if (!materialAsset.IsReady())
+            {
+                const auto defaultMaterialIt = m_defaultMaterialMap.find(materialAssignmentId);
+                if (defaultMaterialIt != m_defaultMaterialMap.end() && defaultMaterialIt->second.IsReady())
+                {
+                    materialAsset = defaultMaterialIt->second;
+                }
+            }
+
+            // If any valid, already has said was found then read the rest of the material values from it
+            if (materialAsset.IsReady())
+            {
+                const auto layout = materialAsset->GetMaterialPropertiesLayout();
+                for (size_t propertyIndex = 0; propertyIndex < layout->GetPropertyCount(); ++propertyIndex)
+                {
+                    auto descriptor = layout->GetPropertyDescriptor(AZ::RPI::MaterialPropertyIndex{ propertyIndex });
+                    auto propertyValue = materialAsset->GetPropertyValues()[propertyIndex];
+                    properties.insert({ descriptor->GetName().GetStringView(), AZ::RPI::MaterialPropertyValue::ToAny(propertyValue) });
+                }
+            }
+
+            return properties;
         }
 
         void MaterialComponentController::SetModelUvOverrides(
@@ -696,14 +750,14 @@ namespace AZ
             const MaterialAssignmentId& materialAssignmentId) const
         {
             const auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
-            return materialIt != m_configuration.m_materials.end() ? materialIt->second.m_matModUvOverrides : AZ::RPI::MaterialModelUvOverrideMap();
+            return materialIt != m_configuration.m_materials.end() ? materialIt->second.m_matModUvOverrides
+                                                                   : AZ::RPI::MaterialModelUvOverrideMap();
         }
 
         void MaterialComponentController::OnMaterialAssignmentSlotsChanged()
         {
             LoadMaterials();
             MaterialComponentNotificationBus::Event(m_entityId, &MaterialComponentNotifications::OnMaterialSlotLayoutChanged);
-
         }
 
         void MaterialComponentController::QueuePropertyChanges(const MaterialAssignmentId& materialAssignmentId)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -81,9 +81,9 @@ namespace AZ
                     ->Event("GetPropertyValueImage", &MaterialComponentRequestBus::Events::GetPropertyValueT<AZ::Data::AssetId>, "GetPropertyOverrideImage")
                     ->Event("GetPropertyValueString", &MaterialComponentRequestBus::Events::GetPropertyValueT<AZStd::string>, "GetPropertyOverrideString")
                     ->Event("GetPropertyValueEnum", &MaterialComponentRequestBus::Events::GetPropertyValueT<uint32_t>, "GetPropertyOverrideEnum")
-                    ->Event("ClearPropertyValue", &MaterialComponentRequestBus::Events::ClearPropertyValue, "ClearPropertyValue")
-                    ->Event("ClearPropertyValues", &MaterialComponentRequestBus::Events::ClearPropertyValues, "ClearPropertyValues")
-                    ->Event("ClearAllPropertyValues", &MaterialComponentRequestBus::Events::ClearAllPropertyValues, "ClearAllPropertyValues")
+                    ->Event("ClearPropertyValue", &MaterialComponentRequestBus::Events::ClearPropertyValue, "ClearPropertyOverride")
+                    ->Event("ClearPropertyValues", &MaterialComponentRequestBus::Events::ClearPropertyValues, "ClearPropertyOverrides")
+                    ->Event("ClearAllPropertyValues", &MaterialComponentRequestBus::Events::ClearAllPropertyValues, "ClearAllPropertyOverrides")
                     ->Event("SetPropertyValues", &MaterialComponentRequestBus::Events::SetPropertyValues, "SetPropertyOverrides")
                     ->Event("GetPropertyValues", &MaterialComponentRequestBus::Events::GetPropertyValues, "GetPropertyOverrides")
                     ;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -46,34 +46,34 @@ namespace AZ
             const MaterialComponentConfig& GetConfiguration() const;
 
             //! MaterialComponentRequestBus overrides...
-            MaterialAssignmentMap GetOriginalMaterialAssignments() const override;
+            MaterialAssignmentMap GetDefautMaterialMap() const override;
             MaterialAssignmentId FindMaterialAssignmentId(const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
-            AZ::Data::AssetId GetActiveMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const override;
             AZ::Data::AssetId GetDefaultMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const override;
-            AZStd::string GetMaterialSlotLabel(const MaterialAssignmentId& materialAssignmentId) const override;
-            void SetMaterialOverrides(const MaterialAssignmentMap& materials) override;
-            const MaterialAssignmentMap& GetMaterialOverrides() const override;
-            void ClearAllMaterialOverrides() override;
-            void ClearModelMaterialOverrides() override;
-            void ClearLodMaterialOverrides() override;
-            void ClearIncompatibleMaterialOverrides() override;
-            void ClearInvalidMaterialOverrides() override;
-            void RepairInvalidMaterialOverrides() override;
-            uint32_t ApplyAutomaticPropertyUpdates() override;
-            void SetDefaultMaterialOverride(const AZ::Data::AssetId& materialAssetId) override;
-            const AZ::Data::AssetId GetDefaultMaterialOverride() const override;
-            void ClearDefaultMaterialOverride() override;
-            void SetMaterialOverride(const MaterialAssignmentId& materialAssignmentId, const AZ::Data::AssetId& materialAssetId) override;
-            AZ::Data::AssetId GetMaterialOverride(const MaterialAssignmentId& materialAssignmentId) const override;
-            void ClearMaterialOverride(const MaterialAssignmentId& materialAssignmentId) override;
-            void SetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::any& value) override;
-            AZStd::any GetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
-            void ClearPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) override;
-            void ClearPropertyOverrides(const MaterialAssignmentId& materialAssignmentId) override;
-            void ClearAllPropertyOverrides() override;
-            void SetPropertyOverrides(
+            AZStd::string GetMaterialLabel(const MaterialAssignmentId& materialAssignmentId) const override;
+            void SetMaterialMap(const MaterialAssignmentMap& materials) override;
+            const MaterialAssignmentMap& GetMaterialMap() const override;
+            void ClearMaterialMap() override;
+            void ClearMaterialsOnModelSlots() override;
+            void ClearMaterialsOnLodSlots() override;
+            void ClearMaterialsOnInvalidSlots() override;
+            void ClearMaterialsWithMissingAssets() override;
+            void RepairMaterialsWithMissingAssets() override;
+            uint32_t RepairMaterialsWithRenamedProperties() override;
+            void SetMaterialAssetIdOnDefaultSlot(const AZ::Data::AssetId& materialAssetId) override;
+            const AZ::Data::AssetId GetMaterialAssetIdOnDefaultSlot() const override;
+            void ClearMaterialAssetIdOnDefaultSlot() override;
+            void SetMaterialAssetId(const MaterialAssignmentId& materialAssignmentId, const AZ::Data::AssetId& materialAssetId) override;
+            AZ::Data::AssetId GetMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const override;
+            void ClearMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) override;
+            bool IsMaterialAssetIdOverridden(const MaterialAssignmentId& materialAssignmentId) const override;
+            void SetPropertyValue(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::any& value) override;
+            AZStd::any GetPropertyValue(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
+            void ClearPropertyValue(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) override;
+            void ClearPropertyValues(const MaterialAssignmentId& materialAssignmentId) override;
+            void ClearAllPropertyValues() override;
+            void SetPropertyValues(
                 const MaterialAssignmentId& materialAssignmentId, const MaterialPropertyOverrideMap& propertyOverrides) override;
-            MaterialPropertyOverrideMap GetPropertyOverrides(const MaterialAssignmentId& materialAssignmentId) const override;
+            MaterialPropertyOverrideMap GetPropertyValues(const MaterialAssignmentId& materialAssignmentId) const override;
             void SetModelUvOverrides(
                 const MaterialAssignmentId& materialAssignmentId, const AZ::RPI::MaterialModelUvOverrideMap& modelUvOverrides) override;
             AZ::RPI::MaterialModelUvOverrideMap GetModelUvOverrides(const MaterialAssignmentId& materialAssignmentId) const override;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -79,7 +79,7 @@ namespace AZ
             AZ::RPI::MaterialModelUvOverrideMap GetModelUvOverrides(const MaterialAssignmentId& materialAssignmentId) const override;
 
             //! MaterialReceiverNotificationBus::Handler overrides...
-            void OnMaterialAssignmentsChanged() override;
+            void OnMaterialAssignmentSlotsChanged() override;
 
         private:
 
@@ -99,6 +99,8 @@ namespace AZ
             void QueuePropertyChanges(const MaterialAssignmentId& materialAssignmentId);
             //! Queue material instance recreation notifications until tick
             void QueueMaterialUpdateNotification();
+            //! Queue material reload so that it only occurs once per tick
+            void QueueLoadMaterials();
 
             //! Converts property overrides storing image asset references into asset IDs. This addresses a problem where image property
             //! overrides are lost during prefab serialization and patching. This suboptimal function will be removed once the underlying
@@ -108,10 +110,10 @@ namespace AZ
             EntityId m_entityId;
             MaterialComponentConfig m_configuration;
             AZStd::unordered_map<MaterialAssignmentId, AZ::Data::Asset<AZ::RPI::MaterialAsset>> m_defaultMaterialMap;
-            AZStd::unordered_map<MaterialAssignmentId, AZ::Data::Asset<AZ::RPI::MaterialAsset>> m_activeMaterialMap;
             AZStd::unordered_map<AZ::Data::AssetId, AZ::Data::Asset<AZ::RPI::MaterialAsset>> m_uniqueMaterialMap;
             AZStd::unordered_set<MaterialAssignmentId> m_materialsWithDirtyProperties;
             bool m_queuedMaterialUpdateNotification = false;
+            bool m_queuedLoadMaterials = false;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -106,10 +106,12 @@ namespace AZ
             //! overrides are lost during prefab serialization and patching. This suboptimal function will be removed once the underlying
             //! problem is resolved.
             void ConvertAssetsForSerialization();
+            void ConvertAssetsForSerialization(MaterialPropertyOverrideMap& propertyMap);
+            AZStd::any ConvertAssetsForSerialization(const AZStd::any& value) const;
 
             EntityId m_entityId;
             MaterialComponentConfig m_configuration;
-            AZStd::unordered_map<MaterialAssignmentId, AZ::Data::Asset<AZ::RPI::MaterialAsset>> m_defaultMaterialMap;
+            MaterialAssignmentMap m_defaultMaterialMap;
             AZStd::unordered_map<AZ::Data::AssetId, AZ::Data::Asset<AZ::RPI::MaterialAsset>> m_uniqueMaterialMap;
             AZStd::unordered_set<MaterialAssignmentId> m_materialsWithDirtyProperties;
             bool m_queuedMaterialUpdateNotification = false;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -321,28 +321,20 @@ namespace AZ
             }
         }
 
-        RPI::ModelMaterialSlotMap MeshComponentController::GetModelMaterialSlots() const
+        MaterialAssignmentLabelMap MeshComponentController::GetMaterialAssignmentLabels() const
         {
-            Data::Asset<const RPI::ModelAsset> modelAsset = GetModelAsset();
-            if (modelAsset.IsReady())
-            {
-                return modelAsset->GetMaterialSlots();
-            }
-            else
-            {
-                return {};
-            }
+            return GetMaterialAssignmentSlotLabelsFromModel(GetModelAsset());
         }
 
         MaterialAssignmentId MeshComponentController::FindMaterialAssignmentId(
             const MaterialAssignmentLodIndex lod, const AZStd::string& label) const
         {
-            return FindMaterialAssignmentIdInModel(GetModel(), lod, label);
+            return FindMaterialAssignmentIdInModel(GetModelAsset(), lod, label);
         }
 
         MaterialAssignmentMap MeshComponentController::GetMaterialAssignments() const
         {
-            return GetMaterialAssignmentsFromModel(GetModel());
+            return GetMaterialAssignmentsFromModel(GetModelAsset());
         }
 
         AZStd::unordered_set<AZ::Name> MeshComponentController::GetModelUvNames() const
@@ -386,7 +378,7 @@ namespace AZ
                 const AZ::EntityId entityId = m_entityComponentIdPair.GetEntityId();
                 m_configuration.m_modelAsset = modelAsset;
                 MeshComponentNotificationBus::Event(entityId, &MeshComponentNotificationBus::Events::OnModelReady, m_configuration.m_modelAsset, model);
-                MaterialReceiverNotificationBus::Event(entityId, &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentsChanged);
+                MaterialReceiverNotificationBus::Event(entityId, &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
                 AZ::Interface<AzFramework::IEntityBoundsUnion>::Get()->RefreshEntityLocalBoundsUnion(entityId);
                 AzFramework::RenderGeometry::IntersectionNotificationBus::Event(
                     m_intersectionNotificationBus, &AzFramework::RenderGeometry::IntersectionNotificationBus::Events::OnGeometryChanged,
@@ -431,7 +423,7 @@ namespace AZ
             {
                 // If there is no model asset to be loaded then we need to invalidate the material slot configuration
                 MaterialReceiverNotificationBus::Event(
-                    m_entityComponentIdPair.GetEntityId(), &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentsChanged);
+                    m_entityComponentIdPair.GetEntityId(), &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
             }
         }
 
@@ -448,7 +440,7 @@ namespace AZ
 
                 // Model has been released which invalidates the material slot configuration
                 MaterialReceiverNotificationBus::Event(
-                    m_entityComponentIdPair.GetEntityId(), &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentsChanged);
+                    m_entityComponentIdPair.GetEntityId(), &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
             }
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -323,18 +323,18 @@ namespace AZ
 
         MaterialAssignmentLabelMap MeshComponentController::GetMaterialLabels() const
         {
-            return GetMaterialAssignmentSlotLabelsFromModel(GetModelAsset());
+            return GetMaterialSlotLabelsFromModelAsset(GetModelAsset());
         }
 
         MaterialAssignmentId MeshComponentController::FindMaterialAssignmentId(
             const MaterialAssignmentLodIndex lod, const AZStd::string& label) const
         {
-            return FindMaterialAssignmentIdInModel(GetModelAsset(), lod, label);
+            return GetMaterialSlotIdFromModelAsset(GetModelAsset(), lod, label);
         }
 
         MaterialAssignmentMap MeshComponentController::GetDefautMaterialMap() const
         {
-            return GetMaterialAssignmentsFromModel(GetModelAsset());
+            return GetDefautMaterialMapFromModelAsset(GetModelAsset());
         }
 
         AZStd::unordered_set<AZ::Name> MeshComponentController::GetModelUvNames() const

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -321,7 +321,7 @@ namespace AZ
             }
         }
 
-        MaterialAssignmentLabelMap MeshComponentController::GetMaterialAssignmentLabels() const
+        MaterialAssignmentLabelMap MeshComponentController::GetMaterialLabels() const
         {
             return GetMaterialAssignmentSlotLabelsFromModel(GetModelAsset());
         }
@@ -332,7 +332,7 @@ namespace AZ
             return FindMaterialAssignmentIdInModel(GetModelAsset(), lod, label);
         }
 
-        MaterialAssignmentMap MeshComponentController::GetMaterialAssignments() const
+        MaterialAssignmentMap MeshComponentController::GetDefautMaterialMap() const
         {
             return GetMaterialAssignmentsFromModel(GetModelAsset());
         }
@@ -395,7 +395,7 @@ namespace AZ
                 const AZ::EntityId entityId = m_entityComponentIdPair.GetEntityId();
 
                 MaterialAssignmentMap materials;
-                MaterialComponentRequestBus::EventResult(materials, entityId, &MaterialComponentRequests::GetMaterialOverrides);
+                MaterialComponentRequestBus::EventResult(materials, entityId, &MaterialComponentRequests::GetMaterialMap);
 
                 m_meshFeatureProcessor->ReleaseMesh(m_meshHandle);
                 MeshHandleDescriptor meshDescriptor;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -137,8 +137,8 @@ namespace AZ
             // MaterialReceiverRequestBus::Handler overrides ...
             MaterialAssignmentId FindMaterialAssignmentId(
                 const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
-            MaterialAssignmentLabelMap GetMaterialAssignmentLabels() const override;
-            MaterialAssignmentMap GetMaterialAssignments() const override;
+            MaterialAssignmentLabelMap GetMaterialLabels() const override;
+            MaterialAssignmentMap GetDefautMaterialMap() const override;
             AZStd::unordered_set<AZ::Name> GetModelUvNames() const override;
 
             // MaterialComponentNotificationBus::Handler overrides ...

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -137,7 +137,7 @@ namespace AZ
             // MaterialReceiverRequestBus::Handler overrides ...
             MaterialAssignmentId FindMaterialAssignmentId(
                 const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
-            RPI::ModelMaterialSlotMap GetModelMaterialSlots() const override;
+            MaterialAssignmentLabelMap GetMaterialAssignmentLabels() const override;
             MaterialAssignmentMap GetMaterialAssignments() const override;
             AZStd::unordered_set<AZ::Name> GetModelUvNames() const override;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedPreviewContent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedPreviewContent.cpp
@@ -111,11 +111,11 @@ namespace AZ
                 m_modelEntity->GetId(), &Render::MeshComponentRequestBus::Events::SetModelAsset, m_modelAsset);
 
             Render::MaterialComponentRequestBus::Event(
-                m_modelEntity->GetId(), &Render::MaterialComponentRequestBus::Events::SetMaterialOverride,
+                m_modelEntity->GetId(), &Render::MaterialComponentRequestBus::Events::SetMaterialAssetId,
                 Render::DefaultMaterialAssignmentId, m_materialAsset.GetId());
 
             Render::MaterialComponentRequestBus::Event(
-                m_modelEntity->GetId(), &Render::MaterialComponentRequestBus::Events::SetPropertyOverrides,
+                m_modelEntity->GetId(), &Render::MaterialComponentRequestBus::Events::SetPropertyValues,
                 Render::DefaultMaterialAssignmentId, m_materialPropertyOverrides);
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Editor/Scripts/Materials/assign_material_to_all_entities.py
+++ b/Gems/AtomLyIntegration/CommonFeatures/Editor/Scripts/Materials/assign_material_to_all_entities.py
@@ -56,8 +56,8 @@ if __name__ == '__main__':
                 editor.EditorComponentAPIBus(bus.Broadcast, 'AddComponentsOfType', current_entity_id, [material_component_type_id])
             
             # Clear all material overrides
-            render.MaterialComponentRequestBus(bus.Event, 'ClearAllMaterialOverrides', current_entity_id)
+            render.MaterialComponentRequestBus(bus.Event, 'ClearMaterialMap', current_entity_id)
 
             # Set the default material to the one we want, which will apply it to every slot since we've cleared all overrides
-            render.MaterialComponentRequestBus(bus.Event, 'SetDefaultMaterialOverride', current_entity_id, material_asset_id)
+            render.MaterialComponentRequestBus(bus.Event, 'SetMaterialAssetIdOnDefaultSlot', current_entity_id, material_asset_id)
 

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -206,18 +206,18 @@ namespace AZ::Render
 
     MaterialAssignmentLabelMap AtomActorInstance::GetMaterialLabels() const
     {
-        return GetMaterialAssignmentSlotLabelsFromModel(GetModelAsset());
+        return GetMaterialSlotLabelsFromModelAsset(GetModelAsset());
     }
 
     MaterialAssignmentId AtomActorInstance::FindMaterialAssignmentId(
         const MaterialAssignmentLodIndex lod, const AZStd::string& label) const
     {
-        return FindMaterialAssignmentIdInModel(GetModelAsset(), lod, label);
+        return GetMaterialSlotIdFromModelAsset(GetModelAsset(), lod, label);
     }
 
     MaterialAssignmentMap AtomActorInstance::GetDefautMaterialMap() const
     {
-        return GetMaterialAssignmentsFromModel(GetModelAsset());
+        return GetDefautMaterialMapFromModelAsset(GetModelAsset());
     }
 
     AZStd::unordered_set<AZ::Name> AtomActorInstance::GetModelUvNames() const

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -204,38 +204,20 @@ namespace AZ::Render
         m_skinnedMeshFeatureProcessor = nullptr;
     }
 
-    RPI::ModelMaterialSlotMap AtomActorInstance::GetModelMaterialSlots() const
+    MaterialAssignmentLabelMap AtomActorInstance::GetMaterialAssignmentLabels() const
     {
-        Data::Asset<const RPI::ModelAsset> modelAsset = GetModelAsset();
-        if (modelAsset.IsReady())
-        {
-            return modelAsset->GetMaterialSlots();
-        }
-        else
-        {
-            return {};
-        }
+        return GetMaterialAssignmentSlotLabelsFromModel(GetModelAsset());
     }
 
     MaterialAssignmentId AtomActorInstance::FindMaterialAssignmentId(
         const MaterialAssignmentLodIndex lod, const AZStd::string& label) const
     {
-        if (m_skinnedMeshInstance && m_skinnedMeshInstance->m_model)
-        {
-            return FindMaterialAssignmentIdInModel(m_skinnedMeshInstance->m_model, lod, label);
-        }
-
-        return MaterialAssignmentId();
+        return FindMaterialAssignmentIdInModel(GetModelAsset(), lod, label);
     }
 
     MaterialAssignmentMap AtomActorInstance::GetMaterialAssignments() const
     {
-        if (m_skinnedMeshInstance && m_skinnedMeshInstance->m_model)
-        {
-            return GetMaterialAssignmentsFromModel(m_skinnedMeshInstance->m_model);
-        }
-
-        return MaterialAssignmentMap{};
+        return GetMaterialAssignmentsFromModel(GetModelAsset());
     }
 
     AZStd::unordered_set<AZ::Name> AtomActorInstance::GetModelUvNames() const
@@ -683,7 +665,7 @@ namespace AZ::Render
         m_skinnedMeshInstance = m_skinnedMeshInputBuffers->CreateSkinnedMeshInstance();
         if (m_skinnedMeshInstance && m_skinnedMeshInstance->m_model)
         {
-            MaterialReceiverNotificationBus::Event(m_entityId, &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentsChanged);
+            MaterialReceiverNotificationBus::Event(m_entityId, &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
 
             RegisterActor();
         }

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -204,7 +204,7 @@ namespace AZ::Render
         m_skinnedMeshFeatureProcessor = nullptr;
     }
 
-    MaterialAssignmentLabelMap AtomActorInstance::GetMaterialAssignmentLabels() const
+    MaterialAssignmentLabelMap AtomActorInstance::GetMaterialLabels() const
     {
         return GetMaterialAssignmentSlotLabelsFromModel(GetModelAsset());
     }
@@ -215,7 +215,7 @@ namespace AZ::Render
         return FindMaterialAssignmentIdInModel(GetModelAsset(), lod, label);
     }
 
-    MaterialAssignmentMap AtomActorInstance::GetMaterialAssignments() const
+    MaterialAssignmentMap AtomActorInstance::GetDefautMaterialMap() const
     {
         return GetMaterialAssignmentsFromModel(GetModelAsset());
     }
@@ -596,7 +596,7 @@ namespace AZ::Render
     void AtomActorInstance::RegisterActor()
     {
         MaterialAssignmentMap materials;
-        MaterialComponentRequestBus::EventResult(materials, m_entityId, &MaterialComponentRequests::GetMaterialOverrides);
+        MaterialComponentRequestBus::EventResult(materials, m_entityId, &MaterialComponentRequests::GetMaterialMap);
         CreateRenderProxy(materials);
 
         InitWrinkleMasks();

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
@@ -126,7 +126,7 @@ namespace AZ
             // MaterialReceiverRequestBus::Handler overrides...
             MaterialAssignmentId FindMaterialAssignmentId(
                 const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
-            RPI::ModelMaterialSlotMap GetModelMaterialSlots() const override;
+            MaterialAssignmentLabelMap GetMaterialAssignmentLabels() const override;
             MaterialAssignmentMap GetMaterialAssignments() const override;
             AZStd::unordered_set<AZ::Name> GetModelUvNames() const override;
 

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
@@ -126,8 +126,8 @@ namespace AZ
             // MaterialReceiverRequestBus::Handler overrides...
             MaterialAssignmentId FindMaterialAssignmentId(
                 const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
-            MaterialAssignmentLabelMap GetMaterialAssignmentLabels() const override;
-            MaterialAssignmentMap GetMaterialAssignments() const override;
+            MaterialAssignmentLabelMap GetMaterialLabels() const override;
+            MaterialAssignmentMap GetDefautMaterialMap() const override;
             AZStd::unordered_set<AZ::Name> GetModelUvNames() const override;
 
             /////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Blast/Code/Source/Editor/EditorBlastMeshDataComponent.cpp
+++ b/Gems/Blast/Code/Source/Editor/EditorBlastMeshDataComponent.cpp
@@ -180,7 +180,7 @@ namespace Blast
         {
             AZ::Render::MaterialAssignmentMap materials;
             AZ::Render::MaterialComponentRequestBus::EventResult(
-                materials, GetEntityId(), &AZ::Render::MaterialComponentRequests::GetMaterialOverrides);
+                materials, GetEntityId(), &AZ::Render::MaterialComponentRequests::GetMaterialMap);
 
             m_meshFeatureProcessor->ReleaseMesh(m_meshHandle);
             m_meshHandle = m_meshFeatureProcessor->AcquireMesh(AZ::Render::MeshHandleDescriptor{ m_meshAssets[0] }, materials);

--- a/Gems/Blast/Code/Source/Editor/EditorBlastMeshDataComponent.cpp
+++ b/Gems/Blast/Code/Source/Editor/EditorBlastMeshDataComponent.cpp
@@ -170,7 +170,7 @@ namespace Blast
                 GetEntityId(), &AZ::Render::MeshComponentNotificationBus::Events::OnModelReady, model->GetModelAsset(),
                 model);
             AZ::Render::MaterialReceiverNotificationBus::Event(
-                GetEntityId(), &AZ::Render::MaterialReceiverNotificationBus::Events::OnMaterialAssignmentsChanged);
+                GetEntityId(), &AZ::Render::MaterialReceiverNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
         }
     }
 

--- a/Gems/Blast/Code/Source/Family/ActorRenderManager.cpp
+++ b/Gems/Blast/Code/Source/Family/ActorRenderManager.cpp
@@ -28,7 +28,7 @@ namespace Blast
         , m_scale(scale)
     {
         AZ::Render::MaterialComponentRequestBus::EventResult(
-            m_materialMap, entityId, &AZ::Render::MaterialComponentRequests::GetMaterialOverrides);
+            m_materialMap, entityId, &AZ::Render::MaterialComponentRequests::GetMaterialMap);
     }
 
     void ActorRenderManager::OnActorCreated(const BlastActor& actor)

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/MaterialComponentRequestBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/MaterialComponentRequestBus.names
@@ -9,17 +9,17 @@
             },
             "methods": [
                 {
-                    "base": "GetPropertyOverrides",
+                    "base": "GetPropertyValues",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Property Overrides"
+                        "tooltip": "When signaled, this will invoke Get Property Values"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Property Overrides is invoked"
+                        "tooltip": "Signaled after Get Property Values is invoked"
                     },
                     "details": {
-                        "name": "Get Property Overrides"
+                        "name": "Get Property Values"
                     },
                     "params": [
                         {
@@ -34,23 +34,23 @@
                         {
                             "typeid": "{6E6962E1-04C9-56F9-89C4-361031CC1384}",
                             "details": {
-                                "name": "Property Override Map"
+                                "name": "Property Value Map"
                             }
                         }
                     ]
                 },
                 {
-                    "base": "SetPropertyOverrides",
+                    "base": "SetPropertyValues",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Property Overrides"
+                        "tooltip": "When signaled, this will invoke Set Property Values"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Property Overrides is invoked"
+                        "tooltip": "Signaled after Set Property Values is invoked"
                     },
                     "details": {
-                        "name": "Set Property Overrides"
+                        "name": "Set Property Values"
                     },
                     "params": [
                         {
@@ -63,23 +63,23 @@
                         {
                             "typeid": "{6E6962E1-04C9-56F9-89C4-361031CC1384}",
                             "details": {
-                                "name": "Property Override Map"
+                                "name": "Property Value Map"
                             }
                         }
                     ]
                 },
                 {
-                    "base": "ClearPropertyOverride",
+                    "base": "ClearPropertyValue",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Clear Property Override"
+                        "tooltip": "When signaled, this will invoke Clear Property Value"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Clear Property Override is invoked"
+                        "tooltip": "Signaled after Clear Property Value is invoked"
                     },
                     "details": {
-                        "name": "Clear Property Override"
+                        "name": "Clear Property Value"
                     },
                     "params": [
                         {
@@ -98,17 +98,17 @@
                     ]
                 },
                 {
-                    "base": "ClearPropertyOverrides",
+                    "base": "ClearPropertyValues",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Clear Property Overrides"
+                        "tooltip": "When signaled, this will invoke Clear Property Values"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Clear Property Overrides is invoked"
+                        "tooltip": "Signaled after Clear Property Values is invoked"
                     },
                     "details": {
-                        "name": "Clear Property Overrides"
+                        "name": "Clear Property Values"
                     },
                     "params": [
                         {
@@ -121,17 +121,17 @@
                     ]
                 },
                 {
-                    "base": "GetPropertyOverrideVector4",
+                    "base": "GetPropertyValueVector4",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Property Override Vector4"
+                        "tooltip": "When signaled, this will invoke Get Property Value Vector4"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Property Override Vector4 is invoked"
+                        "tooltip": "Signaled after Get Property Value Vector4 is invoked"
                     },
                     "details": {
-                        "name": "Get Property Override Vector4"
+                        "name": "Get Property Value Vector4"
                     },
                     "params": [
                         {
@@ -158,17 +158,17 @@
                     ]
                 },
                 {
-                    "base": "GetPropertyOverrideUInt32",
+                    "base": "GetPropertyValueUInt32",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Property Override UInt32"
+                        "tooltip": "When signaled, this will invoke Get Property Value UInt32"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Property Override UInt32 is invoked"
+                        "tooltip": "Signaled after Get Property Value UInt32 is invoked"
                     },
                     "details": {
-                        "name": "Get Property Override UInt32"
+                        "name": "Get Property Value UInt32"
                     },
                     "params": [
                         {
@@ -195,17 +195,17 @@
                     ]
                 },
                 {
-                    "base": "GetPropertyOverrideBool",
+                    "base": "GetPropertyValueBool",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Property Override Bool"
+                        "tooltip": "When signaled, this will invoke Get Property Value Bool"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Property Override Bool is invoked"
+                        "tooltip": "Signaled after Get Property Value Bool is invoked"
                     },
                     "details": {
-                        "name": "Get Property Override Bool"
+                        "name": "Get Property Value Bool"
                     },
                     "params": [
                         {
@@ -232,17 +232,17 @@
                     ]
                 },
                 {
-                    "base": "SetPropertyOverrideEnum",
+                    "base": "SetPropertyValueEnum",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Property Override Enum"
+                        "tooltip": "When signaled, this will invoke Set Property Value Enum"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Property Override Enum is invoked"
+                        "tooltip": "Signaled after Set Property Value Enum is invoked"
                     },
                     "details": {
-                        "name": "Set Property Override Enum"
+                        "name": "Set Property Value Enum"
                     },
                     "params": [
                         {
@@ -267,17 +267,17 @@
                     ]
                 },
                 {
-                    "base": "SetPropertyOverrideVector2",
+                    "base": "SetPropertyValueVector2",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Property Override Vector2"
+                        "tooltip": "When signaled, this will invoke Set Property Value Vector2"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Property Override Vector2 is invoked"
+                        "tooltip": "Signaled after Set Property Value Vector2 is invoked"
                     },
                     "details": {
-                        "name": "Set Property Override Vector2"
+                        "name": "Set Property Value Vector2"
                     },
                     "params": [
                         {
@@ -302,17 +302,17 @@
                     ]
                 },
                 {
-                    "base": "GetPropertyOverrideImage",
+                    "base": "GetPropertyValueImage",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Property Override Image"
+                        "tooltip": "When signaled, this will invoke Get Property Value Image"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Property Override Image is invoked"
+                        "tooltip": "Signaled after Get Property Value Image is invoked"
                     },
                     "details": {
-                        "name": "Get Property Override Image"
+                        "name": "Get Property Value Image"
                     },
                     "params": [
                         {
@@ -339,17 +339,17 @@
                     ]
                 },
                 {
-                    "base": "ClearAllPropertyOverrides",
+                    "base": "ClearAllPropertyValues",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Clear All Property Overrides"
+                        "tooltip": "When signaled, this will invoke Clear All Property Values"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Clear All Property Overrides is invoked"
+                        "tooltip": "Signaled after Clear All Property Values is invoked"
                     },
                     "details": {
-                        "name": "Clear All Property Overrides"
+                        "name": "Clear All Property Values"
                     }
                 },
                 {
@@ -378,23 +378,23 @@
                         {
                             "typeid": "{652ED536-3402-439B-AEBE-4A5DBC554085}",
                             "details": {
-                                "name": "Material Asset"
+                                "name": "Material Asset Id"
                             }
                         }
                     ]
                 },
                 {
-                    "base": "GetMaterialSlotLabel",
+                    "base": "GetMaterialLabel",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Material Slot Label"
+                        "tooltip": "When signaled, this will invoke Get Material Label"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Material Slot Label is invoked"
+                        "tooltip": "Signaled after Get Material Label is invoked"
                     },
                     "details": {
-                        "name": "Get Material Slot Label"
+                        "name": "Get Material Label"
                     },
                     "params": [
                         {
@@ -415,17 +415,17 @@
                     ]
                 },
                 {
-                    "base": "SetPropertyOverrideVector3",
+                    "base": "SetPropertyValueVector3",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Property Override Vector3"
+                        "tooltip": "When signaled, this will invoke Set Property Value Vector3"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Property Override Vector3 is invoked"
+                        "tooltip": "Signaled after Set Property Value Vector3 is invoked"
                     },
                     "details": {
-                        "name": "Set Property Override Vector3"
+                        "name": "Set Property Value Vector3"
                     },
                     "params": [
                         {
@@ -450,31 +450,31 @@
                     ]
                 },
                 {
-                    "base": "ClearInvalidMaterialOverrides",
+                    "base": "ClearMaterialsWithMissingAssets",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Clear Invalid Material Overrides"
+                        "tooltip": "When signaled, this will invoke Clear Materials With Missing Assets"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Clear Invalid Material Overrides is invoked"
+                        "tooltip": "Signaled after Clear Materials With Missing Assets is invoked"
                     },
                     "details": {
-                        "name": "Clear Invalid Material Overrides"
+                        "name": "Clear Materials With Missing Assets"
                     }
                 },
                 {
-                    "base": "SetPropertyOverrideBool",
+                    "base": "SetPropertyValueBool",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Property Override Bool"
+                        "tooltip": "When signaled, this will invoke Set Property Value Bool"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Property Override Bool is invoked"
+                        "tooltip": "Signaled after Set Property Value Bool is invoked"
                     },
                     "details": {
-                        "name": "Set Property Override Bool"
+                        "name": "Set Property Value Bool"
                     },
                     "params": [
                         {
@@ -499,31 +499,31 @@
                     ]
                 },
                 {
-                    "base": "RepairInvalidMaterialOverrides",
+                    "base": "RepairMaterialsWithMissingAssets",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Repair Invalid Material Overrides"
+                        "tooltip": "When signaled, this will invoke Repair Materials With Missing Assets"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Repair Invalid Material Overrides is invoked"
+                        "tooltip": "Signaled after Repair Materials With Missing Assets is invoked"
                     },
                     "details": {
-                        "name": "Repair Invalid Material Overrides"
+                        "name": "Repair Materials With Missing Assets"
                     }
                 },
                 {
-                    "base": "SetPropertyOverrideString",
+                    "base": "SetPropertyValueString",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Property Override String"
+                        "tooltip": "When signaled, this will invoke Set Property Value String"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Property Override String is invoked"
+                        "tooltip": "Signaled after Set Property Value String is invoked"
                     },
                     "details": {
-                        "name": "Set Property Override String"
+                        "name": "Set Property Value String"
                     },
                     "params": [
                         {
@@ -548,61 +548,61 @@
                     ]
                 },
                 {
-                    "base": "SetDefaultMaterialOverride",
+                    "base": "SetMaterialAssetIdOnDefaultSlot",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Default Material Override"
+                        "tooltip": "When signaled, this will invoke Set Material Asset Id On Default Slot"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Default Material Override is invoked"
+                        "tooltip": "Signaled after Set Material Asset Id On Default Slot is invoked"
                     },
                     "details": {
-                        "name": "Set Default Material Override"
+                        "name": "Set Material Asset Id On Default Slot"
                     },
                     "params": [
                         {
                             "typeid": "{652ED536-3402-439B-AEBE-4A5DBC554085}",
                             "details": {
-                                "name": "Material Asset"
+                                "name": "Material Asset Id"
                             }
                         }
                     ]
                 },
                 {
-                    "base": "GetDefaultMaterialOverride",
+                    "base": "GetMaterialAssetIdOnDefaultSlot",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Default Material Override"
+                        "tooltip": "When signaled, this will invoke Get Material Asset Id On Default Slot"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Default Material Override is invoked"
+                        "tooltip": "Signaled after Get Material Asset Id On Default Slot is invoked"
                     },
                     "details": {
-                        "name": "Get Default Material Override"
+                        "name": "Get Material Asset Id On Default Slot"
                     },
                     "results": [
                         {
                             "typeid": "{652ED536-3402-439B-AEBE-4A5DBC554085}",
                             "details": {
-                                "name": "Material Asset"
+                                "name": "Material Asset Id"
                             }
                         }
                     ]
                 },
                 {
-                    "base": "SetMaterialOverrides",
+                    "base": "SetMaterialMap",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Material Overrides"
+                        "tooltip": "When signaled, this will invoke Set Material Map"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Material Overrides is invoked"
+                        "tooltip": "Signaled after Set Material Map is invoked"
                     },
                     "details": {
-                        "name": "Set Material Overrides"
+                        "name": "Set Material Map"
                     },
                     "params": [
                         {
@@ -614,17 +614,17 @@
                     ]
                 },
                 {
-                    "base": "GetPropertyOverrideString",
+                    "base": "GetPropertyValueString",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Property Override String"
+                        "tooltip": "When signaled, this will invoke Get Property Value String"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Property Override String is invoked"
+                        "tooltip": "Signaled after Get Property Value String is invoked"
                     },
                     "details": {
-                        "name": "Get Property Override String"
+                        "name": "Get Property Value String"
                     },
                     "params": [
                         {
@@ -651,17 +651,17 @@
                     ]
                 },
                 {
-                    "base": "GetMaterialOverrides",
+                    "base": "GetMaterialMap",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Material Overrides"
+                        "tooltip": "When signaled, this will invoke Get Material Map"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Material Overrides is invoked"
+                        "tooltip": "Signaled after Get Material Map is invoked"
                     },
                     "details": {
-                        "name": "Get Material Overrides"
+                        "name": "Get Material Map"
                     },
                     "results": [
                         {
@@ -673,17 +673,17 @@
                     ]
                 },
                 {
-                    "base": "GetMaterialOverride",
+                    "base": "GetMaterialAssetId",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Material Override"
+                        "tooltip": "When signaled, this will invoke Get Material Asset Id"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Material Override is invoked"
+                        "tooltip": "Signaled after Get Material Asset Id is invoked"
                     },
                     "details": {
-                        "name": "Get Material Override"
+                        "name": "Get Material Asset Id"
                     },
                     "params": [
                         {
@@ -698,23 +698,23 @@
                         {
                             "typeid": "{652ED536-3402-439B-AEBE-4A5DBC554085}",
                             "details": {
-                                "name": "Material Asset"
+                                "name": "Material Asset Id"
                             }
                         }
                     ]
                 },
                 {
-                    "base": "SetPropertyOverrideVector4",
+                    "base": "SetPropertyValueVector4",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Property Override Vector4"
+                        "tooltip": "When signaled, this will invoke Set Property Value Vector4"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Property Override Vector4 is invoked"
+                        "tooltip": "Signaled after Set Property Value Vector4 is invoked"
                     },
                     "details": {
-                        "name": "Set Property Override Vector4"
+                        "name": "Set Property Value Vector4"
                     },
                     "params": [
                         {
@@ -739,17 +739,17 @@
                     ]
                 },
                 {
-                    "base": "SetPropertyOverrideUInt32",
+                    "base": "SetPropertyValueUInt32",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Property Override UInt32"
+                        "tooltip": "When signaled, this will invoke Set Property Value UInt32"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Property Override UInt32 is invoked"
+                        "tooltip": "Signaled after Set Property Value UInt32 is invoked"
                     },
                     "details": {
-                        "name": "Set Property Override UInt32"
+                        "name": "Set Property Value UInt32"
                     },
                     "params": [
                         {
@@ -813,17 +813,17 @@
                     ]
                 },
                 {
-                    "base": "GetPropertyOverrideInt32",
+                    "base": "GetPropertyValueInt32",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Property Override Int32"
+                        "tooltip": "When signaled, this will invoke Get Property Value Int32"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Property Override Int32 is invoked"
+                        "tooltip": "Signaled after Get Property Value Int32 is invoked"
                     },
                     "details": {
-                        "name": "Get Property Override Int32"
+                        "name": "Get Property Value Int32"
                     },
                     "params": [
                         {
@@ -850,17 +850,17 @@
                     ]
                 },
                 {
-                    "base": "GetPropertyOverrideEnum",
+                    "base": "GetPropertyValueEnum",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Property Override Enum"
+                        "tooltip": "When signaled, this will invoke Get Property Value Enum"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Property Override Enum is invoked"
+                        "tooltip": "Signaled after Get Property Value Enum is invoked"
                     },
                     "details": {
-                        "name": "Get Property Override Enum"
+                        "name": "Get Property Value Enum"
                     },
                     "params": [
                         {
@@ -887,17 +887,17 @@
                     ]
                 },
                 {
-                    "base": "SetPropertyOverride",
+                    "base": "SetPropertyValue",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Property Override"
+                        "tooltip": "When signaled, this will invoke Set Property Value"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Property Override is invoked"
+                        "tooltip": "Signaled after Set Property Value is invoked"
                     },
                     "details": {
-                        "name": "Set Property Override"
+                        "name": "Set Property Value"
                     },
                     "params": [
                         {
@@ -922,17 +922,17 @@
                     ]
                 },
                 {
-                    "base": "GetOriginalMaterialAssignments",
+                    "base": "GetDefautMaterialMap",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Original Material Assignments"
+                        "tooltip": "When signaled, this will invoke Get Defaut Material Map"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Original Material Assignments is invoked"
+                        "tooltip": "Signaled after Get Defaut Material Map is invoked"
                     },
                     "details": {
-                        "name": "Get Original Material Assignments"
+                        "name": "Get Defaut Material Map"
                     },
                     "results": [
                         {
@@ -944,17 +944,17 @@
                     ]
                 },
                 {
-                    "base": "GetPropertyOverride",
+                    "base": "GetPropertyValue",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Property Override"
+                        "tooltip": "When signaled, this will invoke Get Property Value"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Property Override is invoked"
+                        "tooltip": "Signaled after Get Property Value is invoked"
                     },
                     "details": {
-                        "name": "Get Property Override"
+                        "name": "Get Property Value"
                     },
                     "params": [
                         {
@@ -981,17 +981,17 @@
                     ]
                 },
                 {
-                    "base": "ClearModelMaterialOverrides",
+                    "base": "ClearMaterialsOnModelSlots",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Clear Model Material Overrides"
+                        "tooltip": "When signaled, this will invoke Clear Materials On Model Slots"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Clear Model Material Overrides is invoked"
+                        "tooltip": "Signaled after Clear Materials On Model Slots is invoked"
                     },
                     "details": {
-                        "name": "Clear Model Material Overrides"
+                        "name": "Clear Materials On Model Slots"
                     }
                 },
                 {
@@ -1020,23 +1020,23 @@
                         {
                             "typeid": "{652ED536-3402-439B-AEBE-4A5DBC554085}",
                             "details": {
-                                "name": "Material Asset"
+                                "name": "Material Asset Id"
                             }
                         }
                     ]
                 },
                 {
-                    "base": "SetPropertyOverrideInt32",
+                    "base": "SetPropertyValueInt32",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Property Override Int32"
+                        "tooltip": "When signaled, this will invoke Set Property Value Int32"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Property Override Int32 is invoked"
+                        "tooltip": "Signaled after Set Property Value Int32 is invoked"
                     },
                     "details": {
-                        "name": "Set Property Override Int32"
+                        "name": "Set Property Value Int32"
                     },
                     "params": [
                         {
@@ -1061,17 +1061,17 @@
                     ]
                 },
                 {
-                    "base": "SetPropertyOverrideImage",
+                    "base": "SetPropertyValueImage",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Property Override Image"
+                        "tooltip": "When signaled, this will invoke Set Property Value Image"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Property Override Image is invoked"
+                        "tooltip": "Signaled after Set Property Value Image is invoked"
                     },
                     "details": {
-                        "name": "Set Property Override Image"
+                        "name": "Set Property Value Image"
                     },
                     "params": [
                         {
@@ -1096,17 +1096,17 @@
                     ]
                 },
                 {
-                    "base": "GetPropertyOverrideVector2",
+                    "base": "GetPropertyValueVector2",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Property Override Vector2"
+                        "tooltip": "When signaled, this will invoke Get Property Value Vector2"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Property Override Vector2 is invoked"
+                        "tooltip": "Signaled after Get Property Value Vector2 is invoked"
                     },
                     "details": {
-                        "name": "Get Property Override Vector2"
+                        "name": "Get Property Value Vector2"
                     },
                     "params": [
                         {
@@ -1133,31 +1133,31 @@
                     ]
                 },
                 {
-                    "base": "ClearAllMaterialOverrides",
+                    "base": "ClearMaterialMap",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Clear All Material Overrides"
+                        "tooltip": "When signaled, this will invoke Clear Material Map"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Clear All Material Overrides is invoked"
+                        "tooltip": "Signaled after Clear Material Map is invoked"
                     },
                     "details": {
-                        "name": "Clear All Material Overrides"
+                        "name": "Clear Material Map"
                     }
                 },
                 {
-                    "base": "GetPropertyOverrideColor",
+                    "base": "GetPropertyValueColor",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Property Override Color"
+                        "tooltip": "When signaled, this will invoke Get Property Value Color"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Property Override Color is invoked"
+                        "tooltip": "Signaled after Get Property Value Color is invoked"
                     },
                     "details": {
-                        "name": "Get Property Override Color"
+                        "name": "Get Property Value Color"
                     },
                     "params": [
                         {
@@ -1184,17 +1184,17 @@
                     ]
                 },
                 {
-                    "base": "SetPropertyOverrideFloat",
+                    "base": "SetPropertyValueFloat",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Property Override Float"
+                        "tooltip": "When signaled, this will invoke Set Property Value Float"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Property Override Float is invoked"
+                        "tooltip": "Signaled after Set Property Value Float is invoked"
                     },
                     "details": {
-                        "name": "Set Property Override Float"
+                        "name": "Set Property Value Float"
                     },
                     "params": [
                         {
@@ -1219,17 +1219,17 @@
                     ]
                 },
                 {
-                    "base": "ApplyAutomaticPropertyUpdates",
+                    "base": "RepairMaterialsWithRenamedProperties",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Apply Automatic Property Updates"
+                        "tooltip": "When signaled, this will invoke Repair Materials With Renamed Properties"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Apply Automatic Property Updates is invoked"
+                        "tooltip": "Signaled after Repair Materials With Renamed Properties is invoked"
                     },
                     "details": {
-                        "name": "Apply Automatic Property Updates"
+                        "name": "Repair Materials With Renamed Properties"
                     },
                     "results": [
                         {
@@ -1241,17 +1241,17 @@
                     ]
                 },
                 {
-                    "base": "ClearMaterialOverride",
+                    "base": "ClearMaterialAssetId",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Clear Material Override"
+                        "tooltip": "When signaled, this will invoke Clear Material Asset Id"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Clear Material Override is invoked"
+                        "tooltip": "Signaled after Clear Material Asset Id is invoked"
                     },
                     "details": {
-                        "name": "Clear Material Override"
+                        "name": "Clear Material Asset Id"
                     },
                     "params": [
                         {
@@ -1264,45 +1264,45 @@
                     ]
                 },
                 {
-                    "base": "ClearLodMaterialOverrides",
+                    "base": "ClearMaterialsOnLodSlots",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Clear Lod Material Overrides"
+                        "tooltip": "When signaled, this will invoke Clear Materials On Lod Slots"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Clear Lod Material Overrides is invoked"
+                        "tooltip": "Signaled after Clear Materials On Lod Slots is invoked"
                     },
                     "details": {
-                        "name": "Clear Lod Material Overrides"
+                        "name": "Clear Materials On Lod Slots"
                     }
                 },
                 {
-                    "base": "ClearIncompatibleMaterialOverrides",
+                    "base": "ClearMaterialsOnInvalidSlots",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Clear Incompatible Material Overrides"
+                        "tooltip": "When signaled, this will invoke Clear Materials On Invalid Slots"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Clear Incompatible Material Overrides is invoked"
+                        "tooltip": "Signaled after Clear Materials On Invalid Slots is invoked"
                     },
                     "details": {
-                        "name": "Clear Incompatible Material Overrides"
+                        "name": "Clear Materials On Invalid Slots"
                     }
                 },
                 {
-                    "base": "GetPropertyOverrideVector3",
+                    "base": "GetPropertyValueVector3",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Property Override Vector3"
+                        "tooltip": "When signaled, this will invoke Get Property Value Vector3"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Property Override Vector3 is invoked"
+                        "tooltip": "Signaled after Get Property Value Vector3 is invoked"
                     },
                     "details": {
-                        "name": "Get Property Override Vector3"
+                        "name": "Get Property Value Vector3"
                     },
                     "params": [
                         {
@@ -1329,31 +1329,31 @@
                     ]
                 },
                 {
-                    "base": "ClearDefaultMaterialOverride",
+                    "base": "ClearMaterialAssetIdOnDefaultSlot",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Clear Default Material Override"
+                        "tooltip": "When signaled, this will invoke Clear Material Asset Id On Default Slot"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Clear Default Material Override is invoked"
+                        "tooltip": "Signaled after Clear Material Asset Id On Default Slot is invoked"
                     },
                     "details": {
-                        "name": "Clear Default Material Override"
+                        "name": "Clear Material Asset Id On Default Slot"
                     }
                 },
                 {
-                    "base": "SetPropertyOverrideColor",
+                    "base": "SetPropertyValueColor",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Property Override Color"
+                        "tooltip": "When signaled, this will invoke Set Property Value Color"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Property Override Color is invoked"
+                        "tooltip": "Signaled after Set Property Value Color is invoked"
                     },
                     "details": {
-                        "name": "Set Property Override Color"
+                        "name": "Set Property Value Color"
                     },
                     "params": [
                         {
@@ -1378,17 +1378,17 @@
                     ]
                 },
                 {
-                    "base": "SetMaterialOverride",
+                    "base": "SetMaterialAssetId",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Material Override"
+                        "tooltip": "When signaled, this will invoke Set Material Asset Id"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Material Override is invoked"
+                        "tooltip": "Signaled after Set Material Asset Id is invoked"
                     },
                     "details": {
-                        "name": "Set Material Override"
+                        "name": "Set Material Asset Id"
                     },
                     "params": [
                         {
@@ -1401,23 +1401,23 @@
                         {
                             "typeid": "{652ED536-3402-439B-AEBE-4A5DBC554085}",
                             "details": {
-                                "name": "Material Asset"
+                                "name": "Material Asset Id"
                             }
                         }
                     ]
                 },
                 {
-                    "base": "GetPropertyOverrideFloat",
+                    "base": "GetPropertyValueFloat",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Property Override Float"
+                        "tooltip": "When signaled, this will invoke Get Property Value Float"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Property Override Float is invoked"
+                        "tooltip": "Signaled after Get Property Value Float is invoked"
                     },
                     "details": {
-                        "name": "Get Property Override Float"
+                        "name": "Get Property Value Float"
                     },
                     "params": [
                         {


### PR DESCRIPTION
•	Added deprecated names to material component behavior context bindings
•	Updated script canvas display names and descriptions to match renamed functions
•	Changed get property value functions so that they return the default values stored in the active material asset
•	Updated and ran Lua and Python test scripts to verify that all properties are reported correctly
•	Minor changes to Lua scripts because script properties seems to be broken with prefabs
•	Tested using script canvas, Lua test scripts, material instance inspector, material editor, reporting property values to the output window

follow up changes for https://github.com/o3de/o3de/issues/9541