### PR TITLE
early return to exit viewport selection

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorBoxSelect.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorBoxSelect.cpp
@@ -26,7 +26,7 @@ namespace AzToolsFramework
         m_clickDetector.SetDoubleClickInterval(0.0f);
     }
 
-    void EditorBoxSelect::HandleMouseInteraction(const ViewportInteraction::MouseInteractionEvent& mouseInteraction)
+    bool EditorBoxSelect::HandleMouseInteraction(const ViewportInteraction::MouseInteractionEvent& mouseInteraction)
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
 
@@ -77,6 +77,8 @@ namespace AzToolsFramework
         }
 
         m_previousModifiers = mouseInteraction.m_mouseInteraction.m_keyboardModifiers;
+
+        return m_boxSelectRegion.has_value();
     }
 
     void EditorBoxSelect::Display2d(const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorBoxSelect.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorBoxSelect.h
@@ -36,7 +36,7 @@ namespace AzToolsFramework
 
         //! Update the box select for various mouse events.
         //! Call HandleMouseInteraction from type/system implementing MouseViewportRequests interface.
-        void HandleMouseInteraction(
+        bool HandleMouseInteraction(
             const ViewportInteraction::MouseInteractionEvent& mouseInteraction);
 
         //! Responsible for drawing the 2d box representing the selection in screen space.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1835,7 +1835,10 @@ namespace AzToolsFramework
 
         EditorContextMenuUpdate(m_contextMenu, mouseInteraction);
 
-        m_boxSelect.HandleMouseInteraction(mouseInteraction);
+        if (m_boxSelect.HandleMouseInteraction(mouseInteraction))
+        {
+            return true;
+        }
 
         if (Input::CycleManipulator(mouseInteraction))
         {


### PR DESCRIPTION
When the user selects a box in the viewport they should also not be able to interact with the camera.
This PR returns out of HandleMouseInteraction if a box is being selected so it cannot control the camera while selecting.

https://jira.agscollab.com/browse/LYN-13133

Signed-off-by: amzn-ahmadkrm <ahmadkrm@amazon.com>