### PR TITLE
SerializeContextTools: `dumptypes` and `createtype` command 

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
@@ -9,11 +9,8 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
 
     set(SMOKETEST_FILTER "SUITE_smoke and not SerializeContext")
 
-    include(${LY_ROOT_FOLDER}/Code/Tools/SerializeContextTools/Platform/${PAL_PLATFORM_NAME}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
-    if (PAL_TRAIT_BUILD_SERIALIZECONTEXTTOOLS)
-        list(APPEND additional_dependencies AZ::SerializeContextTools) # test_CLITool_SerializeContextTools depends on it
-        set(SMOKETEST_FILTER "SUITE_smoke")
-    endif()
+    list(APPEND additional_dependencies AZ::SerializeContextTools) # test_CLITool_SerializeContextTools depends on it
+    set(SMOKETEST_FILTER "SUITE_smoke")
 
     ly_add_pytest(
         NAME AutomatedTesting::SmokeTest

--- a/AutomatedTesting/Gem/PythonTests/smoke/test_CLITool_SerializeContextTools_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/smoke/test_CLITool_SerializeContextTools_Works.py
@@ -21,11 +21,8 @@ import ly_test_tools
 class TestCLIToolSerializeContextToolsWorks(object):
     def test_CLITool_SerializeContextTools_Works(self, build_directory):
         file_path = os.path.join(build_directory, "SerializeContextTools")
-        help_message = "Converts a file with an ObjectStream to the new JSON"
         # Launch SerializeContextTools
-        output = subprocess.run([file_path, "-help"], capture_output=True, timeout=10)
+        output = subprocess.run([file_path, "--help"], capture_output=True, timeout=10)
         assert (
-            len(output.stderr) == 0 and output.returncode == 0
-        ), f"Error occurred while launching {file_path}: {output.stderr}"
-        # Verify help message
-        assert help_message in str(output.stdout), f"Help Message: {help_message} is not present"
+            len(output.stdout) > 0 and output.returncode == 0
+        ), f"Error occurred while launching {file_path}: {output.stdout}"

--- a/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
@@ -88,6 +88,61 @@ namespace AZ::Debug
 
     AZ_CVAR_SCOPED(int, bg_traceLogLevel, DefaultLogLevel, nullptr, ConsoleFunctorFlags::Null, "Enable trace message logging in release mode.  0=disabled, 1=errors, 2=warnings, 3=info.");
     AZ_CVAR_SCOPED(bool, bg_alwaysShowCallstack, false, nullptr, ConsoleFunctorFlags::Null, "Force stack trace output without allowing ebus interception.");
+}
+
+namespace AZ::ConsoleTypeHelpers
+{
+    template<>
+    inline CVarFixedString ValueToString<AZ::Debug::RedirectCStream>(const AZ::Debug::RedirectCStream& value)
+    {
+        return ConvertString(AZStd::to_string(static_cast<AZStd::underlying_type_t<AZ::Debug::RedirectCStream>>(value)));
+    }
+
+    template<>
+    inline bool StringSetToValue<AZ::Debug::RedirectCStream>(AZ::Debug::RedirectCStream& outValue,
+        const AZ::ConsoleCommandContainer& arguments)
+    {
+        AZStd::underlying_type_t<AZ::Debug::RedirectCStream> underlyingValue;
+        const bool result = StringSetToValue(underlyingValue, arguments);
+        if (result)
+        {
+            outValue = AZ::Debug::RedirectCStream(underlyingValue);
+        }
+        return result;
+    }
+}
+
+namespace AZ::Debug
+{
+    // Allow redirection of trace raw output writes to stdout, stderr or to /dev/null
+    static constexpr const char* fileStreamIdentifier = "raw_c_stream";
+    static AZ::EnvironmentVariable<FILE*> s_fileStream;
+    void SetCFileStream(const RedirectCStream& redirectOption)
+    {
+        s_fileStream = AZ::Environment::FindVariable<FILE*>(fileStreamIdentifier);
+        if (!s_fileStream)
+        {
+            return;
+        }
+
+        switch (redirectOption)
+        {
+        case RedirectCStream::Stdout:
+            *s_fileStream = stdout;
+            break;
+        case RedirectCStream::Stderr:
+            *s_fileStream = stderr;
+            break;
+        case RedirectCStream::None:
+            *s_fileStream = nullptr;
+            break;
+        }
+    }
+
+    AZ_CVAR_SCOPED(RedirectCStream, bg_redirectrawoutput, RedirectCStream::Stdout, SetCFileStream, ConsoleFunctorFlags::Null,
+        "Set to the value of the C stream FILE* object to write raw trace output."
+        " Defaults to the stdout FILE stream");
+
 
     /**
      * If any listener returns true, store the result so we don't outputs detailed information.
@@ -110,10 +165,39 @@ namespace AZ::Debug
             g_ignoredAsserts = AZ::Environment::CreateVariable<AZStd::unordered_set<size_t>>(ignoredAssertUID);
             g_assertVerbosityLevel = AZ::Environment::CreateVariable<int>(assertVerbosityUID);
             g_logVerbosityLevel = AZ::Environment::CreateVariable<int>(logVerbosityUID);
+            s_fileStream = AZ::Environment::CreateVariable<FILE*>(fileStreamIdentifier, stdout);
 
             //default assert level is to log/print asserts this can be overriden with the sys_asserts CVAR
             g_assertVerbosityLevel.Set(assertLevel_log);
             g_logVerbosityLevel.Set(logLevel_full);
+        }
+
+        // Setup the raw C FILE* pointer to allow raw output to write to one of the std streams
+        s_fileStream = AZ::Environment::FindVariable<FILE*>(fileStreamIdentifier);
+        if (!s_fileStream)
+        {
+            FILE* redirectStream = stdout;
+            if (auto console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
+            {
+                if (RedirectCStream redirectOption;
+                    console->GetCvarValue("bg_redirectrawoutput", redirectOption) == AZ::GetValueResult::Success)
+                {
+                    switch (redirectOption)
+                    {
+                    case RedirectCStream::Stdout:
+                        redirectStream = stdout;
+                        break;
+                    case RedirectCStream::Stderr:
+                        redirectStream = stderr;
+                        break;
+                    case RedirectCStream::None:
+                        redirectStream = nullptr;
+                        break;
+                    }
+                }
+            }
+
+            AZ::Environment::CreateVariable<FILE*>(fileStreamIdentifier, redirectStream);
         }
     }
 
@@ -276,7 +360,7 @@ namespace AZ::Debug
 
         va_list mark;
         va_start(mark, format);
-        azvsnprintf(message, g_maxMessageLength - 1, format, mark); // -1 to make room for the "/n" that will be appended below 
+        azvsnprintf(message, g_maxMessageLength - 1, format, mark); // -1 to make room for the "/n" that will be appended below
         va_end(mark);
 
         if (auto logger = Interface<IEventLogger>::Get(); logger)
@@ -336,7 +420,7 @@ namespace AZ::Debug
                     g_ignoredAsserts->insert(assertHash);
                 }
             }
-            
+
             bool assertsAutoBreak = false;
             if (auto* console = Interface<IConsole>::Get())
             {
@@ -414,7 +498,7 @@ namespace AZ::Debug
 
         va_list mark;
         va_start(mark, format);
-        azvsnprintf(message, g_maxMessageLength-1, format, mark); // -1 to make room for the "/n" that will be appended below 
+        azvsnprintf(message, g_maxMessageLength-1, format, mark); // -1 to make room for the "/n" that will be appended below
         va_end(mark);
 
         if (auto logger = Interface<IEventLogger>::Get(); logger)
@@ -463,7 +547,7 @@ namespace AZ::Debug
 
         va_list mark;
         va_start(mark, format);
-        azvsnprintf(message, g_maxMessageLength - 1, format, mark); // -1 to make room for the "/n" that will be appended below 
+        azvsnprintf(message, g_maxMessageLength - 1, format, mark); // -1 to make room for the "/n" that will be appended below
         va_end(mark);
 
         if (auto logger = Interface<IEventLogger>::Get(); logger)
@@ -534,12 +618,12 @@ namespace AZ::Debug
         }
 
         Platform::OutputToDebugger(window, message);
-        
+
         if (!DebugInternal::g_suppressEBusCalls)
         {
             // only call into Ebusses if we are not in a recursive-exception situation as that
             // would likely just lead to even more exceptions.
-            
+
             TraceMessageResult result;
             EBUS_EVENT_RESULT(result, TraceMessageBus, OnOutput, window, message);
             if (result.m_value)
@@ -557,15 +641,22 @@ namespace AZ::Debug
         {
             window = g_dbgSystemWnd;
         }
-        
+
+
         // printf on Windows platforms seem to have a buffer length limit of 4096 characters
-        // Therefore fwrite is used directly to write the window and message to stdout
+        // Therefore fwrite is used directly to write the window and message to stdout or stderr
         AZStd::string_view windowView{ window };
         AZStd::string_view messageView{ message };
         constexpr AZStd::string_view windowMessageSeparator{ ": " };
-        fwrite(windowView.data(), 1, windowView.size(), stdout);
-        fwrite(windowMessageSeparator.data(), 1, windowMessageSeparator.size(), stdout);
-        fwrite(messageView.data(), 1, messageView.size(), stdout);
+
+        // If the raw output stream environment variable is set to a non-nullptr FILE* stream
+        // write to that stream, otherwise write stdout
+        if (FILE* rawOutputStream = s_fileStream ? *s_fileStream : stdout; rawOutputStream != nullptr)
+        {
+            fwrite(windowView.data(), 1, windowView.size(), rawOutputStream);
+            fwrite(windowMessageSeparator.data(), 1, windowMessageSeparator.size(), rawOutputStream);
+            fwrite(messageView.data(), 1, messageView.size(), rawOutputStream);
+        }
     }
 
     //=========================================================================

--- a/Code/Framework/AzCore/AzCore/Debug/Trace.h
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.h
@@ -30,6 +30,14 @@ namespace AZ
             Info = 3
         };
 
+        // Represents the options to select C language FILE* stream to write raw output
+        enum class RedirectCStream
+        {
+            Stdout,
+            Stderr,
+            None
+        };
+
         class Trace
         {
         public:

--- a/Code/Framework/AzCore/AzCore/IO/GenericStreams.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/GenericStreams.cpp
@@ -136,8 +136,8 @@ namespace AZ::IO
         /*
          * StreamerStream
          */
-            
-            
+
+
     /*
      * SystemFileStream
      */
@@ -360,8 +360,13 @@ namespace AZ::IO
 
     AZ::IO::OpenMode StdoutStream::GetModeFlags() const
     {
-        // Avoid including FileIO.h to retrieve values for OpenMode enum 
+        // Avoid including FileIO.h to retrieve values for OpenMode enum
         constexpr AZ::IO::OpenMode modeWrite{ 1 << 1 };
         return modeWrite;
+    }
+
+    const char* StdoutStream::GetFilename() const
+    {
+        return "<stdout>";
     }
 }   // namespace AZ::IO

--- a/Code/Framework/AzCore/AzCore/IO/GenericStreams.h
+++ b/Code/Framework/AzCore/AzCore/IO/GenericStreams.h
@@ -168,5 +168,6 @@ namespace AZ::IO
         AZ::IO::SizeType GetCurPos() const override;
         AZ::IO::SizeType GetLength() const override;
         AZ::IO::OpenMode GetModeFlags() const override;
+        const char* GetFilename() const override;
     };
 }   // namespace AZ::IO

--- a/Code/Framework/AzCore/AzCore/IO/SystemFile.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/SystemFile.cpp
@@ -15,10 +15,7 @@
 
 #include <stdio.h>
 
