### PR TITLE
Asset Processor - Update test_validateDirectPreloadDependency_Found in asset_processor_batch_dependency_tests.py [LYN-11477]

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests.py
@@ -644,12 +644,8 @@ class TestsAssetProcessorBatch_AllPlatforms(object):
 
     @pytest.mark.BAT
     @pytest.mark.assetpipeline
-    @pytest.mark.SUITE_sandbox
     def test_validateDirectPreloadDependency_Found(self, asset_processor, ap_setup_fixture, workspace):
         """
-        Sandboxed: GHI 8,365 - Update assets from .prefab to a different type that allows for preload cyclical
-        dependencies
-
         Tests processing an asset with a circular dependency and verifies that Asset Processor will return an error
         notifying the user about a circular dependency.
 
@@ -665,19 +661,19 @@ class TestsAssetProcessorBatch_AllPlatforms(object):
 
         success, output = asset_processor.batch_process(capture_output=True, expect_failure=False)
         log = APOutputParser(output)
-        for _ in log.get_lines(-1, ["Preload circular dependency detected", "testc.prefab"]):
+        for _ in log.get_lines(-1, ["Preload circular dependency detected", "testb.auto_test_asset"]):
             error_line_found = True
+
+        if not error_line_found:
+            for line in output:
+                print(line)
 
         assert error_line_found, "The error could not be found in the newest run of the AP Batch log."
 
     @pytest.mark.BAT
     @pytest.mark.assetpipeline
-    @pytest.mark.SUITE_sandbox
     def test_validateNestedPreloadDependency_Found(self, asset_processor, ap_setup_fixture, workspace):
         """
-        Sandboxed: GHI 8,365 - Update assets from .prefab to a different type that allows for nested preload
-        dependencies
-
         Tests processing of a nested preload circular dependency and verifies that Asset Processor will return an error
         notifying the user about a circular dependency.
 
@@ -694,8 +690,13 @@ class TestsAssetProcessorBatch_AllPlatforms(object):
 
         success, output = asset_processor.batch_process(capture_output=True, expect_failure=False)
         log = APOutputParser(output)
-        for _ in log.get_lines(-1, ["Preload circular dependency detected", "testa.prefab"]):
+        for _ in log.get_lines(-1, ["Preload circular dependency detected", "testa.auto_test_asset"]):
             error_line_found = True
+
+        if not error_line_found:
+            for line in output:
+                print(line)
+
 
         assert error_line_found, "The error could not be found in the newest run of the AP Batch log."
 

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/assets_with_direct_preload_dependency/testa.auto_test_input
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/assets_with_direct_preload_dependency/testa.auto_test_input
@@ -1,0 +1,1 @@
+assets_with_direct_preload_dependency/testb.auto_test_input

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/assets_with_direct_preload_dependency/testb.auto_test_input
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/assets_with_direct_preload_dependency/testb.auto_test_input
@@ -1,0 +1,1 @@
+assets_with_direct_preload_dependency/testa.auto_test_input

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/assets_with_nested_preload_dependency/testa.auto_test_input
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/assets_with_nested_preload_dependency/testa.auto_test_input
@@ -1,0 +1,1 @@
+assets_with_nested_preload_dependency/testc.auto_test_input

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/assets_with_nested_preload_dependency/testb.auto_test_input
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/assets_with_nested_preload_dependency/testb.auto_test_input
@@ -1,0 +1,1 @@
+assets_with_nested_preload_dependency/testa.auto_test_input

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/assets_with_nested_preload_dependency/testc.auto_test_input
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/assets_with_nested_preload_dependency/testc.auto_test_input
@@ -1,0 +1,1 @@
+assets_with_nested_preload_dependency/testb.auto_test_input

