### PR TITLE
Fix DPE reflection support for bound attributes

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -297,7 +297,12 @@ namespace AZ::DocumentPropertyEditor
 
             static ResultType ValueToResult(const Dom::Value& value)
             {
-                return AZ::Success(AZ::Dom::Utils::ValueToTypeUnsafe<Result>(value));
+                auto result = AZ::Dom::Utils::ValueToType<Result>(value);
+                if (!result.has_value())
+                {
+                    return AZ::Failure<ErrorType>("Failed to convert return value type");
+                }
+                return AZ::Success(AZStd::move(result.value()));
             }
         };
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -294,6 +294,11 @@ namespace AZ::DocumentPropertyEditor
             {
                 return AZ::Success(AZ::Dom::Utils::ValueToTypeUnsafe<Result>(boundMessage(args)));
             }
+
+            static ResultType ValueToResult(const Dom::Value& value)
+            {
+                return AZ::Success(AZ::Dom::Utils::ValueToTypeUnsafe<Result>(value));
+            }
         };
 
         template<typename... Args>
@@ -325,6 +330,11 @@ namespace AZ::DocumentPropertyEditor
             static ResultType InvokeOnBoundMessage(BoundAdapterMessage& boundMessage, const Dom::Value& args)
             {
                 boundMessage(args);
+                return AZ::Success();
+            }
+
+            static ResultType ValueToResult(const Dom::Value&)
+            {
                 return AZ::Success();
             }
         };
@@ -381,7 +391,9 @@ namespace AZ::DocumentPropertyEditor
 
             if (!value.IsOpaqueValue())
             {
-                return AZ::Failure<ErrorType>("This property is holding a value and not a callback");
+                // CallbackAttributes that return a value may be bound to a simple value of that type
+                // In that case, ignore our parameters and simply return the value
+                return CallbackTraits::ValueToResult(value);
             }
 
             const AZStd::any& wrapper = value.GetOpaqueValue();

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -92,6 +92,8 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterPropertyEditor<CheckBox>();
         system->RegisterPropertyEditor<Color>();
         system->RegisterPropertyEditor<ComboBox>();
+        system->RegisterNodeAttribute<ComboBox>(ComboBox::StringList);
+
         system->RegisterPropertyEditor<RadioButton>();
         system->RegisterPropertyEditor<EntityId>();
         system->RegisterPropertyEditor<LayoutPadding>();

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -178,6 +178,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
     struct ComboBox : PropertyEditorDefinition
     {
         static constexpr AZStd::string_view Name = "ComboBox";
+        static constexpr auto StringList = AttributeDefinition<AZStd::vector<AZStd::string>>("StringList");
     };
 
     struct RadioButton : PropertyEditorDefinition


### PR DESCRIPTION
- Ensures the ReflectionAdapter gives attributes the correct instance
- aAd support for CallbackAttributes being bound to plain value types (this fixes up some ChangeNotify calls I saw)

Signed-off-by: Nicholas VanSickle <nvsickle@amazon.com>