### PR TITLE
Added support for automatically registering enums with edit context

### DIFF
--- a/Code/Framework/AzCore/AzCore/Preprocessor/Enum.h
+++ b/Code/Framework/AzCore/AzCore/Preprocessor/Enum.h
@@ -264,8 +264,6 @@ inline namespace AZ_JOIN(EnumTypeName, Namespace) \
     } \
 } \
 \
-template< typename T > struct AzEnumTraits; \
-\
 template<> \
 struct AzEnumTraits< AZ_JOIN(EnumTypeName, Namespace)::EnumTypeName > \
 { \
@@ -273,4 +271,6 @@ struct AzEnumTraits< AZ_JOIN(EnumTypeName, Namespace)::EnumTypeName > \
     inline static constexpr MembersArrayType& Members   = AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Members); \
     inline static constexpr size_t Count                = AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Count); \
     inline static constexpr AZStd::string_view EnumName = AZ_STRINGIZE(EnumTypeName); \
-}; 
+};
+
+template<typename T> struct AzEnumTraits;

--- a/Code/Framework/AzCore/AzCore/Preprocessor/Enum.h
+++ b/Code/Framework/AzCore/AzCore/Preprocessor/Enum.h
@@ -264,13 +264,47 @@ inline namespace AZ_JOIN(EnumTypeName, Namespace) \
     } \
 } \
 \
-template<> \
-struct AzEnumTraits< AZ_JOIN(EnumTypeName, Namespace)::EnumTypeName > \
-{ \
-    using MembersArrayType                              = decltype( AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Members) ); \
-    inline static constexpr MembersArrayType& Members   = AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Members); \
-    inline static constexpr size_t Count                = AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Count); \
-    inline static constexpr AZStd::string_view EnumName = AZ_STRINGIZE(EnumTypeName); \
-};
+    struct AZ_JOIN(EnumTypeName, EnumTraits)                                                                                               \
+    {                                                                                                                                      \
+        using MembersArrayType = decltype(AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Members));                               \
+        inline static constexpr MembersArrayType& Members = AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Members);              \
+        inline static constexpr size_t Count = AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Count);                             \
+        inline static constexpr AZStd::string_view EnumName = AZ_STRINGIZE(EnumTypeName);                                                  \
+        /* Visitor must accept a type convertible from EnumTypeName as the first parameter and an AZStd::string_view as the second */      \
+        template<class Visitor>                                                                                                            \
+        static constexpr void Visit(Visitor&& enumVisitor)                                                                                 \
+        {                                                                                                                                  \
+            for (const auto& member : Members)                                                                                             \
+            {                                                                                                                              \
+                enumVisitor(member.m_value, member.m_string);                                                                              \
+            }                                                                                                                              \
+        }                                                                                                                                  \
+    };                                                                                                                                     \
+                                                                                                                                           \
+    inline auto GetAzEnumTraits(AZ_JOIN(EnumTypeName, Namespace)::EnumTypeName)                                                            \
+    {                                                                                                                                      \
+        return AZ_JOIN(EnumTypeName, EnumTraits){};                                                                                        \
+    };
 
-template<typename T> struct AzEnumTraits;
+namespace AZ::Internal
+{
+    // Deleted function to provide the AZ::Internal namespace with the GetAzEnumTraits symbol
+    // This is to make an overload which the AzEnumTraitsImpl would use with its
+    // template parameter to use Argument Dependent Lookup to find the GetAzEnumTraits
+    // function for the Enum Type in the correct namespace.
+    template<typename T>
+    void GetAzEnumTraits(T&&) = delete;
+    template<typename T>
+    struct AzEnumTraitsImpl
+    {
+        // The AZ_ENUM macros contrive a function which returns a struct
+        // with the enum traits within it
+        // We use decltype here to get the type of that function
+        using type = decltype(GetAzEnumTraits(AZStd::declval<T>()));
+    };
+} // namespace AZ::Internal
+namespace AZ
+{
+    template<typename T>
+    using AzEnumTraits = typename Internal::AzEnumTraitsImpl<T>::type;
+}

