### PR TITLE
Fixed wrong hyperlink for the Animation Editor

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
@@ -388,7 +388,7 @@ namespace EMStudio
 
         menu->addAction("Documentation", this, []
         {
-            QDesktopServices::openUrl(QUrl("https://o3de.org/docs/"));
+            QDesktopServices::openUrl(QUrl("https://o3de.org/docs/user-guide/visualization/animation/"));
         });
 
         menu->addAction("Forums", this, []


### PR DESCRIPTION
Signed-off-by: LB-BartoszCwiek <v-bartosz.cwiek@lionbridge.com>

Fixed wrong hyperlink under Animation Editor > Help > Documentation.

![image](https://user-images.githubusercontent.com/100559077/174979431-c8e48bab-0e0c-4386-8b0c-9fb469217c16.png)


Before changes Animation Editor documentation redirected to:
https://o3de.org/docs/

After changes it redirects to:
https://o3de.org/docs/user-guide/visualization/animation/