### PR TITLE
Removing special invalid entity ID data type from landscape canvas

### DIFF
--- a/Gems/GraphModel/Code/Include/GraphModel/Model/Slot.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/Slot.h
@@ -121,11 +121,11 @@ namespace GraphModel
         SlotDirection GetSlotDirection() const;  
         SlotType GetSlotType() const;        
 
-        //! Returns whether slot value is relevent to this slot's configuration
-        bool SupportsValue() const;
+        //! Returns true if this slot supports assigning values 
+        bool SupportsValues() const;
 
-        //! Returns whether slot data type is relevent to this slot's configuration
-        bool SupportsDataType() const;
+        //! Returns true if this slot supports data types
+        bool SupportsDataTypes() const;
 
         //! Returns whether this slot's configuration allows connections to other slots
         bool SupportsConnections() const;
@@ -234,8 +234,8 @@ namespace GraphModel
         bool Is(SlotDirection slotDirection, SlotType slotType) const;
         SlotDirection GetSlotDirection() const;
         SlotType GetSlotType() const;
-        bool SupportsValue() const;
-        bool SupportsDataType() const;
+        bool SupportsValues() const;
+        bool SupportsDataTypes() const;
         bool SupportsConnections() const;
         bool SupportsExtendability() const;
         const SlotName& GetName() const;                    //!< Valid for all slot configurations
@@ -333,7 +333,7 @@ namespace GraphModel
 
         #if defined(AZ_ENABLE_TRACING)
             DataTypePtr dataTypeUsed = GetDataTypeForTypeId(azrtti_typeid<T>());
