### PR TITLE
Address exception during rebuilding a not fully active networked entity hierarchy

### DIFF
--- a/Gems/Multiplayer/Code/Source/Components/NetworkHierarchyRootComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkHierarchyRootComponent.cpp
@@ -298,7 +298,18 @@ namespace Multiplayer
                         return;
                     }
 
-                    const AZStd::vector<AZ::EntityId> allChildren = candidate->GetTransform()->GetChildren();
+                    AZStd::vector<AZ::EntityId> allChildren;
+                    if (candidate->GetTransform())
+                    {
+                        allChildren = candidate->GetTransform()->GetChildren();
+                    }
+                    else
+                    {
+                        // Child entities may not be in the Active state so skip for now.
+                        // They will notify when ready causing another rebuild.
+                        continue;
+                    }
+
                     for (const AZ::EntityId& newChildId : allChildren)
                     {
                         candidates.push_back(componentApplicationRequests->FindEntity(newChildId));


### PR DESCRIPTION
Networked Entity Hierarchy rebuilds are triggered based on certain events occurring on contained entities. This includes state changes such as Activating. One side effect here is that an Activated entity can trigger a rebuild while children are not in an activated state. This causes the exception outlined in https://github.com/o3de/o3de/issues/10152.

There doesn't appear to be a mechanism to determine when a hierarchy is fully activated so instead this change guards against inactive entities.

A separate issue has been created to track a related problem on the AssetBuilder side of prefabs (https://github.com/o3de/o3de/issues/10196).

Signed-off-by: puvvadar <puvvadar@amazon.com>