### PR TITLE
Take a stab at fixing GCC builds

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -44,11 +44,8 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterNode<Adapter, NodeWithVisiblityControl>();
 
         system->RegisterNode<Row, NodeWithVisiblityControl>();
-
-        for (const auto& rowAttribute : Row::RowAttributes)
-        {
-            system->RegisterNodeAttribute<Row>(rowAttribute);
-        }
+        system->RegisterNodeAttribute<Row>(Row::AutoExpand);
+        system->RegisterNodeAttribute<Row>(Row::ForceAutoExpand);
 
         system->RegisterNode<Label, NodeWithVisiblityControl>();
         system->RegisterNodeAttribute<Label>(Label::Value);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -56,7 +56,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto AutoExpand = AttributeDefinition<bool>("AutoExpand");
         static constexpr auto ForceAutoExpand = AttributeDefinition<bool>("ForceAutoExpand");
 
-        static constexpr auto RowAttributes = { AutoExpand, ForceAutoExpand };
+        static constexpr AZStd::initializer_list<const AttributeDefinitionInterface*> RowAttributes = { &AutoExpand, &ForceAutoExpand };
     };
 
     //! PropertyRefreshLevel: Determines the amount of a property tree that needs to be rebuilt

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -177,7 +177,7 @@ namespace AZ::DocumentPropertyEditor
 
                     for (const auto& rowAttribute : Nodes::Row::RowAttributes)
                     {
-                        if (name == rowAttribute.GetName())
+                        if (name == rowAttribute->GetName())
                         {
                             return;
                         }
@@ -321,10 +321,10 @@ namespace AZ::DocumentPropertyEditor
 
             for (const auto& attribute : Nodes::Row::RowAttributes)
             {
-                auto attributeValue = attributes.Find(attribute.GetName());
+                auto attributeValue = attributes.Find(attribute->GetName());
                 if (!attributeValue.IsNull())
                 {
-                    m_builder.Attribute(attribute, attributeValue);
+                    m_builder.Attribute(attribute->GetName(), attributeValue);
                 }
             }
 


### PR DESCRIPTION
`PropertyEditorNodes` had an initializer list that was implicitly made up of `AttributeDefinition<bool>` copies - this change switches to an explicitly defined `initializer_list` with pointers to `AttributeDefinitionInterface*` in attempt to fix GCC builds (I have no way of validating this locally, but @alexmontAmazon helpfully pointed the issue out to me - if anyone has a way to validate that'd be appreciated!)

Signed-off-by: Nicholas Van Sickle <mail@nickvansickle.com>