-namespace AZ::IO
-{
-
-namespace Platform
+namespace AZ::IO::Platform
 {
     // Forward declaration of platform specific implementations
 
@@ -30,7 +27,7 @@ namespace Platform
     AZ::u64 ModificationTime(FileHandleType handle, const SystemFile* systemFile);
     SystemFile::SizeType Read(FileHandleType handle, const SystemFile* systemFile, SizeType byteSize, void* buffer);
     SystemFile::SizeType Write(FileHandleType handle, const SystemFile* systemFile, const void* buffer, SizeType byteSize);
-    void Flush(FileHandleType handle, const SystemFile* systemFile );
+    void Flush(FileHandleType handle, const SystemFile* systemFile);
     SystemFile::SizeType Length(FileHandleType handle, const SystemFile* systemFile);
 
     bool Exists(const char* fileName);
@@ -46,333 +43,377 @@ namespace Platform
     bool DeleteDir(const char* dirName);
 }
 
-void SystemFile::CreatePath(const char* fileName)
+namespace AZ::IO
 {
-    char folderPath[AZ_MAX_PATH_LEN] = { 0 };
-    const char* delimiter1 = strrchr(fileName, '\\');
-    const char* delimiter2 = strrchr(fileName, '/');
-    const char* delimiter = delimiter2 > delimiter1 ? delimiter2 : delimiter1;
-    if (delimiter > fileName)
+    void SystemFile::CreatePath(const char* fileName)
     {
-        azstrncpy(folderPath, AZ_ARRAY_SIZE(folderPath), fileName, delimiter - fileName);
-        if (!Exists(folderPath))
+        char folderPath[AZ_MAX_PATH_LEN] = { 0 };
+        const char* delimiter1 = strrchr(fileName, '\\');
+        const char* delimiter2 = strrchr(fileName, '/');
+        const char* delimiter = delimiter2 > delimiter1 ? delimiter2 : delimiter1;
+        if (delimiter > fileName)
         {
-            CreateDir(folderPath);
+            azstrncpy(folderPath, AZ_ARRAY_SIZE(folderPath), fileName, delimiter - fileName);
+            if (!Exists(folderPath))
+            {
+                CreateDir(folderPath);
+            }
         }
     }
-}
 
-SystemFile::SystemFile()
-    : m_handle{ AZ_TRAIT_SYSTEMFILE_INVALID_HANDLE }
-{
-}
-
-SystemFile::~SystemFile()
-{
-    if (IsOpen())
+    SystemFile::SystemFile()
+        : m_handle{ AZ_TRAIT_SYSTEMFILE_INVALID_HANDLE }
     {
-        Close();
     }
-}
 
-SystemFile::SystemFile(SystemFile&& other)
-    : SystemFile{}
-{
-    AZStd::swap(m_fileName, other.m_fileName);
-    AZStd::swap(m_handle, other.m_handle);
-}
-
-SystemFile& SystemFile::operator=(SystemFile&& other)
-{
-    // Close the current file and take over the SystemFile handle and filename
-    Close();
-    m_fileName = AZStd::move(other.m_fileName);
-    m_handle = AZStd::move(other.m_handle);
-    other.m_fileName = {};
-    other.m_handle = AZ_TRAIT_SYSTEMFILE_INVALID_HANDLE;
-
-    return *this;
-}
-
-bool SystemFile::Open(const char* fileName, int mode, int platformFlags)
-{
-    if (fileName)       // If we reopen the file we are allowed to have NULL file name
+    SystemFile::~SystemFile()
     {
-        if (strlen(fileName) > m_fileName.max_size())
+        if (IsOpen())
+        {
+            Close();
+        }
+    }
+
+    SystemFile::SystemFile(SystemFile&& other)
+        : SystemFile{}
+    {
+        AZStd::swap(m_fileName, other.m_fileName);
+        AZStd::swap(m_handle, other.m_handle);
+    }
+
+    SystemFile& SystemFile::operator=(SystemFile&& other)
+    {
+        // Close the current file and take over the SystemFile handle and filename
+        Close();
+        m_fileName = AZStd::move(other.m_fileName);
+        m_handle = AZStd::move(other.m_handle);
+        other.m_fileName = {};
+        other.m_handle = AZ_TRAIT_SYSTEMFILE_INVALID_HANDLE;
+
+        return *this;
+    }
+
+    bool SystemFile::Open(const char* fileName, int mode, int platformFlags)
+    {
+        if (fileName)       // If we reopen the file we are allowed to have NULL file name
+        {
+            if (strlen(fileName) > m_fileName.max_size())
+            {
+                return false;
+            }
+
+            // store the filename
+            m_fileName = fileName;
+        }
+
+        AZ_Assert(!IsOpen(), "This file (%s) is already open!", m_fileName.c_str());
+
+        return PlatformOpen(mode, platformFlags);
+    }
+
+    bool SystemFile::ReOpen(int mode, int platformFlags)
+    {
+        AZ_Assert(!m_fileName.empty(), "Missing filename. You must call open first!");
+        return Open(nullptr, mode, platformFlags);
+    }
+
+    void SystemFile::Close()
+    {
+        PlatformClose();
+    }
+
+    void SystemFile::Seek(SeekSizeType offset, SeekMode mode)
+    {
+        Platform::Seek(m_handle, this, offset, mode);
+    }
+
+    SystemFile::SizeType SystemFile::Tell() const
+    {
+        return Platform::Tell(m_handle, this);
+    }
+
+    bool SystemFile::Eof() const
+    {
+        return Platform::Eof(m_handle, this);
+    }
+
+    AZ::u64 SystemFile::ModificationTime()
+    {
+        return Platform::ModificationTime(m_handle, this);
+    }
+
+    SystemFile::SizeType SystemFile::Read(SizeType byteSize, void* buffer)
+    {
+        return Platform::Read(m_handle, this, byteSize, buffer);
+    }
+
+    SystemFile::SizeType SystemFile::Write(const void* buffer, SizeType byteSize)
+    {
+        return Platform::Write(m_handle, this, buffer, byteSize);
+    }
+
+    void SystemFile::Flush()
+    {
+        Platform::Flush(m_handle, this);
+    }
+
+    SystemFile::SizeType SystemFile::Length() const
+    {
+        return Platform::Length(m_handle, this);
+    }
+
+    bool SystemFile::IsOpen() const
+    {
+        return m_handle != AZ_TRAIT_SYSTEMFILE_INVALID_HANDLE;
+    }
+
+    SystemFile::SizeType SystemFile::DiskOffset() const
+    {
+#if AZ_TRAIT_DOES_NOT_SUPPORT_FILE_DISK_OFFSET
+#pragma message("--- File Disk Offset is not available ---")
+#endif
+        return 0;
+    }
+
+    bool SystemFile::Exists(const char* fileName)
+    {
+        return Platform::Exists(fileName);
+    }
+
+    bool SystemFile::IsDirectory(const char* filePath)
+    {
+        return Platform::IsDirectory(filePath);
+    }
+
+    void SystemFile::FindFiles(const char* filter, FindFileCB cb)
+    {
+        Platform::FindFiles(filter, cb);
+    }
+
+    AZ::u64 SystemFile::ModificationTime(const char* fileName)
+    {
+        return Platform::ModificationTime(fileName);
+    }
+
+    SystemFile::SizeType SystemFile::Length(const char* fileName)
+    {
+        return Platform::Length(fileName);
+    }
+
+    SystemFile::SizeType SystemFile::Read(const char* fileName, void* buffer, SizeType byteSize, SizeType byteOffset)
+    {
+        SizeType numBytesRead = 0;
+        SystemFile f;
+        if (f.Open(fileName, SF_OPEN_READ_ONLY))
+        {
+            if (byteSize == 0)
+            {
+                byteSize = f.Length(); // read the entire file
+            }
+            if (byteOffset != 0)
+            {
+                f.Seek(byteOffset, SF_SEEK_BEGIN);
+            }
+
+            numBytesRead = f.Read(byteSize, buffer);
+            f.Close();
+        }
+
+        return numBytesRead;
+    }
+
+    bool SystemFile::Delete(const char* fileName)
+    {
+        if (!Exists(fileName))
         {
             return false;
         }
 
-        // store the filename
-        m_fileName = fileName;
+        return Platform::Delete(fileName);
     }
 
-    AZ_Assert(!IsOpen(), "This file (%s) is already open!", m_fileName.c_str());
-
-    return PlatformOpen(mode, platformFlags);
-}
-
-bool SystemFile::ReOpen(int mode, int platformFlags)
-{
-    AZ_Assert(!m_fileName.empty(), "Missing filename. You must call open first!");
-    return Open(nullptr, mode, platformFlags);
-}
-
-void SystemFile::Close()
-{
-    PlatformClose();
-}
-
-void SystemFile::Seek(SeekSizeType offset, SeekMode mode)
-{
-    Platform::Seek(m_handle, this, offset, mode);
-}
-
-SystemFile::SizeType SystemFile::Tell() const
-{
-    return Platform::Tell(m_handle, this);
-}
-
-bool SystemFile::Eof() const
-{
-    return Platform::Eof(m_handle, this);
-}
-
-AZ::u64 SystemFile::ModificationTime()
-{
-    return Platform::ModificationTime(m_handle, this);
-}
-
-SystemFile::SizeType SystemFile::Read(SizeType byteSize, void* buffer)
-{
-    return Platform::Read(m_handle, this, byteSize, buffer);
-}
-
-SystemFile::SizeType SystemFile::Write(const void* buffer, SizeType byteSize)
-{
-    return Platform::Write(m_handle, this, buffer, byteSize);
-}
-
-void SystemFile::Flush()
-{
-    Platform::Flush(m_handle, this);
-}
-
-SystemFile::SizeType SystemFile::Length() const
-{
-    return Platform::Length(m_handle, this);
-}
-
-bool SystemFile::IsOpen() const
-{
-    return m_handle != AZ_TRAIT_SYSTEMFILE_INVALID_HANDLE;
-}
-
-SystemFile::SizeType SystemFile::DiskOffset() const
-{
-#if AZ_TRAIT_DOES_NOT_SUPPORT_FILE_DISK_OFFSET
-    #pragma message("--- File Disk Offset is not available ---")
-#endif
-    return 0;
-}
-
-bool SystemFile::Exists(const char* fileName)
-{
-    return Platform::Exists(fileName);
-}
-
-bool SystemFile::IsDirectory(const char* filePath)
-{
-    return Platform::IsDirectory(filePath);
-}
-
-void SystemFile::FindFiles(const char* filter, FindFileCB cb)
-{
-    Platform::FindFiles(filter, cb);
-}
-
-AZ::u64 SystemFile::ModificationTime(const char* fileName)
-{
-    return Platform::ModificationTime(fileName);
-}
-
-SystemFile::SizeType SystemFile::Length(const char* fileName)
-{
-    return Platform::Length(fileName);
-}
-
-SystemFile::SizeType SystemFile::Read(const char* fileName, void* buffer, SizeType byteSize, SizeType byteOffset)
-{
-    SizeType numBytesRead = 0;
-    SystemFile f;
-    if (f.Open(fileName, SF_OPEN_READ_ONLY))
+    bool SystemFile::Rename(const char* sourceFileName, const char* targetFileName, bool overwrite)
     {
-        if (byteSize == 0)
+        if (!Exists(sourceFileName))
         {
-            byteSize = f.Length(); // read the entire file
-        }
-        if (byteOffset != 0)
-        {
-            f.Seek(byteOffset, SF_SEEK_BEGIN);
+            return false;
         }
 
-        numBytesRead = f.Read(byteSize, buffer);
-        f.Close();
+        return Platform::Rename(sourceFileName, targetFileName, overwrite);
     }
 
-    return numBytesRead;
-}
-
-bool SystemFile::Delete(const char* fileName)
-{
-    if (!Exists(fileName))
+    bool SystemFile::IsWritable(const char* sourceFileName)
     {
-        return false;
+        return Platform::IsWritable(sourceFileName);
     }
 
-    return Platform::Delete(fileName);
-}
-
-bool SystemFile::Rename(const char* sourceFileName, const char* targetFileName, bool overwrite)
-{
-    if (!Exists(sourceFileName))
+    bool SystemFile::SetWritable(const char* sourceFileName, bool writable)
     {
-        return false;
+        return Platform::SetWritable(sourceFileName, writable);
     }
 
-    return Platform::Rename(sourceFileName, targetFileName, overwrite);
-}
+    bool SystemFile::CreateDir(const char* dirName)
+    {
+        return Platform::CreateDir(dirName);
+    }
 
-bool SystemFile::IsWritable(const char* sourceFileName)
-{
-    return Platform::IsWritable(sourceFileName);
-}
-
-bool SystemFile::SetWritable(const char* sourceFileName, bool writable)
-{
-    return Platform::SetWritable(sourceFileName, writable);
-}
-
-bool SystemFile::CreateDir(const char* dirName)
-{
-    return Platform::CreateDir(dirName);
-}
-
-bool SystemFile::DeleteDir(const char* dirName)
-{
-    return Platform::DeleteDir(dirName);
-}
+    bool SystemFile::DeleteDir(const char* dirName)
+    {
+        return Platform::DeleteDir(dirName);
+    }
 
 
-namespace
-{
+    namespace
+    {
 #define HasPosixEnumOption(EnumValue) \
     static_assert(std::is_enum_v<decltype(EnumValue)>, "PosixInternal enum option " #EnumValue " not defined for platform " AZ_TRAIT_OS_PLATFORM_NAME);
 
-    using namespace AZ::IO::PosixInternal;
-    // Verify all posix internal flags have been defined
-    // If you happen to add any OpenFlag or PermissionModeFlag, please update this list
+        using namespace AZ::IO::PosixInternal;
+        // Verify all posix internal flags have been defined
+        // If you happen to add any OpenFlag or PermissionModeFlag, please update this list
 
-    HasPosixEnumOption(OpenFlags::Append);
-    HasPosixEnumOption(OpenFlags::Create);
-    HasPosixEnumOption(OpenFlags::Temporary);
-    HasPosixEnumOption(OpenFlags::Exclusive);
-    HasPosixEnumOption(OpenFlags::Truncate);
-    HasPosixEnumOption(OpenFlags::ReadOnly);
-    HasPosixEnumOption(OpenFlags::WriteOnly);
-    HasPosixEnumOption(OpenFlags::ReadWrite);
-    HasPosixEnumOption(OpenFlags::NoInherit);
-    HasPosixEnumOption(OpenFlags::Random);
-    HasPosixEnumOption(OpenFlags::Sequential);
-    HasPosixEnumOption(OpenFlags::Binary);
-    HasPosixEnumOption(OpenFlags::Text);
-    HasPosixEnumOption(OpenFlags::U16Text);
-    HasPosixEnumOption(OpenFlags::U8Text);
-    HasPosixEnumOption(OpenFlags::WText);
-    HasPosixEnumOption(OpenFlags::Async);
-    HasPosixEnumOption(OpenFlags::Direct);
-    HasPosixEnumOption(OpenFlags::Directory);
-    HasPosixEnumOption(OpenFlags::NoFollow);
-    HasPosixEnumOption(OpenFlags::NoAccessTime);
-    HasPosixEnumOption(OpenFlags::Path);
+        HasPosixEnumOption(OpenFlags::Append);
+        HasPosixEnumOption(OpenFlags::Create);
+        HasPosixEnumOption(OpenFlags::Temporary);
+        HasPosixEnumOption(OpenFlags::Exclusive);
+        HasPosixEnumOption(OpenFlags::Truncate);
+        HasPosixEnumOption(OpenFlags::ReadOnly);
+        HasPosixEnumOption(OpenFlags::WriteOnly);
+        HasPosixEnumOption(OpenFlags::ReadWrite);
+        HasPosixEnumOption(OpenFlags::NoInherit);
+        HasPosixEnumOption(OpenFlags::Random);
+        HasPosixEnumOption(OpenFlags::Sequential);
+        HasPosixEnumOption(OpenFlags::Binary);
+        HasPosixEnumOption(OpenFlags::Text);
+        HasPosixEnumOption(OpenFlags::U16Text);
+        HasPosixEnumOption(OpenFlags::U8Text);
+        HasPosixEnumOption(OpenFlags::WText);
+        HasPosixEnumOption(OpenFlags::Async);
+        HasPosixEnumOption(OpenFlags::Direct);
+        HasPosixEnumOption(OpenFlags::Directory);
+        HasPosixEnumOption(OpenFlags::NoFollow);
+        HasPosixEnumOption(OpenFlags::NoAccessTime);
+        HasPosixEnumOption(OpenFlags::Path);
 
-    HasPosixEnumOption(PermissionModeFlags::None);
-    HasPosixEnumOption(PermissionModeFlags::Read);
-    HasPosixEnumOption(PermissionModeFlags::Write);
+        HasPosixEnumOption(PermissionModeFlags::None);
+        HasPosixEnumOption(PermissionModeFlags::Read);
+        HasPosixEnumOption(PermissionModeFlags::Write);
 
 #undef HasPosixEnumOption
-}
-
-
-FileDescriptorRedirector::FileDescriptorRedirector(int sourceFileDescriptor)
-    : m_sourceFileDescriptor(sourceFileDescriptor)
-{
-}
-
-FileDescriptorRedirector::~FileDescriptorRedirector()
-{
-    Reset();
-}
-
-void FileDescriptorRedirector::RedirectTo(AZStd::string_view toFileName, Mode mode)
-{
-    if (m_sourceFileDescriptor == -1)
-    {
-        return;
     }
 
-    using OpenFlags = PosixInternal::OpenFlags;
-    using PermissionModeFlags = PosixInternal::PermissionModeFlags;
 
-    AZ::IO::FixedMaxPathString redirectPath = AZ::IO::FixedMaxPathString(toFileName.data(), toFileName.size());
-    const OpenFlags createOrAppend = mode == Mode::Create ? (OpenFlags::Create | OpenFlags::Truncate) : OpenFlags::Append;
-
-    int toFileDescriptor = PosixInternal::Open(redirectPath.c_str(),
-        createOrAppend | OpenFlags::WriteOnly,
-        PermissionModeFlags::Read | PermissionModeFlags::Write);
-
-    if (toFileDescriptor == -1)
+    FileDescriptorRedirector::FileDescriptorRedirector(int sourceFileDescriptor)
+        : m_sourceFileDescriptor(sourceFileDescriptor)
     {
-        return;
     }
 
-    m_redirectionFileDescriptor = toFileDescriptor;
-    // Duplicate the source file descriptor and redirect the opened file descriptor
-    // to the source file descriptor
-    m_dupSourceFileDescriptor = PosixInternal::Dup(m_sourceFileDescriptor);
-    if (PosixInternal::Dup2(m_redirectionFileDescriptor, m_sourceFileDescriptor) == -1)
+    FileDescriptorRedirector::~FileDescriptorRedirector()
     {
-        // Failed to redirect the newly opened file descriptor to the source file descriptor
-        PosixInternal::Close(m_redirectionFileDescriptor);
-        PosixInternal::Close(m_dupSourceFileDescriptor);
-        m_redirectionFileDescriptor = -1;
-        m_dupSourceFileDescriptor = -1;
-        return;
+        Reset();
     }
-}
 
-void FileDescriptorRedirector::Reset()
-{
-    if (m_redirectionFileDescriptor != -1)
+    void FileDescriptorRedirector::RedirectTo(AZStd::string_view toFileName, Mode mode)
     {
-        // Close the redirect file
-        PosixInternal::Close(m_redirectionFileDescriptor);
-        // Restore the redirected file descriptor back to the original
-        PosixInternal::Dup2(m_dupSourceFileDescriptor, m_sourceFileDescriptor);
-        PosixInternal::Close(m_dupSourceFileDescriptor);
-        m_redirectionFileDescriptor = -1;
-        m_dupSourceFileDescriptor = -1;
-    }
-}
+        if (m_sourceFileDescriptor == -1)
+        {
+            return;
+        }
 
-void FileDescriptorRedirector::WriteBypassingRedirect(const void* data, unsigned int size)
-{
-    int targetFileDescriptor = m_sourceFileDescriptor;
-    if (m_redirectionFileDescriptor != -1)
-    {
-        targetFileDescriptor = m_dupSourceFileDescriptor;
+        using OpenFlags = PosixInternal::OpenFlags;
+        using PermissionModeFlags = PosixInternal::PermissionModeFlags;
+
+        AZ::IO::FixedMaxPathString redirectPath = AZ::IO::FixedMaxPathString(toFileName.data(), toFileName.size());
+        const OpenFlags createOrAppend = mode == Mode::Create ? (OpenFlags::Create | OpenFlags::Truncate) : OpenFlags::Append;
+
+        int toFileDescriptor = PosixInternal::Open(redirectPath.c_str(),
+            createOrAppend | OpenFlags::WriteOnly,
+            PermissionModeFlags::Read | PermissionModeFlags::Write);
+
+        if (toFileDescriptor == -1)
+        {
+            return;
+        }
+
+        m_redirectionFileDescriptor = toFileDescriptor;
+        // Duplicate the source file descriptor and redirect the opened file descriptor
+        // to the source file descriptor
+        m_dupSourceFileDescriptor = PosixInternal::Dup(m_sourceFileDescriptor);
+        if (PosixInternal::Dup2(m_redirectionFileDescriptor, m_sourceFileDescriptor) == -1)
+        {
+            // Failed to redirect the newly opened file descriptor to the source file descriptor
+            PosixInternal::Close(m_redirectionFileDescriptor);
+            PosixInternal::Close(m_dupSourceFileDescriptor);
+            m_redirectionFileDescriptor = -1;
+            m_dupSourceFileDescriptor = -1;
+            return;
+        }
     }
-    AZ::IO::PosixInternal::Write(targetFileDescriptor, data, size);
-}
+
+
+    void FileDescriptorRedirector::Reset()
+    {
+        if (m_redirectionFileDescriptor != -1)
+        {
+            // Close the redirect file
+            PosixInternal::Close(m_redirectionFileDescriptor);
+            // Restore the redirected file descriptor back to the original
+            PosixInternal::Dup2(m_dupSourceFileDescriptor, m_sourceFileDescriptor);
+            PosixInternal::Close(m_dupSourceFileDescriptor);
+            m_redirectionFileDescriptor = -1;
+            m_dupSourceFileDescriptor = -1;
+        }
+    }
+
+    void FileDescriptorRedirector::WriteBypassingRedirect(const void* data, unsigned int size)
+    {
+        int targetFileDescriptor = m_sourceFileDescriptor;
+        if (m_redirectionFileDescriptor != -1)
+        {
+            targetFileDescriptor = m_dupSourceFileDescriptor;
+        }
+        AZ::IO::PosixInternal::Write(targetFileDescriptor, data, size);
+    }
+
+
+    // Captures File Descriptor output through a pipe
+    FileDescriptorCapturer::FileDescriptorCapturer(int sourceDescriptor)
+        : m_sourceDescriptor(sourceDescriptor)
+    {
+    }
+
+    FileDescriptorCapturer::~FileDescriptorCapturer()
+    {
+        Reset();
+    }
+
+    void FileDescriptorCapturer::Reset()
+    {
+        if (m_redirectToPipe)
+        {
+            // Close the write end of the pipe first
+            if (m_pipe[WriteEnd] != -1)
+            {
+                PosixInternal::Close(m_pipe[WriteEnd]);
+                m_pipe[WriteEnd] = -1;
+            }
+            // Close the read end of the pipe after the write end is closed
+            if (m_pipe[ReadEnd] != -1)
+            {
+                PosixInternal::Close(m_pipe[ReadEnd]);
+                m_pipe[ReadEnd] = -1;
+            }
+            // Take the duplicate of the original source descriptor and restore it
+            // Afterwards close the duplicate descriptor
+            if (m_dupSourceDescriptor != -1)
+            {
+                PosixInternal::Dup2(m_dupSourceDescriptor, m_sourceDescriptor);
+                PosixInternal::Close(m_dupSourceDescriptor);
+                m_dupSourceDescriptor = -1;
+            }
+
+            m_redirectToPipe = false;
+        }
+    }
 
 } // namespace AZ::IO

--- a/Code/Framework/AzCore/AzCore/IO/SystemFile.h
+++ b/Code/Framework/AzCore/AzCore/IO/SystemFile.h
@@ -11,6 +11,7 @@
 
 #include <AzCore/IO/Path/Path_fwd.h>
 #include <AzCore/IO/SystemFile_Platform.h>
+#include <AzCore/std/containers/span.h>
 #include <AzCore/std/function/function_fwd.h>
 #include <AzCore/std/string/fixed_string.h>
 
@@ -175,6 +176,56 @@ namespace AZ
             int m_sourceFileDescriptor = -1;
             int m_dupSourceFileDescriptor = -1;
             int m_redirectionFileDescriptor = -1;
+        };
+
+        /**
+         * Utility class for capturing the output of file descriptor redirection using with RAII behavior.
+         * Example:
+         *
+         *   printf("Test"); // prints to stdout
+         *   AZ::IO::FileDescriptorCapturer redirectStdoutToFile(1);
+         *   redirectStdoutToFile.Start();
+         *   printf("Test"); // capture stdout as part of pipe
+         *   bool testWasOutput{};
+         *   auto StdoutVisitor [&testWasOutput](AZStd::span<const AZStd::byte> capturedBytes)
+         *   {
+         *       AZStd::string_view capturedString(reinterpret_cast<const char*>(capturedBytes.data()), captureBytes.size());
+         *       testWasOutput = capturedString.contains("Test");
+         *   };
+         *   redirectStdout.Stop(StdoutVisitor); // Invokes visitor 0 or more times with captured data
+         *   EXPECT_TRUE(testWasOutput);
+         */
+        class FileDescriptorCapturer 
+        {
+        public:
+
+            // 64 KiB for the default pipe size
+            inline static constexpr int DefaultPipeSize = (1 << 16);
+
+            FileDescriptorCapturer(int sourceDescriptor);
+            ~FileDescriptorCapturer();
+
+            // Starts capture of file descriptor
+            void Start(int pipeSize = DefaultPipeSize);
+
+            //! Redirects file descriptor to a visitor callback
+            //! Internally a pipe is used to send output to the visitor
+            using OutputRedirectVisitor = AZStd::function<void(AZStd::span<AZStd::byte>)>;
+
+            //! Reads all the data from the pipe and sends it to the visitor
+            void Flush(const OutputRedirectVisitor& redirectCallback);
+
+            //! Stops capture of file descriptor and reset it back to it's previous value
+            void Stop(const OutputRedirectVisitor& redirectCallback);
+
+        private:
+            void Reset();
+            int m_sourceDescriptor = -1;
+            int m_dupSourceDescriptor = -1;
+            inline static constexpr int ReadEnd = 0;
+            inline static constexpr int WriteEnd = 1;
+            int m_pipe[2]{ -1, -1 };
+            bool m_redirectToPipe{};
         };
     }
 }

