### PR TITLE
chore(EmotionFX): update Intersect methods in mesh and replaced with AZ::Transform and AZ::Ray

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/RayIntersection.h
+++ b/Code/Framework/AzCore/AzCore/Math/RayIntersection.h
@@ -1,0 +1,21 @@
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include "AzCore/Math/Vector2.h"
+namespace AZ
+{
+    class Ray;
+    class Vector3;
+
+    namespace RayIntersection
+    {
+        bool RayTriangle(const AZ::Ray& ray, const AZ::Vector3& p1, const AZ::Vector3 p2, const AZ::Vector3& p3, AZ::Vector3& hitPoint, AZ::Vector2& barycentricUV);
+    }
+}
+
+#include <AzCore/Math/RayIntersection.inl>

--- a/Code/Framework/AzCore/AzCore/Math/RayIntersection.inl
+++ b/Code/Framework/AzCore/AzCore/Math/RayIntersection.inl
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "AzCore/Math/Vector2.h"
+#include <AzCore/Math/MathUtils.h>
+#include <AzCore/Math/Ray.h>
+#include <AzCore/Math/Vector3.h>
+
+namespace AZ
+{
+    namespace RayIntersection
+    {
+        bool RayTriangle(
+            const AZ::Ray& ray,
+            const AZ::Vector3& p1,
+            const AZ::Vector3 p2,
+            const AZ::Vector3& p3,
+            AZ::Vector3& hitPoint,
+            AZ::Vector2& barycentricUV)
+        {
+            // calculate two vectors of the polygon
+            const AZ::Vector3 edge1 = p2 - p1;
+            const AZ::Vector3 edge2 = p3 - p1;
+
+            // begin calculating determinant - also used to calculate U parameter
+            const AZ::Vector3 pvec = ray.GetDirection().Cross(edge2);
+
+            // if determinant is near zero, ray lies in plane of triangle
+            const float det = edge1.Dot(pvec);
+            if (det > -Constants::Tolerance && det < Constants::Tolerance)
+            {
+                return false;
+            }
+
+            // calculate distance from vert0 to ray origin
+            const AZ::Vector3 tvec = ray.GetOrigin() - p1;
+
+            // calculate U parameter and test bounds
+            const float inv_det = 1.0f / det;
+            const float u = tvec.Dot(pvec) * inv_det;
+            if (u < 0.0f || u > 1.0f)
+            {
+                return false;
+            }
+
+            // prepare to test V parameter
+            const AZ::Vector3 qvec = tvec.Cross(edge1);
+
+            // calculate V parameter and test bounds
+            const float v = ray.GetDirection().Dot(qvec) * inv_det;
+            if (v < 0.0f || u + v > 1.0f)
+            {
+                return false;
+            }
+
+            // calculate t, ray intersects triangle
+            const float t = edge2.Dot(qvec) * inv_det;
+            if (t < 0.0f || t > 1.0f)
+            {
+                return false;
+            }
+            
+            // output the results
+            barycentricUV = AZ::Vector2(u, v);
+            hitPoint = ray.GetOrigin() + t * ray.GetDirection();
+
+            // yes, there was an intersection
+            return true;
+        }
+    } // namespace RayIntersection
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -337,6 +337,8 @@ set(FILES
     Math/Random.h
     Math/Ray.cpp
     Math/Ray.h
+    Math/RayIntersection.h
+    Math/RayIntersection.inl
     Math/Sfmt.cpp
     Math/Sfmt.h
     Math/ShapeIntersection.cpp

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
@@ -8,6 +8,12 @@
 
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/PackedVector3.h>
+#include <AzCore/Math/Ray.h>
+#include <AzCore/Math/Transform.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/Math/RayIntersection.h>
+#include <AzCore/base.h>
+#include <AzCore/std/limits.h>
 #include "EMotionFXConfig.h"
 #include "Mesh.h"
 #include "SubMesh.h"
@@ -1276,8 +1282,6 @@ namespace EMotionFX
         }
     }
 
-
-
     // intersection test between the mesh and a ray
     bool Mesh::Intersects(const Transform& transform, const MCore::Ray& ray)
     {
@@ -1323,7 +1327,45 @@ namespace EMotionFX
         return false;
     }
 
