### PR TITLE
[Terrain] Misc Bugfixes

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/SurfaceDataRefreshes_RemainsStable.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/SurfaceDataRefreshes_RemainsStable.py
@@ -73,11 +73,13 @@ def SurfaceDataRefreshes_RemainsStable():
             # dirty surface points that cause sectors to be refreshed, and having no dirty surface points or
             # active surface areas to trigger a "delete all sectors" condition.
             if (test_counter % loops_per_surface_changed[test_case]) == 0:
-                azlmbr.surface_data.SurfaceDataSystemNotificationBus(azlmbr.bus.Broadcast,
-                                                                     'OnSurfaceChanged',
-                                                                     surface_entity.id,
-                                                                     azlmbr.math.Aabb(),
-                                                                     azlmbr.math.Aabb())
+                provider_handle = azlmbr.surface_data.SurfaceDataSystemRequestBus(azlmbr.bus.Broadcast,
+                                                                'GetSurfaceDataProviderHandle',
+                                                                surface_entity.id)
+                azlmbr.surface_data.SurfaceDataSystemRequestBus(azlmbr.bus.Broadcast,
+                                                                'RefreshSurfaceData',
+                                                                provider_handle,
+                                                                azlmbr.math.Aabb())
 
             # Move the camera back and forth along the X axis at just the right speed to invalidate sectors that are
             # queued for updating but haven't updated yet, so that when they try to update they crash.

--- a/Gems/GradientSignal/Code/Source/Components/LevelsGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/LevelsGradientComponent.cpp
@@ -220,14 +220,24 @@ namespace GradientSignal
 
     void LevelsGradientComponent::SetInputMin(float value)
     {
+        bool valueChanged = false;
+
         // Only hold the lock while we're changing the data. Don't hold onto it during the OnCompositionChanged call, because that can
         // execute an arbitrary amount of logic, including calls back to this component.
         {
             AZStd::unique_lock lock(m_queryMutex);
-            m_configuration.m_inputMin = value;
+            if (m_configuration.m_inputMin != value)
+            {
+                m_configuration.m_inputMin = value;
+                valueChanged = true;
+            }
         }
 
-        LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+        if (valueChanged)
+        {
+            LmbrCentral::DependencyNotificationBus::Event(
+                GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+        }
     }
 
     float LevelsGradientComponent::GetInputMid() const
@@ -237,14 +247,24 @@ namespace GradientSignal
 
     void LevelsGradientComponent::SetInputMid(float value)
     {
+        bool valueChanged = false;
+
         // Only hold the lock while we're changing the data. Don't hold onto it during the OnCompositionChanged call, because that can
         // execute an arbitrary amount of logic, including calls back to this component.
         {
             AZStd::unique_lock lock(m_queryMutex);
-            m_configuration.m_inputMid = value;
+            if (m_configuration.m_inputMid != value)
+            {
+                m_configuration.m_inputMid = value;
+                valueChanged = true;
+            }
         }
 
-        LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+        if (valueChanged)
+        {
+            LmbrCentral::DependencyNotificationBus::Event(
+                GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+        }
     }
 
     float LevelsGradientComponent::GetInputMax() const
@@ -254,14 +274,24 @@ namespace GradientSignal
 
     void LevelsGradientComponent::SetInputMax(float value)
     {
+        bool valueChanged = false;
+
         // Only hold the lock while we're changing the data. Don't hold onto it during the OnCompositionChanged call, because that can
         // execute an arbitrary amount of logic, including calls back to this component.
         {
             AZStd::unique_lock lock(m_queryMutex);
-            m_configuration.m_inputMax = value;
+            if (m_configuration.m_inputMax != value)
+            {
+                m_configuration.m_inputMax = value;
+                valueChanged = true;
+            }
         }
 
-        LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+        if (valueChanged)
+        {
+            LmbrCentral::DependencyNotificationBus::Event(
+                GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+        }
     }
 
     float LevelsGradientComponent::GetOutputMin() const
@@ -271,14 +301,24 @@ namespace GradientSignal
 
     void LevelsGradientComponent::SetOutputMin(float value)
     {
+        bool valueChanged = false;
+
         // Only hold the lock while we're changing the data. Don't hold onto it during the OnCompositionChanged call, because that can
         // execute an arbitrary amount of logic, including calls back to this component.
         {
             AZStd::unique_lock lock(m_queryMutex);
-            m_configuration.m_outputMin = value;
+            if (m_configuration.m_outputMin != value)
+            {
+                m_configuration.m_outputMin = value;
+                valueChanged = true;
+            }
         }
 
-        LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+        if (valueChanged)
+        {
+            LmbrCentral::DependencyNotificationBus::Event(
+                GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+        }
     }
 
     float LevelsGradientComponent::GetOutputMax() const
@@ -288,14 +328,24 @@ namespace GradientSignal
 
     void LevelsGradientComponent::SetOutputMax(float value)
     {
+        bool valueChanged = false;
+
         // Only hold the lock while we're changing the data. Don't hold onto it during the OnCompositionChanged call, because that can
         // execute an arbitrary amount of logic, including calls back to this component.
         {
             AZStd::unique_lock lock(m_queryMutex);
-            m_configuration.m_outputMax = value;
+            if (m_configuration.m_outputMax != value)
+            {
+                m_configuration.m_outputMax = value;
+                valueChanged = true;
+            }
         }
 
-        LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+        if (valueChanged)
+        {
+            LmbrCentral::DependencyNotificationBus::Event(
+                GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+        }
     }
 
     GradientSampler& LevelsGradientComponent::GetGradientSampler()

--- a/Gems/SurfaceData/Code/Source/SurfaceDataSystemComponent.cpp
+++ b/Gems/SurfaceData/Code/Source/SurfaceDataSystemComponent.cpp
@@ -55,9 +55,13 @@ namespace SurfaceData
                 ;
 
             behaviorContext->EBus<SurfaceDataSystemRequestBus>("SurfaceDataSystemRequestBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Category, "Vegetation")
                 ->Attribute(AZ::Script::Attributes::Module, "surface_data")
                 ->Event("GetSurfacePoints", &SurfaceDataSystemRequestBus::Events::GetSurfacePoints)
+                ->Event("RefreshSurfaceData", &SurfaceDataSystemRequestBus::Events::RefreshSurfaceData)
+                ->Event("GetSurfaceDataProviderHandle", &SurfaceDataSystemRequestBus::Events::GetSurfaceDataProviderHandle)
+                ->Event("GetSurfaceDataModifierHandle", &SurfaceDataSystemRequestBus::Events::GetSurfaceDataModifierHandle)
                 ;
 
             behaviorContext->EBus<SurfaceDataSystemNotificationBus>("SurfaceDataSystemNotificationBus")


### PR DESCRIPTION
This fixes two small bugs:
1. The Levels Component was sending OnCompositionChanged() messages any time a value was set, even if the value was the same. Now it checks for differences before sending the notification.
2. The SurfaceData python test was sending the OnSurfaceChanged() notification to force vegetation refreshes, which broke due to a recent change to the API. However, the correct API for it to use was actually the RefreshSurfaceData() API, so I switched it to use the correct API instead of fixing up the previous notification usage.
