### PR TITLE
feat: improve functionality of Vector3GizmoParameterEditor

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/Vector3GizmoParameterEditor.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/Vector3GizmoParameterEditor.h
@@ -13,6 +13,7 @@
 #include <QPointer>
 
 class QPushButton;
+
 namespace EMStudio
 {
     class Vector3GizmoParameterEditor
@@ -40,17 +41,14 @@ namespace EMStudio
 
     private:
         void OnValueChanged();
-        void UpdateAnimGraphInstanceAttributes();
         void ToggleTranslationGizmo();
 
         AZ::Vector3 GetMinValue() const;
         AZ::Vector3 GetMaxValue() const;
 
-        void OnManipulatorMoved(const AZ::Vector3& position);
-
     private:
         AZ::Vector3 m_currentValue = AZ::Vector3::CreateZero();
-        QPushButton* m_gizmoButton = nullptr;
+        QPointer<QPushButton> m_gizmoButton;
 
         AzToolsFramework::TranslationManipulators m_translationManipulators;
         AZStd::function<void()> m_manipulatorCallback;


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

I applied the changes I made to the RotationParameterEditor.h. there are several improvements with this change. 

- the gizmo fails to get removed from the scene when the parameter is deleted
- updating the value for the vector3 parameter will also update the gadget in the scene.

## How was this PR tested?

- add a Vector3GizmoParameter to the scene check updating the parameter value and also manipulating the gizmo
- verify behavior in the graph. 