+    bool Mesh::Intersects(const AZ::Transform& transform, const AZ::Ray& ray)
+    {
+        const AZ::Vector3* positions = static_cast<AZ::Vector3*>(FindVertexData(Mesh::ATTRIB_POSITIONS));
+        const AZ::Transform invTransform = transform.GetInverse();
+        const AZ::Ray testRay(
+            invTransform.TransformPoint(ray.GetOrigin()), invTransform.TransformVector(ray.GetDirection()));
 
+        // iterate over all polygons, triangulate internally
+        const AZ::u32* indices = GetIndices();
+        const AZ::u8* vertCounts = GetPolygonVertexCounts();
+        AZ::u32 polyStartIndex = 0;
+        const AZ::u32 numPolygons = GetNumPolygons();
+        for (AZ::u32 p = 0; p < numPolygons; p++)
+        {
+            const AZ::u32 numPolyVerts = vertCounts[p];
+
+            // iterate over all triangles inside this polygon
+            // explanation: numPolyVerts-2 == number of triangles
+            // 3 verts=1 triangle, 4 verts=2 triangles, etc
+            for (AZ::u32 i = 2; i < numPolyVerts; i++)
+            {
+                AZ::u32 indexA = indices[polyStartIndex];
+                AZ::u32 indexB = indices[polyStartIndex + i];
+                AZ::u32 indexC = indices[polyStartIndex + i - 1];
+
+                [[maybe_unused]] AZ::Vector3 hitPoint;
+                [[maybe_unused]] AZ::Vector2 barycentricUV;
+                if (AZ::RayIntersection::RayTriangle(testRay, positions[indexA], positions[indexB], positions[indexC], hitPoint, barycentricUV))
+                {
+                    return true;
+                }
+            }
+
+            polyStartIndex += numPolyVerts;
+        }
+
+        // there is no intersection
+        return false;
+    }
 
     // intersection test between the mesh and a ray, includes calculation of intersection point
     bool Mesh::Intersects(const Transform& transform, const MCore::Ray& ray, AZ::Vector3* outIntersect, float* outBaryU, float* outBaryV, uint32* outIndices)
@@ -1418,6 +1460,77 @@ namespace EMotionFX
         return hasIntersected;
     }
 
+    bool Mesh::Intersects(
+        const AZ::Transform& transform,
+        const AZ::Ray& ray,
+        AZ::Vector3& outHitPoint,
+        AZ::Vector2& outBarycentricUV,
+        AZStd::array<AZ::u32, 3>& hitIndecies)
+    {
+        AZ::Vector3* positions = static_cast<AZ::Vector3*>(FindVertexData(Mesh::ATTRIB_POSITIONS));
+        AZ::Transform invTransform = transform.GetInverse();
+
+        // the test ray, in space of the node (object space)
+        // on this way we do not have to convert the vertices into world space
+        const AZ::Ray testRay(
+            invTransform.TransformPoint(ray.GetOrigin()), 
+            invTransform.TransformVector(ray.GetDirection()));
+
+        float closestDist = AZStd::numeric_limits<float>::max();
+        AZ::Vector3 closestIntersect;
+        bool hasIntersected = false;
+
+        // iterate over all polygons, triangulate internally
+        const AZ::u32* indices = GetIndices();
+        const AZ::u8* vertCounts = GetPolygonVertexCounts();
+        AZ::u32 polyStartIndex = 0;
+        const AZ::u32 numPolygons = GetNumPolygons();
+        for (AZ::u32 p = 0; p < numPolygons; p++)
+        {
+            const AZ::u32 numPolyVerts = vertCounts[p];
+
+            // iterate over all triangles inside this polygon
+            // explanation: numPolyVerts-2 == number of triangles
+            // 3 verts=1 triangle, 4 verts=2 triangles, etc
+            for (AZ::u32 i = 2; i < numPolyVerts; i++)
+            {
+                AZ::u32 indexA = indices[polyStartIndex];
+                AZ::u32 indexB = indices[polyStartIndex + i];
+                AZ::u32 indexC = indices[polyStartIndex + i - 1];
+
+                AZ::Vector3 hitPoint;
+                AZ::Vector2 barycentricUV;
+                // test the ray with the triangle (in object space)
+                if (AZ::RayIntersection::RayTriangle(
+                        testRay, positions[indexA], positions[indexB], positions[indexC], hitPoint, barycentricUV))
+                {
+                    // calculate the squared distance between the intersection point and the ray origin
+                    float dist = (hitPoint - testRay.GetOrigin()).GetLengthSq();
+
+                    // if it is the closest intersection point until now, record it as closest intersection
+                    if (dist < closestDist)
+                    {
+                        outBarycentricUV = barycentricUV;
+                        closestDist = dist;
+                        closestIntersect = hitPoint;
+                        hitIndecies[0] = indexA;
+                        hitIndecies[1] = indexB;
+                        hitIndecies[2] = indexC;
+                        hasIntersected = true;
+                    }
+                }
+            }
+
+            polyStartIndex += numPolyVerts;
+        }
+
+        if (hasIntersected)
+        {
+            outHitPoint = transform.TransformPoint(closestIntersect);
+        }
+
+        return hasIntersected;
+    }
 
     // log debugging information
     void Mesh::Log()

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <AzCore/base.h>
+#include <AzCore/std/containers/array.h>
 #include "EMotionFXConfig.h"
 #include <AzCore/Math/Aabb.h>
 #include <AzCore/std/containers/vector.h>
