### PR TITLE
Fix for ImGui error message about duplicate default ImGui passes per pipeline

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -70,45 +70,17 @@ namespace AZ
             , m_tickHandlerFrameStart(*this)
             , m_tickHandlerFrameEnd(*this)
         {
-
             const ImGuiPassData* imguiPassData = RPI::PassUtils::GetPassData<ImGuiPassData>(descriptor);
-            if (imguiPassData)
-            {
-                // check if this is the default ImGui pass.
-                if (imguiPassData->m_isDefaultImGui)
-                {
-                    // Check to see if another default is already set.
-                    ImGuiPass* currentDefaultPass = nullptr;
-                    ImGuiSystemRequestBus::BroadcastResult(currentDefaultPass, &ImGuiSystemRequestBus::Events::GetDefaultImGuiPass);
-
-                    if (currentDefaultPass != nullptr && currentDefaultPass->GetRenderPipeline() == GetRenderPipeline())
-                    {
-                        // Only error when the pipelines match, meaning the default was set multiple times for the same pipeline. When the pipelines differ,
-                        // it's possible that multiple default ImGui passes are intentional, and only the first one to load should actually be set as default.
-                        AZ_Error("ImGuiPass", false, "Default ImGui pass is already set on this pipeline, ignoring request to set this pass as default. Only one ImGui pass should be marked as default in the pipeline.");
-                    }
-                    else
-                    {
-                        m_isDefaultImGuiPass = true;
-                        ImGuiSystemRequestBus::Broadcast(&ImGuiSystemRequestBus::Events::PushDefaultImGuiPass, this);
-                    }
-                }
-            }
-
-            auto imguiContextScope = ImguiContextScope(nullptr);
-
-            m_imguiContext = ImGui::CreateContext();
-            ImGui::StyleColorsDark();
-
-            Init();
-            ImGui::NewFrame();
-
-            AzFramework::InputChannelEventListener::Connect();
-            AzFramework::InputTextEventListener::Connect();
+            m_requestedAsDefaultImguiPass = imguiPassData != nullptr ? imguiPassData->m_isDefaultImGui : false;
         }
 
         ImGuiPass::~ImGuiPass()
         {
+            if (!m_imguiInitialized)
+            {
+                return;
+            }
+
             if (m_isDefaultImGuiPass)
             {
                 ImGuiSystemRequestBus::Broadcast(&ImGuiSystemRequestBus::Events::RemoveDefaultImGuiPass, this);
@@ -432,38 +404,37 @@ namespace AZ
             return shouldCaptureEvent;
         }
 
-        void ImGuiPass::FrameBeginInternal(FramePrepareParams params)
+        void ImGuiPass::InitializeImGui()
         {
-            auto imguiContextScope = ImguiContextScope(m_imguiContext);
+            if (m_requestedAsDefaultImguiPass)
+            {
+                // Check to see if another default is already set.
+                ImGuiPass* currentDefaultPass = nullptr;
+                ImGuiSystemRequestBus::BroadcastResult(currentDefaultPass, &ImGuiSystemRequestBus::Events::GetDefaultImGuiPass);
 
-            m_viewportWidth = static_cast<uint32_t>(params.m_viewportState.m_maxX - params.m_viewportState.m_minX);
-            m_viewportHeight = static_cast<uint32_t>(params.m_viewportState.m_maxY - params.m_viewportState.m_minY);
+                if (currentDefaultPass != nullptr && currentDefaultPass->GetRenderPipeline() == GetRenderPipeline())
+                {
+                    // Only error when the pipelines match, meaning the default was set multiple times for the same pipeline. When the pipelines differ,
+                    // it's possible that multiple default ImGui passes are intentional, and only the first one to load should actually be set as default.
+                    AZ_Error("ImGuiPass", false, "Default ImGui pass is already set on this pipeline, ignoring request to set this pass as default. Only one ImGui pass should be marked as default in the pipeline.");
+                }
+                else
+                {
+                    m_isDefaultImGuiPass = true;
+                    ImGuiSystemRequestBus::Broadcast(&ImGuiSystemRequestBus::Events::PushDefaultImGuiPass, this);
+                }
+            }
+
+            // This ImguiContextScope is just to ensure we set the imgui context to what it was previously at the end of this function
+            // The nullptr param is irrelevant as the imgui context gets set to the new context in ImGui::CreateContext
+            auto imguiContextScope = ImguiContextScope(nullptr);
+            m_imguiContext = ImGui::CreateContext();
+            ImGui::StyleColorsDark();
 
             auto& io = ImGui::GetIO();
-            io.DisplaySize.x = AZStd::max<float>(1.0f, static_cast<float>(m_viewportWidth));
-            io.DisplaySize.y = AZStd::max<float>(1.0f, static_cast<float>(m_viewportHeight));
-
-            Matrix4x4 projectionMatrix =
-                Matrix4x4::CreateFromRows(
-                    AZ::Vector4(2.0f / m_viewportWidth, 0.0f, 0.0f, -1.0f),
-                    AZ::Vector4(0.0f, -2.0f / m_viewportHeight, 0.0f, 1.0f),
-                    AZ::Vector4(0.0f, 0.0f, 0.5f, 0.5f),
-                    AZ::Vector4(0.0f, 0.0f, 0.0f, 1.0f));
-
-            m_resourceGroup->SetConstant(m_projectionMatrixIndex, projectionMatrix);
-
-            m_viewportState = params.m_viewportState;
-
-            Base::FrameBeginInternal(params);
-        }
-
-        void ImGuiPass::Init()
-        {
-            auto imguiContextScope = ImguiContextScope(m_imguiContext);
-            auto& io = ImGui::GetIO();
-        #if defined(AZ_TRAIT_IMGUI_INI_FILENAME)
+#if defined(AZ_TRAIT_IMGUI_INI_FILENAME)
             io.IniFilename = AZ_TRAIT_IMGUI_INI_FILENAME;
-        #endif
+#endif
 
             // ImGui IO Setup
             {
@@ -569,7 +540,7 @@ namespace AZ
             m_imguiFontTexId = io.Fonts->TexID;
 
             // ImGuiPass will support binding 16 textures at most per frame. 
-            const uint8_t instanceData[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+            const uint8_t instanceData[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
             RPI::CommonBufferDescriptor desc;
             desc.m_poolType = RPI::CommonBufferPoolType::StaticInputAssembly;
             desc.m_bufferName = "InstanceBuffer";
@@ -578,15 +549,50 @@ namespace AZ
             desc.m_bufferData = instanceData;
             m_instanceBuffer = RPI::BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
             m_instanceBufferView = RHI::StreamBufferView(*m_instanceBuffer->GetRHIBuffer(), 0, 16, 1);
+
+            ImGui::NewFrame();
+            AzFramework::InputChannelEventListener::Connect();
+            AzFramework::InputTextEventListener::Connect();
         }
 
         void ImGuiPass::InitializeInternal()
         {
+            if (!m_imguiInitialized)
+            {
+                InitializeImGui();
+                m_imguiInitialized = true;
+            }
+
             // Set output format and finalize pipeline state
             m_pipelineState->SetOutputFromPass(this);
             m_pipelineState->Finalize();
 
             Base::InitializeInternal();
+        }
+
+        void ImGuiPass::FrameBeginInternal(FramePrepareParams params)
+        {
+            auto imguiContextScope = ImguiContextScope(m_imguiContext);
+
+            m_viewportWidth = static_cast<uint32_t>(params.m_viewportState.m_maxX - params.m_viewportState.m_minX);
+            m_viewportHeight = static_cast<uint32_t>(params.m_viewportState.m_maxY - params.m_viewportState.m_minY);
+
+            auto& io = ImGui::GetIO();
+            io.DisplaySize.x = AZStd::max<float>(1.0f, static_cast<float>(m_viewportWidth));
+            io.DisplaySize.y = AZStd::max<float>(1.0f, static_cast<float>(m_viewportHeight));
+
+            Matrix4x4 projectionMatrix =
+                Matrix4x4::CreateFromRows(
+                    AZ::Vector4(2.0f / m_viewportWidth, 0.0f, 0.0f, -1.0f),
+                    AZ::Vector4(0.0f, -2.0f / m_viewportHeight, 0.0f, 1.0f),
+                    AZ::Vector4(0.0f, 0.0f, 0.5f, 0.5f),
+                    AZ::Vector4(0.0f, 0.0f, 0.0f, 1.0f));
+
+            m_resourceGroup->SetConstant(m_projectionMatrixIndex, projectionMatrix);
+
+            m_viewportState = params.m_viewportState;
+
+            Base::FrameBeginInternal(params);
         }
 
         void ImGuiPass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
@@ -136,7 +136,8 @@ namespace AZ
             //! Updates the index and vertex buffers, and returns the total number of draw items.
             uint32_t UpdateImGuiResources();
 
-            void Init();
+            // Initializes ImGui related data in the pass. Called during the pass's initialization phase.
+            void InitializeImGui();
 
             ImGuiContext* m_imguiContext = nullptr;
             TickHandlerFrameStart m_tickHandlerFrameStart;
@@ -158,6 +159,9 @@ namespace AZ
             AZStd::vector<ImDrawData> m_drawData;
             bool m_isDefaultImGuiPass = false;
 
+            // Whether the pass data indicated that the pass should be used as the default ImGui pass
+            bool m_requestedAsDefaultImguiPass = false;
+
             // ImGui processes mouse wheel movement on NewFrame(), which could be before input events
             // happen, so save the value to apply the most recent value right before NewFrame().
             float m_lastFrameMouseWheel = 0.0;
@@ -171,6 +175,9 @@ namespace AZ
 
             // cache the font text id
             void* m_imguiFontTexId = nullptr;
+
+            // Whether the pass has already initialized it's ImGui related data.
+            bool m_imguiInitialized = false;
         };
     }   // namespace RPI
 }   // namespace AZ

--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/Device_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/Device_Windows.cpp
@@ -491,6 +491,9 @@ namespace AZ
             }
 
             SetDeviceRemoved();
