### PR TITLE
fix bug with transform being applied twice in capsule debug draw

### DIFF
--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
@@ -1059,13 +1059,12 @@ namespace AZ::AtomBridge
             AZ::Vector3 axisNormalized = axis.GetNormalizedEstimate();
 
             const float scale = GetCurrentTransform().RetrieveScale().GetMaxElement();
-            const AZ::Vector3 worldCenter = ToWorldSpacePosition(center);
             const AZ::Vector3 worldAxis = ToWorldSpaceVector(axis);
 
             // Draw cylinder part (if cylinder height is too small, ignore cylinder and just draw both hemispheres)
             if (heightStraightSection > FLT_EPSILON)
             {
-                DrawWireCylinderNoEnds(worldCenter, worldAxis, scale * radius, scale * heightStraightSection);
+                DrawWireCylinderNoEnds(center, axis, scale * radius, scale * heightStraightSection);
             }
 
             AZ::Vector3 centerToTopCircleCenter = axisNormalized * heightStraightSection * 0.5f;


### PR DESCRIPTION
Signed-off-by: greerdv <greerdv@amazon.com>

## What does this PR do?
Fixes a bug in capsule debug draw where transform was being applied twice (both in DrawWireCapsule and in DrawWireCylinderNoEnds).

## How was this PR tested?
Manually tested with character physics debug draw.
