### PR TITLE
Proposed fix for Issue #10479. Where downloading a gem doesn't work a…

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
@@ -73,7 +73,7 @@ namespace O3DE::ProjectManager
 
     void GemModel::RemoveGem(const QModelIndex& modelIndex)
     {
-        removeRow(modelIndex.row());
+        RemoveRowAndUpdateIndexes(modelIndex.row());
     }
 
     void GemModel::RemoveGem(const QString& gemName)
@@ -81,7 +81,28 @@ namespace O3DE::ProjectManager
         auto nameFind = m_nameToIndexMap.find(gemName);
         if (nameFind != m_nameToIndexMap.end())
         {
-            removeRow(nameFind->row());
+            RemoveRowAndUpdateIndexes(nameFind->row());
+        }
+    }
+
+    void GemModel::RemoveRowAndUpdateIndexes(int arow)
+    {
+        bool doUpdate = arow < rowCount() - 1; // before we remove a row check if we need updating later
+        removeRow(arow);
+
+        if (doUpdate)
+        {
+            /* need to update the index map as it's possible that model indexes updated.
+             * i.e.
+             * rows = [0, 1, 2, 3]
+             * removing row 1 will move the model indexes of 2 and 3 but m_nameToIndexMap will still be pointing to 2 and 3
+             * when it should be pointing to 1 and 2
+             */
+            for (int row = arow; row < rowCount(); ++row)
+            {
+                const QModelIndex modelIndex = index(row, 0);
+                m_nameToIndexMap[GetName(modelIndex)] = modelIndex;
+            }
         }
     }
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
@@ -58,7 +58,6 @@ namespace O3DE::ProjectManager
         QModelIndex AddGem(const GemInfo& gemInfo);
         void RemoveGem(const QModelIndex& modelIndex);
         void RemoveGem(const QString& gemName);
-        void RemoveRowAndUpdateIndexes(int arow);
         void Clear();
         void UpdateGemDependencies();
 
@@ -119,6 +118,7 @@ namespace O3DE::ProjectManager
 
     protected slots: 
         void OnRowsAboutToBeRemoved(const QModelIndex& parent, int first, int last);
+        void OnRowsRemoved(const QModelIndex& parent, int first, int last);
 
     private:
         void GetAllDependingGems(const QModelIndex& modelIndex, QSet<QModelIndex>& inOutGems);

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
@@ -58,6 +58,7 @@ namespace O3DE::ProjectManager
         QModelIndex AddGem(const GemInfo& gemInfo);
         void RemoveGem(const QModelIndex& modelIndex);
         void RemoveGem(const QString& gemName);
+        void RemoveRowAndUpdateIndexes(int arow);
         void Clear();
         void UpdateGemDependencies();
 


### PR DESCRIPTION
…fter a previous gem download.

## What does this PR do?

Fixes the issue [#10479](https://github.com/o3de/o3de/issues/10479)

The issue happens because the index map is not updated when a row is removed and the model indexes in the gem model updates. 

We can walk what happens using the PopcornFX repo.
1. When the repo is added there will be two gems that will be added named "PopcornFX 2.9" and "PopcornFX"
2. Gem Catalog screen's model is filled and two gems are added to the model and their model indexes are placed to "m_nameToIndexMap" which is a QHash for easier retrieval of model indexes later on.
3. "PopcornFX 2.9" is set to row 116 and "PopcornFX" to row 117. Note: this could be different depending on the number of gems in your machine.
4. Downloading "PopcornFX 2.9" will trigger a download and after a successful download the model index will be removed and re-added to the gem model. 
5. The gem model will update "PopcornFX" to row 116 because the previous model index("PopcornFX 2.9") was deleted but later added so "PopcornFX 2.9" is now in row 117.
6. The gem model is correct but the index map is not. When fetching "PopcornFX" it will return row 117 which is now "PopcornFX 2.9" and will not download since the download status is already set to downloaded.


## How was this PR tested?

Using PopcornFX repo as a test, after adding the repo download PopcornFX 2.9 first then see if downloading PopcornFX gem will be successful.
