### PR TITLE
DPE: Ensure instance pointers are correctly resolved

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -13,6 +13,7 @@
 #include <AzCore/Name/Name.h>
 #include <AzCore/RTTI/AttributeReader.h>
 #include <AzCore/RTTI/TypeInfo.h>
+#include <AzCore/Serialization/Utils.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h>
 #include <AzFramework/DocumentPropertyEditor/PropertyEditorSystemInterface.h>
@@ -129,6 +130,12 @@ namespace AZ::Reflection
             bool BeginNode(
                 void* instance, const AZ::SerializeContext::ClassData* classData, const AZ::SerializeContext::ClassElement* classElement)
             {
+                // Ensure our instance pointer is resolved and safe to bind to member attributes
+                if (classElement)
+                {
+                    instance = AZ::Utils::ResolvePointer(instance, *classElement, *m_serializeContext);
+                }
+
                 StackEntry& parentData = m_stack.back();
                 AZStd::string path = parentData.m_path;
                 if (parentData.m_classData && parentData.m_classData->m_container)


### PR DESCRIPTION
This fixes a crash bug at runtime loading inputmapping assets in which a MemberAttribute attempts to bind to an incorrect member pointer. No regression test (yet) but can be tested as part of ReflectionAdapter testing.

Signed-off-by: Nicholas Van Sickle <mail@nickvansickle.com>