### PR TITLE
Update asset catalog, preview renderer, and editor material components to support hot reloading on system tick

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
@@ -692,7 +692,7 @@ namespace AzFramework
         {
             AZ::Data::AssetInfo assetInfo = GetAssetInfoById(assetId);
 
-            AZ::TickBus::QueueFunction([assetId, assetInfo = AZStd::move(assetInfo)]()
+            AZ::SystemTickBus::QueueFunction([assetId, assetInfo = AZStd::move(assetInfo)]()
             {
                 AzFramework::AssetCatalogEventBus::Broadcast(&AzFramework::AssetCatalogEventBus::Events::OnCatalogAssetRemoved, assetId, assetInfo);
             });
@@ -855,7 +855,7 @@ namespace AzFramework
             if (!isNewAsset)
             {
                 // the following deliveries must happen on the main thread of the application:
-                AZ::TickBus::QueueFunction([assetId]() 
+                AZ::SystemTickBus::QueueFunction([assetId]() 
                 {
                     AzFramework::AssetCatalogEventBus::Broadcast(&AzFramework::AssetCatalogEventBus::Events::OnCatalogAssetChanged, assetId);
                 });
@@ -863,7 +863,7 @@ namespace AzFramework
                 // in case someone has an ancient reference, notify on that too.
                 for (const auto& mapping : message.m_legacyAssetIds)
                 {
-                    AZ::TickBus::QueueFunction([mapping]()
+                    AZ::SystemTickBus::QueueFunction([mapping]()
                     {
                         AzFramework::AssetCatalogEventBus::Broadcast(&AzFramework::AssetCatalogEventBus::Events::OnCatalogAssetChanged, mapping);
                     });
@@ -872,13 +872,13 @@ namespace AzFramework
             }
             else
             {
-                AZ::TickBus::QueueFunction([assetId]()
+                AZ::SystemTickBus::QueueFunction([assetId]()
                 {
                     AzFramework::AssetCatalogEventBus::Broadcast(&AzFramework::AssetCatalogEventBus::Events::OnCatalogAssetAdded, assetId);
                 });
                 for (const auto& mapping : message.m_legacyAssetIds)
                 {
-                    AZ::TickBus::QueueFunction([mapping]()
+                    AZ::SystemTickBus::QueueFunction([mapping]()
                     {
                         AzFramework::AssetCatalogEventBus::Broadcast(&AzFramework::AssetCatalogEventBus::Events::OnCatalogAssetAdded, mapping);
                     });
@@ -889,7 +889,7 @@ namespace AzFramework
             
             if (AZ::Data::AssetManager::IsReady())
             {
-                AZ::TickBus::QueueFunction([assetId]()
+                AZ::SystemTickBus::QueueFunction([assetId]()
                 {
                     AZ::Data::AssetManager::Instance().ReloadAsset(assetId, AZ::Data::AssetLoadBehavior::Default, true);
                 });

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
@@ -30,7 +30,7 @@ namespace AtomToolsFramework
 {
     void DisplayErrorMessage(QWidget* parent, const QString& title, const QString& text)
     {
-        AZ_Error("AtomToolsDocumentSystem", false, text.toUtf8().constData());
+        AZ_Error("AtomToolsDocumentSystem", false, "%s: %s", title.toUtf8().constData(), text.toUtf8().constData());
         if (GetSettingsValue<bool>("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/DisplayErrorMessageDialogs", true))
         {
             QMessageBox::critical(parent, title, text);
@@ -39,7 +39,7 @@ namespace AtomToolsFramework
 
     void DisplayWarningMessage(QWidget* parent, const QString& title, const QString& text)
     {
-        AZ_Warning("AtomToolsDocumentSystem", false, text.toUtf8().constData());
+        AZ_Warning("AtomToolsDocumentSystem", false, "%s: %s", title.toUtf8().constData(), text.toUtf8().constData());
         if (GetSettingsValue<bool>("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/DisplayWarningMessageDialogs", true))
         {
             QMessageBox::warning(parent, title, text);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
@@ -194,8 +194,10 @@ namespace AtomToolsFramework
                 if (captureCompleteCallback)
                 {
                     captureCompleteCallback(QPixmap::fromImage(QImage(
-                        result.m_dataBuffer.get()->data(), result.m_imageDescriptor.m_size.m_width,
-                        result.m_imageDescriptor.m_size.m_height, QImage::Format_RGBA8888)));
+                        result.m_dataBuffer.get()->data(),
+                        result.m_imageDescriptor.m_size.m_width,
+                        result.m_imageDescriptor.m_size.m_height,
+                        QImage::Format_RGBA8888)));
                 }
             }
             else

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.h
@@ -66,7 +66,7 @@ namespace AtomToolsFramework
         AZStd::vector<AZStd::string> m_passHierarchy;
         AZStd::unique_ptr<AzFramework::EntityContext> m_entityContext;
 
-        //! Incoming requests are appended to this queue and processed one at a time in OnTick function.
+        //! Incoming requests are appended to this queue and processed one at a time in OnSystemTick function.
         AZStd::queue<PreviewRendererCaptureRequest> m_captureRequestQueue;
         PreviewRendererCaptureRequest m_currentCaptureRequest;
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererCaptureState.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererCaptureState.cpp
@@ -15,17 +15,17 @@ namespace AtomToolsFramework
         : PreviewRendererState(renderer)
     {
         m_renderer->PoseContent();
-        AZ::TickBus::Handler::BusConnect();
+        AZ::SystemTickBus::Handler::BusConnect();
     }
 
     PreviewRendererCaptureState::~PreviewRendererCaptureState()
     {
         AZ::Render::FrameCaptureNotificationBus::Handler::BusDisconnect();
-        AZ::TickBus::Handler::BusDisconnect();
+        AZ::SystemTickBus::Handler::BusDisconnect();
         m_renderer->EndCapture();
     }
 
-    void PreviewRendererCaptureState::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    void PreviewRendererCaptureState::OnSystemTick()
     {
         if (m_ticksToCapture-- <= 0)
         {
@@ -33,7 +33,7 @@ namespace AtomToolsFramework
             if (m_frameCaptureId != AZ::Render::FrameCaptureRequests::s_InvalidFrameCaptureId)
             {
                 AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect();
-                AZ::TickBus::Handler::BusDisconnect();
+                AZ::SystemTickBus::Handler::BusDisconnect();
             }
             // if the start capture call fails the capture will be retried next tick.
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererCaptureState.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererCaptureState.h
@@ -17,7 +17,7 @@ namespace AtomToolsFramework
     //! PreviewRendererCaptureState renders a preview to an image
     class PreviewRendererCaptureState final
         : public PreviewRendererState
-        , public AZ::TickBus::Handler
+        , public AZ::SystemTickBus::Handler
         , public AZ::Render::FrameCaptureNotificationBus::Handler
     {
     public:
@@ -25,8 +25,8 @@ namespace AtomToolsFramework
         ~PreviewRendererCaptureState();
 
     private:
-        //! AZ::TickBus::Handler interface overrides...
-        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        //! AZ::SystemTickBus::Handler interface overrides...
+        void OnSystemTick() override;
 
         //! AZ::Render::FrameCaptureNotificationBus::Handler overrides...
         void OnCaptureFinished(uint32_t frameCaptureId, AZ::Render::FrameCaptureResult result, const AZStd::string& info) override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererIdleState.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererIdleState.cpp
@@ -14,15 +14,15 @@ namespace AtomToolsFramework
     PreviewRendererIdleState::PreviewRendererIdleState(PreviewRenderer* renderer)
         : PreviewRendererState(renderer)
     {
-        AZ::TickBus::Handler::BusConnect();
+        AZ::SystemTickBus::Handler::BusConnect();
     }
 
     PreviewRendererIdleState::~PreviewRendererIdleState()
     {
-        AZ::TickBus::Handler::BusDisconnect();
+        AZ::SystemTickBus::Handler::BusDisconnect();
     }
 
-    void PreviewRendererIdleState::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    void PreviewRendererIdleState::OnSystemTick()
     {
         m_renderer->ProcessCaptureRequests();
     }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererIdleState.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererIdleState.h
@@ -16,14 +16,14 @@ namespace AtomToolsFramework
     //! PreviewRendererIdleState checks whether there are any new thumbnails that need to be rendered every tick
     class PreviewRendererIdleState final
         : public PreviewRendererState
-        , public AZ::TickBus::Handler
+        , public AZ::SystemTickBus::Handler
     {
     public:
         PreviewRendererIdleState(PreviewRenderer* renderer);
         ~PreviewRendererIdleState();
 
     private:
-        //! AZ::TickBus::Handler interface overrides...
-        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        //! AZ::SystemTickBus::Handler interface overrides...
+        void OnSystemTick() override;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererLoadState.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererLoadState.cpp
@@ -15,17 +15,17 @@ namespace AtomToolsFramework
         : PreviewRendererState(renderer)
     {
         m_renderer->LoadContent();
-        AZ::TickBus::Handler::BusConnect();
+        AZ::SystemTickBus::Handler::BusConnect();
     }
 
     PreviewRendererLoadState::~PreviewRendererLoadState()
     {
-        AZ::TickBus::Handler::BusDisconnect();
+        AZ::SystemTickBus::Handler::BusDisconnect();
     }
 
-    void PreviewRendererLoadState::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    void PreviewRendererLoadState::OnSystemTick()
     {
-        if ((m_timeRemainingS += deltaTime) > TimeOutS)
+        if (AZStd::chrono::system_clock::now() > (m_startTime + AZStd::chrono::seconds(5)))
         {
             m_renderer->CancelLoadContent();
             return;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererLoadState.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererLoadState.h
@@ -16,17 +16,16 @@ namespace AtomToolsFramework
     //! PreviewRendererLoadState pauses further rendering until all assets used for rendering a thumbnail have been loaded
     class PreviewRendererLoadState final
         : public PreviewRendererState
-        , public AZ::TickBus::Handler
+        , public AZ::SystemTickBus::Handler
     {
     public:
         PreviewRendererLoadState(PreviewRenderer* renderer);
         ~PreviewRendererLoadState();
 
     private:
-        //! AZ::TickBus::Handler interface overrides...
-        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        //! AZ::SystemTickBus::Handler interface overrides...
+        void OnSystemTick() override;
 
-        static constexpr float TimeOutS = 5.0f;
-        float m_timeRemainingS = 0.0f;
+        AZStd::chrono::system_clock::time_point m_startTime = AZStd::chrono::system_clock::now();
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
@@ -54,7 +54,7 @@ namespace MaterialEditor
     MaterialDocument::~MaterialDocument()
     {
         MaterialDocumentRequestBus::Handler::BusDisconnect();
-        AZ::TickBus::Handler::BusDisconnect();
+        AZ::SystemTickBus::Handler::BusDisconnect();
     }
 
     AZ::Data::Asset<AZ::RPI::MaterialAsset> MaterialDocument::GetAsset() const
@@ -357,14 +357,14 @@ namespace MaterialEditor
         return true;
     }
 
-    void MaterialDocument::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*time*/)
+    void MaterialDocument::OnSystemTick()
     {
         if (m_compilePending)
         {
             if (m_materialInstance->Compile())
             {
                 m_compilePending = false;
-                AZ::TickBus::Handler::BusDisconnect();
+                AZ::SystemTickBus::Handler::BusDisconnect();
             }
         }
     }
@@ -687,7 +687,7 @@ namespace MaterialEditor
     {
         AtomToolsFramework::AtomToolsDocument::Clear();
 
-        AZ::TickBus::Handler::BusDisconnect();
+        AZ::SystemTickBus::Handler::BusDisconnect();
 
         m_materialAsset = {};
         m_materialInstance = {};
@@ -726,7 +726,7 @@ namespace MaterialEditor
     {
         if (!m_compilePending)
         {
-            AZ::TickBus::Handler::BusConnect();
+            AZ::SystemTickBus::Handler::BusConnect();
             m_compilePending = true;
         }
     }

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.h
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.h
@@ -26,7 +26,7 @@ namespace MaterialEditor
     class MaterialDocument
         : public AtomToolsFramework::AtomToolsDocument
         , public MaterialDocumentRequestBus::Handler
-        , public AZ::TickBus::Handler
+        , public AZ::SystemTickBus::Handler
     {
     public:
         AZ_RTTI(MaterialDocument, "{90299628-AD02-4FEB-9527-7278FA2817AD}", AtomToolsFramework::AtomToolsDocument);
@@ -67,8 +67,8 @@ namespace MaterialEditor
         // Map of raw property values for undo/redo comparison and storage
         using PropertyValueMap = AZStd::unordered_map<AZ::Name, AZStd::any>;
 
-        // AZ::TickBus overrides...
-        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        // AZ::SystemTickBus overrides...
+        void OnSystemTick() override;
 
         bool SaveSourceData(AZ::RPI::MaterialSourceData& sourceData, PropertyFilterFunction propertyFilter) const;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentNotificationBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentNotificationBus.h
@@ -25,9 +25,18 @@ namespace AZ
             static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
             static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
 
-            //! Notify that a material preview image is ready
-            virtual void OnRenderMaterialPreviewComplete(
-                const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId, const QPixmap& pixmap) = 0;
+            //! This notification is sent when a material preview image for a given entity and material assignment has been rendered by the
+            //! preview rendering system
+            virtual void OnRenderMaterialPreviewRendered(
+                [[maybe_unused]] const AZ::EntityId& entityId,
+                [[maybe_unused]] const AZ::Render::MaterialAssignmentId& materialAssignmentId,
+                [[maybe_unused]] const QPixmap& pixmap){};
+
+            //! This notification is sent after a material preview image has been rendered and cached
+            virtual void OnRenderMaterialPreviewReady(
+                [[maybe_unused]] const AZ::EntityId& entityId,
+                [[maybe_unused]] const AZ::Render::MaterialAssignmentId& materialAssignmentId,
+                [[maybe_unused]] const QPixmap& pixmap){};
         };
         using EditorMaterialSystemComponentNotificationBus = AZ::EBus<EditorMaterialSystemComponentNotifications>;
     } // namespace Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
@@ -144,13 +144,11 @@ namespace AZ
         {
             BaseClass::Activate();
             MaterialComponentNotificationBus::Handler::BusConnect(GetEntityId());
-            EditorMaterialSystemComponentNotificationBus::Handler::BusConnect();
             UpdateMaterialSlots();
         }
 
         void EditorMaterialComponent::Deactivate()
         {
-            EditorMaterialSystemComponentNotificationBus::Handler::BusDisconnect();
             MaterialComponentNotificationBus::Handler::BusDisconnect();
             BaseClass::Deactivate();
         }
@@ -286,18 +284,6 @@ namespace AZ
             if (materialAssignment.m_materialInstance)
             {
                 materialAssignment.m_materialInstance->SetPsoHandlingOverride(AZ::RPI::MaterialPropertyPsoHandling::Allowed);
-            }
-        }
-
-        void EditorMaterialComponent::OnRenderMaterialPreviewComplete(
-            [[maybe_unused]] const AZ::EntityId& entityId,
-            [[maybe_unused]] const AZ::Render::MaterialAssignmentId& materialAssignmentId,
-            [[maybe_unused]] const QPixmap& pixmap)
-        {
-            if (entityId == GetEntityId())
-            {
-                AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                    &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
             }
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <Atom/Feature/Utils/EditorRenderComponentAdapter.h>
-#include <AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentNotificationBus.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentConstants.h>
 #include <Material/EditorMaterialComponentSlot.h>
@@ -23,7 +22,6 @@ namespace AZ
         class EditorMaterialComponent final
             : public EditorRenderComponentAdapter<MaterialComponentController, MaterialComponent, MaterialComponentConfig>
             , public MaterialComponentNotificationBus::Handler
-            , public EditorMaterialSystemComponentNotificationBus::Handler
         {
         public:
             friend class JsonEditorMaterialComponentSerializer;
@@ -52,10 +50,6 @@ namespace AZ
             //! MaterialComponentNotificationBus::Handler overrides...
             void OnMaterialSlotLayoutChanged() override;
             void OnMaterialInstanceCreated(const MaterialAssignment& materialAssignment) override;
-
-            //! EditorMaterialSystemComponentNotificationBus::Handler overrides...
-            void OnRenderMaterialPreviewComplete(
-                const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId, const QPixmap& pixmap) override;
 
             // Regenerates the editor component material slots based on the material and
             // LOD mapping from the model or other consumer of materials.

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -49,14 +49,14 @@ namespace AZ
                 : AtomToolsFramework::InspectorWidget(parent)
             {
                 CreateHeading();
-                AZ::TickBus::Handler::BusConnect();
+                AZ::SystemTickBus::Handler::BusConnect();
                 AZ::EntitySystemBus::Handler::BusConnect();
                 EditorMaterialSystemComponentNotificationBus::Handler::BusConnect();
             }
 
             MaterialPropertyInspector::~MaterialPropertyInspector()
             {
-                AZ::TickBus::Handler::BusDisconnect();
+                AZ::SystemTickBus::Handler::BusDisconnect();
                 AZ::EntitySystemBus::Handler::BusDisconnect();
                 EditorMaterialSystemComponentNotificationBus::Handler::BusDisconnect();
                 MaterialComponentNotificationBus::MultiHandler::BusDisconnect();
@@ -836,10 +836,8 @@ namespace AZ
                 m_updateUI |= (m_primaryEntityId == entityId);
             }
 
-            void MaterialPropertyInspector::OnTick(float deltaTime, ScriptTimePoint time)
+            void MaterialPropertyInspector::OnSystemTick()
             {
-                AZ_UNUSED(time);
-                AZ_UNUSED(deltaTime);
                 if (m_updateUI)
                 {
                     m_updateUI = false;
@@ -863,7 +861,7 @@ namespace AZ
                 m_updatePreview = true;
             }
 
-            void MaterialPropertyInspector::OnRenderMaterialPreviewComplete(
+            void MaterialPropertyInspector::OnRenderMaterialPreviewReady(
                 const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId, const QPixmap& pixmap)
             {
                 if (m_overviewImage && m_primaryEntityId == entityId && m_materialAssignmentId == materialAssignmentId)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.h
@@ -38,7 +38,7 @@ namespace AZ
                 : public AtomToolsFramework::InspectorWidget
                 , public AzToolsFramework::IPropertyEditorNotify
                 , public AZ::EntitySystemBus::Handler
-                , public AZ::TickBus::Handler
+                , public AZ::SystemTickBus::Handler
                 , public MaterialComponentNotificationBus::MultiHandler
                 , public EditorMaterialSystemComponentNotificationBus::Handler
             {
@@ -96,14 +96,14 @@ namespace AZ
                 void OnEntityDeactivated(const AZ::EntityId& entityId) override;
                 void OnEntityNameChanged(const AZ::EntityId& entityId, const AZStd::string& name) override;
 
-                //! AZ::TickBus::Handler overrides...
-                void OnTick(float deltaTime, ScriptTimePoint time) override;
+                //! AZ::SystemTickBus::Handler overrides...
+                void OnSystemTick() override;
 
                 //! MaterialComponentNotificationBus::MultiHandler overrides...
                 void OnMaterialsEdited() override;
 
                 //! EditorMaterialSystemComponentNotificationBus::Handler overrides...
-                void OnRenderMaterialPreviewComplete(
+                void OnRenderMaterialPreviewReady(
                     const AZ::EntityId& entityId,
                     const AZ::Render::MaterialAssignmentId& materialAssignmentId,
                     const QPixmap& pixmap) override;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -202,8 +202,11 @@ namespace AZ
                 static constexpr const char* DefaultModelPath = "models/sphere.azmodel";
                 static constexpr const char* DefaultLightingPresetPath = "lightingpresets/thumbnail.lightingpreset.azasset";
 
-                for (const auto& [entityId, materialAssignmentId] : m_materialPreviewRequests)
+                for (const auto& materialPreviewRequestPair : m_materialPreviewRequests)
                 {
+                    const auto& entityId = materialPreviewRequestPair.first;
+                    const auto& materialAssignmentId = materialPreviewRequestPair.second;
+
                     AZ::Data::AssetId materialAssetId = {};
                     MaterialComponentRequestBus::EventResult(
                         materialAssetId, entityId, &MaterialComponentRequestBus::Events::GetMaterialAssetId, materialAssignmentId);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -104,6 +104,7 @@ namespace AZ
             AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler::BusConnect();
             AzToolsFramework::EditorMenuNotificationBus::Handler::BusConnect();
             AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
+            AZ::SystemTickBus::Handler::BusConnect();
 
             m_materialBrowserInteractions.reset(aznew MaterialBrowserInteractions);
         }
@@ -117,6 +118,7 @@ namespace AZ
             AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler::BusDisconnect();
             AzToolsFramework::EditorMenuNotificationBus::Handler::BusDisconnect();
             AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect(); 
+            AZ::SystemTickBus::Handler::BusDisconnect();
 
             m_materialBrowserInteractions.reset();
 
@@ -169,54 +171,7 @@ namespace AZ
         void EditorMaterialSystemComponent::RenderMaterialPreview(
             const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId)
         {
-            static constexpr const char* DefaultModelPath = "models/sphere.azmodel";
-            static constexpr const char* DefaultLightingPresetPath = "lightingpresets/thumbnail.lightingpreset.azasset";
-
-            if (auto previewRenderer = AZ::Interface<AtomToolsFramework::PreviewRendererInterface>::Get())
-            {
-                AZ::Data::AssetId materialAssetId = {};
-                MaterialComponentRequestBus::EventResult(
-                    materialAssetId, entityId, &MaterialComponentRequestBus::Events::GetMaterialAssetId, materialAssignmentId);
-                if (!materialAssetId.IsValid())
-                {
-                    return;
-                }
-
-                AZ::Render::MaterialPropertyOverrideMap propertyOverrides;
-                AZ::Render::MaterialComponentRequestBus::EventResult(
-                    propertyOverrides, entityId, &AZ::Render::MaterialComponentRequestBus::Events::GetPropertyValues,
-                    materialAssignmentId);
-
-                AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset;
-                modelAsset.Create(AZ::RPI::AssetUtils::GetAssetIdForProductPath(DefaultModelPath));
-
-                AZ::Data::Asset<AZ::RPI::MaterialAsset> materialAsset;
-                materialAsset.Create(materialAssetId);
-
-                AZ::Data::Asset<AZ::RPI::AnyAsset> lightingPresetAsset;
-                lightingPresetAsset.Create(AZ::RPI::AssetUtils::GetAssetIdForProductPath(DefaultLightingPresetPath));
-
-                previewRenderer->AddCaptureRequest(
-                    { MaterialPreviewResolution,
-                      AZStd::make_shared<AZ::LyIntegration::SharedPreviewContent>(
-                          previewRenderer->GetScene(), previewRenderer->GetView(), previewRenderer->GetEntityContextId(), modelAsset,
-                          materialAsset, lightingPresetAsset, propertyOverrides),
-                      [entityId, materialAssignmentId]()
-                      {
-                          AZ_UNUSED(entityId);
-                          AZ_UNUSED(materialAssignmentId);
-
-                          AZ_Warning(
-                              "EditorMaterialSystemComponent", false, "RenderMaterialPreview capture failed for entity %s slot %s.",
-                              entityId.ToString().c_str(), materialAssignmentId.ToString().c_str());
-                      },
-                      [entityId, materialAssignmentId](const QPixmap& pixmap)
-                      {
-                          AZ::Render::EditorMaterialSystemComponentNotificationBus::Broadcast(
-                              &AZ::Render::EditorMaterialSystemComponentNotificationBus::Events::OnRenderMaterialPreviewComplete, entityId,
-                              materialAssignmentId, pixmap);
-                      } });
-            }
+            m_materialPreviewRequests.emplace(entityId, materialAssignmentId);
         }
 
         QPixmap EditorMaterialSystemComponent::GetRenderedMaterialPreview(
@@ -240,7 +195,76 @@ namespace AZ
             m_materialPreviews.erase(entityId);
         }
 
-        void EditorMaterialSystemComponent::OnRenderMaterialPreviewComplete(
+        void EditorMaterialSystemComponent::OnSystemTick()
+        {
+            if (auto previewRenderer = AZ::Interface<AtomToolsFramework::PreviewRendererInterface>::Get())
+            {
+                static constexpr const char* DefaultModelPath = "models/sphere.azmodel";
+                static constexpr const char* DefaultLightingPresetPath = "lightingpresets/thumbnail.lightingpreset.azasset";
+
+                for (const auto& [entityId, materialAssignmentId] : m_materialPreviewRequests)
+                {
+                    AZ::Data::AssetId materialAssetId = {};
+                    MaterialComponentRequestBus::EventResult(
+                        materialAssetId, entityId, &MaterialComponentRequestBus::Events::GetMaterialAssetId, materialAssignmentId);
+                    if (!materialAssetId.IsValid())
+                    {
+                        return;
+                    }
+
+                    AZ::Render::MaterialPropertyOverrideMap propertyOverrides;
+                    AZ::Render::MaterialComponentRequestBus::EventResult(
+                        propertyOverrides,
+                        entityId,
+                        &AZ::Render::MaterialComponentRequestBus::Events::GetPropertyValues,
+                        materialAssignmentId);
+
+                    AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset;
+                    modelAsset.Create(AZ::RPI::AssetUtils::GetAssetIdForProductPath(DefaultModelPath));
+
+                    AZ::Data::Asset<AZ::RPI::MaterialAsset> materialAsset;
+                    materialAsset.Create(materialAssetId);
+
+                    AZ::Data::Asset<AZ::RPI::AnyAsset> lightingPresetAsset;
+                    lightingPresetAsset.Create(AZ::RPI::AssetUtils::GetAssetIdForProductPath(DefaultLightingPresetPath));
+
+                    previewRenderer->AddCaptureRequest(
+                        { MaterialPreviewResolution,
+                          AZStd::make_shared<AZ::LyIntegration::SharedPreviewContent>(
+                              previewRenderer->GetScene(),
+                              previewRenderer->GetView(),
+                              previewRenderer->GetEntityContextId(),
+                              modelAsset,
+                              materialAsset,
+                              lightingPresetAsset,
+                              propertyOverrides),
+                          [entityId, materialAssignmentId]()
+                          {
+                              AZ_UNUSED(entityId);
+                              AZ_UNUSED(materialAssignmentId);
+
+                              AZ_Warning(
+                                  "EditorMaterialSystemComponent",
+                                  false,
+                                  "RenderMaterialPreview capture failed for entity %s slot %s.",
+                                  entityId.ToString().c_str(),
+                                  materialAssignmentId.ToString().c_str());
+                          },
+                          [entityId, materialAssignmentId](const QPixmap& pixmap)
+                          {
+                              AZ::Render::EditorMaterialSystemComponentNotificationBus::Broadcast(
+                                  &AZ::Render::EditorMaterialSystemComponentNotificationBus::Events::OnRenderMaterialPreviewRendered,
+                                  entityId,
+                                  materialAssignmentId,
+                                  pixmap);
+                          } });
+                }
+
+                m_materialPreviewRequests.clear();
+            }
+        }
+
+        void EditorMaterialSystemComponent::OnRenderMaterialPreviewRendered(
             [[maybe_unused]] const AZ::EntityId& entityId,
             [[maybe_unused]] const AZ::Render::MaterialAssignmentId& materialAssignmentId,
             [[maybe_unused]] const QPixmap& pixmap)
@@ -249,6 +273,12 @@ namespace AZ
 
             // Caching preview so the image will not have to be regenerated every time it's requested
             m_materialPreviews[entityId][materialAssignmentId] = pixmap;
+
+            AZ::Render::EditorMaterialSystemComponentNotificationBus::Broadcast(
+                &AZ::Render::EditorMaterialSystemComponentNotificationBus::Events::OnRenderMaterialPreviewReady,
+                entityId,
+                materialAssignmentId,
+                pixmap);
         }
 
         void EditorMaterialSystemComponent::OnMaterialSlotLayoutChanged()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
@@ -19,6 +19,7 @@
 #include <AzToolsFramework/Viewport/ActionBus.h>
 #include <Material/MaterialBrowserInteractions.h>
 #include <QPixmap>
+#include <AzCore/Component/TickBus.h>
 
 namespace AZ
 {
@@ -34,6 +35,7 @@ namespace AZ
             , public AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler
             , public AzToolsFramework::EditorMenuNotificationBus::Handler
             , public AzToolsFramework::EditorEvents::Bus::Handler
+            , public AZ::SystemTickBus::Handler
         {
         public:
             AZ_COMPONENT(EditorMaterialSystemComponent, "{96652157-DA0B-420F-B49C-0207C585144C}");
@@ -65,8 +67,11 @@ namespace AZ
             // AZ::EntitySystemBus::Handler overrides...
             void OnEntityDeactivated(const AZ::EntityId& entityId) override;
 
+            //! AZ::SystemTickBus::Handler interface overrides...
+            void OnSystemTick() override;
+
             //! EditorMaterialSystemComponentNotificationBus::Handler overrides...
-            void OnRenderMaterialPreviewComplete(
+            void OnRenderMaterialPreviewRendered(
                 const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId, const QPixmap& pixmap) override;
 
             //! MaterialComponentNotificationBus::Router overrides...
@@ -86,6 +91,7 @@ namespace AZ
 
             QAction* m_openMaterialEditorAction = nullptr;
             AZStd::unique_ptr<MaterialBrowserInteractions> m_materialBrowserInteractions;
+            AZStd::unordered_set<AZStd::pair<AZ::EntityId, AZ::Render::MaterialAssignmentId>> m_materialPreviewRequests;
             AZStd::unordered_map<AZ::EntityId, AZStd::unordered_map<AZ::Render::MaterialAssignmentId, QPixmap>> m_materialPreviews;
             static constexpr const size_t MaterialPreviewLimit = 100;
             static constexpr const int MaterialPreviewResolution = 128;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -156,7 +156,7 @@ namespace AZ
             InitializeMaterialInstance(asset);
         }
 
-        void MaterialComponentController::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+        void MaterialComponentController::OnSystemTick()
         {
             if (m_queuedLoadMaterials)
             {
@@ -191,7 +191,7 @@ namespace AZ
                     MaterialComponentNotificationBus::Event(m_entityId, &MaterialComponentNotifications::OnMaterialsUpdated, m_configuration.m_materials);
                 }
 
-                TickBus::Handler::BusDisconnect();
+                SystemTickBus::Handler::BusDisconnect();
             }
         }
 
@@ -290,7 +290,7 @@ namespace AZ
 
         void MaterialComponentController::ReleaseMaterials()
         {
-            TickBus::Handler::BusDisconnect();
+            SystemTickBus::Handler::BusDisconnect();
             Data::AssetBus::MultiHandler::BusDisconnect();
 
             m_defaultMaterialMap.clear();
@@ -762,27 +762,27 @@ namespace AZ
         void MaterialComponentController::QueuePropertyChanges(const MaterialAssignmentId& materialAssignmentId)
         {
             m_materialsWithDirtyProperties.emplace(materialAssignmentId);
-            if (!TickBus::Handler::BusIsConnected())
+            if (!SystemTickBus::Handler::BusIsConnected())
             {
-                TickBus::Handler::BusConnect();
+                SystemTickBus::Handler::BusConnect();
             }
         }
 
         void MaterialComponentController::QueueMaterialUpdateNotification()
         {
             m_queuedMaterialUpdateNotification = true;
-            if (!TickBus::Handler::BusIsConnected())
+            if (!SystemTickBus::Handler::BusIsConnected())
             {
-                TickBus::Handler::BusConnect();
+                SystemTickBus::Handler::BusConnect();
             }
         }
 
         void MaterialComponentController::QueueLoadMaterials()
         {
             m_queuedLoadMaterials = true;
-            if (!TickBus::Handler::BusIsConnected())
+            if (!SystemTickBus::Handler::BusIsConnected())
             {
-                TickBus::Handler::BusConnect();
+                SystemTickBus::Handler::BusConnect();
             }
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -24,7 +24,7 @@ namespace AZ
             : MaterialComponentRequestBus::Handler
             , MaterialReceiverNotificationBus::Handler
             , Data::AssetBus::MultiHandler
-            , TickBus::Handler
+            , SystemTickBus::Handler
         {
         public:
             friend class EditorMaterialComponent;
@@ -89,8 +89,8 @@ namespace AZ
             void OnAssetReady(Data::Asset<Data::AssetData> asset) override;
             void OnAssetReloaded(Data::Asset<Data::AssetData> asset) override;
 
-            // AZ::TickBus overrides...
-            void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+            // AZ::SystemTickBus overrides...
+            void OnSystemTick() override;
 
             void LoadMaterials();
             void InitializeMaterialInstance(const Data::Asset<Data::AssetData>& asset);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnailRenderer.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnailRenderer.cpp
@@ -162,13 +162,22 @@ namespace AZ
                               Render::MaterialPropertyOverrideMap()),
                           [thumbnailKey]()
                           {
+                              // Instead of sending the notification that the thumbnail render failed, we will allow it to succeed and
+                              // substitute it with a blank image. This will prevent the thumbnail system from getting stuck indefinitely
+                              // with a white file icon and allow the thumbnail to reload if the asset changes in the future. The thumbnail
+                              // system should be updated to support state management and recovery automatically.
+                              QPixmap pixmap(1, 1);
+                              pixmap.fill(Qt::black);
                               AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
-                                  thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailFailedToRender);
+                                  thumbnailKey,
+                                  &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailRendered,
+                                  pixmap);
                           },
                           [thumbnailKey](const QPixmap& pixmap)
                           {
                               AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
-                                  thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailRendered,
+                                  thumbnailKey,
+                                  &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailRendered,
                                   pixmap);
                           } });
                 }


### PR DESCRIPTION
The material editor and related tools now support autosaving modified files. Those files will be processed by the AP and should automatically reload in the main editor. Because a lot of the processing was done on TickBus, assets would not reload and the changes would not be reflected until the main editor regained focus. This PR moves a handful of systems to use SystemTickBus instead, allowing those assets to be processed and reloaded without requiring that the main editor have focus. This also fixes issues with Stacking material preview capture requests, preview is not updating when assets change, and previous updating out of order.

These changes should benefit any other external tools or scripts that modify assets that a user or developer would want to see immediately in the main editor without changing context or switching windows.

Fixes
https://github.com/o3de/o3de/issues/9709
https://github.com/o3de/o3de/issues/10028
https://github.com/o3de/o3de/issues/10086
https://github.com/o3de/o3de/issues/10015

Facilitates
https://github.com/o3de/o3de/issues/10016

## How was this PR tested?

Opening the main editor.
Opening the sponza test level.
Using the material component slot context menu used to open multiple materials in the material editor.
Enabling auto save from the material editor Tools->Settings menu.
Making changes to the open materials, seeing them auto save, recooking the asset processor, updating the asset browser, main editor viewport, and material component previews.