### PR TITLE
Added a test option to the assetprocessor.stop function to allow testing assetproces…

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_gui_tests.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_gui_tests.py
@@ -23,8 +23,6 @@ import ly_test_tools.environment.file_system as fs
 import ly_test_tools.environment.process_utils as process_utils
 import ly_test_tools.launchers.launcher_helper as launcher_helper
 from ly_test_tools.o3de.asset_processor import ASSET_PROCESSOR_PLATFORM_MAP
-from ly_test_tools.o3de.asset_processor import AssetProcessorError
-from ly_test_tools.o3de.asset_processor import StopReason
 
 # Import fixtures
 from ..ap_fixtures.asset_processor_fixture import asset_processor as asset_processor
@@ -376,6 +374,7 @@ class TestsAssetProcessorGUI_Windows(object):
         asset_processor.start()
         assert asset_processor.stop() is None, "AP timed out"
 
+    @pytest.mark.assetpipeline
     def test_APStopNoControlConnection_ExceptionThrown(self, ap_setup_fixture, asset_processor):
         """
         Tests AP successfully terminates if no control connection is found during an stop call.

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_gui_tests.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_gui_tests.py
@@ -23,6 +23,7 @@ import ly_test_tools.environment.file_system as fs
 import ly_test_tools.environment.process_utils as process_utils
 import ly_test_tools.launchers.launcher_helper as launcher_helper
 from ly_test_tools.o3de.asset_processor import ASSET_PROCESSOR_PLATFORM_MAP
+from ly_test_tools.o3de.asset_processor import StopReason
 
 # Import fixtures
 from ..ap_fixtures.asset_processor_fixture import asset_processor as asset_processor
@@ -352,7 +353,7 @@ class TestsAssetProcessorGUI_Windows(object):
 
         # Copy in some assets, so that the AP will be busy when the stop command is called.
         asset_processor.prepare_test_environment(ap_setup_fixture["tests_dir"], "TimeOutTest", use_current_root=True)
-        assert asset_processor.stop(timeout=0) == 4, "AP did not time out as expected"
+        assert asset_processor.stop(timeout=0) == StopReason.TIMEOUT, "AP did not time out as expected"
 
     @pytest.mark.assetpipeline
     def test_APStopDefaultTimeout_DoesNotTimeOut(self, asset_processor):
@@ -375,7 +376,7 @@ class TestsAssetProcessorGUI_Windows(object):
         assert asset_processor.stop() is None, "AP timed out"
 
     @pytest.mark.assetpipeline
-    def test_APStopNoControlConnection_ExceptionThrown(self, ap_setup_fixture, asset_processor):
+    def test_APStopNoControlConnection_Terminates(self, ap_setup_fixture, asset_processor):
         """
         Tests AP successfully terminates if no control connection is found during an stop call.
 
@@ -389,4 +390,4 @@ class TestsAssetProcessorGUI_Windows(object):
         asset_processor.create_temp_asset_root()
         asset_processor.start()
         asset_processor.set_control_connection(None)