--- a/Code/Framework/AzCore/AzCore/Utils/Utils.cpp
+++ b/Code/Framework/AzCore/AzCore/Utils/Utils.cpp
@@ -65,6 +65,19 @@ namespace AZ::Utils
         return AZStd::nullopt;
     }
 
+    bool ConvertToAbsolutePath(AZ::IO::FixedMaxPath& outputPath, AZStd::string_view path)
+    {
+        AZ::IO::FixedMaxPathString srcPath{ path };
+        if (ConvertToAbsolutePath(srcPath.c_str(), outputPath.Native().data(), outputPath.Native().capacity()))
+        {
+            // Fix the size value of the fixed string by calculating the c-string length using char traits
+            outputPath.Native().resize_no_construct(AZStd::char_traits<char>::length(outputPath.Native().data()));
+            return true;
+        }
+
+        return false;
+    }
+
     AZ::IO::FixedMaxPathString GetO3deManifestPath()
     {
         AZ::IO::FixedMaxPath o3deManifestPath = GetO3deManifestDirectory();

--- a/Code/Framework/AzCore/AzCore/Utils/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Utils/Utils.h
@@ -68,7 +68,7 @@ namespace AZ
         //! @returns a result object that indicates if the executable directory was able to be stored within the buffer
         ExecutablePathResult GetExecutableDirectory(char* exeStorageBuffer, size_t exeStorageSize);
 
-        //! Retrieves the full path of the directroy containing the executable
+        //! Retrieves the full path of the directory containing the executable
         AZ::IO::FixedMaxPathString GetExecutableDirectory();
 
         //! Retrieves the full path to the engine from settings registry
@@ -104,6 +104,7 @@ namespace AZ
         // Attempts the supplied path to an absolute path.
         //! Returns nullopt if path cannot be converted to an absolute path
         AZStd::optional<AZ::IO::FixedMaxPathString> ConvertToAbsolutePath(AZStd::string_view path);
+        bool ConvertToAbsolutePath(AZ::IO::FixedMaxPath& outputPath, AZStd::string_view path);
         bool ConvertToAbsolutePath(const char* path, char* absolutePath, AZ::u64 absolutePathMaxSize);
 
         //! Save a string to a file. Otherwise returns a failure with error message.

--- a/Code/Framework/AzCore/Platform/Android/AzCore/IO/SystemFile_Android.h
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/IO/SystemFile_Android.h
@@ -71,6 +71,7 @@ namespace AZ
 #else
                 Path         = 0,       // (Not applicable for this platform) Obtain a file descriptor that can be used for two purposes: to indicate a location in the filesystem tree and to perform operations that act purely at the file descriptor level.
 #endif
+                NonBlock     = O_NONBLOCK,   // Opens a pipe in non-blocking mode. If the process tries to perform incompatible access on a file region with an incompatible mandatory lock when this flag is set, then system call fails and returns EAGAIN.
             };
             AZ_DEFINE_ENUM_BITWISE_OPERATORS(OpenFlags);
 
