### PR TITLE
Motion Matching: Added angular joint velocity feature

### DIFF
--- a/Gems/MotionMatching/Code/Source/FeatureAngularVelocity.cpp
+++ b/Gems/MotionMatching/Code/Source/FeatureAngularVelocity.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Console/IConsole.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+#include <Allocators.h>
+#include <EMotionFX/Source/ActorInstance.h>
+#include <EMotionFX/Source/EMotionFXManager.h>
+#include <EMotionFX/Source/EventManager.h>
+#include <EMotionFX/Source/TransformData.h>
+#include <FeatureAngularVelocity.h>
+#include <FrameDatabase.h>
+#include <MotionMatchingData.h>
+#include <MotionMatchingInstance.h>
+#include <PoseDataJointVelocities.h>
+
+namespace EMotionFX::MotionMatching
+{
+    AZ_CVAR_EXTERNED(float, mm_debugDrawVelocityScale);
+
+    AZ_CLASS_ALLOCATOR_IMPL(FeatureAngularVelocity, MotionMatchAllocator, 0)
+
+    void FeatureAngularVelocity::ExtractFeatureValues(const ExtractFeatureContext& context)
+    {
+        const ActorInstance* actorInstance = context.m_actorInstance;
+        const Frame& frame = context.m_frameDatabase->GetFrame(context.m_frameIndex);
+
+        AnimGraphPose* tempPose = context.m_posePool.RequestPose(actorInstance);
+        {
+            // Calculate the joint velocities for the sampled pose using the same method as we do for the frame database.
+            PoseDataJointVelocities* velocityPoseData = tempPose->GetPose().GetAndPreparePoseData<PoseDataJointVelocities>(actorInstance);
+            velocityPoseData->CalculateVelocity(
+                actorInstance, context.m_posePool, frame.GetSourceMotion(), frame.GetSampleTime(), m_relativeToNodeIndex);
+
+            const AZ::Vector3& angularVelocity = velocityPoseData->GetAngularVelocities()[m_jointIndex];
+            context.m_featureMatrix.SetVector3(context.m_frameIndex, m_featureColumnOffset, angularVelocity);
+        }
+        context.m_posePool.FreePose(tempPose);
+    }
+
+    void FeatureAngularVelocity::FillQueryVector(QueryVector& queryVector, const QueryVectorContext& context)
+    {
+        PoseDataJointVelocities* velocityPoseData = context.m_currentPose.GetPoseData<PoseDataJointVelocities>();
+        AZ_Assert(velocityPoseData, "Cannot calculate velocity feature cost without joint velocity pose data.");
+        const AZ::Vector3 currentVelocity = velocityPoseData->GetAngularVelocity(m_jointIndex);
+
+        queryVector.SetVector3(currentVelocity, m_featureColumnOffset);
+    }
+
+    float FeatureAngularVelocity::CalculateFrameCost(size_t frameIndex, const FrameCostContext& context) const
+    {
+        const AZ::Vector3 queryVelocity = context.m_queryVector.GetVector3(m_featureColumnOffset);
+        const AZ::Vector3 frameVelocity = context.m_featureMatrix.GetVector3(frameIndex, m_featureColumnOffset);
+
+        return CalcResidual(queryVelocity, frameVelocity);
+    }
+
+    void FeatureAngularVelocity::DebugDraw(
+        AzFramework::DebugDisplayRequests& debugDisplay,
+        const Pose& pose,
+        const AZ::Vector3& velocity,
+        size_t jointIndex,
+        size_t relativeToJointIndex,
+        const AZ::Color& color)
+    {
+        const Transform jointModelTM = pose.GetModelSpaceTransform(jointIndex);
+        const Transform relativeToWorldTM = pose.GetWorldSpaceTransform(relativeToJointIndex);
+
+        const AZ::Vector3 jointPosition = relativeToWorldTM.TransformPoint(jointModelTM.m_position);
+        const AZ::Vector3 velocityWorldSpace = relativeToWorldTM.TransformVector(velocity);
+
+        DebugDrawVelocity(debugDisplay, jointPosition, velocityWorldSpace * mm_debugDrawVelocityScale, color);
+    }
+
+    void FeatureAngularVelocity::DebugDraw(
+        AzFramework::DebugDisplayRequests& debugDisplay,
+        const Pose& currentPose,
+        const FeatureMatrix& featureMatrix,
+        const FeatureMatrixTransformer* featureTransformer,
+        size_t frameIndex)
+    {
+        if (m_jointIndex == InvalidIndex)
+        {
+            return;
+        }
+
+        AZ::Vector3 angularVelocity = featureMatrix.GetVector3(frameIndex, m_featureColumnOffset);
+        if (featureTransformer)
+        {
+            angularVelocity = featureTransformer->InverseTransform(angularVelocity, m_featureColumnOffset);
+        }
+        DebugDraw(debugDisplay, currentPose, angularVelocity, m_jointIndex, m_relativeToNodeIndex, m_debugColor);
+    }
+
+    void FeatureAngularVelocity::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (!serializeContext)
+        {
+            return;
+        }
+
+        serializeContext->Class<FeatureAngularVelocity, Feature>()->Version(1);
+
+        AZ::EditContext* editContext = serializeContext->GetEditContext();
+        if (!editContext)
+        {
+            return;
+        }
+
+        editContext->Class<FeatureAngularVelocity>("FeatureAngularVelocity", "Matches joint angular velocities.")
+            ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+            ->Attribute(AZ::Edit::Attributes::AutoExpand, "");
+    }
+
+    size_t FeatureAngularVelocity::GetNumDimensions() const
+    {
+        return 3;
+    }
+
+    AZStd::string FeatureAngularVelocity::GetDimensionName(size_t index) const
+    {
+        AZStd::string result = m_jointName;
+        result += '.';
+
+        switch (index)
+        {
+        case 0:
+            {
+                result += "AngularVelocityX";
+                break;
+            }
+        case 1:
+            {
+                result += "AngularVelocityY";
+                break;
+            }
+        case 2:
+            {
+                result += "AngularVelocityZ";
+                break;
+            }
+        default:
+            {
+                result += Feature::GetDimensionName(index);
+            }
+        }
+
+        return result;
+    }
+} // namespace EMotionFX::MotionMatching

