### PR TITLE
Fix for cascade shadowmap pass issues

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/MainPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MainPipeline.pass
@@ -125,7 +125,7 @@
                     ]
                 },
                 {
-                    "Name": "ShadowPass",
+                    "Name": "Shadows",
                     "TemplateName": "ShadowParentTemplate",
                     "Connections": [
                         {
@@ -158,28 +158,28 @@
                         {
                             "LocalSlot": "DirectionalShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "DirectionalShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "DirectionalESM",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "DirectionalESM"
                             }
                         },
                         {
                             "LocalSlot": "ProjectedShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "ProjectedShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "ProjectedESM",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "ProjectedESM"
                             }
                         },
@@ -227,28 +227,28 @@
                         {
                             "LocalSlot": "DirectionalShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "DirectionalShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "DirectionalESM",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "DirectionalESM"
                             }
                         },
                         {
                             "LocalSlot": "ProjectedShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "ProjectedShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "ProjectedESM",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "ProjectedESM"
                             }
                         },

--- a/Gems/Atom/Feature/Common/Assets/Passes/ShadowParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ShadowParent.pass
@@ -56,28 +56,28 @@
                 {
                     "LocalSlot": "DirectionalShadowmap",
                     "AttachmentRef": {
-                        "Pass": "CascadedShadowmapsPass",
+                        "Pass": "Cascades",
                         "Attachment": "Shadowmap"
                     }
                 },
                 {
                     "LocalSlot": "DirectionalESM",
                     "AttachmentRef": {
-                        "Pass": "EsmShadowmapsPassDirectional",
+                        "Pass": "CascadesESM",
                         "Attachment": "EsmShadowmaps"
                     }
                 },
                 {
                     "LocalSlot": "ProjectedShadowmap",
                     "AttachmentRef": {
-                        "Pass": "ProjectedShadowmapsPass",
+                        "Pass": "Projected",
                         "Attachment": "Shadowmap"
                     }
                 },
                 {
                     "LocalSlot": "ProjectedESM",
                     "AttachmentRef": {
-                        "Pass": "EsmShadowmapsPassProjected",
+                        "Pass": "ProjectedESM",
                         "Attachment": "EsmShadowmaps"
                     }
                 },
