### PR TITLE
Atom Tools: Implement drag and drop to open documents

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
@@ -15,6 +15,9 @@
 #include <AzQtComponents/Components/Widgets/TabWidget.h>
 #endif
 
+class QDragEnterEvent;
+class QDragLeaveEvent;
+class QDropEvent;
 class QMenu;
 
 namespace AtomToolsFramework
@@ -101,6 +104,10 @@ namespace AtomToolsFramework
         void OnDocumentSaved(const AZ::Uuid& documentId) override;
 
         void closeEvent(QCloseEvent* closeEvent) override;
+        void dragEnterEvent(QDragEnterEvent* event) override;
+        void dragMoveEvent(QDragMoveEvent* event) override;
+        void dragLeaveEvent(QDragLeaveEvent* event) override;
+        void dropEvent(QDropEvent* event) override;
 
         template<typename Functor>
         QAction* CreateActionAtPosition(

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -24,6 +24,7 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnin
 AZ_POP_DISABLE_WARNING
 
 class QImage;
+class QMimeData;
 class QWidget;
 
 namespace AtomToolsFramework
@@ -181,4 +182,7 @@ namespace AtomToolsFramework
 
     //! Helper function to convert a full path into one containing an alias
     AZStd::string GetPathWithAlias(const AZStd::string& path);
+
+    //! Collect a set of file paths contained within asset browser entry or URL mine data
+    AZStd::set<AZStd::string> GetPathsFromMimeData(const QMimeData* mimeData);
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -305,46 +305,46 @@ namespace AtomToolsFramework
     AZStd::vector<AZStd::shared_ptr<DynamicPropertyGroup>> AtomToolsMainWindow::GetSettingsDialogGroups() const
     {
         AZStd::vector<AZStd::shared_ptr<DynamicPropertyGroup>> groups;
-        groups.push_back(AtomToolsFramework::CreateSettingsGroup(
+        groups.push_back(CreateSettingsGroup(
             "Application Settings",
             "Application Settings",
             {
-                AtomToolsFramework::CreatePropertyFromSetting(
+                CreatePropertyFromSetting(
                     "/O3DE/AtomToolsFramework/Application/ClearLogOnStart",
                     "Clear Log On Start",
                     "Clear the application log on startup",
                     false),
-                AtomToolsFramework::CreatePropertyFromSetting(
+                CreatePropertyFromSetting(
                     "/O3DE/AtomToolsFramework/Application/EnableSourceControl",
                     "Enable Source Control",
                     "Enable source control for the application if it is available",
                     false),
-                AtomToolsFramework::CreatePropertyFromSetting(
+                CreatePropertyFromSetting(
                     "/O3DE/AtomToolsFramework/Application/UpdateIntervalWhenActive",
                     "Update Interval When Active",
                     "Minimum delay between ticks (in milliseconds) when the application has focus",
                     aznumeric_cast<AZ::s64>(1)),
-                AtomToolsFramework::CreatePropertyFromSetting(
+                CreatePropertyFromSetting(
                     "/O3DE/AtomToolsFramework/Application/UpdateIntervalWhenNotActive",
                     "Update Interval When Not Active",
                     "Minimum delay between ticks (in milliseconds) when the application does not have focus",
                     aznumeric_cast<AZ::s64>(250)),
-                AtomToolsFramework::CreatePropertyFromSetting(
+                CreatePropertyFromSetting(
                     "/O3DE/AtomToolsFramework/Application/AllowMultipleInstances",
                     "Allow Multiple Instances",
                     "Allow multiple instances of the application to run",
                     false),
             }));
-        groups.push_back(AtomToolsFramework::CreateSettingsGroup(
+        groups.push_back(CreateSettingsGroup(
             "Asset Browser Settings",
             "Asset Browser Settings",
             {
-                AtomToolsFramework::CreatePropertyFromSetting(
+                CreatePropertyFromSetting(
                     "/O3DE/AtomToolsFramework/AssetBrowser/PromptToOpenMultipleFiles",
                     "Prompt To Open Multiple Files",
                     "Confirm before opening multiple files",
                     true),
-                AtomToolsFramework::CreatePropertyFromSetting(
+                CreatePropertyFromSetting(
                     "/O3DE/AtomToolsFramework/AssetBrowser/PromptToOpenMultipleFilesThreshold",
                     "Prompt To Open Multiple Files Threshold",
                     "Maximum number of files that can be selected before prompting for confirmation",
@@ -355,7 +355,7 @@ namespace AtomToolsFramework
 
     void AtomToolsMainWindow::OpenSettingsDialog()
     {
-        AtomToolsFramework::SettingsDialog dialog(GetSettingsDialogGroups(), this);
+        SettingsDialog dialog(GetSettingsDialogGroups(), this);
         dialog.exec();
     }
 
@@ -382,7 +382,7 @@ namespace AtomToolsFramework
             m_defaultWindowState = m_advancedDockManager->saveState();
             m_mainWindowWrapper->showFromSettings();
             const AZStd::string windowState =
-                AtomToolsFramework::GetSettingsObject("/O3DE/AtomToolsFramework/MainWindow/WindowState", AZStd::string());
+                GetSettingsObject("/O3DE/AtomToolsFramework/MainWindow/WindowState", AZStd::string());
             m_advancedDockManager->restoreState(QByteArray(windowState.data(), aznumeric_cast<int>(windowState.size())));
         }
 
@@ -394,7 +394,7 @@ namespace AtomToolsFramework
         if (closeEvent->isAccepted())
         {
             const QByteArray windowState = m_advancedDockManager->saveState();
-            AtomToolsFramework::SetSettingsObject(
+            SetSettingsObject(
                 "/O3DE/AtomToolsFramework/MainWindow/WindowState", AZStd::string(windowState.begin(), windowState.end()));
             AtomToolsMainWindowNotificationBus::Event(m_toolId, &AtomToolsMainWindowNotifications::OnMainWindowClosing);
         }


### PR DESCRIPTION
## What does this PR do?
This change implements support for dragging supported files from the I said browser, file browser, or other file source into the application client area. This will allow opening whatever document types are supported for that application using drag and drop. For example, material source files can be dragged from explorer or the asset browser into the client area and it will open in the application. Utility functions were added to validate all of the file paths being dragged in to make sure that they are valley inn and supported file folders.

The asset browser entry functions responsible for reading and writing mime data for were updated to support multi selection. Previously, even though the function signatures and comments made it seem like multiple files were supported, only one entry was ever being written.

https://github.com/o3de/o3de/issues/3404

## How was this PR tested?
Testing dragging one or more files into it material editor client area and watching them open.
Before asset browser entry updates, only the last file selected would open.
Ran existing unit tests on windows.