### PR TITLE
Removing all SwapChainOutput uses, replaced with more generic PipelineOutput

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/CheckerboardResolveColor.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/CheckerboardResolveColor.pass
@@ -147,7 +147,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "FormatSource": {
@@ -163,7 +163,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "FormatSource": {
@@ -179,7 +179,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "FormatSource": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/CheckerboardResolveDepth.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/CheckerboardResolveDepth.pass
@@ -33,7 +33,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "FormatSource": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/Depth.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Depth.pass
@@ -31,7 +31,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthCheckerboard.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthCheckerboard.pass
@@ -31,7 +31,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthMSAA.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthMSAA.pass
@@ -31,7 +31,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "MultisampleSource": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthMSAA2x.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthMSAA2x.pass
@@ -31,7 +31,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthMSAA4x.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthMSAA4x.pass
@@ -31,7 +31,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthMSAA8x.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthMSAA8x.pass
@@ -31,7 +31,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthMSAAParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthMSAAParent.pass
@@ -27,7 +27,7 @@
                 },
                 // SwapChain here is only used to reference the frame height and format
                 {
-                    "Name": "SwapChainOutput",
+                    "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
                 }
             ],

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthMax.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthMax.pass
@@ -38,7 +38,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/DisplayMapper.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DisplayMapper.pass
@@ -14,7 +14,7 @@
                 },
                 // SwapChain here is only used to reference the frame height and format
                 {
-                    "Name": "SwapChainOutput",
+                    "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
                 },
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/EnvironmentCubeMapPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/EnvironmentCubeMapPipeline.pass
@@ -8,10 +8,19 @@
             "PassClass": "ParentPass",
             "Slots": [
                 {
-                    "Name": "Output",
+                    "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
                 }
             ],
