### PR TITLE
chore(EmotionFX): update AzEulerAnglesToAzQuat with AZ::Quaternion::CreateFromEulerAnglesRadians

### DIFF
--- a/Gems/EMotionFX/Code/CMakeLists.txt
+++ b/Gems/EMotionFX/Code/CMakeLists.txt
@@ -169,6 +169,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 Legacy::CryCommon
                 AZ::AzTest
                 AZ::AzFramework
+                AZ::AzTestShared
                 Gem::EMotionFX.Static
                 Gem::EMotionFX.Tests.Static
     )

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeTransformNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeTransformNode.cpp
@@ -157,7 +157,7 @@ namespace EMotionFX
             OutputIncomingNode(animGraphInstance, GetInputNode(INPUTPORT_ROTATE_AMOUNT));
             const float rotateFactor = MCore::Clamp<float>(GetInputNumberAsFloat(animGraphInstance, INPUTPORT_ROTATE_AMOUNT), 0.0f, 1.0f);
             const AZ::Vector3 newAngles = m_minRotation.Lerp(m_maxRotation, rotateFactor);
-            outputTransform.m_rotation = inputTransform.m_rotation * AZ::Quaternion::CreateFromEulerAnglesDegrees(newAngles);
+            outputTransform.m_rotation = inputTransform.m_rotation * AZ::Quaternion::CreateFromEulerDegreesZYX(newAngles);
         }
 
         // process the translation

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeTransformNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeTransformNode.cpp
@@ -157,9 +157,7 @@ namespace EMotionFX
             OutputIncomingNode(animGraphInstance, GetInputNode(INPUTPORT_ROTATE_AMOUNT));
             const float rotateFactor = MCore::Clamp<float>(GetInputNumberAsFloat(animGraphInstance, INPUTPORT_ROTATE_AMOUNT), 0.0f, 1.0f);
             const AZ::Vector3 newAngles = m_minRotation.Lerp(m_maxRotation, rotateFactor);
-            outputTransform.m_rotation = inputTransform.m_rotation * MCore::AzEulerAnglesToAzQuat(MCore::Math::DegreesToRadians(newAngles.GetX()), 
-                MCore::Math::DegreesToRadians(newAngles.GetY()), 
-                MCore::Math::DegreesToRadians(newAngles.GetZ()));
+            outputTransform.m_rotation = inputTransform.m_rotation * AZ::Quaternion::CreateFromEulerAnglesDegrees(newAngles);
         }
 
         // process the translation

--- a/Gems/EMotionFX/Code/MCore/Source/AzCoreConversions.h
+++ b/Gems/EMotionFX/Code/MCore/Source/AzCoreConversions.h
@@ -73,7 +73,7 @@ namespace MCore
     }
 
     //! O3DE_DEPRECATION_NOTICE(GHI-10508)
-    //! @deprecated use AZ::Quaternion::CreateFromEulerAnglesRadians
+    //! @deprecated use AZ::Quaternion::CreateFromEulerRadiansZYX
     AZ_FORCE_INLINE AZ::Quaternion AzEulerAnglesToAzQuat(float pitch, float yaw, float roll)
     {
         // In the LY coordinate system, pitch: X, yaw: Z, roll: Y.

--- a/Gems/EMotionFX/Code/MCore/Source/AzCoreConversions.h
+++ b/Gems/EMotionFX/Code/MCore/Source/AzCoreConversions.h
@@ -72,6 +72,8 @@ namespace MCore
         }
     }
 
