### PR TITLE
Prefab/fix const error for get cached instance dom

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
@@ -896,7 +896,7 @@ namespace AzToolsFramework
             return AZStd::move(m_containerEntity);
         }
 
-        PrefabDomValueConstReference Instance::GetCachedInstanceDom() const
+        PrefabDomConstReference Instance::GetCachedInstanceDom() const
         {
             if (m_cachedInstanceDom.IsNull())
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.h
@@ -231,7 +231,7 @@ namespace AzToolsFramework
 
             static InstanceAlias GenerateInstanceAlias();
 
-            PrefabDomValueConstReference GetCachedInstanceDom() const;
+            PrefabDomConstReference GetCachedInstanceDom() const;
             PrefabDomReference GetCachedInstanceDom();
             void SetCachedInstanceDom(PrefabDomValueConstReference instanceDom);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
@@ -159,7 +159,7 @@ namespace AzToolsFramework
             }
 
             PrefabDomUtils::InstanceDomMetadata* instanceDomMetadata = context.GetMetadata().Find<PrefabDomUtils::InstanceDomMetadata>();
-            PrefabDomValueConstReference cachedInstanceDom = instance->GetCachedInstanceDom();
+            PrefabDomConstReference cachedInstanceDom = instance->GetCachedInstanceDom();
 
             if (instanceDomMetadata == nullptr || cachedInstanceDom == AZStd::nullopt)
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
@@ -159,7 +159,7 @@ namespace AzToolsFramework
             }
 
             PrefabDomUtils::InstanceDomMetadata* instanceDomMetadata = context.GetMetadata().Find<PrefabDomUtils::InstanceDomMetadata>();
-            PrefabDomConstReference cachedInstanceDom = instance->GetCachedInstanceDom();
+            PrefabDomReference cachedInstanceDom = instance->GetCachedInstanceDom();
 
             if (instanceDomMetadata == nullptr || cachedInstanceDom == AZStd::nullopt)
             {


### PR DESCRIPTION
Fix a build error detected on mac platform when failing to cast from non-const value to const value for prefab dom.