@@ -106,6 +107,7 @@ namespace AZ
             int Dup(int fileDescriptor);
             int Dup2(int fileDescriptorSource, int fileDescriptorDestination);
 
+            int Pipe(int(&pipeFileDescriptors)[2], int pipeSize, OpenFlags flags);
         } // namespace AZ::IO::PosixInternal
     } // namespace AZ::IO
 } // namespace AZ

--- a/Code/Framework/AzCore/Platform/Common/Apple/AzCore/IO/SystemFile_Apple.h
+++ b/Code/Framework/AzCore/Platform/Common/Apple/AzCore/IO/SystemFile_Apple.h
@@ -70,6 +70,7 @@ namespace AZ
 #else
                 Path         = 0,            // (Not applicable for this platform) Obtain a file descriptor that can be used for two purposes: to indicate a location in the filesystem tree and to perform operations that act purely at the file descriptor level.
 #endif
+                NonBlock     = O_NONBLOCK,   // Opens a pipe in non-blocking mode. If the process tries to perform incompatible access on a file region with an incompatible mandatory lock when this flag is set, then system call fails and returns EAGAIN.
             };
             AZ_DEFINE_ENUM_BITWISE_OPERATORS(OpenFlags);
 
@@ -105,6 +106,7 @@ namespace AZ
             int Dup(int fileDescriptor);
             int Dup2(int fileDescriptorSource, int fileDescriptorDestination);
 
+            int Pipe(int(&pipeFileDescriptors)[2], int pipeSize, OpenFlags flags);
         } // namespace AZ::IO::PosixInternal
     } // namespace AZ::IO
 } // namespace AZ

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
@@ -211,8 +211,9 @@ namespace Platform
         return false;
     }
 } // namespace AZ::IO::Platform
+} // namespace AZ::IO
 
-namespace PosixInternal
+namespace AZ::IO::PosixInternal
 {
     int Dup(int fileDescriptor)
     {
@@ -223,6 +224,93 @@ namespace PosixInternal
     {
         return dup2(fileDescriptorSource, fileDescriptorDestination);
     }
+
+    int Pipe(int(&pipeFileDescriptors)[2], int, OpenFlags pipeFlags)
+    {
+        return pipe2(pipeFileDescriptors, static_cast<int>(pipeFlags));
+    }
 } // namespace AZ::IO::PosixInternal
 
+namespace AZ::IO
+{
+    // FileDescriptorCapturer UnixLike Impl
+    void FileDescriptorCapturer::Start(int pipeSize)
+    {
+        if (m_redirectToPipe)
+        {
+            // Capturer is already in progress
+            return;
+        }
+        if (m_sourceDescriptor == -1)
+        {
+            // Source file descriptor isn't set.
+            return;
+        }
+        int pipeCreated = PosixInternal::Pipe(m_pipe, pipeSize, PosixInternal::OpenFlags::NonBlock);
+
+        if (pipeCreated == -1)
+        {
+            return;
+        }
+
+        // Duplicate the original source descriptor to restore in Stop
+        m_dupSourceDescriptor = PosixInternal::Dup(m_sourceDescriptor);
+
+        // Duplicate the write end of the pipe onto the original source descriptor
+        // This causes the writes to the source descriptor to redirect to the pipe
+        if (PosixInternal::Dup2(m_pipe[WriteEnd], m_sourceDescriptor) == -1)
+        {
+            // Failed to redirect the source descriptor to the pipe
+            PosixInternal::Close(m_dupSourceDescriptor);
+            PosixInternal::Close(m_pipe[WriteEnd]);
+            PosixInternal::Close(m_pipe[ReadEnd]);
+            // Reset pipe descriptor to -1
+            m_pipe[WriteEnd] = -1;
+            m_pipe[ReadEnd] = -1;
+            m_dupSourceDescriptor = -1;
+            return;
+        }
+
+        m_redirectToPipe = true;
+    }
+
+    void FileDescriptorCapturer::Flush(const OutputRedirectVisitor& redirectCallback)
+    {
+        if (!redirectCallback)
+        {
+            return;
+        }
+        constexpr int PipeBufferSize = DefaultPipeSize;
+        AZStd::array<AZStd::byte, PipeBufferSize> capturedBytes;
+
+        int bytesRead{};
+        do
+        {
+            // Pump the read end of the pipe until it is empty
+            // and invoke the visitor for each call
+            bytesRead = PosixInternal::Read(m_pipe[ReadEnd],
+                AZStd::ranges::data(capturedBytes), static_cast<int>(AZStd::ranges::size(capturedBytes)));
+            if (bytesRead > 0)
+            {
+                redirectCallback(AZStd::span(AZStd::ranges::data(capturedBytes), bytesRead));
+            }
+
+        } while (bytesRead > 0);
+    }
+
+    void FileDescriptorCapturer::Stop(const OutputRedirectVisitor& redirectCallback)
+    {
+        // Close the write end of the pipe before flushing
+        // This is required in order to not block the thread when reading from the pipe
+        if (m_pipe[WriteEnd] != -1)
+        {
+            PosixInternal::Close(m_pipe[WriteEnd]);
+            m_pipe[WriteEnd] = -1;
+        }
+
+        // Invoke the visitor with the output in the pipe
+        Flush(redirectCallback);
+        // Closes the pipe and resets the descriptor
+        Reset();
+    }
 } // namespace AZ::IO

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/SystemFile_UnixLike.h
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/SystemFile_UnixLike.h
@@ -69,6 +69,7 @@ namespace AZ
 #else
                 Path         = 0,       // (Not applicable for this platform) Obtain a file descriptor that can be used for two purposes: to indicate a location in the filesystem tree and to perform operations that act purely at the file descriptor level.
 #endif
+                NonBlock     = O_NONBLOCK,   // Opens a pipe in non-blocking mode. If the process tries to perform incompatible access on a file region with an incompatible mandatory lock when this flag is set, then system call fails and returns EAGAIN.
             };
             AZ_DEFINE_ENUM_BITWISE_OPERATORS(OpenFlags);
 
@@ -103,6 +104,8 @@ namespace AZ
 
             int Dup(int fileDescriptor);
             int Dup2(int fileDescriptorSource, int fileDescriptorDestination);
+
+            int Pipe(int(&pipeFileDescriptors)[2], int pipeSize, OpenFlags flags);
         } // namespace AZ::IO::PosixInternal
     } // namespace AZ::IO
 } // namespace AZ

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Utils/Utils_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Utils/Utils_UnixLike.cpp
@@ -68,6 +68,21 @@ namespace AZ::Utils
                 azstrcpy(absolutePath, maxLength, absolutePathBuffer);
                 return true;
             }
+            else if (errno == ENOENT)
+            {
+                // realpath will fail if the source path doesn't refer to an existing file
+                // and set errno to [ENOENT]
+                // > A component of file_name does not name an existing file or file_name points to an empty string.
+
+                // Attempt to create an absolute path by appending path to current working
+                // directory and normalizing it
+                if (AZ::IO::FixedMaxPath normalizedPath; getcwd(absolutePathBuffer, UnixMaxPathLength) != nullptr)
+                {
+                    normalizedPath = (AZ::IO::FixedMaxPath(absolutePathBuffer) / path).LexicallyNormal();
+                    azstrcpy(absolutePath, maxLength, normalizedPath.c_str());
+                    return true;
+                }
+            }
         }
         azstrcpy(absolutePath, maxLength, path);
         return AZ::IO::PathView(absolutePath).IsAbsolute();

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/SystemFile_WinAPI.h
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/SystemFile_WinAPI.h
@@ -56,6 +56,7 @@ namespace AZ
                 NoFollow     = 0,             // (Not applicable in windows) If the trailing component (i.e., basename) of pathname is a symbolic link, then the open fails, with the error ELOOP. Symbolic links in earlier components of the pathname will still be followed.
                 NoAccessTime = 0,             // (Not applicable in windows) Do not update the file last access time.
                 Path         = 0,             // (Not applicable in windows) Obtain a file descriptor that can be used for two purposes: to indicate a location in the filesystem tree and to perform operations that act purely at the file descriptor level.
+                NonBlock     = 0,             // (Not applicable in windows) Opens a pipe in non-blocking mode. If the process tries to perform incompatible access on a file region with an incompatible mandatory lock when this flag is set, then system call fails and returns EAGAIN.
             };
             AZ_DEFINE_ENUM_BITWISE_OPERATORS(OpenFlags);
 
@@ -106,6 +107,8 @@ namespace AZ
             {
                 return _dup2(fileDescriptorSource, fileDescriptorDestination);
             }
+
+            int Pipe(int(&pipeFileDescriptors)[2], int pipeSize, OpenFlags flags);
         } // namespace AZ::IO::PosixInternal
     } // namespace AZ::IO
 } // namespace AZ

--- a/Code/Framework/AzCore/Tests/Debug/Trace.cpp
+++ b/Code/Framework/AzCore/Tests/Debug/Trace.cpp
@@ -10,14 +10,13 @@
 #include <AzCore/Console/Console.h>
 #include <AzCore/Console/IConsole.h>
 #include <AzCore/Interface/Interface.h>
