### PR TITLE
Type name generation updates

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetSerializer.h
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetSerializer.h
@@ -128,7 +128,7 @@ namespace AZ {
         {
         public:
             GenericClassGenericAsset()
-                : m_classData{ SerializeContext::ClassData::Create<ThisType>("Asset", GetSpecializedTypeId(), &m_factory, &AssetSerializer::s_serializer) }
+                : m_classData{ SerializeContext::ClassData::Create<ThisType>(AzTypeInfo<ThisType>::Name(), GetSpecializedTypeId(), &m_factory, &AssetSerializer::s_serializer) }
             {
                 m_classData.m_version = 3;
                 m_classData.m_dataConverter = &m_dataConverter;

--- a/Code/Framework/AzCore/AzCore/RTTI/RTTI.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/RTTI.h
@@ -232,13 +232,9 @@ namespace AZ
         Intrusive,
         External
     };
-    
+
     template<typename T>
-    struct HasAZRttiExternal
-    {
-        static constexpr bool value = false;
-        using type = AZStd::false_type;
-    };
+    struct HasAZRttiExternal : AZStd::false_type {};
 
     template<typename T>
     struct HasAZRtti
@@ -254,7 +250,7 @@ namespace AZ
      * AZ_RTTI includes the functionality of AZ_TYPE_INFO, so you don't have to declare TypeInfo it if you use AZ_RTTI
      * The syntax is AZ_RTTI(ClassName,ClassUuid,(BaseClass1..N)) you can have 0 to N base classes this will allow us
      * to perform dynamic casts and query about types.
-     * 
+     *
      *  \note A more complex use case is when you use templates where you have to group the parameters for the TypeInfo call.
      * ex. AZ_RTTI( ( (ClassName<TemplateArg1, TemplateArg2, ...>), ClassUuid, TemplateArg1, TemplateArg2, ...), BaseClass1...)
      *
@@ -267,17 +263,13 @@ namespace AZ
     // Variadic parameters should be the base class(es) if there are any
     #define AZ_EXTERNAL_RTTI_SPECIALIZE(Type, ...)                                  \
         template<>                                                                  \
-        struct HasAZRttiExternal<Type>                                              \
-        {                                                                           \
-            static const bool value = true;                                         \
-            using type = AZStd::true_type;                                          \
-        };                                                                          \
+        struct HasAZRttiExternal<Type> : AZStd::true_type{};                        \
                                                                                     \
         template<>                                                                  \
             struct AZ::Internal::RttiHelper<Type>                                   \
             : public AZ::Internal::ExternalVariadicRttiHelper<Type, ##__VA_ARGS__>  \
         {                                                                           \
-        };    
+        };
 
      /**
       * Interface for resolving RTTI information when no compile-time type information is available.
@@ -541,7 +533,7 @@ namespace AZ
             {
                 if (outPointer == nullptr)
                 {
-                    // For classes with Intrusive RTTI IsTypeOf is used instead as this External RTTI class does not have 
+                    // For classes with Intrusive RTTI IsTypeOf is used instead as this External RTTI class does not have
                     // virtual RTTI_AddressOf functions for looking up the correct address
                     if (HasAZRttiExternal<T2>::value)
                     {
@@ -604,13 +596,13 @@ namespace AZ
         using TypeInfoTag = AZStd::conditional_t<hasTypeInfo, AZ::Internal::RttiHelperTags::TypeInfoOnly, AZ::Internal::RttiHelperTags::Unavailable>;
         using Tag = AZStd::conditional_t<hasRtti, AZ::Internal::RttiHelperTags::Standard, TypeInfoTag>;
 
-        static_assert(!HasAZRttiIntrusive<ValueType>::value || !AZ::Internal::HasAZTypeInfoSpecialized<ValueType>::value,
+        static_assert(!HasAZRttiIntrusive<ValueType>::value || !AZ::Internal::HasAZTypeInfoSpecialized<ValueType>,
             "Types cannot use AZ_TYPE_INFO_SPECIALIZE macro externally with the AZ_RTTI macro"
             " AZ_RTTI adds virtual functions to the type in order to find the concrete class when looking up a typeid"
             " Specializing AzTypeInfo for a type would cause it not be used");
 
         return AZ::Internal::GetRttiHelper_Internal<ValueType>(Tag{});
-    }                                                      
+    }
 
     namespace Internal
     {
@@ -971,7 +963,7 @@ namespace AZ
     {
         return AZ::Internal::RttiTypeId<U, TypeIdResolverTag>();
     }
-    
+
     template<template<typename...> class U, typename = void>
     inline const AZ::TypeId& RttiTypeId()
     {
@@ -980,7 +972,7 @@ namespace AZ
 
     #if defined(AZ_COMPILER_MSVC)
     // There is a bug with the MSVC compiler when using the 'auto' keyword here. It appears that MSVC is unable to distinguish between a template
-    // template argument with a type variadic pack vs a template template argument with a non-type auto variadic pack. 
+    // template argument with a type variadic pack vs a template template argument with a non-type auto variadic pack.
     template<template<AZStd::size_t...> class U, typename = void>
     #else
     template<template<auto...> class U, typename = void>
@@ -989,25 +981,25 @@ namespace AZ
     {
         return AzGenericTypeInfo::Uuid<U>();
     }
-    
+
     template<template<typename, auto> class U, typename = void>
     inline const AZ::TypeId& RttiTypeId()
     {
         return AzGenericTypeInfo::Uuid<U>();
     }
-    
+
     template<template<typename, typename, auto> class U, typename = void>
     inline const AZ::TypeId& RttiTypeId()
     {
         return AzGenericTypeInfo::Uuid<U>();
     }
-    
+
     template<template<typename, typename, typename, auto> class U, typename = void>
     inline const AZ::TypeId& RttiTypeId()
     {
         return AzGenericTypeInfo::Uuid<U>();
     }
-    
+
     template<class U>
     inline const AZ::TypeId& RttiTypeId(const U& data)
     {
@@ -1036,7 +1028,7 @@ namespace AZ
 
 #if defined(AZ_COMPILER_MSVC)
     // There is a bug with the MSVC compiler when using the 'auto' keyword here. It appears that MSVC is unable to distinguish between a template
-    // template argument with a type variadic pack vs a template template argument with a non-type auto variadic pack. 
+    // template argument with a type variadic pack vs a template template argument with a non-type auto variadic pack.
     template<template<AZStd::size_t...> class T, class U>
 #else
     template<template<auto...> class T, class U>

--- a/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <AzCore/std/typetraits/static_storage.h>
+#include <AzCore/std/containers/array.h>
 #include <AzCore/std/typetraits/is_pointer.h>
 #include <AzCore/std/typetraits/is_const.h>
 #include <AzCore/std/typetraits/is_enum.h>
@@ -15,7 +15,6 @@
 #include <AzCore/std/typetraits/remove_pointer.h>
 #include <AzCore/std/typetraits/remove_const.h>
 #include <AzCore/std/typetraits/remove_reference.h>
-#include <AzCore/std/typetraits/has_member_function.h>
 #include <AzCore/std/typetraits/void_t.h>
 #include <AzCore/std/function/invoke.h>
 #include <AzCore/std/optional.h>
@@ -223,36 +222,34 @@ namespace AZ
     namespace Internal
     {
         /// Check if a class has TypeInfo declared via AZ_TYPE_INFO in its declaration
-        AZ_HAS_MEMBER(AZTypeInfoIntrusive, TYPEINFO_Enable, void, ());
+        template <typename T, class = void>
+        inline constexpr bool HasAZTypeInfoIntrusive = false;
+        template <typename T>
+        inline constexpr bool HasAZTypeInfoIntrusive<T, std::void_t<typename T::TYPEINFO_Enable>> = true;
 
         /// Check if a class has an AzTypeInfo specialization
-        template<typename T, typename = void>
-        struct HasAZTypeInfoSpecialized
-            : AZStd::false_type
-        {
-        };
+        template<typename T, class = void>
+        inline constexpr bool HasAZTypeInfoSpecialized = false;
 
         template<typename T>
-        struct HasAZTypeInfoSpecialized<T, AZStd::enable_if_t<AZStd::is_invocable_r<bool, decltype(&AzTypeInfo<T>::Specialized)>::value>>
-            : AZStd::true_type
-        {
-        };
+        inline constexpr bool HasAZTypeInfoSpecialized<T, AZStd::enable_if_t<AZStd::is_invocable_r_v<bool, decltype(&AzTypeInfo<T>::Specialized)>>>
+            = true;
 
         template <class T>
         struct HasAZTypeInfo
         {
-            static constexpr bool value = HasAZTypeInfoSpecialized<T>::value || HasAZTypeInfoIntrusive<T>::value;
-            using type = typename AZStd::Utils::if_c<value, AZStd::true_type, AZStd::false_type>::type;
+            static constexpr bool value = HasAZTypeInfoSpecialized<T> || HasAZTypeInfoIntrusive<T>;
+            using type = typename AZStd::conditional_t<value, AZStd::true_type, AZStd::false_type>;
         };
 
-        inline void AzTypeInfoSafeCat(char* destination, size_t maxDestination, const char* source)
+        inline constexpr void AzTypeInfoSafeCat(char* destination, size_t maxDestination, const char* source)
         {
             if (!source || !destination || maxDestination == 0)
             {
                 return;
             }
-            size_t destinationLen = strlen(destination);
-            size_t sourceLen = strlen(source);
+            size_t destinationLen = AZStd::char_traits<char>::length(destination);
+            size_t sourceLen = AZStd::char_traits<char>::length(source);
             if (sourceLen == 0)
             {
                 return;
@@ -268,7 +265,7 @@ namespace AZ
                 sourceLen = maxToCopy;
             }
             destination += destinationLen;
-            memcpy(destination, source, sourceLen);
+            AZStd::char_traits<char>::copy(destination, source, sourceLen);
             destination += sourceLen;
             *destination = 0;
         }
@@ -279,11 +276,18 @@ namespace AZ
         template<class T1, class... Tn>
         struct AggregateTypes<T1, Tn...>
         {
-            static void TypeName(char* buffer, size_t bufferSize)
+            static constexpr void TypeNameWithSeparator(char* buffer, size_t bufferSize)
+            {
+                constexpr const char* separator = ", ";
+                AzTypeInfoSafeCat(buffer, bufferSize, separator);
+                AzTypeInfoSafeCat(buffer, bufferSize, AzTypeInfo<T1>::Name());
+                AggregateTypes<Tn...>::TypeNameWithSeparator(buffer, bufferSize);
+            }
+
+            static constexpr void TypeName(char* buffer, size_t bufferSize)
             {
                 AzTypeInfoSafeCat(buffer, bufferSize, AzTypeInfo<T1>::Name());
-                AzTypeInfoSafeCat(buffer, bufferSize, " ");
-                AggregateTypes<Tn...>::TypeName(buffer, bufferSize);
+                AggregateTypes<Tn...>::TypeNameWithSeparator(buffer, bufferSize);
             }
 
             template<typename TypeIdResolverTag = CanonicalTypeIdTag>
@@ -305,9 +309,11 @@ namespace AZ
         template<>
         struct AggregateTypes<>
         {
-            static void TypeName(char* buffer, size_t bufferSize)
+            static constexpr void TypeNameWithSeparator(char*, size_t)
             {
-                (void)buffer; (void)bufferSize;
+            }
+            static constexpr void TypeName(char*, size_t)
+            {
             }
 
             template<typename TypeIdResolverTag = CanonicalTypeIdTag>
@@ -317,12 +323,7 @@ namespace AZ
             }
         };
 
-        // VS2015+/clang init them as part of static init, or interlocked (as per standard)
-#if AZ_TRAIT_COMPILER_USE_STATIC_STORAGE_FOR_NON_POD_STATICS
-        using TypeIdHolder = AZStd::static_storage<AZ::TypeId>;
-#else
         using TypeIdHolder = AZ::TypeId;
-#endif
 
         // Represents the "*" typeid that can be combined with non-pointer types T to form a unique T* typeid
         inline static const AZ::TypeId& PointerTypeId()
@@ -332,7 +333,7 @@ namespace AZ
         }
 
         template<typename T>
-        const char* GetTypeName()
+        constexpr const char* GetTypeName()
         {
             return AZ::AzTypeInfo<T>::Name();
         }
@@ -345,15 +346,30 @@ namespace AZ
         template<> struct NameBufferSize<0, false> { static constexpr const int Size = 2; };
         template<> struct NameBufferSize<0, true> { static constexpr const int Size = 1; };
 
+        // IntTypeName provides Compile time Variable template for c-string
+        // of a converted unsigned integer value
         template<AZStd::size_t N>
-        const char* GetTypeName()
-        {
-            static char buffer[NameBufferSize<N>::Size] = { 0 };
-            if (buffer[0] == 0)
+        inline constexpr AZStd::array<char, NameBufferSize<N>::Size> IntTypeName = []() constexpr
+            -> AZStd::array<char, NameBufferSize<N>::Size>
             {
-                azsnprintf(buffer, AZ_ARRAY_SIZE(buffer), "%zu", N);
-            }
-            return buffer;
+                using BufferType = AZStd::array<char, NameBufferSize<N>::Size>;
+                BufferType buffer{};
+                // Fill the buffer from the end with stringified
+                // conversions of each digit
+                // The buffer is exactly the size to store a null-terminated string
+                // of the integer converted to a string
+                size_t index = buffer.size() - 1;
+                for (size_t value = N; index > 0; value /= 10)
+                {
+                    buffer[--index] = '0' + (value % 10);
+                }
+                return buffer;
+            }();
+
+        template<AZStd::size_t N>
+        constexpr const char* GetTypeName()
+        {
+            return IntTypeName<N>.data();
         }
 
         template<typename T, typename TypeIdResolverTag>
@@ -404,9 +420,9 @@ namespace AZ
     template<class T>
     struct AzTypeInfo<T, false /* is_enum */>
     {
-        static const char* Name()
+        static constexpr const char* Name()
         {
-            static_assert(AZ::Internal::HasAZTypeInfoIntrusive<T>::value,
+            static_assert(AZ::Internal::HasAZTypeInfoIntrusive<T>,
                 "You should use AZ_TYPE_INFO or AZ_RTTI in your class/struct, or use AZ_TYPE_INFO_SPECIALIZE() externally. "
                 "Make sure to include the header containing this information (usually your class header).");
             return T::TYPEINFO_Name();
@@ -414,7 +430,7 @@ namespace AZ
         template<typename TypeIdResolverTag = CanonicalTypeIdTag>
         static const AZ::TypeId& Uuid()
         {
-            static_assert(AZ::Internal::HasAZTypeInfoIntrusive<T>::value,
+            static_assert(AZ::Internal::HasAZTypeInfoIntrusive<T>,
                 "You should use AZ_TYPE_INFO or AZ_RTTI in your class/struct, or use AZ_TYPE_INFO_SPECIALIZE() externally. "
                 "Make sure to include the header containing this information (usually your class header).");
             return T::TYPEINFO_Uuid();
@@ -439,7 +455,7 @@ namespace AZ
     struct AzTypeInfo<T, true /* is_enum */>
     {
         typedef typename AZStd::RemoveEnum<T>::type UnderlyingType;
-        static const char* Name() { return nullptr; }
+        static constexpr const char* Name() { return "<enum>"; }
         template<typename TypeIdResolverTag = CanonicalTypeIdTag>
         static const AZ::TypeId& Uuid() { static AZ::TypeId nullUuid = AZ::TypeId::CreateNull(); return nullUuid; }
         static constexpr TypeTraits GetTypeTraits()
@@ -497,7 +513,7 @@ namespace AZ
     template<>                                                        \
     struct AzTypeInfo<_ClassName, AZStd::is_enum<_ClassName>::value>  \
     {                                                                 \
-        static const char* Name() { return #_ClassName; }             \
+        static constexpr const char* Name() { return #_ClassName; }    \
         template<typename TypeIdResolverTag = CanonicalTypeIdTag>     \
         static const AZ::TypeId& Uuid() {                             \
             static AZ::Internal::TypeIdHolder s_uuid(_ClassUuid);     \
@@ -522,18 +538,43 @@ namespace AZ
     template<class R, class... Args>
     struct AzTypeInfo<R(Args...), false>
     {
-        static const char* Name()
+    private:
+        struct TypeNameInternal
         {
-            static char typeName[64] = { 0 };
-            if (typeName[0] == 0)
+            static constexpr auto TypeName = []() constexpr
             {
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), "{");
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), AZ::AzTypeInfo<R>::Name());
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), "(");
-                AZ::Internal::AggregateTypes<Args...>::TypeName(typeName, AZ_ARRAY_SIZE(typeName));
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), ")}");
+                // Temporary buffer to combine typename within
+                // This buffer is not returned and will not count against the data segment
+                // size of the library the code is compiled into
+                // instead a buffer that is the exact size needed to store the TypeName
+                // is returned from the compile time calculations
+                constexpr auto combineTypeNameBuffer = []() constexpr
+                {
+                    using CombineBufferType = AZStd::array<char, 1024>;
+                    CombineBufferType typeName{};
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), "{");
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), AZ::AzTypeInfo<R>::Name());
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), "(");
+                    AZ::Internal::AggregateTypes<Args...>::TypeName(typeName.data(), typeName.size());
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), ")}");
+                    return typeName;
+                }();
+
+                // Create a buffer that can store the exact number of characters for the type name + NUL
+                constexpr size_t NameLength = AZStd::char_traits<char>::length(combineTypeNameBuffer.data());
+                AZStd::array<char, NameLength + 1> resultBuffer{};
+                AZStd::copy(combineTypeNameBuffer.begin(), combineTypeNameBuffer.begin() + NameLength, resultBuffer.begin());
+                return resultBuffer;
+            }();
+            constexpr const char* operator()() const
+            {
+                return TypeName.data();
             }
