### PR TITLE
Fixes the following lua script context error:

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettings.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettings.h
@@ -30,5 +30,10 @@ namespace AtomToolsFramework
         bool m_enableAlternateSkybox = false;
         float m_fieldOfView = 90.0f;
         AZ::Render::DisplayMapperOperationType m_displayMapperOperationType = AZ::Render::DisplayMapperOperationType::Aces;
+
+        // Added explicit Get & Set functions to avoid serialization errors in
+        // lua script context looking for "const AZ::Render::DisplayMapperOperationType&".
+        AZ::Render::DisplayMapperOperationType GetDisplayMapperOperationType() const;
+        void SetDisplayMapperOperationType(AZ::Render::DisplayMapperOperationType opType);
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettings.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettings.cpp
@@ -55,8 +55,18 @@ namespace AtomToolsFramework
                 ->Property("enableShadowCatcher", BehaviorValueProperty(&EntityPreviewViewportSettings::m_enableShadowCatcher))
                 ->Property("enableAlternateSkybox", BehaviorValueProperty(&EntityPreviewViewportSettings::m_enableAlternateSkybox))
                 ->Property("fieldOfView", BehaviorValueProperty(&EntityPreviewViewportSettings::m_fieldOfView))
-                ->Property("displayMapperOperationType", BehaviorValueProperty(&EntityPreviewViewportSettings::m_displayMapperOperationType))
+                ->Property("displayMapperOperationType", &EntityPreviewViewportSettings::GetDisplayMapperOperationType, &EntityPreviewViewportSettings::SetDisplayMapperOperationType)
                 ;
         }
+    }
+
+    AZ::Render::DisplayMapperOperationType EntityPreviewViewportSettings::GetDisplayMapperOperationType() const
+    {
+        return m_displayMapperOperationType;
+    }
+
+    void EntityPreviewViewportSettings::SetDisplayMapperOperationType(AZ::Render::DisplayMapperOperationType opType)
+    {
+        m_displayMapperOperationType = opType;
     }
 } // namespace AtomToolsFramework


### PR DESCRIPTION


The workaround was to add explicit Get & Set methods to
EntityPreviewViewportSettings, and calling those methods
in the ->Property() function call in BehaviorContext definition.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>

## What does this PR do?
Fixes the following lua script context error:
-----------------------------------------
System: Trace::Assert
 D:/github/o3de/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp(3461):
 (52824) '__cdecl AZ::LuaScriptCaller::LuaScriptCaller(class
 AZ::BehaviorContext *,class AZ::BehaviorMethod *)'
 System: The argument type: const Render::DisplayMapperOperationType&
 for method:
 EntityPreviewViewportSettings::displayMapperOperationType::Setter is
 not serialized and/or reflected for scripting.
 Make sure const Render::DisplayMapperOperationType& is added to the
 SerializeContext and reflected to the BehaviorContext
 For example, verify these two exist and are being called in a Reflect
 function:
 serializeContext->Class<const Render::DisplayMapperOperationType&>();
 behaviorContext->Class<const Render::DisplayMapperOperationType&>();
 EntityPreviewViewportSettings::displayMapperOperationType::Setter will
 not be available for scripting unless these requirements are met.
-----------------------------------------

The new behavior doesn't assert anymore.

## How was this PR tested?
The editor doesn't crash anymore when asserts are enabled when loading.
