### PR TITLE
Update requirements.txt for atomicwrites

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,5 @@
-atomicwrites==1.4.0 \
-    --hash=sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197 \
-    --hash=sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a \
+atomicwrites==1.4.1 \
+    --hash=sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11 \
     # via -r .\requirements.txt, pytest
 attrs==20.1.0 \
     --hash=sha256:0ef97238856430dcf9228e07f316aefc17e8939fc8507e18c6501b761ef1a42a \


### PR DESCRIPTION
Signed-off-by: Mike Chang <changml@amazon.com>

## What does this PR do?

Fixes an issue with the atomicwrites python lib, as the 1.4.0 version was accidentally wiped from Pypi. This updates requirements.txt for version 1.4.1

Resolves https://github.com/o3de/o3de/issues/10590

## How was this PR tested?

Tested in a sandbox Jenkins instance
