### PR TITLE
Basic behavior and edit context reflection for ShaderSourceData and related types

### DIFF
--- a/Code/Framework/AzCore/AzCore/Preprocessor/Enum.h
+++ b/Code/Framework/AzCore/AzCore/Preprocessor/Enum.h
@@ -264,8 +264,6 @@ inline namespace AZ_JOIN(EnumTypeName, Namespace) \
     } \
 } \
 \
-template< typename T > struct AzEnumTraits; \
-\
 template<> \
 struct AzEnumTraits< AZ_JOIN(EnumTypeName, Namespace)::EnumTypeName > \
 { \
@@ -273,4 +271,6 @@ struct AzEnumTraits< AZ_JOIN(EnumTypeName, Namespace)::EnumTypeName > \
     inline static constexpr MembersArrayType& Members   = AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Members); \
     inline static constexpr size_t Count                = AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Count); \
     inline static constexpr AZStd::string_view EnumName = AZ_STRINGIZE(EnumTypeName); \
-}; 
+};
+
+template<typename T> struct AzEnumTraits;

--- a/Code/Framework/AzCore/AzCore/Preprocessor/Enum.h
+++ b/Code/Framework/AzCore/AzCore/Preprocessor/Enum.h
@@ -264,13 +264,47 @@ inline namespace AZ_JOIN(EnumTypeName, Namespace) \
     } \
 } \
 \
-template<> \
-struct AzEnumTraits< AZ_JOIN(EnumTypeName, Namespace)::EnumTypeName > \
-{ \
-    using MembersArrayType                              = decltype( AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Members) ); \
-    inline static constexpr MembersArrayType& Members   = AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Members); \
-    inline static constexpr size_t Count                = AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Count); \
-    inline static constexpr AZStd::string_view EnumName = AZ_STRINGIZE(EnumTypeName); \
-};
+    struct AZ_JOIN(EnumTypeName, EnumTraits)                                                                                               \
+    {                                                                                                                                      \
+        using MembersArrayType = decltype(AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Members));                               \
+        inline static constexpr MembersArrayType& Members = AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Members);              \
+        inline static constexpr size_t Count = AZ_JOIN(EnumTypeName, Namespace)::AZ_JOIN(EnumTypeName, Count);                             \
+        inline static constexpr AZStd::string_view EnumName = AZ_STRINGIZE(EnumTypeName);                                                  \
+        /* Visitor must accept a type convertible from EnumTypeName as the first parameter and an AZStd::string_view as the second */      \
+        template<class Visitor>                                                                                                            \
+        static constexpr void Visit(Visitor&& enumVisitor)                                                                                 \
+        {                                                                                                                                  \
+            for (const auto& member : Members)                                                                                             \
+            {                                                                                                                              \
+                enumVisitor(member.m_value, member.m_string);                                                                              \
+            }                                                                                                                              \
+        }                                                                                                                                  \
+    };                                                                                                                                     \
+                                                                                                                                           \
+    inline auto GetAzEnumTraits(AZ_JOIN(EnumTypeName, Namespace)::EnumTypeName)                                                            \
+    {                                                                                                                                      \
+        return AZ_JOIN(EnumTypeName, EnumTraits){};                                                                                        \
+    };
 
-template<typename T> struct AzEnumTraits;
+namespace AZ::Internal
+{
+    // Deleted function to provide the AZ::Internal namespace with the GetAzEnumTraits symbol
+    // This is to make an overload which the AzEnumTraitsImpl would use with its
+    // template parameter to use Argument Dependent Lookup to find the GetAzEnumTraits
+    // function for the Enum Type in the correct namespace.
+    template<typename T>
+    void GetAzEnumTraits(T&&) = delete;
+    template<typename T>
+    struct AzEnumTraitsImpl
+    {
+        // The AZ_ENUM macros contrive a function which returns a struct
+        // with the enum traits within it
+        // We use decltype here to get the type of that function
+        using type = decltype(GetAzEnumTraits(AZStd::declval<T>()));
+    };
+} // namespace AZ::Internal
+namespace AZ
+{
+    template<typename T>
+    using AzEnumTraits = typename Internal::AzEnumTraitsImpl<T>::type;
+}

--- a/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
+++ b/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
@@ -20,7 +20,7 @@
     static void AZ_JOIN(EnumTypeName, Reflect)(AZ::SerializeContext& context)                                                                           \
     {                                                                                                                                                   \
         auto enumMaker = context.Enum<EnumTypeName>();                                                                                                  \
-        for (auto&& member : AzEnumTraits<EnumTypeName>::Members)                                                                                       \
+        for (auto&& member : AZ::AzEnumTraits<EnumTypeName>::Members)                                                                                       \
         {                                                                                                                                               \
             enumMaker.Value(member.m_string.data(), member.m_value);                                                                                    \
         }                                                                                                                                               \
@@ -31,9 +31,9 @@
     {                                                                                                                                                   \
         if (typeName.empty())                                                                                                                           \
         {                                                                                                                                               \
-            typeName = AzEnumTraits<EnumTypeName>::EnumName;                                                                                            \
+            typeName = AZ::AzEnumTraits<EnumTypeName>::EnumName;                                                                                            \
         }                                                                                                                                               \
-        constexpr auto& enumValueStringPair = AzEnumTraits<EnumTypeName>::Members[Index];                                                               \
+        constexpr auto& enumValueStringPair = AZ::AzEnumTraits<EnumTypeName>::Members[Index];                                                               \
         auto qualifiedEnumName = AZStd::fixed_string<256>::format("%.*s_%.*s", AZ_STRING_ARG(typeName), AZ_STRING_ARG(enumValueStringPair.m_string));   \
         context.Enum<aznumeric_cast<int>(enumValueStringPair.m_value)>(qualifiedEnumName.c_str());                                                      \
     }                                                                                                                                                   \
@@ -46,6 +46,6 @@
                                                                                                                                                         \
     void AZ_JOIN(EnumTypeName, Reflect)(AZ::BehaviorContext& context, AZStd::string_view typeName = {})                                                 \
     {                                                                                                                                                   \
-        AZ_JOIN(EnumTypeName, ReflectValues)(context, typeName, AZStd::make_index_sequence<AzEnumTraits<EnumTypeName>::Members.size()>());              \
-    }
+        AZ_JOIN(EnumTypeName, ReflectValues)(context, typeName, AZStd::make_index_sequence<AZ::AzEnumTraits<EnumTypeName>::Members.size()>());              \
+    }                                                                                                                                                   
 

