### PR TITLE
Fix ScriptCanvas editor node palette sort and cap issues

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasTreeModel.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasTreeModel.cpp
@@ -305,6 +305,7 @@ namespace GraphCanvas
 
     void GraphCanvasTreeModel::ChildAboutToBeAdded(GraphCanvasTreeItem* parentItem, int position)
     {
+        layoutAboutToBeChanged();
         if (position < 0)
         {
             position = parentItem->GetChildCount() - 1;
@@ -317,6 +318,7 @@ namespace GraphCanvas
     {
         endInsertRows();
         Q_EMIT(OnTreeItemAdded(itemAdded));
+        layoutChanged();
     }
 
     #include <StaticLib/GraphCanvas/Widgets/moc_GraphCanvasTreeModel.cpp>

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/MaterialComponentRequestBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/MaterialComponentRequestBus.names
@@ -5,7 +5,8 @@
             "context": "EBusSender",
             "variant": "",
             "details": {
-                "name": "Material Component Request Bus"
+                "name": "Material Component Request Bus",
+                "category": "Render"
             },
             "methods": [
                 {


### PR DESCRIPTION
## What does this PR do?
Address issue reported in https://github.com/o3de/o3de/issues/10485

For sorting issue, seems like lessThan function is triggered when model setup at beginning (which some children items are not added yet, based on https://doc.qt.io/qt-6/qabstractitemmodel.html#layoutChanged we should emit layout changed when view reflected data gets changed)

## How was this PR tested?
Following GHI steps, issue is solved with the fix

Signed-off-by: onecent1101 <liug@amazon.com>