### PR TITLE
Complete current editing before changing entity selection

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -742,6 +742,19 @@ namespace AzToolsFramework
             ClearComponentEditorSelection();
             ClearComponentEditorState();
         }
+
+        // Clear the focus of the current widget in order to trigger editing
+        // completion before the selected entity list is modified. Otherwise,
+        // the entity will not automatically be marked as dirty since it will
+        // no longer be selected when receiving the BeforePropertyModified event
+        if (DoesOwnFocus())
+        {
+            QWidget* widget = QApplication::focusWidget();
+            if (this != widget)
+            {
+                widget->clearFocus();
+            }
+        }
     }
 
     void EntityPropertyEditor::AfterEntitySelectionChanged(


### PR DESCRIPTION
This fixes an issue when "Esc" is pressed to deselect entities while a property control is still in focus in an editing state. The entity's data changes on "Esc", but an undo command is not registered because the selected entities have already been cleared when the BeforePropertyModified event is sent. In BeforePropertyModified, only selected entities are automatically marked as dirty.

To see this issue in the Editor, instantiate a prefab and enter focus mode. Edit a text field in the Entity Inspector and press Esc. Notice that the prefab is not marked as having unsaved changes in the Entity Outliner even though it does have unsaved changes.

This PR clears the focus of the currently focused child widget of the Entity Property Editor in the BeforeEntitySelectionChanged handler to trigger editing completion before the entity selection is cleared.

Signed-off-by: michabr