### PR TITLE
chore(EmotionFX): replace MCore::CreateFromAxisAndAngle with AZ::Quaternion::CreateFromAxisAngle

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeAccumTransformNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeAccumTransformNode.cpp
@@ -186,8 +186,11 @@ namespace EMotionFX
             default:
                 MCORE_ASSERT(false);
             }
-
-            const AZ::Quaternion targetRot = MCore::CreateFromAxisAndAngle(axis, MCore::Math::DegreesToRadians(360.0f * (inputAmount - 0.5f) * invertFactor));
+            AZ::Quaternion targetRot = AZ::Quaternion::CreateIdentity();
+            if (axis.GetLengthSq() > 0.0f)
+            {
+                targetRot = AZ::Quaternion::CreateFromAxisAngle(axis.GetNormalized(), MCore::Math::DegreesToRadians(360.0f * (inputAmount - 0.5f) * invertFactor));
+            }
             AZ::Quaternion deltaRot = AZ::Quaternion::CreateIdentity().Lerp(targetRot, uniqueData->m_deltaTime * factor);
             deltaRot.Normalize();
             uniqueData->m_additiveTransform.m_rotation = uniqueData->m_additiveTransform.m_rotation * deltaRot;

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeAccumTransformNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeAccumTransformNode.cpp
@@ -186,12 +186,13 @@ namespace EMotionFX
             default:
                 MCORE_ASSERT(false);
             }
-            AZ::Quaternion targetRot = AZ::Quaternion::CreateIdentity();
-            if (axis.GetLengthSq() > 0.0f)
-            {
-                targetRot = AZ::Quaternion::CreateFromAxisAngle(axis.GetNormalized(), MCore::Math::DegreesToRadians(360.0f * (inputAmount - 0.5f) * invertFactor));
-            }
-            AZ::Quaternion deltaRot = AZ::Quaternion::CreateIdentity().Lerp(targetRot, uniqueData->m_deltaTime * factor);
+
+            const AZ::Quaternion targetRotation = axis.GetLengthSq() > 0.0f
+                ? AZ::Quaternion::CreateFromAxisAngle(
+                      axis.GetNormalized(), MCore::Math::DegreesToRadians(360.0f * (inputAmount - 0.5f) * invertFactor))
+                : AZ::Quaternion::CreateIdentity();
+
+            AZ::Quaternion deltaRot = AZ::Quaternion::CreateIdentity().Lerp(targetRotation, uniqueData->m_deltaTime * factor);
             deltaRot.Normalize();
             uniqueData->m_additiveTransform.m_rotation = uniqueData->m_additiveTransform.m_rotation * deltaRot;
             outputTransform.m_rotation = (inputTransform.m_rotation * uniqueData->m_additiveTransform.m_rotation);

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeTwoLinkIKNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeTwoLinkIKNode.cpp
@@ -477,8 +477,11 @@ namespace EMotionFX
         float dotProduct = oldForward.Dot(newForward);
         float deltaAngle = MCore::Math::ACos(MCore::Clamp<float>(dotProduct, -1.0f, 1.0f));
         AZ::Vector3 axis = oldForward.Cross(newForward);
-        AZ::Quaternion deltaRot = MCore::CreateFromAxisAndAngle(axis, deltaAngle);
-        globalTransformA.m_rotation = deltaRot * globalTransformA.m_rotation;
+        if (axis.GetLengthSq() > 0.0f)
+        {
+            globalTransformA.m_rotation = AZ::Quaternion::CreateFromAxisAngle(axis.GetNormalized(), deltaAngle) * 
+                globalTransformA.m_rotation;
+        }
         outTransformPose.SetWorldSpaceTransform(nodeIndexA, globalTransformA);
 
         // globalTransformA = outTransformPose.GetGlobalTransformIncludingActorInstanceTransform(nodeIndexA);
@@ -508,14 +511,13 @@ namespace EMotionFX
         {
             deltaAngle = MCore::Math::ACos(MCore::Clamp<float>(dotProduct, -1.0f, 1.0f));
             axis = oldForward.Cross(newForward);
-            deltaRot = MCore::CreateFromAxisAndAngle(axis, deltaAngle);
-        }
-        else
-        {
-            deltaRot = AZ::Quaternion::CreateIdentity();
+            if (axis.GetLengthSq() > 0.0f)
+            {
+                globalTransformB.m_rotation = AZ::Quaternion::CreateFromAxisAngle(axis.GetNormalized(), deltaAngle) * 
+                    globalTransformB.m_rotation;
+            }
         }
 
