### PR TITLE
Add disconnecting state to TcpConnection

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpConnection.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpConnection.cpp
@@ -235,6 +235,13 @@ namespace AzNetworking
         {
             return true;
         }
+        if (m_state == ConnectionState::Disconnecting)
+        {
+            AZStd::string reasonString = ToString(reason);
+            AZLOG_ERROR("Disconnecting an already disconnecting connection due to %s", reasonString.c_str());
+            return false;
+        }
+        m_state = ConnectionState::Disconnecting;
         m_networkInterface.GetConnectionListener().OnDisconnect(this, reason, endpoint);
         m_networkInterface.RequestDisconnect(this, reason);
         m_state = ConnectionState::Disconnected;


### PR DESCRIPTION
This change adds the Disconnecting state to TcpConnection. This allows for disconnect callbacks examining connections to not view the disconnecting connection as active. It also prevents disconnect callbacks from being potentially invoked in an infinite loop.

Signed-off-by: puvvadar <puvvadar@amazon.com>