### PR TITLE
Fixes Script reflection warnings on startup

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderSourceData.cpp
@@ -105,6 +105,31 @@ namespace AZ
 
             if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
             {
+                // declare EntryPoint before things that use it.
+                behaviorContext->Class<ShaderSourceData::EntryPoint>("ShaderSourceData::EntryPoint")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RPI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rpi")
+                    ->Constructor()
+                    ->Constructor<const ShaderSourceData::EntryPoint&>()
+                    ->Property("name", BehaviorValueProperty(&EntryPoint::m_name))
+                    ->Property("type", BehaviorValueProperty(&EntryPoint::m_type))
+                    ;
+                
+                // Declare SupervariantInfo (which uses EntryPoint) before things that use it.
+                behaviorContext->Class<ShaderSourceData::SupervariantInfo>("ShaderSourceData::SupervariantInfo")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RPI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rpi")
+                    ->Constructor()
+                    ->Constructor<const ShaderSourceData::SupervariantInfo&>()
+                    ->Property("name", BehaviorValueProperty(&SupervariantInfo::m_name))
+                    ->Property("removeBuildArguments", BehaviorValueProperty(&SupervariantInfo::m_removeBuildArguments))
+                    ->Property("addBuildArguments", BehaviorValueProperty(&SupervariantInfo::m_addBuildArguments))
+                    ->Property("definitions", BehaviorValueProperty(&SupervariantInfo::m_definitions))
+                    ;
+                
+                // ShaderSourceData uses SuperVariant, so SuperVarient is defined above, before it.
                 behaviorContext->Class<ShaderSourceData>("ShaderSourceData")
                     ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
                     ->Attribute(AZ::Script::Attributes::Category, "RPI")
@@ -132,28 +157,6 @@ namespace AZ
                     ->Constructor()
                     ->Constructor<const ShaderSourceData::ProgramSettings&>()
                     ->Property("entryPoints", BehaviorValueProperty(&ProgramSettings::m_entryPoints))
-                    ;
-
-                behaviorContext->Class<ShaderSourceData::EntryPoint>("ShaderSourceData::EntryPoint")
-                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
-                    ->Attribute(AZ::Script::Attributes::Category, "RPI")
-                    ->Attribute(AZ::Script::Attributes::Module, "rpi")
-                    ->Constructor()
-                    ->Constructor<const ShaderSourceData::EntryPoint&>()
-                    ->Property("name", BehaviorValueProperty(&EntryPoint::m_name))
-                    ->Property("type", BehaviorValueProperty(&EntryPoint::m_type))
-                    ;
-
-                behaviorContext->Class<ShaderSourceData::SupervariantInfo>("ShaderSourceData::SupervariantInfo")
-                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
-                    ->Attribute(AZ::Script::Attributes::Category, "RPI")
-                    ->Attribute(AZ::Script::Attributes::Module, "rpi")
-                    ->Constructor()
-                    ->Constructor<const ShaderSourceData::SupervariantInfo&>()
-                    ->Property("name", BehaviorValueProperty(&SupervariantInfo::m_name))
-                    ->Property("removeBuildArguments", BehaviorValueProperty(&SupervariantInfo::m_removeBuildArguments))
-                    ->Property("addBuildArguments", BehaviorValueProperty(&SupervariantInfo::m_addBuildArguments))
-                    ->Property("definitions", BehaviorValueProperty(&SupervariantInfo::m_definitions))
                     ;
             }
         }


### PR DESCRIPTION
The warnings were due to the order of reflection.
In this case, the type SuperVariant was used by the type
ShaderSourceData, but ShaderSourceData was declared before SuperVariant.

Behavior context is not supposed to be order dependent - but it is,
currently, due to the way Lua binds.

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>

## What does this PR do?
Fixes a bug which causes an assert to pop up whenever AP starts. 

No issues found.

## How was this PR tested?
Tested on a mac.  After moving the code around, no more asserts on startup.

