### PR TITLE
DRAFT - Android VFS fix

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
+++ b/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
@@ -480,6 +480,11 @@ namespace AZ
                 return false;
             }
 
+            if (AZStd::string(path).starts_with("/APK/"))
+            {
+                path += 5;
+            }
+
             if (AZ::IO::PathView(path).HasRootPath())
             {
                 size_t pathLen = strlen(path);

--- a/Code/Tools/Android/ProjectBuilder/build.gradle.in
+++ b/Code/Tools/Android/ProjectBuilder/build.gradle.in
@@ -30,6 +30,7 @@ ${NATIVE_CMAKE_SECTION_DEBUG_CONFIG}
             ${SIGNING_DEBUG_CONFIG}
         }
         profile {
+            getIsDefault().set(true)
             debuggable true
 ${NATIVE_CMAKE_SECTION_PROFILE_CONFIG}
             ${SIGNING_PROFILE_CONFIG}

--- a/cmake/Tools/layout_tool.py
+++ b/cmake/Tools/layout_tool.py
@@ -244,7 +244,11 @@ def copy_asset_files_to_layout(project_asset_folder, target_platform, layout_tar
                             abs_dst)
             continue
 
-        if os.path.isfile(abs_dst):
+        # If the target file doesn't exist, copy it
+        if not os.path.exists(abs_dst):
+            logging.debug("Copying %s -> %s", abs_src, abs_dst)
+            shutil.copy2(abs_src, abs_dst)
+        elif os.path.isfile(abs_dst):
             # The target is a file, do a fingerprint check
             # TODO: Evaluate if we want to just junction the files instead of doing a copy
             src_hash = common.file_fingerprint(abs_src)


### PR DESCRIPTION
I was able to get Android VFS to work with the changes in this PR.

There were 2 issues:
1. Android layout function `copy_asset_files_to_layout` (which is called for VFS layout too) is suppose to copy the files in the root cache, which include necessary files like system files, setreg files, etc. Without these basic files android doesn't know how to connect remotely, it won't generate the expected token base on the project folder (it creates a new one, which is compared with AP's token upon connection and fails). After this fix the files in the root cache folder are copied to the device and it connects successfully to AP.

2. After the communication is successfully done, the next issue was how Android was requesting files to AP, which they include "/APK/" in the beginning. AP on the PC failed to resolve that path. This PR has a workaround (mega hack) which is to remove the "/APK/" part in `LocalFileIO`. By removing "/APK/" in `LocalFileIO::ResolvePath` it will the put @products@"alias first and AP will find the asset in the cache and it starts working correctly. (make sure to get PR https://github.com/o3de/o3de/pull/10187 fix, as that was another error where products alias was wrong)

Steps to use Android VFS:
- Build on PC
- Uncomment this line to generate android assets: https://github.com/o3de/o3de/blob/37315d4040e81474e5e79d609de9c80c31effb58/Registry/AssetProcessorPlatformConfig.setreg#L66
- Modifiy https://github.com/o3de/o3de/blob/development/Registry/bootstrap.setreg file by setting `android_remote_filesystem`, `android_connect_to_remote` and `android_wait_for_connect` to 1.
- Run Asset Processor and wait for all the assets to finish.
- Run the `generate_android_project.py` command with `--asset-mode VFS` option. This is the full command I use:
````
E:\Amazon\GitHub\o3de> python\python.cmd E:\Amazon\GitHub\o3de\cmake\Tools\Platform\Android\generate_android_project.py --engine-root E:\Amazon\GitHub\o3de --project-path E:\Amazon\GitHub\o3de_openxr\OpenXRTest --build-dir  E:\Amazon\GitHub\o3de_openxr\OpenXRTest\build\android_vfs --enable-unity-build --third-party-path E:\Amazon\GitHub\o3de_3rdParty --android-sdk-path C:\Android\AndroidSDK --android-ndk-version 21.4.7075529 --android-sdk-platform 29 --asset-mode VFS --gradle-install-path C:\Android\gradle-7.0.2 --ninja-install-path C:\Android\ninja-win --signconfig-store-file C:\Android\ly-android-keystore.jks --signconfig-store-password android --signconfig-key-alias android_key --signconfig-key-password android --overwrite-existing
````
- Compile and generate apk by running: `.\gradlew assembleProfile` from the `build-dir`. You can now check the apk generated in "app\build\outputs\apk\profile\app-profile.apk" under your `build-dir` path. You can unzip it to check its assets folder only contains the files in the root.
- Prepare android device
    - Connect android device to pc
    - Make sure it's detected by running `adb devices -l` in a terminal
    - Run this command to revert the port used to connect AP (this way the localhost can be used as the remote target and not the IP of the PC, this is why we didn't change `remote_ip` in the bootstrap file): `adb reverse tcp:45643 tcp:45643`
    **IMPORTANT**: this command to reverse the port needs to be run often. For example, each time the device is unplugged or refuse-connections messages are shown in the log. Adb connection is quite temperamental and the connection gets restarted, when that happens the port goes to its original status.
- Deploy the apk to the device by running `deploy_android.py` script. This is the full command I use:
````
E:\Amazon\GitHub\o3de> python\python.cmd E:\Amazon\GitHub\o3de\cmake\Tools\Platform\Android\deploy_android.py --build-dir E:\Amazon\GitHub\o3de_openxr\OpenXRTest\build\android_vfs --configuration profile --clean -t BOTH
````
- Run the app in the device.
 
 If everything goes well the connection will appear in the "Connections" tap in AP.

![image](https://user-images.githubusercontent.com/27999040/174340539-5208218a-2160-4c33-ae49-79d326631787.png)

Signed-off-by: moraaar <moraaar@amazon.com>