### PR TITLE
Fix crash in Project Manager when printing '%' character

### DIFF
--- a/Code/Framework/AzCore/AzCore/UnitTest/TestTypes.h
+++ b/Code/Framework/AzCore/AzCore/UnitTest/TestTypes.h
@@ -37,6 +37,12 @@ namespace UnitTest
 
         void SetupAllocator(const AZ::SystemAllocator::Descriptor& allocatorDesc = {})
         {
+            // Make sure an instance of AZ::Environment exists for AZ::AllocatorManager
+            if (!AZ::Environment::IsReady())
+            {
+                AZ::Environment::Create(nullptr);
+            }
+
             AZ::AllocatorManager::Instance().EnterProfilingMode();
             AZ::AllocatorManager::Instance().SetDefaultTrackingMode(AZ::Debug::AllocationRecords::RECORD_FULL);
 

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoModel.cpp
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoModel.cpp
@@ -119,15 +119,17 @@ namespace O3DE::ProjectManager
     QVector<GemInfo> GemRepoModel::GetIncludedGemInfos(const QModelIndex& modelIndex)
     {
         QString repoUri = GetRepoUri(modelIndex);
-
-        const AZ::Outcome<QVector<GemInfo>, AZStd::string>& gemInfosResult = PythonBindingsInterface::Get()->GetGemInfosForRepo(repoUri);
-        if (gemInfosResult.IsSuccess())
+        if (!repoUri.isEmpty())
         {
-            return gemInfosResult.GetValue();
-        }
-        else
-        {
-            QMessageBox::critical(nullptr, tr("Gems not found"), tr("Cannot find info for gems from repo %1").arg(GetName(modelIndex)));
+            const AZ::Outcome<QVector<GemInfo>, AZStd::string>& gemInfosResult = PythonBindingsInterface::Get()->GetGemInfosForRepo(repoUri);
+            if (gemInfosResult.IsSuccess())
+            {
+                return gemInfosResult.GetValue();
+            }
+            else
+            {
+                QMessageBox::critical(nullptr, tr("Gems not found"), tr("Cannot find info for gems from repo %1").arg(GetName(modelIndex)));
+            }
         }
 
         return QVector<GemInfo>();

--- a/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.cpp
@@ -35,14 +35,8 @@ namespace O3DE::ProjectManager
         QFrame* projectSettingsFrame = new QFrame(this);
         projectSettingsFrame->setObjectName("projectSettings");
 
-        QVBoxLayout* vLayout = new QVBoxLayout();
-        vLayout->setMargin(0);
-        vLayout->setAlignment(Qt::AlignTop);
-        projectSettingsFrame->setLayout(vLayout);
-
         QScrollArea* scrollArea = new QScrollArea(this);
         scrollArea->setWidgetResizable(true);
-        vLayout->addWidget(scrollArea);
 
         QWidget* scrollWidget = new QWidget(this);
         scrollArea->setWidget(scrollWidget);

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -368,7 +368,11 @@ namespace O3DE::ProjectManager
             }
         }
 
-        m_stack->setCurrentWidget(m_projectsContent);
+        if (m_projectsContent)
+        {
+            m_stack->setCurrentWidget(m_projectsContent);
+        }
+
         m_projectsFlowLayout->update();
     }
 

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -202,27 +202,12 @@ namespace RedirectOutput
 
     PyObject* s_RedirectModule = nullptr;
 
-    void Intialize(PyObject* module)
+    void Intialize(PyObject* module, RedirectOutputFunc stdoutFunction, RedirectOutputFunc stderrFunction)
     {
         s_RedirectModule = module;
 
-        SetRedirection("stdout", g_redirect_stdout_saved, g_redirect_stdout, []([[maybe_unused]] const char* msg) {
-            AZ_TracePrintf("Python", msg);
-        });
-
-        SetRedirection("stderr", g_redirect_stderr_saved, g_redirect_stderr, []([[maybe_unused]] const char* msg) {
-            AZStd::string lastPythonError = msg;
-            constexpr const char* pythonErrorPrefix = "ERROR:root:";
-            constexpr size_t lengthOfErrorPrefix = AZStd::char_traits<char>::length(pythonErrorPrefix);
-            auto errorPrefix = lastPythonError.find(pythonErrorPrefix);
-            if (errorPrefix != AZStd::string::npos)
-            {
-                lastPythonError.erase(errorPrefix, lengthOfErrorPrefix);
-            }
-            O3DE::ProjectManager::PythonBindingsInterface::Get()->AddErrorString(lastPythonError);
-
-            AZ_TracePrintf("Python", msg);
-        });
+        SetRedirection("stdout", g_redirect_stdout_saved, g_redirect_stdout, stdoutFunction);
+        SetRedirection("stderr", g_redirect_stderr_saved, g_redirect_stderr, stderrFunction);
 
         PySys_WriteStdout("RedirectOutput installed");
     }