-
-using namespace AZ;
+#include <AzCore/IO/SystemFile.h>
 
 namespace UnitTest
 {
     struct TraceTests
         : ScopedAllocatorSetupFixture
-        , Debug::TraceMessageBus::Handler
+        , AZ::Debug::TraceMessageBus::Handler
     {
         bool OnPreAssert(const char*, int, const char*, const char*) override
         {
@@ -82,7 +81,7 @@ namespace UnitTest
 
     TEST_F(TraceTests, Level0)
     {
-        Interface<IConsole>::Get()->PerformCommand("bg_traceLogLevel 0");
+        AZ::Interface<AZ::IConsole>::Get()->PerformCommand("bg_traceLogLevel 0");
 
         AZ_Assert(false, "test");
         AZ_Error("UnitTest", false, "test");
@@ -97,7 +96,7 @@ namespace UnitTest
 
     TEST_F(TraceTests, Level1)
     {
-        Interface<IConsole>::Get()->PerformCommand("bg_traceLogLevel 1");
+        AZ::Interface<AZ::IConsole>::Get()->PerformCommand("bg_traceLogLevel 1");
 
         AZ_Assert(false, "test");
         AZ_Error("UnitTest", false, "test");
@@ -112,7 +111,7 @@ namespace UnitTest
 
     TEST_F(TraceTests, Level2)
     {
-        Interface<IConsole>::Get()->PerformCommand("bg_traceLogLevel 2");
+        AZ::Interface<AZ::IConsole>::Get()->PerformCommand("bg_traceLogLevel 2");
 
         AZ_Assert(false, "test");
         AZ_Error("UnitTest", false, "test");
@@ -127,7 +126,7 @@ namespace UnitTest
 
     TEST_F(TraceTests, Level3)
     {
-        Interface<IConsole>::Get()->PerformCommand("bg_traceLogLevel 3");
+        AZ::Interface<AZ::IConsole>::Get()->PerformCommand("bg_traceLogLevel 3");
 
         AZ_Assert(false, "test");
         AZ_Error("UnitTest", false, "test");
@@ -138,5 +137,90 @@ namespace UnitTest
         ASSERT_TRUE(m_error);
         ASSERT_TRUE(m_warning);
         ASSERT_TRUE(m_printf);
+    }
+
+    TEST_F(TraceTests, RedirectToRawOutputToStderr_DoesNotOutputToStdout)
+    {
+        constexpr const char* errorMessage = "Test Error\n";
+        bool testErrorMessageFound{};
+        auto GetStdout = [&testErrorMessageFound, expectedMessage = errorMessage](AZStd::span<const AZStd::byte> capturedBytes)
+        {
+            if (AZStd::string_view capturedStrView(reinterpret_cast<const char*>(capturedBytes.data()), capturedBytes.size());
+                capturedStrView.contains(expectedMessage))
+            {
+                testErrorMessageFound = true;
+            }
+        };
+
+        // file descriptor 1 is stdout
+        constexpr int StdoutDescriptor = 1;
+        AZ::IO::FileDescriptorCapturer capturer(StdoutDescriptor);
+        capturer.Start();
+        // This message should get captured
+        AZ::Debug::Trace::RawOutput("UnitTest", errorMessage);
+        fflush(stdout);
+        capturer.Stop(GetStdout);
+        // The message should be found
+        EXPECT_TRUE(testErrorMessageFound);
+
+        // Reset the error message found boolean back to false
+        testErrorMessageFound = false;
+
+        // Redirect the Trace output to stderr
+        AZ::Interface<AZ::IConsole>::Get()->PerformCommand({ "bg_redirectrawoutput", "1" });
+        AZ::Debug::Trace::RawOutput("UnitTest", errorMessage);
+        fflush(stdout);
+        // The message should not be found since trace output should be going to stderr
+        EXPECT_FALSE(testErrorMessageFound);
+
+        // Redirect the Trace output back to stdout
+        AZ::Interface<AZ::IConsole>::Get()->PerformCommand({ "bg_redirectrawoutput", "0" });
+    }
+
+    TEST_F(TraceTests, RedirectToRawOutputNone_DoesNotOutputToStdout_NorStderr)
+    {
+        constexpr const char* errorMessage = "Test Error\n";
+        bool testErrorMessageFound{};
+        auto GetOutput = [&testErrorMessageFound, expectedMessage = errorMessage](AZStd::span<const AZStd::byte> capturedBytes)
+        {
+            if (AZStd::string_view capturedStrView(reinterpret_cast<const char*>(capturedBytes.data()), capturedBytes.size());
+                capturedStrView.contains(expectedMessage))
+            {
+                testErrorMessageFound = true;
+            }
+        };
+
+        // file descriptor 1 is stdout
+        constexpr int StdoutDescriptor = 1;
+        // file descriptor 2 is stderr
+        constexpr int StderrDescriptor = 2;
+
+        AZ::IO::FileDescriptorCapturer stdoutCapturer(StdoutDescriptor);
+        AZ::IO::FileDescriptorCapturer stderrCapturer(StderrDescriptor);
+        stdoutCapturer.Start();
+        stderrCapturer.Start();
+        // This message should get captured
+        AZ::Debug::Trace::RawOutput("UnitTest", errorMessage);
+        // flush both stdout and stderr to make sure it capturer is able to get the data
+        fflush(stdout);
+        fflush(stderr);
+        stdoutCapturer.Stop(GetOutput);
+        stderrCapturer.Stop(GetOutput);
+        // The message should be found
+        EXPECT_TRUE(testErrorMessageFound);
+
+        // Reset the error message found boolean back to false
+        testErrorMessageFound = false;
+
+        // Redirect the Trace output to None
+        AZ::Interface<AZ::IConsole>::Get()->PerformCommand({ "bg_redirectrawoutput", "0" });
+        AZ::Debug::Trace::RawOutput("UnitTest", errorMessage);
+        fflush(stdout);
+        fflush(stderr);
+        // The message should not be found since trace output should be going to stderr
+        EXPECT_FALSE(testErrorMessageFound);
+
+        // Redirect the Trace output back to stdout
+        AZ::Interface<AZ::IConsole>::Get()->PerformCommand({ "bg_redirectrawoutput", "0" });
     }
 }

--- a/Code/Framework/AzCore/Tests/Platform/Common/UnixLike/Tests/UtilsTests_UnixLike.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Common/UnixLike/Tests/UtilsTests_UnixLike.cpp
@@ -16,11 +16,6 @@ namespace UnitTest
     {
     };
 
-    TEST_F(UtilsUnixLikeTestFixture, ConvertToAbsolutePath_OnInvalidPath_Fails)
-    {
-        EXPECT_FALSE(AZ::Utils::ConvertToAbsolutePath("><\\#/@):"));
-    }
-
     TEST_F(UtilsUnixLikeTestFixture, ConvertToAbsolutePath_OnRelativePath_Succeeds)
     {
         AZStd::optional<AZ::IO::FixedMaxPathString> absolutePath = AZ::Utils::ConvertToAbsolutePath("./");
@@ -35,5 +30,12 @@ namespace UnitTest
         AZStd::optional<AZ::IO::FixedMaxPathString> absolutePath = AZ::Utils::ConvertToAbsolutePath(executableDirectory);
         ASSERT_TRUE(absolutePath);
         EXPECT_STRCASEEQ(executableDirectory, absolutePath->c_str());
+    }
+
+    TEST_F(UtilsUnixLikeTestFixture, ConvertToAbsolutePath_OnNonExistentPath_Succeeds)
+    {
+        AZStd::optional<AZ::IO::FixedMaxPathString> absolutePath = AZ::Utils::ConvertToAbsolutePath(
+            "_PathWhichShouldNotExistButIsOkIfItDoesExist");
+        ASSERT_TRUE(absolutePath);
     }
 }

--- a/Code/Tools/SerializeContextTools/Application.cpp
+++ b/Code/Tools/SerializeContextTools/Application.cpp
@@ -37,7 +37,7 @@ namespace AZ
             AZ::IO::FixedMaxPath projectPath = AZ::Utils::GetProjectPath();
             if (projectPath.empty())
             {
-                AZ_Error("Serialize Context Tools", false, "Unable to determine the project path . "
+                AZ_TracePrintf("Serialize Context Tools", "Unable to determine the project path . "
                     "Make sure project has been set or provide via the -project-path option on the command line. (See -help for more info.)");
                 return;
             }
@@ -71,9 +71,9 @@ namespace AZ
                         projectSpecializations.Append(m_commandLine.GetSwitchValue("specializations", specializationIndex));
                     }
                 }
-                // Otherwise, if a config file was passed in, auto-set the specialization based on the config file name.
                 else
                 {
+                    // Otherwise, if a config file was passed in, auto-set the specialization based on the config file name.
                     AZ::IO::PathView configFilenameStem = m_configFilePath.Stem();
                     if (AZ::StringFunc::Equal(configFilenameStem.Native(), "Editor"))
                     {
@@ -83,9 +83,16 @@ namespace AZ
                     {
                         projectSpecializations.Append(projectName + "_GameLauncher");
                     }
+
+                    // If the "dumptypes" or "createtype" supplied attempt to load the editor gem dependencies
+                    if (m_commandLine.GetNumMiscValues() > 0 &&
+                        (m_commandLine.GetMiscValue(0) == "dumptypes" || m_commandLine.GetMiscValue(0) == "createtype"))
+                    {
+                        projectSpecializations.Append("editor");
+                    }
                 }
 
-                // Used the project specializations to merge the build dependencies *.setreg files
+                // Used the project specializations to merge the gem modules dependencies *.setreg files
                 auto registry = AZ::SettingsRegistry::Get();
                 AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_TargetBuildDependencyRegistry(*registry,
                     AZ_TRAIT_OS_PLATFORM_CODENAME, projectSpecializations);
@@ -101,7 +108,7 @@ namespace AZ
         {
             appType.m_maskValue = AZ::ApplicationTypeQuery::Masks::Tool;
         }
- 
+
         void Application::SetSettingsRegistrySpecializations(AZ::SettingsRegistryInterface::Specializations& specializations)
         {
             AZ::ComponentApplication::SetSettingsRegistrySpecializations(specializations);

--- a/Code/Tools/SerializeContextTools/CMakeLists.txt
+++ b/Code/Tools/SerializeContextTools/CMakeLists.txt
@@ -10,11 +10,6 @@ if (NOT PAL_TRAIT_BUILD_HOST_TOOLS)
     return()
 endif()
 
-include(Platform/${PAL_PLATFORM_NAME}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
-if (NOT PAL_TRAIT_BUILD_SERIALIZECONTEXTTOOLS)
-    return()
-endif()
-
 ly_add_target(
     NAME SerializeContextTools EXECUTABLE
     NAMESPACE AZ

--- a/Code/Tools/SerializeContextTools/Converter.cpp
+++ b/Code/Tools/SerializeContextTools/Converter.cpp
@@ -37,7 +37,7 @@ namespace AZ
                 AZ_Error("SerializeContextTools", false, "Command line not available.");
                 return false;
             }
-            
+
             JsonSerializerSettings convertSettings;
             convertSettings.m_keepDefaults = commandLine->HasSwitch("keepdefaults");
             convertSettings.m_registrationContext = application.GetJsonRegistrationContext();
@@ -119,7 +119,7 @@ namespace AZ
                     AZ_Warning("Convert", false, "Failed to load '%s'. File may not contain an object stream.", filePath.c_str());
                     result = false;
                 }
-                
+
                 // If there's only one file, then use the original name instead of the extended name
                 AZ::StringFunc::Path::ReplaceExtension(filePath, extension.c_str());
                 if (documents.size() == 1)
@@ -162,145 +162,6 @@ namespace AZ
                             scratchBuffer.Clear();
                         }
                     }
-                }
-            }
-
-            return result;
-        }
-
-        bool Converter::ConvertApplicationDescriptor(Application& application)
-        {
-            const AZ::CommandLine* commandLine = application.GetAzCommandLine();
-            if (!commandLine)
-            {
-                AZ_Error("SerializeContextTools", false, "Command line not available.");
-                return false;
-            }
-
-            JsonSerializerSettings convertSettings;
-            convertSettings.m_keepDefaults = commandLine->HasSwitch("keepdefaults");
-            convertSettings.m_registrationContext = application.GetJsonRegistrationContext();
-            convertSettings.m_serializeContext = application.GetSerializeContext();
-            if (!convertSettings.m_serializeContext)
-            {
-                AZ_Error("Convert", false, "No serialize context found.");
-                return false;
-            }
-            if (!convertSettings.m_registrationContext)
-            {
-                AZ_Error("Convert", false, "No json registration context found.");
-                return false;
-            }
-            AZStd::string logggingScratchBuffer;
-            SetupLogging(logggingScratchBuffer, convertSettings.m_reporting, *commandLine);
-
-            JsonDeserializerSettings verifySettings;
-            verifySettings.m_registrationContext = application.GetJsonRegistrationContext();
-            verifySettings.m_serializeContext = application.GetSerializeContext();
-            SetupLogging(logggingScratchBuffer, verifySettings.m_reporting, *commandLine);
-
-            bool skipGems = commandLine->HasSwitch("skipgems");
-            bool skipSystem = commandLine->HasSwitch("skipsystem");
-            bool isDryRun = commandLine->HasSwitch("dryrun");
-
-            PathDocumentContainer documents;
-            bool result = true;
-            const AZStd::string& filePath = application.GetConfigFilePath();
-            AZ_Printf("Convert", "Reading '%s' for conversion.\n", filePath.c_str());
-            AZStd::string configurationName;
-            if (!AZ::StringFunc::Path::GetFileName(filePath.c_str(), configurationName) ||
-                configurationName.empty())
-            {
-                AZ_Error("Convert", false, "Unable to extract configuration from '%s'.", filePath.c_str());
-                return false;
-            }
-            // Most folder names start with a capital letter, but most files with lower case. As the configuration name
-            // will be used as a folder, turn the first letter into a capital one.
-            AZStd::to_upper(configurationName.begin(), configurationName.begin() + 1);
-
-            AZ::IO::FixedMaxPath sourceGameFolder;
-            if (auto settingsRegistry = AZ::SettingsRegistry::Get();
-                !settingsRegistry
-                || !settingsRegistry->Get(sourceGameFolder.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath))
-            {
-                AZ_Error("Serialize Context Tools", false, "Unable to determine the game root automatically. "
-                    "Make sure a default project has been set or provide a default option on the command line. (See -help for more info.)");
-                return false;
-            }
-            
-            auto callback = 
-                [&result, skipGems, skipSystem, &configurationName, sourceGameFolder, &documents, &convertSettings, &verifySettings]
-                (void* classPtr, const Uuid& classId, SerializeContext* context)
-            {
-                if (classId == azrtti_typeid<AZ::ComponentApplication::Descriptor>())
-                {
-                    if (!skipSystem)
-                    {
-                        result = ConvertSystemSettings(documents, *reinterpret_cast<AZ::ComponentApplication::Descriptor*>(classPtr), 
-                            configurationName, sourceGameFolder) && result;
-                    }
-
-                    // Cleanup the Serialized Element to allow any classes within the element's hierarchy to delete
-                    // memory allocated by the SerializeContext
-                    const AZ::SerializeContext::ClassData* classData = context->FindClassData(classId);
-                    if (classData)
-                    {
-                        classData->m_factory->Destroy(classPtr);
-                    }
-                }
-                else if (classId == azrtti_typeid<Entity>())
-                {
-                    if (!skipSystem)
-                    {
-                        result = ConvertSystemComponents(documents, *reinterpret_cast<Entity*>(classPtr), configurationName,
-                            sourceGameFolder, convertSettings, verifySettings) && result;
-                    }
-                    const AZ::SerializeContext::ClassData* classData = context->FindClassData(classId);
-                    if (classData)
-                    {
-                        classData->m_factory->Destroy(classPtr);
-                    }
-                }
-                else if (classId == azrtti_typeid<ModuleEntity>())
-                {
-                    if (!skipGems)
-                    {
-                        result = ConvertModuleComponents(documents, *reinterpret_cast<ModuleEntity*>(classPtr), configurationName, 
-                            convertSettings, verifySettings) && result;
-                    }
-                    const AZ::SerializeContext::ClassData* classData = context->FindClassData(classId);
-                    if (classData)
-                    {
-                        classData->m_factory->Destroy(classPtr);
-                    }
-                }
-                else
-                {
-                    AZ_Warning("Convert", false, "Unable to process component in Application Descriptor of type '%s'.", 
-                        classId.ToString<AZStd::string>().c_str());
-                    result = false;
-                }
-                return true;
-            };
-            if (!Utilities::InspectSerializedFile(filePath.c_str(), convertSettings.m_serializeContext, callback))
-            {
-                AZ_Warning("Convert", false, "Failed to load '%s'. File may not contain an object stream.", filePath.c_str());
-                result = false;
-            }
-            
-            if (!isDryRun)
-            {
-                AZStd::string jsonDocumentRootPrefix;
-                if (commandLine->HasSwitch("json-prefix"))
-                {
-                    jsonDocumentRootPrefix = commandLine->GetSwitchValue("json-prefix", 0);
-                }
-
-                rapidjson::StringBuffer scratchBuffer;
-                for (auto& pathDocPair : documents)
-                {
-                    result = WriteDocumentToDisk(pathDocPair.first, pathDocPair.second, jsonDocumentRootPrefix, scratchBuffer) && result;
-                    scratchBuffer.Clear();
                 }
             }
 
@@ -441,248 +302,7 @@ namespace AZ
             return result;
         }
 
