### PR TITLE
chore(EMotionFX): remove m_layerIDsToIgnore from Importer

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/Importer/Importer.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Importer/Importer.cpp
@@ -310,9 +310,6 @@ namespace EMotionFX
             actorSettings.OptimizeForServer();
         }
 
-        // fix any possible conflicting settings
-        ValidateActorSettings(&actorSettings);
-
         // create the actor
         AZStd::unique_ptr<Actor> actor = AZStd::make_unique<Actor>("Unnamed actor");
         MCORE_ASSERT(actor);
@@ -926,37 +923,6 @@ namespace EMotionFX
         // try to process the chunk
         return processor->Process(file, importParams);
     }
-
-
-    // make sure no settings conflict or can cause crashes
-    void Importer::ValidateActorSettings(ActorSettings* settings)
-    {
-        // After atom: Make sure we are not loading the tangents and bitangents
-        if (AZStd::find(begin(settings->m_layerIDsToIgnore), end(settings->m_layerIDsToIgnore), Mesh::ATTRIB_TANGENTS) == end(settings->m_layerIDsToIgnore))
-        {
-            settings->m_layerIDsToIgnore.emplace_back(Mesh::ATTRIB_TANGENTS);
-        }
-
-        if (AZStd::find(begin(settings->m_layerIDsToIgnore), end(settings->m_layerIDsToIgnore), Mesh::ATTRIB_BITANGENTS) == end(settings->m_layerIDsToIgnore))
-        {
-            settings->m_layerIDsToIgnore.emplace_back(Mesh::ATTRIB_BITANGENTS);
-        }
-
-        // make sure we load at least the position and normals and org vertex numbers
-        if(const auto it = AZStd::find(begin(settings->m_layerIDsToIgnore), end(settings->m_layerIDsToIgnore), Mesh::ATTRIB_ORGVTXNUMBERS); it != end(settings->m_layerIDsToIgnore))
-        {
-            settings->m_layerIDsToIgnore.erase(it);
-        }
-        if(const auto it = AZStd::find(begin(settings->m_layerIDsToIgnore), end(settings->m_layerIDsToIgnore), Mesh::ATTRIB_NORMALS); it != end(settings->m_layerIDsToIgnore))
-        {
-            settings->m_layerIDsToIgnore.erase(it);
-        }
-        if(const auto it = AZStd::find(begin(settings->m_layerIDsToIgnore), end(settings->m_layerIDsToIgnore), Mesh::ATTRIB_POSITIONS); it != end(settings->m_layerIDsToIgnore))
-        {
-            settings->m_layerIDsToIgnore.erase(it);
-        }
-    }
-
 
     // make sure no settings conflict or can cause crashes
     void Importer::ValidateMotionSettings(MotionSettings* settings)

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Importer/Importer.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Importer/Importer.h
@@ -83,7 +83,6 @@ namespace EMotionFX
             bool m_optimizeForServer = false;                       /**< Set to true if you witsh to optimize this actor to be used on server. */
             uint32 m_threadIndex = 0;
             AZStd::vector<uint32>    m_chunkIDsToIgnore;      /**< Add chunk ID's to this array. Chunks with these ID's will not be processed. */
-            AZStd::vector<uint32>    m_layerIDsToIgnore;      /**< Add vertex attribute layer ID's to ignore. */
 
             /**
              * If the actor need to be optimized for server, will overwrite a few other actor settings.
@@ -451,11 +450,6 @@ namespace EMotionFX
          */
         bool ProcessChunk(MCore::File* file, Importer::ImportParameters& importParams);
 
-        /**
-         * Validate and resolve any conflicting settings inside a specific actor import settings object.
-         * @param settings The actor settings to verify and fix/modify when needed.
-         */
-        void ValidateActorSettings(ActorSettings* settings);
 
         /**
          * Validate and resolve any conflicting settings inside a specific motion import settings object.


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

this array `m_layerIDsToIgnore` is modified but not used in any meaningful way. 
