### PR TITLE
Revert qt layout change signal

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasTreeModel.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasTreeModel.cpp
@@ -305,7 +305,6 @@ namespace GraphCanvas
 
     void GraphCanvasTreeModel::ChildAboutToBeAdded(GraphCanvasTreeItem* parentItem, int position)
     {
-        layoutAboutToBeChanged();
         if (position < 0)
         {
             position = parentItem->GetChildCount() - 1;
@@ -318,7 +317,6 @@ namespace GraphCanvas
     {
         endInsertRows();
         Q_EMIT(OnTreeItemAdded(itemAdded));
-        layoutChanged();
     }
 
     #include <StaticLib/GraphCanvas/Widgets/moc_GraphCanvasTreeModel.cpp>


### PR DESCRIPTION
## What does this PR do?
More investigation will come later, revert to prevent unexpected behavior from OnAssetReady callback.

Original issue is caused by model changed on the fly not included for sorting. Need to figure out a different way for node palette top category sorting which should be light weighted.

Signed-off-by: onecent1101 <liug@amazon.com>