--- a/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
+++ b/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <AzCore/Preprocessor/Enum.h>
-#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/string/fixed_string.h>
+
 
 //! Call this macro in the same namespace where the AZ_ENUM was defined to generate ReflectEnumType() utility functions.
 //! @param EnumTypeName an enum that was defined using one of the AZ_ENUM macros.
@@ -47,14 +47,5 @@
     void AZ_JOIN(EnumTypeName, Reflect)(AZ::BehaviorContext& context, AZStd::string_view typeName = {})                                                 \
     {                                                                                                                                                   \
         AZ_JOIN(EnumTypeName, ReflectValues)(context, typeName, AZStd::make_index_sequence<AzEnumTraits<EnumTypeName>::Members.size()>());              \
-    }                                                                                                                                                   \
-                                                                                                                                                        \
-    AZStd::vector<AZ::Edit::EnumConstant<uint32_t>> AZ_JOIN(EnumTypeName, EditEnumConstants)()                                                          \
-    {                                                                                                                                                   \
-        AZStd::vector<AZ::Edit::EnumConstant<uint32_t>> enumValues;                                                                                     \
-        for (const auto& member : AzEnumTraits<EnumTypeName>::Members)                                                                                  \
-        {                                                                                                                                               \
-            enumValues.emplace_back(aznumeric_cast<uint32_t>(member.m_value), member.m_string.data());                                                  \
-        }                                                                                                                                               \
-        return enumValues;                                                                                                                              \
-    }                                                                                                                                                   \
+    }
+

--- a/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
+++ b/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <AzCore/Preprocessor/Enum.h>
+#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/string/fixed_string.h>
-
 
 //! Call this macro in the same namespace where the AZ_ENUM was defined to generate ReflectEnumType() utility functions.
 //! @param EnumTypeName an enum that was defined using one of the AZ_ENUM macros.
@@ -47,5 +47,14 @@
     void AZ_JOIN(EnumTypeName, Reflect)(AZ::BehaviorContext& context, AZStd::string_view typeName = {})                                                 \
     {                                                                                                                                                   \
         AZ_JOIN(EnumTypeName, ReflectValues)(context, typeName, AZStd::make_index_sequence<AzEnumTraits<EnumTypeName>::Members.size()>());              \
-    }                                                                                                                                                   
-
+    }                                                                                                                                                   \
+                                                                                                                                                        \
+    AZStd::vector<AZ::Edit::EnumConstant<uint32_t>> AZ_JOIN(EnumTypeName, EditEnumConstants)()                                                          \
+    {                                                                                                                                                   \
+        AZStd::vector<AZ::Edit::EnumConstant<uint32_t>> enumValues;                                                                                     \
+        for (const auto& member : AzEnumTraits<EnumTypeName>::Members)                                                                                  \
+        {                                                                                                                                               \
+            enumValues.emplace_back(aznumeric_cast<uint32_t>(member.m_value), member.m_string.data());                                                  \
+        }                                                                                                                                               \
+        return enumValues;                                                                                                                              \
+    }                                                                                                                                                   \

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
@@ -840,7 +840,7 @@ namespace AZ
         AZStd::vector<EnumConstant<UnderlyingType>> GetEnumConstantsFromTraits()
         {
             AZStd::vector<EnumConstant<UnderlyingType>> enumValues;
-            for (const auto& member : AzEnumTraits<EnumType>::Members)
+            for (const auto& member : AZ::AzEnumTraits<EnumType>::Members)
             {
                 enumValues.emplace_back(aznumeric_cast<UnderlyingType>(member.m_value), member.m_string.data());
             }

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Preprocessor/Enum.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/typetraits/is_function.h>
 
@@ -833,6 +834,18 @@ namespace AZ
             UnderlyingType m_value;
             AZStd::string m_description;
         };
+
+        // Automatically generate a list of EnumConstant from AzEnumTraits
+        template<typename EnumType, typename UnderlyingType = AZStd::underlying_type_t<EnumType>>
+        AZStd::vector<EnumConstant<UnderlyingType>> GetEnumConstantsFromTraits()
+        {
+            AZStd::vector<EnumConstant<UnderlyingType>> enumValues;
+            for (const auto& member : AzEnumTraits<EnumType>::Members)
+            {
+                enumValues.emplace_back(aznumeric_cast<UnderlyingType>(member.m_value), member.m_string.data());
+            }
+            return enumValues;
+        }
     } // namespace Edit
 
     //=========================================================================