Example of error, for searchability
```
AssetBuilder: System: Trace::Assert
AssetBuilder:  /Volumes/Lumberyard/o3de-repos/o3de/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp(3461): (5006536192) 'AZ::LuaScriptCaller::LuaScriptCaller(AZ::BehaviorContext *, AZ::BehaviorMethod *)'
AssetBuilder: System: The argument type: const AZ::RPI::ShaderSourceData::SupervariantInfo& for method: AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, allocator>::push_back is not serialized and/or reflected for scripting.
AssetBuilder: Make sure const AZ::RPI::ShaderSourceData::SupervariantInfo& is added to the SerializeContext and reflected to the BehaviorContext
AssetBuilder: For example, verify these two exist and are being called in a Reflect function:
AssetBuilder: serializeContext->Class<const AZ::RPI::ShaderSourceData::SupervariantInfo&>();
AssetBuilder: behaviorContext->Class<const AZ::RPI::ShaderSourceData::SupervariantInfo&>();
AssetBuilder: AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, allocator>::push_back will not be available for scripting unless these requirements are met.
AssetBuilder: E: The argument type: const AZ::RPI::ShaderSourceData::SupervariantInfo& for method: AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, allocator>::push_back is not serialized and/or reflected for scripting.
AssetBuilder: E: Make sure const AZ::RPI::ShaderSourceData::SupervariantInfo& is added to the SerializeContext and reflected to the BehaviorContext
AssetBuilder: E: For example, verify these two exist and are being called in a Reflect function:
AssetBuilder: E: serializeContext->Class<const AZ::RPI::ShaderSourceData::SupervariantInfo&>();
AssetBuilder: E: behaviorContext->Class<const AZ::RPI::ShaderSourceData::SupervariantInfo&>();
AssetBuilder: E: AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, allocator>::push_back will not be available for scripting unless these requirements are met.
AssetBuilder: : void AZ::EBusEventProcessingPolicy::CallResult<AZ::Debug::TraceMessageResult, bool (AZ::Debug::TraceMessageEvents::*&)(char const*), AZ::Internal::HandlerNode<AZ::Debug::TraceMessageEvents, AZ::Debug::TraceMessageEvents, AZ::Internal::EBusContainer<AZ::De
AssetBuilder: : AZ::Debug::Trace::Assert(char const*, int, char const*, char const*, ...) (+0x4f7) [0x10e4a2127]
AssetBuilder: : AZ::LuaScriptCaller::LuaScriptCaller(AZ::BehaviorContext*, AZ::BehaviorMethod*) (+0x16d) [0x10ee7537d]
AssetBuilder: : AZ::LuaScriptCaller::LuaScriptCaller(AZ::BehaviorContext*, AZ::BehaviorMethod*) (+0x33) [0x10ee710f3]
AssetBuilder: : AZ::ScriptContextImpl::CreateLuaCaller(AZ::BehaviorContext*, AZ::BehaviorMethod*) (+0x113) [0x10ee70c63]
AssetBuilder: : AZ::ScriptContextImpl::BindMethodOnStack(AZ::BehaviorContext*, AZ::BehaviorMethod*) (+0x12f) [0x10ee7032f]
AssetBuilder: : AZ::ScriptContextImpl::BindClassMethodAndProperties(AZ::BehaviorClass*) (+0x285) [0x10ee7c175]
AssetBuilder: : AZ::ScriptContextImpl::BindClass(AZ::BehaviorClass*) (+0x730) [0x10ee7b4c0]
AssetBuilder: : AZ::ScriptContextImpl::OnAddClass(char const*, AZ::BehaviorClass*) (+0x2f) [0x10ee6a57f]
AssetBuilder: : decltype(*(InvokeTraits::forward<AZ::Internal::HandlerNode<AZ::BehaviorContextEvents, AZ::BehaviorContextEvents, AZ::Internal::EBusContainer<AZ::BehaviorContextEvents, AZ::BehaviorContextEvents, (AZ::EBusAddressPolicy)1, (AZ::EBusHandlerPolicy)1>::Handler
AssetBuilder: : void AZ::EBusEventProcessingPolicy::Call<void (AZ::BehaviorContextEvents::*&)(char const*, AZ::BehaviorClass*), AZ::Internal::HandlerNode<AZ::BehaviorContextEvents, AZ::BehaviorContextEvents, AZ::Internal::EBusContainer<AZ::BehaviorContextEvents, AZ::Beha
AssetBuilder: : AZ::BehaviorContext::ClassBuilder<AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, AZStd::allocator> >::~ClassBuilder() (+0x219) [0x19077d829]
AssetBuilder: : AZ::BehaviorContext::ClassBuilder<AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, AZStd::allocator> >::~ClassBuilder() (+0x23) [0x190752193]
AssetBuilder: : AZ::OnDemandReflection<AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, AZStd::allocator> >::Reflect(AZ::ReflectContext*) (+0x2f59) [0x19074df29]
AssetBuilder: : AZ::ReflectContext::ExecuteQueuedOnDemandReflections() (+0xa1) [0x18ed1d451]
AssetBuilder: : AZ::BehaviorContext::ClassBuilder<AZ::RPI::ShaderSourceData>::~ClassBuilder() (+0x2e) [0x190727d2e]
AssetBuilder: : AZ::BehaviorContext::ClassBuilder<AZ::RPI::ShaderSourceData>::~ClassBuilder() (+0x23) [0x1906fbdd3]
AssetBuilder: : AZ::RPI::ShaderSourceData::Reflect(AZ::ReflectContext*) (+0xd67) [0x1906f3297]
AssetBuilder: : AZ::RPI::BuilderComponent::Reflect(AZ::ReflectContext*) (+0x117) [0x19138f037]
AssetBuilder: : AZ::ComponentDescriptorDefault<AZ::RPI::BuilderComponent>::CallReflect(AZ::ReflectContext*, std::__1::integral_constant<bool, true> const&) const (+0x2b) [0x18e31d11b]
AssetBuilder: : AZ::ComponentDescriptorDefault<AZ::RPI::BuilderComponent>::Reflect(AZ::ReflectContext*) const (+0x2f) [0x18e31ccbf]
AssetBuilder: : AZ::ComponentApplication::RegisterComponentDescriptor(AZ::ComponentDescriptor const*)::$_4::operator()(AZ::ReflectContext*) const (+0x2f) [0x10e2b89ef]
AssetBuilder: System: ==================================================================
AssetBuilder: System: 
AssetBuilder: ==================================================================
AssetBuilder: System: Trace::Assert
AssetBuilder:  /Volumes/Lumberyard/o3de-repos/o3de/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp(3461): (5006536192) 'AZ::LuaScriptCaller::LuaScriptCaller(AZ::BehaviorContext *, AZ::BehaviorMethod *)'
AssetBuilder: System: The argument type: const AZ::RPI::ShaderSourceData::SupervariantInfo& for method: AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, allocator>::PushBack_VM is not serialized and/or reflected for scripting.
AssetBuilder: Make sure const AZ::RPI::ShaderSourceData::SupervariantInfo& is added to the SerializeContext and reflected to the BehaviorContext
AssetBuilder: For example, verify these two exist and are being called in a Reflect function:
AssetBuilder: serializeContext->Class<const AZ::RPI::ShaderSourceData::SupervariantInfo&>();
AssetBuilder: behaviorContext->Class<const AZ::RPI::ShaderSourceData::SupervariantInfo&>();
AssetBuilder: AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, allocator>::PushBack_VM will not be available for scripting unless these requirements are met.
AssetBuilder: E: The argument type: const AZ::RPI::ShaderSourceData::SupervariantInfo& for method: AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, allocator>::PushBack_VM is not serialized and/or reflected for scripting.
AssetBuilder: E: Make sure const AZ::RPI::ShaderSourceData::SupervariantInfo& is added to the SerializeContext and reflected to the BehaviorContext
AssetBuilder: E: For example, verify these two exist and are being called in a Reflect function:
AssetBuilder: E: serializeContext->Class<const AZ::RPI::ShaderSourceData::SupervariantInfo&>();
AssetBuilder: E: behaviorContext->Class<const AZ::RPI::ShaderSourceData::SupervariantInfo&>();
AssetBuilder: E: AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, allocator>::PushBack_VM will not be available for scripting unless these requirements are met.
AssetBuilder: : void AZ::EBusEventProcessingPolicy::CallResult<AZ::Debug::TraceMessageResult, bool (AZ::Debug::TraceMessageEvents::*&)(char const*), AZ::Internal::HandlerNode<AZ::Debug::TraceMessageEvents, AZ::Debug::TraceMessageEvents, AZ::Internal::EBusContainer<AZ::De
AssetBuilder: : AZ::Debug::Trace::Assert(char const*, int, char const*, char const*, ...) (+0x4f7) [0x10e4a2127]
AssetBuilder: : AZ::LuaScriptCaller::LuaScriptCaller(AZ::BehaviorContext*, AZ::BehaviorMethod*) (+0x16d) [0x10ee7537d]
AssetBuilder: : AZ::LuaScriptCaller::LuaScriptCaller(AZ::BehaviorContext*, AZ::BehaviorMethod*) (+0x33) [0x10ee710f3]
AssetBuilder: : AZ::ScriptContextImpl::CreateLuaCaller(AZ::BehaviorContext*, AZ::BehaviorMethod*) (+0x113) [0x10ee70c63]
AssetBuilder: : AZ::ScriptContextImpl::BindMethodOnStack(AZ::BehaviorContext*, AZ::BehaviorMethod*) (+0x12f) [0x10ee7032f]
AssetBuilder: : AZ::ScriptContextImpl::BindClassMethodAndProperties(AZ::BehaviorClass*) (+0x285) [0x10ee7c175]
AssetBuilder: : AZ::ScriptContextImpl::BindClass(AZ::BehaviorClass*) (+0x730) [0x10ee7b4c0]
AssetBuilder: : AZ::ScriptContextImpl::OnAddClass(char const*, AZ::BehaviorClass*) (+0x2f) [0x10ee6a57f]
AssetBuilder: : decltype(*(InvokeTraits::forward<AZ::Internal::HandlerNode<AZ::BehaviorContextEvents, AZ::BehaviorContextEvents, AZ::Internal::EBusContainer<AZ::BehaviorContextEvents, AZ::BehaviorContextEvents, (AZ::EBusAddressPolicy)1, (AZ::EBusHandlerPolicy)1>::Handler
AssetBuilder: : void AZ::EBusEventProcessingPolicy::Call<void (AZ::BehaviorContextEvents::*&)(char const*, AZ::BehaviorClass*), AZ::Internal::HandlerNode<AZ::BehaviorContextEvents, AZ::BehaviorContextEvents, AZ::Internal::EBusContainer<AZ::BehaviorContextEvents, AZ::Beha
AssetBuilder: : AZ::BehaviorContext::ClassBuilder<AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, AZStd::allocator> >::~ClassBuilder() (+0x219) [0x19077d829]
AssetBuilder: : AZ::BehaviorContext::ClassBuilder<AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, AZStd::allocator> >::~ClassBuilder() (+0x23) [0x190752193]
AssetBuilder: : AZ::OnDemandReflection<AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, AZStd::allocator> >::Reflect(AZ::ReflectContext*) (+0x2f59) [0x19074df29]
AssetBuilder: : AZ::ReflectContext::ExecuteQueuedOnDemandReflections() (+0xa1) [0x18ed1d451]
AssetBuilder: : AZ::BehaviorContext::ClassBuilder<AZ::RPI::ShaderSourceData>::~ClassBuilder() (+0x2e) [0x190727d2e]
AssetBuilder: : AZ::BehaviorContext::ClassBuilder<AZ::RPI::ShaderSourceData>::~ClassBuilder() (+0x23) [0x1906fbdd3]
AssetBuilder: : AZ::RPI::ShaderSourceData::Reflect(AZ::ReflectContext*) (+0xd67) [0x1906f3297]
AssetBuilder: : AZ::RPI::BuilderComponent::Reflect(AZ::ReflectContext*) (+0x117) [0x19138f037]
AssetBuilder: : AZ::ComponentDescriptorDefault<AZ::RPI::BuilderComponent>::CallReflect(AZ::ReflectContext*, std::__1::integral_constant<bool, true> const&) const (+0x2b) [0x18e31d11b]
AssetBuilder: : AZ::ComponentDescriptorDefault<AZ::RPI::BuilderComponent>::Reflect(AZ::ReflectContext*) const (+0x2f) [0x18e31ccbf]
AssetBuilder: : AZ::ComponentApplication::RegisterComponentDescriptor(AZ::ComponentDescriptor const*)::$_4::operator()(AZ::ReflectContext*) const (+0x2f) [0x10e2b89ef]
AssetBuilder: System: ==================================================================
AssetBuilder: System: 
AssetBuilder: ==================================================================
AssetBuilder: System: Trace::Assert
AssetBuilder:  /Volumes/Lumberyard/o3de-repos/o3de/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp(3461): (5006536192) 'AZ::LuaScriptCaller::LuaScriptCaller(AZ::BehaviorContext *, AZ::BehaviorMethod *)'
AssetBuilder: System: The argument type: AZ::RPI::ShaderSourceData::SupervariantInfo& for method: AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, allocator>::AssignAt is not serialized and/or reflected for scripting.
AssetBuilder: Make sure AZ::RPI::ShaderSourceData::SupervariantInfo& is added to the SerializeContext and reflected to the BehaviorContext
AssetBuilder: For example, verify these two exist and are being called in a Reflect function:
AssetBuilder: serializeContext->Class<AZ::RPI::ShaderSourceData::SupervariantInfo&>();
AssetBuilder: behaviorContext->Class<AZ::RPI::ShaderSourceData::SupervariantInfo&>();
AssetBuilder: AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, allocator>::AssignAt will not be available for scripting unless these requirements are met.
AssetBuilder: E: The argument type: AZ::RPI::ShaderSourceData::SupervariantInfo& for method: AZStd::vector<AZ::RPI::ShaderSourceData::SupervariantInfo, allocator>::AssignAt is not serialized and/or reflected for scripting.
```

