### PR TITLE
Asset Processor - Reserve Builder for CreateJobs

### DIFF
--- a/Code/Tools/AssetProcessor/assetprocessor_test_files.cmake
+++ b/Code/Tools/AssetProcessor/assetprocessor_test_files.cmake
@@ -64,6 +64,8 @@ set(FILES
     native/tests/AssetProcessorMessagesTests.cpp
     native/tests/ApplicationManagerTests.cpp
     native/tests/ApplicationManagerTests.h
+    native/tests/BuilderManagerTests.cpp
+    native/tests/BuilderManagerTests.h
     native/unittests/AssetCacheServerUnitTests.cpp
     native/unittests/AssetProcessingStateDataUnitTests.cpp
     native/unittests/AssetProcessingStateDataUnitTests.h

--- a/Code/Tools/AssetProcessor/native/tests/BuilderManagerTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/BuilderManagerTests.cpp
@@ -7,7 +7,9 @@
  */
 
 #include <AzTest/AzTest.h>
+#include <AzCore/UnitTest/TestTypes.h>
 #include "BuilderManagerTests.h"
+#include <AzCore/std/smart_ptr/make_shared.h>
 #include <native/connection/connectionManager.h>
 
 namespace UnitTests
@@ -26,19 +28,19 @@ namespace UnitTests
         ASSERT_EQ(bm.GetBuilderCreationCount(), 1);
 
         // Request a builder for processing, this will create another builder (and hold on to the reference to prevent it from being re-used)
-        auto processJobBuilder = bm.GetBuilder(BuilderPurpose::ProcessJob);
+        auto processJobBuilder = bm.GetBuilder(AssetProcessor::BuilderPurpose::ProcessJob);
 
         // There should now be 2 builders, because the first one is reserved for CreateJobs
         ASSERT_EQ(bm.GetBuilderCreationCount(), 2);
 
         // As an extra test, request a builder for CreateJobs, which should not create a new builder
-        bm.GetBuilder(BuilderPurpose::CreateJobs);
+        bm.GetBuilder(AssetProcessor::BuilderPurpose::CreateJobs);
 
         // There should still be 2 builders
         ASSERT_EQ(bm.GetBuilderCreationCount(), 2);
     }
 
-    bool TestBuilder::Start(BuilderPurpose /*purpose*/)
+    bool TestBuilder::Start(AssetProcessor::BuilderPurpose /*purpose*/)
     {
         return true;
     }
@@ -53,7 +55,7 @@ namespace UnitTests
         return m_connectionCounter;
     }
 
