### PR TITLE
Android build shows C++ files progression.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Geometry3DUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Geometry3DUtils.cpp
@@ -27,15 +27,16 @@ namespace AZ::Geometry3dUtils
                 return;
             }
 
-            // For each triangle that's passed in, split it into 4 triangles and recursively subdivide those.
-            //           a
-            //           /\
-            //          /  \
-            //     ab  /----\  ca
-            //        / \  / \
-            //       /   \/   \
-            //    b ------------ c
-            //           bc
+            /** For each triangle that's passed in, split it into 4 triangles and recursively subdivide those.
+             *           a
+             *           /\
+             *          /  \
+             *     ab  /----\  ca
+             *        / \  / \
+             *       /   \/   \
+             *    b ------------ c
+             *           bc
+             */
             const AZ::Vector3 ab = (a + b).GetNormalized();
             const AZ::Vector3 bc = (b + c).GetNormalized();
             const AZ::Vector3 ca = (c + a).GetNormalized();

--- a/Code/Framework/AzFramework/Platform/Android/AzFramework/Application/Application_Android.cpp
+++ b/Code/Framework/AzFramework/Platform/Android/AzFramework/Application/Application_Android.cpp
@@ -92,7 +92,9 @@ namespace AzFramework
     private:
         AndroidEventDispatcher* m_eventDispatcher;
         ApplicationLifecycleEvents::Event m_lastEvent;
+#if !defined(AZ_RELEASE_BUILD)
         AZStd::unique_ptr<ThermalInfoHandler> m_thermalInfoHandler;
+#endif
 
         AZStd::atomic<bool> m_requestResponseReceived;
         AZStd::unique_ptr<AZ::Android::JNI::Object> m_lumberyardActivity;

--- a/Code/Tools/Android/ProjectBuilder/gradle.properties.in
+++ b/Code/Tools/Android/ProjectBuilder/gradle.properties.in
@@ -24,3 +24,6 @@ org.gradle.jvmargs=
 
 # required to use Android X libraries
 android.useAndroidX=true
+
+# Show C/C++ files build progression
+android.native.buildOutput=verbose

--- a/cmake/Tools/Platform/Android/android_support.py
+++ b/cmake/Tools/Platform/Android/android_support.py
@@ -506,6 +506,7 @@ class AndroidProjectGenerator(object):
         :param extra_cmake_configure_args Additional arguments to supply cmake when configuring a project
         :param is_test_project:         Flag to indicate if this is a unit test runner project. (If true, project_path, asset_mode, asset_type, and include_assets_in_apk are ignored)
         :param overwrite_existing:      Flag to overwrite existing project files when being generated, or skip if they already exist.
+        :param unity_build_enabled:     Flag to enable unity build.
         """
         self.env = {}
 


### PR DESCRIPTION
when building android the gradle step that builds c++ was not showing anything, making difficult to know the progression. Showing the C++ files compiled in the log, so it's more informative and doesn't spend 15 minutes without seeing anything in the log.

![Android_Verbose](https://user-images.githubusercontent.com/27999040/174102321-42d5e693-6fa9-4406-80a7-35e9ea0aea5d.png)

Also fixed some compilation errors from nightly build:
- `ThermalInfoHandler` is only defined in non release builds.
- multi-line comment error in linux gcc due to ending a line comment with `\`

Signed-off-by: moraaar <moraaar@amazon.com>