### PR TITLE
feat(EmotionFX): remove ATTRIB_COLORS128 and ATTRIB_COLORS32

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
@@ -256,13 +256,6 @@ namespace EMotionFX
                     mesh, Mesh::ATTRIB_BITANGENTS, /*keepOriginals=*/true,
                     AZ::Vector3(1.0f, 0.0f, 0.0f));
             }
-            else if (name == AZ::Name("COLOR"))
-            {
-                AtomMeshHelpers::CreateAndAddVertexAttributeLayer<AZ::Vector4, AtomMeshHelpers::Vector4>(sourceModelLod, modelVertexCount,
-                    name, bufferData,
-                    mesh, Mesh::ATTRIB_COLORS128, /*keepOriginals=*/false,
-                    AZ::Vector4(0.0f, 0.0f, 0.0f, 0.0f));
-            }
             else if (name == AZ::Name("SKIN_JOINTINDICES"))
             {
                 // Atom stores the skin indices as uint16, but the buffer itself is a buffer of uint32 with two id's per element
@@ -1600,38 +1593,6 @@ namespace EMotionFX
         m_indices = (uint32*)MCore::AlignedRealloc(m_indices, sizeof(uint16) * m_numIndices, 32, EMFX_MEMCATEGORY_GEOMETRY_MESHES, Mesh::MEMORYBLOCK_ID);
         return result;
     }
-
-
-    // function to convert the 128bit colors into 32bit ones, if they exist
-    void Mesh::ConvertTo32BitColors()
-    {
-        // get the colors
-        MCore::RGBAColor*   colors128   = (MCore::RGBAColor*)FindOriginalVertexData(Mesh::ATTRIB_COLORS128);
-        uint32*             colors32    = (uint32*)FindOriginalVertexData(Mesh::ATTRIB_COLORS32);
-
-        // check if 32bit colors already exist or 128bit colors do not exist
-        if (colors128 == nullptr || colors32)
-        {
-            return;
-        }
-
-        // get the number of original vertices
-        const uint32 numVertices = GetNumVertices();
-
-        // create new vertex attribute layer for the 32bit colors
-        VertexAttributeLayerAbstractData* layer = VertexAttributeLayerAbstractData::Create(numVertices, Mesh::ATTRIB_COLORS32, sizeof(uint32));
-
-        // fill the layer with the converted float colors
-        uint32* data = (uint32*)layer->GetData();
-        for (uint32 i = 0; i < numVertices; ++i)
-        {
-            data[i] = colors128[i].ToInt();
-        }
-
-        // add the new layer
-        AddVertexAttributeLayer(layer);
-    }
-
 
     // extract the original vertex positions
     void Mesh::ExtractOriginalVertexPositions(AZStd::vector<AZ::Vector3>& outPoints) const

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.h
@@ -20,7 +20,6 @@
 #include <MCore/Source/Vector.h>
 #include <AzCore/std/containers/vector.h>
 #include <MCore/Source/Ray.h>
-#include <MCore/Source/Color.h>
 
 namespace AZ::RPI
 {
@@ -70,9 +69,7 @@ namespace EMotionFX
             ATTRIB_NORMALS          = 1,    /**< Vertex normals. Typecast to AZ::Vector3. Normals are always exist. */
             ATTRIB_TANGENTS         = 2,    /**< Vertex tangents. Typecast to <b> AZ::Vector4 </b>. */
             ATTRIB_UVCOORDS         = 3,    /**< Vertex uv coordinates. Typecast to AZ::Vector2. */
-            ATTRIB_COLORS32         = 4,    /**< Vertex colors in 32-bits. Typecast to uint32. */
             ATTRIB_ORGVTXNUMBERS    = 5,    /**< Original vertex numbers. Typecast to uint32. Original vertex numbers always exist. */
-            ATTRIB_COLORS128        = 6,    /**< Vertex colors in 128-bits. */
             ATTRIB_BITANGENTS       = 7,    /**< Vertex bitangents (aka binormal). Typecast to AZ::Vector3. When tangents exists bitangents may still not exist! */
         };
 
@@ -612,12 +609,6 @@ namespace EMotionFX
          * @return True in case all indices have been ported correctly, false if any of the indices was out of the 16-bit range.
          */
         bool ConvertTo16BitIndices();
-
-        /**
-         * Convert RGBAColors consisting of 4 floats to 32bit DWORD color
-         * if 32bit colors do not exist yet and if 128bit colors do exist.
-         */
-        void ConvertTo32BitColors();
 
         /**
          * Check if this mesh is a pure triangle mesh.

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/NodeWindow/MeshInfo.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/NodeWindow/MeshInfo.cpp
@@ -73,14 +73,8 @@ namespace EMStudio
             case EMotionFX::Mesh::ATTRIB_UVCOORDS:
                 tmpString = "Vertex uv coordinates";
                 break;
-            case EMotionFX::Mesh::ATTRIB_COLORS32:
-                tmpString = "Vertex colors in 32-bits";
-                break;
             case EMotionFX::Mesh::ATTRIB_ORGVTXNUMBERS:
                 tmpString = "Original vertex numbers";
-                break;
-            case EMotionFX::Mesh::ATTRIB_COLORS128:
-                tmpString = "Vertex colors in 128-bits";
                 break;
             case EMotionFX::Mesh::ATTRIB_BITANGENTS:
                 tmpString = "Vertex bitangents";


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

These color attributes are not relevant to atom and the mesh in its current state is only used for querying information for access on the CPU.


## How was this PR tested?

Added a unit test to verify conversion from 128 to 32.
