### PR TITLE
Adding missing image gradient for bilinear filtering test

### DIFF
--- a/AutomatedTesting/Assets/ImageGradients/black_white_gsi.png
+++ b/AutomatedTesting/Assets/ImageGradients/black_white_gsi.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fa0df0937051bc618a12185e25c5a11e4beb685e4144f6b2e54d83245adca43
+size 141


### PR DESCRIPTION
Signed-off-by: jckand-amzn <82226555+jckand-amzn@users.noreply.github.com>

## What does this PR do?

Adds missing test asset required by bilnear filtering test.

Fixes https://github.com/o3de/o3de/issues/10355

## How was this PR tested?

Ran GradientSignal tests locally: 

```
============================= 16 passed in 27.07s =============================
```

Ran periodic_test_profile suite on internal Jenkins:

```
[2022-06-25T20:34:57.506Z]       Start 184: AutomatedTesting::GradientSignalTests_Periodic_Optimized.periodic::TEST_RUN

[2022-06-25T20:35:36.260Z] 21/21 Test #184: AutomatedTesting::GradientSignalTests_Periodic_Optimized.periodic::TEST_RUN ......   Passed   37.72 sec

```