-        bool Converter::ConvertSystemSettings(PathDocumentContainer& documents, const ComponentApplication::Descriptor& descriptor, 
-            const AZStd::string& configurationName, const AZ::IO::PathView& projectFolder)
-        {
-            AZ::IO::FixedMaxPath memoryFilePath{ projectFolder };
-            memoryFilePath /= "Registry";
-            
-            AZ::IO::FixedMaxPath modulesFilePath = memoryFilePath;
-            AZStd::string configurationNameLower = configurationName;
-            AZStd::to_lower(configurationNameLower.begin(), configurationNameLower.end());
-            modulesFilePath /= AZ::IO::FixedMaxPathString::format("module.%s.setreg", configurationNameLower.c_str());
-            memoryFilePath /= AZ::IO::FixedMaxPathString::format("memory.%s.setreg", configurationNameLower.c_str());
-
-            AZ_Printf("Convert", "  Exporting application descriptor to '%s' and '%s'.\n", memoryFilePath.c_str(), modulesFilePath.c_str());
-            
-            rapidjson::Document modulesDoc;
-            modulesDoc.SetObject();
-            rapidjson::Value moduleList(rapidjson::kArrayType);
-            for (auto& module : descriptor.m_modules)
-            {
-                moduleList.PushBack(rapidjson::StringRef(module.m_dynamicLibraryPath.c_str()), modulesDoc.GetAllocator());
-            }
-            modulesDoc.AddMember(rapidjson::StringRef("Modules"), AZStd::move(moduleList), modulesDoc.GetAllocator());
-
-            rapidjson::Value gemPathList(rapidjson::kArrayType);
-            // Visit each gem target "SourcePaths" entry within the settings registry
-            auto AppendGemPaths = [&gemPathList, &modulesDoc]
-            (AZStd::string_view, AZStd::string_view gemPath)
-            {
-                gemPathList.PushBack(rapidjson::StringRef(gemPath.data(), gemPath.size()), modulesDoc.GetAllocator());
-            };
-
-            
-            AZ::SettingsRegistryInterface& registry = *AZ::SettingsRegistry::Get();
-            AZ::SettingsRegistryMergeUtils::VisitActiveGems(registry, AppendGemPaths);
-
-            modulesDoc.AddMember(rapidjson::StringRef("GemFolders"), AZStd::move(gemPathList), modulesDoc.GetAllocator());
-            documents.emplace_back(AZStd::move(modulesFilePath.Native()), AZStd::move(modulesDoc));
-
-            rapidjson::Document memoryDoc;
-            memoryDoc.SetObject();
-            memoryDoc.AddMember(rapidjson::StringRef("useExistingAllocator"),
-                rapidjson::Value(descriptor.m_useExistingAllocator), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("grabAllMemory"),
-                rapidjson::Value(descriptor.m_grabAllMemory), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("allocationRecords"),
-                rapidjson::Value(descriptor.m_allocationRecords), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("allocationRecordsSaveNames"),
-                rapidjson::Value(descriptor.m_allocationRecordsSaveNames), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("allocationRecordsAttemptDecodeImmediately"),
-                rapidjson::Value(descriptor.m_allocationRecordsAttemptDecodeImmediately), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("recordingMode"),
-                rapidjson::Value(descriptor.m_recordingMode), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("stackRecordLevels"),
-                rapidjson::Value(descriptor.m_stackRecordLevels), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("autoIntegrityCheck"),
-                rapidjson::Value(descriptor.m_autoIntegrityCheck), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("markUnallocatedMemory"),
-                rapidjson::Value(descriptor.m_markUnallocatedMemory), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("doNotUsePools"),
-                rapidjson::Value(descriptor.m_doNotUsePools), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("enableScriptReflection"),
-                rapidjson::Value(descriptor.m_enableScriptReflection), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("pageSize"),
-                rapidjson::Value(descriptor.m_pageSize), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("poolPageSize"),
-                rapidjson::Value(descriptor.m_poolPageSize), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("blockAlignment"),
-                rapidjson::Value(descriptor.m_memoryBlockAlignment), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("blockSize"),
-                rapidjson::Value(descriptor.m_memoryBlocksByteSize), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("reservedOS"),
-                rapidjson::Value(descriptor.m_reservedOS), memoryDoc.GetAllocator());
-            memoryDoc.AddMember(rapidjson::StringRef("reservedDebug"),
-                rapidjson::Value(descriptor.m_reservedDebug), memoryDoc.GetAllocator());
-            documents.emplace_back(AZStd::move(memoryFilePath.Native()), AZStd::move(memoryDoc));
-            
-            return true;
-        }
-
-        bool Converter::ConvertSystemComponents(PathDocumentContainer& documents, const Entity& entity, const AZStd::string& configurationName, 
-            const AZ::IO::PathView& projectFolder, const JsonSerializerSettings& convertSettings, const JsonDeserializerSettings& verifySettings)
-        {
-            using namespace AZ::JsonSerializationResult;
-
-            AZ::IO::FixedMaxPath systemFilePath{ projectFolder };
-            systemFilePath /= "Registry";
-            AZStd::string configurationNameLower = configurationName;
-            AZStd::to_lower(configurationNameLower.begin(), configurationNameLower.end());
-            systemFilePath /= AZ::IO::FixedMaxPathString::format("system.%s.setreg", configurationNameLower.c_str());
-            AZ_Printf("Convert", "  Exporting Entity to '%s'\n", systemFilePath.c_str());
-
-            rapidjson::Document systemSettings;
-            ResultCode result = JsonSerialization::Store(systemSettings.SetObject(), systemSettings.GetAllocator(), entity, convertSettings);
-            if (result.GetProcessing() != Processing::Halted)
-            {
-                if (!VerifyConvertedData(systemSettings, &entity, azrtti_typeid(entity), verifySettings))
-                {
-                    // Errors will already be reported by VerifyConvertedData.
-                    return false;
-                }
-
-                if (result.GetProcessing() != Processing::Halted)
-                {
-                    if (result.GetOutcome() == Outcomes::DefaultsUsed)
-                    {
-                        AZ_Printf("Convert", "  System settings not exported as only default values were found.\n");
-                    }
-                    else
-                    {
-                        documents.emplace_back(AZStd::move(systemFilePath.Native()), AZStd::move(systemSettings));
-                    }
-                }
-                else
-                {
-                    AZ_Printf("Convert", "  System settings not exported.\n");
-                }
-                return true;
-            }
-            else
-            {
-                // Other errors will already have been reported by the JsonSerialierManager.
-                return false;
-            }
-        }
-
-        bool Converter::ConvertModuleComponents(PathDocumentContainer& documents, const ModuleEntity& entity, 
-            const AZStd::string& configurationName, const JsonSerializerSettings& convertSettings, const JsonDeserializerSettings& verifySettings)
-        {
-            using namespace AZ::JsonSerializationResult;
-            using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
-            using Type = AZ::SettingsRegistryInterface::Type;
-
-            AZStd::fixed_string<128> gemName;
-            AZ::IO::FixedMaxPath gemModuleSourcePath;
-            AZ::ModuleManagerRequestBus::Broadcast([&gemModuleSourcePath, &gemName, gemModuleClassId = entity.m_moduleClassId](AZ::ModuleManagerRequests* request)
-            {
-                AZ_UNUSED(gemModuleClassId);
-                auto EnumerateGemModules = [&gemModuleSourcePath, &gemName, &gemModuleClassId](const AZ::ModuleData& moduleData) -> bool
-                {
-                    AZ::Module* moduleInst = moduleData.GetModule();
-                    if (moduleInst && AZ::RttiTypeId(*moduleInst) == gemModuleClassId)
-                    {
-                        auto settingsRegistry = AZ::SettingsRegistry::Get();
-                        auto VisitGemObject = [&gemName, &gemModuleSourcePath, settingsRegistry,
-                            moduleFilename = AZStd::string_view(moduleData.GetDynamicModuleHandle()->GetFilename())]
-                            (AZStd::string_view gemNameEntry, AZ::IO::PathView gemSourcePath)
-                        {
-                            auto VisitGemObjectFields = [&gemName, &gemModuleSourcePath, &settingsRegistry, &moduleFilename,
-                                &gemNameEntry, &gemSourcePath]
-                                (AZStd::string_view jsonPath, AZStd::string_view, Type)
-                            {
-                                auto FindModuleFilename = [&gemName, &gemModuleSourcePath, &settingsRegistry, &moduleFilename,
-                                    &gemNameEntry, &gemSourcePath]
-                                    (AZStd::string_view gemModulesElementJsonPath, AZStd::string_view, Type)
-                                {
-                                    AZ::IO::Path modulePath;
-                                    if (settingsRegistry->Get(modulePath.Native(), gemModulesElementJsonPath)
-                                        && modulePath.Native().ends_with(moduleFilename))
-                                    {
-                                        gemName = gemNameEntry;
-                                        gemModuleSourcePath = gemSourcePath;
-                                    }
-                                };
-                                auto gemModulesJsonPath = FixedValueString::format("%.*s/Modules",
-                                    AZ_STRING_ARG(jsonPath));
-                                AZ::SettingsRegistryVisitorUtils::VisitArray(*settingsRegistry, FindModuleFilename, gemModulesJsonPath);
-                            };
-
-                            auto gemObjectJsonPath = AZ::SettingsRegistryInterface::FixedValueString::format("%s/%.*s/Targets",
-                                AZ::SettingsRegistryMergeUtils::ActiveGemsRootKey, AZ_STRING_ARG(gemNameEntry));
-                            AZ::SettingsRegistryVisitorUtils::VisitField(*settingsRegistry, VisitGemObjectFields, gemObjectJsonPath);
-                        };
-
-                        AZ::SettingsRegistryMergeUtils::VisitActiveGems(*settingsRegistry, VisitGemObject);
-                    }
-                    return true;
-                };
-
-                request->EnumerateModules(EnumerateGemModules);
-            });
-
-            if (gemModuleSourcePath.empty())
-            {
-                AZ_Warning("Convert", false, "Unable to find a gem folder to write output registry for module entity '%s'.", entity.GetName().c_str());
-                return false;
-            }
-
-            AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get();
-
-            AZ::IO::FixedMaxPath registryPath;
-            if (!settingsRegistry->Get(registryPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder))
-            {
-                AZ_Warning("Convert", false, "Unable To find Engine Root Path at key '%s' in the Settings Registry",
-                    AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
-            }
-            registryPath /= gemModuleSourcePath;
-            registryPath /= "Registry";
-            AZStd::string configurationNameLower = configurationName;
-            AZStd::to_lower(configurationNameLower.begin(), configurationNameLower.end());
-            registryPath /= AZ::IO::FixedMaxPathString::format("gem.%s.setreg", configurationNameLower.c_str());
-            AZ_Printf("Convert", "  Exporting ModuleEntity to '%s'\n", registryPath.c_str());
-
-            rapidjson::Document moduleSettings;
-            moduleSettings.SetObject().AddMember(rapidjson::Value(gemName.c_str(),
-                aznumeric_cast<rapidjson::SizeType>(gemName.size()), moduleSettings.GetAllocator()),
-                rapidjson::Value(rapidjson::kObjectType).Move(), moduleSettings.GetAllocator());
-            rapidjson::Value& moduleSettingsValue = moduleSettings[gemName.c_str()];
-            ResultCode result = JsonSerialization::Store(moduleSettingsValue, moduleSettings.GetAllocator(), entity, convertSettings);
-            if (result.GetProcessing() != Processing::Halted)
-            {
-                if (!VerifyConvertedData(moduleSettingsValue, &entity, azrtti_typeid(entity), verifySettings))
-                {
-                    // Errors will already be reported by VerifyConvertedData.
-                    return false;
-                }
-
-                if (result.GetProcessing() != Processing::Halted)
-                {
-                    if (result.GetOutcome() == Outcomes::DefaultsUsed)
-                    {
-                        AZ_Printf("Convert", "  Gem settings not exported as only default values were found.\n");
-                    }
-                    else
-                    {
-                        // Add Converted module settings in a JSON pointer path underneath the Gem Name
-                        documents.emplace_back(AZStd::move(registryPath.Native()), AZStd::move(moduleSettings));
-                    }
-                }
-                else
-                {
-                    AZ_Printf("Convert", "  Gem settings not exported.\n");
-                }
-                return true;
-            }
-            else
-            {
-                // Other errors will already have been reported by the JsonSerialization.
-                return false;
-            }
-        }
-
-        bool Converter::VerifyConvertedData(rapidjson::Value& convertedData, const void* original, const Uuid& originalType, 
+        bool Converter::VerifyConvertedData(rapidjson::Value& convertedData, const void* original, const Uuid& originalType,
             const JsonDeserializerSettings& settings)
         {
             using namespace AZ::JsonSerializationResult;
@@ -715,7 +335,7 @@ namespace AZ
                     originalType.ToString<AZStd::string>().c_str());
                 return false;
             }
-            
+
             bool result = false;
             if (data->m_serializer)
             {
@@ -731,8 +351,8 @@ namespace AZ
                 AZ::IO::ByteContainerStream<decltype(loadedData)> loadedStream(&loadedData);
                 AZ::Utils::SaveObjectToStream(loadedStream, AZ::ObjectStream::ST_BINARY,
                     objectPtr, originalType);
-                
-                result = 
+
+                result =
                     (originalData.size() == loadedData.size()) &&
                     (memcmp(originalData.data(), loadedData.data(), originalData.size()) == 0);
             }
@@ -827,7 +447,7 @@ namespace AZ
             scratchBuffer.append(".\n");
             AZ_Printf("SerializeContextTools", "%s", scratchBuffer.c_str());
             scratchBuffer.clear();
-            
+
             return result;
         }
 