-            return typeName;
+        };
+    public:
+        static constexpr const char* Name()
+        {
+            return TypeNameInternal{}();
         }
         template<typename TypeIdResolverTag = CanonicalTypeIdTag>
         static const AZ::TypeId& Uuid()
@@ -558,21 +599,41 @@ namespace AZ
     template<class R, class C, class... Args>
     struct AzTypeInfo<R(C::*)(Args...), false>
     {
-        static const char* Name()
+    private:
+        struct TypeNameInternal
         {
-            static char typeName[128] = { 0 };
-            if (typeName[0] == 0)
+            static constexpr auto TypeName = []() constexpr
             {
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), "{");
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), AZ::AzTypeInfo<R>::Name());
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), "(");
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), AZ::AzTypeInfo<C>::Name());
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), "::*)");
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), "(");
-                AZ::Internal::AggregateTypes<Args...>::TypeName(typeName, AZ_ARRAY_SIZE(typeName));
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), ")}");
+                constexpr auto combineTypeNameBuffer = []() constexpr
+                {
+                    using CombineBufferType = AZStd::array<char, 1024>;
+                    CombineBufferType typeName{};
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), "{");
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), AZ::AzTypeInfo<R>::Name());
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), "(");
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), AZ::AzTypeInfo<C>::Name());
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), "::*)");
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), "(");
+                    AZ::Internal::AggregateTypes<Args...>::TypeName(typeName.data(), typeName.size());
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), ")}");
+                    return typeName;
+                }();
+
+                // Create a buffer that can store the exact number of characters for the type name + NUL
+                constexpr size_t NameLength = AZStd::char_traits<char>::length(combineTypeNameBuffer.data());
+                AZStd::array<char, NameLength + 1> resultBuffer{};
+                AZStd::copy(combineTypeNameBuffer.begin(), combineTypeNameBuffer.begin() + NameLength, resultBuffer.begin());
+                return resultBuffer;
+            }();
+            constexpr const char* operator()() const
+            {
+                return TypeName.data();
             }
-            return typeName;
+        };
+    public:
+        static constexpr const char* Name()
+        {
+            return TypeNameInternal{}();
         }
         template<typename TypeIdResolverTag = CanonicalTypeIdTag>
         static const AZ::TypeId& Uuid()
@@ -602,18 +663,38 @@ namespace AZ
     template<class R, class C>
     struct AzTypeInfo<R C::*, false>
     {
-        static const char* Name()
+    private:
+        struct TypeNameInternal
         {
-            static char typeName[64] = { 0 };
-            if (typeName[0] == 0)
+            static constexpr auto TypeName = []() constexpr
             {
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), "{");
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), AZ::AzTypeInfo<R>::Name());
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), " ");
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), AZ::AzTypeInfo<C>::Name());
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), "::*}");
+                constexpr auto combineTypeNameBuffer = []() constexpr
+                {
+                    using CombineBufferType = AZStd::array<char, 1024>;
+                    CombineBufferType typeName{};
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), "{");
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), AZ::AzTypeInfo<R>::Name());
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), " ");
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), AZ::AzTypeInfo<C>::Name());
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), "::*}");
+                    return typeName;
+                }();
+
+                // Create a buffer that can store the exact number of characters for the type name + NUL
+                constexpr size_t NameLength = AZStd::char_traits<char>::length(combineTypeNameBuffer.data());
+                AZStd::array<char, NameLength + 1> resultBuffer{};
+                AZStd::copy(combineTypeNameBuffer.begin(), combineTypeNameBuffer.begin() + NameLength, resultBuffer.begin());
+                return resultBuffer;
+            }();
+            constexpr const char* operator()() const
+            {
+                return TypeName.data();
             }
-            return typeName;
+        };
+    public:
+        static constexpr const char* Name()
+        {
+            return TypeNameInternal{}();
         }
         template<typename TypeIdResolverTag = CanonicalTypeIdTag>
         static const AZ::TypeId& Uuid()
@@ -638,14 +719,35 @@ namespace AZ
 #define AZ_TYPE_INFO_INTERNAL_SPECIALIZE_CV(_T1, _Specialization, _NamePrefix, _NameSuffix)                      \
     template<class _T1>                                                                                          \
     struct AzTypeInfo<_Specialization, false> {                                                                  \
-        static const char* Name() {                                                                              \
-            static char typeName[64] = { 0 };                                                                    \
-            if (typeName[0] == 0) {                                                                              \
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), _NamePrefix);                 \
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), AZ::AzTypeInfo<_T1>::Name()); \
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), _NameSuffix);                 \
+    private:                                                                                                     \
+        struct TypeNameInternal                                                                                  \
+        {                                                                                                        \
+            static constexpr auto TypeName = []() constexpr                                                      \
+            {                                                                                                    \
+                constexpr auto combineTypeNameBuffer = []() constexpr                                            \
+                {                                                                                                \
+                    using CombineBufferType = AZStd::array<char, 1024>;                                          \
+                    CombineBufferType typeName{};                                                                \
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), _NamePrefix);              \
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), AzTypeInfo<_T1>::Name());  \
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), _NameSuffix);              \
+                    return typeName;                                                                             \
+                }();                                                                                             \
+                /* Create a buffer that can store the exact number of characters for the type name + NUL */      \
+                constexpr size_t NameLength = AZStd::char_traits<char>::length(combineTypeNameBuffer.data());    \
+                AZStd::array<char, NameLength + 1> resultBuffer{};                                               \
+                AZStd::copy(combineTypeNameBuffer.begin(), combineTypeNameBuffer.begin() + NameLength, resultBuffer.begin()); \
+                return resultBuffer;                                                                             \
+            }();                                                                                                 \
+            constexpr const char* operator()() const                                                             \
+            {                                                                                                    \
+                return TypeName.data();                                                                          \
             }                                                                                                    \
