### PR TITLE
Added collision group filtering to Recast Navigation PhysX Provider component

### DIFF
--- a/Gems/RecastNavigation/Code/Source/EditorComponents/EditorRecastNavigationPhysXProviderComponent.cpp
+++ b/Gems/RecastNavigation/Code/Source/EditorComponents/EditorRecastNavigationPhysXProviderComponent.cpp
@@ -76,4 +76,10 @@ namespace RecastNavigation
         BaseClass::BuildGameEntity(gameEntity);
         m_controller.m_config.m_useEditorScene = true;
     }
+
+    AZ::u32 EditorRecastNavigationPhysXProviderComponent::OnConfigurationChanged()
+    {
+        m_controller.OnConfigurationChanged();
+        return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
+    }
 } // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Source/EditorComponents/EditorRecastNavigationPhysXProviderComponent.cpp
+++ b/Gems/RecastNavigation/Code/Source/EditorComponents/EditorRecastNavigationPhysXProviderComponent.cpp
@@ -27,7 +27,28 @@ namespace RecastNavigation
                     "[Collects triangle geometry from PhysX scene for navigation mesh within the area defined by a shape component.]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
-                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                ;
+
+                editContext->Class<RecastNavigationPhysXProviderComponentController>(
+                    "RecastNavigationPhysXProviderComponentController", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &RecastNavigationPhysXProviderComponentController::m_config, "Configuration", "")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ;
+
+                editContext->Class<RecastNavigationPhysXProviderConfig>("Recast Navigation PhysX Provider Config",
+                    "[Navigation PhysX Provider configuration]")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &RecastNavigationPhysXProviderConfig::m_collisionGroupId, "Collision Group",
+                        "If set, only colliders from the specified collision group will be considered.")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
+                    ;
             }
         }
     }

--- a/Gems/RecastNavigation/Code/Source/EditorComponents/EditorRecastNavigationPhysXProviderComponent.cpp
+++ b/Gems/RecastNavigation/Code/Source/EditorComponents/EditorRecastNavigationPhysXProviderComponent.cpp
@@ -47,7 +47,6 @@ namespace RecastNavigation
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &RecastNavigationPhysXProviderConfig::m_collisionGroupId, "Collision Group",
                         "If set, only colliders from the specified collision group will be considered.")
-                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
                     ;
             }
         }

--- a/Gems/RecastNavigation/Code/Source/EditorComponents/EditorRecastNavigationPhysXProviderComponent.h
+++ b/Gems/RecastNavigation/Code/Source/EditorComponents/EditorRecastNavigationPhysXProviderComponent.h
@@ -32,5 +32,7 @@ namespace RecastNavigation
         void Activate() override;
         void Deactivate() override;
         void BuildGameEntity(AZ::Entity* gameEntity) override;
+
+        AZ::u32 OnConfigurationChanged() override;
     };
 } // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshComponentController.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshComponentController.cpp
@@ -424,17 +424,18 @@ namespace RecastNavigation
                         NavigationTileData navigationTileData = CreateNavigationTile(tile.get(),
                             config, m_context.get());
 
+                        {
+                            NavMeshQuery::LockGuard lock(*m_navObject);
+                            if (const dtTileRef tileRef = lock.GetNavMesh()->getTileRefAt(tile->m_tileX, tile->m_tileY, 0))
+                            {
+                                lock.GetNavMesh()->removeTile(tileRef, nullptr, nullptr);
+                            }
+                        }
+
                         if (navigationTileData.IsValid())
                         {
                             AZ_PROFILE_SCOPE(Navigation, "Navigation: UpdateNavigationMeshAsync - tile callback");
 
-                            {
-                                NavMeshQuery::LockGuard lock(*m_navObject);
-                                if (const dtTileRef tileRef = lock.GetNavMesh()->getTileRefAt(tile->m_tileX, tile->m_tileY, 0))
-                                {
-                                    lock.GetNavMesh()->removeTile(tileRef, nullptr, nullptr);
-                                }
-                            }
                             if (navigationTileData.IsValid())
                             {
                                 AttachNavigationTileToMesh(navigationTileData);

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.cpp
@@ -159,7 +159,7 @@ namespace RecastNavigation
 
         AzPhysics::OverlapRequest request = AzPhysics::OverlapRequestHelpers::CreateBoxOverlapRequest(dimension, pose, nullptr);
         request.m_queryType = AzPhysics::SceneQuery::QueryType::Static; // only looking for static PhysX colliders
-        request.m_collisionGroup = AzPhysics::CollisionGroup::All;
+        request.m_collisionGroup = GetCollisionGroupById(m_config.m_collisionGroupId);
 
         AzPhysics::SceneQuery::UnboundedOverlapHitCallback unboundedOverlapHitCallback =
             [&overlapHits](AZStd::optional<AzPhysics::SceneQueryHit>&& hit)

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.cpp
@@ -77,6 +77,7 @@ namespace RecastNavigation
         m_entityComponentIdPair = entityComponentIdPair;
         m_shouldProcessTiles = true;
         m_updateInProgress = false;
+        OnConfigurationChanged();
         RecastNavigationProviderRequestBus::Handler::BusConnect(m_entityComponentIdPair.GetEntityId());
     }
 
@@ -147,6 +148,11 @@ namespace RecastNavigation
         return m_config.m_useEditorScene ? AzPhysics::EditorPhysicsSceneName : AzPhysics::DefaultPhysicsSceneName;
     }
 
