### PR TITLE
hair gem shadow LOD start distance property remove trailing space

### DIFF
--- a/Gems/AtomTressFX/External/Code/src/TressFX/TressFXSettings.cpp
+++ b/Gems/AtomTressFX/External/Code/src/TressFX/TressFXSettings.cpp
@@ -296,7 +296,7 @@ namespace AMD
                         ->Attribute(AZ::Edit::Attributes::Min, 0)
                         ->Attribute(AZ::Edit::Attributes::Max, 100)
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &TressFXRenderingSettings::m_ShadowLODStartDistance, "Shadow LOD Start Distance ",
+                        AZ::Edit::UIHandlers::Default, &TressFXRenderingSettings::m_ShadowLODStartDistance, "Shadow LOD Start Distance",
                         "(Shadow)Distance to begin LOD.")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                     ->DataElement(


### PR DESCRIPTION
removes a trailing space from the property name "Shadow LOD Start Distance" in TressFX hair gem
in testing I dumped the property tree editor property paths with type and this property now reports as
` Info: 'Controller|Configuration|TressFX Render Settings|Shadow LOD Start Distance' ('float', 'Visible')`

**atom component tests run:**
```
.\scripts\ctest\ctest_entrypoint.cmd --build-path atom_dev --suite main --ctest-executable "C:\Program Files\CMake\bin\ctest.exe" --config profile --tests-regex "AutomatedTesting::Atom_Main_Null" --generate-xml
Starting 'main' suite: The default set of tests, covers most of all testing.
Executing CTest None time(s) with command:
  C:\Program Files\CMake\bin\ctest.exe --build-config profile --output-on-failure --parallel 16 --no-tests=error --label-exclude ^(SUITE_smoke|SUITE_periodic|SUITE_benchmark|SUITE_sandbox|SUITE_awsi)$ -T Test --tests-regex AutomatedTesting::Atom_Main_Null
in working directory:
  atom_dev

Cannot find file: D:/workspace/o3de/atom_dev/DartConfiguration.tcl
   Site:
   Build name: (empty)
Cannot find file: D:/workspace/o3de/atom_dev/DartConfiguration.tcl
Test project D:/workspace/o3de/atom_dev
    Start 162: AutomatedTesting::Atom_Main_Null_Render_02.main::TEST_RUN
1/4 Test #162: AutomatedTesting::Atom_Main_Null_Render_02.main::TEST_RUN ...   Passed   68.45 sec
    Start 163: AutomatedTesting::Atom_Main_Null_Render_03.main::TEST_RUN
2/4 Test #163: AutomatedTesting::Atom_Main_Null_Render_03.main::TEST_RUN ...   Passed   43.47 sec
    Start 161: AutomatedTesting::Atom_Main_Null_Render_01.main::TEST_RUN
3/4 Test #161: AutomatedTesting::Atom_Main_Null_Render_01.main::TEST_RUN ...   Passed   38.37 sec
    Start 160: AutomatedTesting::Atom_Main_Null_Render_00.main::TEST_RUN
4/4 Test #160: AutomatedTesting::Atom_Main_Null_Render_00.main::TEST_RUN ...   Passed   33.60 sec

100% tests passed, 0 tests failed out of 4

Label Time Summary:
COMPONENT_Atom      = 183.89 sec*proc (4 tests)
FRAMEWORK_pytest    = 183.89 sec*proc (4 tests)
SUITE_main          = 183.89 sec*proc (4 tests)

Total Test time (real) = 184.21 sec
```
Signed-off-by: Scott Murray <scottmur@amazon.com>