### PR TITLE
Adding an optional index argument to find_child_by_hierarchy()

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/pyside_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/pyside_utils.py
@@ -506,7 +506,7 @@ def find_child_by_pattern(obj=None, pattern=None, recursive=True, **kw):
     return None
 
 
-def find_child_by_hierarchy(parent, *patterns):
+def find_child_by_hierarchy(parent, *patterns, child_index=0):
     """
     Searches for a hierarchy of children descending from parent.
     parent: The Qt object (or list of Qt obejcts) to search within
@@ -542,7 +542,7 @@ def find_child_by_hierarchy(parent, *patterns):
         current_objects = candidates
 
         search_recursively = False
-    return current_objects[0]
+    return current_objects[child_index]
 
 async def wait_for_child_by_hierarchy(parent, *patterns, timeout=1.0):
     """


### PR DESCRIPTION
This change allows us to be more precise about selecting UI widgets in interactive tutorials. 0 is the default index, which is the current behavior.

Signed-off-by: Mike Cronin <58789750+micronAMZN@users.noreply.github.com>

## What does this PR do?

Adds an option to specify the index of the object returned by find_child_by_hierarchy(). Currently it returns the object at index 0 always. In this change, 0 is the default if no index is specified.

## How was this PR tested?

Tested locally in up to date development branch. Manually tested with various scripts, selecting various UI objects by specifying indices or allowing the default 0 index.
