### PR TITLE
Enum support improvements

### DIFF
--- a/Code/Framework/AzCore/AzCore/Console/ConsoleDataWrapper.inl
+++ b/Code/Framework/AzCore/AzCore/Console/ConsoleDataWrapper.inl
@@ -99,7 +99,7 @@ namespace AZ
         const BASE_TYPE currentValue = this->m_value;
         BASE_TYPE newValue = currentValue;
 
-        if (ConsoleTypeHelpers::StringSetToValue(newValue, arguments))
+        if (ConsoleTypeHelpers::ToValue(newValue, arguments))
         {
             if (newValue != currentValue)
             {
@@ -117,7 +117,7 @@ namespace AZ
     void ConsoleDataWrapper<BASE_TYPE, THREAD_SAFETY>::ValueToString(CVarFixedString& outString) const
     {
         const BASE_TYPE currentValue = this->m_value;
-        outString = ConsoleTypeHelpers::ValueToString(currentValue);
+        outString = ConsoleTypeHelpers::ToString(currentValue);
     }
 
     template <typename BASE_TYPE, ThreadSafety THREAD_SAFETY>

--- a/Code/Framework/AzCore/AzCore/Console/ConsoleFunctor.inl
+++ b/Code/Framework/AzCore/AzCore/Console/ConsoleFunctor.inl
@@ -43,7 +43,7 @@ namespace AZ
             return resultCode;
         }
 
-        return ConsoleTypeHelpers::StringToValue(outResult, buffer)
+        return ConsoleTypeHelpers::ToValue(outResult, buffer)
             ? GetValueResult::Success
             : GetValueResult::TypeNotConvertible;
     }

--- a/Code/Framework/AzCore/AzCore/Console/ConsoleTypeHelpers.h
+++ b/Code/Framework/AzCore/AzCore/Console/ConsoleTypeHelpers.h
@@ -10,32 +10,32 @@
 
 #include <AzCore/base.h>
 #include <AzCore/Console/IConsoleTypes.h>
-#include <AzCore/std/string/string.h>
+#include <AzCore/std/string/conversions.h>
+#include <AzCore/std/string/string_view.h>
 
-namespace AZ
+namespace AZ::ConsoleTypeHelpers
 {
-    namespace ConsoleTypeHelpers
-    {
-        //! Helper function for converting a typed value to a string representation.
-        //! @param value the value instance to convert to a string
-        //! @return the string representation of the value
-        template <typename TYPE>
-        CVarFixedString ValueToString(const TYPE& value);
+    //! Helper function for converting a typed value to a string representation.
+    //! @param value the value instance to convert to a string
+    //! @return the string representation of the value
+    template <typename TYPE>
+    auto ValueToString(const TYPE& value)
+        -> AZStd::enable_if_t<AZStd::is_void_v<decltype(AZStd::to_string(AZStd::declval<CVarFixedString&>(), AZStd::declval<TYPE>()))>, CVarFixedString>;
 
-        //! Helper function for converting a set of strings to a value.
-        //! @param outValue  the value instance to write to
-        //! @param arguments the value instance to convert to a string
-        //! @return boolean true on success, false if there was a conversion error
-        template <typename TYPE>
-        bool StringSetToValue(TYPE& outValue, const AZ::ConsoleCommandContainer& arguments);
+    //! Helper function for converting a set of strings to a value.
+    //! Must be either overloaded(preferred) or specialized for type
+    //! @param outValue  the value instance to write to
+    //! @param arguments the value instance to convert to a string
+    //! @return boolean true on success, false if there was a conversion error
+    template <typename TYPE>
+    bool StringSetToValue(TYPE& outValue, const AZ::ConsoleCommandContainer& arguments) = delete;
 
-        //! Helper function for converting a typed value to a string representation.
-        //! @param outValue the value instance to write to
-        //! @param string   the string to 
-        //! @return boolean true on success, false if there was a conversion error
-        template <typename _TYPE>
-        bool StringToValue(_TYPE& outValue, AZStd::string_view string);
-    }
+    //! Helper function for converting a typed value to a string representation.
+    //! @param outValue the value instance to write to
+    //! @param string   the string to 
+    //! @return boolean true on success, false if there was a conversion error
+    template <typename _TYPE>
+    bool StringToValue(_TYPE& outValue, AZStd::string_view string);
 }
 
 #include <AzCore/Console/ConsoleTypeHelpers.inl>

