### PR TITLE
[Terrain] Split out separate API for refreshing terrain region

### DIFF
--- a/Gems/Terrain/Code/Mocks/Terrain/MockTerrain.h
+++ b/Gems/Terrain/Code/Mocks/Terrain/MockTerrain.h
@@ -36,6 +36,9 @@ namespace UnitTest
         MOCK_METHOD1(UnregisterArea, void(AZ::EntityId areaId));
         MOCK_METHOD2(
             RefreshArea, void(AZ::EntityId areaId, AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask changeMask));
+        MOCK_METHOD2(
+            RefreshRegion,
+            void(const AZ::Aabb& dirtyRegion, AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask changeMask));
     };
 
     class MockTerrainAreaHeightRequests : public Terrain::TerrainAreaHeightRequestBus::Handler

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -1308,8 +1308,6 @@ void TerrainSystem::UnregisterArea(AZ::EntityId areaId)
 
 void TerrainSystem::RefreshArea(AZ::EntityId areaId, AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask changeMask)
 {
-    using Terrain = AzFramework::Terrain::TerrainDataNotifications;
-
     AZStd::unique_lock<AZStd::shared_mutex> lock(m_areaMutex);
 
     auto areaAabb = m_registeredAreas.find(areaId);

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -1322,7 +1322,15 @@ void TerrainSystem::RefreshArea(AZ::EntityId areaId, AzFramework::Terrain::Terra
     AZ::Aabb expandedAabb = oldAabb;
     expandedAabb.AddAabb(newAabb);
 
-    m_dirtyRegion.AddAabb(expandedAabb);
+    RefreshRegion(expandedAabb, changeMask);
+}
+
+void TerrainSystem::RefreshRegion(
+    const AZ::Aabb& dirtyRegion, AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask changeMask)
+{
+    using Terrain = AzFramework::Terrain::TerrainDataNotifications;
+
+    m_dirtyRegion.AddAabb(dirtyRegion);
 
     // Keep track of which types of data have changed so that we can send out the appropriate notifications later.
 

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.h
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.h
@@ -54,6 +54,8 @@ namespace Terrain
         void UnregisterArea(AZ::EntityId areaId) override;
         void RefreshArea(
             AZ::EntityId areaId, AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask changeMask) override;
+        void RefreshRegion(
+            const AZ::Aabb& dirtyRegion, AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask changeMask) override;
 
         ///////////////////////////////////////////
         // TerrainDataRequestBus::Handler Impl

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystemBus.h
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystemBus.h
@@ -46,6 +46,8 @@ namespace Terrain
         virtual void RegisterArea(AZ::EntityId areaId) = 0;
         virtual void UnregisterArea(AZ::EntityId areaId) = 0;
         virtual void RefreshArea(AZ::EntityId areaId, AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask changeMask) = 0;
+        virtual void RefreshRegion(
+            const AZ::Aabb& dirtyRegion, AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask changeMask) = 0;
     };
 
     using TerrainSystemServiceRequestBus = AZ::EBus<TerrainSystemServiceRequests>;


### PR DESCRIPTION
## What does this PR do?
Currently, changes to terrain heights and surfaces cause those components to call TerrainSystem::RefreshArea, which refreshes the entire terrain spawner area. This PR creates a new API called TerrainSystem::RefreshRegion that enables just a specific region of the terrain to be marked dirty, instead of the entire spawner area. The code for the new API is just a subset of what was already in RefreshArea.

## How was this PR tested?

RefreshArea() was modified to call the new RefreshRegion() API, so it's being implicitly tested by all of the terrain code already. It's also been separately tested and used separately with another upcoming PR, in which gradients can broadcast a dirty region on changes, instead of just broadcasting that the entire gradient changed.
