### PR TITLE
add AZ::Transform variants for Pose and deprecated EmotionFX::Transform

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/Pose.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Pose.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <EMotionFX/Source/Transform.h>
 #include <EMotionFX/Source/ActorInstance.h>
 #include <EMotionFX/Source/MotionData/MotionData.h>
 #include <EMotionFX/Source/MotionInstance.h>
@@ -275,6 +276,26 @@ namespace EMotionFX
         m_flags[nodeIndex] |= FLAG_LOCALTRANSFORMREADY;
     }
 
+    void Pose::GetLocalSpaceTransform(size_t nodeIndex, AZ::Transform* outResult) const
+    {
+        EMotionFX::Transform result;
+        GetLocalSpaceTransform(nodeIndex, &result);
+        (*outResult) = result.ToAZTransform();
+    }
+
+    void Pose::GetModelSpaceTransform(size_t nodeIndex, AZ::Transform* outResult) const
+    {
+        EMotionFX::Transform result;
+        GetModelSpaceTransform(nodeIndex, &result);
+        (*outResult) = result.ToAZTransform();
+    }
+    
+    void Pose::GetWorldSpaceTransform(size_t nodeIndex, AZ::Transform* outResult) const
+    {
+        EMotionFX::Transform result;
+        GetWorldSpaceTransform(nodeIndex, &result);
+        (*outResult) = result.ToAZTransform();
+    }
 
     // get the local transform
     const Transform& Pose::GetLocalSpaceTransform(size_t nodeIndex) const
@@ -283,13 +304,11 @@ namespace EMotionFX
         return m_localSpaceTransforms[nodeIndex];
     }
 
-
     const Transform& Pose::GetModelSpaceTransform(size_t nodeIndex) const
     {
         UpdateModelSpaceTransform(nodeIndex);
         return m_modelSpaceTransforms[nodeIndex];
     }
-
 
     Transform Pose::GetWorldSpaceTransform(size_t nodeIndex) const
     {
@@ -324,9 +343,23 @@ namespace EMotionFX
         *outResult = m_modelSpaceTransforms[nodeIndex];
     }
 
+    void Pose::SetLocalSpaceTransform(size_t nodeIndex, const AZ::Transform& newTransform, bool invalidateGlobalTransforms)
+    {
+        SetLocalSpaceTransform(nodeIndex, EMotionFX::Transform(newTransform), invalidateGlobalTransforms);
+    }
+
+    void Pose::SetModelSpaceTransform(size_t nodeIndex, const AZ::Transform& newTransform, bool invalidateChildModelSpaceTransforms) 
+    {
+        SetModelSpaceTransform(nodeIndex, EMotionFX::Transform(newTransform), invalidateChildModelSpaceTransforms);
+    }
+
+    void Pose::SetWorldSpaceTransform(size_t nodeIndex, const AZ::Transform& newTransform, bool invalidateChildModelSpaceTransforms)
+    {
+        SetWorldSpaceTransform(nodeIndex, EMotionFX::Transform(newTransform), invalidateChildModelSpaceTransforms);
+    }
 
     // set the local transform
-    void Pose::SetLocalSpaceTransform(size_t nodeIndex, const Transform& newTransform, bool invalidateGlobalTransforms)
+    void Pose::SetLocalSpaceTransform(size_t nodeIndex, const EMotionFX::Transform& newTransform, bool invalidateGlobalTransforms)
     {
         m_localSpaceTransforms[nodeIndex] = newTransform;
         m_flags[nodeIndex] |= FLAG_LOCALTRANSFORMREADY;

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Pose.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Pose.h
@@ -63,13 +63,34 @@ namespace EMotionFX
         const Transform& GetModelSpaceTransform(size_t nodeIndex) const;
         Transform GetWorldSpaceTransform(size_t nodeIndex) const;
 
-        void GetLocalSpaceTransform(size_t nodeIndex, Transform* outResult) const;
-        void GetModelSpaceTransform(size_t nodeIndex, Transform* outResult) const;
-        void GetWorldSpaceTransform(size_t nodeIndex, Transform* outResult) const;
+        // O3DE_DEPRECATION_NOTICE(GHI-XX)  
+        //! @deprecated use GetLocalSpaceTransform with AZ::Transform
+        void GetLocalSpaceTransform(size_t nodeIndex, EMotionFX::Transform* outResult) const;
+        // O3DE_DEPRECATION_NOTICE(GHI-XX)  
+        //! @deprecated use GetLocalSpaceTransform with AZ::Transform
+        void GetModelSpaceTransform(size_t nodeIndex, EMotionFX::Transform* outResult) const;
+        // O3DE_DEPRECATION_NOTICE(GHI-XX)  
+        //! @deprecated use GetLocalSpaceTransform with AZ::Transform
+        void GetWorldSpaceTransform(size_t nodeIndex, EMotionFX::Transform* outResult) const;
 
-        void SetLocalSpaceTransform(size_t nodeIndex, const Transform& newTransform, bool invalidateModelSpaceTransforms = true);
-        void SetModelSpaceTransform(size_t nodeIndex, const Transform& newTransform, bool invalidateChildModelSpaceTransforms = true);
-        void SetWorldSpaceTransform(size_t nodeIndex, const Transform& newTransform, bool invalidateChildModelSpaceTransforms = true);
+        void GetLocalSpaceTransform(size_t nodeIndex, AZ::Transform* outResult) const;
+        void GetModelSpaceTransform(size_t nodeIndex, AZ::Transform* outResult) const;
+        void GetWorldSpaceTransform(size_t nodeIndex, AZ::Transform* outResult) const;
+
+
+        // O3DE_DEPRECATION_NOTICE(GHI-XX)  
+        //! @deprecated use GetLocalSpaceTransform with AZ::Transform
+        void SetLocalSpaceTransform(size_t nodeIndex, const EMotionFX::Transform& newTransform, bool invalidateModelSpaceTransforms = true);
+        // O3DE_DEPRECATION_NOTICE(GHI-XX)  
+        //! @deprecated use GetLocalSpaceTransform with AZ::Transform
+        void SetModelSpaceTransform(size_t nodeIndex, const EMotionFX::Transform& newTransform, bool invalidateChildModelSpaceTransforms = true);
+        // O3DE_DEPRECATION_NOTICE(GHI-XX)  
+        //! @deprecated use GetLocalSpaceTransform with AZ::Transform
+        void SetWorldSpaceTransform(size_t nodeIndex, const EMotionFX::Transform& newTransform, bool invalidateChildModelSpaceTransforms = true);
+
+        void SetLocalSpaceTransform(size_t nodeIndex, const AZ::Transform& newTransform, bool invalidateModelSpaceTransforms = true);
+        void SetModelSpaceTransform(size_t nodeIndex, const AZ::Transform& newTransform, bool invalidateChildModelSpaceTransforms = true);
+        void SetWorldSpaceTransform(size_t nodeIndex, const AZ::Transform& newTransform, bool invalidateChildModelSpaceTransforms = true);
 
         void UpdateModelSpaceTransform(size_t nodeIndex) const;
         void UpdateLocalSpaceTransform(size_t nodeIndex) const;


### PR DESCRIPTION
this just added the AZ::Transform variants but what's confusing me is how to approach some of this. some of these are just returns so you can't really deprecate that type of endpoint. 

- I don't like the raw pointers for GetLocalSpaceTransforms this can easily return just a span of the data
- GetModelSpaceTransform seems pretty much the same as GetModelSpaceTransformDirect. passing out by reference vs assigning as a pointer seems equivalent to me. 


Signed-off-by: Michael Pollind <mpollind@gmail.com>