--- a/Gems/MotionMatching/Code/Source/FeatureAngularVelocity.h
+++ b/Gems/MotionMatching/Code/Source/FeatureAngularVelocity.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/Memory/Memory.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/RTTI/TypeInfo.h>
+#include <AzCore/std/containers/vector.h>
+
+#include <EMotionFX/Source/EMotionFXConfig.h>
+#include <EMotionFX/Source/Velocity.h>
+#include <Feature.h>
+
+namespace AZ
+{
+    class ReflectContext;
+}
+
+namespace EMotionFX::MotionMatching
+{
+    class FrameDatabase;
+
+    class EMFX_API FeatureAngularVelocity : public Feature
+    {
+    public:
+        AZ_RTTI(FeatureAngularVelocity, "{7C346537-E860-4DBE-9A32-492612FD0DFD}", Feature)
+        AZ_CLASS_ALLOCATOR_DECL
+
+        FeatureAngularVelocity() = default;
+        ~FeatureAngularVelocity() override = default;
+
+        void ExtractFeatureValues(const ExtractFeatureContext& context) override;
+        void FillQueryVector(QueryVector& queryVector, const QueryVectorContext& context) override;
+        float CalculateFrameCost(size_t frameIndex, const FrameCostContext& context) const override;
+
+        static void DebugDraw(
+            AzFramework::DebugDisplayRequests& debugDisplay,
+            const Pose& pose,
+            const AZ::Vector3& velocity, // in relative-to-joint space
+            size_t jointIndex,
+            size_t relativeToJointIndex,
+            const AZ::Color& color);
+
+        void DebugDraw(
+            AzFramework::DebugDisplayRequests& debugDisplay,
+            const Pose& currentPose,
+            const FeatureMatrix& featureMatrix,
+            const FeatureMatrixTransformer* featureTransformer,
+            size_t frameIndex) override;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        size_t GetNumDimensions() const override;
+        AZStd::string GetDimensionName(size_t index) const override;
+    };
+} // namespace EMotionFX::MotionMatching

--- a/Gems/MotionMatching/Code/Source/MotionMatchingSystemComponent.cpp
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingSystemComponent.cpp
@@ -19,6 +19,7 @@
 
 #include <BlendTreeMotionMatchNode.h>
 #include <Feature.h>
