### PR TITLE
feat(EmotionFX): add rotation manipulator for RotationParameter

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/RotationParameterEditor.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/RotationParameterEditor.cpp
@@ -13,10 +13,10 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/Viewport/ViewportColors.h>
 #include <AzToolsFramework/Viewport/ViewportSettings.h>
+#include <EMotionFX/Source/ActorManager.h>
 #include <EMotionFX/Source/Parameter/RotationParameter.h>
 #include <EMotionStudio/EMStudioSDK/Source/Allocators.h>
 #include <EMotionStudio/EMStudioSDK/Source/EMStudioManager.h>
-#include <EMotionFX/Source/ActorManager.h>
 #include <MCore/Source/AttributeQuaternion.h>
 
 #include <QPushButton>
@@ -25,7 +25,10 @@ namespace EMStudio
 {
     AZ_CLASS_ALLOCATOR_IMPL(RotationParameterEditor, EMStudio::UIAllocator, 0)
 
-    RotationParameterEditor::RotationParameterEditor(EMotionFX::AnimGraph* animGraph, const EMotionFX::ValueParameter* valueParameter, const AZStd::vector<MCore::Attribute*>& attributes)
+    RotationParameterEditor::RotationParameterEditor(
+        EMotionFX::AnimGraph* animGraph,
+        const EMotionFX::ValueParameter* valueParameter,
+        const AZStd::vector<MCore::Attribute*>& attributes)
         : ValueParameterEditor(animGraph, valueParameter, attributes)
         , m_currentValue(AZ::Quaternion::CreateIdentity())
         , m_gizmoButton(nullptr)
@@ -36,7 +39,8 @@ namespace EMStudio
 
     RotationParameterEditor::~RotationParameterEditor()
     {
-        if(m_rotationManipulator.Registered()) {
+        if (m_rotationManipulator.Registered())
+        {
             m_rotationManipulator.Unregister();
             AZ::TickBus::Handler::BusDisconnect();
         }
@@ -50,10 +54,8 @@ namespace EMStudio
             return;
         }
 
-        serializeContext->Class<RotationParameterEditor, ValueParameterEditor>()
-            ->Version(1)
-            ->Field("value", &RotationParameterEditor::m_currentValue)
-        ;
+        serializeContext->Class<RotationParameterEditor, ValueParameterEditor>()->Version(1)->Field(
+            "value", &RotationParameterEditor::m_currentValue);
 
         AZ::EditContext* editContext = serializeContext->GetEditContext();
         if (!editContext)
@@ -63,15 +65,14 @@ namespace EMStudio
 
         editContext->Class<RotationParameterEditor>("Rotation parameter editor", "")
             ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+            ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+            ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
             ->DataElement(AZ::Edit::UIHandlers::Default, &RotationParameterEditor::m_currentValue, "", "")
-                ->Attribute(AZ::Edit::Attributes::DescriptionTextOverride, &ValueParameterEditor::GetDescription)
-                ->Attribute(AZ::Edit::Attributes::Min, &RotationParameterEditor::GetMinValue)
-                ->Attribute(AZ::Edit::Attributes::Max, &RotationParameterEditor::GetMaxValue)
-                ->Attribute(AZ::Edit::Attributes::ChangeNotify, &RotationParameterEditor::OnValueChanged)
-                ->Attribute(AZ::Edit::Attributes::ReadOnly, &ValueParameterEditor::IsReadOnly)
-        ;
+            ->Attribute(AZ::Edit::Attributes::DescriptionTextOverride, &ValueParameterEditor::GetDescription)
+            ->Attribute(AZ::Edit::Attributes::Min, &RotationParameterEditor::GetMinValue)
+            ->Attribute(AZ::Edit::Attributes::Max, &RotationParameterEditor::GetMaxValue)
+            ->Attribute(AZ::Edit::Attributes::ChangeNotify, &RotationParameterEditor::OnValueChanged)
+            ->Attribute(AZ::Edit::Attributes::ReadOnly, &ValueParameterEditor::IsReadOnly);
     }
 
     void RotationParameterEditor::UpdateValue()
@@ -102,8 +103,15 @@ namespace EMStudio
     QWidget* RotationParameterEditor::CreateGizmoWidget(const AZStd::function<void()>& manipulatorCallback)
     {
         m_gizmoButton = new QPushButton();
-        EMStudioManager::MakeTransparentButton(m_gizmoButton, "Images/Icons/Vector3GizmoDisabled.png", "Show/Hide translation gizmo for visual manipulation");
-        QObject::connect(m_gizmoButton, &QPushButton::clicked, [this]() { ToggleTranslationGizmo(); });
+        EMStudioManager::MakeTransparentButton(
+            m_gizmoButton, "Images/Icons/Vector3GizmoDisabled.png", "Show/Hide translation gizmo for visual manipulation");
+        QObject::connect(
+            m_gizmoButton,
+            &QPushButton::clicked,
+            [this]()
+            {
+                ToggleTranslationGizmo();
+            });
         m_gizmoButton->setCheckable(true);
         m_gizmoButton->setEnabled(!IsReadOnly());
         m_manipulatorCallback = manipulatorCallback;
@@ -111,16 +119,19 @@ namespace EMStudio
         m_rotationManipulator.SetCircleBoundWidth(AzToolsFramework::ManipulatorCicleBoundWidth());
         m_rotationManipulator.SetLocalAxes(AZ::Vector3::CreateAxisX(), AZ::Vector3::CreateAxisY(), AZ::Vector3::CreateAxisZ());
         m_rotationManipulator.ConfigureView(
-            AzToolsFramework::RotationManipulatorRadius(), AzFramework::ViewportColors::XAxisColor, AzFramework::ViewportColors::YAxisColor,
+            AzToolsFramework::RotationManipulatorRadius(),
+            AzFramework::ViewportColors::XAxisColor,
+            AzFramework::ViewportColors::YAxisColor,
             AzFramework::ViewportColors::ZAxisColor);
-        m_rotationManipulator.InstallMouseMoveCallback([this](
-             const AzToolsFramework::AngularManipulator::Action& action
-        ) {
-            SetValue(action.LocalOrientation());
-            if(m_manipulatorCallback) {
-                m_manipulatorCallback();
-            }
-        });
+        m_rotationManipulator.InstallMouseMoveCallback(
+            [this](const AzToolsFramework::AngularManipulator::Action& action)
+            {
+                SetValue(action.LocalOrientation());
+                if (m_manipulatorCallback)
+                {
+                    m_manipulatorCallback();
+                }
+            });
 
         return m_gizmoButton;
     }
@@ -172,11 +183,13 @@ namespace EMStudio
     {
         if (m_gizmoButton->isChecked())
         {
-            EMStudioManager::MakeTransparentButton(m_gizmoButton, "Images/Icons/Vector3Gizmo.svg", "Show/Hide translation gizmo for visual manipulation");
+            EMStudioManager::MakeTransparentButton(
+                m_gizmoButton, "Images/Icons/Vector3Gizmo.svg", "Show/Hide translation gizmo for visual manipulation");
         }
         else
         {
-            EMStudioManager::MakeTransparentButton(m_gizmoButton, "Images/Icons/Vector3GizmoDisabled.png", "Show/Hide translation gizmo for visual manipulation");
+            EMStudioManager::MakeTransparentButton(
+                m_gizmoButton, "Images/Icons/Vector3GizmoDisabled.png", "Show/Hide translation gizmo for visual manipulation");
         }
 
         if (m_rotationManipulator.Registered())
@@ -190,4 +203,4 @@ namespace EMStudio
             m_rotationManipulator.Register(g_animManipulatorManagerId);
         }
     }
