### PR TITLE
Fix android assets packaging in different modes (apk, sdcard, vfs)

### DIFF
--- a/cmake/Tools/Platform/Android/android_deployment.py
+++ b/cmake/Tools/Platform/Android/android_deployment.py
@@ -452,13 +452,13 @@ class AndroidDeployment(object):
                            device_id=target_device)
             logging.info(f"Device '{target_device}': Target cleaned.")
 
-        settings_registry_src = self.build_dir / 'app/src/main/assets/Registry'
-        settings_registry_dst = f'{output_target}/Registry'
+        # Assets layout folder when assets are not included into APK is 'app/src/assets'
+        assets_layout_src = self.build_dir / 'app/src/assets'
+        assets_layout_dst = f'{output_target}'
 
         if self.clean_deploy or not target_timestamp:
             logging.info(f"Device '{target_device}': Pushing {len(self.files_in_asset_path)} files from {str(self.local_asset_path.resolve())} to device ...")
-            paths_to_deploy = [(str(self.local_asset_path.resolve()), output_target),
-                               (str(settings_registry_src), settings_registry_dst)]
+            paths_to_deploy = [(str(assets_layout_src), assets_layout_dst)]
             for path_to_deploy, target_path in paths_to_deploy:
                 try:
                     self.adb_call(arg_list=['push', str(path_to_deploy), target_path],

--- a/cmake/Tools/Platform/Android/android_deployment.py
+++ b/cmake/Tools/Platform/Android/android_deployment.py
@@ -94,7 +94,8 @@ class AndroidDeployment(object):
             if asset_mode == 'PAK':
                 self.local_asset_path = self.dev_root / 'Pak' / f'{game_name.lower()}_{asset_type}_paks'
             else:
-                self.local_asset_path = self.dev_root / game_name / 'Cache' / asset_type
+                # Assets layout folder when assets are not included into APK is 'app/src/assets'
+                self.local_asset_path = self.build_dir / 'app/src/assets'
 
             assert game_name is not None, f"'game_name' is required"
             self.game_name = game_name
@@ -452,22 +453,20 @@ class AndroidDeployment(object):
                            device_id=target_device)
             logging.info(f"Device '{target_device}': Target cleaned.")
 
-        # Assets layout folder when assets are not included into APK is 'app/src/assets'
-        assets_layout_src = self.build_dir / 'app/src/assets'
+        # '/.' is necessary to avoid copying folder 'assets' to destination, but its content.
+        assets_layout_src = f'{str(self.local_asset_path)}/.'
         assets_layout_dst = f'{output_target}'
 
         if self.clean_deploy or not target_timestamp:
-            logging.info(f"Device '{target_device}': Pushing {len(self.files_in_asset_path)} files from {str(self.local_asset_path.resolve())} to device ...")
-            paths_to_deploy = [(str(assets_layout_src), assets_layout_dst)]
-            for path_to_deploy, target_path in paths_to_deploy:
-                try:
-                    self.adb_call(arg_list=['push', str(path_to_deploy), target_path],
-                                  device_id=target_device)
-                except common.LmbrCmdError as err:
-                    # Something went wrong, clean up before leaving
-                    self.adb_shell(command=f'rm -rf {output_target}',
-                                   device_id=target_device)
-                    raise err
+            logging.info(f"Device '{target_device}': Pushing {len(self.files_in_asset_path)} files from {assets_layout_src} to device {assets_layout_dst} ...")
+            try:
+                self.adb_call(arg_list=['push', assets_layout_src, assets_layout_dst],
+                                device_id=target_device)
+            except common.LmbrCmdError as err:
+                # Something went wrong, clean up before leaving
+                self.adb_shell(command=f'rm -rf {output_target}',
+                                device_id=target_device)
+                raise err
 
         else:
             # If no clean was specified, individually inspect all files to see if it needs to be updated
