### PR TITLE
Atom Tools: Implement autosave support and settings for ME MC SMC

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystem.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystem.h
@@ -51,6 +51,7 @@ namespace AtomToolsFramework
         bool SaveDocumentAsCopy(const AZ::Uuid& documentId, const AZStd::string& targetPath) override;
         bool SaveDocumentAsChild(const AZ::Uuid& documentId, const AZStd::string& targetPath) override;
         bool SaveAllDocuments() override;
+        bool SaveAllModifiedDocuments() override;
         AZ::u32 GetDocumentCount() const override;
         bool IsDocumentOpen(const AZ::Uuid& documentId) const override;
         void AddRecentFilePath(const AZStd::string& absolutePath) override;
@@ -60,6 +61,7 @@ namespace AtomToolsFramework
 
     private:
         // AtomToolsDocumentNotificationBus::Handler overrides...
+        void OnDocumentModified(const AZ::Uuid& documentId) override;
         void OnDocumentDependencyModified(const AZ::Uuid& documentId) override;
         void OnDocumentExternallyModified(const AZ::Uuid& documentId) override;
 
@@ -72,6 +74,7 @@ namespace AtomToolsFramework
         AZStd::unordered_set<AZ::Uuid> m_documentIdsWithExternalChanges;
         AZStd::unordered_set<AZ::Uuid> m_documentIdsWithDependencyChanges;
         bool m_queueReopenDocuments = false;
+        bool m_queueSaveAllModifiedDocuments = false;
         const size_t m_maxMessageBoxLineCount = 15;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h
@@ -82,6 +82,9 @@ namespace AtomToolsFramework
         //! Save all documents
         virtual bool SaveAllDocuments() = 0;
 
+        //! Save all modified documents
+        virtual bool SaveAllModifiedDocuments() = 0;
+
         //! Get number of allocated documents
         virtual AZ::u32 GetDocumentCount() const = 0;
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -100,7 +100,7 @@ namespace AtomToolsFramework
     //! @param exportPath absolute path of the file being saved
     //! @param referencePath absolute path of a file that will be treated as an external reference
     //! @param relativeToExportPath specifies if the path is relative to the source asset root or the export path
-    AZStd::string GetExteralReferencePath(
+    AZStd::string GetPathToExteralReference(
         const AZStd::string& exportPath, const AZStd::string& referencePath, const bool relativeToExportPath = false);
 
     //! Traverse up the instance data hierarchy to find a node containing the corresponding type
@@ -177,8 +177,8 @@ namespace AtomToolsFramework
     bool SaveSettingsToFile(const AZ::IO::FixedMaxPath& savePath, const AZStd::vector<AZStd::string>& filters);
 
     //! Helper function to convert a path containing an alias into a full path
-    AZStd::string ConvertAliasToPath(const AZStd::string& path);
+    AZStd::string GetPathWithoutAlias(const AZStd::string& path);
 
     //! Helper function to convert a full path into one containing an alias
-    AZStd::string ConvertPathToAlias(const AZStd::string& path);
+    AZStd::string GetPathWithAlias(const AZStd::string& path);
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -238,9 +238,14 @@ namespace AtomToolsFramework
             "Document System Settings",
             {
                 AtomToolsFramework::CreatePropertyFromSetting(
+                    "/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/DisplayWarningMessageDialogs",
+                    "Display Warning Message Dialogs",
+                    "Display message boxes for warnings opening documents",
+                    true),
+                AtomToolsFramework::CreatePropertyFromSetting(
                     "/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/DisplayErrorMessageDialogs",
                     "Display Error Message Dialogs",
-                    "Display message boxes for warnings and errors opening documents",
+                    "Display message boxes for errors opening documents",
                     true),
                 AtomToolsFramework::CreatePropertyFromSetting(
                     "/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/EnableAutomaticReload",
@@ -252,6 +257,16 @@ namespace AtomToolsFramework
                     "Enable Automatic Reload Prompts",
                     "Confirm before automatically reloading modified documents",
                     true),
+                AtomToolsFramework::CreatePropertyFromSetting(
+                    "/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/AutoSaveEnabled",
+                    "Enable Auto Save",
+                    "Automatically save documents after they are modified",
+                    false),
+                AtomToolsFramework::CreatePropertyFromSetting(
+                    "/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/AutoSaveInterval",
+                    "Auto Save Interval",
+                    "How often (in milliseconds) auto save occurs",
+                    aznumeric_cast<AZ::s64>(250)),
             }));
         return groups;
     }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeConfig.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeConfig.cpp
