### PR TITLE
Fix running android using Virtual File System (VFS)

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.h
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.h
@@ -398,12 +398,13 @@ namespace AZ::IO
         // appends
         //! Joins a path together using the following rule set
         //! let p = other PathView
-        //! # If p.is_absolute() || (p.has_root_name() && p.root.name() != root_name()
+        //! # If p.is_absolute() || p.starts_with_alias() || (p.has_root_name() && p.root.name() != root_name()
         //! Then replaces the current *this path with p
         //! NOTE: This is the case of trying to append something such as
         //! "C:\Foo" / "F:\Foo" = "F:\Foo"
         //! IMPORTANT NOTE: this also applies for the root directory as well
-        //! So appending "test/foo" "/bar" results in "/bar", not "test/foo/bar"
+        //! So appending "test/foo" "/bar" results in "/bar", not "test/foo/bar",
+        //! also appending "test/foo" "@products@/bar" results in "@products@/bar", not "test/foo/@products@/bar".
         //! If "test/foo/bar" is desired then either operator+=/concat can be used with "/bar"
         //! or leading path separator in bar is skipped over so that only "bar" is passed to operator+=
         //!

--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.inl
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.inl
@@ -853,7 +853,10 @@ namespace AZ::IO
             // This follows the behavior of python Pathlib
             return *this;
         }
-        if (Internal::IsAbsolute(first, last, m_preferred_separator))
+
+        // If the path to append is an absolute path or starts with an alias
+        // then replace this with the path.
+        if (Internal::IsAbsolute(first, last, m_preferred_separator) || *first == '@')
         {
             m_path.assign(first, last);
             return *this;

--- a/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
+++ b/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
@@ -298,6 +298,14 @@ namespace AZ
             if (path && assetAliasPath)
             {
                 const AZ::IO::PathView pathView(path);
+
+                const auto devWriteStoragePath = AZ::Utils::GetDevWriteStoragePath();
+                if (devWriteStoragePath.has_value() &&
+                    pathView.IsRelativeTo(devWriteStoragePath->c_str()))
+                {
+                    return;
+                }
+
                 if (pathView.IsRelativeTo(assetAliasPath))
                 {
                     AZ_Error("FileIO", false, "You may not alter data inside the asset cache.  Please check the call stack and consider writing into the source asset folder instead.\n"

--- a/Code/LauncherUnified/Launcher.cpp
+++ b/Code/LauncherUnified/Launcher.cpp
@@ -60,7 +60,7 @@ namespace
         AzFramework::WindowSize newSize = AzFramework::WindowSize(aznumeric_cast<int32_t>(value.GetX()), aznumeric_cast<int32_t>(value.GetY()));
         AzFramework::WindowRequestBus::Broadcast(&AzFramework::WindowRequestBus::Events::ResizeClientArea, newSize);
     }
-    
+
     AZ_CVAR(AZ::Vector2, r_viewportPos, AZ::Vector2::CreateZero(), CVar_OnViewportPosition, AZ::ConsoleFunctorFlags::DontReplicate,
         "The default position for the launcher viewport, 0 0 means top left corner of your main desktop");
 
@@ -238,9 +238,9 @@ namespace O3DELauncher
     {
         if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
         {
-            AZ::ComponentApplicationLifecycle::SignalEvent(*settingsRegistry, "CriticalAssetsCompiled", R"({})");
             // Reload the assetcatalog.xml at this point again
-            // Start Monitoring Asset changes over the network and load the AssetCatalog
+            // Start Monitoring Asset changes over the network and load the AssetCatalog.
+            // Note: When using VFS this is the first time catalog will be loaded using remote's catalog file.
             auto LoadCatalog = [settingsRegistry](AZ::Data::AssetCatalogRequests* assetCatalogRequests)
             {
                 if (AZ::IO::FixedMaxPath assetCatalogPath;
@@ -251,6 +251,9 @@ namespace O3DELauncher
                 }
             };
             AZ::Data::AssetCatalogRequestBus::Broadcast(AZStd::move(LoadCatalog));
+
+            // Broadcast that critical assets are ready
+            AZ::ComponentApplicationLifecycle::SignalEvent(*settingsRegistry, "CriticalAssetsCompiled", R"({})");
         }
     }
 
@@ -305,10 +308,30 @@ namespace O3DELauncher
             AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey, "remote_filesystem");
         if (allowRemoteFilesystem != 0)
         {
-            // The SetInstance calls below will assert if this has already been set and we don't clear first
+            using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
+
             // Application::StartCommon will set a LocalFileIO base first.
             // This provides an opportunity for the RemoteFileIO to override the direct instance
             auto remoteFileIo = new AZ::IO::RemoteFileIO(AZ::IO::FileIOBase::GetDirectInstance()); // Wrap LocalFileIO the direct instance
+
+            // Locally resolve the aliases to themselves to leave them intact,
+            // they will be resolved by the remote file system.
+            remoteFileIo->SetAlias("@engroot@", "@engroot@");
+            remoteFileIo->SetAlias("@projectroot@", "@projectroot@");
+            remoteFileIo->SetAlias("@products@", "@products@");
+            remoteFileIo->SetAlias("@user@", "@user@");
+            remoteFileIo->SetAlias("@log@", "@log@");
+            remoteFileIo->SetAlias("@usercache@", "@usercache@");
+            settingsRegistry->Set(FixedValueString(AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) + "/engine_path", "@engroot@");
+            settingsRegistry->Set(FixedValueString(AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) + "/project_path", "@projectroot@");
+            settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder, "@engroot@");
+            settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath, "@projectroot@");
+            settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_CacheRootFolder, "@products@");
+            settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectUserPath, "@user@");
+            settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectLogPath, "@log@");
+            settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_DevWriteStorage, "@usercache@");
+
+            // SetDirectInstance will assert if this has already been set and we don't clear first
             AZ::IO::FileIOBase::SetDirectInstance(nullptr);
             // Wrap AZ:IO::LocalFileIO the direct instance
             AZ::IO::FileIOBase::SetDirectInstance(remoteFileIo);
