### PR TITLE
remove superfluous check on asset validity, which fixes SC editor node palette and user functions

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Assets/ScriptCanvasAssetHelpers.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Assets/ScriptCanvasAssetHelpers.cpp
@@ -60,10 +60,6 @@ namespace ScriptCanvasEditor
 
         AZ::Data::AssetInfo GetSourceInfoByProductId(AZ::Data::AssetId assetId, AZ::Data::AssetType assetType)
         {
-            AZStd::string watchFolder;
-            AZ::Data::AssetInfo assetInfo;
-            const AZStd::string platformName = ""; // Empty for default
-
             AzToolsFramework::AssetSystemRequestBus::Events* assetSystem = AzToolsFramework::AssetSystemRequestBus::FindFirstHandler();
 
             if (assetSystem == nullptr)
@@ -71,19 +67,11 @@ namespace ScriptCanvasEditor
                 return AZ::Data::AssetInfo();
             }
 
+            AZStd::string watchFolder;
+            AZ::Data::AssetInfo assetInfo;
+            const AZStd::string platformName = ""; // Empty for default
+
             if (!assetSystem->GetAssetInfoById(assetId, assetType, platformName, assetInfo, watchFolder))
-            {
-                return AZ::Data::AssetInfo();
-            }
-
-            AZStd::string sourcePath;
-
-            if (!assetSystem->GetFullSourcePathFromRelativeProductPath(assetInfo.m_relativePath, sourcePath))
-            {
-                return AZ::Data::AssetInfo();
-            }
-
-            if (!assetSystem->GetSourceInfoBySourcePath(sourcePath.c_str(), assetInfo, watchFolder))
             {
                 return AZ::Data::AssetInfo();
             }


### PR DESCRIPTION
Signed-off-by: carlitosan <82187351+carlitosan@users.noreply.github.com>

## What does this PR do?

Removes a superfluous check on asset validity.

Fixes which fixes a bug where the SC editor node palette would not properly load user functions. Fixes #10549 

## How was this PR tested?

Proved the bug in the editor and the fix.
