### PR TITLE
Fix possible race condition with BuildKdTree().

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelAsset.cpp
@@ -134,7 +134,7 @@ namespace AZ
         void ModelAsset::BuildKdTree() const
         {
             AZStd::lock_guard<AZStd::mutex> lock(m_kdTreeLock);
-            if (m_isKdTreeCalculationRunning == false)
+            if ((m_isKdTreeCalculationRunning == false) && !m_kdTree)
             {
                 m_isKdTreeCalculationRunning = true;
 


### PR DESCRIPTION
A recent test failure contained the following assert:
[2022-06-17T08:41:29.792Z] E   [editor_test.log]  <08:40:21> (System) - Trace::Assert
[2022-06-17T08:41:29.792Z] E   [editor_test.log]   D:\workspace\o3de\Code\Framework\AzCore\AzCore/std/containers/vector.h(582): (15200) 'const struct AZ::RPI::ModelKdTree::MeshData &__cdecl AZStd::vector<struct AZ::RPI::ModelKdTree::MeshData,class AZStd::allocator>::operator [](unsigned __int64) const'
[2022-06-17T08:41:29.792Z] E   [editor_test.log]  <08:40:21> (System) - AZStd::vector<>::at - position is out of range
[2022-06-17T08:41:29.799Z] E   [editor_test.log]  <08:40:24> (System) - D:\workspace\o3de\Gems\Atom\RPI\Code\Source\RPI.Reflect\Model\ModelKdTree.cpp (265) : AZ::RPI::ModelKdTree::RayIntersectionRecursively

The line of code that's asserting is the following:
                    const AZStd::span<const float> positionBuffer = m_meshes[nObjIndex].m_vertexData;

For this to assert, it seems likely that m_meshes is getting modified in one thread while getting read in a different thread.  The m_meshes member gets modified in ModelKdTree::Build().

The code that triggers this looks like the following:
 if (!m_kdTree)
             AZStd::lock_guard<AZStd::mutex> lock(m_kdTreeLock);
            if (m_isKdTreeCalculationRunning == false)

A separate thread does the following:
                    AZStd::lock_guard<AZStd::mutex> jobLock(m_kdTreeLock);
                    m_isKdTreeCalculationRunning = false;
                    m_kdTree = AZStd::move(tree);

There's a potential race condition here where m_kdTree can be false, causing the code to advance to the lock. If the other thread is running, sets isRunning to false and sets m_kdTree, the first thread can unlock and try to construct m_kdTree a second time, and it will also start to allow queries against m_kdTree because it's no longer null.

The fix is to check m_kdTree for null inside the lock, so that way it isn't constructed a second time.

I'm not positive this fixes the actual test failure, since it's not reliably reproducible, but it seems like a likely culprit.

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>