--- a/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
+++ b/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
@@ -20,7 +20,7 @@
     static void AZ_JOIN(EnumTypeName, Reflect)(AZ::SerializeContext& context)                                                                           \
     {                                                                                                                                                   \
         auto enumMaker = context.Enum<EnumTypeName>();                                                                                                  \
-        for (auto&& member : AzEnumTraits<EnumTypeName>::Members)                                                                                       \
+        for (auto&& member : AZ::AzEnumTraits<EnumTypeName>::Members)                                                                                       \
         {                                                                                                                                               \
             enumMaker.Value(member.m_string.data(), member.m_value);                                                                                    \
         }                                                                                                                                               \
@@ -31,9 +31,9 @@
     {                                                                                                                                                   \
         if (typeName.empty())                                                                                                                           \
         {                                                                                                                                               \
-            typeName = AzEnumTraits<EnumTypeName>::EnumName;                                                                                            \
+            typeName = AZ::AzEnumTraits<EnumTypeName>::EnumName;                                                                                            \
         }                                                                                                                                               \
-        constexpr auto& enumValueStringPair = AzEnumTraits<EnumTypeName>::Members[Index];                                                               \
+        constexpr auto& enumValueStringPair = AZ::AzEnumTraits<EnumTypeName>::Members[Index];                                                               \
         auto qualifiedEnumName = AZStd::fixed_string<256>::format("%.*s_%.*s", AZ_STRING_ARG(typeName), AZ_STRING_ARG(enumValueStringPair.m_string));   \
         context.Enum<aznumeric_cast<int>(enumValueStringPair.m_value)>(qualifiedEnumName.c_str());                                                      \
     }                                                                                                                                                   \
@@ -46,6 +46,6 @@
                                                                                                                                                         \
     void AZ_JOIN(EnumTypeName, Reflect)(AZ::BehaviorContext& context, AZStd::string_view typeName = {})                                                 \
     {                                                                                                                                                   \
-        AZ_JOIN(EnumTypeName, ReflectValues)(context, typeName, AZStd::make_index_sequence<AzEnumTraits<EnumTypeName>::Members.size()>());              \
-    }
+        AZ_JOIN(EnumTypeName, ReflectValues)(context, typeName, AZStd::make_index_sequence<AZ::AzEnumTraits<EnumTypeName>::Members.size()>());              \
+    }                                                                                                                                                   
 

--- a/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
+++ b/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <AzCore/Preprocessor/Enum.h>
-#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/string/fixed_string.h>
+
 
 //! Call this macro in the same namespace where the AZ_ENUM was defined to generate ReflectEnumType() utility functions.
 //! @param EnumTypeName an enum that was defined using one of the AZ_ENUM macros.
@@ -47,14 +47,5 @@
     void AZ_JOIN(EnumTypeName, Reflect)(AZ::BehaviorContext& context, AZStd::string_view typeName = {})                                                 \
     {                                                                                                                                                   \
         AZ_JOIN(EnumTypeName, ReflectValues)(context, typeName, AZStd::make_index_sequence<AzEnumTraits<EnumTypeName>::Members.size()>());              \
-    }                                                                                                                                                   \
-                                                                                                                                                        \
-    AZStd::vector<AZ::Edit::EnumConstant<uint32_t>> AZ_JOIN(EnumTypeName, EditEnumConstants)()                                                          \
-    {                                                                                                                                                   \
-        AZStd::vector<AZ::Edit::EnumConstant<uint32_t>> enumValues;                                                                                     \
-        for (const auto& member : AzEnumTraits<EnumTypeName>::Members)                                                                                  \
-        {                                                                                                                                               \
-            enumValues.emplace_back(aznumeric_cast<uint32_t>(member.m_value), member.m_string.data());                                                  \
-        }                                                                                                                                               \
-        return enumValues;                                                                                                                              \
-    }                                                                                                                                                   \
+    }
+