@@ -85,12 +85,12 @@ namespace AtomToolsFramework
 
     bool DynamicNodeConfig::Save(const AZStd::string& path) const
     {
-        return AZ::JsonSerializationUtils::SaveObjectToFile(this, ConvertAliasToPath(path)).IsSuccess();
+        return AZ::JsonSerializationUtils::SaveObjectToFile(this, GetPathWithoutAlias(path)).IsSuccess();
     }
 
     bool DynamicNodeConfig::Load(const AZStd::string& path)
     {
-        auto loadResult = AZ::JsonSerializationUtils::LoadAnyObjectFromFile(ConvertAliasToPath(path));
+        auto loadResult = AZ::JsonSerializationUtils::LoadAnyObjectFromFile(GetPathWithoutAlias(path));
         if (loadResult && loadResult.GetValue().is<DynamicNodeConfig>())
         {
             *this = AZStd::any_cast<DynamicNodeConfig>(loadResult.GetValue());

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeManager.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeManager.cpp
@@ -63,7 +63,7 @@ namespace AtomToolsFramework
                     if (AZ::StringFunc::EndsWith(assetInfo.m_relativePath.c_str(), extension))
                     {
                         const AZStd::string& configPath =
-                            ConvertPathToAlias(AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId));
+                            GetPathWithAlias(AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId));
                         configPaths.insert(configPath);
                         AZ_TracePrintf("DynamicNodeManager", "DynamicNodeConfig \"%s\" discovered.\n", configPath.c_str());
                         break;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/MaterialPropertyUtil.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/MaterialPropertyUtil.cpp
@@ -207,11 +207,9 @@ namespace AtomToolsFramework
                 AZ_Error("AtomToolsFramework", false, "Image asset could not be found for property: '%s'.", propertyId.GetCStr());
                 return false;
             }
-            else
-            {
-                propertyValue = GetExteralReferencePath(exportPath, imagePath);
-                return true;
-            }
+
+            propertyValue = GetPathToExteralReference(exportPath, imagePath);
+            return true;
         }
 
         return true;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -255,6 +255,7 @@ namespace AtomToolsFramework
             return {};
         }
 
+        const AZStd::string exportPathWithoutAlias = GetPathWithoutAlias(exportPath);
         const AZStd::string referencePathWithoutAlias = GetPathWithoutAlias(referencePath);
 
         if (!relativeToExportPath)
@@ -276,7 +277,7 @@ namespace AtomToolsFramework
             }
         }
 
-        AZ::IO::BasicPath<AZStd::string> exportFolder(exportPath);
+        AZ::IO::BasicPath<AZStd::string> exportFolder(exportPathWithoutAlias);
         exportFolder.RemoveFilename();
 
         return AZ::IO::PathView(referencePathWithoutAlias).LexicallyRelative(exportFolder).StringAsPosix();

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -161,6 +161,8 @@ namespace AtomToolsFramework
             return false;
         }
 
+        path = GetPathWithoutAlias(path);
+
         if (!AzFramework::StringFunc::Path::Normalize(path))
         {
             return false;
@@ -191,7 +193,7 @@ namespace AtomToolsFramework
         AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
             assetFoldersRetrieved, &AzToolsFramework::AssetSystemRequestBus::Events::GetAssetSafeFolders, assetFolders);
 