--- a/Gems/TestAssetBuilder/Code/Source/Builder/TestDependencyBuilderComponent.cpp
+++ b/Gems/TestAssetBuilder/Code/Source/Builder/TestDependencyBuilderComponent.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AssetBuilderSDK/AssetBuilderSDK.h>
+#include <AssetBuilderSDK/SerializationDependencies.h>
+#include <AzCore/IO/SystemFile.h>
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Asset/GenericAssetHandler.h>
+#include <AzFramework/IO/LocalFileIO.h>
+#include <Builder/TestDependencyBuilderComponent.h>
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Serialization/Json/JsonUtils.h>
+
+namespace TestAssetBuilder
+{
+    namespace Details
+    {
+        AzFramework::GenericAssetHandler<TestAsset>* s_testAssetHandler = nullptr;
+
+        void RegisterAssethandlers()
+        {
+            s_testAssetHandler =
+                aznew AzFramework::GenericAssetHandler<TestAsset>("Automated Test Asset", "Other", "auto_test_asset");
+            s_testAssetHandler->Register();
+        }
+
+        void UnregisterAssethandlers()
+        {
+            if (s_testAssetHandler)
+            {
+                s_testAssetHandler->Unregister();
+                delete s_testAssetHandler;
+                s_testAssetHandler = nullptr;
+            }
+        }
+    } // namespace Details
+
+    void TestAsset::Reflect(AZ::ReflectContext* context)
+    {
+        auto serialize = azrtti_cast<AZ::SerializeContext*>(context);
+
+        if (serialize)
+        {
+            serialize->Class<TestAsset, AZ::Data::AssetData>()->Field("ReferencedAsset", &TestAsset::m_referencedAsset);
+        }
+    }
+
+    void TestDependencyBuilderComponent::Init()
+    {
+    }
+
+    void TestDependencyBuilderComponent::Activate()
+    {
+        Details::RegisterAssethandlers();
+
+        AssetBuilderSDK::AssetBuilderDesc builderDescriptor;
+        builderDescriptor.m_name = "Test Dependency Builder";
+        builderDescriptor.m_version = 1;
+        builderDescriptor.m_patterns.emplace_back("*.auto_test_input", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard);
+        builderDescriptor.m_busId = AZ::Uuid("{13D338AD-745F-442C-B0AA-48EFA6F3F044}");
+        builderDescriptor.m_createJobFunction = AZStd::bind(
+            &TestDependencyBuilderComponent::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);
+        builderDescriptor.m_processJobFunction = AZStd::bind(
+            &TestDependencyBuilderComponent::ProcessJob, this, AZStd::placeholders::_1, AZStd::placeholders::_2);
+
+        BusConnect(builderDescriptor.m_busId);
+
+        AssetBuilderSDK::AssetBuilderBus::Broadcast(&AssetBuilderSDK::AssetBuilderBusTraits::RegisterBuilderInformation, builderDescriptor);
+    }
+
+    void TestDependencyBuilderComponent::Deactivate()
+    {
+        BusDisconnect();
+
+        Details::UnregisterAssethandlers();
+    }
+
+    void TestDependencyBuilderComponent::Reflect(AZ::ReflectContext* context)
+    {
+        TestAsset::Reflect(context);
+
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<TestDependencyBuilderComponent, AZ::Component>()
+                ->Version(0)
+                ->Attribute(AZ::Edit::Attributes::SystemComponentTags, AZStd::vector<AZ::Crc32>({ AssetBuilderSDK::ComponentTags::AssetBuilder }))
+            ;
+        }
+    }
+
+    void TestDependencyBuilderComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC("TestDependencyBuilderComponentPluginService"));
+    }
+
+    void TestDependencyBuilderComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC("TestDependencyBuilderComponentPluginService"));
+    }
+
+    void TestDependencyBuilderComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        AZ_UNUSED(required);
+    }
+
+    void TestDependencyBuilderComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+        AZ_UNUSED(dependent);
+    }
+
+    AZStd::string ReadFile(const char* path)
+    {
+        AZStd::string buffer;
+
+        auto fileSize = AZ::IO::SystemFile::Length(path);
+
+        if (fileSize > 0)
+        {
+            buffer.resize_no_construct(AZ::IO::SystemFile::Length(path));
+            AZ::IO::SystemFile::Read(path, buffer.data(), buffer.size());
+        }
+
+        return buffer;
+    }
+
+    void TestDependencyBuilderComponent::CreateJobs(const AssetBuilderSDK::CreateJobsRequest& request, AssetBuilderSDK::CreateJobsResponse& response)
+    {
+        if (m_isShuttingDown)
+        {
+            response.m_result = AssetBuilderSDK::CreateJobsResultCode::ShuttingDown;
+            return;
+        }
+
+        for (const auto& platform : request.m_enabledPlatforms)
+        {
+            AssetBuilderSDK::JobDescriptor desc{ "", "Auto Test Builder", platform.m_identifier.c_str() };
+            response.m_createJobOutputs.push_back(desc);
+        }
+
+        response.m_result = AssetBuilderSDK::CreateJobsResultCode::Success;
+    }
+
+    void TestDependencyBuilderComponent::ProcessJob(const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response)
+    {
+        TestAsset outputAsset;
+        AZStd::string buffer = ReadFile(request.m_fullPath.c_str());
+
+        if (!buffer.empty())
+        {
+            bool result = false;
+            AZ::Data::AssetInfo assetInfo;
+            AZStd::string watchFolder;
+            AzToolsFramework::AssetSystemRequestBus::BroadcastResult(result, &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath, buffer.c_str(), assetInfo, watchFolder);
+
+            if (!result || !assetInfo.m_assetId.IsValid())
+            {
+                AZ_Error("TestDependencyBuilderComponent", false, "GetSourceInfoBySourcePath failed for %s", buffer.c_str());
+                return;
+            }
+
+            // It's not technically correct to use the source AssetId as a product asset reference, however we know the output will have a
+            // subId of 0 (the default) so we don't actually need that bit of data, we just need the UUID
+            outputAsset.m_referencedAsset = AZ::Data::Asset<TestAsset>(assetInfo.m_assetId, azrtti_typeid<TestAsset>(), buffer);
+            outputAsset.m_referencedAsset.SetAutoLoadBehavior(AZ::Data::PreLoad);
+        }
+
+        auto outputPath = AZ::IO::Path(request.m_tempDirPath) / request.m_sourceFile;
+        outputPath.ReplaceExtension("auto_test_asset");
+
+        AZ::JsonSerializationUtils::SaveObjectToFile(&outputAsset, outputPath.StringAsPosix());
+
+        AssetBuilderSDK::JobProduct jobProduct;
+        AssetBuilderSDK::OutputObject(&outputAsset, outputPath.FixedMaxPathStringAsPosix(), azrtti_typeid<TestAsset>(), 0, jobProduct);
+
+        response.m_outputProducts.push_back(jobProduct);
+        response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Success;
+    }
+
+    void TestDependencyBuilderComponent::ShutDown()
+    {
+        m_isShuttingDown = true;
+    }
+
+} // namespace TestAssetBuilder
+

