### PR TITLE
[Terrain] Possibly fix race condition exposed by unit tests

### DIFF
--- a/Gems/PhysX/Code/Source/HeightfieldCollider.cpp
+++ b/Gems/PhysX/Code/Source/HeightfieldCollider.cpp
@@ -534,13 +534,16 @@ namespace PhysX
             // effectively lets us create an implicit dependency on all the jobs created by that API, because until we start the
             // completion jobs, nothing downstream from them can start either.
 
-            for (size_t jobIndex = 0; jobIndex < updateShapeConfigJobs.size(); jobIndex++)
-            {
-                updateShapeConfigJobs[jobIndex]->Start();
-                updatePhysXHeightfieldJobs[jobIndex]->Start();
-            }
+            // We also need to start all the jobs in the reverse order of execution, so that way we don't encounter a race condition
+            // where a job might finish before we've even started the next one, which potentially prevents it from ever executing.
 
             refreshCompleteJob->Start();
+
+            for (int32_t jobIndex = aznumeric_cast<int32_t>(updateShapeConfigJobs.size() - 1); jobIndex >= 0; jobIndex--)
+            {
+                updatePhysXHeightfieldJobs[jobIndex]->Start();
+                updateShapeConfigJobs[jobIndex]->Start();
+            }
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>

## What does this PR do?

This PR hopefully fixes a race condition that was exposed by the EditorHeightfieldCollider* unit tests. When the race condition occurs, the unit tests get to the point that ~HeightfieldCollider() is called, which tries to cancel and block on any pending jobs, but there are no jobs running, so it locks up forever.

I suspect this state is caused from the order in which the jobs themselves are started. If a job finishes before the next job depending on it is even started, I suspect the next job never runs, causing the state where the final job never gets the chance to clear the "jobs running" state.

This PR reverses the order in which the jobs are started, so that every dependent job will already be started at the point that the job before it finishes.

## How was this PR tested?

Ran the unit tests 10 times locally without a lockup. (Prior to the PR change, running 5 times was enough to cause the lockup)
