### PR TITLE
Fix to contrast adaptive sharpening pass.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/ContrastAdaptiveSharpening.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ContrastAdaptiveSharpening.pass
@@ -35,8 +35,14 @@
                     },
                     "ImageDescriptor": {
                         "Format": "R16G16B16A16_FLOAT",
-                        "BindFlags": "3",
-                        "SharedQueueMask": "1"
+                        "BindFlags": [
+                            "CopyRead",
+                            "Color",
+                            "ShaderReadWrite",
+                            "ShaderWrite",
+                            "ShaderRead"
+                        ],
+                        "SharedQueueMask": "Graphics"
                     }
                 }
             ],


### PR DESCRIPTION
Contrast adaptive sharpening was causing a crash with recent pass changes. This is likely because an enum changed values under the hood, and the numbers used for certain properties in the pass's json changed with it. This changes CAS to use named bind flags and shader queue mask instead of numbers to fix the problem.