### PR TITLE
Fixing LyShine Pass to work with low end pipeline

### DIFF
--- a/Gems/LyShine/Assets/Passes/LyShinePassRequest.azasset
+++ b/Gems/LyShine/Assets/Passes/LyShinePassRequest.azasset
@@ -9,8 +9,8 @@
             {
                 "LocalSlot": "ColorInputOutput",
                 "AttachmentRef": {
-                    "Pass": "DebugOverlayPass",
-                    "Attachment": "InputOutput"
+                    "Pass": "AuxGeomPass",
+                    "Attachment": "ColorInputOutput"
                 }
             },
             {


### PR DESCRIPTION
The Low End Pipeline doesn't have a DebugOverlayPass, but DebugOverlayPass just uses an InputOutput, so we can make the LyShine pass point to the output of the previous pass which is the AuxGeomPass. This makes the LyShine pass injection work with both the Main Pipeline and the Low End Pipeline.

Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>