### PR TITLE
Fix Lua IDE breakpoint stall and failure to register self as host

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Script/ScriptRemoteDebugging.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Script/ScriptRemoteDebugging.cpp
@@ -24,6 +24,7 @@
 #include <AzCore/Math/Crc.h>
 #include <AzCore/std/parallel/thread.h>
 #include <AzCore/std/parallel/atomic.h>
+#include <AzNetworking/Framework/INetworking.h>
 
 namespace AzFramework
 {
@@ -425,6 +426,7 @@ namespace AzFramework
             {
                 EBUS_EVENT(TargetManager::Bus, DispatchMessages, AZ_CRC("ScriptDebugAgent", 0xb6be0836));
                 Process();
+                AZ::Interface<AzNetworking::INetworking>::Get()->ForceUpdate();
                 AZStd::this_thread::yield();
             }
         }

--- a/Code/Framework/AzNetworking/AzNetworking/Framework/INetworking.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Framework/INetworking.h
@@ -89,5 +89,9 @@ namespace AzNetworking
         //! Returns the total time spent updating our UdpReaderThread.
         //! @return the total time spent updating our UdpReaderThread
         virtual AZ::TimeMs GetUdpReaderThreadUpdateTime() const = 0;
+
+        //! Forcibly swaps reader thread buffers and updates all Network Interfaces
+        //! CAUTION: For use when SystemTickBus is suspended or similar
+        virtual void ForceUpdate() = 0;
     };
 }

--- a/Code/Framework/AzNetworking/AzNetworking/Framework/NetworkingSystemComponent.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Framework/NetworkingSystemComponent.cpp
@@ -167,6 +167,11 @@ namespace AzNetworking
         return m_readerThread->GetUpdateTimeMs();
     }
 
+    void NetworkingSystemComponent::ForceUpdate()
+    {
+        OnSystemTick();
+    }
+
     void NetworkingSystemComponent::DumpStats([[maybe_unused]] const AZ::ConsoleCommandContainer& arguments)
     {
         AZLOG_INFO("Total sockets monitored by TcpListenThread: %u", GetTcpListenThreadSocketCount());

--- a/Code/Framework/AzNetworking/AzNetworking/Framework/NetworkingSystemComponent.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Framework/NetworkingSystemComponent.h
@@ -63,6 +63,7 @@ namespace AzNetworking
         AZ::TimeMs GetTcpListenThreadUpdateTime() const override;
         uint32_t GetUdpReaderThreadSocketCount() const override;
         AZ::TimeMs GetUdpReaderThreadUpdateTime() const override;
+        void ForceUpdate() override;
         //! @}
 
         //! Console commands.

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorContext.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorContext.cpp
@@ -1800,6 +1800,13 @@ namespace LUAEditor
         AZStd::string absolutePath = relativePath.substr(1);
         EBUS_EVENT(AzToolsFramework::AssetSystemRequestBus, GetFullSourcePathFromRelativeProductPath, absolutePath, absolutePath);
 
+        // If finding a .lua fails, attempt the equivalent .luac
+        if (absolutePath.empty() && relativePath.ends_with(".lua"))
+        {
+            absolutePath = relativePath.substr(1) + "c";
+            EBUS_EVENT(AzToolsFramework::AssetSystemRequestBus, GetFullSourcePathFromRelativeProductPath, absolutePath, absolutePath); 
+        }
+
         //AZ_TracePrintf(LUAEditorDebugName, "Breakpoint '%s' was hit on line %i\n", assetIdString.c_str(), lineNumber);
         EBUS_EVENT(LUAEditorDebuggerMessages::Bus, GetCallstack);
         EBUS_EVENT(LUAEditor::LUABreakpointRequestMessages::Bus, RequestEditorFocus, absolutePath, lineNumber);

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorContext.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorContext.cpp
@@ -1797,14 +1797,15 @@ namespace LUAEditor
     void Context::OnBreakpointHit(const AZStd::string& relativePath, int lineNumber)
     {
         // Convert from debug path (relative) to absolute path (how the Lua IDE stores files)
-        AZStd::string absolutePath = relativePath.substr(1);
-        EBUS_EVENT(AzToolsFramework::AssetSystemRequestBus, GetFullSourcePathFromRelativeProductPath, absolutePath, absolutePath);
+        AZStd::string absolutePath;
+        AZStd::string formattedRelativePath = relativePath.substr(1);
+        EBUS_EVENT(AzToolsFramework::AssetSystemRequestBus, GetFullSourcePathFromRelativeProductPath, formattedRelativePath, absolutePath);
 
         // If finding a .lua fails, attempt the equivalent .luac
         if (absolutePath.empty() && relativePath.ends_with(".lua"))
         {
-            absolutePath = relativePath.substr(1) + "c";
-            EBUS_EVENT(AzToolsFramework::AssetSystemRequestBus, GetFullSourcePathFromRelativeProductPath, absolutePath, absolutePath); 
+            formattedRelativePath = relativePath.substr(1) + "c";
+            EBUS_EVENT(AzToolsFramework::AssetSystemRequestBus, GetFullSourcePathFromRelativeProductPath, formattedRelativePath, absolutePath); 
         }
 
         //AZ_TracePrintf(LUAEditorDebugName, "Breakpoint '%s' was hit on line %i\n", assetIdString.c_str(), lineNumber);

--- a/Code/Tools/LuaIDE/Source/StandaloneToolsApplication.cpp
+++ b/Code/Tools/LuaIDE/Source/StandaloneToolsApplication.cpp
@@ -76,6 +76,16 @@ namespace StandaloneTools
             }
         }
 
+        // Check Application Entity
+        for (const auto& component : m_applicationEntity->GetComponents())
+        {
+            if (auto targetManagement = azrtti_cast<AzFramework::TargetManagementComponent*>(component))
+            {
+                targetManagement->SetTargetAsHost(true);
+            }
+        }
+
+        // Check Module Entities
         AZ::ModuleManagerRequestBus::Broadcast(
             &AZ::ModuleManagerRequestBus::Events::EnumerateModules,
             [](const AZ::ModuleData& moduleData)


### PR DESCRIPTION
Addresses https://github.com/o3de/o3de/issues/9075

The root cause of the issue is the manner in which Lua IDE halts the Editor when a breakpoint is hit. It does this by entering a while loop that only looks for other debug messages and thread yields. This unfortunately causes all network traffic to cease since network updates are sourced off the main thread's SystemTickBus.

There are a few potential fixes here
1. Allow SystemTickBus to operate in this debug state. Unfortunately, SystemTickBus also triggers things like high priority entity spawning so this did not seem appropriate for a stopped debug state.
2. Create a manual ForceUpdate function to allow AzNetworking to process traffic without SystemTickBus.
3. Move NetworkSystemComponent's updates off the main thread and SystemTickBus entirely.

I implemented the second which works thanks to the while loop having the necessary machinery to to pull TmMessages manually (DispatchMessages' purpose in the loop).

There is a good chance this code will be refactored entirely in the near future.

This change ALSO addresses an issue in which the Lua IDE would startup as a loopback due to TargetManagementComponent being on the Application Entity vs a Module Entity. StandaloneToolsApplication now accounts for both possibilities.

Signed-off-by: puvvadar <puvvadar@amazon.com>