### PR TITLE
Fixes several spurious warnings that occur in the Asset Processor

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -438,6 +438,10 @@ namespace AZ
             m_eventLogger = EventLoggerPtr(static_cast<AZ::Debug::LocalFileEventLogger*>(AZ::Interface<AZ::Debug::IEventLogger>::Get()),
                 EventLoggerDeleter{ true });
         }
+        
+        // we are about to create allocators, so make sure that
+        // the descriptor is filled with at least the defaults:
+        m_descriptor.m_recordingMode = AllocatorManager::Instance().GetDefaultTrackingMode();
 
         // Initializes the OSAllocator and SystemAllocator as soon as possible
         CreateOSAllocator();

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.cpp
@@ -683,7 +683,10 @@ namespace AZ::SettingsRegistryMergeUtils
         }
         if (!configFileOpened)
         {
-            AZ_Warning("SettingsRegistryMergeUtils", false, R"(Unable to open file "%s")", configPath.c_str());
+            // While all parsing and formatting errors are actual errors, config files that are not present
+            // are not an error as they are always optional.  In this case, show a brief trace message
+            // that indicates the location the file could be placed at in order to run it.
+            AZ_TracePrintf("SettingsRegistryMergeUtils", "Optional config file \"%s\" not found.\n", configPath.c_str());
             return false;
         }
 

--- a/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicatorTracePrinter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicatorTracePrinter.cpp
@@ -22,7 +22,6 @@ ProcessCommunicatorTracePrinter::~ProcessCommunicatorTracePrinter()
     Pump();  // get any remaining data if available and split it by newlines
     
     // if there's any further data left over in the buffer then make sure it gets written, too
-    
     WriteCurrentString(false);
     
     // flush stderr

--- a/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicatorTracePrinter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicatorTracePrinter.cpp
@@ -19,6 +19,10 @@ ProcessCommunicatorTracePrinter::ProcessCommunicatorTracePrinter(AzFramework::Pr
 ProcessCommunicatorTracePrinter::~ProcessCommunicatorTracePrinter()
 {
     // flush stdout
+    Pump();  // get any remaining data if available and split it by newlines
+    
+    // if there's any further data left over in the buffer then make sure it gets written, too
+    
     WriteCurrentString(false);
     
     // flush stderr
@@ -80,7 +84,10 @@ void ProcessCommunicatorTracePrinter::WriteCurrentString(bool isFromStdErr)
         }
         else
         {
-            AZ_TracePrintf(m_window.c_str(), "%s", bufferToUse.c_str());
+            // Note that the input string will never have a newline at the end of it
+            // because it comes from ParseDataBuffer above, which splits by newline
+            // but does not include the newlines.
+            AZ_TracePrintf(m_window.c_str(), "%s\n", bufferToUse.c_str());
         }
         bufferToUse.clear();
     }

--- a/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicatorTracePrinter.h
+++ b/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicatorTracePrinter.h
@@ -17,7 +17,7 @@ class ProcessCommunicatorTracePrinter
 public:
     //! Wraps a ProcessCommunicatorTracePrinter around an existing ProcessCommunicator, which it will then
     //! invoke to read from stdout/stderr.
-    //! Because its going to invoke functions on the given ProcessCommuncator which you pass in, it is important
+    //! Because it is going to invoke functions on the given ProcessCommuncator which you pass in, it is important
     //! that the 'communicator' you pass in is only destroyed after you destroyProcessCommunicatorTracePrinter.
     ProcessCommunicatorTracePrinter(AzFramework::ProcessCommunicator* communicator, const char* window);
     ~ProcessCommunicatorTracePrinter();

--- a/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicatorTracePrinter.h
+++ b/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicatorTracePrinter.h
@@ -15,6 +15,10 @@
 class ProcessCommunicatorTracePrinter
 {
 public:
+    //! Wraps a ProcessCommunicatorTracePrinter around an existing ProcessCommunicator, which it will then
+    //! invoke to read from stdout/stderr.
+    //! Because its going to invoke functions on the given ProcessCommuncator which you pass in, it is important
+    //! that the 'communicator' you pass in is only destroyed after you destroyProcessCommunicatorTracePrinter.
     ProcessCommunicatorTracePrinter(AzFramework::ProcessCommunicator* communicator, const char* window);
     ~ProcessCommunicatorTracePrinter();
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FilteredSearchWidget.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FilteredSearchWidget.cpp
@@ -961,6 +961,7 @@ namespace AzQtComponents
                 const auto enabled = settings.value(g_enabledKey);
                 SetFilterState(category.toString(), displayName.toString(), enabled.toBool());
             }
