### PR TITLE
Set the default enum for Multi-Position Audio Component

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Audio/EditorAudioMultiPositionComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Audio/EditorAudioMultiPositionComponent.h
@@ -52,7 +52,7 @@ namespace LmbrCentral
     private:
         //! Serialized Data
         AZStd::vector<AZ::EntityId> m_entityRefs;
-        Audio::MultiPositionBehaviorType m_behaviorType;
+        Audio::MultiPositionBehaviorType m_behaviorType = Audio::MultiPositionBehaviorType::Separate;
     };
 
 } // namespace LmbrCentral


### PR DESCRIPTION
- Sets the behavior type for Multi-Position Audio Component

fixes #10542 