+    void RecastNavigationPhysXProviderComponentController::OnConfigurationChanged()
+    {
+        m_collisionGroup = GetCollisionGroupById(m_config.m_collisionGroupId);
+    }
+
     void RecastNavigationPhysXProviderComponentController::CollectCollidersWithinVolume(const AZ::Aabb& volume, QueryHits& overlapHits)
     {
         AZ_PROFILE_SCOPE(Navigation, "Navigation: CollectGeometryWithinVolume");
@@ -159,7 +165,7 @@ namespace RecastNavigation
 
         AzPhysics::OverlapRequest request = AzPhysics::OverlapRequestHelpers::CreateBoxOverlapRequest(dimension, pose, nullptr);
         request.m_queryType = AzPhysics::SceneQuery::QueryType::Static; // only looking for static PhysX colliders
-        request.m_collisionGroup = GetCollisionGroupById(m_config.m_collisionGroupId);
+        request.m_collisionGroup = m_collisionGroup;
 
         AzPhysics::SceneQuery::UnboundedOverlapHitCallback unboundedOverlapHitCallback =
             [&overlapHits](AZStd::optional<AzPhysics::SceneQueryHit>&& hit)

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.h
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.h
@@ -99,8 +99,12 @@ namespace RecastNavigation
         const char* GetSceneName() const;
 
     protected:
+        void OnConfigurationChanged();
+
         AZ::EntityComponentIdPair m_entityComponentIdPair;
         RecastNavigationPhysXProviderConfig m_config;
+
+        AzPhysics::CollisionGroup m_collisionGroup;
 
         //! A way to check if we should stop tile processing (because we might be deactivating, for example).
         AZStd::atomic<bool> m_shouldProcessTiles{ true };

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderConfig.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderConfig.cpp
@@ -16,7 +16,8 @@ namespace RecastNavigation
         {
             serializeContext->Class<RecastNavigationPhysXProviderConfig>()
                 ->Field("Use Editor Scene", &RecastNavigationPhysXProviderConfig::m_useEditorScene)
-                ->Version(1)
+                ->Field("Collision Group", &RecastNavigationPhysXProviderConfig::m_collisionGroupId)
+                ->Version(2)
                 ;
         }
     }

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderConfig.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderConfig.cpp
@@ -15,9 +15,9 @@ namespace RecastNavigation
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<RecastNavigationPhysXProviderConfig>()
+                ->Version(2)
                 ->Field("Use Editor Scene", &RecastNavigationPhysXProviderConfig::m_useEditorScene)
                 ->Field("Collision Group", &RecastNavigationPhysXProviderConfig::m_collisionGroupId)
-                ->Version(2)
                 ;
         }
     }

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderConfig.h
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderConfig.h
@@ -11,6 +11,7 @@
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzFramework/Physics/Collision/CollisionGroups.h>
 
 namespace RecastNavigation
 {

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderConfig.h
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderConfig.h
@@ -25,5 +25,8 @@ namespace RecastNavigation
 
         //! Either use Editor PhysX world or game PhysX world.
         bool m_useEditorScene = false;
+
+        //! Only colliders from the specified collision group will be considered.
+        AzPhysics::CollisionGroups::Id m_collisionGroupId;
     };
 } // namespace RecastNavigation


### PR DESCRIPTION
Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>

## What does this PR do?

Adds ability to filter which PhysX colliders are considered for navigation mesh calculation based on their assigned collision groups.

![image](https://user-images.githubusercontent.com/5432499/175190010-be56ef47-eefe-4b58-88fd-e99a1b177e3d.png)

## How was this PR tested?

Ran unit tests.

Tested in the Editor that in-editor preview is affected by the collision group setting.