-    AZStd::shared_ptr<Builder> TestBuilderManager::AddNewBuilder()
+    AZStd::shared_ptr<AssetProcessor::Builder> TestBuilderManager::AddNewBuilder()
     {
         auto uuid = AZ::Uuid::CreateRandom();
 

--- a/Code/Tools/AssetProcessor/native/tests/BuilderManagerTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/BuilderManagerTests.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzTest/AzTest.h>
+#include "BuilderManagerTests.h"
+#include <native/connection/connectionManager.h>
+
+namespace UnitTests
+{
+    class BuilderManagerTest : public UnitTest::ScopedAllocatorSetupFixture
+    {
+        
+    };
+
+    TEST_F(BuilderManagerTest, GetBuilder_ReservesFirstBuilderForCreateJobs)
+    {
+        ConnectionManager cm{nullptr};
+        TestBuilderManager bm(&cm);
+
+        // We start off with 1 builder pre-created
+        ASSERT_EQ(bm.GetBuilderCreationCount(), 1);
+
+        // Request a builder for processing, this will create another builder (and hold on to the reference to prevent it from being re-used)
+        auto processJobBuilder = bm.GetBuilder(BuilderPurpose::ProcessJob);
+
+        // There should now be 2 builders, because the first one is reserved for CreateJobs
+        ASSERT_EQ(bm.GetBuilderCreationCount(), 2);
+
+        // As an extra test, request a builder for CreateJobs, which should not create a new builder
+        bm.GetBuilder(BuilderPurpose::CreateJobs);
+
+        // There should still be 2 builders
+        ASSERT_EQ(bm.GetBuilderCreationCount(), 2);
+    }
+
+    bool TestBuilder::Start(BuilderPurpose /*purpose*/)
+    {
+        return true;
+    }
+
+    TestBuilderManager::TestBuilderManager(ConnectionManager* connectionManager): BuilderManager(connectionManager)
+    {
+        AddNewBuilder();
+    }
+
+    int TestBuilderManager::GetBuilderCreationCount() const
+    {
+        return m_connectionCounter;
+    }
+
+    AZStd::shared_ptr<Builder> TestBuilderManager::AddNewBuilder()
+    {
+        auto uuid = AZ::Uuid::CreateRandom();
+
+        m_builders[uuid] = AZStd::make_shared<TestBuilder>(m_quitListener, uuid, ++m_connectionCounter);
+
+        return m_builders[uuid];
+    }
+}

--- a/Code/Tools/AssetProcessor/native/tests/BuilderManagerTests.h
+++ b/Code/Tools/AssetProcessor/native/tests/BuilderManagerTests.h
@@ -13,7 +13,7 @@
 
 namespace UnitTests
 {
-    class TestBuilder : public Builder
+    class TestBuilder : public AssetProcessor::Builder
     {
     public:
         TestBuilder(const AssetUtilities::QuitListener& quitListener, AZ::Uuid uuid, int connectionId)
@@ -23,7 +23,7 @@ namespace UnitTests
         }
 
     protected:
-        bool Start(BuilderPurpose purpose) override;
+        bool Start(AssetProcessor::BuilderPurpose purpose) override;
     };
 
     class TestBuilderManager : public AssetProcessor::BuilderManager
@@ -34,7 +34,7 @@ namespace UnitTests
         int GetBuilderCreationCount() const;
 
     protected:
-        AZStd::shared_ptr<Builder> AddNewBuilder() override;
+        AZStd::shared_ptr<AssetProcessor::Builder> AddNewBuilder() override;
         
         int m_connectionCounter = 0;
     };

--- a/Code/Tools/AssetProcessor/native/tests/BuilderManagerTests.h
+++ b/Code/Tools/AssetProcessor/native/tests/BuilderManagerTests.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <native/utilities/BuilderManager.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+
+namespace UnitTests
+{
+    class TestBuilder : public Builder
+    {
+    public:
+        TestBuilder(const AssetUtilities::QuitListener& quitListener, AZ::Uuid uuid, int connectionId)
+            : Builder(quitListener, uuid)
+        {
+            m_connectionId = connectionId;
+        }
+
+    protected:
+        bool Start(BuilderPurpose purpose) override;
+    };
+
+    class TestBuilderManager : public AssetProcessor::BuilderManager
+    {
+    public:
+        TestBuilderManager(ConnectionManager* connectionManager);
+
+        int GetBuilderCreationCount() const;
+
+    protected:
+        AZStd::shared_ptr<Builder> AddNewBuilder() override;
+        
+        int m_connectionCounter = 0;
+    };
+}

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
@@ -518,6 +518,7 @@ namespace AssetProcessor
                         // Since there is only ever 1 CreateJobs process happening at once, this means CreateJobs will never have to wait to
                         // start up a new builder. This is important since CreateJobs is meant to be quick.
                         ++itr;
+                        continue;
                     }
 
                     auto& builder = itr->second;

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
@@ -143,7 +143,7 @@ namespace AssetProcessor
         }
     }
 
-    bool Builder::Start(bool doRegistration)
+    bool Builder::Start(BuilderPurpose purpose)
     {
         // Get the current BinXXX folder based on the current running AP
         QString applicationDir = QCoreApplication::instance()->applicationDirPath();
@@ -160,7 +160,7 @@ namespace AssetProcessor
             return false;
         }
 
