### PR TITLE
[Terrain] Fixing property tree editor to not explode when a editMetaData has no name

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.cpp
@@ -915,11 +915,11 @@ namespace AzToolsFramework
             bool addChildren = true;
             auto editMetaData = node.GetElementEditMetadata();
 
-            if (editMetaData && !editMetaData->m_name)
-            {
-                AZStd::string nodeName = node.GetElementMetadata()->m_name;
-                AZ_Warning("PropertyTreeEditor", false, "Found ElementData with no name on node \"%s\" with path\"%s\", skipping.", nodeName.c_str(), path.c_str());
-            }
+            AZ_Warning("PropertyTreeEditor",
+                !editMetaData || editMetaData->m_name,
+                "Found ElementData with no name on node \"%s\" with path\"%s\", skipping.",
+                node.GetElementMetadata() && node.GetElementMetadata()->m_name ? node.GetElementMetadata()->m_name : "",
+                path.c_str());
 
             if (editMetaData && editMetaData->m_name)
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.cpp
@@ -914,7 +914,14 @@ namespace AzToolsFramework
 
             bool addChildren = true;
             auto editMetaData = node.GetElementEditMetadata();
-            if (editMetaData)
+
+            if (editMetaData && !editMetaData->m_name)
+            {
+                AZStd::string nodeName = node.GetElementMetadata()->m_name;
+                AZ_Warning("PropertyTreeEditor", false, "Found ElementData with no name on node \"%s\" with path\"%s\", skipping.", nodeName.c_str(), path.c_str());
+            }
+
+            if (editMetaData && editMetaData->m_name)
             {
                 if (!path.empty())
                 {

--- a/Gems/Terrain/Code/Source/TerrainRenderer/Components/TerrainSurfaceMaterialsListComponent.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/Components/TerrainSurfaceMaterialsListComponent.cpp
@@ -47,6 +47,18 @@ namespace Terrain
                     ;
             }
         }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<TerrainSurfaceMaterialMapping>()
+                ->Constructor()
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Category, "Terrain")
+                ->Attribute(AZ::Script::Attributes::Module, "terrain")
+                ->Property("SurfaceTag", BehaviorValueProperty(&TerrainSurfaceMaterialMapping::m_surfaceTag))
+                ->Property("MaterialAsset", BehaviorValueProperty(&TerrainSurfaceMaterialMapping::m_materialAsset))
+                ;
+        }
     }
 
     void TerrainSurfaceMaterialsListConfig::Reflect(AZ::ReflectContext* context)
@@ -78,6 +90,18 @@ namespace Terrain
                         "Material Mappings", "Maps surfaces to materials.");
             }
         }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<TerrainSurfaceMaterialsListConfig>()
+                ->Constructor()
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Category, "Terrain")
+                ->Attribute(AZ::Script::Attributes::Module, "terrain")
+                ->Property("DefaultSurfaceMaterial", BehaviorValueProperty(&TerrainSurfaceMaterialsListConfig::m_defaultSurfaceMaterial))
+                ->Property("SurfaceMaterials", BehaviorValueProperty(&TerrainSurfaceMaterialsListConfig::m_surfaceMaterials))
+                ;
+        }
     }
 
     TerrainSurfaceMaterialsListConfig::TerrainSurfaceMaterialsListConfig()
@@ -88,6 +112,7 @@ namespace Terrain
                aznew AZ::Edit::AttributeData<AZ::Crc32>(AZ::Edit::PropertyVisibility::Hide)
            }
        );
+       m_hideSurfaceTagData.m_name = "hideSurfaceTagData";
     }
 
     const AZ::Edit::ElementData* TerrainSurfaceMaterialsListConfig::GetDynamicData(const void* handlerPtr, const void* elementPtr, const AZ::Uuid& )


### PR DESCRIPTION
Signed-off-by: Ken Pruiksma <pruiksma@amazon.com>

## What does this PR do?

Previously if an ElementData had no name, the PropertyTreeEditor could explode when building a node map. Since it's possible for components to provide their own ElementData using SetDynamicEditDataProvider, there's no guarantee that the ElementData will actually have a name. This change makes it so the node will be skipped if it has no name, and a warning will be generated that helps guide people to the problem.

This change also adds behavior context definitions for a couple terrain classes that were involved in the original bug. While they didn't end up being required to fix the bug, they're still helpful to have. 

Fixes https://github.com/o3de/o3de/issues/7701

## How was this PR tested?

Tested using script provided with bug. The affected component now has a name, so no warning is generated. Also tested situations where the name isn't provided, and a warning is generated in those cases.
