### PR TITLE
Atom Tools: Fixing issues with recent file lists and tabbing between documents

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
@@ -86,9 +86,6 @@ namespace AtomToolsFramework
 
     protected:
         void AddDocumentTabBar();
-
-        void AddRecentFilePath(const AZStd::string& absolutePath);
-        void ClearRecentFilePaths();
         void UpdateRecentFileMenu();
 
         // AtomToolsDocumentNotificationBus::Handler overrides...
@@ -126,7 +123,5 @@ namespace AtomToolsFramework
         QAction* m_actionPreviousTab = {};
 
         AzQtComponents::TabWidget* m_tabWidget = {};
-
-        static constexpr const char* RecentFilePathsKey = "/O3DE/AtomToolsFramework/Document/RecentFilePaths";
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystem.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystem.h
@@ -53,6 +53,10 @@ namespace AtomToolsFramework
         bool SaveAllDocuments() override;
         AZ::u32 GetDocumentCount() const override;
         bool IsDocumentOpen(const AZ::Uuid& documentId) const override;
+        void AddRecentFilePath(const AZStd::string& absolutePath) override;
+        void ClearRecentFilePaths() override;
+        void SetRecentFilePaths(const AZStd::vector<AZStd::string>& absolutePaths) override;
+        const AZStd::vector<AZStd::string> GetRecentFilePaths() const override;
 
     private:
         // AtomToolsDocumentNotificationBus::Handler overrides...

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h
@@ -88,6 +88,18 @@ namespace AtomToolsFramework
         //! Determine if a document is open in the system
         //! @param documentId unique id of document to check
         virtual bool IsDocumentOpen(const AZ::Uuid& documentId) const = 0;
+
+        //! Add a file path to the top of the list of recent file paths
+        virtual void AddRecentFilePath(const AZStd::string& absolutePath) = 0;
+
+        //! Remove all file paths from the list of recent file paths
+        virtual void ClearRecentFilePaths() = 0;
+
+        //! Replace the list of recent file paths in the settings registry
+        virtual void SetRecentFilePaths(const AZStd::vector<AZStd::string>& absolutePaths) = 0;
+
+        //! Retrieve the list of recent file paths from the settings registry
+        virtual const AZStd::vector<AZStd::string> GetRecentFilePaths() const = 0;
     };
 
     using AtomToolsDocumentSystemRequestBus = AZ::EBus<AtomToolsDocumentSystemRequests>;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -265,39 +265,14 @@ namespace AtomToolsFramework
         centralWidget()->layout()->addWidget(m_tabWidget);
     }
 
-    void AtomToolsDocumentMainWindow::AddRecentFilePath(const AZStd::string& absolutePath)
-    {
-        if (!absolutePath.empty())
-        {
-            // Get the list of previously stored recent file paths from the settings registry
-            AZStd::vector<AZStd::string> paths = GetSettingsObject(RecentFilePathsKey, AZStd::vector<AZStd::string>());
-
-            // If the new path is already in the list then remove it Because it will be moved to the front of the list
-            AZStd::erase_if(paths, [&absolutePath](const AZStd::string& currentPath) {
-                return AZ::StringFunc::Equal(currentPath, absolutePath);
-            });
-
-            paths.insert(paths.begin(), absolutePath);
-
-            constexpr const size_t recentFilePathsMax = 10;
-            if (paths.size() > recentFilePathsMax)
-            {
-                paths.resize(recentFilePathsMax);
-            }
-
-            SetSettingsObject(RecentFilePathsKey, paths);
-        }
-    }
-
-    void AtomToolsDocumentMainWindow::ClearRecentFilePaths()
-    {
-        SetSettingsObject(RecentFilePathsKey, AZStd::vector<AZStd::string>());
-    }
-
     void AtomToolsDocumentMainWindow::UpdateRecentFileMenu()
     {
         m_menuOpenRecent->clear();
-        for (const AZStd::string& path : GetSettingsObject(RecentFilePathsKey, AZStd::vector<AZStd::string>()))
+
+        AZStd::vector<AZStd::string> absolutePaths;
+        AtomToolsDocumentSystemRequestBus::EventResult(
+            absolutePaths, m_toolId, &AtomToolsDocumentSystemRequestBus::Handler::GetRecentFilePaths);
+        for (const AZStd::string& path : absolutePaths)
         {
             if (QFile::exists(path.c_str()))
             {
@@ -308,7 +283,10 @@ namespace AtomToolsFramework
         }
 
         m_menuOpenRecent->addAction(tr("Clear Recent Files"), [this]() {
-            QTimer::singleShot(0, this, &AtomToolsDocumentMainWindow::ClearRecentFilePaths);
+            QTimer::singleShot(0, this, [this]() {
+                AtomToolsDocumentSystemRequestBus::Event(
+                    m_toolId, &AtomToolsDocumentSystemRequestBus::Handler::ClearRecentFilePaths);
+            });
         });
     }
 
@@ -543,15 +521,18 @@ namespace AtomToolsFramework
         AZStd::string absolutePath;
         AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
 
-        AddRecentFilePath(absolutePath);
         UpdateDocumentTab(documentId);
         ActivateWindow();
         QueueUpdateMenus(true);
 
-        m_assetBrowser->SelectEntries(absolutePath);
-
         if (isOpen && !absolutePath.empty())
         {
+            // Whenever a document is opened or selected select the corresponding tab
+            m_tabWidget->setCurrentIndex(GetDocumentTabIndex(documentId));
+
+            // Find and select the file path in the asset browser
+            m_assetBrowser->SelectEntries(absolutePath);
+
             SetStatusMessage(tr("Document opened: %1").arg(absolutePath.c_str()));
         }
     }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