-        assert asset_processor.stop() == 1, "AP was not terminated as expected"
+        assert asset_processor.stop() == StopReason.NO_CONTROL, "AP was not terminated as expected"

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_gui_tests.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_gui_tests.py
@@ -390,6 +390,8 @@ class TestsAssetProcessorGUI_Windows(object):
 
     def test_APStopNoControlConnection_ExceptionThrown(self, ap_setup_fixture, asset_processor):
         """
+        Tests AP successfully terminates if no control connection is found during an stop call.
+
         Test Steps:
         1. Create a temporary testing environment
         2. Start Asset Processor

--- a/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
@@ -18,6 +18,7 @@ import tempfile
 import time
 
 from typing import List, Tuple
+from enum import IntEnum
 
 import ly_test_tools
 import ly_test_tools.environment.file_system as file_system
@@ -46,6 +47,22 @@ ASSET_PROCESSOR_SETTINGS_ROOT_KEY = '/Amazon/AssetProcessor/Settings'
 class AssetProcessorError(Exception):
     """ Indicates that the AssetProcessor raised an error """
 
+class StopReason(IntEnum):
+    """
+    Indicates what stop reason was used during the stop() function.
+        NOT_RUNNING = None
+        NO_CONTROL = 1
+        NO_QUIT = 2
+        IO_ERROR = 3
+        TIMEOUT = 4
+        NO_STOP = 5
+    """
+    NOT_RUNNING = 0
+    NO_CONTROL = 1
+    NO_QUIT = 2
+    IO_ERROR = 3
+    TIMEOUT = 4
+    NO_STOP = 5
 
 class AssetProcessor(object):
     def __init__(self, workspace, port=45643):
@@ -263,70 +280,46 @@ class AssetProcessor(object):
         waiter.wait_for(_attempt_connection, timeout=timeout, exc=err)
         return True, None
 
-    def stop(self, timeout=60, ap_stop_test=False):
+    def stop(self, timeout=60):
         """
          Stops the AssetProcessor. First attempts a clean shutdown over the control channel
          if open.  Calls terminate if no control connection is open
          :param timeout: How long to wait, in seconds, for AP to shut down after receiving quit message.
             This timeout is a longer default because AP doesn't quit immediately on receiving the quit message,
             it waits until finishing its current task, which can sometimes take a while.
-         :param ap_stop_test: Informs the stop function whether or not the stop is intentional for testing purposes.
-            If set to true, any terminate call within the function will return a ValueError with a specific string
-            for the tests to compare against.
-         :return: None
+         :return: Returns the StopReason as an Int
          """
         if not self._ap_proc:
             logger.warning("Attempting to quit AP but none running")
-            return
+            return StopReason.NOT_RUNNING
 
         if not self._control_connection:
-            if ap_stop_test:
                 logger.info("No control connection open, using terminate")
                 self.terminate()
-                raise ValueError("NoControlConnection")
-            else:
-                logger.info("No control connection open, using terminate")
-                return self.terminate()
+                return StopReason.NO_CONTROL
 
         try:
             if not self.send_quit():
-                if ap_stop_test:
-                    logger.info("Quit command was not sent, using terminate")
-                    self.terminate()
-                    raise ValueError("NoQuitCommand")
-                else:
-                    logger.warning("Failed to send quit command, using terminate")
-                    self.terminate()
+                logger.warning("Failed to send quit command, using terminate")
+                self.terminate()
+                return StopReason.NO_QUIT
         except IOError as e:
-            if ap_stop_test:
-                logger.info(f"Quit request with error {e} detected, stopping")
-                self.terminate()
-                raise ValueError("IOError")
-            else:
-                logger.warning(f"Failed to send quit request with error {e}, stopping")
-                self.terminate()
+            logger.warning(f"Failed to send quit request with error {e}, stopping")
+            self.terminate()
+            return StopReason.IO_ERROR
 
         wait_timeout = timeout
         try:
             waiter.wait_for(lambda: not self.process_exists(), exc=AssetProcessorError, timeout=wait_timeout)
         except AssetProcessorError:
-            if ap_stop_test:
-                logger.info(f"Timeout attempting to quit asset processor after {wait_timeout} seconds, using terminate")
-                self.terminate()
-                raise ValueError("Timeout")
-            else:
-                logger.warning(f"Timeout attempting to quit asset processor after {wait_timeout} seconds, using terminate")
-                self.terminate()
-            pass
+            logger.warning(f"Timeout attempting to quit asset processor after {wait_timeout} seconds, using terminate")
+            self.terminate()
+            return StopReason.TIMEOUT
 
         if self.process_exists():
-            if ap_stop_test:
-                logger.info(f"Process {self.get_pid()} exists after {wait_timeout} seconds, using terminate")
-                self.terminate()
-                raise ValueError("FailedToStop")
-            else:
-                logger.warning(f"Failed to stop process {self.get_pid()} after {wait_timeout} seconds, using terminate")
-                self.terminate()
+            logger.warning(f"Failed to stop process {self.get_pid()} after {wait_timeout} seconds, using terminate")
+            self.terminate()
+            return StopReason.NO_STOP
         self._ap_proc = None
 
     def terminate(self):

--- a/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
@@ -270,6 +270,9 @@ class AssetProcessor(object):
          :param timeout: How long to wait, in seconds, for AP to shut down after receiving quit message.
             This timeout is a longer default because AP doesn't quit immediately on receiving the quit message,
             it waits until finishing its current task, which can sometimes take a while.
+         :param ap_stop_test: Informs the stop function whether or not the stop is intentional for testing purposes.
+            If set to true, any terminate call within the function will return a ValueError with a specific string
+            for the tests to compare against.
          :return: None
          """
         if not self._ap_proc:
