### PR TITLE
Only pause/resume instance propagation for EntityPropertyEditor instead of all RPEs

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -52,12 +52,10 @@ namespace AzToolsFramework
                 "Check that it is being correctly initialized.");
 
             AZ::Interface<InstanceUpdateExecutorInterface>::Register(this);
-            PropertyEditorGUIMessages::Bus::Handler::BusConnect();
         }
 
         void InstanceUpdateExecutor::UnregisterInstanceUpdateExecutorInterface()
         {
-            PropertyEditorGUIMessages::Bus::Handler::BusDisconnect();
             m_GameModeEventHandler.Disconnect();
             AZ::Interface<InstanceUpdateExecutorInterface>::Unregister(this);
         }
@@ -287,16 +285,6 @@ namespace AzToolsFramework
             return isUpdateSuccessful;
         }
 
-        void InstanceUpdateExecutor::RequestWrite(QWidget*)
-        {
-            m_shouldPausePropagation = true;
-        }
-
-        void InstanceUpdateExecutor::OnEditingFinished(QWidget*)
-        {
-            m_shouldPausePropagation = false;
-        }
-
         void InstanceUpdateExecutor::QueueRootPrefabLoadedNotificationForNextPropagation()
         {
             m_isRootPrefabInstanceLoaded = false;
@@ -305,6 +293,11 @@ namespace AzToolsFramework
                 AZ::Interface<PrefabEditorEntityOwnershipInterface>::Get();
             m_rootPrefabInstanceSourcePath =
                 prefabEditorEntityOwnershipInterface->GetRootPrefabInstance()->get().GetTemplateSourcePath();
+        }
+
+        void InstanceUpdateExecutor::SetShouldPauseInstancePropagation(bool shouldPausePropagation)
+        {
+            m_shouldPausePropagation = shouldPausePropagation;
         }
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -14,7 +14,6 @@
 #include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h>
 #include <AzToolsFramework/Prefab/PrefabIdTypes.h>
-#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 
 namespace AzToolsFramework
 {
@@ -26,7 +25,6 @@ namespace AzToolsFramework
 
         class InstanceUpdateExecutor
             : public InstanceUpdateExecutorInterface
-            , private PropertyEditorGUIMessages::Bus::Handler
         {
         public:
             AZ_RTTI(InstanceUpdateExecutor, "{E21DB0D4-0478-4DA9-9011-31BC96F55837}", InstanceUpdateExecutorInterface);
@@ -39,19 +37,12 @@ namespace AzToolsFramework
             void RemoveTemplateInstanceFromQueue(const Instance* instance) override;
             void QueueRootPrefabLoadedNotificationForNextPropagation() override;
 
+            void SetShouldPauseInstancePropagation(bool shouldPausePropagation);
+
             void RegisterInstanceUpdateExecutorInterface();
             void UnregisterInstanceUpdateExecutorInterface();
 
-        private:
-
-            ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-            // PropertyEditorGUIMessages::Bus::Handler
-            //! When making property changes in the editor, listening to the below notifications and pausing propagation accordingly will
-            //! prevent the user from losing control of the properties they are editing.
-            void RequestWrite(QWidget* editorGUI) override;
-            void OnEditingFinished(QWidget* editorGUI) override;
-            ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-            
+        private:            
             //! Connect the game mode event handler in a lazy fashion rather than at construction of this class.
             //! This is required because the event won't be ready for connection during construction as EditorEntityContextComponent
             //! gets initialized after the PrefabSystemComponent

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
@@ -34,6 +34,11 @@ namespace AzToolsFramework
             // A notification OnRootPrefabInstanceLoaded will fire during the propagation if root
             // prefab instance is loaded for the first time after this function is called.
             virtual void QueueRootPrefabLoadedNotificationForNextPropagation() = 0;
+
+            // Indicates whether to pause instance propagation or not.
+            //! When making property changes in the entity editor, pausing propagation during
+            //! editing will prevent the user from losing control of the properties they are editing.
+            virtual void SetShouldPauseInstancePropagation(bool shouldPausePropagation) = 0;
         };
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
@@ -35,7 +35,7 @@ namespace AzToolsFramework
             // prefab instance is loaded for the first time after this function is called.
             virtual void QueueRootPrefabLoadedNotificationForNextPropagation() = 0;
 
-            // Indicates whether to pause instance propagation or not.
+            //! Sets whether to pause instance propagation or not.
             //! When making property changes in the entity editor, pausing propagation during
             //! editing will prevent the user from losing control of the properties they are editing.
             virtual void SetShouldPauseInstancePropagation(bool shouldPausePropagation) = 0;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -49,6 +49,7 @@ AZ_POP_DISABLE_WARNING
 #include <AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityInterface.h>
 #include <AzToolsFramework/Prefab/PrefabFocusPublicInterface.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
+#include <AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h>
 #include <AzToolsFramework/Slice/SliceDataFlagsCommand.h>
 #include <AzToolsFramework/Slice/SliceMetadataEntityContextBus.h>
 #include <AzToolsFramework/Slice/SliceUtilities.h>
@@ -498,6 +499,9 @@ namespace AzToolsFramework
 
         m_prefabPublicInterface = AZ::Interface<Prefab::PrefabPublicInterface>::Get();
         AZ_Assert(m_prefabPublicInterface != nullptr, "EntityPropertyEditor requires a PrefabPublicInterface instance on Initialize.");
+
+        m_instanceUpdateExecutorInterface = AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get();
+        AZ_Assert(m_instanceUpdateExecutorInterface, "EntityPropertyEditor - Could not retrieve instance of InstanceUpdateExecutorInterface");
 
         m_readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get();
         AZ_Assert(m_readOnlyEntityPublicInterface != nullptr, "EntityPropertyEditor requires a ReadOnlyEntityPublicInterface instance on Initialize.");
@@ -1268,6 +1272,11 @@ namespace AzToolsFramework
         {
             action->setEnabled(true);
         }
+
+        // Make sure that prefab instance propagation is resumed after a property tree refresh.
+        // Note: this is a sanity check in case IPropertyEditorNotify::BeforePropertyModified
+        // is called, but a IPropertyEditorNotify::SetPropertyEditingComplete isn't called
+        m_instanceUpdateExecutorInterface->SetShouldPauseInstancePropagation(false);
     }
 
     void EntityPropertyEditor::GetAllComponentsForEntityInOrder(
@@ -1868,6 +1877,14 @@ namespace AzToolsFramework
         {
             ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::AddDirtyEntity, entityShownId);
         }
