### PR TITLE
Support navigate to translation .names file in any safe assets folder

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.cpp
@@ -136,22 +136,14 @@ namespace ScriptCanvasEditor::TranslationHelper
                             else if (AZStd::string(path).ends_with(fileNameWithExtension))
                             {
                                 filesFound.push_back(path);
+                                foldersToSearch.clear();
+                                return false;
                             }
                             return true;
                         });
                 }
-                if (filesFound.size() > 0)
+                if (filesFound.size() == 1)
                 {
-                    // send out warning messages in case there are multiple matching translation files
-                    if (filesFound.size() > 1)
-                    {
-                        AZStd::string filelist = filesFound.front();
-                        for (size_t index = 1; index < filesFound.size(); ++index)
-                        {
-                            filelist.append(", " + filesFound[index]);
-                        }
-                        AZ_Warning("ScriptCanvas", false, AZStd::string::format("Found multiple matching translation files: [%s]", filelist.c_str()).c_str());
-                    }
                     AZ::IO::FixedMaxPath resolvedPath("");
                     fileIO->ResolvePath(resolvedPath, AZ::IO::PathView(filesFound.front()));
                     return AZ::IO::Path(resolvedPath);

--- a/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.cpp
@@ -8,6 +8,7 @@
 
 #include "TranslationHelper.h"
 #include <AzCore/IO/FileIO.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzFramework/Gem/GemInfo.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 

--- a/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.cpp
@@ -7,6 +7,9 @@
  */
 
 #include "TranslationHelper.h"
+#include <AzCore/IO/FileIO.h>
+#include <AzFramework/Gem/GemInfo.h>
+#include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 
 namespace ScriptCanvasEditor::TranslationHelper
 {
@@ -61,5 +64,101 @@ namespace ScriptCanvasEditor::TranslationHelper
         GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
 
         return details.m_name;
+    }
+
+    AZ::IO::Path GetGemAssetPath(const AZStd::string& gemName)
+    {
+        if (auto settingsRegistry = AZ::Interface<AZ::SettingsRegistryInterface>::Get(); settingsRegistry != nullptr)
+        {
+            AZ::IO::Path gemSourceAssetDirectories;
+            AZStd::vector<AzFramework::GemInfo> gemInfos;
+            if (AzFramework::GetGemsInfo(gemInfos, *settingsRegistry))
+            {
+                auto FindGemByName = [gemName](const AzFramework::GemInfo& gemInfo)
+                {
+                    return gemInfo.m_gemName == gemName;
+                };
+
+                // Gather unique list of Gem Paths from the Settings Registry
+                auto foundIt = AZStd::find_if(gemInfos.begin(), gemInfos.end(), FindGemByName);
+                if (foundIt != gemInfos.end())
+                {
+                    const AzFramework::GemInfo& gemInfo = *foundIt;
+                    for (const AZ::IO::Path& absoluteSourcePath : gemInfo.m_absoluteSourcePaths)
+                    {
+                        gemSourceAssetDirectories = (absoluteSourcePath / gemInfo.GetGemAssetFolder());
+                    }
+
+                    return AZ::IO::Path(gemSourceAssetDirectories.c_str());
+                }
+            }
+        }
+        return AZ::IO::Path();
+    }
+
+    AZ::IO::Path GetTranslationDefaultFolderPath()
+    {
+        AZ::IO::Path folderPath = GetGemAssetPath("ScriptCanvas") / "TranslationAssets";
+        return folderPath;
+    }
+
+    AZ::IO::Path GetTranslationFilePath(const AZStd::string& fileName)
+    {
+        // Check asset safe folders where all loaded translation files
+        AZStd::vector<AZStd::string> scanFolders;
+        bool success = false;
+        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+            success, &AzToolsFramework::AssetSystem::AssetSystemRequest::GetAssetSafeFolders, scanFolders);
+        auto fileIO = AZ::IO::FileIOBase::GetInstance();
+
+        if (fileIO && success && !fileName.empty())
+        {
+            AZStd::string fileNameWithExtension = AZStd::string::format("%s.names", fileName.c_str());
+            for (const AZStd::string& assetSafeFolder : scanFolders)
+            {
+                AZStd::deque<AZStd::string> foldersToSearch;
+                foldersToSearch.push_back(assetSafeFolder);
+                AZ::IO::Result searchResult = AZ::IO::ResultCode::Success;
+
+                AZStd::vector<AZStd::string> filesFound;
+                while (foldersToSearch.size() && searchResult == AZ::IO::ResultCode::Success)
+                {
+                    AZStd::string folderName = foldersToSearch.front();
+                    foldersToSearch.pop_front();
+
+                    searchResult = fileIO->FindFiles(folderName.c_str(), "*",
+                        [&](const char* path)
+                        {
+                            if (fileIO->IsDirectory(path))
+                            {
+                                foldersToSearch.push_back(path);
+                            }
+                            else if (AZStd::string(path).ends_with(fileNameWithExtension))
+                            {
+                                filesFound.push_back(path);
+                            }
+                            return true;
+                        });
+                }
+                if (filesFound.size() > 0)
+                {
+                    // send out warning messages in case there are multiple matching translation files
+                    if (filesFound.size() > 1)
+                    {
+                        AZStd::string filelist = filesFound.front();
+                        for (size_t index = 1; index < filesFound.size(); ++index)
+                        {
+                            filelist.append(", " + filesFound[index]);
+                        }
+                        AZ_Warning("ScriptCanvas", false, AZStd::string::format("Found multiple matching translation files: [%s]", filelist.c_str()).c_str());
+                    }
+                    AZ::IO::FixedMaxPath resolvedPath("");
+                    fileIO->ResolvePath(resolvedPath, AZ::IO::PathView(filesFound.front()));
+                    return AZ::IO::Path(resolvedPath);
+                }
+            }
+        }
+        AZ_Warning("ScriptCanvas", false, AZStd::string::format("No matching translation file found. Please generate translation file first.").c_str());
+        return AZ::IO::Path();
     }
 } // namespace ScriptCanvasEditor::TranslationHelper

