### PR TITLE
Send the client disconnect signal on both of client and server

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
@@ -61,7 +61,7 @@ namespace Multiplayer
 
     using ClientMigrationStartEvent = AZ::Event<ClientInputId>;
     using ClientMigrationEndEvent = AZ::Event<>;
-    using ClientDisconnectedEvent = AZ::Event<>;
+    using ClientDisconnectedEvent = AZ::Event<MultiplayerAgentType>;
     using NotifyClientMigrationEvent = AZ::Event<AzNetworking::ConnectionId, const HostId&, uint64_t, ClientInputId, NetEntityId>;
     using NotifyEntityMigrationEvent = AZ::Event<const ConstNetworkEntityHandle&, const HostId&>;
     using ConnectionAcquiredEvent = AZ::Event<MultiplayerAgentDatum>;

--- a/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
@@ -61,7 +61,7 @@ namespace Multiplayer
 
     using ClientMigrationStartEvent = AZ::Event<ClientInputId>;
     using ClientMigrationEndEvent = AZ::Event<>;
-    using ClientDisconnectedEvent = AZ::Event<MultiplayerAgentType>;
+    using EndpointDisonnectedEvent = AZ::Event<MultiplayerAgentType>;
     using NotifyClientMigrationEvent = AZ::Event<AzNetworking::ConnectionId, const HostId&, uint64_t, ClientInputId, NetEntityId>;
     using NotifyEntityMigrationEvent = AZ::Event<const ConstNetworkEntityHandle&, const HostId&>;
     using ConnectionAcquiredEvent = AZ::Event<MultiplayerAgentDatum>;
@@ -124,9 +124,9 @@ namespace Multiplayer
         //! @param handler The ClientMigrationEndEvent Handler to add
         virtual void AddClientMigrationEndEventHandler(ClientMigrationEndEvent::Handler& handler) = 0;
 
-        //! Adds a ClientDisconnectedEvent Handler which is invoked on the client when a disconnection occurs.
-        //! @param handler The ClientDisconnectedEvent Handler to add
-        virtual void AddClientDisconnectedHandler(ClientDisconnectedEvent::Handler& handler) = 0;
+        //! Adds a EndpointDisonnectedEvent Handler which is invoked on the client when a disconnection occurs.
+        //! @param handler The EndpointDisonnectedEvent Handler to add
+        virtual void AddEndpointDisonnectedHandler(EndpointDisonnectedEvent::Handler& handler) = 0;
 
         //! Adds a NotifyClientMigrationEvent Handler which is invoked when a client migrates from one host to another.
         //! @param handler The NotifyClientMigrationEvent Handler to add

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -45,6 +45,12 @@
 
 AZ_DEFINE_BUDGET(MULTIPLAYER);
 