-            AssertWithTypeInfo(SupportsValue(), dataTypeUsed, "This slot type does not support values");
+            AssertWithTypeInfo(SupportsValues(), dataTypeUsed, "This slot type does not support values");
             AssertWithTypeInfo(IsSupportedDataType(dataTypeUsed), dataTypeUsed, "Slot::GetValue used with the wrong type");
             AssertWithTypeInfo(nullptr != pValue, dataTypeUsed, "m_value does not hold data of the appropriate type");
         #endif

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Core/DataTypes.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Core/DataTypes.h
@@ -19,15 +19,13 @@ namespace LandscapeCanvas
 {
     enum LandscapeCanvasDataTypeEnum
     {
-        InvalidEntity = 0,  // Need a special case data type for the AZ::EntityId::InvalidEntityId to handle the default value since we are re-using the AZ::EntityId type in several node data types
-        Bounds,
+        Bounds = 0,
         Gradient,
         Area,
         String,
         Count
     };
 
-    static const AZ::Uuid InvalidEntityTypeId = "{4CD676F4-2C6E-43A4-8477-623640477D32}";
     static const AZ::Uuid BoundsTypeId = "{746398F1-0325-4A56-A544-FEF561C24E7C}";
     static const AZ::Uuid GradientTypeId = "{F38CF64A-1EB6-41FA-A2CC-73D19B48E59E}";
     static const AZ::Uuid AreaTypeId = "{FE1878D9-D445-4652-894B-D6348706EEAE}";

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Core/GraphContext.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Core/GraphContext.cpp
@@ -40,22 +40,10 @@ namespace LandscapeCanvas
         : GraphModel::GraphContext(SYSTEM_NAME, MODULE_FILE_EXTENSION, {})
     {
         // Construct our custom data types
-        const AZ::EntityId invalidEntity;
-        const AZStd::any defaultValue(invalidEntity);
         const AZStd::string cppName = "AZ::EntityId";
-        auto validEntityIdValidator = [](const AZStd::any& value)
-        {
-            return value.is<AZ::EntityId>() && AZStd::any_cast<AZ::EntityId>(value).IsValid();
-        };
-        auto invalidEntityIdValidator = [](const AZStd::any& value)
-        {
-            return value.empty() || (value.is<AZ::EntityId>() && !AZStd::any_cast<AZ::EntityId>(value).IsValid());
-        };
-
-        m_dataTypes.push_back(AZStd::make_shared<GraphModel::DataType>(LandscapeCanvasDataTypeEnum::InvalidEntity, InvalidEntityTypeId, defaultValue, "InvalidEntity", cppName, invalidEntityIdValidator));
-        m_dataTypes.push_back(AZStd::make_shared<GraphModel::DataType>(LandscapeCanvasDataTypeEnum::Bounds, BoundsTypeId, defaultValue, "Bounds", cppName, validEntityIdValidator));
-        m_dataTypes.push_back(AZStd::make_shared<GraphModel::DataType>(LandscapeCanvasDataTypeEnum::Gradient, GradientTypeId, defaultValue, "Gradient", cppName, validEntityIdValidator));
-        m_dataTypes.push_back(AZStd::make_shared<GraphModel::DataType>(LandscapeCanvasDataTypeEnum::Area, AreaTypeId, defaultValue, "Area", cppName, validEntityIdValidator));
+        m_dataTypes.push_back(AZStd::make_shared<GraphModel::DataType>(LandscapeCanvasDataTypeEnum::Bounds, BoundsTypeId, AZStd::any(AZ::EntityId()), "Bounds", cppName));
+        m_dataTypes.push_back(AZStd::make_shared<GraphModel::DataType>(LandscapeCanvasDataTypeEnum::Gradient, GradientTypeId, AZStd::any(AZ::EntityId()), "Gradient", cppName));
+        m_dataTypes.push_back(AZStd::make_shared<GraphModel::DataType>(LandscapeCanvasDataTypeEnum::Area, AreaTypeId, AZStd::any(AZ::EntityId()), "Area", cppName));
 
         // Construct basic data types
         const AZ::Uuid stringTypeUuid = azrtti_typeid<AZStd::string>();

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/AltitudeFilterNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/AltitudeFilterNode.cpp
@@ -43,14 +43,13 @@ namespace LandscapeCanvas
 
     void AltitudeFilterNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             PIN_TO_SHAPE_SLOT_ID,
             PIN_TO_SHAPE_SLOT_LABEL.toUtf8().constData(),
-            { boundsDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { boundsDataType },
+            AZStd::any(AZ::EntityId()),
             PIN_TO_SHAPE_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
     }
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/DistributionFilterNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/DistributionFilterNode.cpp
@@ -43,14 +43,13 @@ namespace LandscapeCanvas
 
     void DistributionFilterNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_GRADIENT_SLOT_ID,
             INBOUND_GRADIENT_SLOT_LABEL.toUtf8().constData(),
-            { gradientDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
             INBOUND_GRADIENT_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
     }
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/ShapeIntersectionFilterNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/ShapeIntersectionFilterNode.cpp
@@ -43,14 +43,13 @@ namespace LandscapeCanvas
 
     void ShapeIntersectionFilterNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_SHAPE_SLOT_ID,
             INBOUND_SHAPE_SLOT_LABEL.toUtf8().constData(),
-            { boundsDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { boundsDataType },
+            AZStd::any(AZ::EntityId()),
             INBOUND_SHAPE_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
     }
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/PositionModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/PositionModifierNode.cpp
@@ -43,28 +43,27 @@ namespace LandscapeCanvas
 
     void PositionModifierNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             BaseAreaModifierNode::INBOUND_GRADIENT_X_SLOT_ID,
             BaseAreaModifierNode::INBOUND_GRADIENT_X_SLOT_LABEL.toUtf8().constData(),
-            { gradientDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
             BaseAreaModifierNode::INBOUND_GRADIENT_X_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             BaseAreaModifierNode::INBOUND_GRADIENT_Y_SLOT_ID,
             BaseAreaModifierNode::INBOUND_GRADIENT_Y_SLOT_LABEL.toUtf8().constData(),
-            { gradientDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
             BaseAreaModifierNode::INBOUND_GRADIENT_Y_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             BaseAreaModifierNode::INBOUND_GRADIENT_Z_SLOT_ID,
             BaseAreaModifierNode::INBOUND_GRADIENT_Z_SLOT_LABEL.toUtf8().constData(),
-            { gradientDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
             BaseAreaModifierNode::INBOUND_GRADIENT_Z_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
     }
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/RotationModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/RotationModifierNode.cpp
@@ -43,28 +43,27 @@ namespace LandscapeCanvas
 
     void RotationModifierNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             BaseAreaModifierNode::INBOUND_GRADIENT_X_SLOT_ID,
             BaseAreaModifierNode::INBOUND_GRADIENT_X_SLOT_LABEL.toUtf8().constData(),
-            { gradientDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
             BaseAreaModifierNode::INBOUND_GRADIENT_X_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             BaseAreaModifierNode::INBOUND_GRADIENT_Y_SLOT_ID,
             BaseAreaModifierNode::INBOUND_GRADIENT_Y_SLOT_LABEL.toUtf8().constData(),
-            { gradientDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
             BaseAreaModifierNode::INBOUND_GRADIENT_Y_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             BaseAreaModifierNode::INBOUND_GRADIENT_Z_SLOT_ID,
             BaseAreaModifierNode::INBOUND_GRADIENT_Z_SLOT_LABEL.toUtf8().constData(),
-            { gradientDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
             BaseAreaModifierNode::INBOUND_GRADIENT_Z_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
     }
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/ScaleModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/ScaleModifierNode.cpp
@@ -43,14 +43,13 @@ namespace LandscapeCanvas
 
     void ScaleModifierNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_GRADIENT_SLOT_ID,
             INBOUND_GRADIENT_SLOT_LABEL.toUtf8().constData(),
-            { gradientDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
             INBOUND_GRADIENT_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
     }
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/SlopeAlignmentModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/SlopeAlignmentModifierNode.cpp
@@ -43,14 +43,13 @@ namespace LandscapeCanvas
 
     void SlopeAlignmentModifierNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_GRADIENT_SLOT_ID,
             INBOUND_GRADIENT_SLOT_LABEL.toUtf8().constData(),
-            { gradientDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
             INBOUND_GRADIENT_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
     }
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaSelectors/AssetWeightSelectorNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaSelectors/AssetWeightSelectorNode.cpp
@@ -70,14 +70,13 @@ namespace LandscapeCanvas
 
     void AssetWeightSelectorNode::RegisterSlots()
     {
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_GRADIENT_SLOT_ID,
             INBOUND_GRADIENT_SLOT_LABEL.toUtf8().constData(),
-            { gradientDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
             INBOUND_GRADIENT_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
     }
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/AreaBlenderNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/AreaBlenderNode.cpp
@@ -45,7 +45,6 @@ namespace LandscapeCanvas
     {
         CreateEntityNameSlot();
 
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr areaDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Area);
 
         GraphModel::ExtendableSlotConfiguration slotConfig;
@@ -54,8 +53,8 @@ namespace LandscapeCanvas
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_AREA_SLOT_ID,
             INBOUND_AREA_SLOT_LABEL.toUtf8().constData(),
-            { areaDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { areaDataType },
+            AZStd::any(AZ::EntityId()),
             INBOUND_AREA_INPUT_SLOT_DESCRIPTION.toUtf8().constData(),
             &slotConfig));
 

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/BaseAreaNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/BaseAreaNode.cpp
@@ -76,15 +76,14 @@ namespace LandscapeCanvas
     {
         CreateEntityNameSlot();
 
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
         GraphModel::DataTypePtr areaDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Area);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             PLACEMENT_BOUNDS_SLOT_ID,
             PLACEMENT_BOUNDS_SLOT_LABEL.toUtf8().constData(),
-            { boundsDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { boundsDataType },
+            AZStd::any(AZ::EntityId()),
             PLACEMENT_BOUNDS_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
 
         RegisterSlot(GraphModel::SlotDefinition::CreateOutputData(

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/BaseGradientModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/BaseGradientModifierNode.cpp
@@ -53,22 +53,21 @@ namespace LandscapeCanvas
     {
         CreateEntityNameSlot();
 
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
         GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             PREVIEW_BOUNDS_SLOT_ID,
             PREVIEW_BOUNDS_SLOT_LABEL.toUtf8().constData(),
-            { boundsDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { boundsDataType },
+            AZStd::any(AZ::EntityId()),
             PREVIEW_BOUNDS_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_GRADIENT_SLOT_ID,
             INBOUND_GRADIENT_SLOT_LABEL.toUtf8().constData(),
-            { gradientDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
             INBOUND_GRADIENT_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
 
         RegisterSlot(GraphModel::SlotDefinition::CreateOutputData(

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/GradientMixerNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/GradientMixerNode.cpp
@@ -70,15 +70,14 @@ namespace LandscapeCanvas
     {
         CreateEntityNameSlot();
 
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
         GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             PREVIEW_BOUNDS_SLOT_ID,
             PREVIEW_BOUNDS_SLOT_LABEL.toUtf8().constData(),
-            { boundsDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { boundsDataType },
+            AZStd::any(AZ::EntityId()),
             PREVIEW_BOUNDS_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
 
         GraphModel::ExtendableSlotConfiguration slotConfig;
@@ -87,8 +86,8 @@ namespace LandscapeCanvas
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_GRADIENT_SLOT_ID,
             INBOUND_GRADIENT_SLOT_LABEL.toUtf8().constData(),
-            { gradientDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
             INBOUND_GRADIENT_INPUT_SLOT_DESCRIPTION.toUtf8().constData(),
             &slotConfig));
 

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/AltitudeGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/AltitudeGradientNode.cpp
@@ -46,14 +46,13 @@ namespace LandscapeCanvas
         BaseGradientNode::RegisterSlots();
 
         // Altitude Gradient has an additional input slot for an inbound shape
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             PIN_TO_SHAPE_SLOT_ID,
             PIN_TO_SHAPE_SLOT_LABEL.toUtf8().constData(),
-            { boundsDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { boundsDataType },
+            AZStd::any(AZ::EntityId()),
             PIN_TO_SHAPE_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
     }
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/BaseGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/BaseGradientNode.cpp
@@ -51,15 +51,14 @@ namespace LandscapeCanvas
     {
         CreateEntityNameSlot();
 
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
         GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             PREVIEW_BOUNDS_SLOT_ID,
             PREVIEW_BOUNDS_SLOT_LABEL.toUtf8().constData(),
-            { boundsDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { boundsDataType },
+            AZStd::any(AZ::EntityId()),
             PREVIEW_BOUNDS_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
 
         RegisterSlot(GraphModel::SlotDefinition::CreateOutputData(

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/GradientBakerNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/GradientBakerNode.cpp
@@ -57,22 +57,21 @@ namespace LandscapeCanvas
     {
         CreateEntityNameSlot();
 
-        GraphModel::DataTypePtr invalidEntityDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr boundsDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
         GraphModel::DataTypePtr gradientDataType = GraphContext::GetInstance()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INPUT_BOUNDS_SLOT_ID,
             INPUT_BOUNDS_SLOT_LABEL.toUtf8().constData(),
-            { boundsDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { boundsDataType },
+            AZStd::any(AZ::EntityId()),
             INPUT_BOUNDS_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_GRADIENT_SLOT_ID,
             INBOUND_GRADIENT_SLOT_LABEL.toUtf8().constData(),
-            { gradientDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
             INBOUND_GRADIENT_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
     }
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ShapeAreaFalloffGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ShapeAreaFalloffGradientNode.cpp
@@ -46,14 +46,13 @@ namespace LandscapeCanvas
         BaseGradientNode::RegisterSlots();
 
         // Shape Falloff Gradient has an additional input slot for an inbound shape
-        GraphModel::DataTypePtr invalidEntityDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::InvalidEntity);
         GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
 
         RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
             INBOUND_SHAPE_SLOT_ID,
             INBOUND_SHAPE_SLOT_LABEL.toUtf8().constData(),
-            { boundsDataType, invalidEntityDataType },
-            invalidEntityDataType->GetDefaultValue(),
+            { boundsDataType },
+            AZStd::any(AZ::EntityId()),
             INBOUND_SHAPE_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
     }
 } // namespace LandscapeCanvas


### PR DESCRIPTION
## What does this PR do?
This custom data type and its special logic are no longer needed after changes to graph model to support multiple data types per slot.
Having this special data type also broke custom slot coloring after those changes.
Updated some function names and commenting per feedback from a prior PR.
Still debugging loss of automatic connections between landscape nodes with @cgalvan.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>

## How was this PR tested?
Tested restored highlighting to slots with corresponding type IDs