### PR TITLE
Changed two properties parameters in Deferred Fog Component

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/ScreenSpace/DeferredFogComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/ScreenSpace/DeferredFogComponentConfig.h
@@ -90,7 +90,7 @@ namespace AZ
 #include <Atom/Feature/ScreenSpace/DeferredFogParams.inl>
 #include <Atom/Feature/ParamMacros/EndParams.inl>
 
-            bool m_enabled = false;
+            bool m_enabled = true;
             bool m_useNoiseTextureShaderOption = false;
             bool m_enableFogLayerShaderOption = false;
         };

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ScreenSpace/EditorDeferredFogComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ScreenSpace/EditorDeferredFogComponent.cpp
@@ -129,8 +129,8 @@ namespace AZ
                             "Octaves Blend Factor", "The blend factor between the noise octaves")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                         ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
-                        ->Attribute(AZ::Edit::Attributes::SoftMin, 0.2f)
-                        ->Attribute(AZ::Edit::Attributes::SoftMax, 0.8f)
+                        ->Attribute(AZ::Edit::Attributes::SoftMin, 0.0f)
+                        ->Attribute(AZ::Edit::Attributes::SoftMax, 1.0f)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                             ;
                 }


### PR DESCRIPTION
Signed-off-by: Artur Zięba <86952082+LB-ArturZieba@users.noreply.github.com>

## What does this PR do?

Changed two of the Deferred Fog Component's properties parameters:
* Changed the "Enable Deferred Fog" property from "false" by default, to "true". This way when the Deferred Fog, and the PostFX Layer components are added, the fog is displayed right away, which could help avoid confusion for new users.
* Changed the "Octaves Blend Factor" property slider clamped values from [0.2 - 0.8] to [0.0 - 1.0]. Since the allowed values are [0.0 - 1.0], the slider could be used for all available values without impacting the value precision noticeably.

## How was this PR tested?

Verified manually on a separate branch:

https://user-images.githubusercontent.com/86952082/177996798-0a756871-736f-4b92-8897-917cf6ae0723.mp4

Compared to the current build (Development (f7649a0)):

https://user-images.githubusercontent.com/86952082/177997212-3d2c9c15-609d-4170-bfe8-0eff7572e8c5.mp4
