### PR TITLE
Moved the Atom RHI DX12, Metal and Vulkan .Builders dependencies to only be added to the AssetBuilder

### DIFF
--- a/Gems/Atom/Feature/Common/Code/CMakeLists.txt
+++ b/Gems/Atom/Feature/Common/Code/CMakeLists.txt
@@ -132,6 +132,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::Atom_Feature_Common.Public
     )
 
+    set(runtime_dependencies_builders ${pal_source_dir}/runtime_dependencies_builders.cmake)
     ly_add_target(
         NAME Atom_Feature_Common.Builders GEM_MODULE
 
@@ -139,7 +140,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         FILES_CMAKE
             atom_feature_common_builders_files.cmake
         PLATFORM_INCLUDE_FILES
-            ${runtime_dependencies_tools}
+            ${runtime_dependencies_builders}
         INCLUDE_DIRECTORIES
             PRIVATE
                 Source/Builders

--- a/Gems/Atom/Feature/Common/Code/Source/Platform/Linux/runtime_dependencies_builders.cmake
+++ b/Gems/Atom/Feature/Common/Code/Source/Platform/Linux/runtime_dependencies_builders.cmake
@@ -7,7 +7,7 @@
 #
 
 set(LY_RUNTIME_DEPENDENCIES
-    Gem::Atom_RHI_Metal.Private
-    Gem::Atom_RHI_Vulkan.Private
-    Gem::Atom_RHI_DX12.Private
+    Gem::Atom_RHI_Metal.Builders
+    Gem::Atom_RHI_Vulkan.Builders
+    Gem::Atom_RHI_DX12.Builders
 )

--- a/Gems/Atom/Feature/Common/Code/Source/Platform/Linux/runtime_dependencies_tools.cmake
+++ b/Gems/Atom/Feature/Common/Code/Source/Platform/Linux/runtime_dependencies_tools.cmake
@@ -10,7 +10,4 @@ set(LY_RUNTIME_DEPENDENCIES
     Gem::Atom_RHI_Vulkan.Private
     Gem::Atom_RHI_DX12.Private
     Gem::Atom_RHI_Metal.Private
-    Gem::Atom_RHI_Vulkan.Builders
-    Gem::Atom_RHI_DX12.Builders
-    Gem::Atom_RHI_Metal.Builders
 )

--- a/Gems/Atom/Feature/Common/Code/Source/Platform/Mac/runtime_dependencies_builders.cmake
+++ b/Gems/Atom/Feature/Common/Code/Source/Platform/Mac/runtime_dependencies_builders.cmake
@@ -7,7 +7,7 @@
 #
 
 set(LY_RUNTIME_DEPENDENCIES
-    Gem::Atom_RHI_Metal.Private
-    Gem::Atom_RHI_Vulkan.Private
-    Gem::Atom_RHI_DX12.Private
+    Gem::Atom_RHI_Metal.Builders
+    Gem::Atom_RHI_Vulkan.Builders
+    Gem::Atom_RHI_DX12.Builders
 )

--- a/Gems/Atom/Feature/Common/Code/Source/Platform/Windows/runtime_dependencies_builders.cmake
+++ b/Gems/Atom/Feature/Common/Code/Source/Platform/Windows/runtime_dependencies_builders.cmake
@@ -7,7 +7,7 @@
 #
 
 set(LY_RUNTIME_DEPENDENCIES
-    Gem::Atom_RHI_Metal.Private
-    Gem::Atom_RHI_Vulkan.Private
-    Gem::Atom_RHI_DX12.Private
+    Gem::Atom_RHI_Metal.Builders
+    Gem::Atom_RHI_Vulkan.Builders
+    Gem::Atom_RHI_DX12.Builders
 )

--- a/Gems/Atom/Feature/Common/Code/Source/Platform/Windows/runtime_dependencies_tools.cmake
+++ b/Gems/Atom/Feature/Common/Code/Source/Platform/Windows/runtime_dependencies_tools.cmake
@@ -10,7 +10,4 @@ set(LY_RUNTIME_DEPENDENCIES
     Gem::Atom_RHI_Vulkan.Private
     Gem::Atom_RHI_DX12.Private
     Gem::Atom_RHI_Metal.Private
-    Gem::Atom_RHI_Vulkan.Builders
-    Gem::Atom_RHI_DX12.Builders
-    Gem::Atom_RHI_Metal.Builders
 )

--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -269,6 +269,9 @@ function(ly_enable_gems_delayed)
             message(FATAL_ERROR "ly_set_gem_variant_to_load specified TARGET '${target}' but no such target was found.")
         endif()
 
+        get_property(target_gem_variants GLOBAL PROPERTY LY_GEM_VARIANTS_"${target}")
+        message(VERBOSE "Adding gem dependencies for \"${target}\" associated with the Gem variants of \"${target_gem_variants}\"")
+
         # Lookup if the target is scoped to a project
         # In that case the target can only use gem targets that is
         # - not project specific: i.e "__NOPROJECT__"
@@ -304,7 +307,6 @@ function(ly_enable_gems_delayed)
 
             # Gather the Gem variants associated with this target and iterate over them to combine them with the enabled
             # gems for the each project
-            get_property(target_gem_variants GLOBAL PROPERTY LY_GEM_VARIANTS_"${target}")
             foreach(variant ${target_gem_variants})
                 ly_add_gem_dependencies_to_project_variants(
                     PROJECT_NAME ${project}

--- a/cmake/Projects.cmake
+++ b/cmake/Projects.cmake
@@ -48,8 +48,8 @@ function(ly_add_target_dependencies)
 
     unset(ALL_GEM_DEPENDENCIES)
     foreach(dependency_file ${ly_add_gem_dependencies_DEPENDENCIES_FILES})
-    #unset any GEM_DEPENDENCIES and include the dependencies file, that should populate GEM_DEPENDENCIES
-    unset(GEM_DEPENDENCIES)
+        #unset any GEM_DEPENDENCIES and include the dependencies file, that should populate GEM_DEPENDENCIES
+        unset(GEM_DEPENDENCIES)
         include(${dependency_file})
         list(APPEND ALL_GEM_DEPENDENCIES ${GEM_DEPENDENCIES})
     endforeach()
@@ -62,13 +62,16 @@ function(ly_add_target_dependencies)
         ly_add_dependencies(${target} ${ALL_GEM_DEPENDENCIES})
 
         # Add the target to the LY_DELAYED_LOAD_DEPENDENCIES if it isn't already on the list
-        get_property(delayed_load_target_set GLOBAL PROPERTY LY_DELAYED_LOAD_"${ly_add_gem_dependencies_PREFIX},${target}" SET)
-        if(NOT delayed_load_target_set)
+        get_property(load_dependencies_set GLOBAL PROPERTY LY_DELAYED_LOAD_DEPENDENCIES)
+        if(NOT "${ly_add_gem_dependencies_PREFIX},${target}" IN_LIST load_dependencies_set)
             set_property(GLOBAL APPEND PROPERTY LY_DELAYED_LOAD_DEPENDENCIES "${ly_add_gem_dependencies_PREFIX},${target}")
         endif()
         foreach(gem_target ${ALL_GEM_DEPENDENCIES})
             # Add the list of gem dependencies to the LY_TARGET_DELAYED_DEPENDENCIES_${ly_add_gem_dependencies_PREFIX};${target} property
-            set_property(GLOBAL APPEND PROPERTY LY_DELAYED_LOAD_"${ly_add_gem_dependencies_PREFIX},${target}" ${gem_target})
+            get_property(target_load_dependencies GLOBAL PROPERTY LY_DELAYED_LOAD_"${ly_add_gem_dependencies_PREFIX},${target}")
+            if(NOT "${gem_target}" IN_LIST target_load_dependencies)
+                set_property(GLOBAL APPEND PROPERTY LY_DELAYED_LOAD_"${ly_add_gem_dependencies_PREFIX},${target}" ${gem_target})
+            endif()
         endforeach()
     endforeach()
 endfunction()

--- a/cmake/SettingsRegistry.cmake
+++ b/cmake/SettingsRegistry.cmake
@@ -243,6 +243,7 @@ function(ly_delayed_generate_settings_registry)
 
         # Get the gem dependencies for the given project and target combination
         get_property(gem_dependencies GLOBAL PROPERTY LY_DELAYED_LOAD_"${prefix_target}")
+        message(VERBOSE "${prefix_target} has direct gem load dependencies of ${gem_dependencies}")
         list(REMOVE_DUPLICATES gem_dependencies) # Strip out any duplicate gem targets
         unset(all_gem_dependencies)
 


### PR DESCRIPTION
Previously the .Tools variants including the Editor was getting the .Builders target added as dependenciees.

Added more verbose messages to the CMake scripts that determines the gem load dependencies to aid troubleshooting.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