-        globalTransformB.m_rotation = deltaRot * globalTransformB.m_rotation;
         globalTransformB.m_position = midPos;
         outTransformPose.SetWorldSpaceTransform(nodeIndexB, globalTransformB);
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeTwoLinkIKNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeTwoLinkIKNode.cpp
@@ -479,8 +479,8 @@ namespace EMotionFX
         AZ::Vector3 axis = oldForward.Cross(newForward);
         if (axis.GetLengthSq() > 0.0f)
         {
-            globalTransformA.m_rotation = AZ::Quaternion::CreateFromAxisAngle(axis.GetNormalized(), deltaAngle) * 
-                globalTransformA.m_rotation;
+            globalTransformA.m_rotation = AZ::Quaternion::CreateFromAxisAngle(
+                axis.GetNormalized(), deltaAngle) * globalTransformA.m_rotation;
         }
         outTransformPose.SetWorldSpaceTransform(nodeIndexA, globalTransformA);
 
@@ -513,8 +513,8 @@ namespace EMotionFX
             axis = oldForward.Cross(newForward);
             if (axis.GetLengthSq() > 0.0f)
             {
-                globalTransformB.m_rotation = AZ::Quaternion::CreateFromAxisAngle(axis.GetNormalized(), deltaAngle) * 
-                    globalTransformB.m_rotation;
+                globalTransformB.m_rotation = AZ::Quaternion::CreateFromAxisAngle(
+                    axis.GetNormalized(), deltaAngle) * globalTransformB.m_rotation;
             }
         }
 

--- a/Gems/EMotionFX/Code/MCore/Source/AzCoreConversions.h
+++ b/Gems/EMotionFX/Code/MCore/Source/AzCoreConversions.h
@@ -52,8 +52,8 @@ namespace MCore
         return EMotionFX::Transform(azTransform);
     }
 
-    // AZ::Quaternion::CreateFromAxisAngle does not yield to the same results because it's using right handed system.
-    // This is left handed system version in MCore::Quaternion.
+    // O3DE_DEPRECATION_NOTICE(GHI-10471)
+    //! @deprecated AZ::Quaternion::CreateFromAxisAngle where the axis is normalized should be equivelent to MCore::CreateFromAxisAndAngle
     AZ_FORCE_INLINE AZ::Quaternion CreateFromAxisAndAngle(const AZ::Vector3& axis, const float angle)
     {
         const float squaredLength = axis.GetLengthSq();


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

just replaces MCore::CreateFromAxisAndAngle with the equivalent method from AZ::Quaternion::CreateFromAxisAngle. both implements are basically the same the only main difference is MCore version normalizes the vector. not sure about the comment about this version being left handed and the AZCore version being right handed. I ended up writing a test to convince myself that both are equivalent after also comparing both implementations and seeing that they are the same with some subtle changes. There is also a small advantage with using simd operations with this change. 

```
class AngleTestFixture
        : public UnitTest::ScopedAllocatorSetupFixture {
        
    };

    TEST_F(AngleTestFixture, ToAngleTest)
    {
        std::uniform_real_distribution<float> unif;
        std::mt19937_64 rng(100);
        for(int x = 0; x < 1000; x++) {
            float angle = unif(rng);
            AZ::Vector3 v1 = AZ::Vector3(unif(rng), unif(rng), unif(rng)).GetNormalized();
            // MCore::CreateFromAxisAndAngle(v1, angle);
            AZ_Error("ToAngleTest", false, "angle1: %s angle2: %s", 
                AZStd::to_string(AZ::Quaternion::CreateFromAxisAngle(v1, angle)).c_str(),
                AZStd::to_string(MCore::CreateFromAxisAndAngle(v1, angle)).c_str()
                );
            
            EXPECT_THAT(MCore::CreateFromAxisAndAngle(v1, angle), IsClose(AZ::Quaternion::CreateFromAxisAngle(v1, angle)));
        }

    }
```

## How was this PR tested?

