### PR TITLE
Fix Asset Processor UI: splitter turns blue when hovered; columned asset details

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.ui
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.ui
@@ -253,101 +253,8 @@
        </property>
        <layout class="QVBoxLayout" name="scrollableVerticalLayout">
         <item>
-         <layout class="QHBoxLayout" name="productAssetIdLayout">
-          <item>
-           <widget class="QLabel" name="productAssetIdTitleLabel">
-            <property name="styleSheet">
-             <string notr="true">font: bold;</string>
-            </property>
-            <property name="text">
-             <string>Product Asset ID:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="productAssetIdValueLabel">
-            <property name="text">
-             <string>Product asset ID here</string>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="productAssetIdSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="lastTimeProcessedLayout">
-          <item>
-           <widget class="QLabel" name="lastTimeProcessedTitleLabel">
-            <property name="styleSheet">
-             <string notr="true">font: bold;</string>
-            </property>
-            <property name="text">
-             <string>Last Time Processed:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="lastTimeProcessedValueLabel">
-            <property name="text">
-             <string>lastTimeProcessed Here</string>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="lastTimeProcessedSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="jobKeyLayout">
-          <item>
-           <widget class="QLabel" name="jobKeyTitleLabel">
-            <property name="styleSheet">
-             <string notr="true">font: bold;</string>
-            </property>
-            <property name="text">
-             <string>Job Key:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
+         <layout class="QGridLayout" name="headerGrid" columnstretch="1,4">
+          <item row="2" column="1">
            <widget class="QLabel" name="jobKeyValueLabel">
             <property name="text">
              <string>jobKey Here</string>
@@ -357,37 +264,79 @@
             </property>
            </widget>
           </item>
-          <item>
-           <spacer name="jobKeySpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="platformLayout">
-          <item>
+          <item row="3" column="0">
            <widget class="QLabel" name="platformTitleLabel">
             <property name="styleSheet">
              <string notr="true">font: bold;</string>
             </property>
             <property name="text">
-             <string>Platform:</string>
+             <string>Platform</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="productAssetIdTitleLabel">
+            <property name="styleSheet">
+             <string notr="true">font: bold;</string>
+            </property>
+            <property name="text">
+             <string>Product Asset ID</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="productAssetIdValueLabel">
+            <property name="text">
+             <string>Product asset ID here</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="sourceAssetTitleLabel">
+            <property name="styleSheet">
+             <string notr="true">font: bold;</string>
+            </property>
+            <property name="text">
+             <string>Source Asset</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="lastTimeProcessedValueLabel">
+            <property name="text">
+             <string>lastTimeProcessed Here</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="lastTimeProcessedTitleLabel">
+            <property name="styleSheet">
+             <string notr="true">font: bold;</string>
+            </property>
+            <property name="text">
+             <string>Last Time Processed</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
            <widget class="QLabel" name="platformValueLabel">
             <property name="text">
              <string>platform Here</string>
@@ -397,74 +346,48 @@
             </property>
            </widget>
           </item>
-          <item>
-           <spacer name="platformSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="sourceAssetLayout">
-          <item>
-           <widget class="QLabel" name="sourceAssetTitleLabel">
+          <item row="2" column="0">
+           <widget class="QLabel" name="jobKeyTitleLabel">
             <property name="styleSheet">
              <string notr="true">font: bold;</string>
             </property>
             <property name="text">
-             <string>Source Asset:</string>
+             <string>Job Key</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item alignment="Qt::AlignVCenter">
-           <widget class="AssetProcessor::GoToButton" name="gotoAssetButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>24</width>
-              <height>24</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="sourceAssetValueLabel">
-            <property name="text">
-             <string>sourceAsset Here</string>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="sourceAssetSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
+          <item row="4" column="1">
+           <layout class="QHBoxLayout" name="sourceAsset">
+            <item>
+             <widget class="AssetProcessor::GoToButton" name="gotoAssetButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>24</width>
+                <height>24</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="sourceAssetValueLabel">
+              <property name="text">
+               <string>sourceAsset Here</string>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </item>

--- a/Code/Tools/AssetProcessor/native/ui/SourceAssetDetailsPanel.ui
+++ b/Code/Tools/AssetProcessor/native/ui/SourceAssetDetailsPanel.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>743</width>
-    <height>860</height>
+    <width>735</width>
+    <height>837</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -31,8 +31,10 @@
      <property name="font">
       <font>
        <family>16pt</family>
-       <weight>75</weight>
+       <pointsize>12</pointsize>
+       <weight>50</weight>
        <italic>false</italic>
+       <bold>false</bold>
       </font>
      </property>
      <property name="styleSheet">
@@ -211,8 +213,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>721</width>
-          <height>791</height>
+          <width>713</width>
+          <height>760</height>
          </rect>
         </property>
         <property name="sizePolicy">
