### PR TITLE
Fix crashes when using a custom render-pipeline

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -90,8 +90,9 @@ namespace AZ
             PassSystemInterface* passSystem = PassSystemInterface::Get();
 
             PassDescriptor swapChainDescriptor(Name(desc.m_name));
-            Name tempalteName = Name(desc.m_rootPassTemplate.c_str());
-            swapChainDescriptor.m_passTemplate = passSystem->GetPassTemplate(tempalteName);
+            Name templateName = Name(desc.m_rootPassTemplate.c_str());
+            swapChainDescriptor.m_passTemplate = passSystem->GetPassTemplate(templateName);
+            AZ_Assert(swapChainDescriptor.m_passTemplate, "Root-PassTemplate %s not found!", templateName.GetCStr());
 
             pipeline->m_passTree.m_rootPass = aznew SwapChainPass(swapChainDescriptor, &windowContext);
             pipeline->m_windowHandle = windowContext.GetWindowHandle();

--- a/Gems/LyShine/Code/Source/Draw2d.cpp
+++ b/Gems/LyShine/Code/Source/Draw2d.cpp
@@ -103,6 +103,11 @@ void CDraw2d::OnBootstrapSceneReady(AZ::RPI::Scene* bootstrapScene)
     AZ::RPI::SceneId sceneId = scene->GetId();
     LyShinePassRequestBus::EventResult(uiCanvasPass, sceneId, &LyShinePassRequestBus::Events::GetUiCanvasPass);
 
+    if (!uiCanvasPass) {
+        AZ_Warning("Draw2d", false, "No UiCanvasPass found in Render-Pipeline!");
+        return;
+    }
+
     m_dynamicDraw = AZ::RPI::DynamicDrawInterface::Get()->CreateDynamicDrawContext();
     m_dynamicDraw->InitShader(shader);
     m_dynamicDraw->InitVertexFormat(

--- a/Gems/LyShine/Code/Source/Draw2d.cpp
+++ b/Gems/LyShine/Code/Source/Draw2d.cpp
@@ -103,8 +103,9 @@ void CDraw2d::OnBootstrapSceneReady(AZ::RPI::Scene* bootstrapScene)
     AZ::RPI::SceneId sceneId = scene->GetId();
     LyShinePassRequestBus::EventResult(uiCanvasPass, sceneId, &LyShinePassRequestBus::Events::GetUiCanvasPass);
 
-    if (!uiCanvasPass) {
-        AZ_Warning("Draw2d", false, "No UiCanvasPass found in Render-Pipeline!");
+    if (!uiCanvasPass)
+    {
+        AZ_Error("Draw2d", false, "No UiCanvasPass found in Render-Pipeline.");
         return;
     }
 


### PR DESCRIPTION
If the root-pass of a custom renderpipeline isn't found, the engine crashes very late in the process, which makes it hard to attribute the actual cause of the crash.

The Feature Processor for LY-Shine relies on a renderpass with a specific name existing in the renderpipeline, and causes a crash if the pass doesn't exist, instead of disabling the functionality.