### PR TITLE
Display Mapper component unable to set properties from python

### DIFF
--- a/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
+++ b/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
@@ -91,6 +91,7 @@
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Matrix3x3.h>
 #include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Preprocessor/Enum.h>
 
 namespace AZ
 {
@@ -139,15 +140,14 @@ namespace AZ
             float m_scale = 1.0f;
         };
 
-        enum class DisplayMapperOperationType : uint32_t
-        {
-            Aces = 0,
+        AZ_ENUM_CLASS_WITH_UNDERLYING_TYPE(DisplayMapperOperationType, uint32_t,
+            Aces,
             AcesLut,
             Passthrough,
             GammaSRGB,
             Reinhard,
             Invalid
-        };
+        );
 
         enum class ShaperPresetType
         {

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperConfigurationDescriptor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperConfigurationDescriptor.cpp
@@ -114,7 +114,7 @@ namespace AZ
                 DisplayMapperOperationTypeReflect(*serializeContext);
                 
                 serializeContext->Class<DisplayMapperConfigurationDescriptor>()
-                    ->Version(2)
+                    ->Version(3)
                     ->Field("Name", &DisplayMapperConfigurationDescriptor::m_name)
                     ->Field("OperationType", &DisplayMapperConfigurationDescriptor::m_operationType)
                     ->Field("LdrGradingLutEnabled", &DisplayMapperConfigurationDescriptor::m_ldrGradingLutEnabled)

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperConfigurationDescriptor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperConfigurationDescriptor.cpp
@@ -7,6 +7,8 @@
  */
 
 
+#include <AzCore/Preprocessor/Enum.h>
+#include <AzCore/Preprocessor/EnumReflectUtils.h>
 #include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
@@ -103,18 +105,13 @@ namespace AZ
             m_gamma = displayMapperParameters.m_gamma;
         }
 
+        AZ_ENUM_DEFINE_REFLECT_UTILITIES(DisplayMapperOperationType);
+
         void DisplayMapperConfigurationDescriptor::Reflect(AZ::ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
-                serializeContext->Enum<DisplayMapperOperationType>()
-                    ->Value("Aces", DisplayMapperOperationType::Aces)
-                    ->Value("AcesLut", DisplayMapperOperationType::AcesLut)
-                    ->Value("Passthrough", DisplayMapperOperationType::Passthrough)
-                    ->Value("GammaSRGB", DisplayMapperOperationType::GammaSRGB)
-                    ->Value("Reinhard", DisplayMapperOperationType::Reinhard)
-                    ->Value("Invalid", DisplayMapperOperationType::Invalid)
-                    ;
+                DisplayMapperOperationTypeReflect(*serializeContext);
                 
                 serializeContext->Class<DisplayMapperConfigurationDescriptor>()
                     ->Version(2)
@@ -124,18 +121,30 @@ namespace AZ
                     ->Field("LdrColorGradingLut", &DisplayMapperConfigurationDescriptor::m_ldrColorGradingLut)
                     ->Field("AcesParameterOverrides", &DisplayMapperConfigurationDescriptor::m_acesParameterOverrides)
                 ;
+
+                //if (auto editContext = serializeContext->GetEditContext())
+                //{
+                //    editContext->Class<DisplayMapperConfigurationDescriptor>("DisplayMapperConfiguration", "")
+                //        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                //        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_depthBias, "Depth Bias", "")
+                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_depthBiasClamp, "Depth Bias Clamp", "")
+                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_depthBiasSlopeScale, "Depth Bias Slope Scale", "")
+                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_fillMode, "Fill Mode", "")
+                //            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<FillMode>())
+                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_cullMode, "Cull Mode", "")
+                //            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<CullMode>())
+                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_multisampleEnable, "Multisample Enable", "")
+                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_depthClipEnable, "Depth Clip Enable", "")
+                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_conservativeRasterEnable, "Conservative Raster Enable", "")
+                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_forcedSampleCount, "Forced Sample Count", "")
+                //        ;
+                //}
             }
 
             if (auto* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
             {
-                behaviorContext->Class<DisplayMapperOperationType>()
-                    ->Enum<(uint32_t)DisplayMapperOperationType::Aces>("DisplayMapperOperationType_Aces")
-                    ->Enum<(uint32_t)DisplayMapperOperationType::AcesLut>("DisplayMapperOperationType_AcesLut")
-                    ->Enum<(uint32_t)DisplayMapperOperationType::Passthrough>("DisplayMapperOperationType_Passthrough")
-                    ->Enum<(uint32_t)DisplayMapperOperationType::GammaSRGB>("DisplayMapperOperationType_GammaSRGB")
-                    ->Enum<(uint32_t)DisplayMapperOperationType::Reinhard>("DisplayMapperOperationType_Reinhard")
-                    ->Enum<(uint32_t)DisplayMapperOperationType::Invalid>("DisplayMapperOperationType_Invalid")
-                    ;
+                DisplayMapperOperationTypeReflect(*behaviorContext);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperConfigurationDescriptor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperConfigurationDescriptor.cpp
@@ -122,24 +122,6 @@ namespace AZ
                     ->Field("AcesParameterOverrides", &DisplayMapperConfigurationDescriptor::m_acesParameterOverrides)
                 ;
 
-                //if (auto editContext = serializeContext->GetEditContext())
-                //{
-                //    editContext->Class<DisplayMapperConfigurationDescriptor>("DisplayMapperConfiguration", "")
-                //        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                //        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
-                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_depthBias, "Depth Bias", "")
-                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_depthBiasClamp, "Depth Bias Clamp", "")
-                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_depthBiasSlopeScale, "Depth Bias Slope Scale", "")
-                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_fillMode, "Fill Mode", "")
-                //            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<FillMode>())
-                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_cullMode, "Cull Mode", "")
-                //            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<CullMode>())
-                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_multisampleEnable, "Multisample Enable", "")
-                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_depthClipEnable, "Depth Clip Enable", "")
-                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_conservativeRasterEnable, "Conservative Raster Enable", "")
-                //        ->DataElement(AZ::Edit::UIHandlers::Default, &RasterState::m_forcedSampleCount, "Forced Sample Count", "")
-                //        ;
-                //}
             }
 
             if (auto* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettings.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettings.cpp
@@ -38,11 +38,7 @@ namespace AtomToolsFramework
                         ->Attribute(AZ::Edit::Attributes::Min, 60.0f)
                         ->Attribute(AZ::Edit::Attributes::Max, 120.0f)
                     ->DataElement(AZ::Edit::UIHandlers::ComboBox, &EntityPreviewViewportSettings::m_displayMapperOperationType, "Display Mapper Type", "")
-                        ->EnumAttribute(AZ::Render::DisplayMapperOperationType::Aces, "Aces")
-                        ->EnumAttribute(AZ::Render::DisplayMapperOperationType::AcesLut, "AcesLut")
-                        ->EnumAttribute(AZ::Render::DisplayMapperOperationType::Passthrough, "Passthrough")
-                        ->EnumAttribute(AZ::Render::DisplayMapperOperationType::GammaSRGB, "GammaSRGB")
-                        ->EnumAttribute(AZ::Render::DisplayMapperOperationType::Reinhard, "Reinhard")
+                        ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<AZ::Render::DisplayMapperOperationType>())
                     ;
             }
         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/DisplayMapper/EditorDisplayMapperComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/DisplayMapper/EditorDisplayMapperComponent.cpp