@@ -478,17 +477,13 @@ class AndroidDeployment(object):
                     files_to_copy.append(asset_file)
 
             if len(files_to_copy) > 0:
-                logging.info(f"Copying {len(files_to_copy)} assets to device  {target_device}")
+                logging.info(f"Copying {len(files_to_copy)} assets to device {target_device}")
 
             for src_path in files_to_copy:
                 relative_path = os.path.relpath(str(src_path), str(self.local_asset_path)).replace('\\', '/')
                 target_path = f"{output_target}/{relative_path}"
                 self.adb_call(arg_list=['push', str(src_path), target_path],
                               device_id=target_device)
-
-            # Always update the settings registry
-            self.adb_call(arg_list=['push', str(settings_registry_src), settings_registry_dst],
-                          device_id=target_device)
 
         self.update_device_file_timestamp(relative_assets_path=output_target,
                                           device_id=target_device)

--- a/cmake/Tools/Platform/Android/android_support.py
+++ b/cmake/Tools/Platform/Android/android_support.py
@@ -881,23 +881,30 @@ class AndroidProjectGenerator(object):
                                                                                        asset_layout_folder=(self.build_dir / 'app/src/main/assets').resolve().as_posix(),
                                                                                        file_includes='Test.Assets/**/*.*')
             else:
+                # If assets must be included inside the APK do the assets layout under
+                # 'main' folder so they will be included into the APK. Otherwise
+                # do the layout under a different folder so it's created, but not
+                # copied into the APK.
+                if self.include_assets_in_apk:
+                    layout_folder = 'app/src/main/assets'
+                else:
+                    layout_folder = 'app/src/assets'
+
                 gradle_build_env[f'CUSTOM_APPLY_ASSET_LAYOUT_{native_config_upper}_TASK'] = \
                     CUSTOM_APPLY_ASSET_LAYOUT_TASK_FORMAT_STR.format(working_dir=common.normalize_path_for_settings(self.engine_root / 'cmake/Tools'),
                                                                      python_full_path=common.normalize_path_for_settings(self.engine_root / 'python' / PYTHON_SCRIPT),
                                                                      asset_type=self.asset_type,
                                                                      project_path=self.project_path.as_posix(),
                                                                      asset_mode=self.asset_mode if native_config != 'Release' else 'PAK',
-                                                                     asset_layout_folder=(self.build_dir / 'app/src/main/assets').resolve().as_posix(),
+                                                                     asset_layout_folder=(self.build_dir / layout_folder).resolve().as_posix(),
                                                                      config=native_config)
                 # Copy over settings registry files from the Registry folder with build output directory
                 gradle_build_env[f'CUSTOM_APPLY_ASSET_LAYOUT_{native_config_upper}_TASK'] += \
                     CUSTOM_GRADLE_COPY_REGISTRY_FOLDER_FORMAT_STR.format(config=native_config,
                                                                         config_lower=native_config_lower,
-                                                                        asset_layout_folder=(self.build_dir / 'app/src/main/assets').resolve().as_posix())
-                if self.include_assets_in_apk:
-                    # This is a dependency of the layout sync only if we are including assets in the APK
-                    gradle_build_env[f'CUSTOM_APPLY_ASSET_LAYOUT_{native_config_upper}_TASK'] += \
-                        CUSTOM_GRADLE_COPY_REGISTRY_FOLDER_DEPENDENCY_FORMAT_STR.format(config=native_config)
+                                                                        asset_layout_folder=(self.build_dir / layout_folder).resolve().as_posix())
+                gradle_build_env[f'CUSTOM_APPLY_ASSET_LAYOUT_{native_config_upper}_TASK'] += \
+                    CUSTOM_GRADLE_COPY_REGISTRY_FOLDER_DEPENDENCY_FORMAT_STR.format(config=native_config)
 
 
 

