### PR TITLE
[Terrain] Fix the clipmap rendering when macro normal map is not set

### DIFF
--- a/Gems/Terrain/Assets/Shaders/Terrain/ClipmapComputeHelpers.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/ClipmapComputeHelpers.azsli
@@ -124,6 +124,7 @@ struct ClipmapSample
     float3 m_macroColor;
     float3 m_macroNormal;
     bool   m_hasMacro;  // false if world position is out of the clipmap range. Needs increasing max render distance.
+    bool   m_hasMacroNormal; // false if the normal map is not set.
     bool   m_hasDetail; // false if the position doesn't have detail or out of the clipmap range.
     DetailSurface m_detailSurface;
 };
@@ -399,9 +400,11 @@ ClipmapSample SampleClipmap(float2 worldPosition)
             GetMacroClipmapCenterInWorldSpace(macroClipmapLevel.m_closestLevel)
         );
 
-        data.m_macroColor = ColorBilinearSampling(
+        float4 macroColor = ColorBilinearSampling(
             TerrainSrg::m_macroColorClipmaps, macroClipmapUvs, macroClipmapLevel.m_closestLevel,
-            TerrainSrg::m_clipmapData.m_enableMacroClipmapOverlay).rgb;
+            TerrainSrg::m_clipmapData.m_enableMacroClipmapOverlay);
+        data.m_macroColor = macroColor.rgb;
+        data.m_hasMacroNormal = macroColor.a == 1.0;
         data.m_macroNormal = NormalBilinearSampling(TerrainSrg::m_macroNormalClipmaps, macroClipmapUvs, macroClipmapLevel.m_closestLevel);
     }
     else
@@ -420,9 +423,11 @@ ClipmapSample SampleClipmap(float2 worldPosition)
             GetMacroClipmapCenterInWorldSpace(macroClipmapLevel.m_nextLevel)
         );
 
-        data.m_macroColor = ColorTrilinearSampling(
+        float4 macroColor = ColorTrilinearSampling(
             TerrainSrg::m_macroColorClipmaps, macroClipmapUvs1, macroClipmapUvs2, macroClipmapLevel,
-            TerrainSrg::m_clipmapData.m_enableMacroClipmapOverlay).rgb;
+            TerrainSrg::m_clipmapData.m_enableMacroClipmapOverlay);
+        data.m_macroColor = macroColor.rgb;
+        data.m_hasMacroNormal = macroColor.a == 1.0;
         data.m_macroNormal = NormalTrilinearSampling(TerrainSrg::m_macroNormalClipmaps, macroClipmapUvs1, macroClipmapUvs2, macroClipmapLevel);
     }
 

--- a/Gems/Terrain/Assets/Shaders/Terrain/ClipmapComputeHelpers.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/ClipmapComputeHelpers.azsli
@@ -10,6 +10,13 @@
 
 #include <TerrainDetailHelpers.azsli>
 
+// Encoded into macro color alpha, to indicate if macro normal map is vailable.
+#define NO_NORMAL 0.0
+#define HAS_NORMAL 1.0
+// Encoded into detail color alpha, to indicate if detail material exists.
+#define NO_DETAIL 0.0
+#define HAS_DETAIL 1.0
+
 // Used for the debug overlay color for each clipmap level.
 // Only use 5 for better contrast, and we don't really care about far away maps.
 static const uint ClipmapLevelDebugColorCount = 6;
@@ -404,8 +411,11 @@ ClipmapSample SampleClipmap(float2 worldPosition)
             TerrainSrg::m_macroColorClipmaps, macroClipmapUvs, macroClipmapLevel.m_closestLevel,
             TerrainSrg::m_clipmapData.m_enableMacroClipmapOverlay);
         data.m_macroColor = macroColor.rgb;
-        data.m_hasMacroNormal = macroColor.a == 1.0;
-        data.m_macroNormal = NormalBilinearSampling(TerrainSrg::m_macroNormalClipmaps, macroClipmapUvs, macroClipmapLevel.m_closestLevel);
+        data.m_hasMacroNormal = macroColor.a == HAS_NORMAL;
+        if (data.m_hasMacroNormal)
+        {
+            data.m_macroNormal = NormalBilinearSampling(TerrainSrg::m_macroNormalClipmaps, macroClipmapUvs, macroClipmapLevel.m_closestLevel);
+        }
     }
     else
     {
@@ -427,8 +437,11 @@ ClipmapSample SampleClipmap(float2 worldPosition)
             TerrainSrg::m_macroColorClipmaps, macroClipmapUvs1, macroClipmapUvs2, macroClipmapLevel,
             TerrainSrg::m_clipmapData.m_enableMacroClipmapOverlay);
         data.m_macroColor = macroColor.rgb;
-        data.m_hasMacroNormal = macroColor.a == 1.0;
-        data.m_macroNormal = NormalTrilinearSampling(TerrainSrg::m_macroNormalClipmaps, macroClipmapUvs1, macroClipmapUvs2, macroClipmapLevel);
+        data.m_hasMacroNormal = macroColor.a == HAS_NORMAL;
+        if (data.m_hasMacroNormal)
+        {
+            data.m_macroNormal = NormalTrilinearSampling(TerrainSrg::m_macroNormalClipmaps, macroClipmapUvs1, macroClipmapUvs2, macroClipmapLevel);
+        }
     }
 
     if (absDistance.x > TerrainSrg::m_clipmapData.m_detailClipmapMaxRenderRadius || absDistance.y > TerrainSrg::m_clipmapData.m_detailClipmapMaxRenderRadius)