@@ -152,7 +152,7 @@ namespace AZ
 
                     editContext->Class<DisplayMapperComponentConfig>("ToneMapperComponentConfig", "")
                         ->ClassElement(Edit::ClassElements::EditorData, "")
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &DisplayMapperComponentConfig::m_displayMapperOperation, "Type", "Display Mapper Type.")
+                        ->DataElement(AZ::Edit::UIHandlers::ComboBox, &DisplayMapperComponentConfig::m_displayMapperOperation, "Type", "Display Mapper Type.")
                             ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<DisplayMapperOperationType>())
                             ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                         ->DataElement(Edit::UIHandlers::CheckBox,

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/DisplayMapper/EditorDisplayMapperComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/DisplayMapper/EditorDisplayMapperComponent.cpp
@@ -152,17 +152,9 @@ namespace AZ
 
                     editContext->Class<DisplayMapperComponentConfig>("ToneMapperComponentConfig", "")
                         ->ClassElement(Edit::ClassElements::EditorData, "")
-                        ->DataElement(Edit::UIHandlers::ComboBox,
-                            &DisplayMapperComponentConfig::m_displayMapperOperation,
-                            "Type",
-                            "Display Mapper Type.")
-                        ->EnumAttribute(DisplayMapperOperationType::Aces, "Aces")
-                        ->EnumAttribute(DisplayMapperOperationType::AcesLut, "AcesLut")
-                        ->EnumAttribute(DisplayMapperOperationType::Passthrough, "Passthrough")
-                        ->EnumAttribute(DisplayMapperOperationType::GammaSRGB, "GammaSRGB")
-                        ->EnumAttribute(DisplayMapperOperationType::Reinhard, "Reinhard")
-                        ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
-
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &DisplayMapperComponentConfig::m_displayMapperOperation, "Type", "Display Mapper Type.")
+                            ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<DisplayMapperOperationType>())
+                            ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                         ->DataElement(Edit::UIHandlers::CheckBox,
                             &DisplayMapperComponentConfig::m_ldrColorGradingLutEnabled,
                             "Enable LDR color grading LUT",


### PR DESCRIPTION
## What does this PR do?
This fix allows to use integer values when using
GetComponentProperty and SetComponentProperty in python
for `Display Mapper` component
- Example GetComponentProperty:
  propertyPath = "Controller|Configuration|Type"
  outcome = azlmbr.editor.EditorComponentAPIBus(busType,
            'GetComponentProperty', componentIdPair, propertyPath)
  result = outcome.GetValue()
  print(f"value of {propertyPath} is {result}, type = {type(result)}")

In the code above result is of type integer and the value is 0.

- Example SetComponentProperty:
  outcome = azlmbr.editor.EditorComponentAPIBus(busType,
            'SetComponentProperty', componentIdPair, propertyPath, 1)
  print(f"outcome success = {outcome.IsSuccess()}")

Before `SetComponentProperty` required a python class that was not serialized so the
only way around was to use DisplayMapperComponentRequestBus.

(https://github.com/o3de/o3de/issues/8348)

## How was this PR tested?
With the attached python script: 
[display_mapper.zip](https://github.com/o3de/o3de/files/9055390/display_mapper.zip)

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>
