### PR TITLE
bugfix: fix minimization/maximization button for the Editor Window

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/DockBarButton.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/DockBarButton.cpp
@@ -15,6 +15,7 @@
 #include <QStyleOptionToolButton>
 #include <QStylePainter>
 #include <QTimer>
+#include <QEvent>
 
 namespace AzQtComponents
 {
@@ -76,6 +77,12 @@ namespace AzQtComponents
                 break;
         }
 
+        QWidget* topLevelWindow = window();
+        if (topLevelWindow)
+        {
+            topLevelWindow->installEventFilter(this);
+        }
+
         if (m_isDarkStyle)
         {
             Style::addClass(this, QStringLiteral("dark"));
@@ -87,6 +94,15 @@ namespace AzQtComponents
         // Our dock bar buttons only need click focus, they don't need to accept
         // focus by tabbing
         setFocusPolicy(Qt::ClickFocus);
+    }
+
+    bool DockBarButton::eventFilter(QObject* object, QEvent* event)
+    {
+        if (event->type() == QEvent::WindowStateChange)
+        {
+            SetMaximizeRestoreButton();
+        }
+        return QWidget::eventFilter(object, event);
     }
 
     void DockBarButton::paintEvent(QPaintEvent *)
@@ -130,16 +146,6 @@ namespace AzQtComponents
         }
 
         emit buttonPressed(m_buttonType);
-
-        // We need to update the Maximize/Restore button to display the right icon, but for
-        // floating windows, the window() maximize state won't be updated until the following
-        // tick, so we need to delay this update until the next check
-        QTimer::singleShot(0, [this] {
-            if (m_buttonType == DockBarButton::MaximizeButton)
-            {
-                SetMaximizeRestoreButton();
-            }
-        });
     }
 
     void DockBarButton::SetMaximizeRestoreButton()

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/DockBarButton.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/DockBarButton.cpp
@@ -12,10 +12,9 @@
 #include <AzQtComponents/Components/Style.h>
 
 #include <QApplication>
+#include <QEvent>
 #include <QStyleOptionToolButton>
 #include <QStylePainter>
-#include <QTimer>
-#include <QEvent>
 
 namespace AzQtComponents
 {
@@ -98,7 +97,7 @@ namespace AzQtComponents
 
     bool DockBarButton::eventFilter(QObject* object, QEvent* event)
     {
-        if (event->type() == QEvent::WindowStateChange)
+        if (event->type() == QEvent::WindowStateChange && m_buttonType == DockBarButton::MaximizeButton)
         {
             SetMaximizeRestoreButton();
         }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/DockBarButton.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/DockBarButton.h
@@ -74,6 +74,7 @@ namespace AzQtComponents
 
     protected:
         void paintEvent(QPaintEvent* event) override;
+        bool eventFilter(QObject *object, QEvent *event) override;
 
     private:
         friend class Style;


### PR DESCRIPTION
## What does this PR do?

This fixes the minimization/maximization state of the main window. I use `WindowStateChange` event from the main window to determine the maximization state of the resize button. relying on just the user pressing the button does not cover all cases where the window is maximized/minimized.

## How was this PR tested?

test both clicking on the minimize/maximize button and also double clicking on the window. 

ref: https://github.com/o3de/o3de/issues/10048

Signed-off-by: Michael Pollind <mpollind@gmail.com>


