### PR TITLE
Fix TaskGraphEvent asserting when submitted with an empty TaskGraph

### DIFF
--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
@@ -105,6 +105,7 @@ namespace AZ
         {
             if (waitEvent)
             {
+                waitEvent->IncWaitCount();
                 waitEvent->Signal();
             }
             return;

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
@@ -105,6 +105,7 @@ namespace AZ
         {
             if (waitEvent)
             {
+                // TaskGraphEvent asserts if it has a wait count of 0, increment it before signaling.
                 waitEvent->IncWaitCount();
                 waitEvent->Signal();
             }


### PR DESCRIPTION
Add a 'wait' if it's going to be signaled immediately because of an empty TaskGraph

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>

