### PR TITLE
Action Manager | Fix for PrefabIntegrationManager looking for the action manager interface when the system is not enabled and asserting.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -18,6 +18,7 @@
 
 #include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
 #include <AzToolsFramework/ContainerEntity/ContainerEntityInterface.h>
+#include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipInterface.h>
 #include <AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityInterface.h>
@@ -112,15 +113,17 @@ namespace AzToolsFramework
             auto prefabFocusInterface = AZ::Interface<PrefabFocusInterface>::Get();
             prefabFocusInterface->InitializeEditorInterfaces();
 
-            m_actionManagerInterface = AZ::Interface<ActionManagerInterface>::Get();
-            AZ_Assert(
-                m_actionManagerInterface,
-                "Prefab - could not get m_actionManagerInterface on PrefabIntegrationManager construction.");
-
-            // Register an updater that will refresh actions when a level is loaded.
-            if (m_actionManagerInterface)
+            if (IsNewActionManagerEnabled())
             {
-                m_actionManagerInterface->RegisterActionUpdater(LevelLoadedUpdaterIdentifier);
+                m_actionManagerInterface = AZ::Interface<ActionManagerInterface>::Get();
+                AZ_Assert(
+                    m_actionManagerInterface, "Prefab - could not get m_actionManagerInterface on PrefabIntegrationManager construction.");
+
+                // Register an updater that will refresh actions when a level is loaded.
+                if (m_actionManagerInterface)
+                {
+                    m_actionManagerInterface->RegisterActionUpdater(LevelLoadedUpdaterIdentifier);
+                }
             }
             
             EditorContextMenuBus::Handler::BusConnect();


### PR DESCRIPTION
Fix for an assert on Editor start.

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>