### PR TITLE
Adding .names for a couple terrain modules. 

### DIFF
--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MacroMaterialData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MacroMaterialData.names
@@ -1,0 +1,236 @@
+{
+    "entries": [
+        {
+            "base": "MacroMaterialData",
+            "context": "BehaviorClass",
+            "variant": "",
+            "details": {
+                "name": "Macro Material Data"
+            },
+            "methods": [
+                {
+                    "base": "GetNormalFactor",
+                    "context": "Getter",
+                    "details": {
+                        "name": "Get Normal Factor"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{DC68E20A-3251-4E4E-8BC7-F6A2521FEF46}",
+                            "details": {
+                                "name": "Macro Material Data*"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Normal Factor"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetNormalFactor",
+                    "context": "Setter",
+                    "details": {
+                        "name": "Set Normal Factor"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{DC68E20A-3251-4E4E-8BC7-F6A2521FEF46}",
+                            "details": {
+                                "name": "Macro Material Data*"
+                            }
+                        },
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Normal Factor"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetNormalFlipY",
+                    "context": "Getter",
+                    "details": {
+                        "name": "Get Normal FlipY"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{DC68E20A-3251-4E4E-8BC7-F6A2521FEF46}",
+                            "details": {
+                                "name": "Macro Material Data*"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Normal FlipY"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetNormalFlipY",
+                    "context": "Setter",
+                    "details": {
+                        "name": "Set Normal FlipY"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{DC68E20A-3251-4E4E-8BC7-F6A2521FEF46}",
+                            "details": {
+                                "name": "Macro Material Data*"
+                            }
+                        },
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Normal FlipY"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetNormalFlipX",
+                    "context": "Getter",
+                    "details": {
+                        "name": "Get Normal FlipX"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{DC68E20A-3251-4E4E-8BC7-F6A2521FEF46}",
+                            "details": {
+                                "name": "Macro Material Data*"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Normal FlipX"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetNormalFlipX",
+                    "context": "Setter",
+                    "details": {
+                        "name": "Set Normal FlipX"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{DC68E20A-3251-4E4E-8BC7-F6A2521FEF46}",
+                            "details": {
+                                "name": "Macro Material Data*"
+                            }
+                        },
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Normal FlipX"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetBounds",
+                    "context": "Getter",
+                    "details": {
+                        "name": "Get Bounds"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{DC68E20A-3251-4E4E-8BC7-F6A2521FEF46}",
+                            "details": {
+                                "name": "Macro Material Data*"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{A54C2B36-D5B8-46A1-A529-4EBDBD2450E7}",
+                            "details": {
+                                "name": "Bounds"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetBounds",
+                    "context": "Setter",
+                    "details": {
+                        "name": "Set Bounds"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{DC68E20A-3251-4E4E-8BC7-F6A2521FEF46}",
+                            "details": {
+                                "name": "Macro Material Data*"
+                            }
+                        },
+                        {
+                            "typeid": "{A54C2B36-D5B8-46A1-A529-4EBDBD2450E7}",
+                            "details": {
+                                "name": "Bounds"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetEntityId",
+                    "context": "Getter",
+                    "details": {
+                        "name": "Get Entity Id"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{DC68E20A-3251-4E4E-8BC7-F6A2521FEF46}",
+                            "details": {
+                                "name": "Macro Material Data*"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{6383F1D3-BB27-4E6B-A49A-6409B2059EAA}",
+                            "details": {
+                                "name": "Entity Id",
+                                "tooltip": "Entity Unique Id"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetEntityId",
+                    "context": "Setter",
+                    "details": {
+                        "name": "Set Entity Id"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{DC68E20A-3251-4E4E-8BC7-F6A2521FEF46}",
+                            "details": {
+                                "name": "Macro Material Data*"
+                            }
+                        },
+                        {
+                            "typeid": "{6383F1D3-BB27-4E6B-A49A-6409B2059EAA}",
+                            "details": {
+                                "name": "Entity Id",
+                                "tooltip": "Entity Unique Id"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/TerrainSurfaceGradientMapping.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/TerrainSurfaceGradientMapping.names
@@ -1,0 +1,110 @@
+{
+    "entries": [
+        {
+            "base": "TerrainSurfaceGradientMapping",
+            "context": "BehaviorClass",
+            "variant": "",
+            "details": {
+                "name": "Terrain Surface Gradient Mapping"
+            },
+            "methods": [
+                {
+                    "base": "GetGradientEntityId",
+                    "context": "Getter",
+                    "details": {
+                        "name": "Get Gradient Entity Id"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{473AD2CE-F22A-45A9-803F-2192F3D9F2BF}",
+                            "details": {
+                                "name": "Terrain Surface Gradient Mapping",
+                                "tooltip": "Mapping between a gradient and a surface."
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{6383F1D3-BB27-4E6B-A49A-6409B2059EAA}",
+                            "details": {
+                                "name": "Gradient Entity Id",
+                                "tooltip": "Entity Unique Id"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetGradientEntityId",
+                    "context": "Setter",
+                    "details": {
+                        "name": "Set Gradient Entity Id"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{473AD2CE-F22A-45A9-803F-2192F3D9F2BF}",
+                            "details": {
+                                "name": "Terrain Surface Gradient Mapping",
+                                "tooltip": "Mapping between a gradient and a surface."
+                            }
+                        },
+                        {
+                            "typeid": "{6383F1D3-BB27-4E6B-A49A-6409B2059EAA}",
+                            "details": {
+                                "name": "Gradient Entity Id",
+                                "tooltip": "Entity Unique Id"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetSurfaceTag",
+                    "context": "Getter",
+                    "details": {
+                        "name": "Get Surface Tag"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{473AD2CE-F22A-45A9-803F-2192F3D9F2BF}",
+                            "details": {
+                                "name": "Terrain Surface Gradient Mapping",
+                                "tooltip": "Mapping between a gradient and a surface."
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{67C8C6ED-F32A-443E-A777-1CAE48B22CD7}",
+                            "details": {
+                                "name": "Surface Tag",
+                                "tooltip": "Matches a surface value like a mask or material"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetSurfaceTag",
+                    "context": "Setter",
+                    "details": {
+                        "name": "Set Surface Tag"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{473AD2CE-F22A-45A9-803F-2192F3D9F2BF}",
+                            "details": {
+                                "name": "Terrain Surface Gradient Mapping",
+                                "tooltip": "Mapping between a gradient and a surface."
+                            }
+                        },
+                        {
+                            "typeid": "{67C8C6ED-F32A-443E-A777-1CAE48B22CD7}",
+                            "details": {
+                                "name": "Surface Tag",
+                                "tooltip": "Matches a surface value like a mask or material"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.cpp
@@ -37,8 +37,8 @@ namespace Terrain
                 ->Attribute(AZ::Script::Attributes::Category, "Terrain")
                 ->Attribute(AZ::Script::Attributes::Module, "terrain")
                 ->Constructor()
-                ->Property("gradientEntityId", BehaviorValueProperty(&TerrainSurfaceGradientMapping::m_gradientEntityId))
-                ->Property("surfaceTag", BehaviorValueProperty(&TerrainSurfaceGradientMapping::m_surfaceTag));
+                ->Property("GradientEntityId", BehaviorValueProperty(&TerrainSurfaceGradientMapping::m_gradientEntityId))
+                ->Property("SurfaceTag", BehaviorValueProperty(&TerrainSurfaceGradientMapping::m_surfaceTag));
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Ken Pruiksma <pruiksma@amazon.com>

## What does this PR do?

This change adds .names files for some terrain modules. This helps distinquish the Getter & Setter for various properties. Also updated the names internally for TerrainSurfaceGradientListComponent to be more standardized.

Fixes https://github.com/o3de/o3de/issues/8082

## How was this PR tested?

Generated and checked the .names files from the editor.
