### PR TITLE
feat(EMotionFX): improve functionality rotation manipulator by following orientation of target

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.cpp
@@ -192,14 +192,16 @@ namespace EMStudio
             {
                 const AZ::EntityId entityId = m_animViewportWidget->GetAnimViewportRenderer()->GetEntityId();
                 AZ::TransformBus::EventResult(m_mouseDownStartTransform, entityId, &AZ::TransformBus::Events::GetLocalTM);
+                m_rotateManipulators.SetLocalOrientation(m_mouseDownStartTransform.GetRotation());
             });
 
         m_rotateManipulators.InstallMouseMoveCallback(
             [this](const AzToolsFramework::AngularManipulator::Action& action)
             {
                 const AZ::EntityId entityId = m_animViewportWidget->GetAnimViewportRenderer()->GetEntityId();
-                AZ::TransformBus::Event(entityId, &AZ::TransformBus::Events::SetLocalRotationQuaternion,
-                    m_mouseDownStartTransform.GetRotation() * action.m_current.m_delta);
+                AZ::Quaternion localRotation = m_mouseDownStartTransform.GetRotation() * action.m_current.m_delta;
+                AZ::TransformBus::Event(entityId, &AZ::TransformBus::Events::SetLocalRotationQuaternion, localRotation);
+                m_rotateManipulators.SetLocalOrientation(localRotation);
             });
 
         // Setup the scale manipulator


### PR DESCRIPTION
The rotation manipulator was fixed in place making it hard to determine how the target object was oriented. This change makes the rotation manipulator follow the orientation of the target.

https://user-images.githubusercontent.com/854359/174224361-7e2e0063-6553-461e-b553-7bfe8488c43c.mp4


Signed-off-by: Michael Pollind <mpollind@gmail.com>