--- a/Gems/TestAssetBuilder/Code/Source/Builder/TestDependencyBuilderComponent.h
+++ b/Gems/TestAssetBuilder/Code/Source/Builder/TestDependencyBuilderComponent.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AssetBuilderSDK/AssetBuilderBusses.h>
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/EditContext.h>
+
+namespace TestAssetBuilder
+{
+    class TestAsset : public AZ::Data::AssetData
+    {
+    public:
+        AZ_RTTI(TestAsset, "{3BDE90FA-B163-4FB9-BC67-22AC2ABD8C28}", AZ::Data::AssetData);
+        AZ_CLASS_ALLOCATOR(TestAsset, AZ::SystemAllocator, 0);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        TestAsset() = default;
+        virtual ~TestAsset() = default;
+
+        AZ::Data::Asset<TestAsset> m_referencedAsset;
+    };
+
+    //! This builder is intended for automated tests which need an asset that can reference other assets.
+    //! It will take .auto_test_input files containing a single path to a source file and output .auto_test_asset files with an asset
+    //! reference to the assumed product of the referenced asset.  References should be to other .auto_test_input files.
+    class TestDependencyBuilderComponent
+        : public AZ::Component,
+          public AssetBuilderSDK::AssetBuilderCommandBus::MultiHandler
+    {
+    public:
+        AZ_COMPONENT(TestDependencyBuilderComponent, "{E6DEE36F-8F75-41CB-9FEC-7E3231A97C1F}");
+
+        void Init() override;
+        void Activate() override;
+        void Deactivate() override;
+
+        static void Reflect(AZ::ReflectContext* context);
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+        //! Asset Builder Callback Functions
+        void CreateJobs(const AssetBuilderSDK::CreateJobsRequest& request, AssetBuilderSDK::CreateJobsResponse& response);
+        void ProcessJob(const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response);
+
+        //////////////////////////////////////////////////////////////////////////
+        //!AssetBuilderSDK::AssetBuilderCommandBus interface
+        void ShutDown() override; // if you get this you must fail all existing jobs and return.
+        //////////////////////////////////////////////////////////////////////////
+
+    private:
+
+        bool m_isShuttingDown = false;
+    };
+} // namespace TestAssetBuilder

--- a/Gems/TestAssetBuilder/Code/Source/TestAssetBuilderModule.cpp
+++ b/Gems/TestAssetBuilder/Code/Source/TestAssetBuilderModule.cpp
@@ -11,6 +11,7 @@
 
 #include <Builder/TestAssetBuilderComponent.h>
 #include <Builder/TestIntermediateAssetBuilderComponent.h>
+#include <Builder/TestDependencyBuilderComponent.h>
 
 namespace TestAssetBuilder
 {
@@ -27,6 +28,7 @@ namespace TestAssetBuilder
             m_descriptors.insert(m_descriptors.end(), {
                 TestAssetBuilderComponent::CreateDescriptor(),
                 TestIntermediateAssetBuilderComponent::CreateDescriptor(),
+                TestDependencyBuilderComponent::CreateDescriptor(),
             });
         }
     };

--- a/Gems/TestAssetBuilder/Code/testassetbuilder_files.cmake
+++ b/Gems/TestAssetBuilder/Code/testassetbuilder_files.cmake
@@ -11,4 +11,6 @@ set(FILES
     Source/Builder/TestAssetBuilderComponent.cpp
     Source/Builder/TestIntermediateAssetBuilderComponent.h
     Source/Builder/TestIntermediateAssetBuilderComponent.cpp
+    Source/Builder/TestDependencyBuilderComponent.h
+    Source/Builder/TestDependencyBuilderComponent.cpp
 )


### PR DESCRIPTION
## What does this PR do?

Adds a test builder which takes `.auto_test_input` files containing a relative path to another file and outputs `.auto_test_asset` files with an `Asset<T>` reference.

Updated the 2 existing python tests to use the new builder and moved them out of sandbox into periodic

## How was this PR tested?

Ran test locally and on Jenkins