+            "PassData": {
+                "$type": "PassData",
+                "PipelineGlobalConnections": [
+                    {
+                        "GlobalName": "PipelineOutput",
+                        "Slot": "PipelineOutput"
+                    }
+                ]
+            },
             "PassRequests": [
                 {
                     "Name": "MorphTargetPass",
@@ -31,76 +40,6 @@
                     ]
                 },
                 {
-                    "Name": "CascadedShadowmapsPass",
-                    "TemplateName": "CascadedShadowmapsTemplate",
-                    "PassData": {
-                        "$type": "RasterPassData",
-                        "DrawListTag": "shadow",
-                        "PipelineViewTag": "DirectionalLightView"
-                    },
-                    "Connections": [
-                        {
-                            "LocalSlot": "SkinnedMeshes",
-                            "AttachmentRef": {
-                                "Pass": "SkinningPass",
-                                "Attachment": "SkinnedMeshOutputStream"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "ProjectedShadowmapsPass",
-                    "TemplateName": "ProjectedShadowmapsTemplate",
-                    "PassData": {
-                        "$type": "RasterPassData",
-                        "DrawListTag": "shadow",
-                        "PipelineViewTag": "ProjectedShadowView"
-                    },
-                    "Connections": [
-                        {
-                            "LocalSlot": "SkinnedMeshes",
-                            "AttachmentRef": {
-                                "Pass": "SkinningPass",
-                                "Attachment": "SkinnedMeshOutputStream"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "EsmShadowmapsPassDirectional",
-                    "TemplateName": "EsmShadowmapsTemplate",
-                    "PassData": {
-                        "$type": "EsmShadowmapsPassData",
-                        "LightType": "directional"
-                    },
-                    "Connections": [
-                        {
-                            "LocalSlot": "DepthShadowmaps",
-                            "AttachmentRef": {
-                                "Pass": "CascadedShadowmapsPass",
-                                "Attachment": "Shadowmap"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "EsmShadowmapsPassProjected",
-                    "TemplateName": "EsmShadowmapsTemplate",
-                    "PassData": {
-                        "$type": "EsmShadowmapsPassData",
-                        "LightType": "projected"
-                    },
-                    "Connections": [
-                        {
-                            "LocalSlot": "DepthShadowmaps",
-                            "AttachmentRef": {
-                                "Pass": "ProjectedShadowmapsPass",
-                                "Attachment": "Shadowmap"
-                            }
-                        }
-                    ]
-                },
-                {
                     "Name": "DepthPrePass",
                     "TemplateName": "DepthMSAAParentTemplate",
                     "Connections": [
@@ -112,10 +51,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "Output"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -139,107 +78,71 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "Output"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
                 },
                 {
-                    "Name": "ForwardMSAAPass",
-                    "TemplateName": "EnvironmentCubeMapForwardMSAAPassTemplate",
+                    "Name": "Shadows",
+                    "TemplateName": "ShadowParentTemplate",
                     "Connections": [
                         {
-                            "LocalSlot": "DirectionalLightShadowmap",
+                            "LocalSlot": "SkinnedMeshes",
                             "AttachmentRef": {
-                                "Pass": "CascadedShadowmapsPass",
-                                "Attachment": "Shadowmap"
+                                "Pass": "SkinningPass",
+                                "Attachment": "SkinnedMeshOutputStream"
                             }
                         },
                         {
-                            "LocalSlot": "ExponentialShadowmapDirectional",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
-                                "Pass": "EsmShadowmapsPassDirectional",
-                                "Attachment": "EsmShadowmaps"
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
                             }
                         },
                         {
-                            "LocalSlot": "ProjectedShadowmap",
-                            "AttachmentRef": {
-                                "Pass": "ProjectedShadowmapsPass",
-                                "Attachment": "Shadowmap"
-                            }
-                        },
-                        {
-                            "LocalSlot": "ExponentialShadowmapProjected",
-                            "AttachmentRef": {
-                                "Pass": "EsmShadowmapsPassProjected",
-                                "Attachment": "EsmShadowmaps"
-                            }
-                        },
-                        {
-                            "LocalSlot": "DepthStencilInputOutput",
+                            "LocalSlot": "Depth",
                             "AttachmentRef": {
                                 "Pass": "DepthPrePass",
                                 "Attachment": "DepthMSAA"
                             }
-                        },
-                        {
-                            "LocalSlot": "TileLightData",
-                            "AttachmentRef": {
-                                "Pass": "LightCullingPass",
-                                "Attachment": "TileLightData"
-                            }
-                        },
-                        {
-                            "LocalSlot": "LightListRemapped",
-                            "AttachmentRef": {
-                                "Pass": "LightCullingPass",
-                                "Attachment": "LightListRemapped"
-                            }
                         }
-                    ],
-                    "PassData": {
-                        "$type": "RasterPassData",
-                        "DrawListTag": "forward",
-                        "PipelineViewTag": "MainCamera",
-                        "PassSrgShaderAsset": {
-                            "FilePath": "Shaders/ForwardPassSrg.shader"
-                        }
-                    }
+                    ]
                 },
                 {
-                    "Name": "ForwardSubsurfaceMSAAPass",
-                    "TemplateName": "EnvironmentCubeMapForwardSubsurfaceMSAAPassTemplate",
+                    "Name": "OpaquePass",
+                    "TemplateName": "OpaqueParentTemplate",
                     "Connections": [
                         {
-                            "LocalSlot": "DirectionalLightShadowmap",
+                            "LocalSlot": "DirectionalShadowmap",
                             "AttachmentRef": {
-                                "Pass": "CascadedShadowmapsPass",
-                                "Attachment": "Shadowmap"
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalShadowmap"
                             }
                         },
                         {
-                            "LocalSlot": "ExponentialShadowmapDirectional",
+                            "LocalSlot": "DirectionalESM",
                             "AttachmentRef": {
-                                "Pass": "EsmShadowmapsPassDirectional",
-                                "Attachment": "EsmShadowmaps"
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalESM"
                             }
                         },
                         {
                             "LocalSlot": "ProjectedShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ProjectedShadowmapsPass",
-                                "Attachment": "Shadowmap"
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedShadowmap"
                             }
                         },
                         {
-                            "LocalSlot": "ExponentialShadowmapProjected",
+                            "LocalSlot": "ProjectedESM",
                             "AttachmentRef": {
-                                "Pass": "EsmShadowmapsPassProjected",
-                                "Attachment": "EsmShadowmaps"
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedESM"
                             }
                         },
                         {
@@ -256,252 +159,25 @@
                                 "Attachment": "LightListRemapped"
                             }
                         },
-                        // Input/Outputs...
                         {
-                            "LocalSlot": "DepthStencilInputOutput",
-                            "AttachmentRef": {
-                                "Pass": "DepthPrePass",
-                                "Attachment": "DepthMSAA"
-                            }
-                        },
-                        {
-                            "LocalSlot": "DiffuseOutput",
-                            "AttachmentRef": {
-                                "Pass": "ForwardMSAAPass",
-                                "Attachment": "DiffuseOutput"
-                            }
-                        },
-                        {
-                            "LocalSlot": "SpecularOutput",
-                            "AttachmentRef": {
-                                "Pass": "ForwardMSAAPass",
-                                "Attachment": "SpecularOutput"
-                            }
-                        },
-                        {
-                            "LocalSlot": "AlbedoOutput",
-                            "AttachmentRef": {
-                                "Pass": "ForwardMSAAPass",
-                                "Attachment": "AlbedoOutput"
-                            }
-                        },
-                        {
-                            "LocalSlot": "SpecularF0Output",
-                            "AttachmentRef": {
-                                "Pass": "ForwardMSAAPass",
-                                "Attachment": "SpecularF0Output"
-                            }
-                        },
-                        {
-                            "LocalSlot": "NormalOutput",
-                            "AttachmentRef": {
-                                "Pass": "ForwardMSAAPass",
-                                "Attachment": "NormalOutput"
-                            }
-                        }
-                    ],
-                    "PassData": {
-                        "$type": "RasterPassData",
-                        "DrawListTag": "forwardWithSubsurfaceOutput",
-                        "PipelineViewTag": "MainCamera",
-                        "PassSrgShaderAsset": {
-                            "FilePath": "Shaders/ForwardPassSrg.shader"
-                        }
-                    }
-                },
-                {
-                    "Name": "SkyBoxPass",
-                    "TemplateName": "EnvironmentCubeMapSkyBoxPassTemplate",
-                    "Connections": [
-                        {
-                            "LocalSlot": "SpecularInputOutput",
-                            "AttachmentRef": {
-                                "Pass": "ForwardMSAAPass",
-                                "Attachment": "SpecularOutput"
-                            }
-                        },
-                        {
-                            "LocalSlot": "SkyBoxDepth",
-                            "AttachmentRef": {
-                                "Pass": "ForwardMSAAPass",
-                                "Attachment": "DepthStencilInputOutput"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "DiffuseGlobalIlluminationPass",
-                    "TemplateName": "DiffuseGlobalIlluminationPassTemplate",
-                    "Connections": [
-                        {
-                            "LocalSlot": "DiffuseInputOutput",
-                            "AttachmentRef": {
-                                "Pass": "ForwardMSAAPass",
-                                "Attachment": "DiffuseOutput"
-                            }
-                        },
-                        {
-                            "LocalSlot": "AlbedoInput",
-                            "AttachmentRef": {
-                                "Pass": "ForwardMSAAPass",
-                                "Attachment": "AlbedoOutput"
-                            }
-                        },
-                        {
-                            "LocalSlot": "NormalInput",
-                            "AttachmentRef": {
-                                "Pass": "ForwardMSAAPass",
-                                "Attachment": "NormalOutput"
-                            }
-                        },
-                        {
-                            "LocalSlot": "DepthStencilInputOutput",
-                            "AttachmentRef": {
-                                "Pass": "ForwardMSAAPass",
-                                "Attachment": "DepthStencilInputOutput"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "ReflectionCompositePass",
-                    "TemplateName": "ReflectionCompositePassTemplate",
-                    "Connections": [
-                        {
-                            "LocalSlot": "ReflectionInput",
-                            "AttachmentRef": {
-                                "Pass": "ForwardMSAAPass",
-                                "Attachment": "SpecularF0Output"
-                            }
-                        },
-                        {
-                            "LocalSlot": "SpecularInputOutput",
-                            "AttachmentRef": {
-                                "Pass": "SkyBoxPass",
-                                "Attachment": "SpecularInputOutput"
-                            }
-                        },
-                        {
-                            "LocalSlot": "DepthStencilInputOutput",
-                            "AttachmentRef": {
-                                "Pass": "SkyBoxPass",
-                                "Attachment": "SkyBoxDepth"
-                            }
-                        }
-                    ],
-                    "PassData": {
-                        "$type": "FullscreenTrianglePassData",
-                        "ShaderAsset": {
-                            "FilePath": "Shaders/Reflections/ReflectionComposite.shader"
-                        },
-                        "StencilRef": 1, // See RenderCommon.h and ReflectionComposite.shader
-                        "PipelineViewTag": "MainCamera"
-                    }
-                },
-                {
-                    "Name": "MSAAResolveDiffusePass",
-                    "TemplateName": "MSAAResolveColorTemplate",
-                    "Connections": [
-                        {
-                            "LocalSlot": "Input",
-                            "AttachmentRef": {
-                                "Pass": "DiffuseGlobalIlluminationPass",
-                                "Attachment": "DiffuseInputOutput"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "MSAAResolveSpecularPass",
-                    "TemplateName": "MSAAResolveColorTemplate",
-                    "Connections": [
-                        {
-                            "LocalSlot": "Input",
-                            "AttachmentRef": {
-                                "Pass": "ReflectionCompositePass",
-                                "Attachment": "SpecularInputOutput"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "MSAAResolveScatterDistancePass",
-                    "TemplateName": "MSAAResolveColorTemplate",
-                    "Connections": [
-                        {
-                            "LocalSlot": "Input",
-                            "AttachmentRef": {
-                                "Pass": "ForwardSubsurfaceMSAAPass",
-                                "Attachment": "ScatterDistanceOutput"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "SubsurfaceScatteringPass",
-                    "TemplateName": "SubsurfaceScatteringPassTemplate",
-                    "Enabled": true,
-                    "Connections": [
-                        {
-                            "LocalSlot": "InputDiffuse",
-                            "AttachmentRef": {
-                                "Pass": "MSAAResolveDiffusePass",
-                                "Attachment": "Output"
-                            }
-                        },
-                        {
-                            "LocalSlot": "InputLinearDepth",
+                            "LocalSlot": "DepthLinear",
                             "AttachmentRef": {
                                 "Pass": "DepthPrePass",
                                 "Attachment": "DepthLinear"
                             }
                         },
                         {
-                            "LocalSlot": "InputScatterDistance",
+                            "LocalSlot": "DepthStencil",
                             "AttachmentRef": {
-                                "Pass": "MSAAResolveScatterDistancePass",
-                                "Attachment": "Output"
-                            }
-                        }
-                    ],
-                    "PassData": {
-                        "$type": "ComputePassData",
-                        "ShaderAsset": {
-                            "FilePath": "Shaders/PostProcessing/ScreenSpaceSubsurfaceScatteringCS.shader"
-                        },
-                        "Make Fullscreen Pass": true,
-                        "PipelineViewTag": "MainCamera"
-                    }
-                },
-                {
-                    "Name": "Ssao",
-                    "TemplateName": "SsaoParentTemplate",
-                    "Connections": [
-                        {
-                            "LocalSlot": "Modulate",
-                            "AttachmentRef": {
-                                "Pass": "SubsurfaceScatteringPass",
-                                "Attachment": "Output"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "DiffuseSpecularMergePass",
-                    "TemplateName": "DiffuseSpecularMergeTemplate",
-                    "Connections": [
-                        {
-                            "LocalSlot": "InputDiffuse",
-                            "AttachmentRef": {
-                                "Pass": "Ssao",
-                                "Attachment": "Output"
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthMSAA"
                             }
                         },
                         {
-                            "LocalSlot": "InputSpecular",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
-                                "Pass": "MSAAResolveSpecularPass",
-                                "Attachment": "Output"
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -513,7 +189,7 @@
                         {
                             "LocalSlot": "Input",
                             "AttachmentRef": {
-                                "Pass": "DiffuseSpecularMergePass",
+                                "Pass": "OpaquePass",
                                 "Attachment": "Output"
                             }
                         },
@@ -521,7 +197,7 @@
                             "LocalSlot": "Output",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "Output"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]

--- a/Gems/Atom/Feature/Common/Assets/Passes/Forward.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Forward.pass
@@ -162,7 +162,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {
@@ -175,7 +175,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {
@@ -188,7 +188,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {
@@ -201,7 +201,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {
@@ -214,7 +214,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/ForwardCheckerboard.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ForwardCheckerboard.pass
@@ -127,7 +127,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {
@@ -143,7 +143,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {
@@ -159,7 +159,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {
@@ -175,7 +175,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {
@@ -191,7 +191,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {
@@ -207,7 +207,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/ForwardMSAA.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ForwardMSAA.pass
@@ -162,7 +162,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "MultisampleSource": {
@@ -179,7 +179,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "MultisampleSource": {
@@ -196,7 +196,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "MultisampleSource": {
@@ -213,7 +213,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "MultisampleSource": {
@@ -230,7 +230,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "MultisampleSource": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/ForwardSubsurfaceMSAA.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ForwardSubsurfaceMSAA.pass
@@ -130,7 +130,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "MultisampleSource": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/FullscreenShadow.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/FullscreenShadow.pass
@@ -61,7 +61,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/LightAdaptationParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LightAdaptationParent.pass
@@ -14,7 +14,7 @@
                 },
                 // SwapChain here is only used to reference the frame height and format
                 {
-                    "Name": "SwapChainOutput",
+                    "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
                 },
                 // Outputs...
@@ -130,10 +130,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -151,10 +151,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]

--- a/Gems/Atom/Feature/Common/Assets/Passes/LightCullingParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LightCullingParent.pass
@@ -27,7 +27,7 @@
                 },
                 // SwapChain here is only used to reference the frame height and format
                 {
-                    "Name": "SwapChainOutput",
+                    "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
                 }
             ],

--- a/Gems/Atom/Feature/Common/Assets/Passes/LookModificationTransform.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LookModificationTransform.pass
@@ -20,7 +20,7 @@
                 },
                 // SwapChain here is only used to reference the frame height and format
                 {
-                    "Name": "SwapChainOutput",
+                    "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
                 },
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/LowEndForward.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LowEndForward.pass
@@ -98,7 +98,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "MultisampleSource": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/LowEndPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LowEndPipeline.pass
@@ -8,7 +8,7 @@
             "PassClass": "ParentPass",
             "Slots": [
                 {
-                    "Name": "SwapChainOutput",
+                    "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
                 }
             ],
@@ -16,8 +16,8 @@
                 "$type": "PassData",
                 "PipelineGlobalConnections": [
                     {
-                        "GlobalName": "SwapChainOutput",
-                        "Slot": "SwapChainOutput"
+                        "GlobalName": "PipelineOutput",
+                        "Slot": "PipelineOutput"
                     }
                 ]
             },
@@ -51,10 +51,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -78,16 +78,16 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
                 },
                 {
-                    "Name": "ShadowPass",
+                    "Name": "Shadows",
                     "TemplateName": "ShadowParentTemplate",
                     "Connections": [
                         {
@@ -98,19 +98,19 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         },
                         {
                             "LocalSlot": "Depth",
                             "AttachmentRef": {
                                 "Pass": "DepthPrePass",
-                                "Attachment": "DepthMSAA" 
+                                "Attachment": "DepthMSAA"
                             }
-                        }                           
+                        }
                     ]
                 },
                 {
@@ -121,28 +121,28 @@
                         {
                             "LocalSlot": "DirectionalLightShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "DirectionalShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "ExponentialShadowmapDirectional",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "DirectionalESM"
                             }
                         },
                         {
                             "LocalSlot": "ProjectedShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "ProjectedShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "ExponentialShadowmapProjected",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "ProjectedESM"
                             }
                         },
@@ -219,28 +219,28 @@
                         {
                             "LocalSlot": "DirectionalShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "DirectionalShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "DirectionalESM",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "DirectionalESM"
                             }
                         },
                         {
                             "LocalSlot": "ProjectedShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "ProjectedShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "ProjectedESM",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "ProjectedESM"
                             }
                         },
@@ -293,10 +293,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -362,7 +362,7 @@
                             "LocalSlot": "Output",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]

--- a/Gems/Atom/Feature/Common/Assets/Passes/MainPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MainPipeline.pass
@@ -8,7 +8,7 @@
             "PassClass": "ParentPass",
             "Slots": [
                 {
-                    "Name": "SwapChainOutput",
+                    "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
                 }
             ],
@@ -16,8 +16,8 @@
                 "$type": "PassData",
                 "PipelineGlobalConnections": [
                     {
-                        "GlobalName": "SwapChainOutput",
-                        "Slot": "SwapChainOutput"
+                        "GlobalName": "PipelineOutput",
+                        "Slot": "PipelineOutput"
                     }
                 ]
             },
@@ -62,10 +62,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "PipelineGlobal",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -89,10 +89,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "PipelineGlobal",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -116,10 +116,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "PipelineGlobal",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -136,10 +136,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "PipelineGlobal",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         },
                         {
@@ -212,10 +212,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "PipelineGlobal",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -364,10 +364,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "PipelineGlobal",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -494,7 +494,7 @@
                             "LocalSlot": "Output",
                             "AttachmentRef": {
                                 "Pass": "PipelineGlobal",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]

--- a/Gems/Atom/Feature/Common/Assets/Passes/MainPipelineRenderToTexture.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MainPipelineRenderToTexture.pass
@@ -18,7 +18,7 @@
                     "TemplateName": "MainPipeline",
                     "Connections": [
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
                                 "Attachment": "Output"

--- a/Gems/Atom/Feature/Common/Assets/Passes/MeshMotionVector.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MeshMotionVector.pass
@@ -40,7 +40,7 @@
                     "SizeSource": {
                         "Source": {
                             "Pass": "Parent",
-                            "Attachment": "SwapChainOutput"
+                            "Attachment": "PipelineOutput"
                         }
                     },
                     "ImageDescriptor": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/MotionVectorParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MotionVectorParent.pass
@@ -18,7 +18,7 @@
                 },
                 // SwapChain here is only used to reference the frame height and format
                 {
-                    "Name": "SwapChainOutput",
+                    "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
                 },
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/OpaqueParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/OpaqueParent.pass
@@ -52,7 +52,7 @@
                 },
                 // SwapChain here is only used to reference the frame height and format
                 {
-                    "Name": "SwapChainOutput",
+                    "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
                 }
             ],

--- a/Gems/Atom/Feature/Common/Assets/Passes/PostProcessParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PostProcessParent.pass
@@ -22,7 +22,7 @@
                 },
                 // SwapChain here is only used to reference the frame height and format
                 {
-                    "Name": "SwapChainOutput",
+                    "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
                 },
                 // Outputs...
@@ -181,10 +181,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]

--- a/Gems/Atom/Feature/Common/Assets/Passes/ShadowParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ShadowParent.pass
@@ -35,7 +35,7 @@
                 },
                 // SwapChain here is only used to reference the frame height and format
                 {
-                    "Name": "SwapChainOutput",
+                    "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
                 },
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipeline.pass
@@ -8,7 +8,7 @@
             "PassClass": "ParentPass",
             "Slots": [
                 {
-                    "Name": "SwapChainOutput",
+                    "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
                 }
             ],
@@ -16,8 +16,8 @@
                 "$type": "PassData",
                 "PipelineGlobalConnections": [
                     {
-                        "GlobalName": "SwapChainOutput",
-                        "Slot": "SwapChainOutput"
+                        "GlobalName": "PipelineOutput",
+                        "Slot": "PipelineOutput"
                     }
                 ]
             },
@@ -62,10 +62,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -89,10 +89,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -116,16 +116,16 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
                 },
                 {
-                    "Name": "ShadowPass",
+                    "Name": "Shadows",
                     "TemplateName": "ShadowParentTemplate",
                     "Connections": [
                         {
@@ -136,19 +136,19 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         },
                         {
                             "LocalSlot": "Depth",
                             "AttachmentRef": {
                                 "Pass": "DepthPrePass",
-                                "Attachment": "DepthMSAA" 
+                                "Attachment": "DepthMSAA"
                             }
-                        }                          
+                        }
                     ]
                 },
                 {
@@ -158,28 +158,28 @@
                         {
                             "LocalSlot": "DirectionalShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "DirectionalShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "DirectionalESM",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "DirectionalESM"
                             }
                         },
                         {
                             "LocalSlot": "ProjectedShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "ProjectedShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "ProjectedESM",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "ProjectedESM"
                             }
                         },
@@ -212,10 +212,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -227,28 +227,28 @@
                         {
                             "LocalSlot": "DirectionalShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "DirectionalShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "DirectionalESM",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "DirectionalESM"
                             }
                         },
                         {
                             "LocalSlot": "ProjectedShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "ProjectedShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "ProjectedESM",
                             "AttachmentRef": {
-                                "Pass": "ShadowPass",
+                                "Pass": "Shadows",
                                 "Attachment": "ProjectedESM"
                             }
                         },
@@ -364,10 +364,10 @@
                             }
                         },
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]
@@ -467,7 +467,7 @@
                             "LocalSlot": "Output",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "SwapChainOutput"
+                                "Attachment": "PipelineOutput"
                             }
                         }
                     ]

--- a/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipelineRenderToTexture.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipelineRenderToTexture.pass
@@ -18,7 +18,7 @@
                     "TemplateName": "ToolsPipeline",
                     "Connections": [
                         {
-                            "LocalSlot": "SwapChainOutput",
+                            "LocalSlot": "PipelineOutput",
                             "AttachmentRef": {
                                 "Pass": "Parent",
                                 "Attachment": "Output"

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperPass.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperPass.h
@@ -93,7 +93,7 @@ namespace AZ
             DisplayMapperConfigurationDescriptor m_displayMapperConfigurationDescriptor;
             bool m_needToRebuildChildren = false;
 
-            const RPI::PassAttachmentBinding* m_swapChainAttachmentBinding = nullptr;
+            const RPI::PassAttachmentBinding* m_pipelineOutput = nullptr;
 
             AZ::Render::DisplayMapperParameters m_displayMapperParameters = {};
 

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
@@ -82,9 +82,9 @@ namespace AZ
         {
             // [GFX TODO] [ATOM-2450] Logic determine the type of display attached and use it to drive the
             // display mapper parameters.
-            if (m_swapChainAttachmentBinding && m_swapChainAttachmentBinding->GetAttachment())
+            if (m_pipelineOutput && m_pipelineOutput->GetAttachment())
             {
-                m_displayBufferFormat = m_swapChainAttachmentBinding->GetAttachment()->m_descriptor.m_image.m_format;
+                m_displayBufferFormat = m_pipelineOutput->GetAttachment()->m_descriptor.m_image.m_format;
             }
 
             if (m_displayBufferFormat != RHI::Format::Unknown)
@@ -170,7 +170,7 @@ namespace AZ
                 m_ldrGradingLookupTablePass->SetInputReferenceAttachmentName(inputPassAttachment);
             }
 
-            m_swapChainAttachmentBinding = FindAttachmentBinding(Name("SwapChainOutput"));
+            m_pipelineOutput = FindAttachmentBinding(Name("PipelineOutput"));
 
             ParentPass::BuildInternal();
         }

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationTransformPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationTransformPass.cpp
@@ -34,7 +34,7 @@ namespace AZ
 
         void LookModificationPass::BuildInternal()
         {
-            m_swapChainAttachmentBinding = FindAttachmentBinding(Name("SwapChainOutput"));
+            m_pipelineOutput = FindAttachmentBinding(Name("PipelineOutput"));
             ParentPass::BuildInternal();
         }
 
@@ -42,9 +42,9 @@ namespace AZ
         {
             // Get swap chain format
             RHI::Format swapChainFormat = RHI::Format::Unknown;
-            if (m_swapChainAttachmentBinding && m_swapChainAttachmentBinding->GetAttachment())
+            if (m_pipelineOutput && m_pipelineOutput->GetAttachment())
             {
-                swapChainFormat = m_swapChainAttachmentBinding->GetAttachment()->m_descriptor.m_image.m_format;
+                swapChainFormat = m_pipelineOutput->GetAttachment()->m_descriptor.m_image.m_format;
             }
 
             // Update the children passes

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationTransformPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationTransformPass.h
@@ -51,7 +51,7 @@ namespace AZ
             void BuildInternal() override;
 
         private:
-            const RPI::PassAttachmentBinding* m_swapChainAttachmentBinding = nullptr;
+            const RPI::PassAttachmentBinding* m_pipelineOutput = nullptr;
             RHI::Format m_displayBufferFormat = RHI::Format::Unknown;
             OutputDeviceTransformType m_outputDeviceTransformType = OutputDeviceTransformType_48Nits;
             ShaperParams m_shaperParams;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/EnvironmentCubeMapPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/EnvironmentCubeMapPass.cpp
@@ -49,7 +49,7 @@ namespace AZ
             childRequest.m_passName = "Child";
             
             PassConnection childInputConnection;
-            childInputConnection.m_localSlot = "Output";
+            childInputConnection.m_localSlot = "PipelineOutput";
             childInputConnection.m_attachmentRef.m_pass = "Parent";
             childInputConnection.m_attachmentRef.m_attachment = "Output";
             childRequest.m_connections.emplace_back(childInputConnection);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
@@ -73,10 +73,10 @@ namespace AZ
             swapChainImageDesc.m_format = m_swapChainDimensions.m_imageFormat;
             m_swapChainAttachment->m_descriptor = swapChainImageDesc;
 
-            PassAttachmentBinding* swapChainOutput = FindAttachmentBinding(Name("SwapChainOutput"));
+            PassAttachmentBinding* swapChainOutput = FindAttachmentBinding(Name("PipelineOutput"));
             AZ_Assert(swapChainOutput != nullptr &&
                       swapChainOutput->m_slotType == PassSlotType::InputOutput,
-                      "PassTemplate used to create SwapChainPass must have an InputOutput called SwapChainOutput");
+                      "PassTemplate used to create SwapChainPass must have an InputOutput called PipelineOutput");
 
             swapChainOutput->SetAttachment(m_swapChainAttachment);
         }

--- a/Gems/AtomTressFX/Assets/Passes/AtomTressFX_PassRequest.azasset
+++ b/Gems/AtomTressFX/Assets/Passes/AtomTressFX_PassRequest.azasset
@@ -50,28 +50,28 @@
             {
                 "LocalSlot": "DirectionalShadowmap",
                 "AttachmentRef": {
-                    "Pass": "ShadowPass",
+                    "Pass": "Shadows",
                     "Attachment": "DirectionalShadowmap"
                 }
             },
             {
                 "LocalSlot": "DirectionalESM",
                 "AttachmentRef": {
-                    "Pass": "ShadowPass",
+                    "Pass": "Shadows",
                     "Attachment": "DirectionalESM"
                 }
             },
             {
                 "LocalSlot": "ProjectedShadowmap",
                 "AttachmentRef": {
-                    "Pass": "ShadowPass",
+                    "Pass": "Shadows",
                     "Attachment": "ProjectedShadowmap"
                 }
             },
             {
                 "LocalSlot": "ProjectedESM",
                 "AttachmentRef": {
-                    "Pass": "ShadowPass",
+                    "Pass": "Shadows",
                     "Attachment": "ProjectedESM"
                 }
             },


### PR DESCRIPTION
Changed all SwapChainOutput to PipelineOutput to be more reusable across pipelines that don't have a swapchain.
Fixed Hair referencing ShadowPass instead of the new name Shadows, which would spam the output.
Reworked EnvironmentCubeMapPipeline.pass with the new PipelineOutput, it now uses the Shadow and Opaque parent passes and should be much easier to maintain going forward.

Fixes:
https://github.com/o3de/o3de/issues/10413

Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>

Tested Hair spam was fixed and reflection probe works in editor.