-        AZ::IO::FixedMaxPath assetPath = AZ::IO::PathView(path).LexicallyNormal();
+        AZ::IO::FixedMaxPath assetPath = AZ::IO::PathView(GetPathWithoutAlias(path)).LexicallyNormal();
         for (const auto& assetFolder : assetFolders)
         {
             // Check if the path is relative to the asset folder
@@ -206,15 +208,14 @@ namespace AtomToolsFramework
 
     bool IsDocumentPathEditable(const AZStd::string& path)
     {
+        const AZStd::string pathWithoutAlias = GetPathWithoutAlias(path);
+
         for (const auto& [storedPath, flag] :
              GetSettingsObject<AZStd::unordered_map<AZStd::string, bool>>("/O3DE/Atom/Tools/EditablePathSettings"))
         {
-            if (auto resolveResult = AZ::IO::FileIOBase::GetInstance()->ResolvePath(AZ::IO::PathView{ storedPath }))
+            if (pathWithoutAlias == GetPathWithoutAlias(storedPath))
             {
-                if (resolveResult->Compare(path) == 0)
-                {
-                    return flag;
-                }
+                return flag;
             }
         }
         return true;
@@ -222,15 +223,14 @@ namespace AtomToolsFramework
 
     bool IsDocumentPathPreviewable(const AZStd::string& path)
     {
+        const AZStd::string pathWithoutAlias = GetPathWithoutAlias(path);
+
         for (const auto& [storedPath, flag] :
              GetSettingsObject<AZStd::unordered_map<AZStd::string, bool>>("/O3DE/Atom/Tools/PreviewablePathSettings"))
         {
-            if (auto resolveResult = AZ::IO::FileIOBase::GetInstance()->ResolvePath(AZ::IO::PathView{ storedPath }))
+            if (pathWithoutAlias == GetPathWithoutAlias(storedPath))
             {
-                if (resolveResult->Compare(path) == 0)
-                {
-                    return flag;
-                }
+                return flag;
             }
         }
         return true;
@@ -247,7 +247,7 @@ namespace AtomToolsFramework
         return QProcess::startDetached(launchPath.c_str(), arguments, engineRoot.c_str());
     }
 
-    AZStd::string GetExteralReferencePath(
+    AZStd::string GetPathToExteralReference(
         const AZStd::string& exportPath, const AZStd::string& referencePath, const bool relativeToExportPath)
     {
         if (referencePath.empty())
@@ -255,23 +255,31 @@ namespace AtomToolsFramework
             return {};
         }
 
+        const AZStd::string referencePathWithoutAlias = GetPathWithoutAlias(referencePath);
+
         if (!relativeToExportPath)
         {
+            AZStd::string relativePath;
             AZStd::string watchFolder;
             AZ::Data::AssetInfo assetInfo;
-            bool sourceInfoFound = false;
+            bool relativePathFound = false;
             AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
-                sourceInfoFound, &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath, referencePath.c_str(),
-                assetInfo, watchFolder);
-            if (sourceInfoFound)
+                relativePathFound,
+                &AzToolsFramework::AssetSystemRequestBus::Events::GenerateRelativeSourcePath,
+                referencePathWithoutAlias.c_str(),
+                relativePath,
+                watchFolder);
+
+            if (relativePathFound)
             {
-                return assetInfo.m_relativePath;
+                return relativePath;
             }
         }
 
         AZ::IO::BasicPath<AZStd::string> exportFolder(exportPath);
         exportFolder.RemoveFilename();
-        return AZ::IO::PathView(referencePath).LexicallyRelative(exportFolder).StringAsPosix();
+
+        return AZ::IO::PathView(referencePathWithoutAlias).LexicallyRelative(exportFolder).StringAsPosix();
     }
 
     bool SaveSettingsToFile(const AZ::IO::FixedMaxPath& savePath, const AZStd::vector<AZStd::string>& filters)