@@ -26,6 +28,12 @@ namespace AZ::RPI
 {
     class ModelLodAsset;
 }
+
+namespace AZ
+{
+    class Ray;
+    class Transform;
+} // namespace AZ
 
 namespace EMotionFX
 {
@@ -415,6 +423,8 @@ namespace EMotionFX
         //---------------------------------------------------
 
         /**
+         * O3DE_DEPRECATION_NOTICE(GHI-XX)
+         * @deprecated use the variant with AZ::Ray and AZ::Transform
          * Checks for an intersection between the mesh and a given ray.
          * @param transform The transformation of the mesh.
          * @param ray The ray to test with.
@@ -423,6 +433,16 @@ namespace EMotionFX
         bool Intersects(const Transform& transform, const MCore::Ray& ray);
 
         /**
+         * Checks for an intersection between the mesh and a given ray.
+         * @param transform The transformation of the mesh.
+         * @param ray The ray to test with.
+         * @result Returns true when an intersection has occurred, otherwise false.
+         */
+        bool Intersects(const AZ::Transform& transform, const AZ::Ray& ray);
+
+        /**
+         * O3DE_DEPRECATION_NOTICE(GHI-XX)
+         * @deprecated use the variant with AZ::Ray and AZ::Transform
          * Check for an intersection between the mesh a given ray, and calculate the closest intersection point.
          * If you do NOT need to know the intersection point, use the other Intersects method, because that one is faster, since it doesn't need to calculate
          * the closest intersection point.
@@ -437,6 +457,21 @@ namespace EMotionFX
          * @result Returns true when an intersection has occurred, otherwise false.
          */
         bool Intersects(const Transform& transform, const MCore::Ray& ray, AZ::Vector3* outIntersect, float* outBaryU = nullptr, float* outBaryV = nullptr, uint32* outIndices = nullptr);
+
+        /**
+         * Check for an intersection between the mesh a given ray, and calculate the closest intersection point.
+         * If you do NOT need to know the intersection point, use the other Intersects method, because that one is faster, since it doesn't need to calculate
+         * the closest intersection point.
+         * The intersection point returned is in object space.
+         * @param transform The transformation of the mesh.
+         * @param ray The ray to test with.
+         * @param[out] hitPoint A pointer to the vector to store the intersection point in, in case of a collision (nullptr allowed).
+         * @param[out] barycentricUV A barceyntric coordinate, to be used to interpolate values on the triangle (nullptr allowed).
+         * @param[out] hitIndecies A AZStd::array of 3 integers, which will contain the 3 vertex indices of the closest intersecting triangle. Even on polygon meshes with polygons of more than 3 vertices three indices are returned. In that case the indices represent a sub-triangle inside the polygon.
+         *                   A value of nullptr is allowed, which will skip storing the resulting triangle indices.
+         * @result Returns true when an intersection has occurred, otherwise false.
+         */
+        bool Intersects(const AZ::Transform& transform, const AZ::Ray& ray, AZ::Vector3& hitPoint, AZ::Vector2& barycentricUV, AZStd::array<AZ::u32, 3>& hitIndecies);
 
         //---------------------------------------------------
 


### PR DESCRIPTION

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

I introduced this  RayIntersection.h similar to ShapeIntersection.h. I think there was some discussion form this PR where it would make sense to define some of these utilities in a different header there is some context and discussion from the original PR that introduced this Ray object: https://github.com/o3de/o3de/pull/9394. The other header `IntersectSegment` is a bit of a dumping ground so I think it might make sense to migrate some of those methods here. what do you think @hultonha?

The main set of changes was to introduce some replacement Intersection methods under Mesh. This replaces both MCore::Ray and MCore::Transform. 

## How was this PR tested?

This code does not impact any existing behavior in EMotionFX.
