### PR TITLE
Removing duplicate stop call for AP in Editor_Test.py

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -407,7 +407,6 @@ class EditorTestSuite:
         yield test_data  # yield to pytest while test-class executes
         # resumed by pytest after each test-class finishes
         if test_data.asset_processor:  # was assigned an AP to manage
-            test_data.asset_processor.stop(1)
             test_data.asset_processor.teardown()
             test_data.asset_processor = None
             editor_utils.kill_all_ly_processes(include_asset_processor=True)


### PR DESCRIPTION
The removal also changes the stop timeout back to default as opposed to 1 second.

Signed-off-by: Rosario Cox <lesaelr@amazon.com>

## What does this PR do?

Fixes the issues encountered in [Editor Tests](https://github.com/o3de/o3de/issues/10284)

## How was this PR tested?

Tested locally by running multiple test suites.
