### PR TITLE
feat(EmotionFX): add interface for PluginManager

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/EMStudioManager.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/EMStudioManager.cpp
@@ -17,6 +17,7 @@
 #include <EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderOptions.h>
 #include <EMotionFX/CommandSystem/Source/MotionCommands.h>
 #include <EMotionFX/CommandSystem/Source/MotionSetCommands.h>
+#include <EMotionStudio/EMStudioSDK/Source/IPluginManager.h>
 
 // include MCore related
 #include <MCore/Source/LogManager.h>
@@ -93,6 +94,7 @@ namespace EMStudio
         m_commandManager->RegisterCommand(new CommandEditorLoadAnimGraph());
         m_commandManager->RegisterCommand(new CommandEditorLoadMotionSet());
 
+
         m_eventPresetManager         = new MotionEventPresetManager();
         m_pluginManager              = new PluginManager();
         m_layoutManager              = new LayoutManager();
@@ -105,6 +107,7 @@ namespace EMStudio
         // log some information
         LogInfo();
 
+        AZ::Interface<IPluginManager>::Register(m_pluginManager);
         AZ::Interface<EMStudioManager>::Register(this);
     }
 
@@ -122,6 +125,8 @@ namespace EMStudio
 
         // delete all animgraph instances etc
         ClearScene();
+
+        AZ::Interface<IPluginManager>::Unregister(m_pluginManager);
 
         delete m_eventPresetManager;
         delete m_pluginManager;
@@ -144,7 +149,6 @@ namespace EMStudio
         }
         return m_mainWindow;
     }
-
 
     // clear everything
     void EMStudioManager::ClearScene()

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/EMStudioManager.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/EMStudioManager.h
@@ -67,6 +67,9 @@ namespace EMStudio
         MCORE_INLINE QApplication* GetApp()                                     { return m_app; }
         MCORE_INLINE bool HasMainWindow() const                                 { return !m_mainWindow.isNull(); }
         MainWindow* GetMainWindow();
+
+        // O3DE_DEPRECATION_NOTICE(GHI-)
+        //! @deprecated use AZ::Interface<IPluginManager>
         MCORE_INLINE PluginManager* GetPluginManager()                          { return m_pluginManager; }
         MCORE_INLINE LayoutManager* GetLayoutManager()                          { return m_layoutManager; }
         MCORE_INLINE NotificationWindowManager* GetNotificationWindowManager()  { return m_notificationWindowManager; }
@@ -170,6 +173,9 @@ namespace EMStudio
     EMStudioManager* GetManager();
     bool HasMainWindow();
     MainWindow* GetMainWindow();
+
+    // O3DE_DEPRECATION_NOTICE(GHI-)
+    //! @deprecated use AZ::Interface<IPluginManager>
     PluginManager* GetPluginManager();
     LayoutManager* GetLayoutManager();
     NotificationWindowManager* GetNotificationWindowManager();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/IPluginManager.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/IPluginManager.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/base.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+