--- a/Code/Framework/AzCore/Tests/EnumTests.cpp
+++ b/Code/Framework/AzCore/Tests/EnumTests.cpp
@@ -133,7 +133,7 @@ namespace UnitTest
 
     TEST_F(EnumTests, TraitsBehaviorRegular)
     {
-        static_assert(AzEnumTraits<TestEnum>::Members.size() == 26);
+        static_assert(AZ::AzEnumTraits<TestEnum>::Members.size() == 26);
     }
 
 }

--- a/Gems/Atom/RHI/Code/Source/RHI.Edit/ShaderBuildArguments.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Edit/ShaderBuildArguments.cpp
@@ -6,10 +6,13 @@
  *
  */
 
-#include <Atom/RHI.Edit/ShaderBuildArguments.h>
-#include <AzFramework/StringFunc/StringFunc.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/string/regex.h>
+#include <AzFramework/StringFunc/StringFunc.h>
 
+#include <Atom/RHI.Edit/ShaderBuildArguments.h>
 #include <Atom/RHI.Edit/Utils.h>
 
 namespace AZ
@@ -18,7 +21,7 @@ namespace AZ
     {
         void ShaderBuildArguments::Reflect(ReflectContext* context)
         {
-            if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
+            if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<ShaderBuildArguments>()
                     ->Version(1)
@@ -29,6 +32,46 @@ namespace AZ
                     ->Field("spirv-cross", &ShaderBuildArguments::m_spirvCrossArguments)
                     ->Field("metalair", &ShaderBuildArguments::m_metalAirArguments)
                     ->Field("metallib", &ShaderBuildArguments::m_metalLibArguments)
+                    ;
+
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<ShaderBuildArguments>("ShaderBuildArguments", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderBuildArguments::m_generateDebugInfo, "Generate Debug Info", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderBuildArguments::m_preprocessorArguments, "Preprocessor Arguments", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderBuildArguments::m_azslcArguments, "Azslc Arguments", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderBuildArguments::m_dxcArguments, "Dxc Arguments", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderBuildArguments::m_spirvCrossArguments, "Spirv Cross Arguments", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderBuildArguments::m_metalAirArguments, "Metal Air Arguments", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderBuildArguments::m_metalLibArguments, "Metal Lib Arguments", "")
+                        ;
+                }
+            }
+
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<ShaderBuildArguments>("ShaderBuildArguments")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RHI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rhi")
+                    ->Constructor()
+                    ->Constructor<const ShaderBuildArguments&>()
+                    ->Property("generateDebugInfo", BehaviorValueProperty(&ShaderBuildArguments::m_generateDebugInfo))
+                    ->Property("preprocessorArguments", BehaviorValueProperty(&ShaderBuildArguments::m_preprocessorArguments))
+                    ->Property("azslcArguments", BehaviorValueProperty(&ShaderBuildArguments::m_azslcArguments))
+                    ->Property("dxcArguments", BehaviorValueProperty(&ShaderBuildArguments::m_dxcArguments))
+                    ->Property("spirvCrossArguments", BehaviorValueProperty(&ShaderBuildArguments::m_spirvCrossArguments))
+                    ->Property("metalAirArguments", BehaviorValueProperty(&ShaderBuildArguments::m_metalAirArguments))
+                    ->Property("metalLibArguments", BehaviorValueProperty(&ShaderBuildArguments::m_metalLibArguments))
+                    ->Method("AddBuildArguments", &ShaderBuildArguments::operator+=)
+                    ->Method("RemoveBuildArguments", &ShaderBuildArguments::operator-=)
+                    ->Method("HasArgument", &ShaderBuildArguments::HasArgument)
+                    ->Method("AppendArguments", &ShaderBuildArguments::AppendArguments)
+                    ->Method("RemoveArguments", &ShaderBuildArguments::RemoveArguments)
+                    ->Method("AppendDefinitions", &ShaderBuildArguments::AppendDefinitions)
                     ;
             }
         }

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/RenderStates.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/RenderStates.cpp
@@ -5,9 +5,14 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #include <Atom/RHI.Reflect/RenderStates.h>
-#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Preprocessor/Enum.h>
 #include <AzCore/Preprocessor/EnumReflectUtils.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/RTTI/TypeInfo.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Utils/TypeHash.h>
 
 namespace AZ
