### PR TITLE
Fixes gem queue download issue in Gem Catalog ( #9685)

### DIFF
--- a/Code/Tools/ProjectManager/Source/DownloadController.cpp
+++ b/Code/Tools/ProjectManager/Source/DownloadController.cpp
@@ -26,7 +26,7 @@ namespace O3DE::ProjectManager
         connect(&m_workerThread, &QThread::started, m_worker, &DownloadWorker::StartDownload);
         connect(m_worker, &DownloadWorker::Done, this, &DownloadController::HandleResults);
         connect(m_worker, &DownloadWorker::UpdateProgress, this, &DownloadController::UpdateUIProgress);
-        connect(this, &DownloadController::StartGemDownload, m_worker, &DownloadWorker::StartDownload);
+        connect(this, &DownloadController::StartGemDownload, m_worker, &DownloadWorker::SetGemToDownload);
     }
 
     DownloadController::~DownloadController()
@@ -102,7 +102,7 @@ namespace O3DE::ProjectManager
 
         if (!m_gemNames.empty())
         {
-            emit StartGemDownload(m_gemNames.front());
+            emit StartGemDownload(m_gemNames.front(), true);
         }
         else
         {

--- a/Code/Tools/ProjectManager/Source/DownloadController.h
+++ b/Code/Tools/ProjectManager/Source/DownloadController.h
@@ -57,7 +57,7 @@ namespace O3DE::ProjectManager
         void HandleResults(const QString& result, const QString& detailedError);
 
     signals:
-        void StartGemDownload(const QString& gemName);
+        void StartGemDownload(const QString& gemName, bool downloadNow);
         void Done(const QString& gemName, bool success = true);
         void GemDownloadAdded(const QString& gemName);
         void GemDownloadRemoved(const QString& gemName);


### PR DESCRIPTION
## What does this PR do?

Fixes a bug on queued download for remote gems.

Issue is that `m_gemName` is not set when `StartGemDownload` is emitted. Reason is the slot is set to `StartDownload` which doesn't update `m_gemName`. Connecting the signal to an updated `SetGemToDownload` should fix the issue.

This is also dependent to PR [#10487](https://github.com/o3de/o3de/pull/10487). Without it some gems gets removed to the list view.

## How was this PR tested?

Check the repro steps in Issue [#9685](https://github.com/o3de/o3de/issues/9685)
