### PR TITLE
Adopt BinPackArguments: false in .clang-format.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,6 +13,7 @@ AllowShortFunctionsOnASingleLine: None
 AllowShortLambdasOnASingleLine: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
 BinPackParameters: false
 BreakBeforeBraces: Custom
 BraceWrapping:


### PR DESCRIPTION
As discussed in #dev-languages on Discord.

See https://clang.llvm.org/docs/ClangFormatStyleOptions.html

Signed-off-by: Joerg H. Mueller <joerg.mueller@huawei.com>