@@ -239,6 +224,7 @@ namespace RedirectOutput
 
 namespace O3DE::ProjectManager
 {
+
     PythonBindings::PythonBindings(const AZ::IO::PathView& enginePath)
         : m_enginePath(enginePath)
     {
@@ -248,6 +234,31 @@ namespace O3DE::ProjectManager
     PythonBindings::~PythonBindings()
     {
         StopPython();
+    }
+
+    void PythonBindings::OnStdOut(const char* msg)
+    {
+        AZStd::string message{ msg };
+        AZ::StringFunc::Replace(message, "%", "%%", true /* case sensitive since it is faster */);
+        AZ_TracePrintf("Python", message.c_str());
+    }
+
+    void PythonBindings::OnStdError(const char* msg)
+    {
+        AZStd::string lastPythonError = msg;
+        constexpr const char* pythonErrorPrefix = "ERROR:root:";
+        constexpr size_t lengthOfErrorPrefix = AZStd::char_traits<char>::length(pythonErrorPrefix);
+        auto errorPrefix = lastPythonError.find(pythonErrorPrefix);
+        if (errorPrefix != AZStd::string::npos)
+        {
+            lastPythonError.erase(errorPrefix, lengthOfErrorPrefix);
+        }
+        O3DE::ProjectManager::PythonBindingsInterface::Get()->AddErrorString(lastPythonError);
+
+        AZStd::string message{ msg };
+        // escape % characters by using %% in the format string to avoid crashing
+        AZ::StringFunc::Replace(message, "%", "%%", true /* case sensitive since it is faster */);
+        AZ_TracePrintf("Python", message.c_str());
     }
 
     bool PythonBindings::PythonStarted()
@@ -294,7 +305,7 @@ namespace O3DE::ProjectManager
             const bool initializeSignalHandlers = true;
             pybind11::initialize_interpreter(initializeSignalHandlers);
 
-            RedirectOutput::Intialize(PyImport_ImportModule("azlmbr_redirect"));
+            RedirectOutput::Intialize(PyImport_ImportModule("azlmbr_redirect"), &PythonBindings::OnStdOut, &PythonBindings::OnStdError);
 
             // Acquire GIL before calling Python code
             AZStd::lock_guard<decltype(m_lock)> lock(m_lock);
@@ -1379,4 +1390,4 @@ namespace O3DE::ProjectManager
     {
         m_pythonErrorStrings.clear();
     }
-}
+} // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/PythonBindings.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.h
@@ -76,6 +76,10 @@ namespace O3DE::ProjectManager
         void AddErrorString(AZStd::string errorString) override;
         void ClearErrorStrings() override;
 
+    protected:
+        static void OnStdOut(const char* msg); 
+        static void OnStdError(const char* msg); 
+
     private:
         AZ_DISABLE_COPY_MOVE(PythonBindings);
 
@@ -89,7 +93,6 @@ namespace O3DE::ProjectManager
         AZ::Outcome<void, AZStd::string> GemRegistration(const QString& gemPath, const QString& projectPath, bool remove = false);
         bool StopPython();
         IPythonBindings::ErrorPair GetErrorPair();
-
 
         bool m_pythonStarted = false;
 
@@ -111,4 +114,4 @@ namespace O3DE::ProjectManager
         bool m_requestCancelDownload = false;
         AZStd::vector<AZStd::string> m_pythonErrorStrings;
     };
-}
+} // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/UpdateProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectSettingsScreen.cpp
@@ -31,7 +31,7 @@ namespace O3DE::ProjectManager
         connect(m_projectPath->lineEdit(), &QLineEdit::textChanged, this, &UpdateProjectSettingsScreen::UpdateProjectPreviewPath);
         m_verticalLayout->addWidget(m_projectPreview);
 
-        QVBoxLayout* previewExtrasLayout = new QVBoxLayout(this);
+        QVBoxLayout* previewExtrasLayout = new QVBoxLayout();
         previewExtrasLayout->setAlignment(Qt::AlignTop);
         previewExtrasLayout->setContentsMargins(30, 45, 30, 0);
 

--- a/Code/Tools/ProjectManager/tests/PythonBindingsTests.cpp
+++ b/Code/Tools/ProjectManager/tests/PythonBindingsTests.cpp
@@ -10,30 +10,54 @@
 #include <AzTest/Utils.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/Console/Console.h>
 #include <PythonBindings.h>
 #include <ProjectManager_Test_Traits_Platform.h>