--- a/Code/Tools/SerializeContextTools/Converter.h
+++ b/Code/Tools/SerializeContextTools/Converter.h
@@ -33,7 +33,6 @@ namespace AZ
         {
         public:
             static bool ConvertObjectStreamFiles(Application& application);
-            static bool ConvertApplicationDescriptor(Application& application);
             //! Converts Windows INI Style File
             //! Can be used to convert *.ini and *.cfg files
             static bool ConvertConfigFile(Application& application);
@@ -42,13 +41,6 @@ namespace AZ
             using PathDocumentPair = AZStd::pair<AZStd::string, rapidjson::Document>;
             using PathDocumentContainer = AZStd::vector<PathDocumentPair>;
 
-            static bool ConvertSystemSettings(PathDocumentContainer& documents, const ComponentApplication::Descriptor& descriptor, 
-                const AZStd::string& configurationName, const AZ::IO::PathView& projectFolder);
-            static bool ConvertSystemComponents(PathDocumentContainer& documents, const Entity& entity,
-                const AZStd::string& configurationName, const AZ::IO::PathView& projectFolder,
-                const JsonSerializerSettings& convertSettings, const JsonDeserializerSettings& verifySettings);
-            static bool ConvertModuleComponents(PathDocumentContainer& documents, const ModuleEntity& entity, const AZStd::string& configurationName,
-                const JsonSerializerSettings& convertSettings, const JsonDeserializerSettings& verifySettings);
             static bool VerifyConvertedData(rapidjson::Value& convertedData, const void* original, const Uuid& originalType,
                 const JsonDeserializerSettings& settings);
 

--- a/Code/Tools/SerializeContextTools/Dumper.cpp
+++ b/Code/Tools/SerializeContextTools/Dumper.cpp
@@ -10,17 +10,24 @@
 #include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Casting/lossy_cast.h>
 #include <AzCore/Debug/Trace.h>
+#include <AzCore/IO/FileIO.h>
+#include <AzCore/IO/GenericStreams.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/JSON/stringbuffer.h>
+#include <AzCore/JSON/pointer.h>
 #include <AzCore/JSON/prettywriter.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/Json/JsonSerialization.h>
+#include <AzCore/Serialization/Json/JsonSerializationSettings.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/sort.h>
 #include <AzCore/StringFunc/StringFunc.h>
+#include <AzCore/Utils/Utils.h>
 #include <Application.h>
 #include <Utilities.h>
+
 
 namespace AZ::SerializeContextTools
 {
@@ -139,6 +146,333 @@ namespace AZ::SerializeContextTools
 
         outputFile.Write(buffer.GetString(), buffer.GetSize());
         outputFile.Close();
+        return result;
+    }
+
+    bool Dumper::DumpTypes(Application& application)
+    {
+        // outputStream defaults to a stdout stream
+        AZ::IO::SystemFile systemFile;
+        AZStd::variant<AZ::IO::StdoutStream, AZ::IO::SystemFileStream> outputStream;
+
+        AZ::CommandLine& commandLine = *application.GetAzCommandLine();
+        // If the output-file parameter has been supplied open the file path using FileIOStream
+        if (size_t optionCount = commandLine.GetNumSwitchValues("output-file"); optionCount > 0)
+        {
+            AZ::IO::FixedMaxPath outputPath;
+            if (AZ::IO::PathView outputPathView(commandLine.GetSwitchValue("output-file", optionCount - 1));
+                outputPathView.IsRelative())
+            {
+                AZ::Utils::ConvertToAbsolutePath(outputPath, outputPathView.Native());
+            }
+            else
+            {
+                outputPath = outputPathView.LexicallyNormal();
+            }
+
+            constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeCreatePath;
+            auto& fileStream = outputStream.emplace<AZ::IO::SystemFileStream>(&systemFile, true);
+            if (!fileStream.Open(outputPath.c_str(), openMode))
+            {
+                AZ_Printf(
+                    "dumptypes",
+                    R"(Unable to open specified output-file "%s". Object will not be dumped)"
+                    "\n",
+                    outputPath.c_str());
+                return false;
+            }
+        }
+
+        AZ::SerializeContext* context = application.GetSerializeContext();
+
+        struct TypeNameIdPair
+        {
+            AZStd::string m_name;
+            AZ::TypeId m_id;
+
+            bool operator==(const TypeNameIdPair& other) const
+            {
+                return m_name == other.m_name && m_id == other.m_id;
+            }
+            bool operator!=(const TypeNameIdPair& other) const
+            {
+                return !operator==(other);
+            }
+
+            struct Hash
+            {
+                size_t operator()(const TypeNameIdPair& key) const
+                {
+                    size_t hashValue{};
+                    AZStd::hash_combine(hashValue, key.m_name);
+                    AZStd::hash_combine(hashValue, key.m_id);
+                    return hashValue;
+                }
+            };
+        };
+
+
+        // Append the Type names and type ids to a unordered_set to filter out duplicates
+        AZStd::unordered_set<TypeNameIdPair, TypeNameIdPair::Hash> typeNameIdPairsSet;
+        auto AppendTypeInfo = [&typeNameIdPairsSet](const SerializeContext::ClassData* classData, const Uuid&) -> bool
+        {
+            typeNameIdPairsSet.emplace(TypeNameIdPair{ classData->m_name, classData->m_typeId });
+            return true;
+        };
+        context->EnumerateAll(AppendTypeInfo, true);
+
+        // Move over the unordered set over to an array for later
+        // The array is potentially sorted depending on the sort option
+        AZStd::vector<TypeNameIdPair> typeNameIdPairs(
+            AZStd::make_move_iterator(typeNameIdPairsSet.begin()),
+            AZStd::make_move_iterator(typeNameIdPairsSet.end())
+        );
+        // Clear out the Unordered set container
+        typeNameIdPairsSet = {};
+
+        // Sort the TypeNameIdPair based on the --sort option value or by type name if not supplied
+        enum class SortOptions
+        {
+            Name,
+            TypeId,
+            None
+        };
+        SortOptions sortOption{ SortOptions::Name };
+
+        if (size_t sortOptionCount = commandLine.GetNumSwitchValues("sort"); sortOptionCount > 0)
+        {
+            AZStd::string sortOptionString = commandLine.GetSwitchValue("sort", sortOptionCount - 1);
+            if (sortOptionString == "name")
+            {
+                sortOption = SortOptions::Name;
+            }
+            if (sortOptionString == "typeid")
+            {
+                sortOption = SortOptions::TypeId;
+            }
+            else if (sortOptionString == "none")
+            {
+                sortOption = SortOptions::None;
+            }
+            else
+            {
+                AZ_Error(
+                    "dumptypes", false,
+                    R"(Invalid --sort option supplied "%s".)"
+                    " Sorting by type name will be used. See --help for valid values)",
+                    sortOptionString.c_str());
+            }
+        }
+
+        switch (sortOption)
+        {
+        case SortOptions::Name:
+        {
+            auto SortByName = [](const TypeNameIdPair& lhs, const TypeNameIdPair& rhs)
+            {
+                return azstricmp(lhs.m_name.c_str(), rhs.m_name.c_str()) < 0;
+            };
+            AZStd::sort(typeNameIdPairs.begin(), typeNameIdPairs.end(), SortByName);
+            break;
+        }
+        case SortOptions::TypeId:
+        {
+            auto SortByTypeId = [](const TypeNameIdPair& lhs, const TypeNameIdPair& rhs)
+            {
+                return lhs.m_id < rhs.m_id;
+            };
+            AZStd::sort(typeNameIdPairs.begin(), typeNameIdPairs.end(), SortByTypeId);
+            break;
+        }
+        case SortOptions::None:
+            [[fallthrough]];
+        default:
+            break;
+        }
+
+        auto GetOutputPathString = [](auto&& stream) -> const char*
+        {
+            return stream.GetFilename();
+        };
+
+        AZ_Printf(
+            "dumptypes",
+            R"(Writing reflected types to "%s".)"
+            "\n",
+            AZStd::visit(GetOutputPathString, outputStream));
+
+        auto WriteReflectedTypes = [&typeNameIdPairs](auto&& stream) -> bool
+        {
+            AZStd::string typeListContents;
+            for (auto&& [typeName, typeId] : typeNameIdPairs)
+            {
+                typeListContents += AZStd::string::format("%s %s\n", typeName.c_str(), typeId.ToFixedString().c_str());
+            }
+
+            stream.Write(typeListContents.size(), typeListContents.data());
+            stream.Close();
+            return true;
+        };
+        const bool result = AZStd::visit(WriteReflectedTypes, outputStream);
+
+        return result;
+    }
+
+    bool Dumper::CreateType(Application& application)
+    {
+        // outputStream defaults to a stdout stream
+        AZ::IO::SystemFile systemFile;
+        AZStd::variant<AZ::IO::StdoutStream, AZ::IO::SystemFileStream> outputStream;
+
+        AZ::CommandLine& commandLine = *application.GetAzCommandLine();
+        // If the output-file parameter has been supplied open the file path using FileIOStream
+        if (size_t optionCount = commandLine.GetNumSwitchValues("output-file"); optionCount > 0)
+        {
+            AZ::IO::FixedMaxPath outputPath;
+            if (AZ::IO::PathView outputPathView(commandLine.GetSwitchValue("output-file", optionCount - 1));
+                outputPathView.IsRelative())
+            {
+                AZ::Utils::ConvertToAbsolutePath(outputPath, outputPathView.Native());
+            }
+            else
+            {
+                outputPath = outputPathView.LexicallyNormal();
+            }
+
+            constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeCreatePath;
+            auto& fileStream = outputStream.emplace<AZ::IO::SystemFileStream>(&systemFile, true);
+            if (!fileStream.Open(outputPath.c_str(), openMode))
+            {
+                AZ_Printf(
+                    "createtype",
+                    R"(Unable to specified output-file "%s". Object will not be dumped)"
+                    "\n",
+                    outputPath.c_str());
+                return false;
+            }
+        }
+
+        size_t typeIdOptionCount = commandLine.GetNumSwitchValues("type-id");
+        size_t typeNameOptionCount = commandLine.GetNumSwitchValues("type-name");
+        if (typeIdOptionCount == 0 && typeNameOptionCount == 0)
+        {
+            AZ_Error("createtype", false, "One of the following options must be supplied: --type-id or --type-name");
+            return false;
+        }
+        if (typeIdOptionCount > 0 && typeNameOptionCount > 0)
+        {
+            AZ_Error("createtype", false, "The --type-id and --type-name options are mutally exclusive. Only one can be specified");
+            return false;
+        }
+
+        AZ::SerializeContext* context = application.GetSerializeContext();
+        const AZ::SerializeContext::ClassData* classData = nullptr;
+        if (typeIdOptionCount > 0)
+        {
+            AZStd::string typeIdValue = commandLine.GetSwitchValue("type-id", typeIdOptionCount - 1);
+            classData = context->FindClassData(AZ::TypeId(typeIdValue.c_str(), typeIdValue.size()));
+            if (classData == nullptr)
+            {
+                AZ_Error("createtype", false, "Type with ID %s is not registered with the SerializeContext", typeIdValue.c_str());
+                return false;
+            }
+        }
+        else
+        {
+            AZStd::string typeNameValue = commandLine.GetSwitchValue("type-name", typeNameOptionCount - 1);
+            AZStd::vector<AZ::TypeId> classIds = context->FindClassId(AZ::Crc32{ AZStd::string_view{ typeNameValue } });
+            if (classIds.size() != 1)
+            {
+                if (classIds.empty())
+                {
+                    AZ_Error("createtype", false, "Type with name %s is not registered with the SerializeContext", typeNameValue.c_str());
+                }
+                else
+                {
+                    const char* prependComma = "";
+                    AZStd::string classIdString;
+                    for (const AZ::TypeId& classId : classIds)
+                    {
+                        classIdString += prependComma + classId.ToString<AZStd::string>();
+                        prependComma = ", ";
+                    }
+                    AZ_Error(
+                        "createtype", classIds.size() < 2,
+                        "Multiple types with name %s have been registered with the SerializeContext,\n"
+                        "In order to disambiguate which type to use, the --type-id argument must be supplied with one of the following "
+                        "Uuids:\n",
+                        "%s", typeNameValue.c_str(), classIdString.c_str());
+                }
+                return false;
+            }
+
+            // Only one class with this typename has been registered with the serialize context, so look up its ClassData
+            classData = context->FindClassData(classIds.front());
+        }
+
+        // Create a rapidjson document to store the default constructed object
+        const AZStd::any typeInst = context->CreateAny(classData->m_typeId);
+        rapidjson::Document document;
+        rapidjson::Value& root = document.SetObject();
+
+        AZ::JsonSerializerSettings serializerSettings;
+        serializerSettings.m_serializeContext = context;
+        serializerSettings.m_registrationContext = application.GetJsonRegistrationContext();
+        serializerSettings.m_keepDefaults = true;
+
+        using JsonResultCode = AZ::JsonSerializationResult::ResultCode;
+        const JsonResultCode parseResult = AZ::JsonSerialization::Store(
+            root, document.GetAllocator(), AZStd::any_cast<void>(&typeInst), nullptr, typeInst.type(), serializerSettings);
+        if (parseResult.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
+        {
+            AZ_Printf("createtype", "  Failed to store type %s in JSON format.\n", classData->m_name);
+            return false;
+        }
+
+        auto GetOutputPathString = [](auto&& stream)
+        {
+            using StreamType = AZStd::remove_cvref_t<decltype(stream)>;
+            if constexpr (AZStd::is_same_v<StreamType, AZ::IO::StdoutStream>)
+            {
+                return AZ::IO::FixedMaxPath{ "<stdout>" };
+            }
+            else if (AZStd::is_same_v<StreamType, AZ::IO::FileIOStream>)
+            {
+                return AZ::IO::FixedMaxPath{ stream.GetFilename() };
+            }
+            else
+            {
+                AZ_Assert(false, "OutputStream has invalid stream type. It must be StdoutStream or FileIOStream");
+                return AZ::IO::FixedMaxPath{};
+            }
+        };
+
+        AZ_Printf(
+            "createtype",
+            R"(Writing Type "%s" to "%s" using Json Serialization.)"
+            "\n",
+            classData->m_name, AZStd::visit(GetOutputPathString, outputStream).c_str());
+
+        AZStd::string jsonDocumentRootPrefix;
+        if (commandLine.HasSwitch("json-prefix"))
+        {
+            jsonDocumentRootPrefix = commandLine.GetSwitchValue("json-prefix", 0);
+        }
+
+        auto VisitStream = [&document, &jsonDocumentRootPrefix](auto&& stream) -> bool
+        {
+            if (WriteDocumentToStream(stream, document, jsonDocumentRootPrefix))
+            {
+                // Write out a newline to the end of the stream
+                constexpr AZStd::string_view newline = "\n";
+                stream.Write(newline.size(), newline.data());
+                return true;
+            }
+
+            return false;
+        };
+        const bool result = AZStd::visit(VisitStream, outputStream);
+
         return result;
     }
 
@@ -576,6 +910,27 @@ namespace AZ::SerializeContextTools
         {
             output += classId.ToString<AZStd::string>();
         }
+    }
+
+    bool Dumper::WriteDocumentToStream(AZ::IO::GenericStream& outputStream, const rapidjson::Document& document,
+        AZStd::string_view pointerRoot)
+    {
+        rapidjson::StringBuffer scratchBuffer;
+        rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(scratchBuffer);
+
+        // rapidjson::Pointer constructor attempts to dereference the const char* index 0 even if the size is 0
+        // so make sure the string_view isn't referencing a nullptr
+        rapidjson::Pointer jsonPointerAnchor(pointerRoot.data() ? pointerRoot.data() : "", pointerRoot.size());
+
+        // Anchor the content in the Json Document under the Json Pointer root path
+        rapidjson::Document rootDocument;
+        rapidjson::SetValueByPointer(rootDocument, jsonPointerAnchor, document);
+        rootDocument.Accept(writer);
+
+        outputStream.Write(scratchBuffer.GetSize(), scratchBuffer.GetString());
+
+        scratchBuffer.Clear();
+        return true;
     }
     // namespace AZ::SerializeContextTools
 }