--- a/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.h
+++ b/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.h
@@ -50,5 +50,14 @@ namespace ScriptCanvasEditor
         AZStd::string SanitizeCustomNodeFileName(const AZStd::string& nodeName, const AZ::Uuid& nodeUuid);
 
         AZStd::string GetSafeTypeName(ScriptCanvas::Data::Type dataType);
+
+        //! Utility function to get the path to the specified gem asset folder
+        AZ::IO::Path GetGemAssetPath(const AZStd::string& gemName);
+
+        //! Utility function to get translation file default folder path
+        AZ::IO::Path GetTranslationDefaultFolderPath();
+
+        //! Utility function to look for translation file path based on file name
+        AZ::IO::Path GetTranslationFilePath(const AZStd::string& fileName);
     }
 }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/EBusNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/EBusNodePaletteTreeItemTypes.cpp
@@ -139,7 +139,8 @@ namespace ScriptCanvasEditor
 
     AZ::IO::Path EBusSendEventPaletteTreeItem::GetTranslationDataPath() const
     {
-        return AZ::IO::Path(ScriptCanvasEditor::TranslationHelper::AssetPath::EBusSenderPath) / GetBusName();
+        AZStd::string fileName = GetBusName();
+        return ScriptCanvasEditor::TranslationHelper::GetTranslationFilePath(fileName);
     }
 
     void EBusSendEventPaletteTreeItem::GenerateTranslationData()
@@ -356,7 +357,8 @@ namespace ScriptCanvasEditor
 
     AZ::IO::Path EBusHandleEventPaletteTreeItem::GetTranslationDataPath() const
     {
-        return AZ::IO::Path(ScriptCanvasEditor::TranslationHelper::AssetPath::EBusHandlerPath) / GetBusName();
+        AZStd::string fileName = GetBusName();
+        return ScriptCanvasEditor::TranslationHelper::GetTranslationFilePath(fileName);
     }
 
     void EBusHandleEventPaletteTreeItem::GenerateTranslationData()

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
@@ -126,7 +126,8 @@ namespace ScriptCanvasEditor
 
     AZ::IO::Path ClassMethodEventPaletteTreeItem::GetTranslationDataPath() const
     {
-        return AZ::IO::Path(ScriptCanvasEditor::TranslationHelper::AssetPath::BehaviorClassPath) / GetClassMethodName();
+        AZStd::string fileName = GetClassMethodName();
+        return ScriptCanvasEditor::TranslationHelper::GetTranslationFilePath(fileName);
     }
 
     void ClassMethodEventPaletteTreeItem::GenerateTranslationData()
@@ -209,21 +210,19 @@ namespace ScriptCanvasEditor
 
     AZ::IO::Path GlobalMethodEventPaletteTreeItem::GetTranslationDataPath() const
     {
+        AZStd::string fileName = "";
         if (m_isProperty)
         {
             AZStd::string propertyName = m_methodName;
             AZ::StringFunc::Replace(propertyName, "::Getter", "");
             AZ::StringFunc::Replace(propertyName, "::Setter", "");
-
-            AZStd::string filename = GraphCanvas::TranslationKey::Sanitize(propertyName);
-
-            return AZ::IO::Path(ScriptCanvasEditor::TranslationHelper::AssetPath::BehaviorGlobalPropertyPath) / filename;
+            fileName = GraphCanvas::TranslationKey::Sanitize(propertyName);
         }
         else
         {
-            AZStd::string filename = GraphCanvas::TranslationKey::Sanitize(m_methodName);
-            return AZ::IO::Path(ScriptCanvasEditor::TranslationHelper::AssetPath::BehaviorGlobalMethodPath) / filename;
+            fileName = GraphCanvas::TranslationKey::Sanitize(m_methodName);
         }
+        return ScriptCanvasEditor::TranslationHelper::GetTranslationFilePath(fileName);
     }
 
     void GlobalMethodEventPaletteTreeItem::GenerateTranslationData()
