### PR TITLE
Make profile the default configuration in Android.

### DIFF
--- a/Code/Tools/Android/ProjectBuilder/build.gradle.in
+++ b/Code/Tools/Android/ProjectBuilder/build.gradle.in
@@ -30,6 +30,7 @@ ${NATIVE_CMAKE_SECTION_DEBUG_CONFIG}
             ${SIGNING_DEBUG_CONFIG}
         }
         profile {
+            getIsDefault().set(true)
             debuggable true
 ${NATIVE_CMAKE_SECTION_PROFILE_CONFIG}
             ${SIGNING_PROFILE_CONFIG}


### PR DESCRIPTION
Running `deploy_android.py` just generates the gradle solution, but it's not until the first time it's opened in Android Studio that it will run cmake configuration, and since the default configuration was debug it did the cmake for debug. Then when switching to profile it runs cmake configuration again, then you can build the project.

The most common configuration used is profile. So by setting it as default, the first time the Android Studio is opened it'll will configure cmake for profile and that way you only run cmake once and not twice for the most common case.

Signed-off-by: moraaar <moraaar@amazon.com>