@@ -322,13 +330,13 @@ namespace AtomToolsFramework
         return saved;
     }
 
-    AZStd::string ConvertAliasToPath(const AZStd::string& path)
+    AZStd::string GetPathWithoutAlias(const AZStd::string& path)
     {
         auto convertedPath = AZ::IO::FileIOBase::GetInstance()->ResolvePath(AZ::IO::PathView{ path });
         return convertedPath ? convertedPath->StringAsPosix() : path;
     }
 
-    AZStd::string ConvertPathToAlias(const AZStd::string& path)
+    AZStd::string GetPathWithAlias(const AZStd::string& path)
     {
         auto convertedPath = AZ::IO::FileIOBase::GetInstance()->ConvertToAlias(AZ::IO::PathView{ path });
         return convertedPath ? convertedPath->StringAsPosix() : path;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Tests/AtomToolsFrameworkTest.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Tests/AtomToolsFrameworkTest.cpp
@@ -53,11 +53,11 @@ namespace UnitTest
             RegisterSourceAsset("textures/gold.png");
             RegisterSourceAsset("textures/fuzz.png");
 
-            m_assetSystemStub.RegisterScanFolder(ResolvePath("@exefolder@/root1/projects/project1/assets/"));
-            m_assetSystemStub.RegisterScanFolder(ResolvePath("@exefolder@/root1/projects/project2/assets/"));
-            m_assetSystemStub.RegisterScanFolder(ResolvePath("@exefolder@/root1/o3de/gems/atom/assets/"));
-            m_assetSystemStub.RegisterScanFolder(ResolvePath("@exefolder@/root1/o3de/gems/atom/testdata/"));
-            m_assetSystemStub.RegisterScanFolder(ResolvePath("@exefolder@/root1/o3de/gems/atom/tools/materialeditor/assets/"));
+            m_assetSystemStub.RegisterScanFolder(AtomToolsFramework::GetPathWithoutAlias("@exefolder@/root1/projects/project1/assets/"));
+            m_assetSystemStub.RegisterScanFolder(AtomToolsFramework::GetPathWithoutAlias("@exefolder@/root1/projects/project2/assets/"));
+            m_assetSystemStub.RegisterScanFolder(AtomToolsFramework::GetPathWithoutAlias("@exefolder@/root1/o3de/gems/atom/assets/"));
+            m_assetSystemStub.RegisterScanFolder(AtomToolsFramework::GetPathWithoutAlias("@exefolder@/root1/o3de/gems/atom/testdata/"));
+            m_assetSystemStub.RegisterScanFolder(AtomToolsFramework::GetPathWithoutAlias("@exefolder@/root1/o3de/gems/atom/tools/materialeditor/assets/"));
         }
 
         void TearDown() override
@@ -68,17 +68,11 @@ namespace UnitTest
             m_localFileIO.reset();
         }
 
-        AZStd::string ResolvePath(const AZStd::string& path) const
-        {
-            auto result = AZ::IO::FileIOBase::GetInstance()->ResolvePath(AZ::IO::PathView{ path });
-            return result ? result->c_str() : AZStd::string();
-        }
-
         void RegisterSourceAsset(const AZStd::string& path)
         {
             const AZStd::string assetRoot = "@exefolder@/root1/project/assets/";
-            AZ::IO::FixedMaxPath assetRootPath(ResolvePath(assetRoot));
-            AZ::IO::FixedMaxPath normalizedPath(ResolvePath(assetRoot + path));
+            AZ::IO::FixedMaxPath assetRootPath(AtomToolsFramework::GetPathWithoutAlias(assetRoot));
+            AZ::IO::FixedMaxPath normalizedPath(AtomToolsFramework::GetPathWithoutAlias(assetRoot + path));
 
             AZ::Data::AssetInfo assetInfo = {};
             assetInfo.m_assetId = AZ::Uuid::CreateRandom();
@@ -91,64 +85,64 @@ namespace UnitTest
         AZStd::unique_ptr<AZ::IO::FileIOBase> m_localFileIO;
     };
 
