### PR TITLE
fix restart script use of non-pure graphs in interpreter

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Framework/Interpreter.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Framework/Interpreter.cpp
@@ -50,7 +50,7 @@ namespace ScriptCanvasEditor
             {
                 MutexLock lock(m_mutex);
 
-                if (m_runtimePropertiesDirty)
+                if (m_runtimePropertiesDirty || !m_executor.IsPure())
                 {
                     if (m_executor.IsExecutable())
                     {


### PR DESCRIPTION
Signed-off-by: carlitosan <82187351+carlitosan@users.noreply.github.com>

## What does this PR do?

Fixes crash from using the SC interpreter to start and stop a non-pure SC graph, for example one connected to the tick bus. Now, the interpreter will properly call Initialize() on the hosted m_executor after the stop button has been pressed and before the start button is pressed.

## How was this PR tested?

Found bug and proved fix with the SC interpreter widget.
