### PR TITLE
Fixed OIIO include warning as compile error on nightly build

### DIFF
--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientBakerComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientBakerComponent.cpp
@@ -14,7 +14,9 @@
 #include <GradientSignal/Ebuses/GradientPreviewRequestBus.h>
 #include <GradientSignal/Ebuses/ImageGradientRequestBus.h>
 
+AZ_PUSH_DISABLE_WARNING(4777, "-Wunknown-warning-option")
 #include <OpenImageIO/imageio.h>
+AZ_POP_DISABLE_WARNING
 
 namespace GradientSignal
 {


### PR DESCRIPTION
## What does this PR do?

Fixes #10248 

Nightly debug build was flagging a warning as error in an `OpenImageIO` include, so wrapped it with the macro to disable warnings for that include.

## How was this PR tested?

Was unable to reproduce this issue locally, but this should solve the error.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>
