### PR TITLE
Correct payload size calculations for compressed TCP and missing compressor

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpConnection.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpConnection.cpp
@@ -362,8 +362,8 @@ namespace AzNetworking
             // If we can't fit the packet, do not allow the copy to proceed as that would overwrite invalid memory
             return false;
         }
-        outBuffer.Resize(packetSize);
 
+        const uint16_t transmittedPacketSize = packetSize;
         const uint8_t* srcData = serializer.GetUnreadData();
         if (m_compressor && outHeader.IsPacketFlagSet(PacketFlag::Compressed))
         {
@@ -376,10 +376,12 @@ namespace AzNetworking
             packetSize = aznumeric_cast<uint16_t>(outBuffer.GetSize());
         }
 
+        outBuffer.Resize(packetSize);
+
         uint8_t* dstData = outBuffer.GetBuffer();
         memcpy(dstData, srcData, packetSize);
 
-        m_recvRingbuffer.AdvanceReadBuffer(serializer.GetReadSize() + packetSize);
+        m_recvRingbuffer.AdvanceReadBuffer(serializer.GetReadSize() + transmittedPacketSize);
         GetMetrics().LogPacketRecv(packetSize, currentTimeMs);
         m_networkInterface.GetMetrics().m_recvPackets++;
         return true;

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpConnection.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpConnection.cpp
@@ -36,7 +36,8 @@ namespace AzNetworking
         , m_connectionRole(ConnectionRole::Acceptor)
         , m_registeredSocketFd(InvalidSocketFd)
     {
-        ;
+        const AZ::CVarFixedString compressor = static_cast<AZ::CVarFixedString>(net_TcpCompressor);
+        m_compressor = AZ::Interface<INetworking>::Get()->CreateCompressor(compressor);
     }
 
     TcpConnection::TcpConnection
@@ -257,11 +258,11 @@ namespace AzNetworking
         int32_t payloadSize = aznumeric_cast<int32_t>(payloadBuffer.GetSize());
         bool shouldCompress = m_compressor && packetType != aznumeric_cast<PacketType>(CorePackets::PacketType::InitiateConnectionPacket);
 
