### PR TITLE
fix bug with look at component setting uniform scale to 1

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
@@ -171,6 +171,7 @@ namespace LmbrCentral
                 targetPosition,
                 m_forwardAxis
                 );
+            lookAtTransform.SetUniformScale(currentTM.GetUniformScale());
 
             AZ::TransformBus::Event(GetEntityId(), &AZ::TransformInterface::SetWorldTM, lookAtTransform);
         }


### PR DESCRIPTION
Signed-off-by: greerdv <greerdv@amazon.com>

## What does this PR do?
Fixes #10226 (the look at component would always set the uniform scale on the entity transform to 1).

## How was this PR tested?
Made a level with an entity looking at a moving target and verified that the scale was not trampled.