@@ -91,7 +91,7 @@
             ],
             "PassRequests": [
                 {
-                    "Name": "CascadedShadowmapsPass",
+                    "Name": "Cascades",
                     "TemplateName": "CascadedShadowmapsTemplate",
                     "PassData": {
                         "$type": "RasterPassData",
@@ -109,7 +109,7 @@
                     ]
                 },
                 {
-                    "Name": "ProjectedShadowmapsPass",
+                    "Name": "Projected",
                     "TemplateName": "ProjectedShadowmapsTemplate",
                     "PassData": {
                         "$type": "RasterPassData",
@@ -127,7 +127,7 @@
                     ]
                 },
                 {
-                    "Name": "EsmShadowmapsPassDirectional",
+                    "Name": "CascadesESM",
                     "TemplateName": "EsmShadowmapsTemplate",
                     "PassData": {
                         "$type": "EsmShadowmapsPassData",
@@ -137,14 +137,14 @@
                         {
                             "LocalSlot": "DepthShadowmaps",
                             "AttachmentRef": {
-                                "Pass": "CascadedShadowmapsPass",
+                                "Pass": "Cascades",
                                 "Attachment": "Shadowmap"
                             }
                         }
                     ]
                 },
                 {
-                    "Name": "EsmShadowmapsPassProjected",
+                    "Name": "ProjectedESM",
                     "TemplateName": "EsmShadowmapsTemplate",
                     "PassData": {
                         "$type": "EsmShadowmapsPassData",
@@ -154,7 +154,7 @@
                         {
                             "LocalSlot": "DepthShadowmaps",
                             "AttachmentRef": {
-                                "Pass": "ProjectedShadowmapsPass",
+                                "Pass": "Projected",
                                 "Attachment": "Shadowmap"
                             }
                         }
@@ -167,14 +167,14 @@
                         {
                             "LocalSlot": "DirectionalShadowmaps",
                             "AttachmentRef": {
-                                "Pass": "CascadedShadowmapsPass",
+                                "Pass": "Cascades",
                                 "Attachment": "Shadowmap"
                             }
                         },
                         {
                             "LocalSlot": "DirectionalShadowmapsESM",
                             "AttachmentRef": {
-                                "Pass": "EsmShadowmapsPassDirectional",
+                                "Pass": "CascadesESM",
                                 "Attachment": "EsmShadowmaps"
                             }
                         }

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/CascadedShadowmapsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/CascadedShadowmapsPass.cpp
@@ -17,6 +17,8 @@ namespace AZ
 {
     namespace Render
     {
+        // Pass Creation ...
+
         CascadedShadowmapsPass::CascadedShadowmapsPass(const RPI::PassDescriptor& descriptor)
             : Base(descriptor)
         {
@@ -29,7 +31,7 @@ namespace AZ
                 m_basePipelineViewTag = passData->m_pipelineViewTag;
             }
 
-            QueueForUpdateShadowmapImageSize(ShadowmapSize::None, 1);
+            SetShadowmapSize(ShadowmapSize::None, 1);
         }
 
         CascadedShadowmapsPass::~CascadedShadowmapsPass()
@@ -46,28 +48,90 @@ namespace AZ
             return aznew CascadedShadowmapsPass(descriptor);
         }
 
+        // Child pass creation ...
+
+        void CascadedShadowmapsPass::CreateChildShadowMapPass(u16 cascadeIndex)
+        {
+            const Name passName{ AZStd::string::format("%d", cascadeIndex) };
+            auto passData = AZStd::make_shared<RPI::RasterPassData>();
+            passData->m_drawListTag = m_drawListTagName;
+            passData->m_pipelineViewTag = GetPipelineViewTags()[cascadeIndex];
+
+            auto pass = ShadowmapPass::CreateWithPassRequest(passName, passData);
+
+            const RHI::Size imageSize
+            {
+                aznumeric_cast<uint32_t>(m_shadowmapSize),
+                aznumeric_cast<uint32_t>(m_shadowmapSize),
+                m_numCascades
+            };
+            pass->SetViewportScissorFromImageSize(imageSize);
+            pass->SetArraySlice(cascadeIndex);
+
+            AddChild(pass);
+        }
+
+        void CascadedShadowmapsPass::CreateChildPassesInternal()
+        {
+            for (u16 childIdx = 0; childIdx < m_numCascades; ++childIdx)
+            {
+                CreateChildShadowMapPass(childIdx);
+            }
+        }
+
+        void CascadedShadowmapsPass::BuildInternal()
+        {
+            UpdateShadowmapImageSize();
+            Base::BuildInternal();
+        }
+
+        void CascadedShadowmapsPass::SetShadowmapSize(ShadowmapSize shadowmapSize, u16 numCascades)
+        {
+            AZ_Assert(numCascades > 0, "The number of cascades must be positive.");
+
+            bool rebuildPasses = (numCascades != m_numCascades) || (shadowmapSize != m_shadowmapSize);
+            m_numCascades = numCascades;
+            m_shadowmapSize = shadowmapSize;
+
+            if (rebuildPasses)
+            {
+                m_flags.m_createChildren = true;
+                QueueForBuildAndInitialization();
+            }
+
+            m_atlas.Initialize();
+            for (size_t cascadeIndex = 0; cascadeIndex < m_numCascades; ++cascadeIndex)
+            {
+                m_atlas.SetShadowmapSize(cascadeIndex, m_shadowmapSize);
+            }
+            m_atlas.Finalize();
+        }
+
+        void CascadedShadowmapsPass::UpdateShadowmapImageSize()
+        {
+            // [GFX TODO][ATOM-2470] stop caring about attachment
+            RPI::Ptr<RPI::PassAttachment> attachment = m_ownedAttachments.front();
+            AZ_Assert(attachment, "[CascadedShadowmapsPass %s] Cannot find shadowmap image attachment.", GetPathName().GetCStr());
+            AZ_Assert(attachment->m_descriptor.m_type == RHI::AttachmentType::Image, "[CascadedShadowmapsPass %s] requires an image attachment", GetPathName().GetCStr());
+
+            RPI::PassAttachmentBinding& binding = GetOutputBinding(0);
+            binding.SetAttachment(attachment);
+
+            RHI::ImageDescriptor& imageDescriptor = attachment->m_descriptor.m_image;
+            const uint32_t shadowmapWidth = static_cast<uint32_t>(m_atlas.GetBaseShadowmapSize());
+            imageDescriptor.m_size = RHI::Size(shadowmapWidth, shadowmapWidth, 1);
+            imageDescriptor.m_arraySize = m_atlas.GetArraySliceCount();
+        }
+
+        // View related ...
+
         void CascadedShadowmapsPass::SetCameraViewName(const AZStd::string& viewName)
         {
             if (m_cameraViewName != viewName)
             {
                 m_cameraViewName = viewName;
                 m_childrenPipelineViewTags.clear();
-                RemoveChildren();
-
-                if (m_numberOfCascades)
-                {
-                    // No need to remove children as if the cascaded number changed it will
-                    // be updated by SetCascadesCount that will remove and adjust the children.
-                    // We keep it in place to be on the safe side as this is a new camera view
-                    // and we rather start fresh.
-                    GetPipelineViewTags();
-                    SetCascadesCount(m_numberOfCascades);
-                }
-                else
-                {   // This should not really happen - the minimum is 1
-                    AZ_RPI_PASS_WARNING(false,
-                        "CascadedShadowmapsPass::SetCameraViewName - cascaded shadows amount should be greater than 0");
-                } 
+                GetPipelineViewTags();
             }
         }
 
@@ -78,89 +142,16 @@ namespace AZ
                 m_childrenPipelineViewTags.resize(Shadow::MaxNumberOfCascades);
                 for (uint16_t cascadeIndex = 0; cascadeIndex < Shadow::MaxNumberOfCascades; ++cascadeIndex)
                 {
-                    // These pipeline view tags are used to distinguish transient views,
-                    // so we offer distinct tag for each cascade index and for each camera view.
-                    m_childrenPipelineViewTags[cascadeIndex] =
-                        AZStd::string::format("%s_%d_%s",
-                            m_basePipelineViewTag.GetCStr(),
-                            cascadeIndex,
-                            m_cameraViewName.c_str());
+                    // These pipeline view tags are used to distinguish transient views, so we offer distinct tag for each cascade index and for each camera view.
+                    m_childrenPipelineViewTags[cascadeIndex] = AZStd::string::format("%s_%d_%s", m_basePipelineViewTag.GetCStr(), cascadeIndex, m_cameraViewName.c_str());
                 }
             }
             return m_childrenPipelineViewTags;
         }
 
-        void CascadedShadowmapsPass::QueueForUpdateShadowmapImageSize(ShadowmapSize shadowmapSize, uint32_t arraySize)
-        {
-            m_shadowmapSize = shadowmapSize;
-            m_arraySize = arraySize;
-            m_updateChildren = true;
-
-            QueueForBuildAndInitialization();
-
-            m_atlas.Initialize();
-            for (size_t cascadeIndex = 0; cascadeIndex < m_arraySize; ++cascadeIndex)
-            {
-                m_atlas.SetShadowmapSize(cascadeIndex, m_shadowmapSize);
-            }
-            m_atlas.Finalize();
-        }
-
-        void CascadedShadowmapsPass::UpdateChildren()
-        {
-            if (!m_updateChildren)
-            {
-                return;
-            }
-            m_updateChildren = false;
-
-            if (m_atlas.GetBaseShadowmapSize() == ShadowmapSize::None)
-            {
-                // Even when no shadow is given, an execution of child
-                // is required to transit the shadowmap image resource.
-                SetCascadesCount(1);
-                auto* pass = static_cast<ShadowmapPass*>(GetChildren()[0].get());
-                pass->SetArraySlice(0);
-                const RHI::Size imageSize{ 1, 1, 1 };
-                pass->SetViewportScissorFromImageSize(imageSize);
-                return;
-            }
-
-            SetCascadesCount(static_cast<uint16_t>(m_arraySize));
-            const RHI::Size imageSize
-            {
-                aznumeric_cast<uint32_t>(m_shadowmapSize),
-                aznumeric_cast<uint32_t>(m_shadowmapSize),
-                m_arraySize
-            };
-            for (RPI::Ptr<RPI::Pass> child : GetChildren())
-            {
-                auto* shadowmapPass = static_cast<ShadowmapPass*>(child.get());
-                shadowmapPass->SetViewportScissorFromImageSize(imageSize);
-            }
-        }
-
-        ShadowmapAtlas& CascadedShadowmapsPass::GetShadowmapAtlas()
-        {
-            return m_atlas;
-        }
-
-        void CascadedShadowmapsPass::BuildInternal()
-        {
-            UpdateChildren();
-
-            if (GetChildren().empty())
-            {
-                SetCascadesCount(1);
-            }
-
-            UpdateShadowmapImageSize();
-            Base::BuildInternal();
-        }
-
         void CascadedShadowmapsPass::GetPipelineViewTags(RPI::SortedPipelineViewTags& outTags) const
         {
-            for (size_t childIndex = 0; childIndex < m_numberOfCascades; ++childIndex)
+            for (size_t childIndex = 0; childIndex < m_numCascades; ++childIndex)
             {
                 outTags.insert(m_childrenPipelineViewTags[childIndex]);
             }
@@ -177,65 +168,6 @@ namespace AZ
                 outPassesByDrawList[m_drawListTag] = this;
                 outDrawListMask.set(m_drawListTag.GetIndex());
             }
-        }
-
-        RPI::Ptr<ShadowmapPass> CascadedShadowmapsPass::CreateChild(uint16_t cascadeIndex)
-        {
-            const AZStd::span<const RPI::PipelineViewTag> childrenViewTags = GetPipelineViewTags();
-            const Name passName{ AZStd::string::format("DirectionalLightShadowmapPass.%d", cascadeIndex) };
-
-            auto passData = AZStd::make_shared<RPI::RasterPassData>();
-            passData->m_drawListTag = m_drawListTagName;
-            passData->m_pipelineViewTag = childrenViewTags[cascadeIndex];            
-
-            auto pass = ShadowmapPass::CreateWithPassRequest(passName, passData);
-            pass->SetArraySlice(cascadeIndex);
-            return pass;
-        }
-
-        void CascadedShadowmapsPass::SetCascadesCount(uint16_t cascadesCount)
-        {
-            AZ_Assert(cascadesCount > 0, "The number of cascades must be positive.");
-
-            // Orphans unnecessary children.
-            while (GetChildren().size() > cascadesCount)
-            {
-                RemoveChild(GetChildren()[cascadesCount]);
-            }
-
-            // Creates new children.
-            const uint16_t oldCascadeCount = aznumeric_cast<uint16_t>(GetChildren().size());
-            for (uint16_t cascadeIndex = oldCascadeCount; cascadeIndex < cascadesCount; ++cascadeIndex)
-            {
-                RPI::Ptr<ShadowmapPass> child = CreateChild(cascadeIndex);
-                AZ_RPI_PASS_WARNING(child, "CascadedShadowmapsPass child Pass creation failed for %d", cascadeIndex);
-                if (child)
-                {
-                    child->QueueForBuildAndInitialization();
-                    AddChild(child);
-                }
-            }
-            m_numberOfCascades = cascadesCount;
-        }
-
-        void CascadedShadowmapsPass::UpdateShadowmapImageSize()
-        {
-            // [GFX TODO][ATOM-2470] stop caring about attachment
-            RPI::Ptr<RPI::PassAttachment> attachment = m_ownedAttachments.front();
-            if (!attachment)
-            {
-                AZ_Assert(false, "[CascadedShadowmapsPass %s] Cannot find shadowmap image attachment.", GetPathName().GetCStr());
-                return;
-            }
-            AZ_Assert(attachment->m_descriptor.m_type == RHI::AttachmentType::Image, "[CascadedShadowmapsPass %s] requires an image attachment", GetPathName().GetCStr());
-
-            RPI::PassAttachmentBinding& binding = GetOutputBinding(0);
-            binding.SetAttachment(attachment);
-
-            RHI::ImageDescriptor& imageDescriptor = attachment->m_descriptor.m_image;
-            const uint32_t shadowmapWidth = static_cast<uint32_t>(m_atlas.GetBaseShadowmapSize());
-            imageDescriptor.m_size = RHI::Size(shadowmapWidth, shadowmapWidth, 1);
-            imageDescriptor.m_arraySize = m_atlas.GetArraySliceCount();
         }
 
     } // namespace Render

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/CascadedShadowmapsPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/CascadedShadowmapsPass.h
@@ -39,10 +39,10 @@ namespace AZ
             const AZStd::span<const RPI::PipelineViewTag> GetPipelineViewTags();
 
             //! This exposes the shadowmap atlas.