@@ -315,7 +320,7 @@ namespace AZ
 
         void RasterState::Reflect(ReflectContext* context)
         {
-            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
+            if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<RasterState>()
                     ->Version(1)
@@ -327,38 +332,154 @@ namespace AZ
                     ->Field("multisampleEnable", &RasterState::m_multisampleEnable)
                     ->Field("depthClipEnable", &RasterState::m_depthClipEnable)
                     ->Field("conservativeRasterEnable", &RasterState::m_conservativeRasterEnable)
-                    ->Field("forcedSampleCount", &RasterState::m_forcedSampleCount);
+                    ->Field("forcedSampleCount", &RasterState::m_forcedSampleCount)
+                    ;
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<RasterState>("RasterState", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_depthBias, "Depth Bias", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_depthBiasClamp, "Depth Bias Clamp", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_depthBiasSlopeScale, "Depth Bias Slope Scale", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_fillMode, "Fill Mode", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<FillMode>())
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_cullMode, "Cull Mode", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<CullMode>())
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_multisampleEnable, "Multisample Enable", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_depthClipEnable, "Depth Clip Enable", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_conservativeRasterEnable, "Conservative Raster Enable", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_forcedSampleCount, "Forced Sample Count", "")
+                        ;
+                }
+            }
+
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<RasterState>("RasterState")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RHI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rhi")
+                    ->Constructor()
+                    ->Constructor<const RasterState&>()
+                    ->Property("depthBias", BehaviorValueProperty(&RasterState::m_depthBias))
+                    ->Property("depthBiasClamp", BehaviorValueProperty(&RasterState::m_depthBiasClamp))
+                    ->Property("depthBiasSlopeScale", BehaviorValueProperty(&RasterState::m_depthBiasSlopeScale))
+                    ->Property("fillMode", BehaviorValueProperty(&RasterState::m_fillMode))
+                    ->Property("cullMode", BehaviorValueProperty(&RasterState::m_cullMode))
+                    ->Property("multisampleEnable", BehaviorValueProperty(&RasterState::m_multisampleEnable))
+                    ->Property("depthClipEnable", BehaviorValueProperty(&RasterState::m_depthClipEnable))
+                    ->Property("conservativeRasterEnable", BehaviorValueProperty(&RasterState::m_conservativeRasterEnable))
+                    ->Property("forcedSampleCount", BehaviorValueProperty(&RasterState::m_forcedSampleCount))
+                    ;
             }
         }
 
         void StencilOpState::Reflect(ReflectContext* context)
         {
-            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
+            if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<StencilOpState>()
                     ->Version(1)
                     ->Field("failOp", &StencilOpState::m_failOp)
                     ->Field("depthFailOp", &StencilOpState::m_depthFailOp)
                     ->Field("passOp", &StencilOpState::m_passOp)
-                    ->Field("func", &StencilOpState::m_func);
+                    ->Field("func", &StencilOpState::m_func)
+                    ;
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<StencilOpState>("StencilOpState", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &StencilOpState::m_failOp, "Fail Op", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<StencilOp>())
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &StencilOpState::m_depthFailOp, "Depth Fail Op", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<StencilOp>())
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &StencilOpState::m_passOp, "Pass Op", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<StencilOp>())
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &StencilOpState::m_func, "Func", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZStd::vector<AZ::Edit::EnumConstant<ComparisonFunc>>{
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::Never, ToString(ComparisonFunc::Never)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::Less, ToString(ComparisonFunc::Less)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::Equal, ToString(ComparisonFunc::Equal)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::LessEqual, ToString(ComparisonFunc::LessEqual)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::Greater, ToString(ComparisonFunc::Greater)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::NotEqual, ToString(ComparisonFunc::NotEqual)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::GreaterEqual, ToString(ComparisonFunc::GreaterEqual)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::Always, ToString(ComparisonFunc::Always)) })
+                        ;
+                }
+            }
+
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<StencilOpState>("StencilOpState")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RHI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rhi")
+                    ->Constructor()
+                    ->Constructor<const StencilOpState&>()
+                    ->Property("failOp", BehaviorValueProperty(&StencilOpState::m_failOp))
+                    ->Property("depthFailOp", BehaviorValueProperty(&StencilOpState::m_depthFailOp))
+                    ->Property("passOp", BehaviorValueProperty(&StencilOpState::m_passOp))
+                    ->Property("func", BehaviorValueProperty(&StencilOpState::m_func))
+                    ;
             }
         }
 
         void DepthState::Reflect(ReflectContext* context)
         {
-            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
+            if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<DepthState>()
                     ->Version(1)
                     ->Field("enable", &DepthState::m_enable)
                     ->Field("writeMask", &DepthState::m_writeMask)
-                    ->Field("compareFunc", &DepthState::m_func);
+                    ->Field("compareFunc", &DepthState::m_func)
+                    ;
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<DepthState>("DepthState", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &DepthState::m_enable, "Enable", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &DepthState::m_writeMask, "Write Mask", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<DepthWriteMask>())
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &DepthState::m_func, "Func", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZStd::vector<AZ::Edit::EnumConstant<ComparisonFunc>>{
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::Never, ToString(ComparisonFunc::Never)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::Less, ToString(ComparisonFunc::Less)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::Equal, ToString(ComparisonFunc::Equal)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::LessEqual, ToString(ComparisonFunc::LessEqual)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::Greater, ToString(ComparisonFunc::Greater)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::NotEqual, ToString(ComparisonFunc::NotEqual)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::GreaterEqual, ToString(ComparisonFunc::GreaterEqual)),
+                                AZ::Edit::EnumConstant<ComparisonFunc>(ComparisonFunc::Always, ToString(ComparisonFunc::Always)) })
+                        ;
+                }
+            }
+
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<DepthState>("DepthState")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RHI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rhi")
+                    ->Constructor()
+                    ->Constructor<const DepthState&>()
+                    ->Property("enable", BehaviorValueProperty(&DepthState::m_enable))
+                    ->Property("writeMask", BehaviorValueProperty(&DepthState::m_writeMask))
+                    ->Property("compareFunc", BehaviorValueProperty(&DepthState::m_func))
+                    ;
             }
         }
 
         void StencilState::Reflect(ReflectContext* context)
         {
-            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
+            if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<StencilState>()
                     ->Version(1)
@@ -366,24 +487,78 @@ namespace AZ
                     ->Field("readMask", &StencilState::m_readMask)
                     ->Field("writeMask", &StencilState::m_writeMask)
                     ->Field("frontFace", &StencilState::m_frontFace)
-                    ->Field("backFace", &StencilState::m_backFace);
+                    ->Field("backFace", &StencilState::m_backFace)
+                    ;
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<StencilState>("StencilState", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &StencilState::m_enable, "Enable", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &StencilState::m_readMask, "Read Mask", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &StencilState::m_writeMask, "Write Mask", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &StencilState::m_frontFace, "Front Face", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &StencilState::m_backFace, "Back Face", "")
+                        ;
+                }
+            }
+
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<StencilState>("StencilState")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RHI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rhi")
+                    ->Constructor()
+                    ->Constructor<const StencilState&>()
+                    ->Property("enable", BehaviorValueProperty(&StencilState::m_enable))
+                    ->Property("readMask", BehaviorValueProperty(&StencilState::m_readMask))
+                    ->Property("writeMask", BehaviorValueProperty(&StencilState::m_writeMask))
+                    ->Property("frontFace", BehaviorValueProperty(&StencilState::m_frontFace))
+                    ->Property("backFace", BehaviorValueProperty(&StencilState::m_backFace))
+                    ;
             }
         }
 
         void DepthStencilState::Reflect(ReflectContext* context)
         {
-            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
+            if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<DepthStencilState>()
                     ->Version(1)
                     ->Field("depth", &DepthStencilState::m_depth)
-                    ->Field("stencil", &DepthStencilState::m_stencil);
+                    ->Field("stencil", &DepthStencilState::m_stencil)
+                    ;
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<DepthStencilState>("DepthStencilState", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &DepthStencilState::m_depth, "Depth", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &DepthStencilState::m_stencil, "Stencil", "")
+                        ;
+                }
+            }
+
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<DepthStencilState>("DepthStencilState")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RHI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rhi")
+                    ->Constructor()
+                    ->Constructor<const DepthStencilState&>()
+                    ->Property("depth", BehaviorValueProperty(&DepthStencilState::m_depth))
+                    ->Property("stencil", BehaviorValueProperty(&DepthStencilState::m_stencil))
+                    ;
             }
         }
 
         void TargetBlendState::Reflect(ReflectContext* context)
         {
-            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
+            if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<TargetBlendState>()
                     ->Version(1)
@@ -394,30 +569,121 @@ namespace AZ
                     ->Field("blendAlphaSource", &TargetBlendState::m_blendAlphaSource)
                     ->Field("blendAlphaDest", &TargetBlendState::m_blendAlphaDest)
                     ->Field("blendAlphaOp", &TargetBlendState::m_blendAlphaOp)
-                    ->Field("writeMask", &TargetBlendState::m_writeMask);
+                    ->Field("writeMask", &TargetBlendState::m_writeMask)
+                    ;
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<TargetBlendState>("TargetBlendState", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TargetBlendState::m_enable, "Enable", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TargetBlendState::m_blendSource, "Blend Source", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<BlendFactor>())
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TargetBlendState::m_blendDest, "Blend Dest", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<BlendFactor>())
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TargetBlendState::m_blendOp, "Blend Op", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<BlendOp>())
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TargetBlendState::m_blendAlphaSource, "Blend Alpha Source", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<BlendFactor>())
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TargetBlendState::m_blendAlphaDest, "Blend Alpha Dest", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<BlendFactor>())
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TargetBlendState::m_blendAlphaOp, "Blend Alpha Op", "")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<BlendOp>())
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TargetBlendState::m_writeMask, "Write Mask", "")
+                        ;
+                }
+            }
+
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<TargetBlendState>("TargetBlendState")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RHI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rhi")
+                    ->Constructor()
+                    ->Constructor<const TargetBlendState&>()
+                    ->Property("enable", BehaviorValueProperty(&TargetBlendState::m_enable))
+                    ->Property("blendSource", BehaviorValueProperty(&TargetBlendState::m_blendSource))
+                    ->Property("blendDest", BehaviorValueProperty(&TargetBlendState::m_blendDest))
+                    ->Property("blendOp", BehaviorValueProperty(&TargetBlendState::m_blendOp))
+                    ->Property("blendAlphaSource", BehaviorValueProperty(&TargetBlendState::m_blendAlphaSource))
+                    ->Property("blendAlphaDest", BehaviorValueProperty(&TargetBlendState::m_blendAlphaDest))
+                    ->Property("blendAlphaOp", BehaviorValueProperty(&TargetBlendState::m_blendAlphaOp))
+                    ->Property("writeMask", BehaviorValueProperty(&TargetBlendState::m_writeMask))
+                    ;
             }
         }
 
         void BlendState::Reflect(ReflectContext* context)
         {
-            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
+            if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<BlendState>()
                     ->Version(1)
                     ->Field("alphaToCoverageEnable", &BlendState::m_alphaToCoverageEnable)
                     ->Field("independentBlendEnable", &BlendState::m_independentBlendEnable)
-                    ->Field("targets", &BlendState::m_targets);
+                    ->Field("targets", &BlendState::m_targets)
+                    ;
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<BlendState>("BlendState", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &BlendState::m_alphaToCoverageEnable, "Alpha To Coverage Enable", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &BlendState::m_independentBlendEnable, "Independent Blend Enable", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &BlendState::m_targets, "Targets", "")
+                        ;
+                }
+            }
+
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<BlendState>("BlendState")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RHI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rhi")
+                    ->Constructor()
+                    ->Constructor<const BlendState&>()
+                    ->Property("alphaToCoverageEnable", BehaviorValueProperty(&BlendState::m_alphaToCoverageEnable))
+                    ->Property("independentBlendEnable", BehaviorValueProperty(&BlendState::m_independentBlendEnable))
+                    ->Property("targets", BehaviorValueProperty(&BlendState::m_targets))
+                    ;
             }
         }
 
         void SamplePosition::Reflect(ReflectContext* context)
         {
-            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
+            if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<SamplePosition>()
                     ->Version(1)
                     ->Field("x", &SamplePosition::m_x)
                     ->Field("y", &SamplePosition::m_y)
+                    ;
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<SamplePosition>("SamplePosition", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &SamplePosition::m_x, "X", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &SamplePosition::m_y, "Y", "")
+                        ;
+                }
+            }
+
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<SamplePosition>("SamplePosition")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RHI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rhi")
+                    ->Constructor()
+                    ->Constructor<const SamplePosition&>()
+                    ->Property("x", BehaviorValueProperty(&SamplePosition::m_x))
+                    ->Property("y", BehaviorValueProperty(&SamplePosition::m_y))
                     ;
             }
         }
