### PR TITLE
Fix bug on FileServer converting QString to const char*

### DIFF
--- a/Code/Tools/AssetProcessor/native/FileServer/fileServer.cpp
+++ b/Code/Tools/AssetProcessor/native/FileServer/fileServer.cpp
@@ -102,7 +102,7 @@ void FileServer::ConnectionAdded(unsigned int connId, Connection* connection)
             if ((fileIO) && (!connection->AssetPlatforms().isEmpty())) // when someone disconnects, the asset platform may be cleared before disconnect is set.
             {
                 QDir projectCacheRoot;
-                // Because the platform based aliases below can only be one platform at at a time we need to prefer a single platform in case multiple listening platforms
+                // Because the platform based aliases below can only be one platform at a time we need to prefer a single platform in case multiple listening platforms
                 // exist on the same connection
                 QString assetPlatform = connection->AssetPlatforms().first();
                 if (!AssetUtilities::ComputeProjectCacheRoot(projectCacheRoot))
@@ -113,8 +113,8 @@ void FileServer::ConnectionAdded(unsigned int connId, Connection* connection)
                 {
                     projectCacheRoot = QDir(projectCacheRoot.absoluteFilePath(assetPlatform));
                 }
-                const char* projectCachePath = projectCacheRoot.absolutePath().toUtf8().data();
-                fileIO->SetAlias("@products@", projectCachePath);
+
+                fileIO->SetAlias("@products@", projectCacheRoot.absolutePath().toUtf8().data());
 
                 if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
                 {

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewUndo.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewUndo.cpp
@@ -608,7 +608,7 @@ void CUndoTrackEventRemove::Undo(bool bUndo)
 
         keyHandle.GetKey(&eventKey);
         // re-set the eventKey with the m_eventName
-        eventKey.event = rawName.c_str();
+        eventKey.event = rawName;
         keyHandle.SetKey(&eventKey);
     }
 }

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewUndo.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewUndo.cpp
@@ -596,9 +596,9 @@ CUndoTrackEventRemove::CUndoTrackEventRemove(CUiAnimViewSequence* pSequence, con
 void CUndoTrackEventRemove::Undo(bool bUndo)
 {
     AZ_UNUSED(bUndo);
-    const char* rawName = m_eventName.toUtf8().data();
+    const AZStd::string rawName = m_eventName.toUtf8().data();
 
-    m_pSequence->AddTrackEvent(rawName);
+    m_pSequence->AddTrackEvent(rawName.c_str());
 
     const uint numKeys = m_changedKeys.GetKeyCount();
     for (uint keyIndex = 0; keyIndex < numKeys; ++keyIndex)
@@ -608,7 +608,7 @@ void CUndoTrackEventRemove::Undo(bool bUndo)
 
         keyHandle.GetKey(&eventKey);
         // re-set the eventKey with the m_eventName
-        eventKey.event = rawName;
+        eventKey.event = rawName.c_str();
         keyHandle.SetKey(&eventKey);
     }
 }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/EBusNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/EBusNodePaletteTreeItemTypes.cpp
@@ -147,8 +147,7 @@ namespace ScriptCanvasEditor
         AZ::BehaviorContext* behaviorContext{};
         AZ::ComponentApplicationBus::BroadcastResult(behaviorContext, &AZ::ComponentApplicationRequests::GetBehaviorContext);
 
-        const char* ebusName = m_busName.toUtf8().data();
-        auto behaviorEbus = behaviorContext->m_ebuses.find(ebusName);
+        auto behaviorEbus = behaviorContext->m_ebuses.find(m_busName.toUtf8().data());
 
         ScriptCanvasEditorTools::TranslationGeneration translation;
         translation.TranslateEBus(behaviorEbus->second);

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
@@ -134,7 +134,7 @@ namespace ScriptCanvasEditor
         AZ::BehaviorContext* behaviorContext{};
         AZ::ComponentApplicationBus::BroadcastResult(behaviorContext, &AZ::ComponentApplicationRequests::GetBehaviorContext);
 
-        const char* className = m_className.toUtf8().data();
+        const AZStd::string className = GetClassMethodName();
         if (behaviorContext->m_classes.contains(className))
         {
             auto behaviorClass = behaviorContext->m_classes.find(className);


### PR DESCRIPTION
`toUtf8()` returns an object which will be destroyed as soon a the call finishes. By assigning its data to a `const char*` it keeps a reference to a deleted object. Fixed by passing it as parameter to the function, that way the data will be valid until the function finishes.

Signed-off-by: moraaar <moraaar@amazon.com>