### PR TITLE
[Terrain] Removing clipmap generation shaders from mac until it supports bindless.

### DIFF
--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailClipmapGenerationPass.shader
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailClipmapGenerationPass.shader
@@ -10,5 +10,7 @@
           "type": "Compute"
         }
       ]
-    }
+    },
+    
+    "DisabledRHIBackends": ["metal"]
 }

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroClipmapGenerationPass.shader
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroClipmapGenerationPass.shader
@@ -10,5 +10,7 @@
           "type": "Compute"
         }
       ]
-    }
+    },
+    
+    "DisabledRHIBackends": ["metal"]
 }


### PR DESCRIPTION
Signed-off-by: Ken Pruiksma <pruiksma@amazon.com>

## What does this PR do?

Currently certain terrain shaders are failing on mac since mac doesn't support bindless textures. The solution for now is to just turn off those shaders on mac. 

https://github.com/o3de/o3de/issues/8601

## How was this PR tested?

Tested to make sure the shaders continue to work on pc and the shader assets build successfully.