-    TEST_F(AtomToolsFrameworkTest, GetExteralReferencePath_Succeeds)
+    TEST_F(AtomToolsFrameworkTest, GetPathToExteralReference_Succeeds)
     {
-        ASSERT_EQ(AtomToolsFramework::GetExteralReferencePath("", "", true), "");
-        ASSERT_EQ(AtomToolsFramework::GetExteralReferencePath(ResolvePath("@exefolder@/root1/project/assets/materials/condor.material"), "", true), "");
-        ASSERT_EQ(AtomToolsFramework::GetExteralReferencePath(ResolvePath("@exefolder@/root1/project/assets/materials/talisman.material"), "", false), "");
-        ASSERT_EQ(AtomToolsFramework::GetExteralReferencePath(ResolvePath("@exefolder@/root1/project/assets/materials/talisman.material"), ResolvePath("@exefolder@/root1/project/assets/textures/gold.png"), true), "../textures/gold.png");
-        ASSERT_EQ(AtomToolsFramework::GetExteralReferencePath(ResolvePath("@exefolder@/root1/project/assets/materials/talisman.material"), ResolvePath("@exefolder@/root1/project/assets/textures/gold.png"), false), "textures/gold.png");
-        ASSERT_EQ(AtomToolsFramework::GetExteralReferencePath(ResolvePath("@exefolder@/root1/project/assets/objects/upgrades/materials/supercondor.material"), ResolvePath("@exefolder@/root1/project/assets/materials/condor.material"), true), "../../../materials/condor.material");
-        ASSERT_EQ(AtomToolsFramework::GetExteralReferencePath(ResolvePath("@exefolder@/root1/project/assets/objects/upgrades/materials/supercondor.material"), ResolvePath("@exefolder@/root1/project/assets/materials/condor.material"), false), "materials/condor.material");
+        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("", "", true), "");
+        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/materials/condor.material", "", true), "");
+        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/materials/talisman.material", "", false), "");
+        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/materials/talisman.material", "@exefolder@/root1/project/assets/textures/gold.png", true), "../textures/gold.png");
+        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/materials/talisman.material", "@exefolder@/root1/project/assets/textures/gold.png", false), "textures/gold.png");
+        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/objects/upgrades/materials/supercondor.material", "@exefolder@/root1/project/assets/materials/condor.material", true), "../../../materials/condor.material");
+        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/objects/upgrades/materials/supercondor.material", "@exefolder@/root1/project/assets/materials/condor.material", false), "materials/condor.material");
     }
 
     TEST_F(AtomToolsFrameworkTest, IsDocumentPathInSupportedFolder_Succeeds)
     {
-        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder(ResolvePath("@exefolder@/root1/somerandomasset.json")));
-        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder(ResolvePath("@exefolder@/root1/project/somerandomasset.json")));
-        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder(ResolvePath("@exefolder@/root1/projects/somerandomasset.json")));
-        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder(ResolvePath("@exefolder@/root1/projects/project1/somerandomasset.json")));
-        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder(ResolvePath("@exefolder@/root2/projects/project1/assets/somerandomasset.json")));
-        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder(ResolvePath("@exefolder@/root2/projects/project1/assets/subfolder/somerandomasset.json")));
-        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder(ResolvePath("@exefolder@/root2/projects/project2/assets/somerandomasset.json")));
-        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder(ResolvePath("@exefolder@/root2/o3de/gems/atom/tools/materialeditor/assets/somerandomasset.json")));
-        ASSERT_TRUE(AtomToolsFramework::IsDocumentPathInSupportedFolder(ResolvePath("@exefolder@/root1/projects/project1/assets/somerandomasset.json")));
-        ASSERT_TRUE(AtomToolsFramework::IsDocumentPathInSupportedFolder(ResolvePath("@exefolder@/root1/projects/project1/assets/subfolder/somerandomasset.json")));
-        ASSERT_TRUE(AtomToolsFramework::IsDocumentPathInSupportedFolder(ResolvePath("@exefolder@/root1/projects/project2/assets/somerandomasset.json")));
-        ASSERT_TRUE(AtomToolsFramework::IsDocumentPathInSupportedFolder(ResolvePath("@exefolder@/root1/o3de/gems/atom/tools/materialeditor/assets/somerandomasset.json")));
+        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder("@exefolder@/root1/somerandomasset.json"));
+        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder("@exefolder@/root1/project/somerandomasset.json"));
+        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder("@exefolder@/root1/projects/somerandomasset.json"));
+        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder("@exefolder@/root1/projects/project1/somerandomasset.json"));
+        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder("@exefolder@/root2/projects/project1/assets/somerandomasset.json"));
+        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder("@exefolder@/root2/projects/project1/assets/subfolder/somerandomasset.json"));
+        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder("@exefolder@/root2/projects/project2/assets/somerandomasset.json"));
+        ASSERT_FALSE(AtomToolsFramework::IsDocumentPathInSupportedFolder("@exefolder@/root2/o3de/gems/atom/tools/materialeditor/assets/somerandomasset.json"));
+        ASSERT_TRUE(AtomToolsFramework::IsDocumentPathInSupportedFolder("@exefolder@/root1/projects/project1/assets/somerandomasset.json"));
+        ASSERT_TRUE(AtomToolsFramework::IsDocumentPathInSupportedFolder("@exefolder@/root1/projects/project1/assets/subfolder/somerandomasset.json"));
+        ASSERT_TRUE(AtomToolsFramework::IsDocumentPathInSupportedFolder("@exefolder@/root1/projects/project2/assets/somerandomasset.json"));
+        ASSERT_TRUE(AtomToolsFramework::IsDocumentPathInSupportedFolder("@exefolder@/root1/o3de/gems/atom/tools/materialeditor/assets/somerandomasset.json"));
     }
 
     TEST_F(AtomToolsFrameworkTest, ValidateDocumentPath_Succeeds)
     {
         AZStd::string testPath;
         ASSERT_FALSE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("somerandomasset.json");
+        testPath = "somerandomasset.json";
         ASSERT_FALSE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("../somerandomasset.json");
+        testPath = "../somerandomasset.json";
         ASSERT_FALSE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("@exefolder@/root1/somerandomasset.json");
+        testPath = "@exefolder@/root1/somerandomasset.json";
         ASSERT_FALSE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("@exefolder@/root1/project/somerandomasset.json");
+        testPath = "@exefolder@/root1/project/somerandomasset.json";
         ASSERT_FALSE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("@exefolder@/root1/projects/somerandomasset.json");
+        testPath = "@exefolder@/root1/projects/somerandomasset.json";
         ASSERT_FALSE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("@exefolder@/root1/projects/project1/somerandomasset.json");
+        testPath = "@exefolder@/root1/projects/project1/somerandomasset.json";
         ASSERT_FALSE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("@exefolder@/root2/projects/project1/assets/somerandomasset.json");
+        testPath = "@exefolder@/root2/projects/project1/assets/somerandomasset.json";
         ASSERT_FALSE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("@exefolder@/root2/projects/project1/assets/subfolder/somerandomasset.json");
+        testPath = "@exefolder@/root2/projects/project1/assets/subfolder/somerandomasset.json";
         ASSERT_FALSE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("@exefolder@/root2/projects/project2/assets/somerandomasset.json");
+        testPath = "@exefolder@/root2/projects/project2/assets/somerandomasset.json";
         ASSERT_FALSE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("@exefolder@/root2/o3de/gems/atom/tools/materialeditor/assets/somerandomasset.json");
+        testPath = "@exefolder@/root2/o3de/gems/atom/tools/materialeditor/assets/somerandomasset.json";
         ASSERT_FALSE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("@exefolder@/root1/projects/project1/assets/somerandomasset.json");
+        testPath = "@exefolder@/root1/projects/project1/assets/somerandomasset.json";
         ASSERT_TRUE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("@exefolder@/root1/projects/project1/assets/subfolder/somerandomasset.json");
+        testPath = "@exefolder@/root1/projects/project1/assets/subfolder/somerandomasset.json";
         ASSERT_TRUE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("@exefolder@/root1/projects/project2/assets/somerandomasset.json");
+        testPath = "@exefolder@/root1/projects/project2/assets/somerandomasset.json";
         ASSERT_TRUE(AtomToolsFramework::ValidateDocumentPath(testPath));
-        testPath = ResolvePath("@exefolder@/root1/o3de/gems/atom/tools/materialeditor/assets/somerandomasset.json");
+        testPath = "@exefolder@/root1/o3de/gems/atom/tools/materialeditor/assets/somerandomasset.json";
         ASSERT_TRUE(AtomToolsFramework::ValidateDocumentPath(testPath));
     }
 

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
@@ -198,8 +198,8 @@ namespace MaterialEditor
         // populate sourceData with modified or overridden properties and save object
         AZ::RPI::MaterialSourceData sourceData;
         sourceData.m_materialTypeVersion = m_materialAsset->GetMaterialTypeAsset()->GetVersion();