-        const AZStd::vector<AZStd::string> params = BuildParams("resident", buildersFolder.c_str(), UuidString(), "", "", doRegistration);
+        const AZStd::vector<AZStd::string> params = BuildParams("resident", buildersFolder.c_str(), UuidString(), "", "", purpose);
 
         m_processWatcher = LaunchProcess(fullExePathString.c_str(), params);
 
@@ -184,7 +184,7 @@ namespace AssetProcessor
         return !m_processWatcher || (m_processWatcher && m_processWatcher->IsProcessRunning(exitCode));
     }
 
-    AZStd::vector<AZStd::string> Builder::BuildParams(const char* task, const char* moduleFilePath, const AZStd::string& builderGuid, const AZStd::string& jobDescriptionFile, const AZStd::string& jobResponseFile, bool doRegistration) const
+    AZStd::vector<AZStd::string> Builder::BuildParams(const char* task, const char* moduleFilePath, const AZStd::string& builderGuid, const AZStd::string& jobDescriptionFile, const AZStd::string& jobResponseFile, BuilderPurpose purpose) const
     {
         QDir projectCacheRoot;
         AssetUtilities::ComputeProjectCacheRoot(projectCacheRoot);
@@ -205,7 +205,7 @@ namespace AssetProcessor
         params.emplace_back(AZStd::string::format(R"(-engine-path="%s")", enginePath.c_str()));
         params.emplace_back(AZStd::string::format("-port=%d", portNumber));
 
-        if(doRegistration)
+        if (purpose == BuilderPurpose::Registration)
         {
             params.emplace_back("--register");
         }
@@ -500,7 +500,7 @@ namespace AssetProcessor
         m_builderDebugOutput[builderId].m_assetsProcessed.push_back(sourceAsset);
     }
 
