### PR TITLE
Fixes a faulty error message about an invalid server address.

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/AssetServerHandler.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/AssetServerHandler.cpp
@@ -223,7 +223,8 @@ namespace AssetProcessor
         if (!IsServerAddressValid())
         {
             m_serverAddress = previousServerAddress;
-            AZ_Error(AssetProcessor::DebugChannel, false,
+            AZ_Error(AssetProcessor::DebugChannel,
+                m_assetCachingMode == AssetServerMode::Inactive,
                 "Server address (%.*s) is invalid! Reverting back to (%.*s)",
                 AZ_STRING_ARG(address),
                 AZ_STRING_ARG(previousServerAddress));


### PR DESCRIPTION
## What does this PR do?

Fixes starting up AP: Server address () is invalid! Reverting back to ()

## How was this PR tested?

Started AP with no setreg for the asset cache server and no error message came up

Signed-off-by: Allen Jackson <23512001+jackalbe@users.noreply.github.com>