@@ -305,10 +304,9 @@ namespace ScriptCanvasEditor
 
     AZ::IO::Path CustomNodePaletteTreeItem::GetTranslationDataPath() const
     {
-        AZStd::string filename =
+        AZStd::string fileName =
             ScriptCanvasEditor::TranslationHelper::SanitizeCustomNodeFileName(GetName().toUtf8().data(), GetInfo().m_typeId);
-
-        return AZ::IO::Path(ScriptCanvasEditor::TranslationHelper::AssetPath::CustomNodePath) / filename;
+        return ScriptCanvasEditor::TranslationHelper::GetTranslationFilePath(fileName);
     }
 
     void CustomNodePaletteTreeItem::GenerateTranslationData()

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.cpp
@@ -847,15 +847,11 @@ namespace ScriptCanvasEditor
         {
             if (nodePaletteItem)
             {
-                AZ::IO::Path gemPath = ScriptCanvasEditorTools::Helpers::GetGemPath("ScriptCanvas");
-                gemPath = gemPath / AZ::IO::Path("TranslationAssets");
-                gemPath = gemPath / nodePaletteItem->GetTranslationDataPath();
-                gemPath.ReplaceExtension(".names");
-
+                AZ::IO::Path filePath = nodePaletteItem->GetTranslationDataPath();
                 AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance();
-                if (fileIO && fileIO->Exists(gemPath.c_str()))
+                if (fileIO && !filePath.empty() && fileIO->Exists(filePath.c_str()))
                 {
-                    AzQtComponents::ShowFileOnDesktop(gemPath.c_str());
+                    AzQtComponents::ShowFileOnDesktop(filePath.c_str());
                 }
             }
         }

--- a/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
+++ b/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
@@ -24,8 +24,6 @@
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/std/string/regex.h>
 
-#include <AzFramework/Gem/GemInfo.h>
-
 #include <Libraries/Core/AzEventHandler.h>
 #include <Libraries/Libraries.h>
 #include <Libraries/Core/GetVariable.h>
@@ -1264,8 +1262,7 @@ namespace ScriptCanvasEditorTools
 
         document.AddMember("entries", entries, document.GetAllocator());
 
-        AZ::IO::Path gemPath = Helpers::GetGemPath("ScriptCanvas");
-        gemPath = gemPath / AZ::IO::Path("TranslationAssets");
+        AZ::IO::Path gemPath = ScriptCanvasEditor::TranslationHelper::GetTranslationDefaultFolderPath();
         gemPath = gemPath / filename;
         gemPath.ReplaceExtension(".names");
 
@@ -1362,36 +1359,6 @@ namespace ScriptCanvasEditorTools
                     outName = classData->m_name;
                 }
             }
-        }
-
-        AZStd::string GetGemPath(const AZStd::string& gemName)
-        {
-            if (auto settingsRegistry = AZ::Interface<AZ::SettingsRegistryInterface>::Get(); settingsRegistry != nullptr)
-            {
-                AZ::IO::Path gemSourceAssetDirectories;
-                AZStd::vector<AzFramework::GemInfo> gemInfos;
-                if (AzFramework::GetGemsInfo(gemInfos, *settingsRegistry))
-                {
-                    auto FindGemByName = [gemName](const AzFramework::GemInfo& gemInfo)
-                    {
-                        return gemInfo.m_gemName == gemName;
-                    };
-
-                    // Gather unique list of Gem Paths from the Settings Registry
-                    auto foundIt = AZStd::find_if(gemInfos.begin(), gemInfos.end(), FindGemByName);
-                    if (foundIt != gemInfos.end())
-                    {
-                        const AzFramework::GemInfo& gemInfo = *foundIt;
-                        for (const AZ::IO::Path& absoluteSourcePath : gemInfo.m_absoluteSourcePaths)
-                        {
-                            gemSourceAssetDirectories = (absoluteSourcePath / gemInfo.GetGemAssetFolder());
-                        }
-
-                        return gemSourceAssetDirectories.c_str();
-                    }
-                }
-            }
-            return "";
         }
 
         AZStd::string GetCategory(const AZ::SerializeContext::ClassData* classData)

--- a/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
+++ b/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
@@ -21,7 +21,6 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
-#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/std/string/regex.h>
 
 #include <Libraries/Core/AzEventHandler.h>

--- a/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.h
+++ b/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.h
@@ -206,9 +206,6 @@ namespace ScriptCanvasEditorTools
         //! Utility function to find a valid name from the ClassData/EditContext
         void GetTypeNameAndDescription(AZ::TypeId typeId, AZStd::string& outName, AZStd::string& outDescription);
 
-        //! Utility function to get the path to the specified gem
-        AZStd::string GetGemPath(const AZStd::string& gemName);
-
         //! Get the category attribute for a given ClassData
         AZStd::string GetCategory(const AZ::SerializeContext::ClassData* classData);
 


### PR DESCRIPTION
## What does this PR do?
Previously if .names file is located in other Gems/Project, SC Editor won't be able to locate it.
With this change, it should help user to locate their .names files easily.

Extra: put translation related util functions in common TranslationHelper

## How was this PR tested?
Change is Editor related only, tested locally with different node file, file searching works as expected

Signed-off-by: onecent1101 <liug@amazon.com>