### PR TITLE
Mac and iOS Utils_UnixLike.cpp build fix

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Utils/Utils_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Utils/Utils_UnixLike.cpp
@@ -8,6 +8,7 @@
 
 #include <AzCore/Utils/Utils.h>
 
+#include <cerrno>
 #include <cstdlib>
 #include <pwd.h>
 


### PR DESCRIPTION
The cerror header is needed for errno and ENOENT symbols.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
