### PR TITLE
[Terrain] Expose spline bus to scripting

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Spline.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Spline.cpp
@@ -98,13 +98,17 @@ namespace AZ
         if (BehaviorContext* behaviorContext = azrtti_cast<BehaviorContext*>(context))
         {
             behaviorContext->Class<SplineAddress>()->
-                Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::ListOnly)->
                 Constructor<u64, float>()->
                 Attribute(Script::Attributes::Storage, Script::Attributes::StorageType::Value)->
                 Attribute(Script::Attributes::ConstructorOverride, &Internal::SplineAddressScriptConstructor)->
                 Attribute(Script::Attributes::GenericConstructorOverride, &Internal::SplineAddressDefaultConstructor)->
                 Property("segmentIndex", BehaviorValueProperty(&SplineAddress::m_segmentIndex))->
-                Property("segmentFraction", BehaviorValueProperty(&SplineAddress::m_segmentFraction));
+                Property("segmentFraction", BehaviorValueProperty(&SplineAddress::m_segmentFraction))->
+                Method("GetSegmentIndexAndFraction", [](SplineAddress* thisPtr)
+                    {
+                        return AZStd::make_tuple(thisPtr->m_segmentIndex, thisPtr->m_segmentFraction);
+                    })
+                ;
 
             behaviorContext->Class<PositionSplineQueryResult>()->
                 Attribute(Script::Attributes::Storage, Script::Attributes::StorageType::Value)->
@@ -118,7 +122,6 @@ namespace AZ
                 Property("rayDistance", [](RaySplineQueryResult* thisPtr) { return thisPtr->m_rayDistance; }, nullptr);
 
             behaviorContext->Class<Spline>()->
-                Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::ListOnly)->
                 Attribute(Script::Attributes::Storage, Script::Attributes::StorageType::RuntimeOwn)->
                 Method("GetNearestAddressRay", &Spline::GetNearestAddressRay)->
                 Method("GetNearestAddressPosition", &Spline::GetNearestAddressPosition)->

--- a/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.cpp
@@ -182,7 +182,7 @@ namespace LmbrCentral
                 Handler<BehaviorSplineComponentNotificationBusHandler>();
 
             behaviorContext->EBus<SplineComponentRequestBus>("SplineComponentRequestBus")
-                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Edit::Attributes::Category, "Shape")
                 ->Attribute(AZ::Script::Attributes::Module, "shape")
                 ->Event("GetSpline", &SplineComponentRequestBus::Events::GetSpline)

--- a/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.cpp
@@ -185,7 +185,11 @@ namespace LmbrCentral
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Edit::Attributes::Category, "Shape")
                 ->Attribute(AZ::Script::Attributes::Module, "shape")
