### PR TITLE
Create a separate Validation stage

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -31,6 +31,8 @@ DEFAULT_BUILD_SNAPSHOT = BUILD_SNAPSHOTS_WITH_EMPTY.get(0)
 // Branches with build snapshots as comma separated value string
 env.BUILD_SNAPSHOTS = BUILD_SNAPSHOTS.join(",")
 
+VALIDATION_PIPELINE = /validation_pipe/
+
 def pipelineProperties = []
 
 def pipelineParameters = [
@@ -693,7 +695,7 @@ def CreateSingleNode(Map pipelineConfig, def platform, def build_job, Map envVar
                         if (params && params.containsKey('TEST_RESULTS') && params.TEST_RESULTS == 'True') {
                             CreateExportTestResultsStage(pipelineConfig, platform.key, build_job_name, envVars, params).call()
                         }
-                        if (!(build_job.key ==~ /validation_pipe/) && fileExists(GetCrashArtifactDir())) {
+                        if (!(build_job.key ==~ "${VALIDATION_PIPELINE}") && fileExists(GetCrashArtifactDir())) {
                             CreateUploadCrashArtifactStage(build_job_name, platform.key).call()
                         }
                         if (params && params.containsKey('TEST_SCREENSHOTS') && params.TEST_SCREENSHOTS == 'True' && currentResult == 'FAILURE') {
@@ -927,7 +929,7 @@ try {
                     envVars['JENKINS_JOB_NAME'] = env.JOB_NAME // Save original Jenkins job name to JENKINS_JOB_NAME
                     envVars['JOB_NAME'] = "${branchName}_${platform.key}_${build_job.key}" // backwards compatibility, some scripts rely on this
                     someBuildHappened = true
-                    if ("${build_job.key}" ==~ /validation_pipe/) {
+                    if ("${build_job.key}" ==~ "${VALIDATION_PIPELINE}") {
                         validateConfig["${platform.key} [${build_job.key}]"] = CreateBuildJobs(pipelineConfig, platform, build_job, envVars, branchName, pipelineName, repositoryName, projectName)
                     }
                     else {

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -935,7 +935,7 @@ try {
         timestamps {
             stage('Validate') {
                 try {
-                    if buildConfigs.containsKey('validation_pipe') {
+                    if (buildConfigs.containsKey('validation_pipe')) {
                         buildConfigs['validation_pipe']
                     }
                 }

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -693,7 +693,7 @@ def CreateSingleNode(Map pipelineConfig, def platform, def build_job, Map envVar
                         if (params && params.containsKey('TEST_RESULTS') && params.TEST_RESULTS == 'True') {
                             CreateExportTestResultsStage(pipelineConfig, platform.key, build_job_name, envVars, params).call()
                         }
-                        if (fileExists(GetCrashArtifactDir())) {
+                        if (!(build_job.key ==~ /validation_pipe/) && fileExists(GetCrashArtifactDir())) {
                             CreateUploadCrashArtifactStage(build_job_name, platform.key).call()
                         }
                         if (params && params.containsKey('TEST_SCREENSHOTS') && params.TEST_SCREENSHOTS == 'True' && currentResult == 'FAILURE') {
@@ -917,6 +917,7 @@ try {
 
         // Build and Post-Build Testing Stage
         def buildConfigs = [:]
+        def validateConfig = [:] 
 
         // Platform Builds run on EC2
         pipelineConfig.platforms.each { platform ->
@@ -926,8 +927,12 @@ try {
                     envVars['JENKINS_JOB_NAME'] = env.JOB_NAME // Save original Jenkins job name to JENKINS_JOB_NAME
                     envVars['JOB_NAME'] = "${branchName}_${platform.key}_${build_job.key}" // backwards compatibility, some scripts rely on this
                     someBuildHappened = true
-
-                    buildConfigs["${platform.key} [${build_job.key}]"] = CreateBuildJobs(pipelineConfig, platform, build_job, envVars, branchName, pipelineName, repositoryName, projectName)
+                    if ("${build_job.key}" ==~ /validation_pipe/) {
+                        validateConfig["${platform.key} [${build_job.key}]"] = CreateBuildJobs(pipelineConfig, platform, build_job, envVars, branchName, pipelineName, repositoryName, projectName)
+                    }
+                    else {
+                        buildConfigs["${platform.key} [${build_job.key}]"] = CreateBuildJobs(pipelineConfig, platform, build_job, envVars, branchName, pipelineName, repositoryName, projectName)
+                    }
                 }
             }
         }
@@ -935,9 +940,7 @@ try {
         timestamps {
             stage('Validate') {
                 try {
-                    if (buildConfigs.containsKey('validation_pipe')) {
-                        buildConfigs[validation_pipe]
-                    }
+                    parallel validateConfig
                 }
                 catch (Exception e) {
                     echo "Exception block: ${e}"

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -933,6 +933,16 @@ try {
         }
 
         timestamps {
+            stage('Validate') {
+                try {
+                    if buildConfigs.containsKey('validation_pipe') {
+                        buildConfigs['validation_pipe']
+                    }
+                }
+                catch (Exception e) {
+                    echo "Exception block: ${e}"
+                }
+            }
 
             stage('Build') {
                 if (params.FAIL_FAST) {

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -936,7 +936,7 @@ try {
             stage('Validate') {
                 try {
                     if (buildConfigs.containsKey('validation_pipe')) {
-                        buildConfigs['validation_pipe']
+                        buildConfigs[validation_pipe]
                     }
                 }
                 catch (Exception e) {

--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -28,6 +28,22 @@
       "SCRIPT_PARAMETERS": "--platform=Linux --repository=${REPOSITORY_NAME} --jobname=${JOB_NAME} --jobnumber=${BUILD_NUMBER} --jobnode=${NODE_LABEL} --changelist=${CHANGE_ID}"
     }
   },
+  "validation_pipe": {
+    "TAGS": [
+      "default",
+      "snapshot"
+    ],
+    "steps": [
+      "validation"
+    ]
+  },
+  "validation": {
+    "TAGS": [],
+    "COMMAND": "python_linux.cmd",
+    "PARAMETERS": {
+      "SCRIPT_PATH": "scripts/commit_validation/validate_file_or_folder.py"
+    }
+  },
   "debug": {
     "TAGS": [
       "periodic-incremental-daily",

--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -39,7 +39,7 @@
   },
   "validation": {
     "TAGS": [],
-    "COMMAND": "python_linux.cmd",
+    "COMMAND": "python_linux.sh",
     "PARAMETERS": {
       "SCRIPT_PATH": "scripts/commit_validation/validate_file_or_folder.py"
     }

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -7,15 +7,6 @@
       "CMAKE_LY_PROJECTS": "AutomatedTesting"
     }
   },
-  "validation_pipe": {
-    "TAGS": [
-      "default",
-      "snapshot"
-    ],
-    "steps": [
-      "validation"
-    ]
-  },
   "debug_pipe": {
     "TAGS": [
       "periodic-incremental-daily",
@@ -42,13 +33,6 @@
     "COMMAND": "python_windows.cmd",
     "PARAMETERS": {
       "SCRIPT_PATH": "scripts/build/scrubbing_job.py"
-    }
-  },
-  "validation": {
-    "TAGS": [],
-    "COMMAND": "python_windows.cmd",
-    "PARAMETERS": {
-      "SCRIPT_PATH": "scripts/commit_validation/validate_file_or_folder.py"
     }
   },
   "metrics": {

--- a/scripts/build/bootstrap/incremental_build_util.py
+++ b/scripts/build/bootstrap/incremental_build_util.py
@@ -215,7 +215,7 @@ def get_availability_zone():
         error('No EC2 metadata! Check if you are running this script on an EC2 instance.')
 
 
-def kill_processes(workspace='/dev/'):
+def kill_processes(workspace='/data'):
     """
     Kills all processes that have open file paths associated with the workspace.
     Uses PSUtil for cross-platform compatibility

--- a/scripts/build/bootstrap/incremental_build_util.py
+++ b/scripts/build/bootstrap/incremental_build_util.py
@@ -395,7 +395,7 @@ def unmount_volume_from_device():
         offline_drive()
     else:
         kill_processes(MOUNT_PATH)
-        subprocess.call(['umount', '-f', MOUNT_PATH])
+        subprocess.call(['umount', '-fl', MOUNT_PATH])
 
 
 def detach_volume_from_ec2_instance(volume, ec2_instance_id, force, timeout_duration=DEFAULT_TIMEOUT):


### PR DESCRIPTION
## What does this PR do?

This will move the validation build to its own stage in the pipeline (`Validate`), ahead of the `Build` stage. This will allow us to fast fail the build if there are validation issues, rather than spinning up all nodes for an AR that would always fail review.

In addition, we can use this stage for the opposite use case: We can bypass the build stage if the validation stage determines the PR contains non-code files (like an update to a Markdown file). This will likely be defined as specific paths, rather than a wildcard.

There is a small penalty for running this stage, however, as the validation task adds approx 5 mins to spin up, validate, and tear down the stage. I've also included some speedups to hopefully offset this:
- Add a fix for Linux incremental disk unmounting (essentially a lazy unmount regardless of open files). We've discovered that Linux jobs would spend 5 mins attempting to unmount the workspace disk over 50% of the time, due to the process killer not being able to kill zombie processes that leave open files.
- Converted the validation job itself to a Linux build from a Windows build. Linux EC2 instances startup faster and are cheaper to run than Windows instances.

Here's what the pipeline workflow looks like in Blue Ocean:

![image](https://user-images.githubusercontent.com/62353586/178854573-5e1ac7a0-977b-45a8-bded-e767a3e7280c.png)

## How was this PR tested?

Tested in a sandbox Jenkins instance
