### PR TITLE
Behavior context enum decay update

### DIFF
--- a/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
+++ b/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
@@ -15,37 +15,46 @@
 
 //! Call this macro in the same namespace where the AZ_ENUM was defined to generate ReflectEnumType() utility functions.
 //! @param EnumTypeName an enum that was defined using one of the AZ_ENUM macros.
-#define AZ_ENUM_DEFINE_REFLECT_UTILITIES(EnumTypeName)                                                                                                  \
-                                                                                                                                                        \
-    static void AZ_JOIN(EnumTypeName, Reflect)(AZ::SerializeContext& context)                                                                           \
-    {                                                                                                                                                   \
-        auto enumMaker = context.Enum<EnumTypeName>();                                                                                                  \
-        for (auto&& member : AZ::AzEnumTraits<EnumTypeName>::Members)                                                                                       \
-        {                                                                                                                                               \
-            enumMaker.Value(member.m_string.data(), member.m_value);                                                                                    \
-        }                                                                                                                                               \
-    }                                                                                                                                                   \
-                                                                                                                                                        \
-    template <size_t Index>                                                                                                                             \
-    void AZ_JOIN(EnumTypeName, ReflectValue)(AZ::BehaviorContext& context, AZStd::string_view typeName = {})                                            \
-    {                                                                                                                                                   \
-        if (typeName.empty())                                                                                                                           \
-        {                                                                                                                                               \
-            typeName = AZ::AzEnumTraits<EnumTypeName>::EnumName;                                                                                            \
-        }                                                                                                                                               \
-        constexpr auto& enumValueStringPair = AZ::AzEnumTraits<EnumTypeName>::Members[Index];                                                               \
-        auto qualifiedEnumName = AZStd::fixed_string<256>::format("%.*s_%.*s", AZ_STRING_ARG(typeName), AZ_STRING_ARG(enumValueStringPair.m_string));   \
-        context.Enum<aznumeric_cast<int>(enumValueStringPair.m_value)>(qualifiedEnumName.c_str());                                                      \
-    }                                                                                                                                                   \
-                                                                                                                                                        \
-    template <size_t... Indices>                                                                                                                        \
-    void AZ_JOIN(EnumTypeName, ReflectValues)(AZ::BehaviorContext& context, AZStd::string_view typeName, AZStd::index_sequence<Indices...>)             \
-    {                                                                                                                                                   \
-        (AZ_JOIN(EnumTypeName, ReflectValue)<Indices>(context, typeName), ...);                                                                         \
-    }                                                                                                                                                   \
-                                                                                                                                                        \
-    void AZ_JOIN(EnumTypeName, Reflect)(AZ::BehaviorContext& context, AZStd::string_view typeName = {})                                                 \
-    {                                                                                                                                                   \
-        AZ_JOIN(EnumTypeName, ReflectValues)(context, typeName, AZStd::make_index_sequence<AZ::AzEnumTraits<EnumTypeName>::Members.size()>());              \
-    }                                                                                                                                                   
-
+#define AZ_ENUM_DEFINE_REFLECT_UTILITIES(EnumTypeName)                                                                                             \
+                                                                                                                                                   \
+    static void AZ_JOIN(EnumTypeName, Reflect)(AZ::SerializeContext& context)                                                                      \
+    {                                                                                                                                              \
+        auto enumMaker = context.Enum<EnumTypeName>();                                                                                             \
+        for (auto&& member : AZ::AzEnumTraits<EnumTypeName>::Members)                                                                              \
+        {                                                                                                                                          \
+            enumMaker.Value(member.m_string.data(), member.m_value);                                                                               \
+        }                                                                                                                                          \
+    }                                                                                                                                              \
+                                                                                                                                                   \
+    template <size_t Index>                                                                                                                        \
+    void AZ_JOIN(EnumTypeName, ReflectValue)(AZ::BehaviorContext& context, AZ::BehaviorContext::ClassBuilder<EnumTypeName>& enumTypeBuilder,       \
+        AZStd::string_view typeName)                                                                                                               \
+    {                                                                                                                                              \
+        constexpr auto&& enumValue = AZ::AzEnumTraits<EnumTypeName>::Members[Index].m_value;                                                       \
+        constexpr auto&& enumOptionName = AZ::AzEnumTraits<EnumTypeName>::Members[Index].m_string;                                                 \
+        auto qualifiedEnumName = AZStd::fixed_string<256>::format("%.*s_%.*s", AZ_STRING_ARG(typeName), AZ_STRING_ARG(enumOptionName));            \
+        /* Reflect the enum option as a global Behavior Context property of the form "<enum-type-name>_<enum-option-name>" */                      \
+        context.Enum<enumValue>(qualifiedEnumName.c_str());                                                                                        \
+        /* Reflect the enum option as a property on the Behavior Class <enum-type-name>. This allows <dot> syntax to be used to access the enum */ \
+        /* i.e <enum-type-name>.<enum-option-name> */                                                                                              \
+        enumTypeBuilder.Enum<enumValue>(enumOptionName.data());                                                                                    \
+    }                                                                                                                                              \
+                                                                                                                                                   \
+    template <size_t... Indices>                                                                                                                   \
+    void AZ_JOIN(EnumTypeName, ReflectValues)(AZ::BehaviorContext& context, AZ::BehaviorContext::ClassBuilder<EnumTypeName>& enumTypeBuilder,      \
+        AZStd::string_view typeName, AZStd::index_sequence<Indices...>)                                                                            \
+    {                                                                                                                                              \
+        (AZ_JOIN(EnumTypeName, ReflectValue)<Indices>(context, enumTypeBuilder, typeName), ...);                                                   \
+    }                                                                                                                                              \
+                                                                                                                                                   \
+    void AZ_JOIN(EnumTypeName, Reflect)(AZ::BehaviorContext& context, AZStd::string_view typeName = {})                                            \
+    {                                                                                                                                              \
+        if (typeName.empty())                                                                                                                      \
+        {                                                                                                                                          \
+            typeName = AZ::AzEnumTraits<EnumTypeName>::EnumName;                                                                                   \
+        }                                                                                                                                          \
+        /* Reflect the enum type as behavior class for storing constants of the enum option */                                                     \
+        auto enumTypeBuilder = context.Class<EnumTypeName>();                                                                                      \
+        AZ_JOIN(EnumTypeName, ReflectValues)(context, enumTypeBuilder, typeName,                                                                   \
+        AZStd::make_index_sequence<AZ::AzEnumTraits<EnumTypeName>::Members.size()>());                                                             \
+    }