+namespace AZ
+{
+    AZ_TYPE_INFO_SPECIALIZE(Multiplayer::MultiplayerAgentType, "{53EA1938-5FFB-4305-B50A-D20730E8639B}");
+}
+
+
 namespace AZ::ConsoleTypeHelpers
 {
     template <>
@@ -123,10 +129,15 @@ namespace Multiplayer
             behaviorContext->Class<ClientInputId>();
             behaviorContext->Class<HostFrameId>();
 
+            behaviorContext->Enum<(int)MultiplayerAgentType::Uninitialized>("MultiplayerAgentType_Uninitialized")
+                ->Enum<(int)MultiplayerAgentType::Client>("MultiplayerAgentType_Client")
+                ->Enum<(int)MultiplayerAgentType::ClientServer>("MultiplayerAgentType_ClientServer")
+                ->Enum<(int)MultiplayerAgentType::DedicatedServer>("MultiplayerAgentType_DedicatedServer");
+
             behaviorContext->Class<MultiplayerSystemComponent>("MultiplayerSystemComponent")
                 ->Attribute(AZ::Script::Attributes::Module, "multiplayer")
                 ->Attribute(AZ::Script::Attributes::Category, "Multiplayer")
-                ->Method("GetOnClientDisconnectedEvent", [](AZ::EntityId id) -> AZ::Event<>*
+                ->Method("GetOnClientDisconnectedEvent", [](AZ::EntityId id) -> ClientDisconnectedEvent*
                 {
                     AZ::Entity* entity = AZ::Interface<AZ::ComponentApplicationRequests>::Get()->FindEntity(id);
                     if (!entity)
@@ -839,7 +850,6 @@ namespace Multiplayer
         if (m_agentType == MultiplayerAgentType::Client)
         {
             AZ_Assert(connection->GetConnectionRole() == ConnectionRole::Connector, "Client connection role should only ever be Connector");
-            m_clientDisconnectedEvent.Signal();
         }
         else if (m_agentType == MultiplayerAgentType::DedicatedServer || m_agentType == MultiplayerAgentType::ClientServer)
         {
@@ -877,6 +887,8 @@ namespace Multiplayer
                 }
             }
         }
+
+        m_clientDisconnectedEvent.Signal(m_agentType);
 
         // Clean up any multiplayer connection data we've bound to this connection instance
         if (connection->GetUserData() != nullptr)

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -137,23 +137,23 @@ namespace Multiplayer
             behaviorContext->Class<MultiplayerSystemComponent>("MultiplayerSystemComponent")
                 ->Attribute(AZ::Script::Attributes::Module, "multiplayer")
                 ->Attribute(AZ::Script::Attributes::Category, "Multiplayer")
-                ->Method("GetOnClientDisconnectedEvent", [](AZ::EntityId id) -> ClientDisconnectedEvent*
+                ->Method("GetOnEndpointDisonnectedEvent", [](AZ::EntityId id) -> EndpointDisonnectedEvent*
                 {
                     AZ::Entity* entity = AZ::Interface<AZ::ComponentApplicationRequests>::Get()->FindEntity(id);
                     if (!entity)
                     {
-                        AZ_Warning("Multiplayer Property", false, "MultiplayerSystemComponent GetOnClientDisconnectedEvent failed. The entity with id %s doesn't exist, please provide a valid entity id.", id.ToString().c_str())
+                        AZ_Warning("Multiplayer Property", false, "MultiplayerSystemComponent GetOnEndpointDisonnectedEvent failed. The entity with id %s doesn't exist, please provide a valid entity id.", id.ToString().c_str())
                         return nullptr;
                     }
 
                     MultiplayerSystemComponent* mpComponent = entity->FindComponent<MultiplayerSystemComponent>();
                     if (!mpComponent)
                     {
-                        AZ_Warning("Multiplayer Property", false, "MultiplayerSystemComponent GetOnClientDisconnected failed. Entity '%s' (id: %s) is missing MultiplayerSystemComponent, be sure to add MultiplayerSystemComponent to this entity.", entity->GetName().c_str(), id.ToString().c_str())
+                        AZ_Warning("Multiplayer Property", false, "MultiplayerSystemComponent GetOnEndpointDisonnectedEvent failed. Entity '%s' (id: %s) is missing MultiplayerSystemComponent, be sure to add MultiplayerSystemComponent to this entity.", entity->GetName().c_str(), id.ToString().c_str())
                         return nullptr;
                     }
 
-                    return &mpComponent->m_clientDisconnectedEvent;
+                    return &mpComponent->m_endpointDisonnectedEvent;
                 })
                 ->Attribute(
                     AZ::Script::Attributes::AzEventDescription,
@@ -888,7 +888,7 @@ namespace Multiplayer
             }
         }
 
-        m_clientDisconnectedEvent.Signal(m_agentType);
+        m_endpointDisonnectedEvent.Signal(m_agentType);
 
         // Clean up any multiplayer connection data we've bound to this connection instance
         if (connection->GetUserData() != nullptr)
@@ -986,9 +986,9 @@ namespace Multiplayer
         handler.Connect(m_clientMigrationEndEvent);
     }
 
-    void MultiplayerSystemComponent::AddClientDisconnectedHandler(ClientDisconnectedEvent::Handler& handler)
+    void MultiplayerSystemComponent::AddEndpointDisonnectedHandler(EndpointDisonnectedEvent::Handler& handler)
     {
-        handler.Connect(m_clientDisconnectedEvent);
+        handler.Connect(m_endpointDisonnectedEvent);
     }
 
     void MultiplayerSystemComponent::AddNotifyClientMigrationHandler(NotifyClientMigrationEvent::Handler& handler)

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -144,7 +144,7 @@ namespace Multiplayer
                     {
                         AZ_Warning("Multiplayer Property", false,
                             "MultiplayerSystemComponent GetOnEndpointDisonnectedEvent failed."
-                            "The entity with id % s doesn't exist, please provide a valid entity id.",
+                            "The entity with id %s doesn't exist, please provide a valid entity id.",
                             id.ToString().c_str())
                         return nullptr;
                     }
@@ -154,7 +154,7 @@ namespace Multiplayer
                     {
                         AZ_Warning("Multiplayer Property", false,
                             "MultiplayerSystemComponent GetOnEndpointDisonnectedEvent failed."
-                            "Entity '%s' (id: % s) is missing MultiplayerSystemComponent, be sure to add MultiplayerSystemComponent to this entity.",
+                            "Entity '%s' (id: %s) is missing MultiplayerSystemComponent, be sure to add MultiplayerSystemComponent to this entity.",
                             entity->GetName().c_str(), id.ToString().c_str())
                         return nullptr;
                     }

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -142,14 +142,20 @@ namespace Multiplayer
                     AZ::Entity* entity = AZ::Interface<AZ::ComponentApplicationRequests>::Get()->FindEntity(id);
                     if (!entity)
                     {
-                        AZ_Warning("Multiplayer Property", false, "MultiplayerSystemComponent GetOnEndpointDisonnectedEvent failed. The entity with id %s doesn't exist, please provide a valid entity id.", id.ToString().c_str())
+                        AZ_Warning("Multiplayer Property", false,
+                            "MultiplayerSystemComponent GetOnEndpointDisonnectedEvent failed."
+                            "The entity with id % s doesn't exist, please provide a valid entity id.",
+                            id.ToString().c_str())
                         return nullptr;
                     }
 
                     MultiplayerSystemComponent* mpComponent = entity->FindComponent<MultiplayerSystemComponent>();
                     if (!mpComponent)
                     {
-                        AZ_Warning("Multiplayer Property", false, "MultiplayerSystemComponent GetOnEndpointDisonnectedEvent failed. Entity '%s' (id: %s) is missing MultiplayerSystemComponent, be sure to add MultiplayerSystemComponent to this entity.", entity->GetName().c_str(), id.ToString().c_str())
+                        AZ_Warning("Multiplayer Property", false,
+                            "MultiplayerSystemComponent GetOnEndpointDisonnectedEvent failed."
+                            "Entity '%s' (id: % s) is missing MultiplayerSystemComponent, be sure to add MultiplayerSystemComponent to this entity.",
+                            entity->GetName().c_str(), id.ToString().c_str())
                         return nullptr;
                     }
 

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -115,7 +115,7 @@ namespace Multiplayer
         void Terminate(AzNetworking::DisconnectReason reason) override;
         void AddClientMigrationStartEventHandler(ClientMigrationStartEvent::Handler& handler) override;
         void AddClientMigrationEndEventHandler(ClientMigrationEndEvent::Handler& handler) override;
-        void AddClientDisconnectedHandler(ClientDisconnectedEvent::Handler& handler) override;
+        void AddEndpointDisonnectedHandler(EndpointDisonnectedEvent::Handler& handler) override;
         void AddNotifyClientMigrationHandler(NotifyClientMigrationEvent::Handler& handler) override;
         void AddNotifyEntityMigrationEventHandler(NotifyEntityMigrationEvent::Handler& handler) override;
         void AddConnectionAcquiredHandler(ConnectionAcquiredEvent::Handler& handler) override;
@@ -164,7 +164,7 @@ namespace Multiplayer
         SessionShutdownEvent m_shutdownEvent;
         ConnectionAcquiredEvent m_connectionAcquiredEvent;
         ServerAcceptanceReceivedEvent m_serverAcceptanceReceivedEvent;
-        ClientDisconnectedEvent m_clientDisconnectedEvent;
+        EndpointDisonnectedEvent m_endpointDisonnectedEvent;
         ClientMigrationStartEvent m_clientMigrationStartEvent;
         ClientMigrationEndEvent m_clientMigrationEndEvent;
         NotifyClientMigrationEvent m_notifyClientMigrationEvent;

--- a/Gems/Multiplayer/Code/Tests/CommonBenchmarkSetup.h
+++ b/Gems/Multiplayer/Code/Tests/CommonBenchmarkSetup.h
@@ -303,7 +303,7 @@ namespace Multiplayer
         bool StartHosting([[maybe_unused]] uint16_t port, [[maybe_unused]] bool isDedicated) override { return {}; }
         bool Connect([[maybe_unused]] const AZStd::string& remoteAddress, [[maybe_unused]] uint16_t port) override { return {}; }
         void Terminate([[maybe_unused]] AzNetworking::DisconnectReason reason) override {}
-        void AddClientDisconnectedHandler([[maybe_unused]] ClientDisconnectedEvent::Handler& handler) override {}
+        void AddEndpointDisonnectedHandler([[maybe_unused]] EndpointDisonnectedEvent::Handler& handler) override {}
         void AddConnectionAcquiredHandler([[maybe_unused]] ConnectionAcquiredEvent::Handler& handler) override {}
         void AddServerAcceptanceReceivedHandler([[maybe_unused]] ServerAcceptanceReceivedEvent::Handler& handler) override {}
         void AddSessionInitHandler([[maybe_unused]] SessionInitEvent::Handler& handler) override {}

--- a/Gems/Multiplayer/Code/Tests/MockInterfaces.h
+++ b/Gems/Multiplayer/Code/Tests/MockInterfaces.h
@@ -27,7 +27,7 @@ namespace UnitTest
         MOCK_METHOD1(Terminate, void(AzNetworking::DisconnectReason));
         MOCK_METHOD1(AddClientMigrationStartEventHandler, void(Multiplayer::ClientMigrationStartEvent::Handler&));
         MOCK_METHOD1(AddClientMigrationEndEventHandler, void(Multiplayer::ClientMigrationEndEvent::Handler&));
-        MOCK_METHOD1(AddClientDisconnectedHandler, void(AZ::Event<>::Handler&));
+        MOCK_METHOD1(AddClientDisconnectedHandler, void(Multiplayer::ClientDisconnectedEvent::Handler&));
         MOCK_METHOD1(AddNotifyClientMigrationHandler, void(Multiplayer::NotifyClientMigrationEvent::Handler&));
         MOCK_METHOD1(AddNotifyEntityMigrationEventHandler, void(Multiplayer::NotifyEntityMigrationEvent::Handler&));
         MOCK_METHOD1(AddConnectionAcquiredHandler, void(Multiplayer::ConnectionAcquiredEvent::Handler&));

--- a/Gems/Multiplayer/Code/Tests/MockInterfaces.h
+++ b/Gems/Multiplayer/Code/Tests/MockInterfaces.h
@@ -27,7 +27,7 @@ namespace UnitTest
         MOCK_METHOD1(Terminate, void(AzNetworking::DisconnectReason));
         MOCK_METHOD1(AddClientMigrationStartEventHandler, void(Multiplayer::ClientMigrationStartEvent::Handler&));
         MOCK_METHOD1(AddClientMigrationEndEventHandler, void(Multiplayer::ClientMigrationEndEvent::Handler&));
-        MOCK_METHOD1(AddClientDisconnectedHandler, void(Multiplayer::ClientDisconnectedEvent::Handler&));
+        MOCK_METHOD1(AddEndpointDisonnectedHandler, void(Multiplayer::EndpointDisonnectedEvent::Handler&));
         MOCK_METHOD1(AddNotifyClientMigrationHandler, void(Multiplayer::NotifyClientMigrationEvent::Handler&));
         MOCK_METHOD1(AddNotifyEntityMigrationEventHandler, void(Multiplayer::NotifyEntityMigrationEvent::Handler&));
         MOCK_METHOD1(AddConnectionAcquiredHandler, void(Multiplayer::ConnectionAcquiredEvent::Handler&));

--- a/Gems/Multiplayer/Code/Tests/MultiplayerSystemTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/MultiplayerSystemTests.cpp
@@ -44,8 +44,8 @@ namespace UnitTest
             m_mpComponent->AddSessionShutdownHandler(m_shutdownHandler);
             m_connAcquiredHandler = Multiplayer::ConnectionAcquiredEvent::Handler([this](Multiplayer::MultiplayerAgentDatum value) { TestConnectionAcquiredEvent(value); });
             m_mpComponent->AddConnectionAcquiredHandler(m_connAcquiredHandler);
-            m_clientDisconnectedHandler = Multiplayer::ClientDisconnectedEvent::Handler([this](Multiplayer::MultiplayerAgentType value) { TestClientDisconnectedEvent(value); });
-            m_mpComponent->AddClientDisconnectedHandler(m_clientDisconnectedHandler);
+            m_endpointDisonnectedHandler = Multiplayer::EndpointDisonnectedEvent::Handler([this](Multiplayer::MultiplayerAgentType value) { TestEndpointDisonnectedEvent(value); });
+            m_mpComponent->AddEndpointDisonnectedHandler(m_endpointDisonnectedHandler);
             m_mpComponent->Activate();
         }
 