+#include <QString>
+
+namespace EMStudio
+{
+    class EMStudioPlugin;
+    class PersistentPlugin;
+} // namespace EMStudio
+
+namespace EMStudio
+{
+    class IPluginManager
+    {
+    public:
+        AZ_RTTI(IPluginManager, "{556595c0-f830-11ec-b939-0242ac120002}");
+
+        using PluginVector = AZStd::vector<EMStudio::EMStudioPlugin*>;
+        using PersistentPluginVector = AZStd::vector<AZStd::unique_ptr<EMStudio::PersistentPlugin>>;
+        
+        template<class PluginType>
+        typename AZStd::enable_if_t<AZStd::is_convertible_v<PluginType*, EMStudioPlugin*>, PluginType*> FindActivePlugin() const
+        {
+            return static_cast<PluginType*>(FindActivePlugin(PluginType::CLASS_ID));
+        }
+
+        IPluginManager() = default;
+        virtual ~IPluginManager() = default;
+
+        // Plugin prototypes (persistent plugins are not included)
+        virtual void RegisterPlugin(EMStudio::EMStudioPlugin* plugin) = 0;
+        virtual size_t GetNumRegisteredPlugins() const = 0;
+        virtual EMStudio::EMStudioPlugin* GetRegisteredPlugin(size_t index) = 0;
+        virtual size_t FindRegisteredPluginIndex(const char* pluginType) const = 0;
+        virtual const PluginVector& GetRegisteredPlugins() = 0;
+
+        // Active window plugins
+        virtual EMStudioPlugin* CreateWindowOfType(const char* pluginType, const char* objectName = nullptr) = 0;
+        virtual void RemoveActivePlugin(EMStudioPlugin* plugin) = 0;
+
+        virtual size_t GetNumActivePlugins() const = 0;
+        virtual EMStudioPlugin* GetActivePlugin(AZ::u32 index) = 0;
+        virtual const PluginVector& GetActivePlugins() = 0;
+
+        virtual EMStudioPlugin* FindActivePluginByTypeString(const char* pluginType) const = 0;
+        virtual EMStudio::EMStudioPlugin* FindActivePlugin(AZ::u32 classID) const = 0;
+        
+        virtual size_t CalcNumActivePluginsOfType(const char* pluginType) const = 0;
+        virtual size_t CalcNumActivePluginsOfType(AZ::u32 classID) const = 0;
+
+        virtual void AddPersistentPlugin(PersistentPlugin* plugin) = 0;
+        virtual void RemovePersistentPlugin(PersistentPlugin* plugin) = 0;
+        virtual size_t GetNumPersistentPlugins() const = 0;
+        virtual PersistentPlugin* GetPersistentPlugin(size_t index) = 0;
+        virtual const PersistentPluginVector& GetPersistentPlugins() = 0;
+
+        virtual QString GenerateObjectName() const = 0;
+        virtual void RegisterDefaultPlugins() = 0;
+    };
+
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PluginManager.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PluginManager.cpp
@@ -48,6 +48,7 @@
 
 namespace EMStudio
 {
+
     PluginManager::~PluginManager()
     {
         UnloadPlugins();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PluginManager.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PluginManager.h
@@ -14,56 +14,50 @@
 #include "EMStudioPlugin.h"
 #include <AzCore/PlatformIncl.h>
 #include <EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/PersistentPlugin.h>
+#include <EMotionStudio/EMStudioSDK/Source/IPluginManager.h>
 #endif
 
 namespace EMStudio
 {
-    class EMSTUDIO_API PluginManager
+    class EMSTUDIO_API PluginManager final : 
+        public EMStudio::IPluginManager
     {
     public:
-        typedef AZStd::vector<EMStudioPlugin*> PluginVector;
-        typedef AZStd::vector<AZStd::unique_ptr<PersistentPlugin>> PersistentPluginVector;
+        AZ_RTTI(PluginManager, "{5c60f9be-f835-11ec-b939-0242ac120002}", IPluginManager);
 
         PluginManager() = default;
-        ~PluginManager();
+        ~PluginManager() override;
 
         // Plugin prototypes (persistent plugins are not included)
-        void RegisterPlugin(EMStudioPlugin* plugin) { m_registeredPlugins.push_back(plugin); }
-        size_t GetNumRegisteredPlugins() const { return m_registeredPlugins.size(); }
-        EMStudioPlugin* GetRegisteredPlugin(size_t index) { return m_registeredPlugins[index]; }
-        size_t FindRegisteredPluginIndex(const char* pluginType) const;
-        const PluginVector& GetRegisteredPlugins() { return m_registeredPlugins; }
+        virtual void RegisterPlugin(EMStudioPlugin* plugin) override { m_registeredPlugins.push_back(plugin); }
+        virtual size_t GetNumRegisteredPlugins() const override { return m_registeredPlugins.size(); }
+        virtual EMStudioPlugin* GetRegisteredPlugin(size_t index) override { return m_registeredPlugins[index]; }
+        virtual size_t FindRegisteredPluginIndex(const char* pluginType) const override;
+        virtual const PluginVector& GetRegisteredPlugins() override { return m_registeredPlugins; }
 
         // Active window plugins
-        EMStudioPlugin* CreateWindowOfType(const char* pluginType, const char* objectName = nullptr);
-        void RemoveActivePlugin(EMStudioPlugin* plugin);
+        virtual EMStudioPlugin* CreateWindowOfType(const char* pluginType, const char* objectName = nullptr) override;
+        virtual void RemoveActivePlugin(EMStudioPlugin* plugin) override;
 
-        size_t GetNumActivePlugins() const { return m_activePlugins.size(); }
-        EMStudioPlugin* GetActivePlugin(uint32 index) { return m_activePlugins[index]; }
-        const PluginVector& GetActivePlugins() { return m_activePlugins; }
+        virtual size_t GetNumActivePlugins() const override{ return m_activePlugins.size(); }
+        virtual EMStudioPlugin* GetActivePlugin(uint32 index) override { return m_activePlugins[index]; }
+        virtual const PluginVector& GetActivePlugins() override{ return m_activePlugins; }
 
-        EMStudioPlugin* FindActivePluginByTypeString(const char* pluginType) const;
+        virtual EMStudioPlugin* FindActivePluginByTypeString(const char* pluginType) const override;
+        virtual EMStudioPlugin* FindActivePlugin(uint32 classID) const override;
 
-        // Reqire that PluginType is a subclass of EMStudioPlugin
-        template<class PluginType>
-        typename AZStd::enable_if_t<AZStd::is_convertible_v<PluginType*, EMStudioPlugin*>, PluginType*> FindActivePlugin() const
-        {
-            return static_cast<PluginType*>(FindActivePlugin(PluginType::CLASS_ID));
-        }
-        EMStudioPlugin* FindActivePlugin(uint32 classID) const;
-
-        size_t CalcNumActivePluginsOfType(const char* pluginType) const;
-        size_t CalcNumActivePluginsOfType(uint32 classID) const;
+        virtual size_t CalcNumActivePluginsOfType(const char* pluginType) const override;
+        virtual size_t CalcNumActivePluginsOfType(uint32 classID) const override;
 
         // Persistent plugins
-        void AddPersistentPlugin(PersistentPlugin* plugin) { m_persistentPlugins.push_back(AZStd::unique_ptr<PersistentPlugin>(plugin)); }
-        void RemovePersistentPlugin(PersistentPlugin* plugin);
-        size_t GetNumPersistentPlugins() const { return m_persistentPlugins.size(); }
-        PersistentPlugin* GetPersistentPlugin(size_t index) { return m_persistentPlugins[index].get(); }
-        const PersistentPluginVector& GetPersistentPlugins() { return m_persistentPlugins; }
+        virtual void AddPersistentPlugin(PersistentPlugin* plugin) override { m_persistentPlugins.push_back(AZStd::unique_ptr<PersistentPlugin>(plugin)); }
+        virtual void RemovePersistentPlugin(PersistentPlugin* plugin) override;
+        virtual size_t GetNumPersistentPlugins() const override { return m_persistentPlugins.size(); }
+        virtual PersistentPlugin* GetPersistentPlugin(size_t index) override { return m_persistentPlugins[index].get(); }
+        virtual const PersistentPluginVector& GetPersistentPlugins() override { return m_persistentPlugins; }
 
-        QString GenerateObjectName() const;
-        void RegisterDefaultPlugins();
+        virtual QString GenerateObjectName() const override;
+        virtual void RegisterDefaultPlugins() override;
 
     private:
         PluginVector m_registeredPlugins;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/emstudiosdk_files.cmake
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/emstudiosdk_files.cmake
@@ -33,6 +33,7 @@ set(FILES
     Source/PersistentPlugin.h
     Source/PluginManager.cpp
     Source/PluginManager.h
+    Source/IPluginManager.h
     Source/PluginOptions.h
     Source/PluginOptionsBus.h
     Source/PreferencesWindow.cpp


### PR DESCRIPTION
## What does this PR do?

This logic would be a lot easier to test if this wasn't managed as a singleton through EMStudioManager. this just add an interface and registers the PluginManager through AZ::Interface.

## How was this PR tested?

shouldn't change any existing logic. the same getters are still there just need to deprecate the usage. 