--- a/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
@@ -88,32 +88,7 @@ namespace AZ::Debug
 
     AZ_CVAR_SCOPED(int, bg_traceLogLevel, DefaultLogLevel, nullptr, ConsoleFunctorFlags::Null, "Enable trace message logging in release mode.  0=disabled, 1=errors, 2=warnings, 3=info.");
     AZ_CVAR_SCOPED(bool, bg_alwaysShowCallstack, false, nullptr, ConsoleFunctorFlags::Null, "Force stack trace output without allowing ebus interception.");
-}
 
-namespace AZ::ConsoleTypeHelpers
-{
-    template<>
-    inline CVarFixedString ValueToString<AZ::Debug::RedirectCStream>(const AZ::Debug::RedirectCStream& value)
-    {
-        return ConvertString(AZStd::to_string(static_cast<AZStd::underlying_type_t<AZ::Debug::RedirectCStream>>(value)));
-    }
-
-    template<>
-    inline bool StringSetToValue<AZ::Debug::RedirectCStream>(AZ::Debug::RedirectCStream& outValue,
-        const AZ::ConsoleCommandContainer& arguments)
-    {
-        AZStd::underlying_type_t<AZ::Debug::RedirectCStream> underlyingValue;
-        const bool result = StringSetToValue(underlyingValue, arguments);
-        if (result)
-        {
-            outValue = AZ::Debug::RedirectCStream(underlyingValue);
-        }
-        return result;
-    }
-}
-
-namespace AZ::Debug
-{
     // Allow redirection of trace raw output writes to stdout, stderr or to /dev/null
     static constexpr const char* fileStreamIdentifier = "raw_c_stream";
     static AZ::EnvironmentVariable<FILE*> s_fileStream;
@@ -141,7 +116,8 @@ namespace AZ::Debug
 
     AZ_CVAR_SCOPED(RedirectCStream, bg_redirectrawoutput, RedirectCStream::Stdout, SetCFileStream, ConsoleFunctorFlags::Null,
         "Set to the value of the C stream FILE* object to write raw trace output."
-        " Defaults to the stdout FILE stream");
+        " Defaults to the stdout FILE stream."
+        " Valid values are 0 = stdout, 1 = stderr, 2 = redirect to NUL");
 
 
     /**

--- a/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AzCore/std/containers/array.h>
+#include <AzCore/Preprocessor/Enum.h>
 #include <AzCore/std/typetraits/is_pointer.h>
 #include <AzCore/std/typetraits/is_const.h>
 #include <AzCore/std/typetraits/is_enum.h>
@@ -510,7 +511,17 @@ namespace AZ
     struct AzTypeInfo<T, true /* is_enum */>
     {
         typedef typename AZStd::RemoveEnum<T>::type UnderlyingType;
-        static constexpr const char* Name() { return "<enum>"; }
+        static constexpr const char* Name()
+        {
+            if constexpr (AZ::HasAzEnumTraits_v<T>)
+            {
+                return AzEnumTraits<T>::EnumName.data();
+            }
+            else
+            {
+                return "[enum]";
+            }
+        }
         template<typename TypeIdResolverTag = CanonicalTypeIdTag>
         static const AZ::TypeId& Uuid() { static AZ::TypeId nullUuid = AZ::TypeId::CreateNull(); return nullUuid; }
         static constexpr TypeTraits GetTypeTraits()

--- a/Code/Framework/AzCore/AzCore/RTTI/TypeSafeIntegral.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TypeSafeIntegral.h
@@ -34,27 +34,9 @@ namespace AZStd
 
 //! This implements cvar binding methods for a type safe integral alias.
 //! This must be placed in global scope (not in a namespace) and the TYPE_NAME should be fully qualified.
-#define AZ_TYPE_SAFE_INTEGRAL_CVARBINDING(TYPE_NAME)                                                                                                \
-    namespace AZ::ConsoleTypeHelpers                                                                                                                \
-    {                                                                                                                                               \
-        template <>                                                                                                                                 \
-        inline CVarFixedString ValueToString<TYPE_NAME>(const TYPE_NAME& value)                                                                     \
-        {                                                                                                                                           \
-            return ConvertString(AZStd::to_string(static_cast<AZStd::underlying_type<TYPE_NAME>::type>(value)));                                    \
-        }                                                                                                                                           \
-                                                                                                                                                    \
-        template <>                                                                                                                                 \
-        inline bool StringSetToValue<TYPE_NAME>(TYPE_NAME& outValue, const AZ::ConsoleCommandContainer& arguments)                                  \
-        {                                                                                                                                           \
-            AZStd::underlying_type<TYPE_NAME>::type underlyingValue;                                                                                \
-            const bool result = StringSetToValue(underlyingValue, arguments);                                                                       \
-            if (result)                                                                                                                             \
-            {                                                                                                                                       \
-                outValue = TYPE_NAME(underlyingValue);                                                                                              \
-            }                                                                                                                                       \
-            return result;                                                                                                                          \
-        }                                                                                                                                           \
-    }
+//! O3DE_DEPRECATED This macro no longer needs to be used
+//! The ConsoleTypeHelpers automatically support cvar bindings for Enums
+#define AZ_TYPE_SAFE_INTEGRAL_CVARBINDING(TYPE_NAME)
 
 #define AZ_TYPE_SAFE_INTEGRAL_SERIALIZEBINDING(TYPE_NAME) \
     namespace AZStd \

--- a/Code/Framework/AzCore/AzCore/std/containers/fixed_vector.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/fixed_vector.h
@@ -9,8 +9,8 @@
 
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/std/algorithm.h>
-#include <AzCore/std/concepts/concepts.h>
 #include <AzCore/std/createdestroy.h>
+#include <AzCore/std/ranges/ranges.h>
 #include <AzCore/std/typetraits/typetraits.h>
 
 namespace AZStd::Internal
@@ -437,10 +437,11 @@ namespace AZStd
             rhs.clear();
         }
 