-        sourceData.m_materialType = AtomToolsFramework::GetExteralReferencePath(m_absolutePath, m_materialSourceData.m_materialType);
-        sourceData.m_parentMaterial = AtomToolsFramework::GetExteralReferencePath(m_absolutePath, m_materialSourceData.m_parentMaterial);
+        sourceData.m_materialType = AtomToolsFramework::GetPathToExteralReference(m_absolutePath, m_materialSourceData.m_materialType);
+        sourceData.m_parentMaterial = AtomToolsFramework::GetPathToExteralReference(m_absolutePath, m_materialSourceData.m_parentMaterial);
         auto propertyFilter = [](const AtomToolsFramework::DynamicProperty& property) {
             return !AtomToolsFramework::ArePropertyValuesEqual(property.GetValue(), property.GetConfig().m_parentValue);
         };
@@ -234,8 +234,8 @@ namespace MaterialEditor
         // populate sourceData with modified or overridden properties and save object
         AZ::RPI::MaterialSourceData sourceData;
         sourceData.m_materialTypeVersion = m_materialAsset->GetMaterialTypeAsset()->GetVersion();
-        sourceData.m_materialType = AtomToolsFramework::GetExteralReferencePath(m_savePathNormalized, m_materialSourceData.m_materialType);
-        sourceData.m_parentMaterial = AtomToolsFramework::GetExteralReferencePath(m_savePathNormalized, m_materialSourceData.m_parentMaterial);
+        sourceData.m_materialType = AtomToolsFramework::GetPathToExteralReference(m_savePathNormalized, m_materialSourceData.m_materialType);
+        sourceData.m_parentMaterial = AtomToolsFramework::GetPathToExteralReference(m_savePathNormalized, m_materialSourceData.m_parentMaterial);
         auto propertyFilter = [](const AtomToolsFramework::DynamicProperty& property) {
             return !AtomToolsFramework::ArePropertyValuesEqual(property.GetValue(), property.GetConfig().m_parentValue);
         };