@@ -425,7 +691,7 @@ namespace AZ
         void MultisampleState::Reflect(ReflectContext* context)
         {
             SamplePosition::Reflect(context);
-            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
+            if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<MultisampleState>()
                     ->Version(1)
@@ -434,19 +700,74 @@ namespace AZ
                     ->Field("customPositions", &MultisampleState::m_customPositions)
                     ->Field("customPositionsCount", &MultisampleState::m_customPositionsCount)
                     ;
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<MultisampleState>("MultisampleState", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &MultisampleState::m_samples, "Samples", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &MultisampleState::m_quality, "Quality", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &MultisampleState::m_customPositions, "Custom Positions", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &MultisampleState::m_customPositionsCount, "Custom Positions Count", "")
+                        ;
+                }
+            }
+
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<MultisampleState>("MultisampleState")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RHI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rhi")
+                    ->Constructor()
+                    ->Constructor<const MultisampleState&>()
+                    ->Property("samples", BehaviorValueProperty(&MultisampleState::m_samples))
+                    ->Property("quality", BehaviorValueProperty(&MultisampleState::m_quality))
+                    ->Property("customPositions", BehaviorValueProperty(&MultisampleState::m_customPositions))
+                    ->Property("customPositionsCount", BehaviorValueProperty(&MultisampleState::m_customPositionsCount))
+                    ;
             }
         }
 
         void RenderStates::Reflect(ReflectContext* context)
         {
-            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
+            if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<RenderStates>()
                     ->Version(1)
                     ->Field("rasterState", &RenderStates::m_rasterState)
                     ->Field("multisampleState", &RenderStates::m_multisampleState)
                     ->Field("depthStencilState", &RenderStates::m_depthStencilState)
-                    ->Field("blendState", &RenderStates::m_blendState);
+                    ->Field("blendState", &RenderStates::m_blendState)
+                    ;
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<RenderStates>("RenderStates", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &RenderStates::m_rasterState, "Raster State", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &RenderStates::m_multisampleState, "Multisample State", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &RenderStates::m_depthStencilState, "DepthStencil State", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &RenderStates::m_blendState, "Blend State", "")
+                        ;
+                }
+            }
+
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<RenderStates>("RenderStates")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RHI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rhi")
+                    ->Constructor()
+                    ->Constructor<const RenderStates&>()
+                    ->Property("rasterState", BehaviorValueProperty(&RenderStates::m_rasterState))
+                    ->Property("multisampleState", BehaviorValueProperty(&RenderStates::m_multisampleState))
+                    ->Property("depthStencilState", BehaviorValueProperty(&RenderStates::m_depthStencilState))
+                    ->Property("blendState", BehaviorValueProperty(&RenderStates::m_blendState))
+                    ;
             }
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderSourceData.cpp
@@ -6,10 +6,11 @@
  *
  */
 