@@ -288,7 +291,7 @@ class AssetProcessor(object):
         try:
             if not self.send_quit():
                 if ap_stop_test:
-                    logger.info("Failed to send quit command, using terminate")
+                    logger.info("Quit command was not sent, using terminate")
                     self.terminate()
                     raise ValueError("NoQuitCommand")
                 else:
@@ -296,7 +299,7 @@ class AssetProcessor(object):
                     self.terminate()
         except IOError as e:
             if ap_stop_test:
-                logger.info(f"Failed to send quit request with error {e}, stopping")
+                logger.info(f"Quit request with error {e} detected, stopping")
                 self.terminate()
                 raise ValueError("IOError")
             else:
@@ -318,7 +321,7 @@ class AssetProcessor(object):
 
         if self.process_exists():
             if ap_stop_test:
-                logger.info(f"Failed to stop process {self.get_pid()} after {wait_timeout} seconds, using terminate")
+                logger.info(f"Process {self.get_pid()} exists after {wait_timeout} seconds, using terminate")
                 self.terminate()
                 raise ValueError("FailedToStop")
             else:

--- a/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
@@ -320,7 +320,6 @@ class AssetProcessor(object):
             logger.warning(f"Failed to stop process {self.get_pid()} after {wait_timeout} seconds, using terminate")
             self.terminate()
             return StopReason.NO_STOP
-        self._ap_proc = None
 
     def terminate(self):
         """

--- a/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
@@ -317,7 +317,7 @@ class AssetProcessor(object):
             else:
                 logger.warning(f"Timeout attempting to quit asset processor after {wait_timeout} seconds, using terminate")
                 self.terminate()
-                pass
+            pass
 
         if self.process_exists():
             if ap_stop_test:

--- a/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
@@ -294,9 +294,9 @@ class AssetProcessor(object):
             return StopReason.NOT_RUNNING
 
         if not self._control_connection:
-                logger.info("No control connection open, using terminate")
-                self.terminate()
-                return StopReason.NO_CONTROL
+            logger.info("No control connection open, using terminate")
+            self.terminate()
+            return StopReason.NO_CONTROL
 
         try:
             if not self.send_quit():
@@ -320,6 +320,8 @@ class AssetProcessor(object):
             logger.warning(f"Failed to stop process {self.get_pid()} after {wait_timeout} seconds, using terminate")
             self.terminate()
             return StopReason.NO_STOP
+
+        self._ap_proc = None
 
     def terminate(self):
         """

--- a/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
@@ -50,7 +50,7 @@ class AssetProcessorError(Exception):
 class StopReason(IntEnum):
     """
     Indicates what stop reason was used during the stop() function.
-        NOT_RUNNING = None
+        NOT_RUNNING = 0
         NO_CONTROL = 1
         NO_QUIT = 2
         IO_ERROR = 3


### PR DESCRIPTION
…sor.stop without causing issues in other tests if AP does not shut down cleanly.

Added an additional assetprocessor.stop test as an example.

Signed-off-by: Rosario Cox <lesaelr@amazon.com>