### PR TITLE
Fixed incompatible variable type error wording

### DIFF
--- a/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotLayoutComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotLayoutComponent.cpp
@@ -159,7 +159,7 @@ namespace GraphCanvas
                                     anchorPoint = QPointF(1.0f, 0.5f);
                                 }
                                 
-                                AzQtComponents::ToastConfiguration toastConfiguration(AzQtComponents::ToastType::Error, "Unable to drop onto to slot", error.c_str());
+                                AzQtComponents::ToastConfiguration toastConfiguration(AzQtComponents::ToastType::Error, "Unable to drop onto slot", error.c_str());
                                 toastConfiguration.m_closeOnClick = false;
 
                                 m_toastId = viewHandler->ShowToastAtPoint(globalConnectionPoint.toPoint(), anchorPoint, toastConfiguration);


### PR DESCRIPTION
Signed-off-by: Artur Zięba <86952082+LB-ArturZieba@users.noreply.github.com>

**Change summary**
* Fixed a wording error on a tooltip that displays when attempting to drop an incompatible variable type onto Script Canvas node.

This fixes https://github.com/o3de/o3de/issues/10239.