### PR TITLE
Don't connect to TagGlobalRequestBus from editor tag component

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Scripting/EditorTagComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/EditorTagComponent.cpp
@@ -113,7 +113,8 @@ namespace LmbrCentral
 
         TagComponentNotificationsBus::Event(entityId, &TagComponentNotificationsBus::Events::OnTagAdded, tag);
         TagGlobalNotificationBus::Event(tag, &TagGlobalNotificationBus::Events::OnEntityTagAdded, entityId);
-        TagGlobalRequestBus::MultiHandler::BusConnect(tag);
+        // Intentionally don't connect to the TagGlobalRequestBus for the editor component because its bus Id and params are
+        // not tied to any entity Id. This can collide with the runtime tag component which will have the same tag name
     }
 
     void EditorTagComponent::DeactivateTag(const char* tagName)
@@ -121,7 +122,6 @@ namespace LmbrCentral
         Tag tag(tagName);
         const AZ::EntityId entityId = GetEntityId();
 
-        TagGlobalRequestBus::MultiHandler::BusDisconnect(tag);
         TagGlobalNotificationBus::Event(tag, &TagGlobalNotificationBus::Events::OnEntityTagRemoved, entityId);
         TagComponentNotificationsBus::Event(entityId, &TagComponentNotificationsBus::Events::OnTagRemoved, tag);
 

--- a/Gems/LmbrCentral/Code/Source/Scripting/EditorTagComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Scripting/EditorTagComponent.h
@@ -25,7 +25,6 @@ namespace LmbrCentral
     class EditorTagComponent
         : public AzToolsFramework::Components::EditorComponentBase
         , private LmbrCentral::EditorTagComponentRequestBus::Handler
-        , private LmbrCentral::TagGlobalRequestBus::MultiHandler
     {
     public:
         AZ_COMPONENT(EditorTagComponent,
@@ -62,11 +61,6 @@ namespace LmbrCentral
 
         //////////////////////////////////////////////////////////////////////////
 
-
-        //////////////////////////////////////////////////////////////////////////
-        // TagGlobalRequestBus::MultiHandler
-        const AZ::EntityId RequestTaggedEntities() override { return GetEntityId(); }
-        //////////////////////////////////////////////////////////////////////////
 
         //////////////////////////////////////////////////////////////////////////
         // EditorTagComponentRequestBus::Handler


### PR DESCRIPTION
The editor version of the tag component was connecting to the TagGlobalRequestBus which returns the entityIds of all the entities with a specified tag. Since the editor component's tag is the same as the runtime component's tag, a runtime script can get access to an editor component in game mode and change it.

Level entities are not actually affected by this issue because the level entities are deactivated during game mode, but UI canvas entities are affected because each UI canvas has its own entity context and doesn't need to deactivate during game mode.

I've looked through the codebase and didn't find any editor code that was actually making requests on the TagGlobalRequestBus, so this change shouldn't break anything. PostFxLayerComponentController uses the TagComponentRequestBus, EditorTagComponentRequestBus and TagGlobalNotificationBus but those take entityId into account. With this change, we won't need the restriction of deactivating editor components during game mode.

Fixes #9771. 

Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>