-#include <Atom/RPI.Edit/Shader/ShaderSourceData.h>
 #include <Atom/RHI.Edit/Utils.h>
-#include <AzCore/std/string/regex.h>
-#include <AzFramework/StringFunc/StringFunc.h>
+#include <Atom/RPI.Edit/Shader/ShaderSourceData.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
 {
@@ -17,7 +18,7 @@ namespace AZ
     {
         void ShaderSourceData::Reflect(ReflectContext* context)
         {
-            if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
+            if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<ShaderSourceData>()
                     ->Version(6) // Introduction of "AddBuildArguments" & "RemoveBuildArguments"
@@ -34,23 +35,125 @@ namespace AZ
                     ->Field("Supervariants", &ShaderSourceData::m_supervariants)
                     ;
 
-                serializeContext->Class<ShaderSourceData::ProgramSettings>()
+                serializeContext->Class<ProgramSettings>()
                     ->Version(1)
                     ->Field("EntryPoints", &ProgramSettings::m_entryPoints)
                     ;
 
-                serializeContext->Class<ShaderSourceData::EntryPoint>()
+                serializeContext->Class<EntryPoint>()
                     ->Version(1)
                     ->Field("Name", &EntryPoint::m_name)
                     ->Field("Type", &EntryPoint::m_type)
                     ;
 
-                serializeContext->Class<ShaderSourceData::SupervariantInfo>()
+                serializeContext->Class<SupervariantInfo>()
                     ->Version(2) // Introduction of "AddBuildArguments" & "RemoveBuildArguments"
                     ->Field("Name", &SupervariantInfo::m_name)
                     ->Field("RemoveBuildArguments", &SupervariantInfo::m_removeBuildArguments)
                     ->Field("AddBuildArguments", &SupervariantInfo::m_addBuildArguments)
                     ->Field("Definitions", &SupervariantInfo::m_definitions)
+                    ;
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<ShaderSourceData>("ShaderSourceData", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderSourceData::m_source, "Source", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderSourceData::m_drawListName, "Draw List", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderSourceData::m_depthStencilState, "Depth Stencil State", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderSourceData::m_rasterState, "Raster State", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderSourceData::m_blendState, "Blend State", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderSourceData::m_programSettings, "Program Settings", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderSourceData::m_removeBuildArguments, "Remove Build Arguments", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderSourceData::m_addBuildArguments, "Add Build Arguments", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderSourceData::m_definitions, "Definitions", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderSourceData::m_disabledRhiBackends, "Disabled RHI Backends", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderSourceData::m_supervariants, "Super Variants", "")
+                        ;
+
+                    editContext->Class<ProgramSettings>("ShaderSourceData::ProgramSettings", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ProgramSettings::m_entryPoints, "Entry Points", "")
+                        ;
+
+                    editContext->Class<EntryPoint>("ShaderSourceData::EntryPoint", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &EntryPoint::m_name, "Name", "")
+                        ->DataElement(AZ::Edit::UIHandlers::ComboBox, &EntryPoint::m_type, "Type", "")
+                            ->EnumAttribute(ShaderStageType::Vertex, ToString(ShaderStageType::Vertex))
+                            ->EnumAttribute(ShaderStageType::Geometry, ToString(ShaderStageType::Geometry))
+                            ->EnumAttribute(ShaderStageType::TessellationControl, ToString(ShaderStageType::TessellationControl))
+                            ->EnumAttribute(ShaderStageType::TessellationEvaluation, ToString(ShaderStageType::TessellationEvaluation))
+                            ->EnumAttribute(ShaderStageType::Fragment, ToString(ShaderStageType::Fragment))
+                            ->EnumAttribute(ShaderStageType::Compute, ToString(ShaderStageType::Compute))
+                            ->EnumAttribute(ShaderStageType::RayTracing, ToString(ShaderStageType::RayTracing))
+                        ;
+
+                    editContext->Class<SupervariantInfo>("ShaderSourceData::SupervariantInfo", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &SupervariantInfo::m_name, "Name", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &SupervariantInfo::m_removeBuildArguments, "Remove Build Arguments", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &SupervariantInfo::m_addBuildArguments, "Add Build Arguments", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &SupervariantInfo::m_definitions, "Definitions", "")
+                        ;
+                }
+            }
+
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<ShaderSourceData>("ShaderSourceData")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RPI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rpi")
+                    ->Constructor()
+                    ->Constructor<const ShaderSourceData&>()
+                    ->Property("source", BehaviorValueProperty(&ShaderSourceData::m_source))
+                    ->Property("drawListName", BehaviorValueProperty(&ShaderSourceData::m_drawListName))
+                    ->Property("depthStencilState", BehaviorValueProperty(&ShaderSourceData::m_depthStencilState))
+                    ->Property("rasterState", BehaviorValueProperty(&ShaderSourceData::m_rasterState))
+                    ->Property("blendState", BehaviorValueProperty(&ShaderSourceData::m_blendState))
+                    ->Property("programSettings", BehaviorValueProperty(&ShaderSourceData::m_programSettings))
+                    ->Property("removeBuildArguments", BehaviorValueProperty(&ShaderSourceData::m_removeBuildArguments))
+                    ->Property("addBuildArguments", BehaviorValueProperty(&ShaderSourceData::m_addBuildArguments))
+                    ->Property("definitions", BehaviorValueProperty(&ShaderSourceData::m_definitions))
+                    ->Property("disabledRhiBackends", BehaviorValueProperty(&ShaderSourceData::m_disabledRhiBackends))
+                    ->Property("superVariants", BehaviorValueProperty(&ShaderSourceData::m_supervariants))
+                    ->Method("IsRhiBackendDisabled", &ShaderSourceData::IsRhiBackendDisabled)
+                    ;
+
+                behaviorContext->Class<ShaderSourceData::ProgramSettings>("ShaderSourceData::ProgramSettings")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RPI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rpi")
+                    ->Constructor()
+                    ->Constructor<const ShaderSourceData::ProgramSettings&>()
+                    ->Property("entryPoints", BehaviorValueProperty(&ProgramSettings::m_entryPoints))
+                    ;
+
+                behaviorContext->Class<ShaderSourceData::EntryPoint>("ShaderSourceData::EntryPoint")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RPI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rpi")
+                    ->Constructor()
+                    ->Constructor<const ShaderSourceData::EntryPoint&>()
+                    ->Property("name", BehaviorValueProperty(&EntryPoint::m_name))
+                    ->Property("type", BehaviorValueProperty(&EntryPoint::m_type))
+                    ;
+
+                behaviorContext->Class<ShaderSourceData::SupervariantInfo>("ShaderSourceData::SupervariantInfo")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RPI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rpi")
+                    ->Constructor()
+                    ->Constructor<const ShaderSourceData::SupervariantInfo&>()
+                    ->Property("name", BehaviorValueProperty(&SupervariantInfo::m_name))
+                    ->Property("removeBuildArguments", BehaviorValueProperty(&SupervariantInfo::m_removeBuildArguments))
+                    ->Property("addBuildArguments", BehaviorValueProperty(&SupervariantInfo::m_addBuildArguments))
+                    ->Property("definitions", BehaviorValueProperty(&SupervariantInfo::m_definitions))
                     ;
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderVariantListSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderVariantListSourceData.cpp
@@ -6,11 +6,11 @@
  *
  */
 
-#include <Atom/RPI.Edit/Shader/ShaderVariantListSourceData.h>
 #include <Atom/RPI.Edit/Common/JsonUtils.h>
+#include <Atom/RPI.Edit/Shader/ShaderVariantListSourceData.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-
 
 namespace AZ
 {
@@ -18,7 +18,7 @@ namespace AZ
     {
         void ShaderVariantListSourceData::Reflect(ReflectContext* context)
         {
-            if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
+            if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<ShaderVariantListSourceData::VariantInfo>()
                     ->Version(1)
@@ -31,9 +31,32 @@ namespace AZ
                     ->Field("Shader", &ShaderVariantListSourceData::m_shaderFilePath)
                     ->Field("Variants", &ShaderVariantListSourceData::m_shaderVariants)
                     ;
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<ShaderVariantListSourceData::VariantInfo>("ShaderVariantListSourceData::VariantInfo", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderVariantListSourceData::VariantInfo::m_stableId, "Stable Id", "Unique identifier for this shader variant within the list")
+                            ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderVariantListSourceData::VariantInfo::m_options, "Options", "Table of shader options for configuring this variant")
+                            ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
+                            ->Attribute(AZ::Edit::Attributes::ContainerReorderAllow, false)
+                        ;
+
+                    editContext->Class<ShaderVariantListSourceData>("ShaderVariantListSourceData", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderVariantListSourceData::m_shaderFilePath, "Shader File Path", "Path to the shader source this variant list represents")
+                            ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderVariantListSourceData::m_shaderVariants, "Shader Variants", "Container of all variants and options configured for the shader")
+                            ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
+                            ->Attribute(AZ::Edit::Attributes::ContainerReorderAllow, false)
+                        ;
+                }
             }
 
