### PR TITLE
Fix an issue where the build for a project with AWSMetrics gem enabled may fail because of missing AWSCore headers

### DIFF
--- a/Gems/AWSMetrics/Code/Include/MetricsAttribute.h
+++ b/Gems/AWSMetrics/Code/Include/MetricsAttribute.h
@@ -8,12 +8,15 @@
 
 #pragma once
 
-#include <Framework/JsonWriter.h>
-
 #include <AzCore/JSON/document.h>
 #include <AzCore/RTTI/TypeInfo.h>
 #include <AzCore/std/containers/variant.h>
 #include <AzCore/std/string/string.h>
+
+namespace AWSCore
+{
+    class JsonWriter;
+}
 
 namespace AWSMetrics
 {

--- a/Gems/AWSMetrics/Code/Source/MetricsAttribute.cpp
+++ b/Gems/AWSMetrics/Code/Source/MetricsAttribute.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AWSMetricsConstant.h>
+#include <Framework/JsonWriter.h>
 #include <MetricsAttribute.h>
 
 #include <AzCore/std/containers/vector.h>

--- a/Gems/AWSMetrics/Code/Source/MetricsEvent.cpp
+++ b/Gems/AWSMetrics/Code/Source/MetricsEvent.cpp
@@ -8,6 +8,7 @@
 
 #include <MetricsEvent.h>
 #include <AWSMetricsConstant.h>
+#include <Framework/JsonWriter.h>
 
 #include <AzCore/JSON/schema.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>

--- a/Gems/AWSMetrics/Code/Tests/MetricsAttributeTest.cpp
+++ b/Gems/AWSMetrics/Code/Tests/MetricsAttributeTest.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AWSMetricsConstant.h>
+#include <Framework/JsonWriter.h>
 #include <MetricsAttribute.h>
 
 #include <AzCore/UnitTest/TestTypes.h>

--- a/Gems/AWSMetrics/Code/Tests/MetricsEventTest.cpp
+++ b/Gems/AWSMetrics/Code/Tests/MetricsEventTest.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AWSMetricsConstant.h>
+#include <Framework/JsonWriter.h>
 #include <MetricsEvent.h>
 
 #include <AzCore/UnitTest/TestTypes.h>

--- a/Gems/AWSMetrics/Code/Tests/MetricsQueueTest.cpp
+++ b/Gems/AWSMetrics/Code/Tests/MetricsQueueTest.cpp
@@ -8,6 +8,7 @@
 
 #include <AWSMetricsConstant.h>
 #include <AWSMetricsGemMock.h>
+#include <Framework/JsonWriter.h>
 #include <MetricsEvent.h>
 #include <MetricsQueue.h>
 


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Forward declare AWSCore class to remove build dependency

## How was this PR tested?

- Unit tests passed
- Verified with the MultiplayerSample project manually