-        // Extension csontructor for copying other vector like container types
-        // into a fixed_vector given that the type in question isn't the same type as this fixed_vector type
+        // Extension constructor for copying other container types that models a span
+        // into a fixed_vector
         template <typename VectorContainer, typename = AZStd::enable_if_t<!AZStd::is_same_v<VectorContainer, fixed_vector>
-            && !AZStd::is_convertible_v<VectorContainer, size_type>>>
+            && !AZStd::is_convertible_v<VectorContainer, size_type>
+            && AZStd::constructible_from<value_type, AZStd::ranges::range_reference_t<VectorContainer>>>>
         fixed_vector(VectorContainer&& rhs)
         {
             constexpr bool is_const_or_lvalue_reference = AZStd::is_lvalue_reference_v<VectorContainer>

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/CvarAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/CvarAdapter.cpp
@@ -45,7 +45,7 @@ namespace AZ::DocumentPropertyEditor
                         {
                             buffer = aznumeric_cast<T>(value.GetDouble());
                         }
-                        (*functor)({ ConsoleTypeHelpers::ValueToString(buffer) });
+                        (*functor)({ ConsoleTypeHelpers::ToString(buffer) });
                         m_adapter->OnContentsChanged(path, value);
                     });
 
@@ -105,7 +105,7 @@ namespace AZ::DocumentPropertyEditor
                         AZStd::fixed_vector<CVarFixedString, ElementCount> newValue;
                         for (int i = 0; i < ElementCount; ++i)
                         {
-                            newValue.push_back(ConsoleTypeHelpers::ValueToString(newContainer.GetElement(i)));
+                            newValue.push_back(ConsoleTypeHelpers::ToString(newContainer.GetElement(i)));
                         }
                         (*functor)(ConsoleCommandContainer(newValue));
                         m_adapter->OnContentsChanged(path, value);