--- a/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
+++ b/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <AzCore/Preprocessor/Enum.h>
+#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/string/fixed_string.h>
-
 
 //! Call this macro in the same namespace where the AZ_ENUM was defined to generate ReflectEnumType() utility functions.
 //! @param EnumTypeName an enum that was defined using one of the AZ_ENUM macros.
@@ -47,5 +47,14 @@
     void AZ_JOIN(EnumTypeName, Reflect)(AZ::BehaviorContext& context, AZStd::string_view typeName = {})                                                 \
     {                                                                                                                                                   \
         AZ_JOIN(EnumTypeName, ReflectValues)(context, typeName, AZStd::make_index_sequence<AzEnumTraits<EnumTypeName>::Members.size()>());              \
-    }                                                                                                                                                   
-
+    }                                                                                                                                                   \
+                                                                                                                                                        \
+    AZStd::vector<AZ::Edit::EnumConstant<uint32_t>> AZ_JOIN(EnumTypeName, EditEnumConstants)()                                                          \
+    {                                                                                                                                                   \
+        AZStd::vector<AZ::Edit::EnumConstant<uint32_t>> enumValues;                                                                                     \
+        for (const auto& member : AzEnumTraits<EnumTypeName>::Members)                                                                                  \
+        {                                                                                                                                               \
+            enumValues.emplace_back(aznumeric_cast<uint32_t>(member.m_value), member.m_string.data());                                                  \
+        }                                                                                                                                               \
+        return enumValues;                                                                                                                              \
+    }                                                                                                                                                   \

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
@@ -840,7 +840,7 @@ namespace AZ
         AZStd::vector<EnumConstant<UnderlyingType>> GetEnumConstantsFromTraits()
         {
             AZStd::vector<EnumConstant<UnderlyingType>> enumValues;
-            for (const auto& member : AzEnumTraits<EnumType>::Members)
+            for (const auto& member : AZ::AzEnumTraits<EnumType>::Members)
             {
                 enumValues.emplace_back(aznumeric_cast<UnderlyingType>(member.m_value), member.m_string.data());
             }

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Preprocessor/Enum.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/typetraits/is_function.h>
 
@@ -833,6 +834,18 @@ namespace AZ
             UnderlyingType m_value;
             AZStd::string m_description;
         };
+
+        // Automatically generate a list of EnumConstant from AzEnumTraits
+        template<typename EnumType, typename UnderlyingType = AZStd::underlying_type_t<EnumType>>
+        AZStd::vector<EnumConstant<UnderlyingType>> GetEnumConstantsFromTraits()
+        {
+            AZStd::vector<EnumConstant<UnderlyingType>> enumValues;
+            for (const auto& member : AzEnumTraits<EnumType>::Members)
+            {
+                enumValues.emplace_back(aznumeric_cast<UnderlyingType>(member.m_value), member.m_string.data());
+            }
+            return enumValues;
+        }
     } // namespace Edit
 
     //=========================================================================

--- a/Code/Framework/AzCore/Tests/EnumTests.cpp
+++ b/Code/Framework/AzCore/Tests/EnumTests.cpp
@@ -133,7 +133,7 @@ namespace UnitTest
 
     TEST_F(EnumTests, TraitsBehaviorRegular)
     {
-        static_assert(AzEnumTraits<TestEnum>::Members.size() == 26);
+        static_assert(AZ::AzEnumTraits<TestEnum>::Members.size() == 26);
     }
 
 }


### PR DESCRIPTION
Currently in the process of reflecting several material and shader related structs that use enums extensively. The same enum is used multiple times throughout some of the structs.

This utility function removes the boilerplate of adding all of the values manually for every data element.

Intended usage example
```
->DataElement(AZ::Edit::UIHandlers::Default, &StencilOpState::m_failOp, "Fail Op", "")
    ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<StencilOp>())
->DataElement(AZ::Edit::UIHandlers::Default, &StencilOpState::m_depthFailOp, "Depth Fail Op", "")
    ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<StencilOp>())
->DataElement(AZ::Edit::UIHandlers::Default, &StencilOpState::m_passOp, "Pass Op", "")
    ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<StencilOp>())

```

Signed-off-by: Guthrie Adams <guthadam@amazon.com>