### PR TITLE
Code inside AZ_RHI_ENABLE_VALIDATION define doesn't compile

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -927,11 +927,16 @@ namespace AZ
             const RHI::PipelineLayoutDescriptor& pipelineLayoutDescriptor = pipelineLayout->GetPipelineLayoutDescriptor();
             for (uint32_t i = 0; i < pipelineLayout->GetDescriptorSetLayoutCount(); ++i)
             {
-                uint32_t slot = pipelineLayout->GetAZSLBindingSlotOfIndex(i);
-                const ShaderResourceGroup* shaderResourceGroup = bindings.m_SRGByAzslBindingSlot[slot];
-                AZ_Assert(shaderResourceGroup != nullptr, "NULL srg bound");
-                
-                m_validator.ValidateShaderResourceGroup(*shaderResourceGroup, pipelineLayoutDescriptor.GetShaderResourceGroupBindingInfo(i));
+                const auto& srgBitset = pipelineLayout->GetAZSLBindingSlotsOfIndex(i);
+                for (uint32_t bindingSlot = 0; bindingSlot < srgBitset.size(); ++bindingSlot)
+                {
+                    if (srgBitset[bindingSlot])
+                    {
+                        const ShaderResourceGroup* shaderResourceGroup = bindings.m_SRGByAzslBindingSlot[bindingSlot];
+                        AZ_Assert(shaderResourceGroup != nullptr, "NULL srg bound");
+                        m_validator.ValidateShaderResourceGroup(*shaderResourceGroup, pipelineLayoutDescriptor.GetShaderResourceGroupBindingInfo(i));
+                    }
+                }
             }
 #endif
         }


### PR DESCRIPTION

CommandList::ValidateShaderResourceGroups() wasn't updated when the AZSL BindingSlot was changed to a bitset.
And since the AZ_RHI_ENABLE_VALIDATION - define is not set by default, this didn't cause any issues.