-}
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/RotationParameterEditor.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/RotationParameterEditor.cpp
@@ -154,7 +154,7 @@ namespace EMStudio
         return parameter->GetMaxValue();
     }
 
-    void RotationParameterEditor::OnTick(float delta, AZ::ScriptTimePoint timePoint)
+    void RotationParameterEditor::OnTick([[maybe_unused]] float delta, [[maybe_unused]] AZ::ScriptTimePoint timePoint)
     {
         EMotionFX::ActorInstance* selectedActorInstance = EMotionFX::GetActorManager().GetFirstEditorActorInstance();
         if (selectedActorInstance)

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/RotationParameterEditor.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/RotationParameterEditor.h
@@ -8,14 +8,11 @@
 
 #pragma once
 
-#include "ValueParameterEditor.h"
 #include <AzCore/Math/Quaternion.h>
-#include <QPushButton>
+#include <AzToolsFramework/Manipulators/RotationManipulators.h>
+#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/ValueParameterEditor.h>
 
-namespace MCommon
-{
-    class RotateManipulator;
-}
+class QPushButton;
 
 namespace EMStudio
 {
@@ -58,7 +55,7 @@ namespace EMStudio
         AZ::Quaternion m_currentValue;
 
         QPushButton* m_gizmoButton;
-        MCommon::RotateManipulator* m_transformationGizmo;
+        AzToolsFramework::RotationManipulators m_rotationManipulator;
         AZStd::function<void()> m_manipulatorCallback;
     };
 }

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/RotationParameterEditor.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/RotationParameterEditor.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Component/TickBus.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzToolsFramework/Manipulators/RotationManipulators.h>
 #include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/ValueParameterEditor.h>
@@ -18,6 +19,7 @@ namespace EMStudio
 {
     class RotationParameterEditor
         : public ValueParameterEditor
+        , private AZ::TickBus::Handler
     {
     public:
         AZ_RTTI(RotationParameterEditor, "{55C122A9-AA80-49FB-8663-2113C7AC97C0}", ValueParameterEditor)
@@ -45,6 +47,9 @@ namespace EMStudio
         AZ::Quaternion GetCurrentValue() const { return m_currentValue; }
 
     private:
+        // AZ::TickBus::Handler overrides ...
+        void OnTick(float delta, AZ::ScriptTimePoint timePoint) override;
+
         void OnValueChanged();
 
         AZ::Quaternion GetMinValue() const;


### PR DESCRIPTION
one thing to note is how is this going to be used in practice seems kind of inconvenient to have the manipulator sit at 0,0,0? I would imagine this following the position of another parameter or parenting this to an existing bone. 

- add RotationManipulator for atom viewport
- remove MCore RotateManipulator
- fixed include paths 

https://user-images.githubusercontent.com/854359/174221449-6af8f018-adc9-42dd-97da-035753e48588.mp4


Signed-off-by: Michael Pollind <mpollind@gmail.com>