### PR TITLE
Jcurtisk/tiaftestexclude

### DIFF
--- a/scripts/build/TestImpactAnalysis/tiaf.py
+++ b/scripts/build/TestImpactAnalysis/tiaf.py
@@ -312,17 +312,17 @@ class TestImpact:
         logger.info(f"Test suite is set to '{suite}'.")
 
         # Exclude tests
-        if exclude_file is not None:
+        if exclude_file:
             args.append(f"--exclude_file={exclude_file}")
             logger.info(f"Exclude file found, excluding the tests stored at '{exclude_file}'.")
         else:
             logger.info(f'Exclude file not found, skipping.')
 
         # Timeouts
-        if test_timeout is not None:
+        if test_timeout:
             args.append(f"--ttimeout={test_timeout}")
             logger.info(f"Test target timeout is set to {test_timeout} seconds.")
-        if global_timeout is not None:
+        if global_timeout:
             args.append(f"--gtimeout={global_timeout}")
             logger.info(f"Global sequence timeout is set to {test_timeout} seconds.")
 
@@ -340,7 +340,7 @@ class TestImpact:
                 report = json.load(json_file)
 
             # Attempt to store the historic data for this branch and sequence
-            if self._is_source_of_truth_branch and persistent_storage is not None:
+            if self._is_source_of_truth_branch and persistent_storage:
                 persistent_storage.update_and_store_historic_data()
         else:
             logger.error(f"The test impact analysis runtime returned with error: '{runtime_result.returncode}'.")

--- a/scripts/build/TestImpactAnalysis/tiaf.py
+++ b/scripts/build/TestImpactAnalysis/tiaf.py
@@ -311,7 +311,7 @@ class TestImpact:
         args.append(f"--suite={suite}")
         logger.info(f"Test suite is set to '{suite}'.")
 
-        #Exclude tests
+        # Exclude tests
         if exclude_file is not None:
             args.append(f"--exclude_file={exclude_file}")
             logger.info(f"Exclude file found, excluding the tests stored at '{exclude_file}'.")

--- a/scripts/build/TestImpactAnalysis/tiaf.py
+++ b/scripts/build/TestImpactAnalysis/tiaf.py
@@ -163,7 +163,7 @@ class TestImpact:
 
     def run(self, commit: str, src_branch: str, dst_branch: str, s3_bucket: str, s3_top_level_dir: str, suite: str, test_failure_policy: str, safe_mode: bool, test_timeout: int, global_timeout: int, exclude_file: str):
         """
-        Determins the type of sequence to run based on the commit, source branch and test branch before running the
+        Determines the type of sequence to run based on the commit, source branch and test branch before running the
         sequence with the specified values.
 
         @param commit:              The commit hash of the changes to run test impact analysis on. 
@@ -176,6 +176,7 @@ class TestImpact:
         @param safe_mode:           Flag to run impact analysis tests in safe mode (ignored when seeding).
         @param test_timeout:        Maximum run time (in seconds) of any test target before being terminated (unlimited if None).
         @param global_timeout:      Maximum run time of the sequence before being terminated (unlimited if None).
+        @param exclude_file:        Path to exclude file, containing a list of tests to exclude from this run.
         """
 
         args = []
@@ -310,7 +311,7 @@ class TestImpact:
         args.append(f"--suite={suite}")
         logger.info(f"Test suite is set to '{suite}'.")
 
-        #Exclude file
+        #Exclude tests
         if exclude_file is not None:
             args.append(f"--exclude_file={exclude_file}")
             logger.info(f"Exclude file found, excluding the tests stored at '{exclude_file}'.")

--- a/scripts/build/TestImpactAnalysis/tiaf.py
+++ b/scripts/build/TestImpactAnalysis/tiaf.py
@@ -161,7 +161,7 @@ class TestImpact:
         result["change_list"] = self._change_list
         return result
 
-    def run(self, commit: str, src_branch: str, dst_branch: str, s3_bucket: str, s3_top_level_dir: str, suite: str, test_failure_policy: str, safe_mode: bool, test_timeout: int, global_timeout: int):
+    def run(self, commit: str, src_branch: str, dst_branch: str, s3_bucket: str, s3_top_level_dir: str, suite: str, test_failure_policy: str, safe_mode: bool, test_timeout: int, global_timeout: int, exclude_file: str):
         """
         Determins the type of sequence to run based on the commit, source branch and test branch before running the
         sequence with the specified values.
@@ -309,6 +309,13 @@ class TestImpact:
         # Suite
         args.append(f"--suite={suite}")
         logger.info(f"Test suite is set to '{suite}'.")
+
+        #Exclude file
+        if exclude_file is not None:
+            args.append(f"--exclude_file={exclude_file}")
+            logger.info(f"Exclude file found, excluding the tests stored at '{exclude_file}'.")
+        else:
+            logger.info(f'Exclude file not found, skipping.')
 
         # Timeouts
         if test_timeout is not None:

--- a/scripts/build/TestImpactAnalysis/tiaf_driver.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_driver.py
@@ -134,6 +134,13 @@ def parse_args():
         required=False
     )
 
+    parser.add_argument(
+        '--exclude_file',
+        type=valid_file_path,
+        help="Path to file containing tests to exclude from this run",
+        required=False
+    )
+
     args = parser.parse_args()
     
     return args

--- a/scripts/build/TestImpactAnalysis/tiaf_driver.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_driver.py
@@ -135,7 +135,7 @@ def parse_args():
     )
 
     parser.add_argument(
-        '--exclude_file',
+        '--exclude-file',
         type=valid_file_path,
         help="Path to file containing tests to exclude from this run",
         required=False

--- a/scripts/build/TestImpactAnalysis/tiaf_driver.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_driver.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
             s3_top_level_dir = "tiaf"
 
         tiaf = TestImpact(args.config)
-        tiaf_result = tiaf.run(args.commit, args.src_branch, args.dst_branch, args.s3_bucket, s3_top_level_dir, args.suite, args.test_failure_policy, args.safe_mode, args.test_timeout, args.global_timeout)
+        tiaf_result = tiaf.run(args.commit, args.src_branch, args.dst_branch, args.s3_bucket, s3_top_level_dir, args.suite, args.test_failure_policy, args.safe_mode, args.test_timeout, args.global_timeout, args.exclude_file)
         
         if args.mars_index_prefix:
             logger.info("Transmitting report to MARS...")


### PR DESCRIPTION
## What does this PR do?
This PR adds a new argument to the tiaf_driver script, `--exclude-file`, that allows the user to specify the path to a file that will contain tests to exclude from this run of TIAF. It then passes this to the C++ runtime, which will handle the actual exclusion of tests.

## How was this PR tested?

Manually tested that script fails when path is invalid, passes the path to the runtime when path is valid, and acknowledges that no tests will be skipped when argument is not specified
