### PR TITLE
Update unit tests for Android related python scripts under cmake/Tools/Platform

### DIFF
--- a/cmake/Tools/Platform/Android/android_deployment.py
+++ b/cmake/Tools/Platform/Android/android_deployment.py
@@ -481,7 +481,10 @@ class AndroidDeployment(object):
                 logging.info(f"Copying {len(files_to_copy)} assets to device  {target_device}")
 
             for src_path in files_to_copy:
-                relative_path = os.path.relpath(str(src_path), str(self.local_asset_path)).replace('\\', '/')
+                if os.path.isabs(str(src_path)):
+                    relative_path = os.path.relpath(str(src_path), str(self.local_asset_path)).replace('\\', '/')
+                else:
+                    relative_path = str(src_path)
                 target_path = f"{output_target}/{relative_path}"
                 self.adb_call(arg_list=['push', str(src_path), target_path],
                               device_id=target_device)

--- a/cmake/Tools/Platform/Android/unit_test_generate_android_project.py
+++ b/cmake/Tools/Platform/Android/unit_test_generate_android_project.py
@@ -76,12 +76,12 @@ def test_verify_gradle(tmpdir, from_override, version_str, expected_result):
 
 @pytest.mark.parametrize(
     "from_override, version_str, expected_result", [
-        pytest.param(False, b"cmake version 3.17.0\nKit Ware", LooseVersion('3.17.0'), id='equalMinVersion'),
-        pytest.param(False, b"cmake version 4.0.0\nKit Ware", LooseVersion('4.0.0'), id='greaterThanMinVersion'),
-        pytest.param(False, b"cmake version 1.0.0\nKit Ware", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR), id='lessThanMinVersion'),
-        pytest.param(True, b"cmake version 3.17.0\nKit Ware", LooseVersion('3.17.0'), id='override_equalMinVersion'),
-        pytest.param(True, b"cmake version 4.0.0\nKit Ware", LooseVersion('4.0.0'), id='override_greaterThanMinVersion'),
-        pytest.param(True, b"cmake version 1.0.0\nKit Ware", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR), id='override_lessThanMinVersion'),
+        pytest.param(False, f"cmake version {generate_android_project.CMAKE_MIN_VERSION}\nKit Ware", generate_android_project.CMAKE_MIN_VERSION, id='equalMinVersion'),
+        pytest.param(False, "cmake version 4.0.0\nKit Ware", LooseVersion('4.0.0'), id='greaterThanMinVersion'),
+        pytest.param(False, "cmake version 1.0.0\nKit Ware", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR), id='lessThanMinVersion'),
+        pytest.param(True, f"cmake version {generate_android_project.CMAKE_MIN_VERSION}\nKit Ware", generate_android_project.CMAKE_MIN_VERSION, id='override_equalMinVersion'),
+        pytest.param(True, "cmake version 4.0.0\nKit Ware", LooseVersion('4.0.0'), id='override_greaterThanMinVersion'),
+        pytest.param(True, "cmake version 1.0.0\nKit Ware", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR), id='override_lessThanMinVersion'),
     ]
 )
 def test_verify_cmake(tmpdir, from_override, version_str, expected_result):
@@ -95,14 +95,14 @@ def test_verify_cmake(tmpdir, from_override, version_str, expected_result):
     else:
         override_cmake_install_path = None
 
-    def _mock_check_output(args, shell):
+    def _mock_check_output(args, shell, stderr):
         assert args
         assert shell is True
         if from_override:
             assert args[0] == os.path.normpath(f'{override_cmake_install_path}/bin/{cmake_exe}')
         assert args[1] == '--version'
 
-        return version_str
+        return version_str.encode(encoding='UTF-8')
 
     subprocess.check_output = _mock_check_output
 
@@ -141,7 +141,7 @@ def test_verify_ninja(tmpdir, from_override, version_str, expected_result):
     else:
         override_cmake_install_path = None
 
-    def _mock_check_output(args, shell):
+    def _mock_check_output(args, shell, stderr):
         assert args
         assert shell is True
         if from_override:


### PR DESCRIPTION

Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>

## What does this PR do?
Fixes the following unit test errors when pytest on cmake\Tools\Platform
```
...
FAILED Android\unit_test_android_deployment.py::test_execute_incremental_deploy_success[profile-org.o3de.foo-\data\fool_storage] - ValueError: path is on mount 'D:', start on mount...
...
FAILED Android\unit_test_generate_android_project.py::test_verify_cmake[equalMinVersion] - TypeError: _mock_check_output() got an unexpected keyword argument 'stderr'
```
* Logic that converts an absolute path to a relative path didn't check if the source path was already relative
* One of the mock functions (_check_output) was not updated when the argument 'stderr' was added to the real check_output a while ago
* Updated later error (after above fix) to make sure the test cases keep up with the current minimum cmake version (instead of being hard coded)


## How was this PR tested?

Ran the following command under ```cmake\Tools\Platform```

```
..\..\..\python\python.cmd -m pytest
```