@@ -75,20 +75,20 @@ namespace UnitTest
             m_connectionAcquiredCount += aznumeric_cast<uint32_t>(datum.m_id);
         }
 
-        void TestClientDisconnectedEvent([[maybe_unused]] Multiplayer::MultiplayerAgentType value)
+        void TestEndpointDisonnectedEvent([[maybe_unused]] Multiplayer::MultiplayerAgentType value)
         {
-            ++m_clientDisconnectedCount;
+            ++m_endpointDisonnectedCount;
         }
 
         uint32_t m_initEventTriggerCount = 0;
         uint32_t m_shutdownEventTriggerCount = 0;
         uint32_t m_connectionAcquiredCount = 0;
-        uint32_t m_clientDisconnectedCount = 0;
+        uint32_t m_endpointDisonnectedCount = 0;
 
         Multiplayer::SessionInitEvent::Handler m_initHandler;
         Multiplayer::SessionShutdownEvent::Handler m_shutdownHandler;
         Multiplayer::ConnectionAcquiredEvent::Handler m_connAcquiredHandler;
-        Multiplayer::ClientDisconnectedEvent::Handler m_clientDisconnectedHandler;
+        Multiplayer::EndpointDisonnectedEvent::Handler m_endpointDisonnectedHandler;
 
         AzNetworking::NetworkingSystemComponent* m_netComponent = nullptr;
         Multiplayer::MultiplayerSystemComponent* m_mpComponent = nullptr;
