### PR TITLE
chore: remove OrbitCamera from RenderOptions

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderOptions.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderOptions.cpp
@@ -10,7 +10,6 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx>
-#include <EMotionFX/Rendering/Common/OrbitCamera.h>
 #include <EMotionFX/Source/EMotionFXManager.h>
 #include <Integration/Rendering/RenderActorSettings.h>
 #include <MysticQt/Source/MysticQtConfig.h>
@@ -80,6 +79,9 @@ namespace EMStudio
         , m_tangentsScale(1.0f)
         , m_nodeOrientationScale(1.0f)
         , m_scaleBonesOnLength(true)
+        , m_nearClipPlaneDistance(0.1f)
+        , m_farClipPlaneDistance(200.0f)
+        , m_fov(55.0f)
         , m_mainLightIntensity(1.0f)
         , m_mainLightAngleA(0.0f)
         , m_mainLightAngleB(0.0f)
@@ -125,10 +127,6 @@ namespace EMStudio
         , m_lastUsedLayout("Single")
         , m_renderSelectionBox(true)
     {
-        MCommon::OrbitCamera tempCam;
-        m_nearClipPlaneDistance = tempCam.GetNearClipDistance();
-        m_farClipPlaneDistance = tempCam.GetFarClipDistance();
-        m_fov = tempCam.GetFOV();
     }
 
     RenderOptions& RenderOptions::operator=(const RenderOptions& other)


### PR DESCRIPTION
these are the default properties set by Orbit camera just moved the assignment directly to the property. I'm planning on remove the EmotionFX Camera. 

I plan to remove the rest of the manipulators after this change: https://github.com/o3de/o3de/pull/10181


Signed-off-by: Michael Pollind <mpollind@gmail.com>