### PR TITLE
Fix typenames of CreateStandardNodeEvent, NamedId and TUiAnimTrack

### DIFF
--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/NodePalette/StandardNodePaletteItem.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/NodePalette/StandardNodePaletteItem.h
@@ -59,7 +59,7 @@ namespace GraphModelIntegration
         : public GraphCanvas::GraphCanvasMimeEvent
     {
     public:
-        AZ_RTTI( ( (CreateStandardNodeMimeEvent<NodeType>), "{DF6213A0-5C60-4C22-88F1-4CEA6D8A17EF}", NodeType), GraphCanvas::GraphCanvasMimeEvent);
+        AZ_RTTI((CreateStandardNodeMimeEvent, "{DF6213A0-5C60-4C22-88F1-4CEA6D8A17EF}", NodeType), GraphCanvas::GraphCanvasMimeEvent);
         AZ_CLASS_ALLOCATOR(CreateStandardNodeMimeEvent, AZ::SystemAllocator, 0);
 
         static void Reflect(AZ::ReflectContext* reflectContext)

--- a/Gems/LyShine/Code/Source/Animation/AnimTrack.h
+++ b/Gems/LyShine/Code/Source/Animation/AnimTrack.h
@@ -23,7 +23,7 @@ class TUiAnimTrack
 {
 public:
     AZ_CLASS_ALLOCATOR(TUiAnimTrack, AZ::SystemAllocator, 0)
-    AZ_RTTI((TUiAnimTrack<KeyType>, "{5513FA16-991D-40DD-99B2-9C5531AC872C}", KeyType), IUiAnimTrack);
+    AZ_RTTI((TUiAnimTrack, "{5513FA16-991D-40DD-99B2-9C5531AC872C}", KeyType), IUiAnimTrack);
 
     TUiAnimTrack();
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NamedId.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NamedId.h
@@ -26,7 +26,7 @@ namespace ScriptCanvas
         using ThisType = NamedId<t_Id>;
 
         AZ_CLASS_ALLOCATOR(NamedId<t_Id>, AZ::SystemAllocator, 0);
-        AZ_RTTI(((NamedId<t_Id>) , "{7DFA6B31-B283-48BE-9D6F-260D8994C593}", t_Id), t_Id);
+        AZ_RTTI((NamedId , "{7DFA6B31-B283-48BE-9D6F-260D8994C593}", t_Id), t_Id);
 
         static void Reflect(AZ::ReflectContext* context)
         {

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
@@ -41,6 +41,7 @@ set(FILES
     Include/ScriptCanvas/Core/GraphScopedTypes.h
     Include/ScriptCanvas/Core/MethodConfiguration.h
     Include/ScriptCanvas/Core/ModifiableDatumView.h
+    Include/ScriptCanvas/Core/NamedId.h
     Include/ScriptCanvas/Core/Node.h
     Include/ScriptCanvas/Core/Nodeable.h
     Include/ScriptCanvas/Core/NodeableNode.h


### PR DESCRIPTION
The CreateStandardNodeEvent and NamedId were surrounded with an extra set paranthesis and contained the name of the template parameter
The TUiAnimTrack contained the name of the template parameter "KeyType"

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com

Here is how the names now look when running the following command
```
D:\o3de\o3de>build\windows_vs2019\bin\profile\SerializeContextTools.exe dumptypes --project-path AutomatedTesting > reflected_types_with_automated_testing_gems_by_typeid.txt
```
[reflected_types_with_automated_testing_gems_by_name.txt](https://github.com/o3de/o3de/files/8969984/reflected_types_with_automated_testing_gems_by_name.txt)
>