### PR TITLE
chore: remove unused variables from ApplicationManagerBase

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -1855,7 +1855,6 @@ bool ApplicationManagerBase::OnError(const char* /*window*/, const char* /*messa
 bool ApplicationManagerBase::CheckSufficientDiskSpace(qint64 requiredSpace, bool shutdownIfInsufficient)
 {
     QDir cacheDir;
-    AZ_UNUSED(cacheDir);
     if (!AssetUtilities::ComputeProjectCacheRoot(cacheDir))
     {
         AZ_Error(

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -1854,9 +1854,8 @@ bool ApplicationManagerBase::OnError(const char* /*window*/, const char* /*messa
 
 bool ApplicationManagerBase::CheckSufficientDiskSpace(qint64 requiredSpace, bool shutdownIfInsufficient)
 {
-    bool createdDirectory = false;
-
     QDir cacheDir;
+    AZ_UNUSED(cacheDir);
     if (!AssetUtilities::ComputeProjectCacheRoot(cacheDir))
     {
         AZ_Error(
@@ -1872,7 +1871,7 @@ bool ApplicationManagerBase::CheckSufficientDiskSpace(qint64 requiredSpace, bool
     {
         // GetFreeDiskSpace will fail if the path does not exist
         QDir dir;
-        createdDirectory = dir.mkpath(savePath);
+        dir.mkpath(savePath);
     }
 
     qint64 bytesFree = 0;


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

my clang build was failing because these variables are unused. 