### PR TITLE
Promoting DuplicatePrefab test to Main suite

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Prefab/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/CMakeLists.txt
@@ -19,14 +19,14 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
             AutomatedTesting.Assets
     )
 
-    ly_add_pytest(
-        NAME AutomatedTesting::PrefabTests_Periodic
-        TEST_SUITE periodic
-        TEST_SERIAL
-        PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Periodic.py
-        RUNTIME_DEPENDENCIES
-            Legacy::Editor
-            AZ::AssetProcessor
-            AutomatedTesting.Assets
-    )
+    #ly_add_pytest(
+    #    NAME AutomatedTesting::PrefabTests_Periodic
+    #    TEST_SUITE periodic
+    #    TEST_SERIAL
+    #    PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Periodic.py
+    #    RUNTIME_DEPENDENCIES
+    #        Legacy::Editor
+    #        AZ::AssetProcessor
+    #        AutomatedTesting.Assets
+    #)
 endif()

--- a/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Main.py
@@ -66,6 +66,9 @@ class TestAutomationNoAutoTestMode(EditorTestSuite):
     class test_DuplicatePrefab_ContainingASingleEntity(EditorSharedTest):
         from .tests.duplicate_prefab import DuplicatePrefab_ContainingASingleEntity as test_module
 
+    class test_DuplicatePrefab_ContainingNestedEntitiesAndNestedPrefabs(EditorSharedTest):
+        from .tests.duplicate_prefab import DuplicatePrefab_ContainingNestedEntitiesAndNestedPrefabs as test_module
+
     class test_PrefabNotifications_PropagationNotificationsReceived(EditorSharedTest):
         from .tests.prefab_notifications import PrefabNotifications_PropagationNotificationsReceived as test_module
 

--- a/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Periodic.py
@@ -17,6 +17,3 @@ class TestAutomationNoAutoTestMode(EditorTestSuite):
 
     # Enable only -BatchMode for these tests. Some tests cannot run in -autotest_mode due to UI interactions
     global_extra_cmdline_args = ["-BatchMode"]
-
-    class test_DuplicatePrefab_ContainingNestedEntitiesAndNestedPrefabs(EditorSharedTest):
-        from .tests.duplicate_prefab import DuplicatePrefab_ContainingNestedEntitiesAndNestedPrefabs as test_module


### PR DESCRIPTION
Signed-off-by: jckand-amzn <82226555+jckand-amzn@users.noreply.github.com>

## What does this PR do?

In order to reduce AR disruptions, newly created Prefab automated tests will be run for at least a week in the Periodic suite, only executing nightly. Once stability has been proven on Jenkins, these tests will be promoted to the Main suite.

This PR moves test_DuplicatePrefab_ContainingNestedEntitiesAndNestedPrefabs to the Main Prefab test suite after a week+ of passing results in the Periodic suite.

## How was this PR tested?

Ran updated TestSuite_Main locally with 0 failures:

```
================= 20 passed, 10 skipped, 1 warning in 28.96s ==================
```

Monitored results of nightly periodic build for intermittent test failures: 
https://jenkins.build.o3de.org/job/O3DE_periodic-incremental-daily/job/development/