@@ -266,12 +266,12 @@ namespace MaterialEditor
         // populate sourceData with modified or overridden properties and save object
         AZ::RPI::MaterialSourceData sourceData;
         sourceData.m_materialTypeVersion = m_materialAsset->GetMaterialTypeAsset()->GetVersion();
-        sourceData.m_materialType = AtomToolsFramework::GetExteralReferencePath(m_savePathNormalized, m_materialSourceData.m_materialType);
+        sourceData.m_materialType = AtomToolsFramework::GetPathToExteralReference(m_savePathNormalized, m_materialSourceData.m_materialType);
 
         // Only assign a parent path if the source was a .material
         if (AzFramework::StringFunc::Path::IsExtension(m_absolutePath.c_str(), AZ::RPI::MaterialSourceData::Extension))
         {
-            sourceData.m_parentMaterial = AtomToolsFramework::GetExteralReferencePath(m_savePathNormalized, m_absolutePath);
+            sourceData.m_parentMaterial = AtomToolsFramework::GetPathToExteralReference(m_savePathNormalized, m_absolutePath);
         }
 
         auto propertyFilter = [](const AtomToolsFramework::DynamicProperty& property) {

--- a/Gems/Atom/Utils/Code/Source/TestUtils/AssetSystemStub.cpp
+++ b/Gems/Atom/Utils/Code/Source/TestUtils/AssetSystemStub.cpp
@@ -78,6 +78,17 @@ namespace UnitTest
         [[maybe_unused]] const AZStd::string& sourcePath, [[maybe_unused]] AZStd::string& relativePath,
         [[maybe_unused]] AZStd::string& watchFolder)
     {
+        AZStd::string normalizedSourcePath = sourcePath;
+        AzFramework::StringFunc::Path::Normalize(normalizedSourcePath);
+
+        auto iter = m_sourcePath_sourceInfo_map.find(normalizedSourcePath);
+        if (iter != m_sourcePath_sourceInfo_map.end())
+        {
+            relativePath = iter->second.m_assetInfo.m_relativePath;
+            watchFolder = iter->second.m_watchFolder;
+            return true;
+        }
+
         return false;
     }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
