### PR TITLE
[Terrain] Misc Bugfixes

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.cpp
@@ -195,7 +195,15 @@ namespace LmbrCentral
                 ->Event("UpdateVertex", &SplineComponentRequestBus::Events::UpdateVertex)
                 ->Event("InsertVertex", &SplineComponentRequestBus::Events::InsertVertex)
                 ->Event("RemoveVertex", &SplineComponentRequestBus::Events::RemoveVertex)
-                ->Event("ClearVertices", &SplineComponentRequestBus::Events::ClearVertices);
+                ->Event("ClearVertices", &SplineComponentRequestBus::Events::ClearVertices)
+                ->Event("GetVertex",
+                    [](SplineComponentRequests* handler, size_t index) -> AZStd::tuple<AZ::Vector3, bool>
+                    {
+                        AZ::Vector3 vertex;
+                        bool vertexFound = handler->GetVertex(index, vertex);
+                        return AZStd::make_tuple(vertex, vertexFound);
+                    })
+                ->Event("GetVertexCount", &SplineComponentRequestBus::Events::Size);
         }
     }
 

--- a/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.cpp
@@ -199,7 +199,7 @@ namespace LmbrCentral
                 ->Event("GetVertex",
                     [](SplineComponentRequests* handler, size_t index) -> AZStd::tuple<AZ::Vector3, bool>
                     {
-                        AZ::Vector3 vertex;
+                        AZ::Vector3 vertex(0.0f);
                         bool vertexFound = handler->GetVertex(index, vertex);
                         return AZStd::make_tuple(vertex, vertexFound);
                     })

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/SplineComponentRequestBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/SplineComponentRequestBus.names
@@ -54,6 +54,42 @@
                     ]
                 },
                 {
+                    "base": "GetVertex",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Vertex"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Vertex is invoked"
+                    },
+                    "details": {
+                        "name": "Get Vertex"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{D6597933-47CD-4FC8-B911-63F3E2B0993A}",
+                            "details": {
+                                "name": "Index"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "details": {
+                                "name": "Vertex"
+                            }
+                        },
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Found"
+                            }
+                        }
+                    ]
+                },
+                {
                     "base": "UpdateVertex",
                     "entry": {
                         "name": "In",
@@ -85,6 +121,28 @@
                             "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
                             "details": {
                                 "name": "bool"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetVertexCount",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Vertex Count"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Vertex Count is invoked"
+                    },
+                    "details": {
+                        "name": "Get Vertex Count"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{D6597933-47CD-4FC8-B911-63F3E2B0993A}",
+                            "details": {
+                                "name": "Count"
                             }
                         }
                     ]

--- a/Gems/SurfaceData/Code/Source/SurfacePointList.cpp
+++ b/Gems/SurfaceData/Code/Source/SurfacePointList.cpp
@@ -159,7 +159,7 @@ namespace SurfaceData
         // If we've made it here, we're adding the point, not merging it.
 
         // Verify we aren't adding more points than expected.
-        AZ_Assert(m_numSurfacePointsPerInput[inPositionIndex] < m_maxSurfacePointsPerInput, "Adding too many surface points.");
+        AZ_Assert(m_numSurfacePointsPerInput[inPositionIndex] <= m_maxSurfacePointsPerInput, "Adding too many surface points.");
 
         // Expand our output AABB to include this point.
         m_surfacePointBounds.AddPoint(position);

--- a/Gems/Terrain/Code/Source/Components/TerrainWorldComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainWorldComponent.cpp
@@ -35,6 +35,10 @@ namespace Terrain
         result.Combine(ContinueLoadingFromJsonObjectField(
             &configInstance->m_worldMax, azrtti_typeid<decltype(configInstance->m_worldMax)>(), inputValue, "WorldMax", context));
 
+        result.Combine(ContinueLoadingFromJsonObjectField(
+            &configInstance->m_surfaceDataQueryResolution, azrtti_typeid<decltype(configInstance->m_surfaceDataQueryResolution)>(),
+            inputValue, "SurfaceDataQueryResolution", context));
+
         rapidjson::Value::ConstMemberIterator itr = inputValue.FindMember("HeightQueryResolution");
         if (itr != inputValue.MemberEnd())
         {


### PR DESCRIPTION
## What does this PR do?
1. Exposed "Get Vertex" and "Get Vertex Count" from the Spline Component to Script Canvas. 
2. Fixed an unrelated assert that I found that was incorrectly using "<" instead of "<=" when looking for overflows.
3. Fixed serialization of Surface Query Resolution for the Terrain World component.


## How was this PR tested?

1. Used the new methods in a Script Canvas script that dynamically modifies splines and verified that they work correctly.

![image](https://user-images.githubusercontent.com/82224783/178578485-ccac0a95-f45b-442f-b533-e17f301502a9.png)

2. Verified that the assert no longer spuriously triggered.
3. Saved a level with a modified value and verified the new value appeared.