### PR TITLE
make white box collider component incompatible with rigid body component

### DIFF
--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.h
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.h
@@ -66,6 +66,7 @@ namespace PhysX
             incompatible.push_back(AZ_CRC("PhysXRigidBodyService", 0x1d4c64a8));
             incompatible.push_back(AZ_CRC("PhysicsService", 0xa7350d22));
             incompatible.push_back(AZ_CRC("LegacyCryPhysicsService", 0xbb370351));
+            incompatible.push_back(AZ_CRC_CE("PhysicsStaticRigidBodyService"));
         }
 
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)

--- a/Gems/PhysX/Code/Source/RigidBodyComponent.h
+++ b/Gems/PhysX/Code/Source/RigidBodyComponent.h
@@ -53,6 +53,7 @@ namespace PhysX
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
         {
             incompatible.push_back(AZ_CRC("PhysXRigidBodyService", 0x1d4c64a8));
+            incompatible.push_back(AZ_CRC_CE("PhysicsStaticRigidBodyService"));
             incompatible.push_back(AZ_CRC("PhysicsService", 0xa7350d22));
         }
 

--- a/Gems/WhiteBox/Code/Source/Components/EditorWhiteBoxColliderComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/Components/EditorWhiteBoxColliderComponent.cpp
@@ -62,6 +62,7 @@ namespace WhiteBox
     void EditorWhiteBoxColliderComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
     {
         provided.push_back(AZ_CRC("WhiteBoxColliderService", 0x480d5b06));
+        provided.push_back(AZ_CRC_CE("PhysicsStaticRigidBodyService"));
     }
 
     void EditorWhiteBoxColliderComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)

--- a/Gems/WhiteBox/Code/Source/Components/WhiteBoxColliderComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/Components/WhiteBoxColliderComponent.cpp
@@ -33,6 +33,11 @@ namespace WhiteBox
         }
     }
 
+    void WhiteBoxColliderComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("PhysicsStaticRigidBodyService"));
+    }
+
     void WhiteBoxColliderComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC("TransformService", 0x8ee22c50));

--- a/Gems/WhiteBox/Code/Source/Components/WhiteBoxColliderComponent.h
+++ b/Gems/WhiteBox/Code/Source/Components/WhiteBoxColliderComponent.h
@@ -36,6 +36,7 @@ namespace WhiteBox
         WhiteBoxColliderComponent& operator=(const WhiteBoxColliderComponent&) = delete;
 
     private:
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
 


### PR DESCRIPTION
Signed-off-by: greerdv <greerdv@amazon.com>

## What does this PR do?
Makes white box collider component incompatible with PhysX rigid body component (because the white box collider creates a rigid body itself, and since it uses a triangle mesh the rigid body can only be static or kinematic). Fixes #10349.

## How was this PR tested?
Manually verified that a rigid body component could not be added to an entity with a white box collider component.