-            if (BehaviorContext* behaviorContext = azrtti_cast<BehaviorContext*>(context))
+            if (auto behaviorContext = azrtti_cast<BehaviorContext*>(context))
             {
                 behaviorContext->Class<VariantInfo>("ShaderVariantInfo")
                     ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderVariantListSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderVariantListSourceData.cpp
@@ -20,7 +20,7 @@ namespace AZ
         {
             if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
             {
-                serializeContext->Class<ShaderVariantListSourceData::VariantInfo>()
+                serializeContext->Class<VariantInfo>()
                     ->Version(1)
                     ->Field("StableId", &VariantInfo::m_stableId)
                     ->Field("Options", &VariantInfo::m_options)
@@ -34,12 +34,12 @@ namespace AZ
 
                 if (auto editContext = serializeContext->GetEditContext())
                 {
-                    editContext->Class<ShaderVariantListSourceData::VariantInfo>("ShaderVariantListSourceData::VariantInfo", "")
+                    editContext->Class<VariantInfo>("VariantInfo", "")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderVariantListSourceData::VariantInfo::m_stableId, "Stable Id", "Unique identifier for this shader variant within the list")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &VariantInfo::m_stableId, "Stable Id", "Unique identifier for this shader variant within the list")
                             ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &ShaderVariantListSourceData::VariantInfo::m_options, "Options", "Table of shader options for configuring this variant")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &VariantInfo::m_options, "Options", "Table of shader options for configuring this variant")
                             ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
                             ->Attribute(AZ::Edit::Attributes::ContainerReorderAllow, false)
                         ;


### PR DESCRIPTION
Basic behavior and edit context reflection for ShaderBuildArguments, RenderState, ShaderSourceData, ShaderVariantListSourceData.

This does not yet include passes for descriptions or custom controls besides combo boxes for enum values. Descriptions, custom controls, and attributes for each property can be filled in iteratively by anyone familiar with the options, valid ranges, suitable control types.

Extends https://github.com/o3de/o3de/pull/10183 which adds a function for automatically populating edit context enum value attributes.

Screenshots testing edit context reflection in shader management console. Shader source data was only added for testing. 
![image](https://user-images.githubusercontent.com/82461473/174419991-ce287acf-4dc4-4cfb-9bc5-546b6315420a.png)
![image](https://user-images.githubusercontent.com/82461473/174420028-fdbc405e-3826-43f8-b195-d4081bed9072.png)
![image](https://user-images.githubusercontent.com/82461473/174420166-98c697c2-7257-4a19-bb19-529b88acf248.png)