+            settings.endArray();
         }
 
         emit TextFilterChanged(textFilter());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/StyledTracePrintFLogPanel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/StyledTracePrintFLogPanel.h
@@ -65,6 +65,7 @@ namespace AzToolsFramework
 
         private Q_SLOTS:
             void DrainMessages();
+            void ScheduleDrainMessages();
 
         public slots:
             virtual void Clear();

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -3869,19 +3869,12 @@ namespace AssetProcessor
                         {
                             if (auto result = jobDependenciesDuplicateCheck.insert(jobDependency); !result.second)
                             {
-                                auto warningMessage = AZStd::string::format(
-                                    "Builder `%s` declared duplicate Job Dependencies for file `%s`.  Dependency: (`%s` `%s` `%s`).  Duplicates will be skipped.  "
-                                    "Please update the builder or content to remove the duplicates.",
-                                    builderInfo.m_name.c_str(),
-                                    actualRelativePath.toUtf8().constData(),
-                                    jobDependency.m_sourceFile.ToString().c_str(),
-                                    jobDependency.m_jobKey.c_str(),
-                                    jobDependency.m_platformIdentifier.c_str());
-
-                                AZ_Warning(AssetProcessor::DebugChannel, false, "%s", warningMessage.c_str());
-
-                                newJob.m_warnings.push_back(AZStd::move(warningMessage));
-
+                                // It is not an error or warning to supply the same job dependency
+                                // repeatedly as a duplicate.  It is common for builders to be parsing
+                                // source files which may mention the same dependency repeatedly.
+                                // Rather than require all of them do filtering on their end, it is
+                                // cleaner to do the de-duplication here and drop the duplicates.
+                                
                                 continue;
                             }
 

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
@@ -79,6 +79,9 @@ namespace AssetProcessor
     void RCController::QuitRequested()
     {
         m_shuttingDown = true;
+        
+        // cancel all jobs:
+        AssetBuilderSDK::JobCommandBus::Broadcast(&AssetBuilderSDK::JobCommandBus::Events::Cancel);
 
         if (m_RCJobListModel.jobsInFlight() == 0)
         {

--- a/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeModel.h
+++ b/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeModel.h
@@ -54,7 +54,12 @@ namespace AssetProcessor
         void PopulateIncomingProductDependencies(ProductDependencyTreeItem* parent, AZ::s64 parentProductId);
 
         AZStd::shared_ptr<AzToolsFramework::AssetDatabase::AssetDatabaseConnection> m_sharedDbConnection;
-        AZStd::shared_ptr<AssetTreeFilterModel> m_productFilterModel = nullptr;
+        
+        // Note that the following pointer is passed in down from the main window.
+        // We cache the raw pointer here as this window does not own it and is not
+        // responsible for destroying it (the main window will).
+        AssetTreeFilterModel* m_productFilterModel = nullptr;
+        
         AZStd::unique_ptr<ProductDependencyTreeItem> m_root;
         AZStd::unordered_set<AZ::s64> m_trackedProductIds;
         DependencyTreeType m_treeType;

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
@@ -504,7 +504,13 @@ namespace AssetProcessor
     {
         AZStd::shared_ptr<Builder> newBuilder;
         BuilderRef builderRef;
+        if (m_quitListener.WasQuitRequested())
+        {
+            // don't hand out new builders if we're quitting.
+            return builderRef;
+        }
 
+        // the below scope is intentional, to contain the scoped lock.
         {
             AZStd::unique_lock<AZStd::mutex> lock(m_buildersMutex);
 

--- a/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
@@ -443,6 +443,13 @@ bool GUIApplicationManager::OnError(const char* /*window*/, const char* message)
         return true;
     }
 
+    if (!InitiatedShutdown())
+    {
+        // During quitting, we don't pop up error message boxes.
+        // instead, we're going to return true, which will cause it to
+        // process to the log file instead.
+        return true;
+    }
     // If we're the main thread, then consider showing the message box directly.
     // note that all other threads will PAUSE if they emit a message while the main thread is showing this box
     // due to the way the trace system EBUS is mutex-protected.

--- a/Gems/LmbrCentral/Code/Source/Builders/SliceBuilder/SliceBuilderWorker.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/SliceBuilder/SliceBuilderWorker.cpp
@@ -241,7 +241,9 @@ namespace SliceBuilder
 
             if (!m_settingsWarning.empty())
             {
-                jobDescriptor.m_jobParameters.insert(AZStd::make_pair(AZ::u32(AZ_CRC("JobParam_SettingsFileWarning", 0xae8d98ac)), AZStd::string("Requires Re-save")));
+                jobDescriptor.m_jobParameters.insert(
+                    AZStd::make_pair(AZ_CRC_CE("JobParam_SettingsFileWarning"), m_settingsWarning)
+                    );
             }
 
             if (requiresUpgrade)
@@ -282,10 +284,12 @@ namespace SliceBuilder
         }
 
         // Emit a settings file warning if required. We wait until now so the warnings will be clearly visible in the AP GUI.
-        if (request.m_jobDescription.m_jobParameters.find(AZ_CRC("JobParam_SettingsFileWarning", 0xae8d98ac)) != request.m_jobDescription.m_jobParameters.end())
+        const auto& settingsWarning = request.m_jobDescription.m_jobParameters.find(AZ_CRC_CE("JobParam_SettingsFileWarning"));
+        
+        if (settingsWarning != request.m_jobDescription.m_jobParameters.end())
         {
             // .../dev/SliceBuilderSettings.json must exist and must be readable.
-            AZ_Warning(s_sliceBuilder, false, m_settingsWarning.c_str());
+            AZ_Warning(s_sliceBuilder, false, settingsWarning->second.c_str());
         }
 
         AZStd::string fullPath;

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -172,7 +172,7 @@ namespace Multiplayer
             {
                 m_serverProcessWatcher->TerminateProcess(0);
 
-                // the TracePrinter hangs onto a pointer to an object that is owned by
+                // The TracePrinter hangs onto a pointer to an object that is owned by
                 // the ProcessWatcher.  Make sure to destroy the TracePrinter first, before ProcessWatcher.
                 m_serverProcessTracePrinter = nullptr;
                 m_serverProcessWatcher = nullptr;

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -171,14 +171,11 @@ namespace Multiplayer
             if (m_serverProcessWatcher)
             {
                 m_serverProcessWatcher->TerminateProcess(0);
-                if (m_serverProcessTracePrinter)
-                {
-                    m_serverProcessTracePrinter->Pump();
-                    m_serverProcessTracePrinter->WriteCurrentString(true);
-                    m_serverProcessTracePrinter->WriteCurrentString(false);
-                }
-                m_serverProcessWatcher = nullptr;
+
+                // the TracePrinter hangs onto a pointer to an object that is owned by
+                // the ProcessWatcher.  Make sure to destroy the TracePrinter first, before ProcessWatcher.
                 m_serverProcessTracePrinter = nullptr;
+                m_serverProcessWatcher = nullptr;
             }
 
             const AZ::Name editorInterfaceName = AZ::Name(MpEditorInterfaceName);


### PR DESCRIPTION
These bugs were noticed on Mac but may apply to other platforms.
1. Spurious "Allocator mode changed" warning that occurs because
   the allocator default mode is not the same between the Allocator
   Manager and the Application Descriptor.  The remedy is to
   set the Application Descriptor to contain the same default tracking
   mode as the Allocator Manager, so changing it one place will
   change it across the board.
2. Config Files (CFG) parsing is always optional, and is no longer
   a warning, just a printf if its missing.
3. Pump the stderror/stdout IPC handles before shutting down to make
   sure no errors and warnings are lost
4. IPC from out-of-process builders was being consumed and split by
   newlines (with the newlines not being included in the forwarded
   output).  This causes subsequent printfs to be missing newlines.
5. Qt error during settings load that would indicate a missing endArray
6. Qt error about using timer::SingleShot on a thread that isn't a
   Qt thread (replaced with metacall)
7. Skipping duplicates warning removed, with explanation why.
8. Slice Builder Worker would incorrectly assume the same process
   that created warning message would be the one later printing out
   that warning message and was using an uninitialized string.

Also fixes 3 additional crash-on-shutdown bugs:
* One caused by shutting down while jobs are in flight - the
  new code which retries jobs if their process is terminated caused
  there to be floating job threads after a critical part of shutdown.
* One caused by passing a raw pointer down as a shared ptr, when the
  intention was not to change ownership.
* One caused by jobs printing to STDERR during shutdown causing the AP
  GUI to show a modal error box during the shutdown sequence when the
  app was already starting to tear down.  Instead, we let these
  messages go to the log.


Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>