-    BuilderRef BuilderManager::GetBuilder(bool doRegistration)
+    BuilderRef BuilderManager::GetBuilder(BuilderPurpose purpose)
     {
         AZStd::shared_ptr<Builder> newBuilder;
         BuilderRef builderRef;
@@ -508,10 +508,18 @@ namespace AssetProcessor
         {
             AZStd::unique_lock<AZStd::mutex> lock(m_buildersMutex);
 
-            if (!doRegistration)
+            if (purpose != BuilderPurpose::Registration)
             {
                 for (auto itr = m_builders.begin(); itr != m_builders.end();)
                 {
+                    if (itr == m_builders.begin() && purpose != BuilderPurpose::CreateJobs)
+                    {
+                        // The first builder is always reserved for create jobs.
+                        // Since there is only ever 1 CreateJobs process happening at once, this means CreateJobs will never have to wait to
+                        // start up a new builder. This is important since CreateJobs is meant to be quick.
+                        ++itr;
+                    }
+
                     auto& builder = itr->second;
 
                     if (!builder->m_busy)
@@ -543,7 +551,7 @@ namespace AssetProcessor
             builderRef = BuilderRef(newBuilder);
         }
 
-        if (!newBuilder->Start(doRegistration))
+        if (!newBuilder->Start(purpose))
         {
             AZ_Error("BuilderManager", false, "Builder failed to start");
 

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.h
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.h
@@ -27,6 +27,14 @@ namespace AssetProcessor
     //! Indicates if job request files should be created on success.  Can be useful for debugging
     static const bool s_createRequestFileForSuccessfulJob = false;
 
+    //! Enum used to indicate the purpose of a builder which may result in special handling
+    enum class BuilderPurpose
+    {
+        CreateJobs,
+        ProcessJob,
+        Registration
+    };
+
     //! This EBUS is used to request a free builder from the builder manager pool
     class BuilderManagerBusTraits
         : public AZ::EBusTraits
@@ -39,7 +47,7 @@ namespace AssetProcessor
         virtual ~BuilderManagerBusTraits() = default;
 
         //! Returns a builder for doing work
-        virtual BuilderRef GetBuilder(bool doRegistration) = 0;
+        virtual BuilderRef GetBuilder(BuilderPurpose purpose) = 0;
 
         virtual void AddAssetToBuilderProcessedList(const AZ::Uuid& /*builderId*/, const AZStd::string& /*sourceAsset*/)
         {
@@ -102,12 +110,12 @@ namespace AssetProcessor
     private:
 
         //! Starts the builder process and waits for it to connect
-        bool Start(bool doRegistration);
+        bool Start(BuilderPurpose purpose);
 
         //! Sets the connection id and signals that the builder has connected
         void SetConnection(AZ::u32 connId);
 
-        AZStd::vector<AZStd::string> BuildParams(const char* task, const char* moduleFilePath, const AZStd::string& builderGuid, const AZStd::string& jobDescriptionFile, const AZStd::string& jobResponseFile, bool doRegistration) const;
+        AZStd::vector<AZStd::string> BuildParams(const char* task, const char* moduleFilePath, const AZStd::string& builderGuid, const AZStd::string& jobDescriptionFile, const AZStd::string& jobResponseFile, BuilderPurpose purpose) const;
         AZStd::unique_ptr<AzFramework::ProcessWatcher> LaunchProcess(const char* fullExePath, const AZStd::vector<AZStd::string>& params) const;
 
         //! Waits for the builder exe to send the job response and pumps stdout/err
@@ -115,7 +123,7 @@ namespace AssetProcessor
 
         //! Writes the request out to disk for debug purposes and logs info on how to manually run the asset builder
         template<typename TRequest>
-        bool DebugWriteRequestFile(QString tempFolderPath, const TRequest& request, const AZStd::string& task, const AZStd::string& modulePath) const;
+        bool DebugWriteRequestFile(QString tempFolderPath, const TRequest& request, const AZStd::string& task, const AZStd::string& modulePath, BuilderPurpose purpose) const;
 
         const AZ::Uuid m_uuid;
 
@@ -184,7 +192,7 @@ namespace AssetProcessor
         void ConnectionLost(AZ::u32 connId);
 
         //BuilderManagerBus
-        BuilderRef GetBuilder(bool doRegistration) override;
+        BuilderRef GetBuilder(BuilderPurpose purpose) override;
         void AddAssetToBuilderProcessedList(const AZ::Uuid& builderId, const AZStd::string& sourceAsset) override;
 
     private:

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.h
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.h
@@ -78,7 +78,7 @@ namespace AssetProcessor
             : m_uuid(uuid),
             m_quitListener(quitListener)
         {}
-        ~Builder() = default;
+        virtual ~Builder() = default;
 
         // Disable copy and move (can't move a semaphore)
         AZ_DISABLE_COPY_MOVE(Builder);
@@ -107,10 +107,10 @@ namespace AssetProcessor
         template<typename TNetRequest, typename TNetResponse, typename TRequest, typename TResponse>
         BuilderRunJobOutcome RunJob(const TRequest& request, TResponse& response, AZ::u32 processTimeoutLimitInSeconds, const AZStd::string& task, const AZStd::string& modulePath, AssetBuilderSDK::JobCancelListener* jobCancelListener = nullptr, AZStd::string tempFolderPath = AZStd::string()) const;
 
-    private:
+    protected:
 
         //! Starts the builder process and waits for it to connect
-        bool Start(BuilderPurpose purpose);
+        virtual bool Start(BuilderPurpose purpose);
 
         //! Sets the connection id and signals that the builder has connected
         void SetConnection(AZ::u32 connId);
@@ -195,10 +195,10 @@ namespace AssetProcessor
         BuilderRef GetBuilder(BuilderPurpose purpose) override;
         void AddAssetToBuilderProcessedList(const AZ::Uuid& builderId, const AZStd::string& sourceAsset) override;
 
-    private:
+    protected:
 
         //! Makes a new builder, adds it to the pool, and returns a shared pointer to it
-        AZStd::shared_ptr<Builder> AddNewBuilder();
+        virtual AZStd::shared_ptr<Builder> AddNewBuilder();
 
         //! Handles incoming builder connections
         void IncomingBuilderPing(AZ::u32 connId, AZ::u32 type, AZ::u32 serial, QByteArray payload, QString platform);

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
@@ -74,7 +74,11 @@ namespace AssetProcessor
         if (!netResponse.m_response.Succeeded() || s_createRequestFileForSuccessfulJob)
         {
             // we write the request out to disk for failure or debugging
-            if (!DebugWriteRequestFile(tempFolderPath.c_str(), request, task, modulePath))
+            BuilderPurpose purpose = azrtti_typeid<TRequest>() == azrtti_typeid<AssetBuilderSDK::CreateJobsRequest>()
+                ? BuilderPurpose::CreateJobs
+                : BuilderPurpose::ProcessJob;
+
+            if (!DebugWriteRequestFile(tempFolderPath.c_str(), request, task, modulePath, purpose))
             {
                 return BuilderRunJobOutcome::FailedToWriteDebugRequest;
             }
@@ -86,7 +90,7 @@ namespace AssetProcessor
     }
 
     template<typename TRequest>
-    bool Builder::DebugWriteRequestFile(QString tempFolderPath, const TRequest& request, const AZStd::string& task, const AZStd::string& modulePath) const
+    bool Builder::DebugWriteRequestFile(QString tempFolderPath, const TRequest& request, const AZStd::string& task, const AZStd::string& modulePath, BuilderPurpose purpose) const
     {
         if (tempFolderPath.isEmpty())
         {
@@ -106,7 +110,7 @@ namespace AssetProcessor
             return false;
         }
 
-        auto params = BuildParams(task.c_str(), modulePath.c_str(), "", jobRequestFile, jobResponseFile, false);
+        auto params = BuildParams(task.c_str(), modulePath.c_str(), "", jobRequestFile, jobResponseFile, purpose);
         AZStd::string paramString;
         AZ::StringFunc::Join(paramString, params.begin(), params.end(), " ");
 

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
@@ -285,7 +285,7 @@ namespace AssetUtilities
     //! Finds the top level source that produced an intermediate product.  If the source is not yet recorded in the database or has no top level source, this will return nothing
     AZStd::optional<AzToolsFramework::AssetDatabase::SourceDatabaseEntry> GetTopLevelSourceForProduct(AZ::IO::PathView relativePath, AZStd::shared_ptr<AssetProcessor::AssetDatabaseConnection> db);
 
-    //! Finds all the souces (up and down) in an intermediate output chain
+    //! Finds all the sources (up and down) in an intermediate output chain
     AZStd::vector<AZStd::string> GetAllIntermediateSources(
         AZ::IO::PathView relativeSourcePath, AZStd::shared_ptr<AssetProcessor::AssetDatabaseConnection> db);
 


### PR DESCRIPTION
## What does this PR do?

Add BuilderPurpose and reserve first builder for CreateJobs.
This will reduce the likelihood of CreateJobs having to wait for a builder to start up which should keep CreateJobs fast.

Usually this isn't an issue but when a lot of jobs are being cancelled (due to the user making changes while a file is processing) the AssetBuilders can be killed off and leave none left to run CreateJobs, which causes a delay before CreateJobs can run.

This is mostly for the use case when a user is (rapidly/frequently) making updates to a file.  When a job is in-flight, the only way it can be canceled is by another job for the same file, which requires CreateJobs to finish running.  This change ensures we can quickly complete CreateJobs to invalidate the old jobs ASAP.

## How was this PR tested?

Manually running AP