+    //! O3DE_DEPRECATION_NOTICE(GHI-10508)
+    //! @deprecated use AZ::Quaternion::CreateFromEulerAnglesRadians
     AZ_FORCE_INLINE AZ::Quaternion AzEulerAnglesToAzQuat(float pitch, float yaw, float roll)
     {
         // In the LY coordinate system, pitch: X, yaw: Z, roll: Y.

--- a/Gems/EMotionFX/Code/Tests/MCore/AZCoreConversionsTest.cpp
+++ b/Gems/EMotionFX/Code/Tests/MCore/AZCoreConversionsTest.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/Math/Quaternion.h>
+#include <AzTest/AzTest.h>
+#include <MCore/Source/AzCoreConversions.h>
+
+namespace MCore
+{
+
+    struct EularTestArgs {
+        AZ::Vector3 eular;
+        AZ::Quaternion result;
+    };
+    
+    using AngleRadianTestFixtureXYZ = ::testing::TestWithParam<EularTestArgs>;
+
+    TEST_P(AngleRadianTestFixtureXYZ, EularRadiansXYZ) {
+        auto& param = GetParam();
+        EXPECT_THAT(MCore::AzEulerAnglesToAzQuat(param.eular.GetX(),param.eular.GetY(),param.eular.GetZ()), IsClose(param.result));
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        MATH_Quaternion,
+        AngleRadianTestFixtureXYZ,
+        ::testing::Values(
+            EularTestArgs{ AZ::Vector3(AZ::Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(AZ::Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, AZ::Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(AZ::Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, 0, AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) },
+
+            EularTestArgs{ AZ::Vector3(-AZ::Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(-AZ::Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, -AZ::Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(-AZ::Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, 0, -AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(-AZ::Constants::QuarterPi) },
+
+            EularTestArgs{ AZ::Vector3(AZ::Constants::QuarterPi, AZ::Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(AZ::Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationX(AZ::Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, AZ::Constants::QuarterPi, AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationY(AZ::Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(AZ::Constants::QuarterPi, 0, AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationX(AZ::Constants::QuarterPi)}));
+
+} // namespace MCore

--- a/Gems/EMotionFX/Code/Tests/MCore/AZCoreConversionsTest.cpp
+++ b/Gems/EMotionFX/Code/Tests/MCore/AZCoreConversionsTest.cpp
@@ -23,7 +23,7 @@ namespace MCore
 
     TEST_P(AngleRadianTestFixtureXYZ, AzEulerAnglesToAzQuat) {
         auto& param = GetParam();
-        EXPECT_THAT(MCore::AzEulerAnglesToAzQuat(param.eular.GetX(),param.eular.GetY(),param.eular.GetZ()), IsClose(param.result));
+        EXPECT_THAT(MCore::AzEulerAnglesToAzQuat(param.eular.GetX(),param.eular.GetY(),param.eular.GetZ()), UnitTest::IsClose(param.result));
     }
 
     // same test cases in QuaternionTests.cpp AngleRadianTestFixtureZYX

--- a/Gems/EMotionFX/Code/Tests/MCore/AZCoreConversionsTest.cpp
+++ b/Gems/EMotionFX/Code/Tests/MCore/AZCoreConversionsTest.cpp
@@ -6,8 +6,9 @@
  *
  */
 
-#include <AzCore/Math/Vector3.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
 #include <AzCore/Math/Quaternion.h>
+#include <AzCore/Math/Vector3.h>
 #include <AzTest/AzTest.h>
 #include <MCore/Source/AzCoreConversions.h>
 

--- a/Gems/EMotionFX/Code/Tests/MCore/AZCoreConversionsTest.cpp
+++ b/Gems/EMotionFX/Code/Tests/MCore/AZCoreConversionsTest.cpp
@@ -13,36 +13,49 @@
 
 namespace MCore
 {
-
-    struct EularTestArgs {
+    struct EulerTestArgs {
         AZ::Vector3 eular;
         AZ::Quaternion result;
     };
     
-    using AngleRadianTestFixtureXYZ = ::testing::TestWithParam<EularTestArgs>;
+    using AngleRadianTestFixtureXYZ = ::testing::TestWithParam<EulerTestArgs>;
 
-    TEST_P(AngleRadianTestFixtureXYZ, EularRadiansXYZ) {
+    TEST_P(AngleRadianTestFixtureXYZ, AzEulerAnglesToAzQuat) {
         auto& param = GetParam();
         EXPECT_THAT(MCore::AzEulerAnglesToAzQuat(param.eular.GetX(),param.eular.GetY(),param.eular.GetZ()), IsClose(param.result));
     }
 
+    // same test cases in QuaternionTests.cpp AngleRadianTestFixtureZYX
     INSTANTIATE_TEST_CASE_P(
-        MATH_Quaternion,
+        MATH_AZCoreConversions,
         AngleRadianTestFixtureXYZ,
         ::testing::Values(
-            EularTestArgs{ AZ::Vector3(AZ::Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(AZ::Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, AZ::Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(AZ::Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, 0, AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(AZ::Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(AZ::Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, AZ::Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(AZ::Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, 0, AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) },
 
-            EularTestArgs{ AZ::Vector3(-AZ::Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(-AZ::Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, -AZ::Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(-AZ::Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, 0, -AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(-AZ::Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(-AZ::Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(-AZ::Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, -AZ::Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(-AZ::Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, 0, -AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(-AZ::Constants::QuarterPi) },
 
-            EularTestArgs{ AZ::Vector3(AZ::Constants::QuarterPi, AZ::Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(AZ::Constants::QuarterPi) *
+            EulerTestArgs{ AZ::Vector3(AZ::Constants::QuarterPi,AZ::Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(AZ::Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationX(AZ::Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, AZ::Constants::QuarterPi, AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) *
+            EulerTestArgs{ AZ::Vector3(0,AZ::Constants::QuarterPi,AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationY(AZ::Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(AZ::Constants::QuarterPi, 0, AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) *
-                AZ::Quaternion::CreateRotationX(AZ::Constants::QuarterPi)}));
+            EulerTestArgs{ AZ::Vector3(AZ::Constants::QuarterPi, 0,AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationX(AZ::Constants::QuarterPi)},
+                
+            EulerTestArgs{ AZ::Vector3(AZ::Constants::HalfPi, 0,AZ::Constants::QuarterPi), 
+                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationX(AZ::Constants::HalfPi)},
+            EulerTestArgs{ AZ::Vector3(-AZ::Constants::QuarterPi, -AZ::Constants::HalfPi,AZ::Constants::QuarterPi), 
+                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationY(-AZ::Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationX(-AZ::Constants::QuarterPi)},
+            EulerTestArgs{ AZ::Vector3(-AZ::Constants::QuarterPi,AZ::Constants::HalfPi,AZ::Constants::TwoOverPi), 
+                AZ::Quaternion::CreateRotationZ(AZ::Constants::TwoOverPi) *
+                AZ::Quaternion::CreateRotationY(AZ::Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationX(-AZ::Constants::QuarterPi)}
+        ));
 
 } // namespace MCore

--- a/Gems/EMotionFX/Code/Tests/TransformUnitTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/TransformUnitTests.cpp
@@ -104,11 +104,11 @@ namespace EMotionFX
         }
         AZ::Quaternion ExpectedRotation() const
         {
-            return MCore::AzEulerAnglesToAzQuat(
+            return AZ::Quaternion::CreateFromEulerAnglesRadians(AZ::Vector3(
                 ::testing::get<0>(::testing::get<1>(GetParam())),
                 ::testing::get<1>(::testing::get<1>(GetParam())),
                 ::testing::get<2>(::testing::get<1>(GetParam()))
-            );
+            ));
         }
         const AZ::Vector3& ExpectedScale() const
         {

--- a/Gems/EMotionFX/Code/Tests/TransformUnitTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/TransformUnitTests.cpp
@@ -104,7 +104,7 @@ namespace EMotionFX
         }
         AZ::Quaternion ExpectedRotation() const
         {
-            return AZ::Quaternion::CreateFromEulerAnglesRadians(AZ::Vector3(
+            return AZ::Quaternion::CreateFromEulerRadiansZYX(AZ::Vector3(
                 ::testing::get<0>(::testing::get<1>(GetParam())),
                 ::testing::get<1>(::testing::get<1>(GetParam())),
                 ::testing::get<2>(::testing::get<1>(GetParam()))

--- a/Gems/EMotionFX/Code/emotionfx_tests_files.cmake
+++ b/Gems/EMotionFX/Code/emotionfx_tests_files.cmake
@@ -38,6 +38,7 @@ set(FILES
     Tests/AnimGraphParameterActionTests.cpp
     Tests/AnimGraphParameterActionTests.cpp
     Tests/AnimGraphParameterConditionCommandTests.cpp
+    Tests/MCore/AZCoreConversionsTest.cpp
     Tests/AnimGraphParameterConditionTests.cpp
     Tests/AnimGraphParameterConditionCommandTests.cpp
     Tests/AnimGraphRefCountTests.cpp


### PR DESCRIPTION

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

replaces the MCore variant with AZ::Quaternion::CreateFromEulerAnglesRadians 

## How was this PR tested?

this should be covered under the existing unit test. 