@@ -113,8 +113,8 @@ namespace AZ
                 // Construct the material source data object that will be exported
                 AZ::RPI::MaterialSourceData exportData;
                 exportData.m_materialTypeVersion = editData.m_materialTypeAsset->GetVersion();
-                exportData.m_materialType = AtomToolsFramework::GetExteralReferencePath(path, editData.m_materialTypeSourcePath);
-                exportData.m_parentMaterial = AtomToolsFramework::GetExteralReferencePath(path, editData.m_materialParentSourcePath);
+                exportData.m_materialType = AtomToolsFramework::GetPathToExteralReference(path, editData.m_materialTypeSourcePath);
+                exportData.m_parentMaterial = AtomToolsFramework::GetPathToExteralReference(path, editData.m_materialParentSourcePath);
 
                 // Copy all of the properties from the material asset to the source data that will be exported
                 bool result = true;


### PR DESCRIPTION
## What does this PR do?

Added a new setting and support for auto saving documents in material editor, material canvas, shader management console. Autosave is currently disabled by default. It can be enabled and the interval configured in the settings dialog.

Other settings were also added to suppress warning messages that pop up when opening materials and other documents that might generate warnings or need to be resaved. These messages will still be logged. Disabling all of the dialogs and prompts in the settings dialog while enabling automatic save and automatic reload makes editing and seeing updates almost seamless without invasive changes. Only concern is thrashing the hard drive and asset processor with continuous changes.

As part of this, I also updated some utility functions and unit tests to handle paths containing aliases.

https://github.com/o3de/o3de/issues/10015

## How was this PR tested?

Tested auto save with the material editor by enabling the feature and setting the timer to a low interval. Making changes in the inspector apply their normal modifications. Notifications are sent to the document manager to trigger automatic saving. As soon as the timer expires, all modified documents are saved. This immediately kicks off the asset processor. Assuming nothing else is being built, anything set up to hot reload materials will update almost immediately. Thumbnails and previews update in the asset browser. The main o3de editor also receives and applies the updates but the changes are not visible until switch into the editor to give it focus. This is probably because material component changes are applied on tick instead of system tick.

There are other issues in the thumbnail system that will eventually cause thumbnails to stop updating. They will display a white, missing file icon. This will need to be addressed separately.