-            ShadowmapAtlas& GetShadowmapAtlas();
+            ShadowmapAtlas& GetShadowmapAtlas() { return m_atlas; }
 
             //! This queues the image size and array size which will be updated in the beginning of the frame.
-            void QueueForUpdateShadowmapImageSize(ShadowmapSize shadowmapSize, uint32_t arraySize);
+            void SetShadowmapSize(ShadowmapSize shadowmapSize, u16 numCascades);
 
         private:
             CascadedShadowmapsPass() = delete;
@@ -53,11 +53,9 @@ namespace AZ
             void GetPipelineViewTags(RPI::SortedPipelineViewTags& outTags) const override;
             void GetViewDrawListInfo(RHI::DrawListMask& outDrawListMask, RPI::PassesByDrawList& outPassesByDrawList, const RPI::PipelineViewTag& viewTag) const override;
 
-            RPI::Ptr<ShadowmapPass> CreateChild(uint16_t cascadeIndex);
+            void CreateChildPassesInternal() override;
+            void CreateChildShadowMapPass(u16 cascadeIndex);
 
-            void UpdateChildren();
-
-            void SetCascadesCount(uint16_t cascadesCount);
             void UpdateShadowmapImageSize();
 
             const Name m_slotName{ "Shadowmap" };
@@ -73,13 +71,10 @@ namespace AZ
 
             // Generated pipeline view tags for the children (ShadowmapPass).
             AZStd::fixed_vector<RPI::PipelineViewTag, Shadow::MaxNumberOfCascades> m_childrenPipelineViewTags;
