### PR TITLE
Fix DRED error marker off-by-one error

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/Device_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/Device_Windows.cpp
@@ -614,7 +614,7 @@ namespace AZ
                         {
                             D3D12_AUTO_BREADCRUMB_OP op = currentNode->pCommandHistory[i];
 
-                            if (errorOccurred && i == actual + 1)
+                            if (errorOccurred && i == actual)
                             {
                                 // This is the first op that exceeds the number of ops that finished
                                 line = "===ERROR START===\n";


### PR DESCRIPTION
This bug carried over from the previous DRED implementation. Because
breadcrumbs are 0-indexed, we should be comparing the last breadcrumb
value to the breadcrumb indices directly.

Signed-off-by: Jeremy Ong <jcong@amazon.com>