@@ -74,6 +74,10 @@ namespace AtomToolsFramework
                 ->Event("SaveAllDocuments", &AtomToolsDocumentSystemRequestBus::Events::SaveAllDocuments)
                 ->Event("GetDocumentCount", &AtomToolsDocumentSystemRequestBus::Events::GetDocumentCount)
                 ->Event("IsDocumentOpen", &AtomToolsDocumentSystemRequestBus::Events::IsDocumentOpen)
+                ->Event("AddRecentFilePath", &AtomToolsDocumentSystemRequestBus::Events::AddRecentFilePath)
+                ->Event("ClearRecentFilePaths", &AtomToolsDocumentSystemRequestBus::Events::ClearRecentFilePaths)
+                ->Event("SetRecentFilePaths", &AtomToolsDocumentSystemRequestBus::Events::SetRecentFilePaths)
+                ->Event("GetRecentFilePaths", &AtomToolsDocumentSystemRequestBus::Events::GetRecentFilePaths)
                 ;
         }
     }
@@ -199,7 +203,12 @@ namespace AtomToolsFramework
             }
 
             // Send document open notification after creating new one
+            AddRecentFilePath(savePath);
             AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
+        }
+        else
+        {
+            AddRecentFilePath(openPath);
         }
 
         if (traceRecorder.GetWarningCount(true) > 0)
@@ -238,6 +247,7 @@ namespace AtomToolsFramework
                 openDocumentPath, documentPair.first, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
             if (AZ::StringFunc::Equal(openDocumentPath, openPath))
             {
+                AddRecentFilePath(openPath);
                 AtomToolsDocumentNotificationBus::Event(
                     m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentPair.first);
                 return documentPair.first;
@@ -413,6 +423,7 @@ namespace AtomToolsFramework
             return false;
         }
 
+        AddRecentFilePath(savePath);
         return true;
     }
 
@@ -451,6 +462,7 @@ namespace AtomToolsFramework
             return false;
         }
 
+        AddRecentFilePath(savePath);
         return true;
     }
 
@@ -478,6 +490,45 @@ namespace AtomToolsFramework
         bool result = false;
         AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsDocumentRequestBus::Events::IsOpen);
         return result;
+    }
+
+    void AtomToolsDocumentSystem::AddRecentFilePath(const AZStd::string& absolutePath)
+    {
+        if (!absolutePath.empty())
+        {
+            // Get the list of previously stored recent file paths from the settings registry
+            AZStd::vector<AZStd::string> paths = GetRecentFilePaths();
+
+            // If the new path is already in the list then remove it Because it will be moved to the front of the list
+            AZStd::erase_if(paths, [&absolutePath](const AZStd::string& currentPath) {
+                return AZ::StringFunc::Equal(currentPath, absolutePath);
+            });
+
+            paths.insert(paths.begin(), absolutePath);
+
+            constexpr const size_t recentFilePathsMax = 10;
+            if (paths.size() > recentFilePathsMax)
+            {
+                paths.resize(recentFilePathsMax);
+            }
+
+            SetRecentFilePaths(paths);
+        }
+    }
+
+    void AtomToolsDocumentSystem::ClearRecentFilePaths()
+    {
+        SetRecentFilePaths(AZStd::vector<AZStd::string>());
+    }
+
+    void AtomToolsDocumentSystem::SetRecentFilePaths(const AZStd::vector<AZStd::string>& absolutePaths)
+    {
+        SetSettingsObject("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/RecentFilePaths", absolutePaths);
+    }
+
+    const AZStd::vector<AZStd::string> AtomToolsDocumentSystem::GetRecentFilePaths() const
+    {
+        return GetSettingsObject("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/RecentFilePaths", AZStd::vector<AZStd::string>());
     }
 
 


### PR DESCRIPTION
• Recent file list was being shuffled every time users switched between document tabs
• This change moves all of the recent file management to the document system and only updates the list whenever documents are explicitly requested to be opened or saved to a different filename
• This also fixes a bug where a document was not being activated when the corresponding tab was selected in some scenarios

Signed-off-by: Guthrie Adams <guthadam@amazon.com>

## What does this PR do?

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

_Please add links to any issues, RFCs or other items that are relevant to this PR._

## How was this PR tested?

_Please describe any testing performed._