@@ -114,7 +114,7 @@ namespace UnitTest
         m_mpComponent->OnDisconnect(&connMock1, AzNetworking::DisconnectReason::None, AzNetworking::TerminationEndpoint::Local);
         m_mpComponent->OnDisconnect(&connMock2, AzNetworking::DisconnectReason::None, AzNetworking::TerminationEndpoint::Local);
 
-        EXPECT_EQ(m_clientDisconnectedCount, 2);
+        EXPECT_EQ(m_endpointDisonnectedCount, 2);
         EXPECT_EQ(m_shutdownEventTriggerCount, 1);
     }
 
@@ -132,7 +132,7 @@ namespace UnitTest
         m_mpComponent->OnDisconnect(&connMock1, AzNetworking::DisconnectReason::None, AzNetworking::TerminationEndpoint::Local);
         m_mpComponent->OnDisconnect(&connMock2, AzNetworking::DisconnectReason::None, AzNetworking::TerminationEndpoint::Local);
 
-        EXPECT_EQ(m_clientDisconnectedCount, 2);
+        EXPECT_EQ(m_endpointDisonnectedCount, 2);
     }
 
     TEST_F(MultiplayerSystemTests, TestSpawnerEvents)
@@ -152,7 +152,7 @@ namespace UnitTest
         m_mpComponent->OnDisconnect(&connMock, AzNetworking::DisconnectReason::None, AzNetworking::TerminationEndpoint::Local);
         AZ_TEST_STOP_TRACE_SUPPRESSION(2);
 