--- a/cmake/Tools/Platform/Android/generate_android_project.py
+++ b/cmake/Tools/Platform/Android/generate_android_project.py
@@ -410,7 +410,7 @@ def main(args):
                                                         gradle_version=gradle_version,
                                                         gradle_plugin_version=android_gradle_plugin_version,
                                                         override_ninja_path=override_ninja_path,
-                                                        include_assets_in_apk=parsed_args.get_argument(INCLUDE_APK_ASSETS_ARGUMENT_NAME),
+                                                        include_assets_in_apk=parsed_args.include_apk_assets,
                                                         asset_mode=parsed_args.get_argument(ASSET_MODE_ARGUMENT_NAME),
                                                         asset_type=parsed_args.get_argument(ASSET_TYPE_ARGUMENT_NAME),
                                                         signing_config=signing_config,

--- a/cmake/Tools/layout_tool.py
+++ b/cmake/Tools/layout_tool.py
@@ -244,7 +244,11 @@ def copy_asset_files_to_layout(project_asset_folder, target_platform, layout_tar
                             abs_dst)
             continue
 
-        if os.path.isfile(abs_dst):
+        # If the target file doesn't exist, copy it
+        if not os.path.exists(abs_dst):
+            logging.debug("Copying %s -> %s", abs_src, abs_dst)
+            shutil.copy2(abs_src, abs_dst)
+        elif os.path.isfile(abs_dst):
             # The target is a file, do a fingerprint check
             # TODO: Evaluate if we want to just junction the files instead of doing a copy
             src_hash = common.file_fingerprint(abs_src)
@@ -407,10 +411,11 @@ def sync_layout_vfs(target_platform, project_path, asset_type, warning_on_missin
     # Create the link
     create_link(vfs_asset_source, temp_vfs_layout_project_config_path, copy)
 
-    # Create the assets to the layout
-    copy_asset_files_to_layout(project_asset_folder=project_asset_folder,
-                               target_platform=target_platform,
-                               layout_target=layout_target)
+    # Copy minimum assets to the layout necessary for vfs
+    root_assets = ['engine.json', 'bootstrap.game.debug.setreg', 'bootstrap.game.profile.setreg', 'bootstrap.game.release.setreg']
+    for root_asset in root_assets:
+        logging.debug("Copying %s -> %s",  os.path.join(project_asset_folder, root_asset), layout_target)
+        shutil.copy2(os.path.join(project_asset_folder, root_asset), layout_target)
 
     # Reset the 'gems' junction if any in the layout
     layout_gems_folder_src = os.path.join(project_asset_folder, 'gems')


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

- Fixes how the parameter `--include-apk-assets` is read by the script. It was expecting a True/False value, but it's very easy to make the mistake of not putting True/False because all the other similar parameters do not work with a bool (`--overwrite-existing`, `--enable_unity_build`, `--unit-test`, `--debug`). So to make it consistent now  `--include-apk-assets` works like the others, they work by being there or not, but not with a bool.
- Fixes bug where android asset were always added into the APK, even when `--include-apk-assets` was not used.
- Fixes `copy_asset_files_to_layout` function, which it was missing to copy files if they don't exist in the target path.
- VFS assets now only copies the minimum assets that are necessary, not all the files in the root cache folder. These are the asset for VFS.
![image](https://user-images.githubusercontent.com/27999040/175925167-68d6508b-1a52-4c8c-9246-cb59d42cfb83.png)

Left packaging mode PAK (adding assets into OBB) out for now since that's the one use when shipping, which is still far away of a goal and not as relevant as the others during development cycle.

## How was this PR tested?

- Built android to have assets into the APK (`"--include-apk-assets --asset-mode LOOSE"` used running `generate_android_project.py`). The assets were correctly copied into the APK. 
- Built android to have assets in sdcard and not APK (`"--asset-mode LOOSE"` used running `generate_android_project.py`). The assets were correctly generated and copied into sdcard, not into APK.
- Built android to use VFS  (`"--asset-mode VFS"` used running `generate_android_project.py`). The minimum assets were correctly generated and copied into sdcard, not into APK.