--- a/Code/Framework/AzCore/Tests/EnumTests.cpp
+++ b/Code/Framework/AzCore/Tests/EnumTests.cpp
@@ -13,6 +13,7 @@
 
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Script/ScriptContext.h>
 
 AZ_ENUM_CLASS(GlobalScopeTestEnum, Foo, Bar);
 AZ_ENUM_DEFINE_REFLECT_UTILITIES(GlobalScopeTestEnum)
@@ -50,6 +51,12 @@ namespace UnitTest
 
     class EnumTests : public AllocatorsTestFixture
     {
+    };
+
+    struct TypeWithEnumMember
+    {
+        AZ_TYPE_INFO(TypeWithEnumMember, "{1ACB4CCC-8070-4D21-8A52-37FD4391EFF5}");
+        TestEnum m_testEnum;
     };
 
     TEST_F(EnumTests, BasicProperties_AreConstexpr)
@@ -178,14 +185,67 @@ namespace UnitTest
         TestEnumReflect(context);
         OtherEnumTestNamespace::TestEnumReflect(context, "OtherTestEnum");
 
-        EXPECT_TRUE(context.m_properties.find("GlobalScopeTestEnum_Foo") != context.m_properties.end());
-        EXPECT_TRUE(context.m_properties.find("GlobalScopeTestEnum_Bar") != context.m_properties.end());
+        EXPECT_NE(context.m_properties.end(), context.m_properties.find("GlobalScopeTestEnum_Foo"));
+        EXPECT_NE(context.m_properties.end(), context.m_properties.find("GlobalScopeTestEnum_Bar"));
 