+#include <FeatureAngularVelocity.h>
 #include <FeaturePosition.h>
 #include <FeatureTrajectory.h>
 #include <FeatureVelocity.h>
@@ -73,6 +74,7 @@ namespace EMotionFX::MotionMatching
         EMotionFX::MotionMatching::FeaturePosition::Reflect(context);
         EMotionFX::MotionMatching::FeatureTrajectory::Reflect(context);
         EMotionFX::MotionMatching::FeatureVelocity::Reflect(context);
+        EMotionFX::MotionMatching::FeatureAngularVelocity::Reflect(context);
 
         EMotionFX::MotionMatching::PoseDataJointVelocities::Reflect(context);
 

--- a/Gems/MotionMatching/Code/Source/PoseDataJointVelocities.cpp
+++ b/Gems/MotionMatching/Code/Source/PoseDataJointVelocities.cpp
@@ -186,14 +186,22 @@ namespace EMotionFX::MotionMatching
 
             for (size_t jointIndex = 0; jointIndex < numJoints; ++jointIndex)
             {
-                const AZ::Vector3 prevWorldPosition = prevPose->GetPose().GetWorldSpaceTransform(jointIndex).m_position;
-                const AZ::Vector3 currentWorldPosition = currentPose->GetPose().GetWorldSpaceTransform(jointIndex).m_position;
-                const AZ::Vector3 prevPosition = inverseJointWorldTransform.TransformPoint(prevWorldPosition);
-                const AZ::Vector3 currentPosition = inverseJointWorldTransform.TransformPoint(currentWorldPosition);
+                const Transform prevWorldTransform = prevPose->GetPose().GetWorldSpaceTransform(jointIndex);
+                const Transform currentWorldTransform = currentPose->GetPose().GetWorldSpaceTransform(jointIndex);
 
                 // Calculate the linear velocity.
-                const AZ::Vector3 velocity = CalculateLinearVelocity(prevPosition, currentPosition, frameDelta);
-                m_velocities[jointIndex] += velocity;
+                const AZ::Vector3 prevPosition = inverseJointWorldTransform.TransformPoint(prevWorldTransform.m_position);
+                const AZ::Vector3 currentPosition = inverseJointWorldTransform.TransformPoint(currentWorldTransform.m_position);
+
+                const AZ::Vector3 linearVelocity = CalculateLinearVelocity(prevPosition, currentPosition, frameDelta);
+                m_velocities[jointIndex] += linearVelocity;
+
+                // Calculate the angular velocity.
+                const AZ::Quaternion prevRotation = inverseJointWorldTransform.m_rotation * prevWorldTransform.m_rotation;
+                const AZ::Quaternion currentRotation = inverseJointWorldTransform.m_rotation * currentWorldTransform.m_rotation;
+
+                const AZ::Vector3 angularVelocity = CalculateAngularVelocity(prevRotation, currentRotation, frameDelta);
+                m_angularVelocities[jointIndex] += angularVelocity;
             }
 
             *prevPose = *currentPose;

--- a/Gems/MotionMatching/Code/motionmatching_files.cmake
+++ b/Gems/MotionMatching/Code/motionmatching_files.cmake
@@ -25,6 +25,8 @@ set(FILES
     Source/FeatureMatrixMinMaxScaler.cpp
     Source/FeatureMatrixMinMaxScaler.h
     Source/FeatureMatrixTransformer.h
+    Source/FeatureAngularVelocity.cpp
+    Source/FeatureAngularVelocity.h
     Source/FeaturePosition.cpp
     Source/FeaturePosition.h
     Source/FeatureSchema.cpp


### PR DESCRIPTION
Angular joint velocities visualized:
https://user-images.githubusercontent.com/43751992/177787079-34431e48-a040-4fcb-81d5-4a418868ebc7.mp4

Comparison of a motion matching node using angular joint velocities (plus an extra positional feature on the spine) vs. the default configuration:
https://user-images.githubusercontent.com/43751992/177787123-d13b7c26-b67c-4f21-abd5-2d48975f47a1.mp4

We can see that the left character (having the extra features) deviates from the path more while keeping especially the upper body more smooth in the body's movement phases. Basically we trade animation smoothness with path/control accuracy here.