@@ -227,26 +229,26 @@
            <x>10</x>
            <y>10</y>
            <width>833</width>
-           <height>551</height>
+           <height>425</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="scrollableVerticalLayout">
           <item>
-           <layout class="QHBoxLayout" name="ScanFolderLayout">
-            <item>
+           <layout class="QGridLayout" name="headerGrid" columnstretch="1,4">
+            <item row="0" column="0">
              <widget class="QLabel" name="scanFolderTitleLabel">
               <property name="styleSheet">
                <string notr="true">font: bold;</string>
               </property>
               <property name="text">
-               <string>Scan Folder:</string>
+               <string>Scan Folder</string>
               </property>
               <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
               </property>
              </widget>
             </item>
-            <item>
+            <item row="0" column="1">
              <widget class="QLabel" name="scanFolderValueLabel">
               <property name="text">
                <string>Scan folder name here</string>
@@ -256,37 +258,7 @@
               </property>
              </widget>
             </item>
-            <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="sourceGuidLayout">
-            <item>
-             <widget class="QLabel" name="sourceGuidTitleLabel">
-              <property name="styleSheet">
-               <string notr="true">font: bold;</string>
-              </property>
-              <property name="text">
-               <string>Source Guid:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
+            <item row="1" column="1">
              <widget class="QLabel" name="sourceGuidValueLabel">
               <property name="text">
                <string>Source guid here</string>
@@ -296,18 +268,18 @@
               </property>
              </widget>
             </item>
-            <item>
-             <spacer name="horizontalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+            <item row="1" column="0">
+             <widget class="QLabel" name="sourceGuidTitleLabel">
+              <property name="styleSheet">
+               <string notr="true">font: bold;</string>
               </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
+              <property name="text">
+               <string>Source Guid</string>
               </property>
-             </spacer>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
@@ -440,10 +412,10 @@
               <attribute name="horizontalHeaderVisible">
                <bool>false</bool>
               </attribute>
-              <attribute name="horizontalHeaderDefaultSectionSize">
+              <attribute name="horizontalHeaderMinimumSectionSize">
                <number>24</number>
               </attribute>
-              <attribute name="horizontalHeaderMinimumSectionSize">
+              <attribute name="horizontalHeaderDefaultSectionSize">
                <number>24</number>
               </attribute>
               <attribute name="horizontalHeaderStretchLastSection">
@@ -575,10 +547,10 @@
             <attribute name="horizontalHeaderVisible">
              <bool>false</bool>
             </attribute>
-            <attribute name="horizontalHeaderDefaultSectionSize">
+            <attribute name="horizontalHeaderMinimumSectionSize">
              <number>24</number>
             </attribute>
-            <attribute name="horizontalHeaderMinimumSectionSize">
+            <attribute name="horizontalHeaderDefaultSectionSize">
              <number>24</number>
             </attribute>
             <attribute name="horizontalHeaderStretchLastSection">
@@ -708,10 +680,10 @@
             <attribute name="horizontalHeaderVisible">
              <bool>false</bool>
             </attribute>
-            <attribute name="horizontalHeaderDefaultSectionSize">
+            <attribute name="horizontalHeaderMinimumSectionSize">
              <number>24</number>
             </attribute>
-            <attribute name="horizontalHeaderMinimumSectionSize">
+            <attribute name="horizontalHeaderDefaultSectionSize">
              <number>24</number>
             </attribute>
             <attribute name="horizontalHeaderStretchLastSection">

--- a/Code/Tools/AssetProcessor/native/ui/style/AssetsTab.qss
+++ b/Code/Tools/AssetProcessor/native/ui/style/AssetsTab.qss
@@ -121,10 +121,6 @@ QFrame#jobContextLogLabel {
     margin-top: 12px;
 }
 
-QSplitter:handle {
-    background-color: #222222;
-}
-
 QLabel#jobLogPlaceholderLabel,
 QLabel#jobContextLogPlaceholderLabel {
     background-color: rgb(34,34,34);


### PR DESCRIPTION
This PR addresses the comment in PR #9983 ([issue comment link](https://github.com/o3de/o3de/pull/9983#issuecomment-1159036165)) regarding Asset Processor UI fixes. It made the following fixes:
- Splitters turn blue when cursor hovers over them (the default behavior).
- The headers of Source/Product Asset Details page are columned. Field names and values are aligned to left with other items in different rows.

Current behavior video:
https://user-images.githubusercontent.com/30003118/174852736-2b200627-c8cd-46ef-b968-be8ec1fa7b07.mp4

Check the original video in PR #9983 for the original behavior.

Tests: To test the header info is properly shown after the change, I decreased the width of asset details page by 1) shrinking the entire Asset Processor window width from the right, and 2) expanding the asset tree view panel (left to the asset details page) to the right. In both cases, there will be a horizontal scroll bar at the details page's bottom. By dragging it, all information can be seen.