### PR TITLE
[Terrain] Fix bugs in terrain clipmap

### DIFF
--- a/Gems/Terrain/Assets/Shaders/Terrain/ClipmapComputeHelpers.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/ClipmapComputeHelpers.azsli
@@ -191,6 +191,7 @@ ClipmapLevel CalculateMacroClipmapLevel(float2 worldPosition)
         float contains = CircleContainsPoint(clipmapCenterInWorldSpace, extent, worldPosition);
         closestLevel += contains;
     }
+
     clipmapLevel.m_closestLevel = TerrainSrg::m_clipmapData.m_macroClipmapStackSize - uint(closestLevel);
     clipmapLevel.m_nextLevel = clipmapLevel.m_closestLevel + 1;
 
@@ -224,6 +225,7 @@ ClipmapLevel CalculateDetailClipmapLevel(float2 worldPosition)
         float contains = CircleContainsPoint(clipmapCenterInWorldSpace, extent, worldPosition);
         closestLevel += contains;
     }
+
     clipmapLevel.m_closestLevel = TerrainSrg::m_clipmapData.m_detailClipmapStackSize - uint(closestLevel);
     clipmapLevel.m_nextLevel = clipmapLevel.m_closestLevel + 1;
 
@@ -318,10 +320,10 @@ float4 ColorBilinearSampling(Texture2DArray<float4> colorClipmap, BilinearUvs uv
 float3 NormalBilinearSampling(Texture2DArray<float2> normalClipmap, BilinearUvs uvs, uint clipmapLevel)
 {
     float3 normal00 = UnpackNormal(normalClipmap[uint3(uvs.m_u0v0, clipmapLevel)]);
-    float3 normal01 = UnpackNormal(normalClipmap[uint3(uvs.m_u1v0, clipmapLevel)]);
-    float3 normal10 = UnpackNormal(normalClipmap[uint3(uvs.m_u0v1, clipmapLevel)]);
+    float3 normal10 = UnpackNormal(normalClipmap[uint3(uvs.m_u1v0, clipmapLevel)]);
+    float3 normal01 = UnpackNormal(normalClipmap[uint3(uvs.m_u0v1, clipmapLevel)]);
     float3 normal11 = UnpackNormal(normalClipmap[uint3(uvs.m_u1v1, clipmapLevel)]);
-    
+
     float3 normal0 = normalize(lerp(normal00.rgb, normal01.rgb, uvs.m_weight.y));
     float3 normal1 = normalize(lerp(normal10.rgb, normal11.rgb, uvs.m_weight.y));
     return normalize(lerp(normal0, normal1, uvs.m_weight.x));
@@ -375,7 +377,7 @@ ClipmapSample SampleClipmap(float2 worldPosition)
 {
     ClipmapSample data;
 
-    float2 distance = worldPosition - GetDetailClipmapCenterInWorldSpace(TerrainSrg::m_clipmapData.m_macroClipmapStackSize - 1);
+    float2 distance = worldPosition - GetMacroClipmapCenterInWorldSpace(TerrainSrg::m_clipmapData.m_macroClipmapStackSize - 1);
     float2 absDistance = abs(distance);
     if (absDistance.x > TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius || absDistance.y > TerrainSrg::m_clipmapData.m_macroClipmapMaxRenderRadius)
     {

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainPBR_ForwardPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainPBR_ForwardPass.azsl
@@ -87,17 +87,18 @@ void GatherSurfaceDataFromClipmaps(
     )
 {
     ClipmapSample clipmapSample = SampleClipmap(position);
-    hasDetailSurface = clipmapSample.m_hasDetail;
 
     if (clipmapSample.m_hasMacro)
     {
         macroColor = clipmapSample.m_macroColor;
         macroNormal = clipmapSample.m_macroNormal;
     }
-    if (hasDetailSurface)
+    if (detailFactor < 1.0)
     {
+        hasDetailSurface = clipmapSample.m_hasDetail;
         detailSurface = clipmapSample.m_detailSurface;
     }
+
 }
 
 ForwardPassOutput TerrainPBR_MainPassPS(VSOutput input)
@@ -107,7 +108,6 @@ ForwardPassOutput TerrainPBR_MainPassPS(VSOutput input)
     surface.position = input.m_worldPosition.xyz;
     surface.vertexNormal = normalize(input.m_normal);
     float viewDistance = length(ViewSrg::m_worldPosition - input.m_worldPosition.xyz);
-    float detailFactor = saturate((viewDistance - TerrainMaterialSrg::m_detailFadeDistance) / max(TerrainMaterialSrg::m_detailFadeLength, EPSILON));
 
     // Surface data to be gathered from clipmaps or materials.
     float3 macroNormal = surface.vertexNormal;
@@ -115,12 +115,17 @@ ForwardPassOutput TerrainPBR_MainPassPS(VSOutput input)
     bool hasDetailSurface = false;
     DetailSurface detailSurface = GetDefaultDetailSurface();
 
+    float detailFactor;
     if (o_useClipmap)
     {
+        // Clipmap has a max render distance. The true fade distance should be the min.
+        float detailFadeDistance = min(TerrainMaterialSrg::m_detailFadeDistance, TerrainSrg::m_clipmapData.m_detailClipmapMaxRenderRadius - TerrainMaterialSrg::m_detailFadeLength);
+        detailFactor = saturate((viewDistance - detailFadeDistance) / max(TerrainMaterialSrg::m_detailFadeLength, EPSILON));
         GatherSurfaceDataFromClipmaps(surface.position.xy, detailFactor, macroColor, macroNormal, hasDetailSurface, detailSurface);
     }
     else
     {
+        detailFactor = saturate((viewDistance - TerrainMaterialSrg::m_detailFadeDistance) / max(TerrainMaterialSrg::m_detailFadeLength, EPSILON));
         GatherSurfaceDataFromMaterials(surface.position.xy, detailFactor, macroColor, macroNormal, hasDetailSurface, detailSurface);
     }
 

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainSrg.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainSrg.azsli
@@ -219,10 +219,9 @@ ShaderResourceGroup TerrainSrg : SRG_Terrain
     // Clipmap Sampler
     Sampler m_clipmapSampler
     {
-        MaxAnisotropy = 16;
-        AddressU = Wrap;
-        AddressV = Wrap;
-        AddressW = Wrap;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
     };
     
     // The region of the clipmap that needs update.

--- a/Gems/Terrain/Code/Source/TerrainRenderer/ClipmapBounds.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/ClipmapBounds.cpp
@@ -286,8 +286,8 @@ namespace Terrain
     AZ::Vector2 ClipmapBounds::GetCenterInWorldSpace() const
     {
         AZ::Vector2 worldCenter;
-        worldCenter.SetX(m_center.m_x * m_clipmapToWorldScale + 0.5f);
-        worldCenter.SetY(m_center.m_y * m_clipmapToWorldScale + 0.5f);
+        worldCenter.SetX(m_center.m_x * m_clipmapToWorldScale);
+        worldCenter.SetY(m_center.m_y * m_clipmapToWorldScale);
         return worldCenter;
     }
 

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.h
@@ -165,7 +165,7 @@ namespace Terrain
         //! Data to be passed to shaders
         struct ClipmapData
         {
-            // Current viewport size.
+            //! Current viewport size.
             RawVector2f m_viewportSize;
 
             //! The max range that the clipmap is covering.


### PR DESCRIPTION
Normal bilinear has a typo and causes square blocks on terrain.
Add detail factor for clipmap so that it blends to macro at detail clipmap max distance.
Signed-off-by: jiaweig <51759646+jiaweig-amzn@users.noreply.github.com>