### PR TITLE
Change fail_fast variable to params key

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -935,7 +935,7 @@ try {
         timestamps {
 
             stage('Build') {
-                if (env.FAIL_FAST) {
+                if (params.FAIL_FAST) {
                     echo "Fail fast option enabled"
                     buildConfigs.failFast = true
                 }
@@ -977,7 +977,8 @@ finally {
                     "build_failure": buildFailure,
                     "recreate_volume": env.RECREATE_VOLUME,
                     "clean_output_directory": env.CLEAN_OUTPUT_DIRECTORY,
-                    "clean_assets": env.CLEAN_ASSETS
+                    "clean_assets": env.CLEAN_ASSETS,
+                    "fail_fast": env.FAIL_FAST
                 ]
                 snsPublish(
                     topicArn: env.POST_AR_BUILD_SNS_TOPIC,


### PR DESCRIPTION
Signed-off-by: Mike Chang <changml@amazon.com>

## What does this PR do?

Fixes a condition in which the nightly build uses the boolean parameter as environment string, which always evaluates to true. Using the params key properly returns the boolean value 

## How was this PR tested?

Tested in a sandbox Jenkins instance using a test nightly build pipeline