-            return typeName;                                                                                     \
+        };                                                                                                       \
+    public:                                                                                                      \
+        static constexpr const char* Name()                                                                      \
+        {                                                                                                        \
+            return TypeNameInternal{}();                                                                         \
         }                                                                                                        \
         /*                                                                                                       \
         * By default the specialization for pointer types defaults to PointerRemovedTypeIdTag                    \
@@ -683,27 +785,27 @@ namespace AZ
 #define AZ_TYPE_INFO_INTERNAL_TYPENAME__TYPE typename
 #define AZ_TYPE_INFO_INTERNAL_TYPENAME__ARG(A) A
 #define AZ_TYPE_INFO_INTERNAL_TYPENAME__UUID(Tag, A) AZ::Internal::GetTypeId< A , Tag >()
-#define AZ_TYPE_INFO_INTERNAL_TYPENAME__NAME(A) AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), AZ::Internal::GetTypeName< A >())
+#define AZ_TYPE_INFO_INTERNAL_TYPENAME__NAME(A) AZ::Internal::AzTypeInfoSafeCat(AZStd::data(typeName), AZStd::size(typeName), AZ::Internal::GetTypeName< A >())
 
 #define AZ_TYPE_INFO_INTERNAL_CLASS__TYPE class
 #define AZ_TYPE_INFO_INTERNAL_CLASS__ARG(A) A
 #define AZ_TYPE_INFO_INTERNAL_CLASS__UUID(Tag, A) AZ::Internal::GetTypeId< A , Tag >()
-#define AZ_TYPE_INFO_INTERNAL_CLASS__NAME(A) AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), AZ::Internal::GetTypeName< A >())
+#define AZ_TYPE_INFO_INTERNAL_CLASS__NAME(A) AZ::Internal::AzTypeInfoSafeCat(AZStd::data(typeName), AZStd::size(typeName), AZ::Internal::GetTypeName< A >())
 
 #define AZ_TYPE_INFO_INTERNAL_TYPENAME_VARARGS__TYPE typename...
 #define AZ_TYPE_INFO_INTERNAL_TYPENAME_VARARGS__ARG(A) A...
 #define AZ_TYPE_INFO_INTERNAL_TYPENAME_VARARGS__UUID(Tag, A) AZ::Internal::AggregateTypes< A... >::template Uuid< Tag >()
-#define AZ_TYPE_INFO_INTERNAL_TYPENAME_VARARGS__NAME(A) AZ::Internal::AggregateTypes< A... >::TypeName(typeName, AZ_ARRAY_SIZE(typeName))
+#define AZ_TYPE_INFO_INTERNAL_TYPENAME_VARARGS__NAME(A) AZ::Internal::AggregateTypes< A... >::TypeName(AZStd::data(typeName), AZStd::size(typeName))
 
 #define AZ_TYPE_INFO_INTERNAL_CLASS_VARARGS__TYPE class...
 #define AZ_TYPE_INFO_INTERNAL_CLASS_VARARGS__ARG(A) A...
 #define AZ_TYPE_INFO_INTERNAL_CLASS_VARARGS__UUID(Tag, A) AZ::Internal::AggregateTypes< A... >::template Uuid< Tag >()
-#define AZ_TYPE_INFO_INTERNAL_CLASS_VARARGS__NAME(A) AZ::Internal::AggregateTypes< A... >::TypeName(typeName, AZ_ARRAY_SIZE(typeName));
+#define AZ_TYPE_INFO_INTERNAL_CLASS_VARARGS__NAME(A) AZ::Internal::AggregateTypes< A... >::TypeName(AZStd::data(typeName), AZStd::size(typeName));
 
 #define AZ_TYPE_INFO_INTERNAL_AUTO__TYPE auto
 #define AZ_TYPE_INFO_INTERNAL_AUTO__ARG(A) A
 #define AZ_TYPE_INFO_INTERNAL_AUTO__UUID(Tag, A) AZ::Internal::GetTypeId< A , Tag >()
-#define AZ_TYPE_INFO_INTERNAL_AUTO__NAME(A) AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), AZ::Internal::GetTypeName< A >())
+#define AZ_TYPE_INFO_INTERNAL_AUTO__NAME(A) AZ::Internal::AzTypeInfoSafeCat(AZStd::data(typeName), AZStd::size(typeName), AZ::Internal::GetTypeName< A >())
 
 #define AZ_TYPE_INFO_INTERNAL_EXPAND_I(NAME, TARGET)     NAME##__##TARGET
 #define AZ_TYPE_INFO_INTERNAL_EXPAND(NAME, TARGET)       AZ_TYPE_INFO_INTERNAL_EXPAND_I(NAME, TARGET)
@@ -724,10 +826,10 @@ namespace AZ
 #define AZ_TYPE_INFO_INTERNAL_TEMPLATE_ARGUMENT_EXPANSION(...) AZ_MACRO_SPECIALIZE(AZ_TYPE_INFO_INTERNAL_TEMPLATE_ARGUMENT_EXPANSION_, AZ_VA_NUM_ARGS(__VA_ARGS__), (__VA_ARGS__))
 
 #define AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_1(_1)                                                                                                                                                          AZ_TYPE_INFO_INTERNAL_EXPAND(_1, NAME)(T1);
-#define AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_2(_1, _2)             AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_1(_1)             AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), ", "); AZ_TYPE_INFO_INTERNAL_EXPAND(_2, NAME)(T2);
-#define AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_3(_1, _2, _3)         AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_2(_1, _2)         AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), ", "); AZ_TYPE_INFO_INTERNAL_EXPAND(_3, NAME)(T3);
-#define AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_4(_1, _2, _3, _4)     AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_3(_1, _2, _3)     AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), ", "); AZ_TYPE_INFO_INTERNAL_EXPAND(_4, NAME)(T4);
-#define AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_5(_1, _2, _3, _4, _5) AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_4(_1, _2, _3, _4) AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), ", "); AZ_TYPE_INFO_INTERNAL_EXPAND(_5, NAME)(T5);
+#define AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_2(_1, _2)             AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_1(_1)             AZ::Internal::AzTypeInfoSafeCat(AZStd::data(typeName), AZStd::size(typeName), ", "); AZ_TYPE_INFO_INTERNAL_EXPAND(_2, NAME)(T2);
+#define AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_3(_1, _2, _3)         AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_2(_1, _2)         AZ::Internal::AzTypeInfoSafeCat(AZStd::data(typeName), AZStd::size(typeName), ", "); AZ_TYPE_INFO_INTERNAL_EXPAND(_3, NAME)(T3);
+#define AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_4(_1, _2, _3, _4)     AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_3(_1, _2, _3)     AZ::Internal::AzTypeInfoSafeCat(AZStd::data(typeName), AZStd::size(typeName), ", "); AZ_TYPE_INFO_INTERNAL_EXPAND(_4, NAME)(T4);
+#define AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_5(_1, _2, _3, _4, _5) AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_4(_1, _2, _3, _4) AZ::Internal::AzTypeInfoSafeCat(AZStd::data(typeName), AZStd::size(typeName), ", "); AZ_TYPE_INFO_INTERNAL_EXPAND(_5, NAME)(T5);
 #define AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION(...) AZ_MACRO_SPECIALIZE(AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION_, AZ_VA_NUM_ARGS(__VA_ARGS__), (__VA_ARGS__))
 
 #define AZ_TYPE_INFO_INTERNAL_TEMPLATE_UUID_EXPANSION_1(Tag, _1)                                                                                         AZ_TYPE_INFO_INTERNAL_EXPAND(_1, UUID)(Tag, T1)
@@ -741,14 +843,35 @@ namespace AZ
     AZ_TYPE_INFO_INTERNAL_VARIATION_GENERIC(_Specialization, _ClassUuid)                                            \
     template<AZ_TYPE_INFO_INTERNAL_TEMPLATE_TYPE_EXPANSION(__VA_ARGS__)>                                            \
     struct AzTypeInfo<_Specialization<AZ_TYPE_INFO_INTERNAL_TEMPLATE_ARGUMENT_EXPANSION(__VA_ARGS__)>, false> {     \
-        static const char* Name() {                                                                                 \
-            static char typeName[128] = { 0 };                                                                      \
-            if (typeName[0] == 0) {                                                                                 \
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), _Name "<");                      \
-                AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION(__VA_ARGS__)                                          \
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), ">");                            \
+    private:                                                                                                        \
+        struct TypeNameInternal                                                                                     \
+        {                                                                                                           \
+            static constexpr auto TypeName = []() constexpr                                                         \
+            {                                                                                                       \
+                constexpr auto combineTypeNameBuffer = []() constexpr                                               \
+                {                                                                                                   \
+                    using CombineBufferType = AZStd::array<char, 1024>;                                             \
+                    CombineBufferType typeName{};                                                                   \
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), _Name "<");                   \
+                    AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION(__VA_ARGS__)                                      \
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), ">");                         \
+                    return typeName;                                                                                \
+                }();                                                                                                \
+                /* Create a buffer that can store the exact number of characters for the type name + NUL */         \
+                constexpr size_t NameLength = AZStd::char_traits<char>::length(combineTypeNameBuffer.data());       \
+                AZStd::array<char, NameLength + 1> resultBuffer{};                                                  \
+                AZStd::copy(combineTypeNameBuffer.begin(), combineTypeNameBuffer.begin() + NameLength, resultBuffer.begin()); \
+                return resultBuffer;                                                                                \
+            }();                                                                                                    \
+            constexpr const char* operator()() const                                                                \
+            {                                                                                                       \
+                return TypeName.data();                                                                             \
             }                                                                                                       \
-            return typeName;                                                                                        \
+        };                                                                                                          \
+    public:                                                                                                         \
+        static constexpr const char* Name()                                                                         \
+        {                                                                                                           \
+            return TypeNameInternal{}();                                                                            \
         }                                                                                                           \
     private:                                                                                                        \
         static const AZ::TypeId& UuidTag(AZ::TypeIdResolverTags::CanonicalTypeIdTag)                                \
@@ -793,14 +916,35 @@ namespace AZ
     AZ_TYPE_INFO_INTERNAL_VARIATION_GENERIC(_Specialization, _ClassUuid)                                            \
     template<AZ_TYPE_INFO_INTERNAL_TEMPLATE_TYPE_EXPANSION(__VA_ARGS__)>                                            \
     struct AzTypeInfo<_Specialization<AZ_TYPE_INFO_INTERNAL_TEMPLATE_ARGUMENT_EXPANSION(__VA_ARGS__)>, false> {     \
-        static const char* Name() {                                                                                 \
-            static char typeName[128] = { 0 };                                                                      \
-            if (typeName[0] == 0) {                                                                                 \
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), #_Specialization "<");           \
-                AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION(__VA_ARGS__)                                          \
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), ">");                            \
+    private:                                                                                                        \
+        struct TypeNameInternal                                                                                     \
+        {                                                                                                           \
+            static constexpr auto TypeName = []() constexpr                                                         \
+            {                                                                                                       \
+                constexpr auto combineTypeNameBuffer = []() constexpr                                               \
+                {                                                                                                   \
+                    using CombineBufferType = AZStd::array<char, 1024>;                                             \
+                    CombineBufferType typeName{};                                                                   \
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), #_Specialization "<");        \
+                    AZ_TYPE_INFO_INTERNAL_TEMPLATE_NAME_EXPANSION(__VA_ARGS__)                                      \
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), ">");                         \
+                    return typeName;                                                                                \
+                }();                                                                                                \
+                /* Create a buffer that can store the exact number of characters for the type name + NUL */         \
+                constexpr size_t NameLength = AZStd::char_traits<char>::length(combineTypeNameBuffer.data());       \
+                AZStd::array<char, NameLength + 1> resultBuffer{};                                                  \
+                AZStd::copy(combineTypeNameBuffer.begin(), combineTypeNameBuffer.begin() + NameLength, resultBuffer.begin()); \
+                return resultBuffer;                                                                                \
+            }();                                                                                                    \
+            constexpr const char* operator()() const                                                                \
+            {                                                                                                       \
+                return TypeName.data();                                                                             \
             }                                                                                                       \
-            return typeName;                                                                                        \
+        };                                                                                                          \
+    public:                                                                                                         \
+        static constexpr const char* Name()                                                                         \
+        {                                                                                                           \
+            return TypeNameInternal{}();                                                                            \
         }                                                                                                           \
     private:                                                                                                        \
         static const AZ::TypeId& UuidTag(AZ::TypeIdResolverTags::CanonicalTypeIdTag)                                \
@@ -845,16 +989,37 @@ namespace AZ
     AZ_TYPE_INFO_INTERNAL_VARIATION_GENERIC(_Specialization, _ClassUuid) \
     template<typename R, typename... Args> \
     struct AzTypeInfo<_Specialization<R(Args...)>, false> {\
-        static const char* Name() { \
-            static char typeName[128] = { 0 }; \
-            if (typeName[0] == 0) { \
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), #_Specialization "<"); \
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), AZ::AzTypeInfo<R>::Name()); \
-                AZ::Internal::AggregateTypes<Args...>::TypeName(typeName, AZ_ARRAY_SIZE(typeName)); \
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), ">"); \
-            }\
-            return typeName; \
-        } \
+    private: \
+        struct TypeNameInternal                                                                                     \
+        {                                                                                                           \
+            static constexpr auto TypeName = []() constexpr                                                         \
+            {                                                                                                       \
+                constexpr auto combineTypeNameBuffer = []() constexpr                                               \
+                {                                                                                                   \
+                    using CombineBufferType = AZStd::array<char, 1024>;                                             \
+                    CombineBufferType typeName{};                                                                   \
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), #_Specialization "<");        \
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), AZ::AzTypeInfo<R>::Name());   \
+                    AZ::Internal::AggregateTypes<Args...>::TypeName(typeName.data(), typeName.size());              \
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), ">");                         \
+                    return typeName;                                                                                \
+                }();                                                                                                \
+                /* Create a buffer that can store the exact number of characters for the type name + NUL */         \
+                constexpr size_t NameLength = AZStd::char_traits<char>::length(combineTypeNameBuffer.data());       \
+                AZStd::array<char, NameLength + 1> resultBuffer{};                                                  \
+                AZStd::copy(combineTypeNameBuffer.begin(), combineTypeNameBuffer.begin() + NameLength, resultBuffer.begin()); \
+                return resultBuffer;                                                                                \
+            }();                                                                                                    \
+            constexpr const char* operator()() const                                                                \
+            {                                                                                                       \
+                return TypeName.data();                                                                             \
+            }                                                                                                       \
+        };                                                                                                          \
+    public:                                                                                                         \
+        static constexpr const char* Name()                                                                         \
+        {                                                                                                           \
+            return TypeNameInternal{}();                                                                            \
+        }                                                                                                           \
     private: \
         static const AZ::TypeId& UuidTag(AZ::TypeIdResolverTags::CanonicalTypeIdTag) \
         { \
@@ -899,14 +1064,35 @@ namespace AZ
     AZ_TYPE_INFO_INTERNAL_VARIATION_GENERIC(_Specialization, _AddUuid)                                               \
     template<class _T1, class _T2>                                                                                   \
     struct AzTypeInfo<_Specialization<_T1, _T2>, false> {                                                            \
-        static const char* Name() {                                                                                  \
-            static char typeName[128] = { 0 };                                                                       \
-            if (typeName[0] == 0) {                                                                                  \
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), #_Specialization "<");            \
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), AZ::AzTypeInfo<_T1>::Name());     \
-                AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), ">");                             \
+    private:                                                                                                         \
+        struct TypeNameInternal                                                                                      \
+        {                                                                                                            \
+            static constexpr auto TypeName = []() constexpr                                                          \
+            {                                                                                                        \
+                constexpr auto combineTypeNameBuffer = []() constexpr                                                \
+                {                                                                                                    \
+                    using CombineBufferType = AZStd::array<char, 1024>;                                              \
+                    CombineBufferType typeName{};                                                                    \
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), #_Specialization "<");         \
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), AZ::AzTypeInfo<_T1>::Name());  \
+                    AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), ">");                          \
+                    return typeName;                                                                                 \
+                }();                                                                                                 \
+                /* Create a buffer that can store the exact number of characters for the type name + NUL */          \
+                constexpr size_t NameLength = AZStd::char_traits<char>::length(combineTypeNameBuffer.data());        \
+                AZStd::array<char, NameLength + 1> resultBuffer{};                                                   \
+                AZStd::copy(combineTypeNameBuffer.begin(), combineTypeNameBuffer.begin() + NameLength, resultBuffer.begin()); \
+                return resultBuffer;                                                                                 \
+            }();                                                                                                     \
+            constexpr const char* operator()() const                                                                 \
+            {                                                                                                        \
+                return TypeName.data();                                                                              \
             }                                                                                                        \
