### PR TITLE
Exposing spawnable products

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
@@ -38,8 +38,8 @@ namespace AzFramework::Scripts
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     // m_asset
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SpawnableScriptAssetRef::m_asset, "asset", "")
-                    ->Attribute(AZ::Edit::Attributes::ShowProductAssetFileName, false)
-                    ->Attribute(AZ::Edit::Attributes::HideProductFilesInAssetPicker, true)
+                    ->Attribute(AZ::Edit::Attributes::ShowProductAssetFileName, true)
+                    ->Attribute(AZ::Edit::Attributes::HideProductFilesInAssetPicker, false)
                     ->Attribute(AZ::Edit::Attributes::AssetPickerTitle, "Spawnable Asset")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SpawnableScriptAssetRef::OnSpawnAssetChanged);
             }


### PR DESCRIPTION
Signed-off-by: Mikhail Naumov <mnaumov@amazon.com>

## What does this PR do?

Displays spawnable products in prefabs and allows to pick individual products in AssetPicker.
![image](https://user-images.githubusercontent.com/82239319/178349855-e969dab7-60ae-4efd-bb7a-22174ccf70cf.png)

Also displays actual product in AssetCtrl:
![image](https://user-images.githubusercontent.com/82239319/178349957-415a92ad-ed3b-4fde-a502-b6115958a3bc.png)

## How was this PR tested?

Manual testing
