### PR TITLE
Fix entity sort order for spawnables that have network components

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/SpawnableUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/SpawnableUtils.cpp
@@ -111,6 +111,12 @@ namespace AzToolsFramework::Prefab::SpawnableUtils
                 AZ_STRING_ARG(alias), AZ_STRING_ARG(sourcePrefabName));
             // A new entity id can be used for the placeholder as `ReplaceEntity` will swap the entity ids.
             auto placeholder = AZStd::make_unique<AZ::Entity>(AZ::Entity::MakeId(), entityData->get().GetName());
+            // Keep a transform component on the placeholder to maintain parent/child relationship.
+            // This is used during prefab processing to sort the corresponding spawnable's entities by hierarchy
+            AzFramework::TransformComponent* transformComponent = aznew AzFramework::TransformComponent();
+            auto entityTransformComponent = entityData->get().FindComponent<AzFramework::TransformComponent>();
+            transformComponent->SetParentRelative(entityTransformComponent->GetParentId());
+            placeholder->AddComponent(transformComponent);
             return instance->ReplaceEntity(AZStd::move(placeholder), alias);
         }
 


### PR DESCRIPTION
This fixes the entity order of spawnables that have dependent spawnables with entity aliases. Specifically, it fixes GHI #10196 where spawnables contain network components. This is because the network prefab processor generates two separate spawnables per prefab, and moves network entities from the first spawnable to the second "network spawnable", leaving an empty placeholder entity in the original spawnable.

This PR adds a transform component to the empty placeholder entity in order to preserve parent/child hierarchy for correct sorting of spawnable entities later in the prefab processing.

Signed-off-by: abrmich <abrmich@amazon.com>