### PR TITLE
[Terrain] Validating that the world min bounds is less than the world max bounds.

### DIFF
--- a/Gems/Terrain/Code/Source/Components/TerrainWorldComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainWorldComponent.cpp
@@ -89,9 +89,11 @@ namespace Terrain
                     ->DataElement(AZ::Edit::UIHandlers::Default, &TerrainWorldConfig::m_worldMin, "World Bounds (Min)", "")
                         ->Attribute(AZ::Edit::Attributes::Min, -65536.0f)
                         ->Attribute(AZ::Edit::Attributes::Max, 65536.0f)
+                        ->Attribute(AZ::Edit::Attributes::ChangeValidate, &TerrainWorldConfig::ValidateBoundsMin)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &TerrainWorldConfig::m_worldMax, "World Bounds (Max)", "")
                         ->Attribute(AZ::Edit::Attributes::Min, -65536.0f)
                         ->Attribute(AZ::Edit::Attributes::Max, 65536.0f)
+                        ->Attribute(AZ::Edit::Attributes::ChangeValidate, &TerrainWorldConfig::ValidateBoundsMax)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &TerrainWorldConfig::m_heightQueryResolution, "Height Query Resolution (m)", "")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.1f)

--- a/Gems/Terrain/Code/Source/Components/TerrainWorldComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainWorldComponent.h
@@ -47,6 +47,25 @@ namespace Terrain
         AZ::Vector3 m_worldMax{ 1024.0f, 1024.0f, 1024.0f };
         float m_heightQueryResolution{ 1.0f };
         float m_surfaceDataQueryResolution{ 1.0f };
+
+        static AZ::Outcome<void, AZStd::string> ValidateBounds(AZ::Vector3& minBounds, AZ::Vector3& maxBounds)
+        {
+            if (!minBounds.IsLessEqualThan(maxBounds))
+            {
+                return AZ::Failure(AZStd::string("World bounds min must be less than max."));
+            }
+            return AZ::Success();
+        }
+
+        AZ::Outcome<void, AZStd::string> ValidateBoundsMin(void* newValue, [[maybe_unused]] const AZ::Uuid& valueType)
+        {
+            return ValidateBounds(*static_cast<AZ::Vector3*>(newValue), m_worldMax);
+        }
+
+        AZ::Outcome<void, AZStd::string> ValidateBoundsMax(void* newValue, [[maybe_unused]] const AZ::Uuid& valueType)
+        {
+            return ValidateBounds(m_worldMin, *static_cast<AZ::Vector3*>(newValue));
+        }
     };
 
 


### PR DESCRIPTION
Signed-off-by: Ken Pruiksma <pruiksma@amazon.com>

## What does this PR do?

Previously users could put in a min value into the world bounds that was larger than the max value iand visa versa. This change makes an error message pop up when you attempt to do that, and doesn't actually apply the value unless it's valid.

Fixes https://github.com/o3de/o3de/issues/9783

## How was this PR tested?

Tested setting the min/max value in the editor to make sure invalid values were not allowed to be applied.