-        EXPECT_TRUE(context.m_properties.find("TestEnum_A") != context.m_properties.end());
-        EXPECT_TRUE(context.m_properties.find("TestEnum_Z") != context.m_properties.end());
+        EXPECT_NE(context.m_properties.end(), context.m_properties.find("TestEnum_A"));
+        EXPECT_NE(context.m_properties.end(), context.m_properties.find("TestEnum_Z"));
 
-        EXPECT_TRUE(context.m_properties.find("OtherTestEnum_Walk") != context.m_properties.end());
-        EXPECT_TRUE(context.m_properties.find("OtherTestEnum_Run") != context.m_properties.end());
-        EXPECT_TRUE(context.m_properties.find("OtherTestEnum_Fly") != context.m_properties.end());
+        EXPECT_NE(context.m_properties.end(), context.m_properties.find("OtherTestEnum_Walk"));
+        EXPECT_NE(context.m_properties.end(), context.m_properties.find("OtherTestEnum_Run"));
+        EXPECT_NE(context.m_properties.end(), context.m_properties.find("OtherTestEnum_Fly"));
+    }
+
+    TEST_F(EnumTests, BehaviorContextReflect_Contains_BehaviorClassOfEnum)
+    {
+        AZ::BehaviorContext context;
+
+        TestEnumReflect(context);
+
+        // Validate that the enum type is reflected as a BehaviorClass on the BehaviorContext
+        auto enumClassIter = context.m_classes.find("UnitTest::TestEnum");
+        ASSERT_NE(context.m_classes.end(), enumClassIter);
+
+        // Verify that the enum type BehaviorClass contains properties for the enum options
+        AZ::BehaviorClass* enumClass = enumClassIter->second;
+        auto VerifyEnumOptionReflectionOnEnumType = [&properties = enumClass->m_properties]
+        (TestEnum expectedValue, AZStd::string_view enumOptionName)
+        {
+            auto propertyIt = properties.find(enumOptionName);
+            ASSERT_NE(properties.end(), propertyIt);
+            TestEnum testValue{};
+            EXPECT_TRUE(propertyIt->second->m_getter->InvokeResult(testValue));
+            EXPECT_EQ(expectedValue, testValue);
+        };
+        AZ::AzEnumTraits<TestEnum>::Visit(VerifyEnumOptionReflectionOnEnumType);
+
+        // Verify that the enum options are also available as global constants on the BehaviorContext
+        auto VerifyEnumOptionReflectionAsGlobalConstant = [&properties = context.m_properties]
+        (TestEnum expectedValue, AZStd::string_view enumOptionName)
+        {
+            // Compose the combinded global enum option name
+            auto qualifiedOptionName = AZStd::fixed_string<256>::format("TestEnum_%.*s",
+                AZ_STRING_ARG(enumOptionName));
+            auto propertyIt = properties.find(AZStd::string_view(qualifiedOptionName));
+            ASSERT_NE(properties.end(), propertyIt);
+            TestEnum testValue{};
+            EXPECT_TRUE(propertyIt->second->m_getter->InvokeResult(testValue));
+            EXPECT_EQ(expectedValue, testValue);
+        };
+        AZ::AzEnumTraits<TestEnum>::Visit(VerifyEnumOptionReflectionAsGlobalConstant);
+    }
+
+    TEST_F(EnumTests, ScriptContext_BindTo_BehaviorContext_DoesNotAssert_WithEnumType_ReflectedAsProperty)
+    {
+        AZ::BehaviorContext context;
+
+        TestEnumReflect(context);
+
+        context.Class<TypeWithEnumMember>()
+            ->Property("testenum", BehaviorValueProperty(&TypeWithEnumMember::m_testEnum))
+            ;
+
+        AZ::ScriptContext scriptContext;
+        scriptContext.BindTo(&context);
     }
 }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettings.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettings.h