@@ -490,11 +513,15 @@ namespace O3DELauncher
             AZ::Interface<AZ::IConsole>::Get()->PerformCommand("sv_isDedicated false");
         }
 
-        bool remoteFileSystemEnabled{};
+        AZ::s64 remoteFileSystemEnabled{};
         AZ::SettingsRegistryMergeUtils::PlatformGet(*settingsRegistry, remoteFileSystemEnabled,
             AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey, "remote_filesystem");
-        if (remoteFileSystemEnabled)
+        if (remoteFileSystemEnabled != 0)
         {
+            // Reset local variable pathToAssets now that it's using remote file system
+            pathToAssets = "";
+            settingsRegistry->Get(pathToAssets, AZ::SettingsRegistryMergeUtils::FilePathKey_CacheRootFolder);
+
             AZ_TracePrintf("Launcher", "Application is configured for VFS");
             AZ_TracePrintf("Launcher", "Log and cache files will be written to the Cache directory on your host PC");
 


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Fixes android running using VFS.
APK only has binaries in it, minimum assets necessary to launch the app and setup VFS will be in sdcard ("/sdcard/Android/data/com.o3de.PROJECT/files"), all the assets will be obtained via network connecting to a PC ("PROJECT/Cache/android/").

The main issue was to sort out the aliases and settings registry paths in a way that the files keep the alias when sent to the remote system for it to resolve it remotely and find the files in the PC cache correctly. 

Known issues:
- It prints out errors indicating `@log@/Game.log` couldn't be created. To be fixed in a subsequent PR.

## How was this PR tested?

These 2 fixes are necessary as well to package and deploy correctly the assets:
- https://github.com/o3de/o3de/pull/10323
- https://github.com/o3de/o3de/pull/10366

<html>
<body>
<!--StartFragment--><p style="margin: 10px 0px 0px; padding: 0px; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Full Build Steps</p><ul style="margin: 10px 0px 0px; list-style-type: disc; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Modify "o3de\Registry\bootstrap.setreg" by setting the variables "<strong>android_remote_filesystem</strong>", "<strong>android_connect_to_remote</strong>" and "<strong>android_wait_for_connect</strong>" to 1.</li><li>Generate solution: Run generate_android_project.py script using options "--asset-mode VFS"</li><li>Build apk: BUILD_FOLDER&gt;.\gradlew assembleProfile</li><li>Deploy apk and minimum assets: Run deploy_android.py script using option "-t BOTH"<ul style="margin: 0px; list-style-type: disc;"><li><span style="color: rgb(255, 0, 0);"><strong>BUG</strong></span>: Minimum assets are not copied into sdcard at the moment due to an "<em>remote secure_mkdirs failed: Operation not permitted</em>" error from adb push command.<br>Workaround: On windows explorer open the mobile device, navigate to "Android\data", create folder "org.o3de.PROJECT\files\" and copy all the files from "BUILD_FOLDER\app\src\assets" into it.</li></ul></li><li>With the mobile device connected to PC run this command from the console: <code class="notranslate" style="font-family: SFMono-Medium, &quot;SF Mono&quot;, &quot;Segoe UI Mono&quot;, &quot;Roboto Mono&quot;, &quot;Ubuntu Mono&quot;, Menlo, Courier, monospace;">adb reverse tcp:45643 tcp:45643</code><br><span>IMPORTANT</span>: this command to reverse the port needs to be run often. For example, each time the device is plugged-in or refuse-connections messages are shown in the log. Adb connection is quite temperamental and the connection gets restarted, when that happens the port goes to its original status.</li></ul><p style="margin: 10px 0px 0px; padding: 0px; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Iteration Steps each time <strong>code changes</strong>:</p><ul style="margin: 10px 0px 0px; list-style-type: disc; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Build apk: Run .\gradlew assembleProfile from BUILD_FOLDER.</li><li>Deploy apk: Run deploy_android.py script using option "-t APK". WARNING: using "--clean" option will delete the app and its sdcard data, only use when necessary.</li></ul><p style="margin: 10px 0px 0px; padding: 0px; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Iteration Steps each time <strong>assets change</strong>:</p><ul style="margin: 10px 0px 0px; list-style-type: disc; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Nothing, just relaunch app.</li></ul><p style="margin: 10px 0px 0px; padding: 0px; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Iteration Steps each time a <strong>minimal asset changes</strong>:</p><ul style="margin: 10px 0px 0px; list-style-type: disc; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><p class="auto-cursor-target" style="margin: 0px; padding: 0px;">Regenerate minimum assets layout: Run these 2 commands from BUILD_FOLDER</p>
.\gradlew syncLYLayoutModeProfile

.\gradlew copyRegistryFolderProfile
</li><li>Deploy minimum assets: Run deploy_android.py script using option "-t ASSETS". Avoid using "--clean" option unless necessary, without it it will copy only the files that have changed.<ul style="margin: 0px; list-style-type: disc;"><li><span style="color: rgb(255, 0, 0);"><strong>BUG</strong></span>: Assets are not copied into sdcard at the moment due to an "<em>remote secure_mkdirs failed: Operation not permitted</em>" error from adb push command.<br>Workaround: On windows explorer open the mobile device, navigate to "Android\data", create folder "org.o3de.PROJECT\files\" and copy all the files from "BUILD_FOLDER\app\src\assets" into it.</li></ul></li><li>What changes affect minimal assets?<ul style="margin: 0px; list-style-type: disc;"><li>Adding/Removing gems to the project.</li><li>o3de/engine.json file changes.</li><li>Any .setreg file changes. (To be improved in the future by separating into another file the options necessary to launch the app and setup VFS, but at the moment it's all baked into one setreg file)</li><li>Any changes in config files from "PROJECT\Cache\android\config" (To be improved in the future)</li></ul></li></ul><!--EndFragment-->
</body>
</html>
