### PR TITLE
Split PAL implementation of PosixInternal::Pipe for UnixLike

### DIFF
--- a/Code/Framework/AzCore/Platform/Android/AzCore/IO/SystemFile_Android.cpp
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/IO/SystemFile_Android.cpp
@@ -354,3 +354,11 @@ namespace Platform
 } // namespace AZ::IO::Platform
 
 } // namespace AZ::IO
+
+namespace AZ::IO::PosixInternal
+{
+    int Pipe(int(&pipeFileDescriptors)[2], int, OpenFlags pipeFlags)
+    {
+        return pipe2(pipeFileDescriptors, static_cast<int>(pipeFlags));
+    }
+} // namespace AZ::IO::PosixInternal

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
@@ -224,11 +224,6 @@ namespace AZ::IO::PosixInternal
     {
         return dup2(fileDescriptorSource, fileDescriptorDestination);
     }
-
-    int Pipe(int(&pipeFileDescriptors)[2], int, OpenFlags pipeFlags)
-    {
-        return pipe2(pipeFileDescriptors, static_cast<int>(pipeFlags));
-    }
 } // namespace AZ::IO::PosixInternal
 
 namespace AZ::IO

--- a/Code/Framework/AzCore/Platform/Linux/AzCore/IO/SystemFile_Linux.cpp
+++ b/Code/Framework/AzCore/Platform/Linux/AzCore/IO/SystemFile_Linux.cpp
@@ -48,3 +48,11 @@ namespace AZ::IO::Platform
         }
     }
 }
+
+namespace AZ::IO::PosixInternal
+{
+    int Pipe(int(&pipeFileDescriptors)[2], int, OpenFlags pipeFlags)
+    {
+        return pipe2(pipeFileDescriptors, static_cast<int>(pipeFlags));
+    }
+} // namespace AZ::IO::PosixInternal


### PR DESCRIPTION
BSD based platforms such as MacOS and iOS do not support the system calls of `pipe2`.

Therefore the Apple platform implementation of [pipe](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/pipe.2.html) + [fcntl](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html)

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## What does this PR do?

Fixes compilation issue of AzCore.Tests on MacOS

## How was this PR tested?

The AzCore.Tests Trace UnitTest for MacOS were run

```
a483e72e0e72:o3de [user]$ build/mac_xcode/bin/profile/AzTestRunner libAzCore.T
ests.dylib AzRunUnitTests --gtest_filter=Trace*
cwd = /Users/Shared/Developer/o3de/o3de
LIB: libAzCore.Tests.dylib
Loading: libAzCore.Tests.dylib
OKAY Library loaded: libAzCore.Tests.dylib
OKAY Symbol found: AzRunUnitTests
Note: Google Test filter = Trace*
[==========] Running 7 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 1 test from TraceTest
[ RUN      ] TraceTest.Test

[       OK ] TraceTest.Test (0 ms)
[----------] 1 test from TraceTest (0 ms total)

[----------] 6 tests from TraceTests
[ RUN      ] TraceTests.Level0
[       OK ] TraceTests.Level0 (1 ms)
[ RUN      ] TraceTests.Level1
[       OK ] TraceTests.Level1 (1 ms)
[ RUN      ] TraceTests.Level2
[       OK ] TraceTests.Level2 (1 ms)
[ RUN      ] TraceTests.Level3
[       OK ] TraceTests.Level3 (0 ms)
[ RUN      ] TraceTests.RedirectToRawOutputToStderr_DoesNotOutputToStdout
UnitTest: Test Error
[       OK ] TraceTests.RedirectToRawOutputToStderr_DoesNotOutputToStdout (1 ms)
[ RUN      ] TraceTests.RedirectToRawOutputNone_DoesNotOutputToStdout_NorStderr
UnitTest: Test Error
[       OK ] TraceTests.RedirectToRawOutputNone_DoesNotOutputToStdout_NorStderr
(1 ms)
[----------] 6 tests from TraceTests (5 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 2 test cases ran. (6 ms total)
[  PASSED  ] 7 tests.
OKAY AzRunUnitTests() returned 0
Returning code: 0
```
