### PR TITLE
add a check if a view is already registered

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
@@ -98,6 +98,7 @@ namespace AZ
 
             // Data type for render pipeline's views' information
             using PipelineViewMap = AZStd::map<PipelineViewTag, PipelineViews, AZNameSortAscending>;
+            using ViewToViewTagMap = AZStd::map<const View*, PipelineViewTag>;
 
             //! Assign a view for a PipelineViewTag used in this pipeline. 
             //! This reference of this view will be saved until it's replaced in another SetPersistentView call.
@@ -233,6 +234,9 @@ namespace AZ
             // Retrieves a previously added pipeline global connection via name
             const PipelineGlobalBinding* GetPipelineGlobalConnection(const Name& globalName) const;
 
+            // Checks if the view is already registered with a different viewTag
+            bool CanRegisterView(const PipelineViewTag& allowedViewTag, const View* view) const;
+
             // Clears the lists of global attachments and binding that passes use to reference attachments in a global manner
             // This is called from the pipeline root pass during the pass reset phase
             void ClearGlobalBindings();
@@ -284,7 +288,9 @@ namespace AZ
             AZStd::vector<PipelineGlobalBinding> m_pipelineGlobalConnections;
 
             PipelineViewMap m_pipelineViewsByTag;
-            
+            ViewToViewTagMap m_persistentViewsByViewTag;
+            ViewToViewTagMap m_transientViewsByViewTag;
+
             // RenderPipeline's name id, it will be used to identify the render pipeline when it's added to a Scene
             RenderPipelineId m_nameId;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -172,7 +172,7 @@ namespace AZ
             auto registeredViewItr = m_persistentViewsByViewTag.find(view);
             if (registeredViewItr != m_persistentViewsByViewTag.end() && registeredViewItr->second != allowedViewTag)
             {
-                AZ_Error("RenderPipeline", false, "View [%s] is already registered for persistent ViewTag [%s].",
+                AZ_Warning("RenderPipeline", false, "View [%s] is already registered for persistent ViewTag [%s].",
                          view->GetName().GetCStr(), registeredViewItr->second.GetCStr());
                 return false;
             }
@@ -180,7 +180,7 @@ namespace AZ
             registeredViewItr = m_transientViewsByViewTag.find(view);
             if (registeredViewItr != m_transientViewsByViewTag.end() && registeredViewItr->second != allowedViewTag)
             {
-                AZ_Error("RenderPipeline", false, "View [%s] is already registered for transient ViewTag [%s].",
+                AZ_Warning("RenderPipeline", false, "View [%s] is already registered for transient ViewTag [%s].",
                          view->GetName().GetCStr(), registeredViewItr->second.GetCStr());
                 return false;
             }
@@ -193,8 +193,11 @@ namespace AZ
             // DrawList it was registered last, which will cause a crash during SortDrawList later. So we check
             // here if the view is already registered with another viewTag.
             // TODO: remove this check and merge the PassesByDrawList if that behaviour is actually needed.
-            AZ_Assert(CanRegisterView(viewTag, view.get()), "Can't register view [%s] with viewTag [%s]",
-                      view->GetName().GetCStr(), viewTag.GetCStr());
+            if (!CanRegisterView(viewTag, view.get()))
+            {
+                AZ_Assert(false, "Can't register view [%s] with viewTag [%s]", view->GetName().GetCStr(), viewTag.GetCStr());
+                return;
+            }
 
             auto viewItr = m_pipelineViewsByTag.find(viewTag);
             if (viewItr != m_pipelineViewsByTag.end())
@@ -268,7 +271,11 @@ namespace AZ
             // DrawList it was registered last, which will cause a crash during SortDrawList later. So we check
             // here if the view is already registered with another viewTag.
             // TODO: remove this check and merge the PassesByDrawList if that behaviour is actually needed.
-            AZ_Assert(CanRegisterView(viewTag, view.get()), "View [%s] is already registered for ViewTag [%s].", view->GetName().GetCStr(), viewTag.GetCStr());
+            if (!CanRegisterView(viewTag, view.get()))
+            {
+                AZ_Assert(false, "Can't register transient view [%s] with viewTag [%s]", view->GetName().GetCStr(), viewTag.GetCStr());
+                return;
+            }
 
             auto viewItr = m_pipelineViewsByTag.find(viewTag);
             if (viewItr != m_pipelineViewsByTag.end())

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -193,8 +193,7 @@ namespace AZ
             // DrawList it was registered last, which will cause a crash during SortDrawList later. So we check
             // here if the view is already registered with another viewTag.
             // TODO: remove this check and merge the PassesByDrawList if that behaviour is actually needed.
-            auto canRegister = CanRegisterView(viewTag, view.get());
-            AZ_Assert(canRegister, "Can't register view [%s] with viewTag [%s]",
+            AZ_Assert(CanRegisterView(viewTag, view.get()), "Can't register view [%s] with viewTag [%s]",
                       view->GetName().GetCStr(), viewTag.GetCStr());
 
             auto viewItr = m_pipelineViewsByTag.find(viewTag);
@@ -269,8 +268,7 @@ namespace AZ
             // DrawList it was registered last, which will cause a crash during SortDrawList later. So we check
             // here if the view is already registered with another viewTag.
             // TODO: remove this check and merge the PassesByDrawList if that behaviour is actually needed.
-            auto canRegister = CanRegisterView(viewTag, view.get());
-            AZ_Assert(canRegister, "View [%s] is already registered for ViewTag [%s].", view->GetName().GetCStr(), viewTag.GetCStr());
+            AZ_Assert(CanRegisterView(viewTag, view.get()), "View [%s] is already registered for ViewTag [%s].", view->GetName().GetCStr(), viewTag.GetCStr());
 
             auto viewItr = m_pipelineViewsByTag.find(viewTag);
             if (viewItr != m_pipelineViewsByTag.end())
@@ -607,7 +605,7 @@ namespace AZ
         {
             return m_renderMode;
         }
-        
+
         bool RenderPipeline::NeedsRender() const
         {
             return m_renderMode != RenderMode::NoRender;
@@ -652,7 +650,7 @@ namespace AZ
                 return false;
             }
 
-            // insert the pass 
+            // insert the pass
             auto parentPass = foundPass->GetParent();
             auto passIndex = parentPass->FindChildPassIndex(referencePassName);
             // Note: no need to check if passIndex is valid since the pass was already found
@@ -660,7 +658,7 @@ namespace AZ
         }
 
         bool RenderPipeline::AddPassAfter(Ptr<Pass> newPass, const AZ::Name& referencePassName)
-        {            
+        {
             auto foundPass = FindFirstPass(referencePassName);
 
             if (!foundPass)
@@ -670,7 +668,7 @@ namespace AZ
                 return false;
             }
 
-            // insert the pass 
+            // insert the pass
             auto parentPass = foundPass->GetParent();
             auto passIndex = parentPass->FindChildPassIndex(referencePassName);
             // Note: no need to check if passIndex is valid since the pass was already found

--- a/Gems/Atom/RPI/Code/Tests/System/RenderPipelineTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/System/RenderPipelineTests.cpp
@@ -84,8 +84,10 @@ namespace UnitTest
 
         const RPI::PipelineViewTag viewTag1{ "viewTag1" };
         const RPI::PipelineViewTag viewTag2{ "viewTag2" };
+        const RPI::PipelineViewTag viewTag3{ "viewTag3" };
         const Name drawListTagString1{ "drawListTag1" };
         const Name drawListTagString2{ "drawListTag2" };
+        const Name drawListTagString3{ "drawListTag3" };
 
         // Create render pipeline
         RPI::RenderPipelineDescriptor desc;
@@ -108,21 +110,29 @@ namespace UnitTest
         RPI::Ptr<TestPass> testPassC = aznew TestPass(passDescriptor);
         testPassC->Initialize(drawListTagString2, viewTag2);
 
+        passDescriptor.m_passName = "TestPassD";
+        RPI::Ptr<TestPass> testPassD = aznew TestPass(passDescriptor);
+        testPassD->Initialize(drawListTagString3, viewTag3);
+
         EXPECT_TRUE(testPassA->HasDrawListTag());
         EXPECT_TRUE(testPassB->HasDrawListTag());
         EXPECT_TRUE(testPassC->HasDrawListTag());
+        EXPECT_TRUE(testPassD->HasDrawListTag());
 
         RHI::DrawListTag drawListTag1 = drawListTagRegistry->FindTag(drawListTagString1);
         RHI::DrawListTag drawListTag2 = drawListTagRegistry->FindTag(drawListTagString2);
+        RHI::DrawListTag drawListTag3 = drawListTagRegistry->FindTag(drawListTagString3);
 
         EXPECT_TRUE(testPassA->GetDrawListTag() == drawListTag1);
         EXPECT_TRUE(testPassB->GetDrawListTag() == drawListTag1);
         EXPECT_TRUE(testPassC->GetDrawListTag() == drawListTag2);
+        EXPECT_TRUE(testPassD->GetDrawListTag() == drawListTag3);
 
         bool skipStateCheckWhenRunningTests = true;
         rootPass->AddChild(testPassA, skipStateCheckWhenRunningTests);
         testPassA->AddChild(testPassB, skipStateCheckWhenRunningTests);
         testPassA->AddChild(testPassC, skipStateCheckWhenRunningTests);
+        testPassA->AddChild(testPassD, skipStateCheckWhenRunningTests);
 
         pipeline->UpdatePasses();
 
@@ -147,10 +157,12 @@ namespace UnitTest
         // View functions
         RPI::ViewPtr view1 = RPI::View::CreateView(AZ::Name("testViewA"), RPI::View::UsageCamera);
         RPI::ViewPtr view2 = RPI::View::CreateView(AZ::Name("testViewB"), RPI::View::UsageCamera);
+        RPI::ViewPtr view3 = RPI::View::CreateView(AZ::Name("testViewC"), RPI::View::UsageCamera);
 
         // Persistent view
         pipeline->SetPersistentView(viewTag1, view1);
         EXPECT_TRUE(pipeline->GetViews(viewTag1).size() == 1);
+        // Replace persistent view
         pipeline->SetPersistentView(viewTag1, view2);
         auto& viewsFromTag1 = pipeline->GetViews(viewTag1);
         EXPECT_TRUE(viewsFromTag1.size() == 1);
@@ -161,6 +173,23 @@ namespace UnitTest
         pipeline->AddTransientView(viewTag1, view1);
         AZ_TEST_STOP_ASSERTTEST(1); 
         EXPECT_TRUE(pipeline->GetViews(viewTag1).size() == 1);
+
+        // Try to register a view with multiple viewTags, persistent or transient
+        AZ_TEST_START_ASSERTTEST;
+        pipeline->SetPersistentView(viewTag3, view2);
+        AZ_TEST_STOP_ASSERTTEST(1);
+        EXPECT_TRUE(pipeline->GetViews(viewTag3).size() == 0);
+
+        AZ_TEST_START_ASSERTTEST;
+        pipeline->AddTransientView(viewTag2, view2);
+        AZ_TEST_STOP_ASSERTTEST(1);
+        EXPECT_TRUE(pipeline->GetViews(viewTag2).size() == 0);
+
+        // overwrite persistent view 2 with view 3;
+        pipeline->SetPersistentView(viewTag1, view3);
+        auto& viewsFromTag1_2 = pipeline->GetViews(viewTag1);
+        EXPECT_TRUE(viewsFromTag1_2.size() == 1);
+        EXPECT_TRUE(view3 == viewsFromTag1_2[0]);
 
         // Transient view
         pipeline->AddTransientView(viewTag2, view1);


### PR DESCRIPTION
Proposed quick fix for #9559: Check and assert if a view is registered a second time with a different view tag.

This is the easiest proposed fix in that it just doesn't allow registering a view with a different ViewTag. Not sure if this is a problem, or if using a view for multiple ViewTags is something people want to use.

Unfortunately the only way to unregister a persistent view is to register a different view with the same ViewTag, so this makes the Pipeline somewhat less flexible.