-        EXPECT_EQ(m_clientDisconnectedCount, 1);
+        EXPECT_EQ(m_endpointDisonnectedCount, 1);
         EXPECT_EQ(m_mpSpawnerMock.m_playerCount, 0);
         AZ::Interface<Multiplayer::IMultiplayerSpawner>::Unregister(&m_mpSpawnerMock);
     }

--- a/Gems/Multiplayer/Code/Tests/MultiplayerSystemTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/MultiplayerSystemTests.cpp
@@ -44,6 +44,8 @@ namespace UnitTest
             m_mpComponent->AddSessionShutdownHandler(m_shutdownHandler);
             m_connAcquiredHandler = Multiplayer::ConnectionAcquiredEvent::Handler([this](Multiplayer::MultiplayerAgentDatum value) { TestConnectionAcquiredEvent(value); });
             m_mpComponent->AddConnectionAcquiredHandler(m_connAcquiredHandler);
+            m_clientDisconnectedHandler = Multiplayer::ClientDisconnectedEvent::Handler([this](Multiplayer::MultiplayerAgentType value) { TestClientDisconnectedEvent(value); });
+            m_mpComponent->AddClientDisconnectedHandler(m_clientDisconnectedHandler);
             m_mpComponent->Activate();
         }
 
@@ -73,13 +75,20 @@ namespace UnitTest
             m_connectionAcquiredCount += aznumeric_cast<uint32_t>(datum.m_id);
         }
 
