### PR TITLE
Prevent entity set as dirty while entity's parent is temporary invalid during propagation

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
@@ -362,6 +362,7 @@ namespace AzToolsFramework
             if (parentInfo.HasChild(childId))
             {
                 ReparentChild(childId, entityId, AZ::EntityId());
+                AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::RemoveDirtyEntity, childId);
             }
         }
 
@@ -389,6 +390,7 @@ namespace AzToolsFramework
         for (auto childId : children)
         {
             ReparentChild(childId, AZ::EntityId(), entityId);
+            AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::RemoveDirtyEntity, childId);
             m_entityOrphanTable[entityId].insert(childId);
         }
 


### PR DESCRIPTION
During the process of resolving #9780, we notice that we will generate undo nodes and update cache even for temporary making entity's parent id invalid during prefab propagation. This fix is to prevent these corner cases so that the workaround mentioned in #9780 could work as expected.

Tested following the workaround steps from #9780 with workaround changes https://github.com/aws-lumberyard-dev/o3de/pull/374.

Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>