### PR TITLE
Disabling SC Spawnables tests for investigation

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Main.py
@@ -72,18 +72,23 @@ class TestAutomationNoAutoTestMode(EditorTestSuite):
     class test_PrefabNotifications_RootPrefabLoadedNotificationsReceived(EditorSharedTest):
         from .tests.prefab_notifications import PrefabNotifications_RootPrefabLoadedNotificationsReceived as test_module
 
+    @pytest.mark.skip(reason="https://github.com/o3de/o3de/issues/9789")
     class test_SC_Spawnables_SimpleSpawnAndDespawn(EditorSharedTest):
         from .tests.spawnables import SC_Spawnables_SimpleSpawnAndDespawn as test_module
 
+    @pytest.mark.skip(reason="https://github.com/o3de/o3de/issues/9789")
     class test_SC_Spawnables_EntityClearedOnGameModeExit(EditorSharedTest):
         from .tests.spawnables import SC_Spawnables_EntityClearedOnGameModeExit as test_module
 
+    @pytest.mark.skip(reason="https://github.com/o3de/o3de/issues/9789")
     class test_SC_Spawnables_MultipleSpawnsFromSingleTicket(EditorSharedTest):
         from .tests.spawnables import SC_Spawnables_MultipleSpawnsFromSingleTicket as test_module
 
+    @pytest.mark.skip(reason="https://github.com/o3de/o3de/issues/9789")
     class test_SC_Spawnables_NestedSpawn(EditorSharedTest):
         from .tests.spawnables import SC_Spawnables_NestedSpawn as test_module
 
+    @pytest.mark.skip(reason="https://github.com/o3de/o3de/issues/9789")
     class test_SC_Spawnables_DespawnOnEntityDeactivate(EditorSharedTest):
         from .tests.spawnables import SC_Spawnables_DespawnOnEntityDeactivate as test_module
 


### PR DESCRIPTION
Signed-off-by: jckand-amzn <82226555+jckand-amzn@users.noreply.github.com>

## What does this PR do?

Disables Script Canvas Spawnables test to investigate an intermittent failure.

Task to Re-enable: https://github.com/o3de/o3de/issues/9789

## How was this PR tested?

Ran Prefab TestSuite_Main.py: 
```
================= 19 passed, 10 skipped, 1 warning in 24.14s ==================
```