@@ -452,7 +465,7 @@ ClipmapSample SampleClipmap(float2 worldPosition)
                 TerrainSrg::m_detailColorClipmaps, detailClipmapUvs, detailClipmapLevel.m_closestLevel,
                 TerrainSrg::m_clipmapData.m_enableDetailClipmapOverlay);
             // alpha represents hasDetailSurface, 1.0 for true and 0.0 for false.
-            data.m_hasDetail = detailColor.a == 1.0;
+            data.m_hasDetail = detailColor.a == HAS_DETAIL;
 
             if (data.m_hasDetail)
             {
@@ -485,7 +498,7 @@ ClipmapSample SampleClipmap(float2 worldPosition)
                 TerrainSrg::m_detailColorClipmaps, detailClipmapUvs1, detailClipmapUvs2, detailClipmapLevel,
                 TerrainSrg::m_clipmapData.m_enableDetailClipmapOverlay);
             // alpha represents hasDetailSurface, 1.0 for true and 0.0 for false.
-            data.m_hasDetail = detailColor.a == 1.0;
+            data.m_hasDetail = detailColor.a == HAS_DETAIL;
 
             if (data.m_hasDetail)
             {

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailClipmapGenerationPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailClipmapGenerationPass.azsl
@@ -12,8 +12,6 @@
 
 #define THREAD_NUM_X 8
 #define THREAD_NUM_Y 8
-#define NO_DETAIL 0.0
-#define HAS_DETAIL 1.0
 
 ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroClipmapGenerationPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroClipmapGenerationPass.azsl
@@ -12,6 +12,8 @@
 
 #define THREAD_NUM_X 8
 #define THREAD_NUM_Y 8
+#define NO_NORMAL 0.0
+#define HAS_NORMAL 1.0
 
 ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {
@@ -57,9 +59,10 @@ void MainCS(
 
             float3 macroColor = TerrainMaterialSrg::m_baseColor.rgb;
             float3 macroNormal = float3(0.0, 0.0, 1.0);
-            SampleMacroTexture(worldPosition, positionDdx, positionDdy, macroColor, macroNormal);
+            bool hasNormal;
+            SampleMacroTexture(worldPosition, positionDdx, positionDdy, macroColor, macroNormal, hasNormal);
 
-            PassSrg::m_macroColorClipmaps[texelIndex] = float4(macroColor, 1.0);
+            PassSrg::m_macroColorClipmaps[texelIndex] = float4(macroColor, hasNormal ? HAS_NORMAL : NO_NORMAL);
             PassSrg::m_macroNormalClipmaps[texelIndex] = macroNormal.xy;
         }
     }

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroClipmapGenerationPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroClipmapGenerationPass.azsl
@@ -12,8 +12,6 @@
 
 #define THREAD_NUM_X 8
 #define THREAD_NUM_Y 8
-#define NO_NORMAL 0.0
-#define HAS_NORMAL 1.0
 
 ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroHelpers.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroHelpers.azsli
@@ -11,9 +11,10 @@
 
 static const uint InvalidMacroMaterialRef = 0x0000FFFF;
 
-void SampleMacroTexture(float2 worldPosition, float2 positionDdx, float2 positionDdy, out float3 macroColor, inout float3 macroNormal)
+void SampleMacroTexture(float2 worldPosition, float2 positionDdx, float2 positionDdy, out float3 macroColor, inout float3 macroNormal, out bool hasNormal)
 {
     macroColor = TerrainMaterialSrg::m_baseColor.rgb;
+    hasNormal = false;
 
     // ------- Macro Data -------
     uint2 macroGridResolution = TerrainSrg::GetMacroGridResolution();
@@ -63,7 +64,8 @@ void SampleMacroTexture(float2 worldPosition, float2 positionDdx, float2 positio
             macroColor = TransformColor(macroColor, ColorSpaceId::LinearSRGB, ColorSpaceId::ACEScg);
         }
 
-        if (macroMaterialData.m_normalMapId != 0xFFFF)
+        hasNormal = macroMaterialData.m_normalMapId != 0xFFFF;
+        if (hasNormal)
         {
             bool flipX = macroMaterialData.m_flags & 1;
             bool flipY = macroMaterialData.m_flags & 2;

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainPBR_ForwardPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainPBR_ForwardPass.azsl
@@ -57,7 +57,8 @@ void GatherSurfaceDataFromMaterials(
     // ------- Macro Data -------
     float2 positionDdx = ddx(position);
     float2 positionDdy = ddy(position);
-    SampleMacroTexture(position, positionDdx, positionDdy, macroColor, macroNormal);
+    bool hasNormal;
+    SampleMacroTexture(position, positionDdx, positionDdy, macroColor, macroNormal, hasNormal);
 
     // ------- Detail Data -------
     float2 detailUv = position.xy * TerrainMaterialSrg::m_detailTextureMultiplier;
@@ -86,7 +87,10 @@ void GatherSurfaceDataFromClipmaps(
     if (clipmapSample.m_hasMacro)
     {
         macroColor = clipmapSample.m_macroColor;
-        macroNormal = clipmapSample.m_macroNormal;
+        if (clipmapSample.m_hasMacroNormal)
+        {
+            macroNormal = clipmapSample.m_macroNormal;
+        }
     }
     if (detailFactor < 1.0)
     {


### PR DESCRIPTION
Encoded the "has normal" info into the macro color alpha channel, so that in the forward pass it knows when to use the vertex normal instead.

Signed-off-by: jiaweig <51759646+jiaweig-amzn@users.noreply.github.com>