-            return typeName;                                                                                         \
+        };                                                                                                           \
+    public:                                                                                                          \
+        static constexpr const char* Name()                                                                          \
+        {                                                                                                            \
+            return TypeNameInternal{}();                                                                             \
         }                                                                                                            \
     private:                                                                                                         \
         static const AZ::TypeId& UuidTag(AZ::TypeIdResolverTags::CanonicalTypeIdTag)                                 \
@@ -1011,22 +1197,42 @@ namespace AZ
     AZ_TYPE_INFO_INTERNAL_SPECIALIZED_TEMPLATE_POSTFIX_UUID(FixedStringTypeInfo, "{FA339E31-C383-49C7-80AC-5E1A3D8FA296}", AZ_TYPE_INFO_INTERNAL_TYPENAME, AZ_TYPE_INFO_INTERNAL_AUTO, AZ_TYPE_INFO_INTERNAL_TYPENAME);
 
     static constexpr const char* s_variantTypeId{ "{1E8BB1E5-410A-4367-8FAA-D43A4DE14D4B}" };
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZED_TEMPLATE_PREFIX_UUID(AZStd::variant, "variant", s_variantTypeId, AZ_TYPE_INFO_INTERNAL_TYPENAME_VARARGS);
+    AZ_TYPE_INFO_INTERNAL_SPECIALIZED_TEMPLATE_PREFIX_UUID(AZStd::variant, "AZStd::variant", s_variantTypeId, AZ_TYPE_INFO_INTERNAL_TYPENAME_VARARGS);
 
     AZ_TYPE_INFO_INTERNAL_FUNCTION_VARIATION_SPECIALIZATION(AZStd::function, "{C9F9C644-CCC3-4F77-A792-F5B5DBCA746E}");
 } // namespace AZ
 
 // Template class type info
 #define AZ_TYPE_INFO_INTERNAL_TEMPLATE(_ClassName, _ClassUuid, ...)\
-    void TYPEINFO_Enable() {}\
-    static const char* TYPEINFO_Name() {\
-         static char typeName[128] = { 0 };\
-         if (typeName[0]==0) {\
-            AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), #_ClassName "<");\
-            AZ::Internal::AggregateTypes<__VA_ARGS__>::TypeName(typeName, AZ_ARRAY_SIZE(typeName));\
-            AZ::Internal::AzTypeInfoSafeCat(typeName, AZ_ARRAY_SIZE(typeName), ">");\
-                           }\
-         return typeName; } \
+    struct TYPEINFO_Enable{};\
+    struct TypeNameInternal\
+    {\
+        static constexpr auto TypeName = []() constexpr \
+        {\
+            constexpr auto combineTypeNameBuffer = []() constexpr \
+            {\
+                using CombineBufferType = AZStd::array<char, 1024>;\
+                CombineBufferType typeName{};\
+                AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), #_ClassName "<");\
+                AZ::Internal::AggregateTypes<__VA_ARGS__>::TypeName(typeName.data(), typeName.size());\
+                AZ::Internal::AzTypeInfoSafeCat(typeName.data(), typeName.size(), ">");\
+                return typeName;\
+            }();\
+            /* Create a buffer that can store the exact number of characters for the type name + NUL */ \
+            constexpr size_t NameLength = AZStd::char_traits<char>::length(combineTypeNameBuffer.data());\
+            AZStd::array<char, NameLength + 1> resultBuffer{};\
+            AZStd::copy(combineTypeNameBuffer.begin(), combineTypeNameBuffer.begin() + NameLength, resultBuffer.begin());\
+            return resultBuffer;\
+        }();\
+        constexpr const char* operator()() const \
+        { \
+            return TypeName.data(); \
+        } \
+    }; \
+    static constexpr const char* TYPEINFO_Name() \
+    { \
+        return TypeNameInternal{}(); \
+    } \
     static const AZ::TypeId& TYPEINFO_Uuid() {\
         static AZ::Internal::TypeIdHolder s_uuid(AZ::TypeId(_ClassUuid) + AZ::Internal::AggregateTypes<__VA_ARGS__>::Uuid());\
         return s_uuid;\

--- a/Code/Framework/AzCore/AzCore/RTTI/TypeInfoSimple.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TypeInfoSimple.h
@@ -17,8 +17,9 @@ namespace AZ
 
 #define AZ_TYPE_INFO_INTERNAL_1(_ClassName) static_assert(false, "You must provide a ClassName,ClassUUID")
 #define AZ_TYPE_INFO_INTERNAL_2(_ClassName, _ClassUuid)        \
-    void TYPEINFO_Enable(){}                                   \
-    static const char* TYPEINFO_Name() { return #_ClassName; } \
+    struct TYPEINFO_Enable{}; \
+    struct TypeNameInternal { constexpr const char* operator()() const { return #_ClassName; } }; \
+    static constexpr const char* TYPEINFO_Name() { return TypeNameInternal{}(); } \
     static const AZ::TypeId& TYPEINFO_Uuid() { static AZ::TypeId s_uuid(_ClassUuid); return s_uuid; }
 
 #define AZ_TYPE_INFO_1 AZ_TYPE_INFO_INTERNAL_1

--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -204,7 +204,7 @@ namespace AZ
                 const T* arrayPtr = reinterpret_cast<const T*>(instance);
                 return arrayPtr->size();
             }
-            
+
             /// Returns the capacity of the container. Returns 0 for objects without fixed capacity.
             size_t Capacity(void* instance) const override
             {
@@ -363,7 +363,7 @@ namespace AZ
         public:
             typedef typename T::value_type ValueType;
             typedef typename AZStd::remove_pointer<typename T::value_type>::type ValueClass;
-            
+
             /// Returns the capacity of the container. Returns 0 for objects without fixed capacity.
             size_t Capacity(void* instance) const override
             {
@@ -472,7 +472,7 @@ namespace AZ
                 (void)instance;
                 return N;
             }
-            
+
             /// Returns the capacity of the container. Returns 0 for objects without fixed capacity.
             size_t Capacity(void* instance) const override
             {
@@ -547,7 +547,7 @@ namespace AZ
             bool    RemoveElement(void* instance, const void* element, SerializeContext* deletePointerDataContext) override
             {
                 (void)element;
-                
+
                 AZ_Assert((reinterpret_cast<uintptr_t>(element) & (alignof(ValueType) - 1)) == 0, "element memory address does not match alignment of ValueType");
                 ContainerType* arrayPtr = reinterpret_cast<ContainerType*>(instance);
                 ptrdiff_t arrayIndex = reinterpret_cast<const ValueType*>(element) - arrayPtr->data();
@@ -562,7 +562,7 @@ namespace AZ
                 {
                     DeletePointerData(deletePointerDataContext, &m_classElement, element);
                 }
-                
+
                 // If the element that's removed is the last added element, decrement the insertion counter.
                 GenericClassInfo* containerClassInfo = SerializeGenericTypeInfo<ContainerType>::GetGenericInfo();
                 const bool eventHandlerAvailable = containerClassInfo && containerClassInfo->GetClassData() && containerClassInfo->GetClassData()->m_eventHandler;
@@ -643,7 +643,7 @@ namespace AZ
                 AZ::TypeId uuid = azrtti_typeid<WrappedKeyType>();
 
                /**
-                * This should technically bind the reference value from the GetCurrentSerializeContextModule() call 
+                * This should technically bind the reference value from the GetCurrentSerializeContextModule() call
                 * as that will always return the current module that set the allocator.
                 * But as the AZStdAssociativeContainer instance will not be accessed outside of the module it was
                 * created within then this will return this .dll/.exe module allocator
@@ -711,7 +711,7 @@ namespace AZ
                 const T* arrayPtr = reinterpret_cast<const T*>(instance);
                 return arrayPtr->size();
             }
-            
+
             /// Returns the capacity of the container. Returns 0 for objects without fixed capacity.
             size_t Capacity(void* instance) const override
             {
@@ -802,7 +802,7 @@ namespace AZ
                 {
                     DeletePointerData(deletePointerDataContext, &m_classElement, element);
                 }
-                
+
                 T* containerPtr = reinterpret_cast<T*>(instance);
                 ValueType* valuePtr = reinterpret_cast<ValueType*>(element);
                 valuePtr->~ValueType();
@@ -817,7 +817,7 @@ namespace AZ
                 const auto& key = T::traits_type::key_from_value(*reinterpret_cast<const ValueType*>(element));
                 AZStd::pair<typename T::iterator, typename T::iterator> valueRange = containerPtr->equal_range(key);
                 while (valueRange.first != valueRange.second) // in a case of multi key support iterate over all elements with that key until we find the one
-                { 
+                {
                     if (&(*valueRange.first) == element)
                     {
                         // Extracts the node from the associative container without deleting it
@@ -960,7 +960,7 @@ namespace AZ
                 (void)instance;
                 return 2;
             }
-            
+
             /// Returns the capacity of the container. Returns 0 for objects without fixed capacity.
             size_t Capacity(void* instance) const override
             {
@@ -1599,7 +1599,7 @@ namespace AZ
                 (void)instance;
                 return 1;
             }
-            
+
             /// Returns the capacity of the container. Returns 0 for objects without fixed capacity.
             size_t Capacity(void* instance) const override
             {
@@ -2078,7 +2078,7 @@ namespace AZ
             AZ_TYPE_INFO(GenericClassInfoVector, GetGenericClassInfoVectorTypeId());
             GenericClassInfoVector()
             {
-                m_classData = SerializeContext::ClassData::Create<ContainerType>("AZStd::vector", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage);
+                m_classData = SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage);
             }
 
             SerializeContext::ClassData* GetClassData() override
@@ -2158,7 +2158,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassInfoFixedVector, GetGenericClassInfoFixedVectorTypeId());
             GenericClassInfoFixedVector()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::fixed_vector", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
             }
 
@@ -2234,7 +2234,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassInfoList, "{B845AD64-B5A0-4ccd-A86B-3477A36779BE}");
             GenericClassInfoList()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::list", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
             }
 
@@ -2310,7 +2310,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassInfoForwardList, "{D48E20E1-D3A3-46F7-A869-927F5EF50127}");
             GenericClassInfoForwardList()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::forward_list", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
             }
 
@@ -2391,7 +2391,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassInfoArray, GetGenericClassInfoArrayTypeId());
             GenericClassInfoArray()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::array", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
                 m_classData.m_eventHandler = &m_eventHandler;
             }
@@ -2474,7 +2474,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassSet, GetGenericClassSetTypeId());
             GenericClassSet()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::set", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
             }
 
@@ -2490,7 +2490,7 @@ namespace AZ
 
             const Uuid& GetTemplatedTypeId(size_t /*element*/) override
             {
-                return SerializeGenericTypeInfo<K>::GetClassTypeId();               
+                return SerializeGenericTypeInfo<K>::GetClassTypeId();
             }
 
             const Uuid& GetSpecializedTypeId() const override
@@ -2555,7 +2555,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassUnorderedSet, GetGenericClassUnorderedSetTypeId());
             GenericClassUnorderedSet()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::unordered_set", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
             }
 
@@ -2632,7 +2632,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassUnorderedMultiSet, "{B619DA0D-F050-41AA-B092-416CACB7C710}");
             GenericClassUnorderedMultiSet()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::unordered_multiset", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
             }
 
@@ -2714,7 +2714,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassOutcome, GetGenericOutcomeTypeId());
             GenericClassOutcome()
-                : m_classData{ SerializeContext::ClassData::Create<OutcomeType>("AZ::Outcome", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr) }
+                : m_classData{ SerializeContext::ClassData::Create<OutcomeType>(AZ::AzTypeInfo<OutcomeType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr) }
             {
             }
 
@@ -2799,7 +2799,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassPair, GetGenericClassPairTypeId());
             GenericClassPair()
-                : m_classData{ SerializeContext::ClassData::Create<PairType>("AZStd::pair", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_pairContainer) }
+                : m_classData{ SerializeContext::ClassData::Create<PairType>(AZ::AzTypeInfo<PairType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_pairContainer) }
             {
             }
 
@@ -2891,7 +2891,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassTuple, GetGenericClassTupleTypeId());
             GenericClassTuple()
-                : m_classData{ SerializeContext::ClassData::Create<TupleType>("AZStd::tuple", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_tupleContainer) }
+                : m_classData{ SerializeContext::ClassData::Create<TupleType>(AZ::AzTypeInfo<TupleType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_tupleContainer) }
             {
             }
 
