### PR TITLE
Fixed the rebuild required window title typo

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -584,7 +584,7 @@ namespace O3DE::ProjectManager
         if (showMessage)
         {
             QMessageBox::information(this,
-                tr("Project Should be rebuilt."),
+                tr("Project should be rebuilt."),
                 projectInfo.GetProjectDisplayName() + tr(" project likely needs to be rebuilt."));
         }
     }


### PR DESCRIPTION
Signed-off-by: LB-BartoszCwiek <v-bartosz.cwiek@lionbridge.com>

Fixed typo in sentence "Project Should be rebuilt." by changing capital letter "S" to lowercase "s".

Before changes:
![ProjectShouldBeRebuilt](https://user-images.githubusercontent.com/100559077/173527722-ff9ed850-cd6e-4807-9e9c-7b8587c3391b.png)

After changes:
![ProjectShouldBeRebuiltAfterChanges](https://user-images.githubusercontent.com/100559077/173528057-70fc2156-a963-4d2c-a3c2-3cff1737c9bd.png)