-            uint16_t m_numberOfCascades = 0;
+            u16 m_numCascades = 0;
 
             ShadowmapAtlas m_atlas;
-
             ShadowmapSize m_shadowmapSize = ShadowmapSize::None;
-            uint32_t m_arraySize = 1;
-            bool m_updateChildren = true;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -969,7 +969,7 @@ namespace AZ
             {
                 for (CascadedShadowmapsPass* pass : it.second)
                 {
-                    pass->QueueForUpdateShadowmapImageSize(ShadowmapSize::None, 1);
+                    pass->SetShadowmapSize(ShadowmapSize::None, 1);
                 }
             }
             for (const auto& it : m_esmShadowmapsPasses)
@@ -1139,7 +1139,7 @@ namespace AZ
             for (const auto& segmentIt : property.m_segments)
             {
                 DirectionalLightShadowData& shadowData = m_shadowData.at(segmentIt.first).GetData(handle.GetIndex());
-                const uint16_t numCascades = aznumeric_cast<uint16_t>(segmentIt.second.size());
+                const u16 numCascades = aznumeric_cast<u16>(segmentIt.second.size());
 
                 // [GFX TODO][ATOM-2012] shadow for multiple directional lights
                 if (handle == m_shadowingLightHandle && numCascades > 0)
@@ -1149,7 +1149,7 @@ namespace AZ
                     {
                         for (CascadedShadowmapsPass* pass : it.second)
                         {
-                            pass->QueueForUpdateShadowmapImageSize(shadowmapSize, numCascades);
+                            pass->SetShadowmapSize(shadowmapSize, numCascades);
                         }
                     }
                     for (const auto& it : m_esmShadowmapsPasses)

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ProjectedShadowmapsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ProjectedShadowmapsPass.cpp
@@ -25,6 +25,9 @@ namespace AZ
         ProjectedShadowmapsPass::ProjectedShadowmapsPass(const RPI::PassDescriptor& descriptor)
             : Base(descriptor)
         {
+            // Pass has it's own logic for managing children, forgo ParentPass logic
+            m_flags.m_createChildren = false;
+
             const RPI::RasterPassData* passData = RPI::PassUtils::GetPassData<RPI::RasterPassData>(descriptor);
             if (passData)
             {

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
@@ -13,7 +13,9 @@
 namespace AZ
 {
     namespace Render
-    {        
+    {
+        // --- Pass Creation ---
+
         RPI::Ptr<Render::ShadowmapPass> ShadowmapPass::Create(const RPI::PassDescriptor& descriptor)
         {
             return aznew ShadowmapPass(descriptor);
@@ -50,11 +52,6 @@ namespace AZ
             return Create(descriptor);
         }
 
-        void ShadowmapPass::SetArraySlice(uint16_t arraySlice)
-        {
-            m_arraySlice = arraySlice;
-        }
-
         void ShadowmapPass::CreatePassTemplate()
         {
             AZStd::shared_ptr<RPI::PassTemplate> m_childTemplate = AZStd::make_shared<RPI::PassTemplate>();
@@ -82,26 +79,7 @@ namespace AZ
             RPI::PassSystemInterface::Get()->AddPassTemplate(Name{ "ShadowmapPassTemplate" }, m_childTemplate);
         }
 
-        void ShadowmapPass::SetClearEnabled(bool enabled)
-        {
-            m_clearEnabled = enabled;
-        }
-
-        void ShadowmapPass::SetViewportScissorFromImageSize(const RHI::Size& imageSize)
-        {
-            const RHI::Viewport viewport(
-                0.f, imageSize.m_width * 1.f,
-                0.f, imageSize.m_height * 1.f);
-            const RHI::Scissor scissor(
-                0, 0, imageSize.m_width, imageSize.m_height);
-            SetViewportScissor(viewport, scissor);
-        }
-
-        void ShadowmapPass::SetViewportScissor(const RHI::Viewport& viewport, const RHI::Scissor& scissor)
-        {
-            m_viewportState = viewport;
-            m_scissorState = scissor;
-        }
+        // --- Build Override ---
 
         void ShadowmapPass::BuildInternal()
         {
@@ -134,5 +112,33 @@ namespace AZ
             Base::BuildInternal();
         }
 
-      } // namespace Render
+        // --- Setters ---
+
+        void ShadowmapPass::SetArraySlice(uint16_t arraySlice)
+        {
+            m_arraySlice = arraySlice;
+        }
+
+        void ShadowmapPass::SetClearEnabled(bool enabled)
+        {
+            m_clearEnabled = enabled;
+        }
+
+        void ShadowmapPass::SetViewportScissorFromImageSize(const RHI::Size& imageSize)
+        {
+            const RHI::Viewport viewport(
+                0.f, imageSize.m_width * 1.f,
+                0.f, imageSize.m_height * 1.f);
+            const RHI::Scissor scissor(
+                0, 0, imageSize.m_width, imageSize.m_height);
+            SetViewportScissor(viewport, scissor);
+        }
+
+        void ShadowmapPass::SetViewportScissor(const RHI::Viewport& viewport, const RHI::Scissor& scissor)
+        {
+            m_viewportState = viewport;
+            m_scissorState = scissor;
+        }
+
+    } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -85,6 +85,7 @@ namespace AZ
 
         Pass::~Pass()
         {
+            AZ_RPI_BREAK_ON_TARGET_PASS;
             PassSystemInterface::Get()->UnregisterPass(this);
         }
 
@@ -138,25 +139,25 @@ namespace AZ
 
         void Pass::OnHierarchyChange()
         {
-            if (m_parent == nullptr)
+            if (m_parent != nullptr)
             {
-                return;
-            }
+                // Set new tree depth and path
+                m_flags.m_parentEnabled = m_parent->m_flags.m_enabled && (m_parent->m_flags.m_parentEnabled || m_parent->m_parent == nullptr);
+                m_treeDepth = m_parent->m_treeDepth + 1;
+                m_path = ConcatPassName(m_parent->m_path, m_name);
+                m_flags.m_partOfHierarchy = m_parent->m_flags.m_partOfHierarchy;
 
-            // Set new tree depth and path
-            m_flags.m_parentEnabled = m_parent->m_flags.m_enabled && (m_parent->m_flags.m_parentEnabled || m_parent->m_parent == nullptr);
-            m_treeDepth = m_parent->m_treeDepth + 1;
-            m_path = ConcatPassName(m_parent->m_path, m_name);
-            m_flags.m_partOfHierarchy = m_parent->m_flags.m_partOfHierarchy;
-
-            if (m_state == PassState::Orphaned)
-            {
-                QueueForBuildAndInitialization();
+                if (m_state == PassState::Orphaned)
+                {
+                    QueueForBuildAndInitialization();
+                }
             }
+            AZ_RPI_BREAK_ON_TARGET_PASS;
         }
 
         void Pass::RemoveFromParent()
         {
+            AZ_RPI_BREAK_ON_TARGET_PASS;
             AZ_RPI_PASS_ASSERT(m_parent != nullptr, "Trying to remove pass from parent but pointer to the parent pass is null.");
             m_parent->RemoveChild(Ptr<Pass>(this));
             m_queueState = PassQueueState::NoQueue;
@@ -165,6 +166,7 @@ namespace AZ
 
         void Pass::OnOrphan()
         {
+            AZ_RPI_BREAK_ON_TARGET_PASS;
             if (m_flags.m_containsGlobalReference && m_pipeline != nullptr)
             {
                 m_pipeline->RemovePipelineGlobalConnectionsFromPass(this);
@@ -1118,6 +1120,8 @@ namespace AZ
 
         void Pass::Reset()
         {
+            AZ_RPI_BREAK_ON_TARGET_PASS;
+
             // Ensure we're in a valid state to reset. This ensures the pass won't be reset multiple times in the same frame.
             bool execute = (m_state == PassState::Idle);
             execute = execute || (m_state == PassState::Queued && m_queueState == PassQueueState::QueuedForBuildAndInitialization);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -53,7 +53,7 @@ namespace AZ
         RHI::RenderAttachmentConfiguration RenderPass::GetRenderAttachmentConfiguration() const
         {
             RHI::RenderAttachmentLayoutBuilder builder;
-            auto* pass = builder.AddSubpass();
+            auto* layoutBuilder = builder.AddSubpass();
 
             for (size_t slotIndex = 0; slotIndex < m_attachmentBindings.size(); ++slotIndex)
             {
@@ -67,7 +67,7 @@ namespace AZ
                 // Handle the depth-stencil attachment. There should be only one.
                 if (binding.m_scopeAttachmentUsage == RHI::ScopeAttachmentUsage::DepthStencil)
                 {
-                    pass->DepthStencilAttachment(binding.GetAttachment()->m_descriptor.m_image.m_format);
+                    layoutBuilder->DepthStencilAttachment(binding.GetAttachment()->m_descriptor.m_image.m_format);
                     continue;
                 }
 
@@ -80,7 +80,7 @@ namespace AZ
                 if (binding.m_scopeAttachmentUsage == RHI::ScopeAttachmentUsage::RenderTarget)
                 {
                     RHI::Format format = binding.GetAttachment()->m_descriptor.m_image.m_format;
-                    pass->RenderTargetAttachment(format);
+                    layoutBuilder->RenderTargetAttachment(format);
                 }
             }
 


### PR DESCRIPTION
The cascade shadowmap pass was creating and managing it's children in a very weird and dangerous way. Changed it to be a bit more streamlined and use the CreatePassesInternal function instead. Also changed some naming around shadow passes because
`Root.Pipeline1.ShadowPass.EsmShadowmapsPassDirectional.DirectionalLightShadowmapPass.0`
Is incredibly long and
`Root.Pipeline1.Shadows.CascadesESM.0`
Is just so much better.
Also added Errors to ParentPass to catch when passes are added/removed outside of the removal/build phases.

Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>