### PR TITLE
Asset Processor - Stack overflow trying to display product dependency loop [LYN-13661]

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeModel.h
+++ b/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeModel.h
@@ -50,8 +50,9 @@ namespace AssetProcessor
         void AssetDataSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
     protected:
 
-        void PopulateOutgoingProductDependencies(ProductDependencyTreeItem* parent, AZ::s64 parentProductId);
-        void PopulateIncomingProductDependencies(ProductDependencyTreeItem* parent, AZ::s64 parentProductId);
+        // visitedDependencies is intentionally a copy because we need to independently track the chain for each branch in the graph
+        void PopulateOutgoingProductDependencies(ProductDependencyTreeItem* parent, AZ::s64 parentProductId, QSet<AZ::s64> visitedDependencies);
+        void PopulateIncomingProductDependencies(ProductDependencyTreeItem* parent, AZ::s64 parentProductId, QSet<AZ::s64> visitedDependencies);
 
         AZStd::shared_ptr<AzToolsFramework::AssetDatabase::AssetDatabaseConnection> m_sharedDbConnection;
         

--- a/Gems/TestAssetBuilder/Code/Source/Builder/TestDependencyBuilderComponent.h
+++ b/Gems/TestAssetBuilder/Code/Source/Builder/TestDependencyBuilderComponent.h
@@ -29,7 +29,7 @@ namespace TestAssetBuilder
         TestAsset() = default;
         virtual ~TestAsset() = default;
 
-        AZ::Data::Asset<TestAsset> m_referencedAsset;
+        AZStd::vector<AZ::Data::Asset<TestAsset>> m_referencedAssets;
     };
 
     //! This builder is intended for automated tests which need an asset that can reference other assets.


### PR DESCRIPTION
## What does this PR do?

Fixes a stack overflow crash when trying to display a dependency loop in the Assets tab.

## How was this PR tested?

Updated TestDependencyBuilder to support multiple dependencies.  Manually tested using this to verify crash is fixed and dependencies are displayed correctly