--- a/Code/Tools/SerializeContextTools/Dumper.h
+++ b/Code/Tools/SerializeContextTools/Dumper.h
@@ -15,43 +15,51 @@
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/string/string_view.h>
 
-namespace AZ
+
+namespace AZ::IO
 {
-    namespace SerializeContextTools
+    class GenericStream;
+}
+namespace AZ::SerializeContextTools
+{
+    class Application;
+
+    class Dumper
     {
-        class Application;
+    public:
+        static bool DumpFiles(Application& application);
+        static bool DumpSerializeContext(Application& application);
 
-        class Dumper
-        {
-        public:
-            static bool DumpFiles(Application& application);
-            static bool DumpSerializeContext(Application& application);
+        static bool DumpTypes(Application& application);
+        static bool CreateType(Application& application);
 
-        private:
-            static AZStd::vector<Uuid> CreateFilterListByNames(SerializeContext* context, AZStd::string_view name);
-            
-            static AZStd::string_view ExtractNamespace(const AZStd::string& name);
+    private:
+        static AZStd::vector<Uuid> CreateFilterListByNames(SerializeContext* context, AZStd::string_view name);
 
-            static rapidjson::Value WriteToJsonValue(const Uuid& uuid, rapidjson::Document& document);
-            
-            static bool DumpClassContent(const SerializeContext::ClassData* classData, rapidjson::Value& parent, rapidjson::Document& document, 
-                const AZStd::vector<Uuid>& systemComponents, SerializeContext* context, AZStd::string& scratchStringBuffer);
-            static bool DumpClassContent(AZStd::string& output, void* classPtr, const Uuid& classId, SerializeContext* context);
-            
-            static void DumpElementInfo(const SerializeContext::ClassElement& element, const SerializeContext::ClassData* classData, SerializeContext* context, 
-                rapidjson::Value& fields, rapidjson::Value& bases, rapidjson::Document& document, AZStd::string& scratchStringBuffer);
-            static void DumpElementInfo(AZStd::string& output, const SerializeContext::ClassElement* classElement, SerializeContext* context);
-            
-            static void DumpGenericStructure(AZStd::string& output, GenericClassInfo* genericClassInfo, SerializeContext* context);
-            static rapidjson::Value DumpGenericStructure(GenericClassInfo* genericClassInfo, SerializeContext* context, 
-                rapidjson::Document& parentDoc, AZStd::string& scratchStringBuffer);
-            
-            static void DumpPrimitiveTag(AZStd::string& output, const SerializeContext::ClassData* classData, 
-                const SerializeContext::ClassElement* classElement);
-            static void DumpClassName(rapidjson::Value& parent, SerializeContext* context, const SerializeContext::ClassData* classData, 
-                rapidjson::Document& parentDoc, AZStd::string& scratchStringBuffer);
-            
-            static void AppendTypeName(AZStd::string& output, const SerializeContext::ClassData* classData, const Uuid& classId);
-        };
-    } // namespace SerializeContextTools
-} // namespace AZ
+        static AZStd::string_view ExtractNamespace(const AZStd::string& name);
+
+        static rapidjson::Value WriteToJsonValue(const Uuid& uuid, rapidjson::Document& document);
+
+        static bool DumpClassContent(const SerializeContext::ClassData* classData, rapidjson::Value& parent, rapidjson::Document& document,
+            const AZStd::vector<Uuid>& systemComponents, SerializeContext* context, AZStd::string& scratchStringBuffer);
+        static bool DumpClassContent(AZStd::string& output, void* classPtr, const Uuid& classId, SerializeContext* context);
+
+        static void DumpElementInfo(const SerializeContext::ClassElement& element, const SerializeContext::ClassData* classData, SerializeContext* context,
+            rapidjson::Value& fields, rapidjson::Value& bases, rapidjson::Document& document, AZStd::string& scratchStringBuffer);
+        static void DumpElementInfo(AZStd::string& output, const SerializeContext::ClassElement* classElement, SerializeContext* context);
+
+        static void DumpGenericStructure(AZStd::string& output, GenericClassInfo* genericClassInfo, SerializeContext* context);
+        static rapidjson::Value DumpGenericStructure(GenericClassInfo* genericClassInfo, SerializeContext* context,
+            rapidjson::Document& parentDoc, AZStd::string& scratchStringBuffer);
+
+        static void DumpPrimitiveTag(AZStd::string& output, const SerializeContext::ClassData* classData,
+            const SerializeContext::ClassElement* classElement);
+        static void DumpClassName(rapidjson::Value& parent, SerializeContext* context, const SerializeContext::ClassData* classData,
+            rapidjson::Document& parentDoc, AZStd::string& scratchStringBuffer);
+
+        static void AppendTypeName(AZStd::string& output, const SerializeContext::ClassData* classData, const Uuid& classId);
+
+        static bool WriteDocumentToStream(AZ::IO::GenericStream& outputstream, const rapidjson::Document& document,
+            AZStd::string_view pointerRoot);
+    };
+} // namespace AZ::SerializeContextTools

--- a/Code/Tools/SerializeContextTools/Platform/Linux/PAL_linux.cmake
+++ b/Code/Tools/SerializeContextTools/Platform/Linux/PAL_linux.cmake
@@ -1,9 +1,0 @@
-#
-# Copyright (c) Contributors to the Open 3D Engine Project.
-# For complete copyright and license terms please see the LICENSE at the root of this distribution.
-#
-# SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-#
-
-set(PAL_TRAIT_BUILD_SERIALIZECONTEXTTOOLS FALSE)

--- a/Code/Tools/SerializeContextTools/Platform/Mac/PAL_mac.cmake
+++ b/Code/Tools/SerializeContextTools/Platform/Mac/PAL_mac.cmake
@@ -1,9 +1,0 @@
-#
-# Copyright (c) Contributors to the Open 3D Engine Project.
-# For complete copyright and license terms please see the LICENSE at the root of this distribution.
-#
-# SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-#
-
-set(PAL_TRAIT_BUILD_SERIALIZECONTEXTTOOLS TRUE)

--- a/Code/Tools/SerializeContextTools/Platform/Windows/PAL_windows.cmake
+++ b/Code/Tools/SerializeContextTools/Platform/Windows/PAL_windows.cmake
@@ -1,9 +1,0 @@
-#
-# Copyright (c) Contributors to the Open 3D Engine Project.
-# For complete copyright and license terms please see the LICENSE at the root of this distribution.
-#
-# SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-#
-
-set(PAL_TRAIT_BUILD_SERIALIZECONTEXTTOOLS TRUE)


### PR DESCRIPTION
Added a `dumptypes` command to the SerializeContextTools that can dump the reflected types(name and Uuid) to stdout or to a file using the --output-file.
The name and Uuid are separated by whitespace.

Added a `createtype` command to the SerializeContextTools that can create an instance of a reflected type and output it in json format. The instance can be written to stdout or to a file.

The dumptypes command can be run as follows
```bash
# Dumps all SerializeContext reflected types to a file and sorts them by name
build/linux_ninja/bin/profile/SerializeContextTools dumptypes --project-path AutomatedTesting --output-file=<types.txt>

# Dumps all SerializeContext reflected types to a file and sorts them by UUID
build/linux_ninja/bin/profile/SerializeContextTools dumptypes --project-path AutomatedTesting --output-file=<types.txt> --sort=id
```

An example createtype command could be
```bash
# Dumps the Streamer ReadSplitterConfig instance as JSON using the typename
build/linux_ninja/bin/profile/SerializeContextTools createtype --project-path AutomatedTesting --type-name="AZ::IO::ReadSplitterConfig" --output-file=<content.json>

# Dumps the Streamer ReadSplitterConfig instance as JSON using the typeid
build/linux_ninja/bin/profile/SerializeContextTools createtype --project-path AutomatedTesting --type-id="{EDDD6CE5-D7BC-4FAB-8EBA-68F5C0390B05}" --output-file=<content.json>
```

The types that can be created for the `createtype` command can be determined by the `dumptypes` command.

resolves #7567


Updated the type name generation in AzTypeInfo to be consistent for aggregate types such as tuple.
Updated the `AzTypeInfo::Name()` function to be constexpr, as well as the `TYPEINFO_Name()` function that gets added by the AZ_TYPE_INFO macro.
Updated the TypeInfo names of AZStd container types to be consistent across the board.

resolves #9488


The StdoutStream now overrides the GetFilename function to return a filename of "<stdout>" instead of "".
Added a ConvertToAbsolutePath overload which returns a boolean and accepts an AZ::IO::FixedMaxPath output parameter by reference.
Fixed the Unix ConvertToAbsolutePath implementation to return an absolute path even for non-existent paths.


Added support to the Trace RawOutput function to redirect writes to stdout, stderr or nowhere at all.
This functionality is exposed through the `bg_redirectrawoutput` CVar.


Removed ConvertSystemSettings, ConvertSystemComponents and ConvertModuleComponents functions
As there are no existing Editor.xml/Game.xml files in O3DE, there is no reason to keep these conversion functions around.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