-                ->Event("GetSpline", &SplineComponentRequestBus::Events::GetSpline)
+                ->Event("GetSpline",
+                    [](SplineComponentRequests* handler) -> const AZ::Spline&
+                    {
+                        return *(handler->GetSpline());
+                    })
                 ->Event("SetClosed", &SplineComponentRequestBus::Events::SetClosed)
                 ->Event("AddVertex", &SplineComponentRequestBus::Events::AddVertex)
                 ->Event("UpdateVertex", &SplineComponentRequestBus::Events::UpdateVertex)

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SplineAddress.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SplineAddress.names
@@ -1,0 +1,138 @@
+{
+    "entries": [
+        {
+            "base": "SplineAddress",
+            "context": "BehaviorClass",
+            "variant": "",
+            "details": {
+                "name": "Spline Address"
+            },
+            "methods": [
+                {
+                    "base": "GetSegmentIndexAndFraction",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Segment Index And Fraction"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Segment Index And Fraction is invoked"
+                    },
+                    "details": {
+                        "name": "Get Segment Index And Fraction"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{865BA2EC-43C5-4E1F-9B6F-2D63F6DC2E70}",
+                            "details": {
+                                "name": "Spline Address"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{D6597933-47CD-4FC8-B911-63F3E2B0993A}",
+                            "details": {
+                                "name": "Index"
+                            }
+                        },
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Fraction"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetsegmentIndex",
+                    "context": "Getter",
+                    "details": {
+                        "name": "Get Segment Index"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{865BA2EC-43C5-4E1F-9B6F-2D63F6DC2E70}",
+                            "details": {
+                                "name": "Spline Address"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{D6597933-47CD-4FC8-B911-63F3E2B0993A}",
+                            "details": {
+                                "name": "segment Index"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetsegmentIndex",
+                    "context": "Setter",
+                    "details": {
+                        "name": "Set Segment Index"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{865BA2EC-43C5-4E1F-9B6F-2D63F6DC2E70}",
+                            "details": {
+                                "name": "Spline Address"
+                            }
+                        },
+                        {
+                            "typeid": "{D6597933-47CD-4FC8-B911-63F3E2B0993A}",
+                            "details": {
+                                "name": "segment Index"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetsegmentFraction",
+                    "context": "Getter",
+                    "details": {
+                        "name": "Get Segment Fraction"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{865BA2EC-43C5-4E1F-9B6F-2D63F6DC2E70}",
+                            "details": {
+                                "name": "Spline Address"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "segment Fraction"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetsegmentFraction",
+                    "context": "Setter",
+                    "details": {
+                        "name": "Set Segment Fraction"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{865BA2EC-43C5-4E1F-9B6F-2D63F6DC2E70}",
+                            "details": {
+                                "name": "Spline Address"
+                            }
+                        },
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "segment Fraction"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/SplineComponentRequestBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/SplineComponentRequestBus.names
@@ -128,7 +128,7 @@
                         {
                             "typeid": "{E13859C4-1F24-5C44-A133-F17B4B050D7C}",
                             "details": {
-                                "name": "AZStd::shared_ptr"
+                                "name": "Spline"
                             }
                         }
                     ]


### PR DESCRIPTION
This exposes the Spline Request Bus and associated classes to both Script Canvas and lua, so that it's possible to write simple scripts for entities to follow splines.

![image](https://user-images.githubusercontent.com/82224783/174104547-6a3d0c2d-6887-40cb-81d7-0140c861fe4e.png)

```
function PathFollower:OnTick(deltaTime, scriptTime)
	if self.Spline == nil then
		self.Spline = SplineComponentRequestBus.Event.GetSpline(self.Properties.Path)
		self.SplineOrigin = TransformBus.Event.GetWorldTranslation(self.Properties.Path)
		self.Address.segmentIndex = 0
		self.Address.segmentFraction = 0
	end
	
	if self.Spline ~= nil then
		self.Address = self.Spline:GetAddressByDistance(self.Distance)
		local position = self.Spline:GetPosition(self.Address)
		-- get the player speed
		local speed = self.Properties.Speed * self.SpeedMultiplier
		
		local totalDistance = self.Spline:GetSplineLength()

		if (self.Distance >= (totalDistance - self.StoppingDistance)) then
		    speed = speed * ((totalDistance - self.Distance) / self.StoppingDistance)
			if speed < 0.1 then
				speed = 0.0
				self.tickHandler:Disconnect()
				self.tickHandler = nil
			end
		end

		self.Distance = self.Distance + deltaTime * speed
		
		if self.Distance >= totalDistance then
			self.Distance = totalDistance
			self.tickHandler:Disconnect()
			self.tickHandler = nil
		end
		
		local lookAhead = self.Distance + self.Properties.LookAheadAmount
		local lookAheadAddress = self.Spline:GetAddressByDistance(lookAhead)
		local lookAheadPosition = self.Spline:GetPosition(lookAheadAddress)
		
		local tm = MathUtils.CreateLookAt(position, lookAheadPosition, AxisType.YPositive)
		tm:SetTranslation(self.SplineOrigin + position)		
		TransformBus.Event.SetWorldTM(self.entityId, tm)
	end
end
```