@@ -30,10 +30,5 @@ namespace AtomToolsFramework
         bool m_enableAlternateSkybox = false;
         float m_fieldOfView = 90.0f;
         AZ::Render::DisplayMapperOperationType m_displayMapperOperationType = AZ::Render::DisplayMapperOperationType::Aces;
-
-        // Added explicit Get & Set functions to avoid serialization errors in
-        // lua script context looking for "const AZ::Render::DisplayMapperOperationType&".
-        AZ::Render::DisplayMapperOperationType GetDisplayMapperOperationType() const;
-        void SetDisplayMapperOperationType(AZ::Render::DisplayMapperOperationType opType);
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettings.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettings.cpp
@@ -55,18 +55,8 @@ namespace AtomToolsFramework
                 ->Property("enableShadowCatcher", BehaviorValueProperty(&EntityPreviewViewportSettings::m_enableShadowCatcher))
                 ->Property("enableAlternateSkybox", BehaviorValueProperty(&EntityPreviewViewportSettings::m_enableAlternateSkybox))
                 ->Property("fieldOfView", BehaviorValueProperty(&EntityPreviewViewportSettings::m_fieldOfView))
-                ->Property("displayMapperOperationType", &EntityPreviewViewportSettings::GetDisplayMapperOperationType, &EntityPreviewViewportSettings::SetDisplayMapperOperationType)
+                ->Property("displayMapperOperationType", BehaviorValueProperty(&EntityPreviewViewportSettings::m_displayMapperOperationType))
                 ;
         }
-    }
-
-    AZ::Render::DisplayMapperOperationType EntityPreviewViewportSettings::GetDisplayMapperOperationType() const
-    {
-        return m_displayMapperOperationType;
-    }
-
-    void EntityPreviewViewportSettings::SetDisplayMapperOperationType(AZ::Render::DisplayMapperOperationType opType)
-    {
-        m_displayMapperOperationType = opType;
     }
 } // namespace AtomToolsFramework


### PR DESCRIPTION
## What does this PR do?

Fix the issue the underlying issue with reflecting a method that contains a parameter that accepts cv-qualified, ref-qualified or pointer decorated enum type to the BehaviorContext.

The issue is that the BehaviorContext internal `SetParameters` function was only providing the underlying type for an unqualified enum type and not an enum type decoarated with cvref qualifiers and pointers.
For example given an enum type of `enum class TestEnum`, the underlying type was only provided if a method took a `TestEnum` by value

|EnumType|Type after RemoveEnumT|
|---|---|
|`TestEnum`|`int`|
|`const TestEnum`|`const TestEnum`|
|`TestEnum&`|`TestEnum&`|
|`TestEnum*`|`TestEnum*`|
|`const TestEnum&`|`const TestEnum&`|

The SetParametersStripped function has now been updated to provide the underlying type by removing the qualifiers and any pointer decorations before calling `RemoveEnumT`


|EnumType|Type with `SetParametersStripped` changes|
|---|---|
|`TestEnum`|`int`|
|`const TestEnum`|`const int`|
|`TestEnum&`|`int&`|
|`TestEnum*`|`int*`|
|`const TestEnum&`|`const int`|

## How was this PR tested?

Ran the Editor with the custom property getter and setter for the `AZ::Render::DisplayMapperOperationType` member of the EntityPreviewViewportSettings class removed.

Added a UnitTest to validate that the `AZ_ENUM_DEFINE_REFLECT_UTILITIES` reflects the enum type to the BehaviorContext as a BehaviorClass

Also added a unit test to validate that using BehaviorValueSetter macro with an enum member variable doesn't cause the LuaScriptCaller to assert when binding methods to the Lua ScriptContext