-        // Create and serialize header...
+        // Create and serialize uncompressed version of header
         TcpPacketEncodingBuffer headerBuffer;
         {
-            TcpPacketHeader header(packetType, aznumeric_cast<uint16_t>(payloadBuffer.GetSize()));
-            header.SetPacketFlag(PacketFlag::Compressed, shouldCompress);
+            TcpPacketHeader header(packetType, aznumeric_cast<uint16_t>(payloadSize));
+            header.SetPacketFlag(PacketFlag::Compressed, false);
             NetworkInputSerializer serializer(headerBuffer.GetBuffer(), static_cast<uint32_t>(headerBuffer.GetCapacity()));
             if (!header.Serialize(serializer))
             {
@@ -270,23 +271,15 @@ namespace AzNetworking
             headerBuffer.Resize(serializer.GetSize());
         }
 
-        const uint16_t headerSize = aznumeric_cast<uint16_t>(headerBuffer.GetSize());
         const uint8_t* srcData = reinterpret_cast<const uint8_t*>(payloadBuffer.GetBuffer());
-        uint8_t* dstData = reinterpret_cast<uint8_t*>(m_sendRingbuffer.ReserveBlockForWrite(headerSize + payloadSize));
-
-        if (dstData == nullptr)
-        {
-            AZLOG_ERROR("Send ringbuffer full, dropped packet");
-            return false;
-        }
 
         // Compress send data
         TcpPacketEncodingBuffer writeBuffer;
         if (m_compressor && packetType != aznumeric_cast<PacketType>(CorePackets::PacketType::InitiateConnectionPacket))
         {
-            const AZStd::size_t maxSizeNeeded = m_compressor->GetMaxCompressedBufferSize(payloadBuffer.GetSize());
+            const AZStd::size_t maxSizeNeeded = m_compressor->GetMaxCompressedBufferSize(payloadSize);
             AZStd::size_t compressionMemBytesUsed = 0;
-            CompressorError compErr = m_compressor->Compress(payloadBuffer.GetBuffer(), payloadBuffer.GetSize(), writeBuffer.GetBuffer(), maxSizeNeeded, compressionMemBytesUsed);
+            CompressorError compErr = m_compressor->Compress(payloadBuffer.GetBuffer(), payloadSize, writeBuffer.GetBuffer(), maxSizeNeeded, compressionMemBytesUsed);
 
             if (compErr != CompressorError::Ok)
             {
@@ -299,12 +292,36 @@ namespace AzNetworking
                 // Track how many packets are being sent with no compression gain
                 m_networkInterface.GetMetrics().m_sendCompressedPacketsNoGain++;
             }
-            // Track byte delta caused by compression
-            m_networkInterface.GetMetrics().m_sendBytesCompressedDelta += (payloadSize - compressionMemBytesUsed);
 
-            writeBuffer.Resize(aznumeric_cast<int32_t>(compressionMemBytesUsed));
-            payloadSize = static_cast<uint32_t>(writeBuffer.GetSize());
-            srcData = writeBuffer.GetBuffer();
+            // Only use compression if there's actual gain
+            if (compressionMemBytesUsed < payloadSize)
+            {
+                // Track byte delta caused by compression
+                m_networkInterface.GetMetrics().m_sendBytesCompressedDelta += (payloadSize - compressionMemBytesUsed);
+
+                writeBuffer.Resize(aznumeric_cast<int32_t>(compressionMemBytesUsed));
+                payloadSize = static_cast<uint32_t>(writeBuffer.GetSize());
+                srcData = writeBuffer.GetBuffer();
+
+                // Recreate and reserialize header with compressed payload size and compression flag
+                TcpPacketHeader header(packetType, aznumeric_cast<uint16_t>(payloadSize));
+                header.SetPacketFlag(PacketFlag::Compressed, shouldCompress);
+                NetworkInputSerializer serializer(headerBuffer.GetBuffer(), static_cast<uint32_t>(headerBuffer.GetCapacity()));
+                if (!header.Serialize(serializer))
+                {
+                    return false;
+                }
+                headerBuffer.Resize(serializer.GetSize());
+            }
+        }
+
+        const uint16_t headerSize = aznumeric_cast<uint16_t>(headerBuffer.GetSize());
+        uint8_t* dstData = reinterpret_cast<uint8_t*>(m_sendRingbuffer.ReserveBlockForWrite(headerSize + payloadSize));
+
+        if (dstData == nullptr)
+        {
+            AZLOG_ERROR("Send ringbuffer full, dropped packet");
+            return false;
         }
 
         // Copy the header data to the ring buffer

--- a/Code/Tools/RemoteConsole/Core/RemoteConsoleCore.cpp
+++ b/Code/Tools/RemoteConsole/Core/RemoteConsoleCore.cpp
@@ -131,7 +131,10 @@ void SRemoteServer::StartServer()
 void SRemoteServer::StopServer()
 {
     m_bAcceptClients = false;
-    AZ::AzSock::CloseSocket(m_socket);
+    if (AZ::AzSock::IsAzSocketValid(m_socket))
+    {
+        AZ::AzSock::CloseSocket(m_socket);
+    }
     m_socket = SOCKET_ERROR;
 
     AZStd::unique_lock<AZStd::recursive_mutex> lock(m_mutex);


### PR DESCRIPTION
This addresses https://github.com/o3de/o3de/issues/10030. 

Issues addressed:
1. When a packet is compressed via TCP, the packet header continues to use the uncompressed payload size which causes buffer position issues on the receiving end.
2. TcpConnection's constructor for listeners never sets up m_compressor
3. When a packet is decompressed via TCP, the read buffer is advanced by the uncompressed size vs the compressed size. The read buffer has no concept of compression so it requires the size as received (compressed).
4. Not related, but RemoteConsole throws an AzSock error on startup. This just needed some edge case handling.

Signed-off-by: puvvadar <puvvadar@amazon.com>