### PR TITLE
Adding missing include DispatchRaysItem.h in CommandList header, which causes Mac/iOS to fail to compile

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
@@ -22,7 +22,6 @@ namespace AZ
     {
         class Query;
         class ScopeProducer;
-        struct DispatchRaysItem;
 
         /**
         * Supported operations for rendering predication.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
@@ -11,6 +11,7 @@
 #include <Atom/RHI.Reflect/Scissor.h>
 #include <Atom/RHI/DrawItem.h>
 #include <Atom/RHI/DispatchItem.h>
+#include <Atom/RHI/DispatchRaysItem.h>
 #include <Atom/RHI/CopyItem.h>
 #include <Atom/RHI/RayTracingAccelerationStructure.h>
 #include <Atom/RHI/RayTracingBufferPools.h>


### PR DESCRIPTION
Fix the following compilation issue on Mac and iOS.

````
/Users/lybuilder/workspace/o3de/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp:207:32: error: no viable conversion from 'const RHI::DispatchRaysItem' to 'const AZ::RHI::SubmitItem'
            ValidateSubmitItem(dispatchRaysItem);
````

Signed-off-by: moraaar <moraaar@amazon.com>

