### PR TITLE
Attempting to add an option to calculate navigation mesh on level load

### DIFF
--- a/Gems/RecastNavigation/Code/Source/Components/RecastNavigationMeshComponent.cpp
+++ b/Gems/RecastNavigation/Code/Source/Components/RecastNavigationMeshComponent.cpp
@@ -47,4 +47,27 @@ namespace RecastNavigation
                 ->Handler<RecastNavigationNotificationHandler>();
         }
     }
+
+    void RecastNavigationMeshComponent::Activate()
+    {
+        BaseClass::Activate();
+        if (m_controller.GetConfiguration().m_calculateOnLevelLoad)
+        {
+            AzFramework::GameEntityContextEventBus::Handler::BusConnect();
+        }
+    }
+
+    void RecastNavigationMeshComponent::Deactivate()
+    {
+        if (m_controller.GetConfiguration().m_calculateOnLevelLoad)
+        {
+            AzFramework::GameEntityContextEventBus::Handler::BusDisconnect();
+        }
+        BaseClass::Deactivate();
+    }
+
+    void RecastNavigationMeshComponent::OnGameEntitiesStarted()
+    {
+        m_controller.UpdateNavigationMeshAsync();
+    }
 } // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Source/Components/RecastNavigationMeshComponent.h
+++ b/Gems/RecastNavigation/Code/Source/Components/RecastNavigationMeshComponent.h
@@ -11,9 +11,10 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/EBus/ScheduledEvent.h>
 #include <AzFramework/Components/ComponentAdapter.h>
+#include <AzFramework/Entity/GameEntityContextBus.h>
+#include <Misc/RecastNavigationConstants.h>
 #include <Misc/RecastNavigationMeshComponentController.h>
 #include <Misc/RecastNavigationMeshConfig.h>
-#include <Misc/RecastNavigationConstants.h>
 
 namespace RecastNavigation
 {
@@ -21,6 +22,7 @@ namespace RecastNavigation
     //! Path calculation is done using @DetourNavigationComponent.
     class RecastNavigationMeshComponent final
         : public AzFramework::Components::ComponentAdapter<RecastNavigationMeshComponentController, RecastNavigationMeshConfig>
+        , public AzFramework::GameEntityContextEventBus::Handler
     {
         using BaseClass = AzFramework::Components::ComponentAdapter<RecastNavigationMeshComponentController, RecastNavigationMeshConfig>;
     public:
@@ -29,5 +31,16 @@ namespace RecastNavigation
         explicit RecastNavigationMeshComponent(const RecastNavigationMeshConfig& config);
 
         static void Reflect(AZ::ReflectContext* context);
+
+        //! ComponentAdapter overrides ...
+        //! @{
+        void Activate() override;
+        void Deactivate() override;
+        //! @}
+
+        //! GameEntityContextEventBus overrides ...
+        //! @{
+        void OnGameEntitiesStarted() override;
+        //! @}
     };
 } // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Source/EditorComponents/EditorRecastNavigationMeshComponent.cpp
+++ b/Gems/RecastNavigation/Code/Source/EditorComponents/EditorRecastNavigationMeshComponent.cpp
@@ -90,6 +90,8 @@ namespace RecastNavigation
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &RecastNavigationMeshConfig::m_enableDebugDraw,
                         "Debug Draw", "If enabled, draw the navigation mesh in game mode. Does not affect Editor preview.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &RecastNavigationMeshConfig::m_calculateOnLevelLoad,
+                        "Calculate on Level Load", "If enabled, calculates the mesh when the level is loaded.")
 
                     // Advanced configuration
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Advanced Configuration")

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshConfig.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshConfig.cpp
@@ -37,7 +37,8 @@ namespace RecastNavigation
                 ->Field("Border Size", &Self::m_borderSize)
                 ->Field("Debug Draw", &Self::m_enableDebugDraw)
                 ->Field("Editor Preview", &Self::m_enableEditorPreview)
-                ->Version(1)
+                ->Field("Calculate on Level Load", &Self::m_calculateOnLevelLoad)
+                ->Version(2)
                 ;
         }
     }

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshConfig.h
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshConfig.h
@@ -57,6 +57,9 @@ namespace RecastNavigation
 
         //! If enabled, previews the navigation mesh in the Editor's viewport.
         bool m_enableEditorPreview = false;
+
+        //! If enabled, calculates the mesh when the level is loaded.
+        bool m_calculateOnLevelLoad = false;
     };
 
 } // namespace RecastNavigation


### PR DESCRIPTION
Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>

(Note: this is a draft! This doesn't work yet since `AzFramework::GameEntityContextEventBus::Events::OnGameEntitiesStarted` is not being invoked when entering game mode in the Editor.

## What does this PR do?

Added a helper option to calculate the navigation mesh on level load without requiring users to invoke that API using scripting or C++. In practice, projects will want to control this behavior but for prototyping and testing, this is quite useful.

## How was this PR tested?

Automated Testing project, in a new navigation level.
