### PR TITLE
Fix for Vulkan crash if the multisampling state is changed

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -262,9 +262,10 @@ namespace AZ
 
             RenderPipelinePtr m_defaultPipeline;
 
-            // Mapping of draw list tag and a group of pipeline states info built from scene's render pipeline passes
-            bool m_pipelineStatesLookup_needs_rebuild = false;
+            // Rebuild the m_pipelineStatesLookup after queued Pipeline changes have been applied.
+            bool m_pipelineStatesLookupNeedsRebuild = false;
 
+            // Mapping of draw list tag and a group of pipeline states info built from scene's render pipeline passes
             AZStd::map<RHI::DrawListTag, PipelineStateList> m_pipelineStatesLookup;
 
             // reference of dynamic draw system (from RPISystem)

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -176,7 +176,7 @@ namespace AZ
         protected:
             // SceneFinder overrides...
             void OnSceneNotifictaionHandlerConnected(SceneNotification* handler);
-            void PipelineStateLookupNeedsRebuild();
+            void PipelineStateLookupNeedsRebuild() override;
 
             // Cpu simulation which runs all active FeatureProcessor Simulate() functions.
             // @param jobPolicy if it's JobPolicy::Parallel, the function will spawn a job thread for each FeatureProcessor's simulation.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -176,7 +176,8 @@ namespace AZ
         protected:
             // SceneFinder overrides...
             void OnSceneNotifictaionHandlerConnected(SceneNotification* handler);
-                        
+            void PipelineStateLookupNeedsRebuild();
+
             // Cpu simulation which runs all active FeatureProcessor Simulate() functions.
             // @param jobPolicy if it's JobPolicy::Parallel, the function will spawn a job thread for each FeatureProcessor's simulation.
             // @param simulationTime the number of seconds since the application started
@@ -262,6 +263,8 @@ namespace AZ
             RenderPipelinePtr m_defaultPipeline;
 
             // Mapping of draw list tag and a group of pipeline states info built from scene's render pipeline passes
+            bool m_pipelineStatesLookup_needs_rebuild = false;
+
             AZStd::map<RHI::DrawListTag, PipelineStateList> m_pipelineStatesLookup;
 
             // reference of dynamic draw system (from RPISystem)

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/SceneBus.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/SceneBus.h
@@ -81,6 +81,9 @@ namespace AZ
             using BusIdType = SceneId;
 
             virtual void OnSceneNotifictaionHandlerConnected(SceneNotification* handler) = 0;
+
+            //! Causes an update of the PipelineStateLookup during the next render tick,
+            //! after queued Pipeline changes are executed.
             virtual void PipelineStateLookupNeedsRebuild() = 0;
         };
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/SceneBus.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/SceneBus.h
@@ -81,6 +81,7 @@ namespace AZ
             using BusIdType = SceneId;
 
             virtual void OnSceneNotifictaionHandlerConnected(SceneNotification* handler) = 0;
+            virtual void PipelineStateLookupNeedsRebuild() = 0;
         };
 
         using SceneRequestBus = AZ::EBus<SceneRequest>;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -364,6 +364,7 @@ namespace AZ
                 if (m_scene)
                 {
                     SceneNotificationBus::Event(m_scene->GetId(), &SceneNotification::OnRenderPipelinePassesChanged, this);
+                    SceneRequestBus::Event(m_scene->GetId(), &SceneRequest::PipelineStateLookupNeedsRebuild);
                 }
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -696,9 +696,10 @@ namespace AZ
             }
 
             // the pipeline states might have changed during the OnStartFrame, rebuild the lookup
-            if (m_pipelineStatesLookup_needs_rebuild) {
+            if (m_pipelineStatesLookupNeedsRebuild)
+            {
                 RebuildPipelineStatesLookup();
-                m_pipelineStatesLookup_needs_rebuild = false;
+                m_pipelineStatesLookupNeedsRebuild = false;
             }
 
             // Return if there is no active render pipeline
@@ -894,9 +895,8 @@ namespace AZ
 
         void Scene::PipelineStateLookupNeedsRebuild()
         {
-            m_pipelineStatesLookup_needs_rebuild = true;
+            m_pipelineStatesLookupNeedsRebuild = true;
         }
-
 
         bool Scene::ConfigurePipelineState(RHI::DrawListTag drawListTag, RHI::PipelineStateDescriptorForDraw& outPipelineState) const
         {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -699,7 +699,6 @@ namespace AZ
             if (m_pipelineStatesLookupNeedsRebuild)
             {
                 RebuildPipelineStatesLookup();
-                m_pipelineStatesLookupNeedsRebuild = false;
             }
 
             // Return if there is no active render pipeline
@@ -1027,6 +1026,7 @@ namespace AZ
                     }
                 }
             }
+            m_pipelineStatesLookupNeedsRebuild = false;
         }
 
         RenderPipelinePtr Scene::FindRenderPipelineForWindow(AzFramework::NativeWindowHandle windowHandle)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -695,6 +695,12 @@ namespace AZ
                 }
             }
 
+            // the pipeline states might have changed during the OnStartFrame, rebuild the lookup
+            if (m_pipelineStatesLookup_needs_rebuild) {
+                RebuildPipelineStatesLookup();
+                m_pipelineStatesLookup_needs_rebuild = false;
+            }
+
             // Return if there is no active render pipeline
             if (activePipelines.empty())
             {
@@ -885,7 +891,13 @@ namespace AZ
                 }
             }
         }
-        
+
+        void Scene::PipelineStateLookupNeedsRebuild()
+        {
+            m_pipelineStatesLookup_needs_rebuild = true;
+        }
+
+
         bool Scene::ConfigurePipelineState(RHI::DrawListTag drawListTag, RHI::PipelineStateDescriptorForDraw& outPipelineState) const
         {
             auto pipelineStatesItr = m_pipelineStatesLookup.find(drawListTag);


### PR DESCRIPTION
Proposed fix for #9245: 

Add the event `PipelineStateLookupNeedsRebuild()` that causes a call to `RebuildPipelineStatesLookup()` during the next  `Scene::PrepareRender()`.

Trigger that event from `RenderPipeline::OnPassModified()` when appropriate.


Signed-off-by: Karl Haubenwallner <karl.haubenwallner@huawei.com>