### PR TITLE
Fixed Gradient Baker not updating its dependency monitor when the configuration changes

### DIFF
--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientBakerComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientBakerComponent.cpp
@@ -368,13 +368,8 @@ namespace GradientSignal
             SetDirty();
         }
 
-        m_dependencyMonitor.Reset();
-        m_dependencyMonitor.ConnectOwner(GetEntityId());
-        m_dependencyMonitor.ConnectDependency(m_configuration.m_gradientSampler.m_gradientId);
-
-        // Connect to GradientRequestBus after the gradient sampler and dependency monitor is configured
-        // before listening for gradient queries.
-        GradientRequestBus::Handler::BusConnect(GetEntityId());
+        // Setup the dependency monitor and listen for gradient requests
+        SetupDependencyMonitor();
 
         UpdatePreviewSettings();
 
@@ -449,6 +444,19 @@ namespace GradientSignal
         }
 
         return entityIds;
+    }
+
+    void EditorGradientBakerComponent::SetupDependencyMonitor()
+    {
+        GradientRequestBus::Handler::BusDisconnect();
+
+        m_dependencyMonitor.Reset();
+        m_dependencyMonitor.ConnectOwner(GetEntityId());
+        m_dependencyMonitor.ConnectDependency(m_configuration.m_gradientSampler.m_gradientId);
+
+        // Connect to GradientRequestBus after the gradient sampler and dependency monitor is configured
+        // before listening for gradient queries.
+        GradientRequestBus::Handler::BusConnect(GetEntityId());
     }
 
     void EditorGradientBakerComponent::BakeImage()
@@ -587,6 +595,10 @@ namespace GradientSignal
     {
         // Cancel any pending preview refreshes before locking, to help ensure the preview itself isn't holding the lock
         auto entityIds = CancelPreviewRendering();
+
+        // Re-setup the dependency monitor when the configuratio changes because the gradient sampler
+        // could've changed
+        SetupDependencyMonitor();
 
         // Refresh any of the previews that we canceled that were still in progress so they can be completed
         for (auto entityId : entityIds)

--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientBakerComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientBakerComponent.cpp
@@ -596,7 +596,7 @@ namespace GradientSignal
         // Cancel any pending preview refreshes before locking, to help ensure the preview itself isn't holding the lock
         auto entityIds = CancelPreviewRendering();
 
-        // Re-setup the dependency monitor when the configuratio changes because the gradient sampler
+        // Re-setup the dependency monitor when the configuration changes because the gradient sampler
         // could've changed
         SetupDependencyMonitor();
 

--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientBakerComponent.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientBakerComponent.h
@@ -141,6 +141,8 @@ namespace GradientSignal
         void UpdatePreviewSettings() const;
         AzToolsFramework::EntityIdList CancelPreviewRendering() const;
 
+        void SetupDependencyMonitor();
+
         void BakeImage();
         void StartBakeImageJob();
         bool IsBakeDisabled() const;


### PR DESCRIPTION
## What does this PR do?

Fixes #10381

The gradient baker component doesn't inherit from the `EditorGradientComponentBase` since it's an Editor-only component, so it was missing the logic that re-configures the dependency monitor when the configuration changes. The issue was noticed in the gradient baker node because if you created a new one (as per the steps in #10381), it's preview wouldn't be updated when there were changes in its dependencies because the dependency monitor wasn't being re-setup. The gradient baker node did function properly if you were loading a graph of an existing gradient baker component that had already been configured.

## How was this PR tested?

Ran unit tests and the repro steps in #10381. Here's gif of it working, where previously the gradient baker node preview would stay static when the random seed button was being pushed on the FastNoise gradient.

![BakerNodeUpdateOnDependencyChange](https://user-images.githubusercontent.com/7519264/176784286-db336cde-a78d-417c-84ee-1080003b5d48.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>