@@ -126,7 +126,7 @@ namespace AZ::DocumentPropertyEditor
                 builder.OnEditorChanged(
                     [this, functor](const Dom::Path& path, const Dom::Value& value, Nodes::PropertyEditor::ValueChangeType)
                     {
-                        (*functor)({ ConsoleTypeHelpers::ValueToString(value.GetBool()) });
+                        (*functor)({ ConsoleTypeHelpers::ToString(value.GetBool()) });
                         m_adapter->OnContentsChanged(path, value);
                     });
                 builder.EndPropertyEditor();

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -53,14 +53,12 @@ namespace AZ
 
 namespace AZ::ConsoleTypeHelpers
 {
-    template <>
     inline CVarFixedString ValueToString(const AzNetworking::ProtocolType& value)
     {
         return (value == AzNetworking::ProtocolType::Tcp) ? "tcp" : "udp";
     }
 
-    template <>
-    inline bool StringSetToValue<AzNetworking::ProtocolType>(AzNetworking::ProtocolType& outValue, const ConsoleCommandContainer& arguments)
+    inline bool StringSetToValue(AzNetworking::ProtocolType& outValue, const ConsoleCommandContainer& arguments)
     {
         if (!arguments.empty())
         {


### PR DESCRIPTION
Added a boolean to detect if a type specializes AzEnumTraits through the `HasAzEnumTraits_v` constexpr variable

The AzTypeInfo::Name method will output the name of the EnumType if that type specializes AzEnumTraits.
This occurs even if the type doesn't specialize AzTypeInfo

The AZ::Console now supports setting CVars of Enum type automatically without the need to specialized the ConsoleTypeHelpers `ValueToString` and `StringSetToValue` functions.
Additionally if the Enum type specializes the AzEnumTraits(this can be done by using the AZ_ENUM* macros), then AZ::Console also supports setting the CVar values using name of the enum option.

Fixed issue in fixed_vector extension constructor causing an ambiguous overload when attempting supply an AZStd::fixed_string<512>(CVarString) to an overloaded function accepting an AZStd::string_view and another one accepting an AZStd::fixed_string<AZStd::string_view>

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## What does this PR do?
Add support to set CVar of a enum using the Enum option name in addition to the numeric vlaue

## How was this PR tested?

Added an AzCore.Tests ConsoleTests which validates the functionality.

Defining an Enum as follows using the AZ_ENUM* family of macros
```
AZ_ENUM_CLASS(ConsoleTestEnum,
    Option1,
    (Option2, 5),
    Option3);
```
And setting a CVar with the type of that enum
```
AZ_CVAR(ConsoleTestEnum, testEnum, ConsoleTestEnum::Option1, nullptr, ConsoleFunctorFlags::Null,
    "Supports setting the ConsoleTestEnum via the string or integer argument."
    " Option1/0 sets the CVar to the Option1 value"
    ", Option2/5 sets the CVar to the Option2 value"
    ", Option3/6 sets the CVar to the Option3 value");
```

The AZ::Console will allow setting the enum value without using the name of the option
```
testEnum 0 # Sets the value to 0 
testEnum Option1 # Sets the value to 0 since Option1 = 0
testEnum Option2 # Sets the value to 5 since Option2 = 5
testEnum 3 # Sets the value to 3
```