### PR TITLE
Mark variable only used in non-release builds as unused

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderReloadDebugTracker.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderReloadDebugTracker.h
@@ -99,7 +99,7 @@ namespace AZ
 
             private:
                 SectionName m_sectionName;
-                bool m_shouldEndSection = false;
+                [[maybe_unused]] bool m_shouldEndSection = false;
             };
 
         private:


### PR DESCRIPTION
This silences a warning about a variable that is only used in
non-release builds.

Signed-off-by: Chris Burel <burelc@amazon.com>