+
+            // Assert before continuing so users have a chance to inspect the TDR before the log output gets burried under the ensuing RHI errors
+            AZ_Assert(false, "GPU device lost!");
         }
 
         void HandleDeviceRemoved(PVOID context, BOOLEAN)

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
@@ -298,7 +298,7 @@ namespace AZ
         {
             if (!CommitShaderResources<RHI::PipelineStateType::Dispatch>(dispatchItem))
             {
-                AZ_Warning("CommandList", false, "Failed to bind shader resources for draw item. Skipping.");
+                AZ_Warning("CommandList", false, "Failed to bind shader resources for dispatch item. Skipping.");
                 return;
             }
 


### PR DESCRIPTION
This fix is simpler than it looks. The ImGui pass was checking if it was the default ImGui pass for it's pipeline in the pass constructor, which was getting called at points where the pass didn't yet have a pipeline (such as during the construction of the pipeline). Moved the logic in the pass constructor into the Init function, which I renamed to InitializeImGui and now call from the pass's InitializeInternal function.
Other changes: - Moved FrameBeginInternal lower in the .cpp to match the pass phase logic of Init -> Frame Begin -> Compile
- Fixed a copy-paste error in commandlist.cpp
- Added an AZ_Assert to OnDeviceRemoved so Atom execution breaks when device is lost instead of breaking down the line after a bunch of RHI spam has been added to the output log (because it's trying to build resources without a device)

Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>