+        void TestClientDisconnectedEvent([[maybe_unused]] Multiplayer::MultiplayerAgentType value)
+        {
+            ++m_clientDisconnectedCount;
+        }
+
         uint32_t m_initEventTriggerCount = 0;
         uint32_t m_shutdownEventTriggerCount = 0;
         uint32_t m_connectionAcquiredCount = 0;
+        uint32_t m_clientDisconnectedCount = 0;
 
         Multiplayer::SessionInitEvent::Handler m_initHandler;
         Multiplayer::SessionShutdownEvent::Handler m_shutdownHandler;
         Multiplayer::ConnectionAcquiredEvent::Handler m_connAcquiredHandler;
+        Multiplayer::ClientDisconnectedEvent::Handler m_clientDisconnectedHandler;
 
         AzNetworking::NetworkingSystemComponent* m_netComponent = nullptr;
         Multiplayer::MultiplayerSystemComponent* m_mpComponent = nullptr;
@@ -105,6 +114,7 @@ namespace UnitTest
         m_mpComponent->OnDisconnect(&connMock1, AzNetworking::DisconnectReason::None, AzNetworking::TerminationEndpoint::Local);
         m_mpComponent->OnDisconnect(&connMock2, AzNetworking::DisconnectReason::None, AzNetworking::TerminationEndpoint::Local);
 
+        EXPECT_EQ(m_clientDisconnectedCount, 2);
         EXPECT_EQ(m_shutdownEventTriggerCount, 1);
     }
 
@@ -121,6 +131,8 @@ namespace UnitTest
         // Clean up connection data
         m_mpComponent->OnDisconnect(&connMock1, AzNetworking::DisconnectReason::None, AzNetworking::TerminationEndpoint::Local);
         m_mpComponent->OnDisconnect(&connMock2, AzNetworking::DisconnectReason::None, AzNetworking::TerminationEndpoint::Local);