+
+        // Notify prefab system to pause instance propagation during editing.
+        // This is done here in the BeforePropertyModified handler and not in SetPropertyEditingActive
+        // because SetPropertyEditingActive is not hooked up to be called from anywhere and never gets hit.
+        // BeforePropertyModified/AfterPropertyModified are called multiple times while a property is being
+        // modified (ex. while moving a slider handle), and SetPropertyEditingComplete is called once when
+        // editing is complete (ex. doing a mouse up on the slider handle)
+        m_instanceUpdateExecutorInterface->SetShouldPauseInstancePropagation(true);
     }
 
     void EntityPropertyEditor::AfterPropertyModified(InstanceDataNode* pNode)
@@ -1927,12 +1944,16 @@ namespace AzToolsFramework
 
     void EntityPropertyEditor::SetPropertyEditingActive(InstanceDataNode* /*pNode*/)
     {
+        // Note: This signal doesn't actually get called. It doesn't seem to be hooked up to anything
         MarkPropertyEditorBusyStart();
     }
 
     void EntityPropertyEditor::SetPropertyEditingComplete(InstanceDataNode* /*pNode*/)
     {
         MarkPropertyEditorBusyEnd();
+
+        // Notify prefab system to resume instance propagation now that editing is complete
+        m_instanceUpdateExecutorInterface->SetShouldPauseInstancePropagation(false);
     }
 
     void EntityPropertyEditor::OnPropertyRefreshRequired()
@@ -2701,6 +2722,7 @@ namespace AzToolsFramework
         }
 
         AfterPropertyModified(fieldNode);
+        SetPropertyEditingComplete(fieldNode);
 
         // We must refresh the entire tree, because restoring previous entity state may've had major structural effects.
         InvalidatePropertyDisplay(Refresh_EntireTree);
@@ -2718,6 +2740,8 @@ namespace AzToolsFramework
             command->SetParent(m_currentUndoOperation);
 
             AfterPropertyModified(node);
+            SetPropertyEditingComplete(node);
+
             InvalidatePropertyDisplay(Refresh_AttributesAndValues);
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
@@ -77,6 +77,7 @@ namespace AzToolsFramework
     namespace Prefab
     {
         class PrefabPublicInterface;
+        class InstanceUpdateExecutorInterface;
     };
 
     namespace UndoSystem
@@ -635,6 +636,7 @@ namespace AzToolsFramework
         EntityIdSet m_overrideSelectedEntityIds;
 
         Prefab::PrefabPublicInterface* m_prefabPublicInterface = nullptr;
+        Prefab::InstanceUpdateExecutorInterface* m_instanceUpdateExecutorInterface = nullptr;
         bool m_prefabsAreEnabled = false;
 
         ReadOnlyEntityPublicInterface* m_readOnlyEntityPublicInterface = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
@@ -400,6 +400,11 @@ namespace AzToolsFramework
             {
                 EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
             });
+        connect(newCtrl, &PropertyColorCtrl::editingFinished, this, [newCtrl]()
+            {
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &PropertyEditorGUIMessages::OnEditingFinished, newCtrl);
+            });
         // note:  Qt automatically disconnects objects from each other when either end is destroyed, no need to worry about delete.
 
         return newCtrl;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
@@ -405,7 +405,7 @@ namespace AzToolsFramework
                 AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
                     &PropertyEditorGUIMessages::OnEditingFinished, newCtrl);
             });
-        // note:  Qt automatically disconnects objects from each other when either end is destroyed, no need to worry about delete.
+        // note: Qt automatically disconnects objects from each other when either end is destroyed, no need to worry about delete.
 
         return newCtrl;
     }


### PR DESCRIPTION
The InstanceUpdateExecutor was listening to PropertyEditorGUIMessages' RequestWrite and OnEditingFinished to pause/resume instance propagation during property editing. However, these messages are sent from any RPE. 

Instead, this PR moves the pausing/resuming of instance propagation to handlers within the EntityPropertyEditor.

Also checked that all AzToolsFramework property handlers send OnEditingFinished.

Fixes #9853. The FBX settings tool uses the RPE and adds its own custom controls that don't send OnEditingFinished events. That won't matter now because we're only pausing/resuming propagation on tools that use the EntityPropertyEditor (Entity Inspector). 

Signed-off-by: abrmich <abrmich@amazon.com>