### PR TITLE
VS2022 17.3.0 warning workaround with referencing a lambda variable.

### DIFF
--- a/Code/Framework/AzCore/Tests/Name/NameTests.cpp
+++ b/Code/Framework/AzCore/Tests/Name/NameTests.cpp
@@ -302,7 +302,8 @@ namespace UnitTest
         for (const AZStd::string& nameString : localDictionary)
         {
             auto& globalDictionary = NameDictionaryTester::GetDictionary();
-            auto it = AZStd::find_if(globalDictionary.begin(), globalDictionary.end(), [&nameString](AZStd::pair<AZ::Name::Hash, AZ::Internal::NameData*> entry) {
+            // Workaround VS2022 17.3 issue with incorrect detection of unused lambda captures assigning the nameString reference to a same type
+            auto it = AZStd::find_if(globalDictionary.begin(), globalDictionary.end(), [&nameString = nameString](AZStd::pair<AZ::Name::Hash, AZ::Internal::NameData*> entry) {
                 return entry.second->GetName() == nameString;
             });
             EXPECT_TRUE(it != globalDictionary.end()) << "Can't find '" << nameString.data() << "' in local dictionary.";


### PR DESCRIPTION
For some reason it is tagging a clearly used variable as unused.
So the workaround is to provide the nameString capture a name of "nameString" which the MSVC compiler doesn't choke on.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>