+
+        EXPECT_EQ(m_clientDisconnectedCount, 2);
     }
 
     TEST_F(MultiplayerSystemTests, TestSpawnerEvents)
@@ -140,6 +152,7 @@ namespace UnitTest
         m_mpComponent->OnDisconnect(&connMock, AzNetworking::DisconnectReason::None, AzNetworking::TerminationEndpoint::Local);
         AZ_TEST_STOP_TRACE_SUPPRESSION(2);
 
+        EXPECT_EQ(m_clientDisconnectedCount, 1);
         EXPECT_EQ(m_mpSpawnerMock.m_playerCount, 0);
         AZ::Interface<Multiplayer::IMultiplayerSpawner>::Unregister(&m_mpSpawnerMock);
     }

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Properties/MultiplayerAgentType_Client.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Properties/MultiplayerAgentType_Client.names
@@ -1,0 +1,29 @@
+{
+    "entries": [
+        {
+            "base": "MultiplayerAgentType_Client",
+            "context": "Constant",
+            "variant": "",
+            "details": {
+                "name": "Client Agent Type",
+                "category": "Multiplayer/Agent Type"
+            },
+            "methods": [
+                {
+                    "base": "GetMultiplayerAgentType_Client",
+                    "details": {
+                        "name": "Client Agent Type"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}",
+                            "details": {
+                                "name": "int"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Properties/MultiplayerAgentType_ClientServer.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Properties/MultiplayerAgentType_ClientServer.names
@@ -1,0 +1,29 @@
+{
+    "entries": [
+        {
+            "base": "MultiplayerAgentType_ClientServer",
+            "context": "Constant",
+            "variant": "",
+            "details": {
+                "name": "ClientServer Agent Type",
+                "category": "Multiplayer/Agent Type"
+            },
+            "methods": [
+                {
+                    "base": "GetMultiplayerAgentType_ClientServer",
+                    "details": {
+                        "name": "ClientServer Agent Type"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}",
+                            "details": {
+                                "name": "int"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Properties/MultiplayerAgentType_DedicatedServer.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Properties/MultiplayerAgentType_DedicatedServer.names
@@ -1,0 +1,29 @@
+{
+    "entries": [
+        {
+            "base": "MultiplayerAgentType_DedicatedServer",
+            "context": "Constant",
+            "variant": "",
+            "details": {
+                "name": "DedicatedServer Agent Type",
+                "category": "Multiplayer/Agent Type"
+            },
+            "methods": [
+                {
+                    "base": "GetMultiplayerAgentType_DedicatedServer",
+                    "details": {
+                        "name": "DedicatedServer Agent Type"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}",
+                            "details": {
+                                "name": "int"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Properties/MultiplayerAgentType_Uninitialized.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Properties/MultiplayerAgentType_Uninitialized.names
@@ -1,0 +1,29 @@
+{
+    "entries": [
+        {
+            "base": "MultiplayerAgentType_Uninitialized",
+            "context": "Constant",
+            "variant": "",
+            "details": {
+                "name": "Uninitialized Agent Type",
+                "category": "Multiplayer/Agent Type"
+            },
+            "methods": [
+                {
+                    "base": "GetMultiplayerAgentType_Uninitialized",
+                    "details": {
+                        "name": "Uninitialized Agent Type"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}",
+                            "details": {
+                                "name": "int"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Currently the client disconnect signal will only be sent on the client side during disconnection but there're use cases where the server needs to handle this event as well (e.g. send player leave metrics event to the backend). With this PR, the signal will be sent on both of the client and server side. This PR also reflects MultiplayerAgentType to Behavior context so that the GetOnClientDisconnectedEvent method output can be represented properly in Script Canvas.

## How was this PR tested?

Unit tests for the Multiplayer Gem passed. Also verified that the signal was sent out on the client and server manually.