+
 
 #include <QDir>
 
 namespace O3DE::ProjectManager
 {
+    class TestablePythonBindings
+        : public PythonBindings
+    {
+    public:
+        TestablePythonBindings(const AZ::IO::PathView& enginePath)
+            : PythonBindings(enginePath)
+        {
+
+        }
+
+        FRIEND_TEST(PythonBindingsTests, PythonBindings_Print_Percent_Does_Not_Crash);
+    };
+
     class PythonBindingsTests 
         : public ::UnitTest::ScopedAllocatorSetupFixture
+        , public AZ::Debug::TraceMessageBus::Handler
     {
     public:
 
-        PythonBindingsTests()
+        void SetUp() override
         {
             const AZStd::string engineRootPath{ AZ::Test::GetEngineRootPath() };
-            m_pythonBindings = AZStd::make_unique<PythonBindings>(AZ::IO::PathView(engineRootPath));
+            m_pythonBindings = AZStd::make_unique<TestablePythonBindings>(AZ::IO::PathView(engineRootPath));
         }
 
-        ~PythonBindingsTests()
+        void TearDown() override
         {
             m_pythonBindings.reset();
         }
 
-        AZStd::unique_ptr<ProjectManager::PythonBindings> m_pythonBindings;
+        //! AZ::Debug::TraceMessageBus
+        bool OnPrintf(const char*, const char* message) override
+        {
+            m_gatheredMessages.emplace_back(message);
+            return true;
+        }
+
+        AZStd::unique_ptr<ProjectManager::TestablePythonBindings> m_pythonBindings;
+        AZStd::vector<AZStd::string> m_gatheredMessages;
     };
 
     TEST_F(PythonBindingsTests, PythonBindings_Start_Python_Succeeds)
@@ -67,4 +91,36 @@ namespace O3DE::ProjectManager
         EXPECT_EQ(projectInfo.m_path, resultProjectInfo.m_path);
         EXPECT_EQ(projectInfo.m_projectName, resultProjectInfo.m_projectName);
     }
-}
+
+    TEST_F(PythonBindingsTests, PythonBindings_Print_Percent_Does_Not_Crash)
+    {
+        bool testMessageFound = false;
+        bool testErrorFound = false;
+        const char* testMessage = "PythonTestMessage%";
+        const char* testError = "PythonTestError%";
+
+        AZ::Debug::TraceMessageBus::Handler::BusConnect();
+
+        PythonBindings::OnStdOut(testMessage);
+        PythonBindings::OnStdError(testError);
+
+        AZ::Debug::TraceMessageBus::Handler::BusDisconnect();
+
+        // currently, PythonBindings sends errors to AZ_TracePrintf instead of AZ_Error
+        // if this changes, we'll need to handle OnError() and check that instead
+        for (const auto& message : m_gatheredMessages)
+        {
+            if ( message.contains(testMessage))
+            {
+                testMessageFound = true;
+            }
+            else if ( message.contains(testError))
+            {
+                testErrorFound = true;
+            }
+        }
+
+        EXPECT_TRUE(testMessageFound);
+        EXPECT_TRUE(testErrorFound);
+    }
+} // namespace O3DE::ProjectManager

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -163,7 +163,7 @@ def backup_folder(folder: str or pathlib.Path) -> None:
                 renamed = True
 
 
-def download_file(parsed_uri, download_path: pathlib.Path, force_overwrite: bool = False, object_name = str, download_progress_callback = None) -> int:
+def download_file(parsed_uri, download_path: pathlib.Path, force_overwrite: bool = False, object_name: str = "", download_progress_callback = None) -> int:
     """
     Download file
     :param parsed_uri: uniform resource identifier to zip file to download
@@ -248,7 +248,7 @@ def download_file(parsed_uri, download_path: pathlib.Path, force_overwrite: bool
     return 0
 
 
-def download_zip_file(parsed_uri, download_zip_path: pathlib.Path, force_overwrite: bool, object_name = str, download_progress_callback = None) -> int:
+def download_zip_file(parsed_uri, download_zip_path: pathlib.Path, force_overwrite: bool, object_name: str, download_progress_callback = None) -> int:
     """
     :param parsed_uri: uniform resource identifier to zip file to download
     :param download_zip_path: path to output zip file


### PR DESCRIPTION
Fixes #9980  and a few other warnings and errors I ran into along the way.
- assert when running tests in debug mode due to missing AZ::Environment
- a couple Qt errors regarding adding layouts or setting layouts multiple times
- Qt error setting a nullptr widget as the current widget
- python error trying to get repo information for an empty repo URI

**Testing**
- Added unit test
- Ran Project Manager in debug mode and stepped through the code