### PR TITLE
Codex shawstar armorpaint

### DIFF
--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/ArmorPaint/export_presets/LICENSE
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/ArmorPaint/export_presets/LICENSE
@@ -1,0 +1,9 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+# -------------------------------------------------------------------------
+
+This folder contains the AmrorPaint Texture Export Presets for O3DE.

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/ArmorPaint/export_presets/README.md
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/ArmorPaint/export_presets/README.md
@@ -8,3 +8,13 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 # -------------------------------------------------------------------------
 
 This folder contains the AmrorPaint Texture Export Presets for O3DE.
+
+To install:
+
+Inside of the ArmorPaint software, the top menu bar under File > Export Textures...
+
+Use the Presets tab.
+
+Press the Import button and find the o3de.json export preset file found in this repositoy. 
+
+Now, under the Export Textures Tab, Preset menu dropdown now should have an o3de option to select.

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/ArmorPaint/export_presets/README.md
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/ArmorPaint/export_presets/README.md
@@ -1,0 +1,10 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+# -------------------------------------------------------------------------
+
+This folder contains the AmrorPaint Texture Export Presets for O3DE.

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/ArmorPaint/export_presets/README.md
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/ArmorPaint/export_presets/README.md
@@ -15,6 +15,6 @@ Inside of the ArmorPaint software, the top menu bar under File > Export Textures
 
 Use the Presets tab.
 
-Press the Import button and find the o3de.json export preset file found in this repositoy. 
+Press the Import button and find the o3de.json export preset file found in this repository. 
 
 Now, under the Export Textures Tab, Preset menu dropdown now should have an o3de option to select.

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/ArmorPaint/export_presets/o3de.json
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/ArmorPaint/export_presets/o3de.json
@@ -1,0 +1,10 @@
+{"textures":[
+    {"name":"BaseColor","channels":["base_r","base_g","base_b","1.0"],"color_space":"linear"},
+    {"name":"Opacity","channels":["opac","opac","opac","1.0"],"color_space":"linear"},
+    {"name":"Metallic","channels":["metal","metal","metal","1.0"],"color_space":"linear"},
+    {"name":"Roughness","channels":["rough","rough","rough","1.0"],"color_space":"linear"},
+    {"name":"Normal","channels":["nor_r","nor_g","nor_b","1.0"],"color_space":"linear"},
+    {"name":"AO","channels":["occ","occ","occ","1.0"],"color_space":"linear"},
+    {"name":"Emissive","channels":["emis","emis","emis","1.0"],"color_space":"linear"},
+    {"name":"Height","channels":["height","height","height","1.0"],"color_space":"linear"},
+    {"name":"Subsurface","channels":["subs","subs","subs","1.0"],"color_space":"linear"}]}


### PR DESCRIPTION
This PR contains the AmrorPaint Texture Export Presets for O3DE.

ArmorPaint https://github.com/armory3d/armorpaint

To install:

Inside of the ArmorPaint software, the top menu bar under File > Export Textures...

Use the Presets tab.

Press the Import button and find the o3de.json export preset file found in this repository.

Now, under the Export Textures Tab, Preset menu drop-down now should have an o3de option to select.