### PR TITLE
Preparation of bring overrides authoring prototype to development

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
@@ -362,6 +362,7 @@ namespace AzToolsFramework
             if (parentInfo.HasChild(childId))
             {
                 ReparentChild(childId, entityId, AZ::EntityId());
+                AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::RemoveDirtyEntity, childId);
             }
         }
 
@@ -389,6 +390,7 @@ namespace AzToolsFramework
         for (auto childId : children)
         {
             ReparentChild(childId, AZ::EntityId(), entityId);
+            AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::RemoveDirtyEntity, childId);
             m_entityOrphanTable[entityId].insert(childId);
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -17,6 +17,7 @@
 #include <AzToolsFramework/Prefab/Instance/Instance.h>
 #include <AzToolsFramework/Prefab/Instance/TemplateInstanceMapperInterface.h>
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
+#include <AzToolsFramework/Prefab/PrefabFocusInterface.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <AzToolsFramework/Prefab/PrefabPublicNotificationBus.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
@@ -27,6 +28,8 @@ namespace AzToolsFramework
 {
     namespace Prefab
     {
+        AzFramework::EntityContextId InstanceUpdateExecutor::s_editorEntityContextId = AzFramework::EntityContextId::CreateNull();
+
         InstanceUpdateExecutor::InstanceUpdateExecutor(int instanceCountToUpdateInBatch)
             : m_instanceCountToUpdateInBatch(instanceCountToUpdateInBatch)
             , m_GameModeEventHandler(
@@ -39,6 +42,15 @@ namespace AzToolsFramework
 
         void InstanceUpdateExecutor::RegisterInstanceUpdateExecutorInterface()
         {
+            // Get EditorEntityContextId
+            EditorEntityContextRequestBus::BroadcastResult(s_editorEntityContextId, &EditorEntityContextRequests::GetEditorEntityContextId);
+
+            m_prefabFocusInterface = AZ::Interface<PrefabFocusInterface>::Get();
+            AZ_Assert(m_prefabFocusInterface != nullptr,
+                "Prefab - InstanceUpdateExecutor::RegisterInstanceUpdateExecutorInterface - "
+                "Prefab Focus Interface could not be found. "
+                "Check that it is being correctly initialized.");
+
             m_prefabSystemComponentInterface = AZ::Interface<PrefabSystemComponentInterface>::Get();
             AZ_Assert(m_prefabSystemComponentInterface != nullptr,
                 "Prefab - InstanceUpdateExecutor::RegisterInstanceUpdateExecutorInterface - "
@@ -60,6 +72,21 @@ namespace AzToolsFramework
             PropertyEditorGUIMessages::Bus::Handler::BusDisconnect();
             m_GameModeEventHandler.Disconnect();
             AZ::Interface<InstanceUpdateExecutorInterface>::Unregister(this);
+        }
+
+        void InstanceUpdateExecutor::AddInstanceToQueue(InstanceOptionalReference instance)
+        {
+            if (instance == AZStd::nullopt)
+            {
+                AZ_Warning(
+                    "Prefab", false,
+                    "InstanceUpdateExecutor::AddInstanceToQueue - "
+                    "Caller tried to insert null instance into the queue.");
+
+                return;
+            }
+
+            m_instancesUpdateQueue.emplace_back(&instance->get());
         }
 
         void InstanceUpdateExecutor::AddTemplateInstancesToQueue(TemplateId instanceTemplateId, InstanceOptionalConstReference instanceToExclude)
@@ -94,9 +121,108 @@ namespace AzToolsFramework
         void InstanceUpdateExecutor::RemoveTemplateInstanceFromQueue(const Instance* instance)
         {
             AZStd::erase_if(m_instancesUpdateQueue, [instance](Instance* entry)
+                {
+                    return entry == instance;
+                }
+            );
+        }
+
+        const void InstanceUpdateExecutor::ReplaceFocusedContainerTransformAccordingToRoot(
+            const Instance* focusedInstance, PrefabDom& focusedInstanceDom) const
+        {
+            // Climb from the focused instance to the root and store the path.
+            AZStd::string rootToFocusedInstance;
+            auto rootInstance = PrefabDomUtils::ClimbUpToTargetInstance(focusedInstance, nullptr, rootToFocusedInstance);
+
+            if (rootInstance != focusedInstance)
             {
-                return entry == instance;
-            });
+                // Create the path from the root instance to the container entity of the focused instance.
+                AZStd::string rootToFocusedInstanceContainer =
+                    AZStd::string::format("%s/%s", rootToFocusedInstance.c_str(), PrefabDomUtils::ContainerEntityName);
+                PrefabDomPath rootToFocusedInstanceContainerPath(rootToFocusedInstanceContainer.c_str());
+
+                // Retrieve the dom of the root instance.
+                PrefabDom rootDom;
+                rootDom.CopyFrom(
+                    m_prefabSystemComponentInterface->FindTemplateDom(rootInstance->GetTemplateId()), focusedInstanceDom.GetAllocator());
+
+                PrefabDom containerDom;
+                containerDom.CopyFrom(*rootToFocusedInstanceContainerPath.Get(rootDom), focusedInstanceDom.GetAllocator());
+
+                // Paste the focused instance container dom as seen from the root into instanceDom.
+                AZStd::string containerName =
+                    AZStd::string::format("/%s", PrefabDomUtils::ContainerEntityName);
+                PrefabDomPath containerPath(containerName.c_str());
+                containerPath.Set(focusedInstanceDom, containerDom, focusedInstanceDom.GetAllocator());
+            }
+        }
+
+        bool InstanceUpdateExecutor::GenerateInstanceDomAccordingToCurrentFocus(const Instance* instance, PrefabDom& instanceDom)
+        {
+            // Retrieve focused instance
+            auto focusedInstance = m_prefabFocusInterface->GetFocusedPrefabInstance(s_editorEntityContextId);
+
+            AZStd::string aliasPath;
+            auto domSourceInstance = PrefabDomUtils::ClimbUpToTargetInstance(instance, &focusedInstance->get(), aliasPath);
+            
+            PrefabDomPath domSourcePath(aliasPath.c_str());
+            PrefabDom partialInstanceDom;
+            partialInstanceDom.CopyFrom(
+                m_prefabSystemComponentInterface->FindTemplateDom(domSourceInstance->GetTemplateId()), instanceDom.GetAllocator());
+
+            auto instanceDomValueFromSource = domSourcePath.Get(partialInstanceDom);
+            if (!instanceDomValueFromSource)
+            {
+                return false;
+            }
+
+            instanceDom.CopyFrom(*instanceDomValueFromSource, instanceDom.GetAllocator());
+
+            // If the focused instance is not an ancestor of our instance, verify if it's a descendant.
+            if (domSourceInstance != &focusedInstance->get())
+            {
+                AZStd::string aliasPathToFocus;
+                auto focusedInstanceAncestor = PrefabDomUtils::ClimbUpToTargetInstance(&focusedInstance->get(), instance, aliasPathToFocus);
+
+                // If the focused instance is a descendant (or the instance itself), we need to replace its portion of the dom with the template one.
+                if (focusedInstanceAncestor == instance)
+                {
+                    // Get the dom for the focused instance from its template.
+                    PrefabDom focusedInstanceDom;
+                    focusedInstanceDom.CopyFrom(
+                        m_prefabSystemComponentInterface->FindTemplateDom(focusedInstance->get().GetTemplateId()),
+                        instanceDom.GetAllocator());
+
+                    // Replace the container entity with the one as seen by the root
+                    // TODO - this function should only replace the transform!
+                    ReplaceFocusedContainerTransformAccordingToRoot(&focusedInstance->get(), focusedInstanceDom);
+                    
+                    // Copy the focused instance dom inside the dom that will be used to refresh the instance.
+                    PrefabDomPath domSourceToFocusPath(aliasPathToFocus.c_str());
+                    domSourceToFocusPath.Set(instanceDom, focusedInstanceDom, instanceDom.GetAllocator());
+
+                    // Force a deep copy
+                    PrefabDom instanceDomCopy;
+                    instanceDomCopy.CopyFrom(instanceDom, instanceDom.GetAllocator());
+
+                    instanceDom.CopyFrom(instanceDomCopy, instanceDom.GetAllocator());
+                }
+            }
+            // If our instance is the focused instance, fix the container
+            else if (&focusedInstance->get() == instance)
+            {
+                // Replace the container entity with the one as seen by the root
+                // TODO - this function should only replace the transform!
+                ReplaceFocusedContainerTransformAccordingToRoot(instance, instanceDom);
+            }
+
+            PrefabDomValueReference instanceDomFromRoot = instanceDom;
+            if (!instanceDomFromRoot.has_value())
+            {
+                return false;
+            }
+
+            return true;
         }
         void InstanceUpdateExecutor::LazyConnectGameModeEventHandler()
         {
@@ -132,7 +258,7 @@ namespace AzToolsFramework
 
                     EntityIdList selectedEntityIds;
                     ToolsApplicationRequestBus::BroadcastResult(selectedEntityIds, &ToolsApplicationRequests::GetSelectedEntities);
-                    PrefabDom instanceDomFromRootDocument;
+                    PrefabDom instanceDomAccordingToFocus;
 
                     // Process all instances in the queue, capped to the batch size.
                     // Even though we potentially initialized the batch size to the queue, it's possible for the queue size to shrink
@@ -179,30 +305,9 @@ namespace AzToolsFramework
 
                         EntityList newEntities;
 
-                        // Climb up to the root of the instance hierarchy from this instance
-                        InstanceOptionalConstReference rootInstance = *instanceToUpdate;
-                        AZStd::vector<InstanceOptionalConstReference> pathOfInstances;
-
-                        while (rootInstance->get().GetParentInstance() != AZStd::nullopt)
-                        {
-                            pathOfInstances.emplace_back(rootInstance);
-                            rootInstance = rootInstance->get().GetParentInstance();
-                        }
-
-                        AZStd::string aliasPathResult = "";
-                        for (auto instanceIter = pathOfInstances.rbegin(); instanceIter != pathOfInstances.rend(); ++instanceIter)
-                        {
-                            aliasPathResult.append("/Instances/");
-                            aliasPathResult.append((*instanceIter)->get().GetInstanceAlias());
-                        }
-
-                        PrefabDomPath rootPrefabDomPath(aliasPathResult.c_str());
-
-                        PrefabDom& rootPrefabTemplateDom =
-                            m_prefabSystemComponentInterface->FindTemplateDom(rootInstance->get().GetTemplateId());
-
-                        auto instanceDomFromRootValue = rootPrefabDomPath.Get(rootPrefabTemplateDom);
-                        if (!instanceDomFromRootValue)
+                        // TODO - Add relevant comment.
+                        bool instanceDomGenerated = GenerateInstanceDomAccordingToCurrentFocus(instanceToUpdate, instanceDomAccordingToFocus);
+                        if (!instanceDomGenerated)
                         {
                             AZ_Assert(
                                 false,
@@ -213,27 +318,12 @@ namespace AzToolsFramework
                             continue;
                         }
 
-                        PrefabDomValueConstReference instanceDomFromRoot = *instanceDomFromRootValue;
-                        if (!instanceDomFromRoot.has_value())
-                        {
-                            AZ_Assert(
-                                false,
-                                "InstanceUpdateExecutor::UpdateTemplateInstancesInQueue - "
-                                "Could not load Instance DOM from the top level ancestor's DOM.");
-
-                            isUpdateSuccessful = false;
-                            continue;
-                        }
-
-                        // If a link was created for a nested instance before the changes were propagated,
-                        // then we associate it correctly here
-                        instanceDomFromRootDocument.CopyFrom(instanceDomFromRoot->get(), instanceDomFromRootDocument.GetAllocator());
-                        if (PrefabDomUtils::LoadInstanceFromPrefabDom(*instanceToUpdate, newEntities, instanceDomFromRootDocument, PrefabDomUtils::LoadFlags::UseSelectiveDeserialization))
+                        if (PrefabDomUtils::LoadInstanceFromPrefabDom(*instanceToUpdate, newEntities, instanceDomAccordingToFocus))
                         {
                             Template& currentTemplate = currentTemplateReference->get();
                             instanceToUpdate->GetNestedInstances([&](AZStd::unique_ptr<Instance>& nestedInstance) 
                             {
-                                if (nestedInstance->GetLinkId() != InvalidLinkId)
+                                if (!nestedInstance || nestedInstance->GetLinkId() != InvalidLinkId)
                                 {
                                     return;
                                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -11,8 +11,10 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/std/containers/deque.h>
+#include <AzFramework/Entity/EntityContext.h>
 #include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h>
+#include <AzToolsFramework/Prefab/PrefabDomTypes.h>
 #include <AzToolsFramework/Prefab/PrefabIdTypes.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 
@@ -21,6 +23,7 @@ namespace AzToolsFramework
     namespace Prefab
     {
         class Instance;
+        class PrefabFocusInterface;
         class PrefabSystemComponentInterface;
         class TemplateInstanceMapperInterface;
 
@@ -34,6 +37,7 @@ namespace AzToolsFramework
 
             explicit InstanceUpdateExecutor(int instanceCountToUpdateInBatch = 0);
 
+            void AddInstanceToQueue(InstanceOptionalReference instance) override;
             void AddTemplateInstancesToQueue(TemplateId instanceTemplateId, InstanceOptionalConstReference instanceToExclude = AZStd::nullopt) override;
             bool UpdateTemplateInstancesInQueue() override;
             void RemoveTemplateInstanceFromQueue(const Instance* instance) override;
@@ -43,6 +47,13 @@ namespace AzToolsFramework
             void UnregisterInstanceUpdateExecutorInterface();
 
         private:
+            PrefabFocusInterface* m_prefabFocusInterface = nullptr;
+
+            // focusedInstance is the pointer to the focused instance.
+            // instanceDom is the dom of the instance that is being propagated, and will be edited by this function.
+            const void ReplaceFocusedContainerTransformAccordingToRoot(const Instance* focusedInstance, PrefabDom& focusedInstanceDom) const;
+
+            bool GenerateInstanceDomAccordingToCurrentFocus(const Instance* instance, PrefabDom& instanceDom);
 
             ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // PropertyEditorGUIMessages::Bus::Handler
@@ -63,6 +74,7 @@ namespace AzToolsFramework
             AZStd::deque<Instance*> m_instancesUpdateQueue;
             AZ::Event<GameModeState>::Handler m_GameModeEventHandler;
             int m_instanceCountToUpdateInBatch = 0;
+            static AzFramework::EntityContextId s_editorEntityContextId;
             bool m_isRootPrefabInstanceLoaded = false;
             bool m_shouldPausePropagation = false;
             bool m_updatingTemplateInstancesInQueue { false };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
@@ -22,7 +22,10 @@ namespace AzToolsFramework
             AZ_RTTI(InstanceUpdateExecutorInterface, "{26BB4ACF-6EA5-4668-84E7-AB75B90BA449}");
             virtual ~InstanceUpdateExecutorInterface() = default;
 
-            // Add all Instances of Template with given Id into a queue for updating them later.
+            // Add an instance into the queue so it's updated at the end of the frame.
+            virtual void AddInstanceToQueue(InstanceOptionalReference instance) = 0;
+
+            // Add all Instances of Template with given Id into a queue so it's updated at the end of the frame.
             virtual void AddTemplateInstancesToQueue(TemplateId instanceTemplateId, InstanceOptionalConstReference instanceToExclude = AZStd::nullopt) = 0;
 
             // Update Instances in the waiting queue.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -451,6 +451,45 @@ namespace AzToolsFramework
 
                 qDebug() << printMessage.data() << "\n" << prefabBuffer.GetString();
             }
+
+            AZStd::string PrefabDomValueToString(const PrefabDomValue& prefabDomValue)
+            {
+                rapidjson::StringBuffer prefabBuffer;
+                rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(prefabBuffer);
+                prefabDomValue.Accept(writer);
+
+                return prefabBuffer.GetString();
+            }
+
+            
+            const Instance* ClimbUpToTargetInstance(
+                const Instance* startInstance, const Instance* targetInstance, AZStd::string& aliasPath)
+            {
+                if (!startInstance)
+                {
+                    return nullptr;
+                }
+
+                // Climb up the instance hierarchy from this instance until you hit the target or the root.
+                InstanceOptionalConstReference instance = *startInstance;
+                AZStd::vector<InstanceOptionalConstReference> instancePath;
+
+                while (&instance->get() != targetInstance && instance->get().GetParentInstance() != AZStd::nullopt)
+                {
+                    instancePath.emplace_back(instance);
+                    instance = instance->get().GetParentInstance();
+                }
+
+                aliasPath = "";
+                for (auto instanceIter = instancePath.rbegin(); instanceIter != instancePath.rend(); ++instanceIter)
+                {
+                    aliasPath.append("/Instances/");
+                    aliasPath.append((*instanceIter)->get().GetInstanceAlias());
+                }
+
+                return &instance->get();
+            }
+
         } // namespace PrefabDomUtils
     } // namespace Prefab
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -197,6 +197,8 @@ namespace AzToolsFramework
                 [[maybe_unused]] const AZStd::string_view printMessage,
                 [[maybe_unused]] const AzToolsFramework::Prefab::PrefabDomValue& prefabDomValue);
 
+            AZStd::string PrefabDomValueToString(const PrefabDomValue& prefabDomValue);
+
             //! An empty struct for passing to JsonSerializerSettings.m_metadata that is consumed by InstanceSerializer::Store.
             //! If present in metadata, linkIds will be stored to instance dom.
             struct LinkIdMetadata
@@ -205,6 +207,13 @@ namespace AzToolsFramework
 
                 virtual ~LinkIdMetadata() {}
             };
+
+            /**
+             * Climbs up the instance hierarchy tree from startInstance.
+             * Stops when it hits either the targetInstance or the root.
+             */
+            const Instance* ClimbUpToTargetInstance(
+                const Instance* startInstance, const Instance* targetInstance, AZStd::string& aliasPath);
 
             //! An empty struct to pass to the JsonDeserializerSettings, which will be used to identify whether we should selectively
             //! deserialize only modified entities.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusPublicInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusPublicInterface.h
@@ -20,6 +20,12 @@ namespace AzToolsFramework::Prefab
 {
     using PrefabFocusOperationResult = AZ::Outcome<void, AZStd::string>;
 
+    enum class PrefabEditScope
+    {
+        NESTED_TEMPLATES = 0,
+        NESTED_INSTANCES
+    };
+
     //! Public Interface for external systems to utilize the Prefab Focus system.
     class PrefabFocusPublicInterface
     {
@@ -36,6 +42,10 @@ namespace AzToolsFramework::Prefab
         //! Set the focused prefab instance to the instance at position index of the current path. Supports undo/redo.
         //! @param index The index of the instance in the current path that we want the prefab system to focus on.
         virtual PrefabFocusOperationResult FocusOnPathIndex(AzFramework::EntityContextId entityContextId, int index) = 0;
+
+        //! Opens the prefab instance owning the entityId provided.Supports undo/redo.
+        //! @param entityId The entityId of the entity whose owning instance we want to open for overrides.
+        virtual PrefabFocusOperationResult SetOwningPrefabInstanceOpenState(AZ::EntityId entityId, bool openState) = 0;
 
         //! Returns the entity id of the container entity for the instance the prefab system is focusing on.
         virtual AZ::EntityId GetFocusedPrefabContainerEntityId(AzFramework::EntityContextId entityContextId) const = 0;
@@ -56,6 +66,17 @@ namespace AzToolsFramework::Prefab
 
         //! Returns the size of the path to the currently focused instance.
         virtual const int GetPrefabFocusPathLength(AzFramework::EntityContextId entityContextId) const = 0;
+
+        //! Returns the current focus mode.
+        virtual PrefabEditScope GetPrefabEditScope(AzFramework::EntityContextId entityContextId) const = 0;
+
+        //! Sets the current focus mode.
+        virtual void SetPrefabEditScope(AzFramework::EntityContextId entityContextId, PrefabEditScope mode) = 0;
+
+        // TEMP
+        virtual int GetOpenInstanceMode() = 0;
+        virtual bool GetAllowContextMenuInstanceExpanding() = 0;
+        virtual bool GetContainerStepByStepSelection() = 0;
     };
 
     /**

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndo.cpp
@@ -290,7 +290,7 @@ namespace AzToolsFramework
                 "Prefab",
                 (result.GetOutcome() != AZ::JsonSerializationResult::Outcomes::Skipped) &&
                 (result.GetOutcome() != AZ::JsonSerializationResult::Outcomes::PartialSkip),
-                "Some of the patches are not successfully applied.");
+                "Some of the patches are not successfully applied:\n%s.", PrefabDomUtils::PrefabDomValueToString(patch).c_str());
 
             // Remove the link ids if present in the doms. We don't want any overrides to be created on top of linkIds because
             // linkIds are not persistent and will be created dynamically when prefabs are loaded into the editor.


### PR DESCRIPTION
Modify InstanceUpdateExecutor, PrefabDomUtils, and PrefabFocusPublicInterface for bring overrides authoring prototype to development later.