@@ -2971,9 +2971,11 @@ namespace AZ
         class GenericClassWrapper
             : public GenericClassInfo
         {
+            inline static constexpr AZStd::fixed_string<128> ClassName = AZStd::fixed_string<128>("Internal::RValueToLValueWrapper<")
+                + AZ::AzTypeInfo<T>::Name() + ">";
         public:
             GenericClassWrapper()
-                : m_classData{ SerializeContext::ClassData::Create<WrapperType>("Internal::RValueToLValueWrapper", "{642ABA5E-BB70-40EF-A986-933420D89F85}", Internal::NullFactory::GetInstance(), nullptr, &m_wrapperContainer) }
+                : m_classData{ SerializeContext::ClassData::Create<WrapperType>(ClassName.c_str(), "{642ABA5E-BB70-40EF-A986-933420D89F85}", Internal::NullFactory::GetInstance(), nullptr, &m_wrapperContainer) }
             {
             }
 
@@ -3044,7 +3046,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassMap, GetGenericClassMapTypeId());
             GenericClassMap()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::map", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
             }
 
@@ -3132,7 +3134,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassUnorderedMap, GetGenericClassUnorderedMapTypeId());
             GenericClassUnorderedMap()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::unordered_map", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
             }
 
@@ -3215,7 +3217,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassUnorderedMultiMap, "{119669B8-92BF-468F-97D9-9D45F298BCD4}");
             GenericClassUnorderedMultiMap()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::unordered_multimap", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
             }
 
@@ -3298,8 +3300,18 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassBasicString, "{EF8FF807-DDEE-4eb0-B678-4CA3A2C490A4}");
             GenericClassBasicString()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::string", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), &m_stringSerializer, nullptr) }
             {
+                const char* className = "";
+                if constexpr (AZStd::is_same_v<ContainerType, AZStd::string>)
+                {
+                    className = "AZStd::string";
+                }
+                else
+                {
+                    className = AZ::AzTypeInfo<ContainerType>::Name();
+                }
+                m_classData = SerializeContext::ClassData::Create<ContainerType>(className, GetSpecializedTypeId(),
+                    Internal::NullFactory::GetInstance(), &m_stringSerializer, nullptr);
             }
 
             SerializeContext::ClassData* GetClassData() override
@@ -3436,7 +3448,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassBitSet, "{1C0270B7-F5E1-4bd6-B7BC-8D25A74B79B4}");
             GenericClassBitSet()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("BitSet", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), &m_dataSerializer, nullptr) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), &m_dataSerializer, nullptr) }
             {
             }
 
@@ -3502,7 +3514,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassSharedPtr, "{D5B5ACA6-A81E-410E-8151-80C97B8CD2A0}");
             GenericClassSharedPtr()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::shared_ptr", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
             }
 
@@ -3583,7 +3595,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassIntrusivePtr, "{C4B5400B-5CDC-4B14-932E-BFA30BC1DE35}");
             GenericClassIntrusivePtr()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::intrusive_ptr", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
             }
 
@@ -3664,7 +3676,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassUniquePtr, "{D37DF835-5B18-4F9E-9C8F-03B967483080}");
             GenericClassUniquePtr()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::unique_ptr", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
             }
 
@@ -3745,7 +3757,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassOptional, "{2C75B779-4661-4102-9D40-B2A680B6DE36}");
             GenericClassOptional()
-                : m_classData{ SerializeContext::ClassData::Create<ContainerType>("AZStd::optional", GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
+                : m_classData{ SerializeContext::ClassData::Create<ContainerType>(AZ::AzTypeInfo<ContainerType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_containerStorage) }
             {
             }
 

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
@@ -602,6 +602,13 @@ namespace AZ
         {
             retVal.push_back(currentIter->second);
         }
+
+        findResult = m_deprecatedNameToTypeIdMap.equal_range(classNameCrc);
+        for (auto&& currentIter = findResult.first; currentIter != findResult.second; ++currentIter)
+        {
+            AZ_TracePrintf("Serialize", "Found TypeId using deprecated class name CRC value of %u", static_cast<AZ::u32>(classNameCrc));
+            retVal.push_back(currentIter->second);
+        }
         return retVal;
     }
 

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
@@ -2784,6 +2784,10 @@ namespace AZ
 
             // if we get here, its a FLG_POINTER
             const void* dataPtr = *reinterpret_cast<void* const*>(element);
+            if (dataPtr == nullptr)
+            {
+                return; // Pointer element is nullptr, nothing to delete
+            }
             if (classData->m_factory)
             {
                 classData->m_factory->Destroy(dataPtr);

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
@@ -1357,7 +1357,8 @@ namespace AZ
     private:
         EditContext* m_editContext;  ///< Pointer to optional edit context.
         UuidToClassMap  m_uuidMap;      ///< Map for all class in this serialize context
-        AZStd::unordered_multimap<AZ::Crc32, AZ::Uuid> m_classNameToUuid;  /// Map all class names to their uuid
+        AZStd::unordered_multimap<AZ::Crc32, AZ::Uuid> m_classNameToUuid;  ///< Map all class names to their uuid
+        AZStd::unordered_multimap<AZ::Crc32, AZ::Uuid> m_deprecatedNameToTypeIdMap;  ///< Stores a mapping of deprecated type names that a type exposes through the AzDeprecatedTypeNameVisitor
         AZStd::unordered_multimap<Uuid, GenericClassInfo*>  m_uuidGenericMap;      ///< Uuid to ClassData map of reflected classes with GenericTypeInfo
         AZStd::unordered_multimap<Uuid, Uuid> m_legacySpecializeTypeIdToTypeIdMap; ///< Keep a map of old legacy specialized typeids of template classes to new specialized typeids
         AZStd::unordered_map<Uuid, CreateAnyFunc>  m_uuidAnyCreationMap;      ///< Uuid to Any creation function map
@@ -1922,6 +1923,26 @@ namespace AZ
             {
                 RemoveClassData(&mapIt->second);
 
+
+                // Remove the deprecated type name -> typeid mapping
+                auto RemoveDeprecatedNames = [this, &typeUuid](AZStd::string_view deprecatedName)
+                {
+                    auto deprecatedNameRange = m_deprecatedNameToTypeIdMap.equal_range(Crc32(deprecatedName));
+                    for (auto classNameRangeIter = deprecatedNameRange.first; classNameRangeIter != deprecatedNameRange.second;)
+                    {
+                        if (classNameRangeIter->second == typeUuid)
+                        {
+                            classNameRangeIter = m_deprecatedNameToTypeIdMap.erase(classNameRangeIter);
+                        }
+                        else
+                        {
+                            ++classNameRangeIter;
+                        }
+                    }
+                };
+                DeprecatedTypeNameVisitor<T>(RemoveDeprecatedNames);
+
+                // Remove the current class name -> typeid mapping
                 auto classNameRange = m_classNameToUuid.equal_range(Crc32(name));
                 for (auto classNameRangeIter = classNameRange.first; classNameRangeIter != classNameRange.second;)
                 {
@@ -1941,6 +1962,13 @@ namespace AZ
         }
         else
         {
+            // Add any the deprecated type names to the deprecated type name to type id map
+            auto AddDeprecatedNames = [this, &typeUuid](AZStd::string_view deprecatedName)
+            {
+                m_deprecatedNameToTypeIdMap.emplace(deprecatedName, typeUuid);
+            };
+            DeprecatedTypeNameVisitor<T>(AddDeprecatedNames);
+
             m_classNameToUuid.emplace(AZ::Crc32(name), typeUuid);
             UuidToClassMap::pair_iter_bool result = m_uuidMap.insert(AZStd::make_pair(typeUuid, ClassData::Create<T>(name, typeUuid, factory)));
             AZ_Assert(result.second, "This class type %s could not be registered with duplicated Uuid: %s.", name, typeUuid.ToString<AZStd::string>().c_str());

--- a/Code/Framework/AzCore/AzCore/Serialization/std/VariantReflection.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/std/VariantReflection.inl
@@ -270,7 +270,7 @@ namespace AZ
                     return true;
                 }
 
-                // Next check if the convertible type id is exactly equal to one of the non-pointer alternatives 
+                // Next check if the convertible type id is exactly equal to one of the non-pointer alternatives
                 // i.e Variant<int*, int> would match can only match the `int` alternative at this point
                 for (const SerializeContext::ClassElement& altClassElement : m_dataContainer.m_alternativeClassElements)
                 {
@@ -422,7 +422,7 @@ namespace AZ
         public:
             AZ_TYPE_INFO(GenericClassVariant, AZ::s_variantTypeId);
             GenericClassVariant()
-                : m_classData{ SerializeContext::ClassData::Create<VariantType>("variant", GetSpecializedTypeId(), &m_variantInstanceFactory, nullptr, &m_variantContainer) }
+                : m_classData{ SerializeContext::ClassData::Create<VariantType>(AZ::AzTypeInfo<VariantType>::Name(), GetSpecializedTypeId(), &m_variantInstanceFactory, nullptr, &m_variantContainer) }
             {
                 m_classData.m_dataConverter = &m_dataConverter;
                 // As the SerializeGenericTypeInfo is created on demand when a variant is reflected(in static memory)
@@ -496,7 +496,7 @@ namespace AZ
                     altClassElement.m_offset = 0;
                     VariantSerializationInternal::SetupClassElementFromType<AltType>(altClassElement);
                     const AZ::Uuid& altTypeId = altClassElement.m_typeId;
-                    
+
                     const SerializeContext::ClassData* altClassData = context.FindClassData(altTypeId);
                     AZ_Error("Serialize", altClassData, "Unable to find ClassData for variant alternative with name %s and typeid of %s", AzTypeInfo<AltType>::Name(), altTypeId.ToString<AZStd::string>().data());
                     return altClassData ? callContext.m_context->EnumerateInstanceConst(&callContext, &elementAlt, altTypeId, altClassData, &altClassElement) : false;

--- a/Code/Framework/AzCore/AzCore/std/any.h
+++ b/Code/Framework/AzCore/AzCore/std/any.h
@@ -29,7 +29,7 @@ namespace AZStd
         // Size of small buffer optimization buffer
         enum { ANY_SBO_BUF_SIZE = 32 };
     }
-    
+
     /// distinguishes between any Extension constructor calls
     struct transfer_ownership_t { explicit transfer_ownership_t() = default; };
     const transfer_ownership_t s_transfer_ownership{};
@@ -43,7 +43,7 @@ namespace AZStd
     class any
     {
     public:
-        AZ_TYPE_INFO(any, "{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}");
+        AZ_TYPE_INFO(AZStd::any, "{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}");
         AZ_CLASS_ALLOCATOR(any, AZ::SystemAllocator, 0);
 
         /// Typed used to identify other types (acquired via azrtti_typeid<Type>())
@@ -62,7 +62,7 @@ namespace AZStd
             Copy,
             // dest: The any to move into. If using heap space, \ref Reserve must have already been called. source: The any to move from (NOTE: const is removed from source when calling Move).
             Move,
-            // dest: The any to destruct, occurs before Destroy 
+            // dest: The any to destruct, occurs before Destroy
             Destruct,
             // dest: The any to destroy. The heap space is freed, and buffer is 0'ed. source: unused
             Destroy,
@@ -114,15 +114,15 @@ namespace AZStd
             temp.m_typeInfo = typeInfo;
 
             // since the copy will be from m_pointer
-            temp.m_typeInfo.m_useHeap = true; 
-            
+            temp.m_typeInfo.m_useHeap = true;
+
             // Call copy-from so that we don't try to clear temp
             copy_from(temp, typeInfo, Action::Copy);
 
             // Make sure temp doesn't try to clear memory (we don't own it)
             temp.m_typeInfo = type_info();
         }
-                
+
         /// [Extension] Create an any with a custom typeinfo (takes ownership of value in pointer using typeInfo)
         any(transfer_ownership_t, void* pointer, const type_info& typeInfo)
         {
@@ -139,11 +139,11 @@ namespace AZStd
                 temp.m_pointer = const_cast<void*>(pointer);
                 temp.m_typeInfo = typeInfo;
                 // since the copy will be from m_pointer
-                temp.m_typeInfo.m_useHeap = true; 
-                
+                temp.m_typeInfo.m_useHeap = true;
+
                 // the Action::Reserve in the SBO handler should do nothing
                 copy_from(temp, typeInfo, Action::Move);
-                
+
                 // don't modify the source (like by calling a destructor on it)
                 temp.m_typeInfo = type_info();
             }
@@ -190,7 +190,7 @@ namespace AZStd
             // Reserve heap space if necessary
             m_typeInfo.m_handler(Action::Reserve, this, nullptr);
 
-            // Call copy constructor 
+            // Call copy constructor
             construct<decay_t<ValueType>>(this, forward<ValueType>(val));
         }
 
@@ -356,7 +356,7 @@ namespace AZStd
                 {
                     AZ_Assert(source == nullptr, "Internal error: Destroy called with non-nullptr source.");
                     AZ_Assert(!dest->empty() && dest->get_data(), "Internal error: dest is invalid.");
-                    
+
                     // Clear memory
                     if (dest->m_typeInfo.m_useHeap)
                     {

--- a/Code/Framework/AzCore/AzCore/std/tuple.h
+++ b/Code/Framework/AzCore/AzCore/std/tuple.h
@@ -34,6 +34,7 @@ namespace AZStd
     using std::tuple_cat;
     using std::get;
 
+
     //! Creates an hash specialization for tuple types using the hash_combine function
     //! The std::tuple implementation does not have this support. This is an extension
     template <typename... Types>
@@ -54,6 +55,31 @@ namespace AZStd
             return ElementHasher(value, AZStd::make_index_sequence<sizeof...(Types)>{});
         }
     };
+}
+
+namespace AZ
+{
+    // Specialize the AzDeprcatedTypeNameVisitor for tuple to make sure their
+    // is a mapping of the old type name to current type id
+    inline namespace DeprecatedTypeNames
+    {
+        template<typename... Types>
+        struct AzDeprecatedTypeNameVisitor<AZStd::tuple<Types...>>
+        {
+            template<class Functor>
+            constexpr void operator()(Functor&& visitCallback) const
+            {
+                // AZStd::tuple previous name was place into a buffer of size 128
+                AZStd::array<char, 128> deprecatedName{};
+
+                AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), "tuple<");
+                (AggregateTypeNameOld<Types>(deprecatedName.data(), deprecatedName.size()), ...);
+                AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), ">");
+
+                AZStd::invoke(AZStd::forward<Functor>(visitCallback), deprecatedName.data());
+            }
+        };
+    }
 }
 
 namespace AZStd

--- a/Code/Framework/AzCore/AzCore/std/tuple.h
+++ b/Code/Framework/AzCore/AzCore/std/tuple.h
@@ -270,7 +270,7 @@ namespace AZStd
     };
 }
 
-// AZStd::apply implemenation helper block 
+// AZStd::apply implemenation helper block
 namespace AZStd
 {
     namespace Internal
@@ -345,5 +345,5 @@ namespace std
 // Adds typeinfo specialization for tuple type
 namespace AZ
 {
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZED_TEMPLATE_PREFIX_UUID(AZStd::tuple, "tuple", "{F99F9308-DC3E-4384-9341-89CBF1ABD51E}", AZ_TYPE_INFO_INTERNAL_TYPENAME_VARARGS);
+    AZ_TYPE_INFO_INTERNAL_SPECIALIZED_TEMPLATE_PREFIX_UUID(AZStd::tuple, "AZStd::tuple", "{F99F9308-DC3E-4384-9341-89CBF1ABD51E}", AZ_TYPE_INFO_INTERNAL_TYPENAME_VARARGS);
 }

--- a/Code/Framework/AzCore/Tests/Patching.cpp
+++ b/Code/Framework/AzCore/Tests/Patching.cpp
@@ -420,7 +420,7 @@ namespace UnitTest
         {
             public:
             AZ_CLASS_ALLOCATOR(ObjectDerivedClass3, SystemAllocator, 0);
-            AZ_RTTI(ObjectDerivedClass2, "{E80E926B-5750-4E8D-80E0-D06057692847}", ObjectBaseClass);
+            AZ_RTTI(ObjectDerivedClass3, "{E80E926B-5750-4E8D-80E0-D06057692847}", ObjectBaseClass);
             static void Reflect(AZ::SerializeContext& sc)
             {
                 sc.Class<ObjectDerivedClass3>();
@@ -619,11 +619,11 @@ namespace UnitTest
             {
                 editableAddress = GetValidAddressForXMLDataPatchV1AddressTypeIntXML();
             }
-            
+
             return AZStd::string::format(m_XMLDataPatchV1AddressTypeIntOverrideTemplate, editableAddress.c_str(), intValue);
         }
 
-        /* 
+        /*
            Sets the data values and persistentId values for the ContainedObjectPersistentId type stored in m_XMLDataPatchV1AddressTypeIntVectorOverrideTemplate's xml stream
            Can also optionally set the address of the first element otherwise defaults to a valid address if testAddress is nullptr
            The stream contains 5 elements within the vector
@@ -1499,7 +1499,7 @@ namespace UnitTest
             ObjectDerivedClass3::Reflect(*m_serializeContext);
             ObjectWithVectorOfBaseClasses::Reflect(*m_serializeContext);
 
-            // step 1:  Make a patch that includes deprecated classes. 
+            // step 1:  Make a patch that includes deprecated classes.
             ObjectWithVectorOfBaseClasses sourceObject;
             ObjectWithVectorOfBaseClasses targetObject;
             targetObject.m_vectorOfBaseClasses.push_back(new ObjectDerivedClass1());
@@ -1588,7 +1588,7 @@ namespace UnitTest
             // Apply provides the remaining class data to complete the conversion
             DataPatch patch;
             LoadPatchFromXML(legacyPatchXML, patch);
-            
+
             // Apply the patch and complete conversion
             ObjectToPatch sourceObj;
             AZStd::unique_ptr<ObjectToPatch> generatedObj(patch.Apply(&sourceObj, m_serializeContext.get()));
@@ -1733,7 +1733,7 @@ namespace UnitTest
                     </Class>
             </ObjectStream>
             )";
-            
+
             // Load the patch from XML
             // This triggers the Legacy DataPatch converter
             // Patch Data will be wrapped in the StreamWrapper type until Apply is called
@@ -2433,7 +2433,7 @@ namespace UnitTest
             const int expectedAddressElement = 4321;
             const int expectedVersion = 2222;
 
-            DataPatch::AddressTypeElement addressTypeElement = 
+            DataPatch::AddressTypeElement addressTypeElement =
                 m_addressTypeSerializer->LoadAddressElementFromPath(AZStd::string::format("somecharacters(%s)#%i%s%i/",
                 expectedTypeId,
                 expectedAddressElement,
@@ -2475,7 +2475,7 @@ namespace UnitTest
 
         TEST_F(PatchingTest, AddressTypeElementLoad_TypeIdMissingParentheses_LoadFails_FT)
         {
-            AZStd::string pathMissingParentheses = AZStd::string::format("somecharacters{3A8D5EC9-D70E-41CB-879C-DEF6A6D6ED03}::classE%s3000%s", 
+            AZStd::string pathMissingParentheses = AZStd::string::format("somecharacters{3A8D5EC9-D70E-41CB-879C-DEF6A6D6ED03}::classE%s3000%s",
                                                                          V1AddressTypeElementVersionDelimiter,
                                                                          V1AddressTypeElementPathDelimiter);
 
@@ -2486,7 +2486,7 @@ namespace UnitTest
 
         TEST_F(PatchingTest, AddressTypeElementLoad_TypeIdMissingCurlyBraces_LoadFails_FT)
         {
-            AZStd::string pathMissingCurlyBraces = AZStd::string::format("somecharacters(07DEDB71-0585-5BE6-83FF-1C9029B9E5DB)::classF%s9876%s", 
+            AZStd::string pathMissingCurlyBraces = AZStd::string::format("somecharacters(07DEDB71-0585-5BE6-83FF-1C9029B9E5DB)::classF%s9876%s",
                                                                          V1AddressTypeElementVersionDelimiter,
                                                                          V1AddressTypeElementPathDelimiter);
 
@@ -2497,7 +2497,7 @@ namespace UnitTest
 
         TEST_F(PatchingTest, AddressTypeElementLoad_ClassTypePathElementMissingColons_LoadFails_FT)
         {
-            AZStd::string pathElementMissingColons = AZStd::string::format("somecharacters({861A12B0-BD91-528E-9CEC-505246EE98DE})classC%s5432%s", 
+            AZStd::string pathElementMissingColons = AZStd::string::format("somecharacters({861A12B0-BD91-528E-9CEC-505246EE98DE})classC%s5432%s",
                                                                            V1AddressTypeElementVersionDelimiter,
                                                                            V1AddressTypeElementPathDelimiter);
 
@@ -2508,7 +2508,7 @@ namespace UnitTest
 
         TEST_F(PatchingTest, AddressTypeElementLoad_IndexTypePathElementMissingPound_LoadFails_FT)
         {
-            AZStd::string pathElementMissingPound = AZStd::string::format("somecharacters({ADFD596B-7177-5519-9752-BC418FE42963})91011%s1122%s", 
+            AZStd::string pathElementMissingPound = AZStd::string::format("somecharacters({ADFD596B-7177-5519-9752-BC418FE42963})91011%s1122%s",
                                                                           V1AddressTypeElementVersionDelimiter,
                                                                           V1AddressTypeElementPathDelimiter);
 
@@ -2565,7 +2565,7 @@ namespace UnitTest
             InnerObjectFieldConverterV1::Reflect(m_serializeContext.get());
             InnerObjectFieldConverterDerivedV1::Reflect(m_serializeContext.get());
             ObjectFieldConverterV1::Reflect(m_serializeContext.get());
-            
+
             const ObjectFieldConverterV1 initialObject;
             ObjectFieldConverterV1 testObject;
             // Change the defaults of elements on the ObjectFieldConverterV1 object
@@ -2573,7 +2573,7 @@ namespace UnitTest
             testObject.m_rootStringVector.emplace_back("Test2");
             testObject.m_rootInnerObject.m_stringField = "InnerTest1";
             testObject.m_rootInnerObject.m_stringVector.emplace_back("InnerTest2");
-            
+
             auto derivedInnerObject = aznew InnerObjectFieldConverterDerivedV1;
             derivedInnerObject->m_stringField = "DerivedTest1";
             derivedInnerObject->m_stringVector.emplace_back("DerivedTest2");
@@ -2634,7 +2634,7 @@ namespace UnitTest
                             // This occurs when patched element is a pointer to a class. In that case the entire class is serialized out
                             // Therefore when the DataPatch is loaded, the patch Data will load it's AZStd::any, which goes through the normal
                             // serialization flow, so if the class stored in the AZStd::any is an old version it needs to run through a Version Converter
-                            ->Version(2, &VersionConverter) 
+                            ->Version(2, &VersionConverter)
                             ->Field("InnerBaseIntField", &InnerObjectFieldConverterV2::m_int64Field)
                             ->TypeChange("InnerBaseStringField", 1, 2, AZStd::function<int64_t(const AZStd::string&)>(&StringToInt64))
                             ->NameChange(1, 2, "InnerBaseStringField", "InnerBaseIntField")
@@ -2736,7 +2736,7 @@ namespace UnitTest
                     AZ::IO::ByteContainerStream<decltype(byteBuffer)> byteStream(&byteBuffer);
                     WritePatchToByteStream(testPatch, byteBuffer);
                 }
-                // Now unreflect the ObjectFieldConverterV1, InnerObjectFieldConverterDerivedV1 and InnerObjectFieldConverterDerivedV1 
+                // Now unreflect the ObjectFieldConverterV1, InnerObjectFieldConverterDerivedV1 and InnerObjectFieldConverterDerivedV1
                 // and reflect ObjectFieldConverterV1WithMemberVersionChange, InnerObjectFieldConverterV2 and InnerObjectFieldConverterDerivedV1WithV2Base
                 {
                     m_serializeContext->EnableRemoveReflection();
@@ -2751,7 +2751,7 @@ namespace UnitTest
                 }
 
                 // Read DataPatch from ByteStream after reflecting Version 2 of the InnerObjectFieldConverterV2 class
-                // the reason this is required is the testPatch variable has as part of the patch data AZStd::any 
+                // the reason this is required is the testPatch variable has as part of the patch data AZStd::any
                 // that wraps a instance of an InnerObjectFieldConverterDerivedV1 stored in an InnerObjectFieldConverterV1 pointer
                 // The virtual table points to the InnerObjectFieldConverterDerivedV1 class, which in a normal patching scenario
                 // The Data Patch would be loaded from disk after the new version of the InnerObjectFieldConverterV2 has reflected
@@ -3070,7 +3070,7 @@ namespace UnitTest
                     if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(reflectContext))
                     {
                         // Because containers are implicitly reflected when used as part of a class reflection
-                        // the ObjectFieldConverterV1 AZStd::vector<AZStd::string> class is not reflected 
+                        // the ObjectFieldConverterV1 AZStd::vector<AZStd::string> class is not reflected
                         // if the ObjectFieldConverterV1 did not reflect
                         serializeContext->RegisterGenericType<AZStd::vector<AZStd::string>>();
                         serializeContext->Class<ClassType>()
@@ -3126,7 +3126,7 @@ namespace UnitTest
                             ->Version(3)
                             ->Field("RootStringField", &ClassType::m_rootStringField)
                             ->Field("RootStringList", &ClassType::m_rootStringList)
-                            // The TypeChange and NameChange converters are interleaved purposefully to make sure that the order of declaration 
+                            // The TypeChange and NameChange converters are interleaved purposefully to make sure that the order of declaration
                             // of the converters doesn't affect the conversion result
                             ->TypeChange("RootStringVector", 1, 3, AZStd::function<AZStd::list<AZStd::string>(const AZStd::vector<AZStd::string>&)>(&ConvertStringVectorToStringList))
                             ->NameChange(1, 3, "RootStringVector", "RootStringList")

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -7794,7 +7794,7 @@ namespace UnitTest
     class GenericsLoadInPlaceHolder final
     {
     public:
-        AZ_RTTI(((GenericsLoadInPlaceHolder<T>), "{98328203-83F0-4644-B1F6-34DDF50F3416}", T));
+        AZ_RTTI((GenericsLoadInPlaceHolder, "{98328203-83F0-4644-B1F6-34DDF50F3416}", T));
 
         static void Reflect(AZ::SerializeContext& sc)
         {

--- a/Code/Framework/AzFramework/AzFramework/Asset/SimpleAsset.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/SimpleAsset.h
@@ -99,7 +99,7 @@ namespace AzFramework
     {
     public:
         AZ_CLASS_ALLOCATOR(SimpleAssetReference<AssetType>, AZ::SystemAllocator, 0);
-        AZ_RTTI((SimpleAssetReference<AssetType>, SimpleAssetReferenceTypeId, AssetType), SimpleAssetReferenceBase);
+        AZ_RTTI((SimpleAssetReference, SimpleAssetReferenceTypeId, AssetType), SimpleAssetReferenceBase);
 
         static void Register(AZ::SerializeContext& context)
         {

--- a/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.cpp
@@ -50,7 +50,7 @@ namespace AzPhysics
         {
             if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
-                if (auto* editContext = azrtti_cast<AZ::EditContext*>(serializeContext->GetEditContext()))
+                if (auto* editContext = serializeContext->GetEditContext())
                 {
                     editContext->Enum<QueryType>("Query Type Flags", "Object types to include in the query")
                         ->Value("Static", QueryType::Static)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GenericComboBoxCtrl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GenericComboBoxCtrl.h
@@ -58,7 +58,7 @@ namespace AzToolsFramework
     {
         friend class GenericComboBoxHandler<T>;
     public:
-        AZ_RTTI(((GenericComboBoxCtrl<T>), "{FA7EC12F-1DA3-4734-ABDE-CBFD99450571}", T), GenericComboBoxCtrlBase);
+        AZ_RTTI((GenericComboBoxCtrl, "{FA7EC12F-1DA3-4734-ABDE-CBFD99450571}", T), GenericComboBoxCtrlBase);
         AZ_CLASS_ALLOCATOR(GenericComboBoxCtrl, AZ::SystemAllocator, 0);
 
         using GenericType = T;

--- a/Code/Framework/AzToolsFramework/Tests/PropertyTreeEditorTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/PropertyTreeEditorTests.cpp
@@ -134,7 +134,7 @@ namespace UnitTest
                     ->Field("myMap", &PropertyTreeEditorTester::m_myMap)
                     ->Field("mySubBlock", &PropertyTreeEditorTester::m_mySubBlock)
                     ->Field("myHiddenDouble", &PropertyTreeEditorTester::m_myHiddenDouble)
-                    ->Field("myReadOnlyShort", &PropertyTreeEditorTester::m_myReadOnlyShort)                    
+                    ->Field("myReadOnlyShort", &PropertyTreeEditorTester::m_myReadOnlyShort)
                     ->Field("nestedTesterHiddenChildren", &PropertyTreeEditorTester::m_nestedTesterHiddenChildren)
                     ->Field("myAssetData", &PropertyTreeEditorTester::m_myAssetData)
                     ->Field("myTestSimpleAsset", &PropertyTreeEditorTester::m_myTestSimpleAsset)
@@ -174,7 +174,7 @@ namespace UnitTest
                             ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
                         ->DataElement(nullptr, &PropertyTreeEditorTester::m_mySubBlock, "My Sub Block", "sub block test")
                             ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
-                            ->Attribute(AZ::Edit::Attributes::AutoExpand, true)                            
+                            ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->ClassElement(AZ::Edit::ClassElements::Group, "Grouped")
                             ->DataElement(AZ::Edit::UIHandlers::Default, &PropertyTreeEditorTester::m_myGroupedString, "My Grouped String", "A test grouped string.")
                         ;
@@ -197,7 +197,7 @@ namespace UnitTest
         {
             m_app.Start(AzFramework::Application::Descriptor());
             // Without this, the user settings component would attempt to save on finalize/shutdown. Since the file is
-            // shared across the whole engine, if multiple tests are run in parallel, the saving could cause a crash 
+            // shared across the whole engine, if multiple tests are run in parallel, the saving could cause a crash
             // in the unit tests.
             AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
         }
@@ -279,7 +279,7 @@ namespace UnitTest
         }
 
     }
-    
+
     TEST_F(PropertyTreeEditorTests, WritePropertyTreeValues)
     {
         AZ::ComponentApplicationBus::BroadcastResult(m_serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
@@ -622,11 +622,11 @@ namespace UnitTest
 
         // GetPropertyType
         {
-            EXPECT_STREQ("AZStd::unordered_map", propertyTree.GetPropertyType("My Map").c_str());
-            EXPECT_STREQ("AZStd::vector", propertyTree.GetPropertyType("My New List").c_str());
-            EXPECT_STREQ("AZStd::string", propertyTree.GetPropertyType("Nested|My Nested String").c_str());
-            EXPECT_STREQ("double", propertyTree.GetPropertyType("My Hidden Double").c_str());
-            EXPECT_STREQ("PropertyTreeEditorTester", propertyTree.GetPropertyType("Nested").c_str());
+            EXPECT_TRUE(propertyTree.GetPropertyType("My Map").starts_with("AZStd::unordered_map"));
+            EXPECT_TRUE(propertyTree.GetPropertyType("My New List").starts_with("AZStd::vector"));
+            EXPECT_EQ("AZStd::string", propertyTree.GetPropertyType("Nested|My Nested String"));
+            EXPECT_EQ("double", propertyTree.GetPropertyType("My Hidden Double"));
+            EXPECT_EQ("PropertyTreeEditorTester", propertyTree.GetPropertyType("Nested"));
         }
 
         // BuildPathsList after enforcement removes the "show children only" nodes from the paths

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawSystem.cpp
@@ -129,6 +129,9 @@ namespace AZ
 
         void DynamicDrawSystem::FrameEnd()
         {
+            // The DynamicDrawSystem::Init function must have been invoked
+            // for m_bufferAlloc to be non-nullptr
+            if (m_bufferAlloc != nullptr)
             {
                 AZStd::lock_guard<AZStd::mutex> lock(m_mutexBufferAlloc);
                 m_bufferAlloc->FrameEnd();

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Parameter/DefaultValueParameter.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Parameter/DefaultValueParameter.h
@@ -19,7 +19,7 @@ namespace EMotionFX
         : public ValueParameter
     {
     public:
-        AZ_RTTI(((DefaultValueParameter<ValueType, Derived>), "{AE70C43D-6BAE-4EDF-A1CF-FC18B9F92ABB}", ValueType, Derived), ValueParameter);
+        AZ_RTTI((DefaultValueParameter, "{AE70C43D-6BAE-4EDF-A1CF-FC18B9F92ABB}", ValueType, Derived), ValueParameter);
 
         explicit DefaultValueParameter(const ValueType& defaultValue, AZStd::string name = {}, AZStd::string description = {})
             : ValueParameter(AZStd::move(name), AZStd::move(description))

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Parameter/RangedValueParameter.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Parameter/RangedValueParameter.h
@@ -18,7 +18,7 @@ namespace EMotionFX
     {
         using BaseType = DefaultValueParameter<ValueType, RangedValueParameter<ValueType, Derived>>;
     public:
-        AZ_RTTI(((RangedValueParameter<ValueType, Derived>), "{83572845-AFBD-4685-AACD-0D15CF79006A}", ValueType, Derived), BaseType);
+        AZ_RTTI((RangedValueParameter, "{83572845-AFBD-4685-AACD-0D15CF79006A}", ValueType, Derived), BaseType);
 
         RangedValueParameter(const ValueType& defaultValue, const ValueType& minValue, const ValueType& maxValue, bool hasMinValue = true, bool hasMaxValue = true, AZStd::string name = {}, AZStd::string description = {})
             : BaseType(defaultValue, AZStd::move(name), AZStd::move(description))

--- a/Gems/EditorPythonBindings/Code/Tests/PythonAssetTypesTests.cpp
+++ b/Gems/EditorPythonBindings/Code/Tests/PythonAssetTypesTests.cpp
@@ -386,7 +386,7 @@ namespace UnitTest
         EXPECT_TRUE(behaviorClasses.find("Asset<AssetData>") != behaviorClasses.end());
         EXPECT_TRUE(behaviorClasses.find("Asset<MyTestAssetData>") != behaviorClasses.end());
         EXPECT_TRUE(behaviorClasses.find("SimpleAssetReferenceBase") != behaviorClasses.end());
-        EXPECT_TRUE(behaviorClasses.find("SimpleAssetReference<AssetType><FooMockSimpleAsset >") != behaviorClasses.end());
+        EXPECT_TRUE(behaviorClasses.find("SimpleAssetReference<FooMockSimpleAsset>") != behaviorClasses.end());
     }
 
     TEST_F(PythonAssetTypesTests, AssetIdValues)
@@ -655,7 +655,7 @@ namespace UnitTest
 
                 # using FooMockSimpleAsset inside a SimpleAssetReference<> template
                 newFakeAssetPath = 'another/fake/asset_file.foo'
-                simpleRef = azlmbr.object.construct('SimpleAssetReference<AssetType><FooMockSimpleAsset >')
+                simpleRef = azlmbr.object.construct('SimpleAssetReference<FooMockSimpleAsset>')
                 simpleRef.set_asset_path(newFakeAssetPath)
                 if(simpleRef.assetPath == newFakeAssetPath):
                     print('SimpleAssetReference: simpleRef {}'.format(newFakeAssetPath))

--- a/Gems/EditorPythonBindings/Code/Tests/PythonTupleTests.cpp
+++ b/Gems/EditorPythonBindings/Code/Tests/PythonTupleTests.cpp
@@ -238,12 +238,12 @@ namespace UnitTest
                 test = azlmbr.object.create('PythonReflectionTupleTypes')
 
                 # Create a tuple with default values - note the odd naming syntax :(
-                test_tuple = azlmbr.object.create('tuple<bool int float >')
+                test_tuple = azlmbr.object.create('AZStd::tuple<bool, int, float>')
                 if (test_tuple):
                     print ('TupleTypeTest_ConstructWithDefaultValues')
 
                 # Create a tuple with parameters and verify that the parameters can be read back correctly.
-                test_tuple = azlmbr.object.construct('tuple<bool int float >', True, 5, 10.0)
+                test_tuple = azlmbr.object.construct('AZStd::tuple<bool, int, float>', True, 5, 10.0)
                 if (test_tuple and test_tuple.Get0() == True and test_tuple.Get1() == 5 and test_tuple.Get2() == 10.0):
                     print ('TupleTypeTest_ConstructWithParameters')
 

--- a/Gems/EditorPythonBindings/Code/Tests/PythonTupleTests.cpp
+++ b/Gems/EditorPythonBindings/Code/Tests/PythonTupleTests.cpp
@@ -237,7 +237,7 @@ namespace UnitTest
                 # Create the test fixture
                 test = azlmbr.object.create('PythonReflectionTupleTypes')
 
-                # Create a tuple with default values - note the odd naming syntax :(
+                # Create a tuple with default values
                 test_tuple = azlmbr.object.create('AZStd::tuple<bool, int, float>')
                 if (test_tuple):
                     print ('TupleTypeTest_ConstructWithDefaultValues')

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Types/SceneMemberComponentSaveData.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Types/SceneMemberComponentSaveData.h
@@ -21,7 +21,7 @@ namespace GraphCanvas
         , public EntitySaveDataRequestBus::Handler
     {
     public:
-        AZ_RTTI(((SceneMemberComponentSaveData<DataType>), "{2DF9A652-DF5D-43B1-932F-B6A838E36E97}", DataType), ComponentSaveData);
+        AZ_RTTI((SceneMemberComponentSaveData, "{2DF9A652-DF5D-43B1-932F-B6A838E36E97}", DataType), ComponentSaveData);
         AZ_CLASS_ALLOCATOR(SceneMemberComponentSaveData, AZ::SystemAllocator, 0);
 
         SceneMemberComponentSaveData()

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/NodePalette/InputOutputNodePaletteItem.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/NodePalette/InputOutputNodePaletteItem.h
@@ -56,7 +56,7 @@ namespace GraphModelIntegration
         : public GraphCanvas::GraphCanvasMimeEvent
     {
     public:
-        AZ_RTTI(((CreateInputOutputNodeMimeEvent<NodeType>), "{16BED069-A386-4E5C-8A5A-0827121991E7}", NodeType), GraphCanvas::GraphCanvasMimeEvent);
+        AZ_RTTI((CreateInputOutputNodeMimeEvent, "{16BED069-A386-4E5C-8A5A-0827121991E7}", NodeType), GraphCanvas::GraphCanvasMimeEvent);
         AZ_CLASS_ALLOCATOR(CreateInputOutputNodeMimeEvent, AZ::SystemAllocator, 0);
 
         static void Reflect(AZ::ReflectContext* reflectContext)

--- a/Gems/LyShine/Code/Source/Animation/AnimSplineTrack.h
+++ b/Gems/LyShine/Code/Source/Animation/AnimSplineTrack.h
@@ -23,7 +23,7 @@ class TUiAnimSplineTrack
 {
 public:
     AZ_CLASS_ALLOCATOR(TUiAnimSplineTrack, AZ::SystemAllocator, 0)
-    AZ_RTTI((TUiAnimSplineTrack, "{A78AAC62-84D0-4E2E-958E-564F51A140D2}", Vec2), IUiAnimTrack);
+    AZ_RTTI((TUiAnimSplineTrack, "{A78AAC62-84D0-4E2E-958E-564F51A140D2}", ValueType), IUiAnimTrack);
 
     TUiAnimSplineTrack()
         : m_refCount(0)

--- a/Gems/Maestro/Code/Source/Cinematics/AnimSplineTrack.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimSplineTrack.h
@@ -26,7 +26,24 @@ class TAnimSplineTrack
 {
 public:
     AZ_CLASS_ALLOCATOR(TAnimSplineTrack, AZ::SystemAllocator, 0);
-    AZ_RTTI((TAnimSplineTrack, "{6D72D5F6-61A7-43D4-9104-8F7DCCC19E10}", Vec2), IAnimTrack)
+    AZ_RTTI((TAnimSplineTrack, "{6D72D5F6-61A7-43D4-9104-8F7DCCC19E10}", ValueType), IAnimTrack);
+
+    static constexpr void DeprecatedTypeNameVisitor(
+        const AZ::DeprecatedTypeNameCallback& visitCallback)
+    {
+        // TAnimSplineTrack previously restricted the typename to 128 bytes
+        AZStd::array<char, 128> deprecatedName{};
+
+        // The old TAnimSplineTrack TypeName mistakenly used Vec2 as the template parameter and not ValueType
+        // Also the extra space before the '>' is due to the AZ::Internal::AggregateTypes template
+        // always adding a space after each argument
+        AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), "TAnimSplineTrack<Vec2 >");
+
+        if (visitCallback)
+        {
+            visitCallback(deprecatedName.data());
+        }
+    }
 
     TAnimSplineTrack()
         : m_refCount(0)

--- a/Gems/Maestro/Code/Source/Cinematics/AnimTrack.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimTrack.h
@@ -24,7 +24,7 @@ class TAnimTrack
 {
 public:
     AZ_CLASS_ALLOCATOR(TAnimTrack, AZ::SystemAllocator, 0);
-    AZ_RTTI((TAnimTrack<KeyType>, "{D6E0F0E3-8843-46F0-8484-7B6E130409AE}", KeyType), IAnimTrack);
+    AZ_RTTI((TAnimTrack, "{D6E0F0E3-8843-46F0-8484-7B6E130409AE}", KeyType), IAnimTrack);
 
     TAnimTrack();
 
@@ -44,7 +44,7 @@ public:
     void SetParameterType(CAnimParamType type) override { m_nParamType = type; };
 
     //////////////////////////////////////////////////////////////////////////
-    // for intrusive_ptr support 
+    // for intrusive_ptr support
     void add_ref() override;
     void release() override;
     //////////////////////////////////////////////////////////////////////////
@@ -224,7 +224,7 @@ public:
     {
         m_trackMultiplier = trackMultiplier;
     }
- 
+
     void SetExpanded([[maybe_unused]] bool expanded) override
     {
         AZ_Assert(false, "Not expected to be used.");

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.h
@@ -221,7 +221,7 @@ namespace ScriptCanvas
     {
         using ThisType = TaggedParent<t_Tag, t_Parent>;
         AZ_CLASS_ALLOCATOR(ThisType, AZ::SystemAllocator, 0);
-        AZ_RTTI(((TaggedParent<t_Tag, t_Parent>), "{CF75CEEE-2305-49D4-AD41-407E82F819D7}", t_Tag, t_Parent), t_Parent, LoggableEvent);
+        AZ_RTTI((TaggedParent, "{CF75CEEE-2305-49D4-AD41-407E82F819D7}", t_Tag, t_Parent), t_Parent, LoggableEvent);
 
         static void Reflect(AZ::ReflectContext* context)
         {
@@ -397,7 +397,7 @@ namespace ScriptCanvas
         using ThisType = TaggedDataValue<t_Tag>;
         
         AZ_CLASS_ALLOCATOR(TaggedDataValue<t_Tag>, AZ::SystemAllocator, 0);
-        AZ_RTTI(((TaggedDataValue<t_Tag>), "{893B73BA-E1CC-4D91-92D1-C1CF46817A57}", t_Tag), DatumValue, GraphInfo, LoggableEvent);
+        AZ_RTTI((TaggedDataValue, "{893B73BA-E1CC-4D91-92D1-C1CF46817A57}", t_Tag), DatumValue, GraphInfo, LoggableEvent);
         using DatumValue::DatumValue;
         
         static void Reflect(AZ::ReflectContext* context)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphScopedTypes.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphScopedTypes.h
@@ -21,6 +21,23 @@ namespace ScriptCanvas
     {
     public:
         AZ_RTTI((GraphScopedIdentifier, "{1B01849B-57BA-4926-8DF6-252966E2BF8F}", T));
+
+        static constexpr void DeprecatedTypeNameVisitor(
+            const AZ::DeprecatedTypeNameCallback& visitCallback)
+        {
+            // GraphScopedIdentifier previously restricted the typename to 128 bytes
+            AZStd::array<char, 128> deprecatedName{};
+
+            AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), "GraphScopedIdentifier<");
+            AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), AZ::AzTypeInfo<T>::Name());
+            // The old AZ::Internal::AggregateTypes implementations placed a space after each argument
+            AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), " >");
+
+            if (visitCallback)
+            {
+                visitCallback(deprecatedName.data());
+            }
+        }
         
         GraphScopedIdentifier() = default;
         GraphScopedIdentifier(const ScriptCanvasId& scriptCanvasId, const T& identifier)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
@@ -40,7 +40,7 @@ namespace ScriptCanvas
     {
     public:
         AZ_PUSH_DISABLE_WARNING(5046, "-Wunknown-warning-option") // 'function' : Symbol involving type with internal linkage not defined
-        AZ_RTTI(((NodeFunctionGenericMultiReturn<t_Func, t_Traits, function>), "{DC5B1799-6C5B-4190-8D90-EF0C2D1BCE4E}", t_Func, t_Traits), Node);
+        AZ_RTTI((NodeFunctionGenericMultiReturn, "{DC5B1799-6C5B-4190-8D90-EF0C2D1BCE4E}", t_Func, t_Traits), Node);
         AZ_COMPONENT_INTRUSIVE_DESCRIPTOR_TYPE(NodeFunctionGenericMultiReturn);
         AZ_COMPONENT_BASE(NodeFunctionGenericMultiReturn, Node);
         AZ_POP_DISABLE_WARNING

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
@@ -39,11 +39,48 @@ namespace ScriptCanvas
         : public Node
     {
     public:
-        AZ_PUSH_DISABLE_WARNING(5046, "-Wunknown-warning-option") // 'function' : Symbol involving type with internal linkage not defined
+        AZ_PUSH_DISABLE_WARNING(5046, "-Wunknown-warning-option"); // 'function' : Symbol involving type with internal linkage not defined
         AZ_RTTI((NodeFunctionGenericMultiReturn, "{DC5B1799-6C5B-4190-8D90-EF0C2D1BCE4E}", t_Func, t_Traits), Node);
         AZ_COMPONENT_INTRUSIVE_DESCRIPTOR_TYPE(NodeFunctionGenericMultiReturn);
         AZ_COMPONENT_BASE(NodeFunctionGenericMultiReturn, Node);
-        AZ_POP_DISABLE_WARNING
+        AZ_POP_DISABLE_WARNING;
+
+        static constexpr void DeprecatedTypeNameVisitor(
+            const AZ::DeprecatedTypeNameCallback& visitCallback)
+        {
+            // NodeFunctionGenericMultiReturn previously restricted the typename to 128 bytes
+            AZStd::array<char, 128> deprecatedName{};
+
+            // Due to the extra set of parenthesis, the actual type name of NodeFunctionGenericMultiReturn started literally as
+            // "(NodeFunctionGenericMultiReturn<t_Func, t_Traits, function>"
+            AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), "(NodeFunctionGenericMultiReturn<t_Func, t_Traits, function>)<");
+            auto AppendDeprecatedFunctionName = [&deprecatedName](AZStd::string_view deprecatedFuncName)
+            {
+                // The function signature name was restricted to 64 bytes
+                AZStd::array<char, 64> deprecatedFuncSignature{};
+                AZ::Internal::AzTypeInfoSafeCat(deprecatedFuncSignature.data(), deprecatedFuncSignature.size(), deprecatedFuncName.data());
+
+                // If the function type was a pointer then it a '*' needs to be appended to it.
+                // But the AZ_TYPE_INFO_INTERNAL_SPECIALIZE_CV macro will only append a '*' if the function signature buffer has room for it
+                if constexpr (AZStd::is_pointer_v<t_Func>)
+                {
+                    AZ::Internal::AzTypeInfoSafeCat(deprecatedFuncSignature.data(), deprecatedFuncSignature.size(), "*");
+                }
+
+                // Now copy the function signature to the deprecatedName buffer
+                AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), deprecatedFuncSignature.data());
+            };
+            AZ::DeprecatedTypeNameVisitor<t_Func>(AppendDeprecatedFunctionName);
+            // The old AZ::Internal::AggregateTypes implementations placed a space after each argument as a separator
+            AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), " ");
+            AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), AZ::AzTypeInfo<t_Traits>::Name());
+            AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), " >");
+
+            if (visitCallback)
+            {
+                visitCallback(deprecatedName.data());
+            }
+        }
 
 
         static const char* GetNodeFunctionName()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Messages/Notify.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Messages/Notify.h
@@ -43,7 +43,7 @@ namespace ScriptCanvas
             {
             public:
                 AZ_CLASS_ALLOCATOR(NotificationPayload<t_Payload>, AZ::SystemAllocator, 0);
-                AZ_RTTI(((NotificationPayload<t_Payload>), "{AC9FC9F9-C660-43DC-BCB8-0CD390432ED1}", t_Payload), Notification);
+                AZ_RTTI((NotificationPayload, "{AC9FC9F9-C660-43DC-BCB8-0CD390432ED1}", t_Payload), Notification);
 
                 t_Payload m_payload;
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Messages/Request.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Messages/Request.h
@@ -43,7 +43,7 @@ namespace ScriptCanvas
             {
             public:
                 AZ_CLASS_ALLOCATOR(TaggedRequest<t_Tag>, AZ::SystemAllocator, 0);
-                AZ_RTTI(((TaggedRequest<t_Tag>), "{DFFD8D88-1C50-457C-B0D0-C0640D78FB76}", t_Tag), Request);
+                AZ_RTTI((TaggedRequest, "{DFFD8D88-1C50-457C-B0D0-C0640D78FB76}", t_Tag), Request);
 
                 TaggedRequest() = default;
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorLerpNodeable.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorLerpNodeable.h
@@ -44,8 +44,27 @@ namespace ScriptCanvas
             using ThisType = LerpBetweenNodeable<t_Operand>;
 
         public:
-            AZ_RTTI(((LerpBetweenNodeable<t_Operand>), "{3467EB2B-801E-4799-B47A-AFEA621A152B}", t_Operand), Nodeable);
+            AZ_RTTI((LerpBetweenNodeable, "{3467EB2B-801E-4799-B47A-AFEA621A152B}", t_Operand), Nodeable);
             AZ_CLASS_ALLOCATOR(LerpBetweenNodeable<t_Operand>, AZ::SystemAllocator, 0);
+
+            static constexpr void DeprecatedTypeNameVisitor(
+                const AZ::DeprecatedTypeNameCallback& visitCallback)
+            {
+                // LerpBetweenNodeable previously restricted the typename to 128 bytes
+                AZStd::array<char, 128> deprecatedName{};
+
+                // Due to the extra set of parenthesis, the actual type name of LerpBetweenNodeable started out literally as
+                // "(LerpBetweenNodeable<t_Operand>)"
+                AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), "(LerpBetweenNodeable<t_Operand>)<");
+                AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), AZ::AzTypeInfo<t_Operand>::Name());
+                // The old AZ::Internal::AggregateTypes implementations placed a space after each argument as a separator
+                AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), " >");
+
+                if (visitCallback)
+                {
+                    visitCallback(deprecatedName.data());
+                }
+            }
 
             static void Reflect(AZ::ReflectContext* reflectContext)
             {

--- a/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_MethodOverload.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_MethodOverload.cpp
@@ -27,7 +27,7 @@ private:
     using ClassName = SingleTypeNodeable<Type>;
 
 public:
-    AZ_RTTI(((SingleTypeNodeable<Type>), "{62F173B5-596B-4872-B88B-E03DFCD5D059}", Type), ScriptCanvas::Nodeable);
+    AZ_RTTI((SingleTypeNodeable, "{62F173B5-596B-4872-B88B-E03DFCD5D059}", Type), ScriptCanvas::Nodeable);
     AZ_CLASS_ALLOCATOR(SingleTypeNodeable<Type>, AZ::SystemAllocator, 0);
 
     static void Reflect(AZ::ReflectContext* reflectContext)


### PR DESCRIPTION
Updated the type name generation in AzTypeInfo to be consistent for aggregate types such as tuple.
Updated the AzTypeInfo::Name() function to be constexpr, as well as the TYPEINFO_Name() function that gets added by the AZ_TYPE_INFO macro.
Updated the TypeInfo names of AZStd container types to be consistent across the board.

Removed parentheses around type names.

resolves #9488

The StdoutStream now overrides the GetFilename function to return a filename of "" instead of "".
Added a ConvertToAbsolutePath overload which returns a boolean and accepts an AZ::IO::FixedMaxPath output parameter by reference.