### PR TITLE
Fix GammaSRGB Display Mapper to output sRGB

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DisplayMapperSRGB.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DisplayMapperSRGB.azsl
@@ -11,7 +11,8 @@
 #include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 #include <Atom/Features/PostProcessing/PostProcessUtil.azsli>
-#include <Atom/Features/PostProcessing/Aces.azsli>
+
+#include <Atom/Features/ColorManagement/GeneratedTransforms/AcesCg_To_LinearSrgb.azsli>
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -36,7 +37,7 @@ PSOutput MainPS(VSOutput IN)
     PSOutput OUT;
 
     float3 color = PassSrg::m_framebuffer.Sample(PassSrg::LinearSampler, IN.m_texCoord).rgb;
-    OUT.m_color.rgb = pow(color, 1.0 / 2.2);
+    OUT.m_color.rgb = LinearToSRGB(AcesCg_To_LinearSrgb(color));
     OUT.m_color.w = 1;
 
     return OUT;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DisplayMapperSRGB.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DisplayMapperSRGB.azsl
@@ -12,7 +12,7 @@
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 #include <Atom/Features/PostProcessing/PostProcessUtil.azsli>
 
-#include <Atom/Features/ColorManagement/GeneratedTransforms/AcesCg_To_LinearSrgb.azsli>
+#include <Atom/Features/ColorManagement/TransformColor.azsli>
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -37,7 +37,7 @@ PSOutput MainPS(VSOutput IN)
     PSOutput OUT;
 
     float3 color = PassSrg::m_framebuffer.Sample(PassSrg::LinearSampler, IN.m_texCoord).rgb;
-    OUT.m_color.rgb = LinearToSRGB(AcesCg_To_LinearSrgb(color));
+    OUT.m_color.rgb = TransformColor(color, ColorSpaceId::ACEScg, ColorSpaceId::SRGB);
     OUT.m_color.w = 1;
 
     return OUT;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DisplayMapperSRGB.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DisplayMapperSRGB.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "DisplayMapperOnlyGammaCorrection.azsl",
+    "Source" : "DisplayMapperSRGB.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
+++ b/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
@@ -456,8 +456,8 @@ set(FILES
     Shaders/PostProcessing/DiffuseSpecularMerge.shader
     Shaders/PostProcessing/DisplayMapper.azsl
     Shaders/PostProcessing/DisplayMapper.shader
-    Shaders/PostProcessing/DisplayMapperOnlyGammaCorrection.azsl
-    Shaders/PostProcessing/DisplayMapperOnlyGammaCorrection.shader
+    Shaders/PostProcessing/DisplayMapperSRGB.azsl
+    Shaders/PostProcessing/DisplayMapperSRGB.shader
     Shaders/PostProcessing/DownsampleLuminanceMinAvgMaxCS.azsl
     Shaders/PostProcessing/DownsampleLuminanceMinAvgMaxCS.shader
     Shaders/PostProcessing/DownsampleMinAvgMaxCS.azsl

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperPass.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperPass.h
@@ -101,14 +101,14 @@ namespace AZ
             AZStd::shared_ptr<RPI::PassTemplate> m_acesOutputTransformLutTemplate;
             AZStd::shared_ptr<RPI::PassTemplate> m_bakeAcesOutputTransformLutTemplate;
             AZStd::shared_ptr<RPI::PassTemplate> m_passthroughTemplate;
-            AZStd::shared_ptr<RPI::PassTemplate> m_gammaCorrectionTemplate;
+            AZStd::shared_ptr<RPI::PassTemplate> m_sRGBTemplate;
             AZStd::shared_ptr<RPI::PassTemplate> m_ldrGradingLookupTableTemplate;
             AZStd::shared_ptr<RPI::PassTemplate> m_outputTransformTemplate;
             RPI::Ptr<AcesOutputTransformPass> m_acesOutputTransformPass = nullptr;
             RPI::Ptr<BakeAcesOutputTransformLutPass> m_bakeAcesOutputTransformLutPass = nullptr;
             RPI::Ptr<AcesOutputTransformLutPass> m_acesOutputTransformLutPass = nullptr;
             RPI::Ptr<DisplayMapperFullScreenPass> m_displayMapperPassthroughPass = nullptr;
-            RPI::Ptr<DisplayMapperFullScreenPass> m_displayMapperOnlyGammaCorrectionPass = nullptr;
+            RPI::Ptr<DisplayMapperFullScreenPass> m_displayMapperSRGBPass = nullptr;
             RPI::Ptr<ApplyShaperLookupTablePass> m_ldrGradingLookupTablePass = nullptr;
             RPI::Ptr<OutputTransformPass> m_outputTransformPass = nullptr;
 
@@ -119,7 +119,7 @@ namespace AZ
             const Name m_bakeAcesOutputTransformLutPassName = Name{ "BakeAcesOutputTransformLut" };
             const Name m_acesOutputTransformLutPassName = Name{ "AcesLutPass" };
             const Name m_displayMapperPassthroughPassName = Name{ "DisplayMapperPassthrough" };
-            const Name m_displayMapperOnlyGammaCorrectionPassName = Name{ "DisplayMapperOnlyGammaCorrection" };
+            const Name m_displayMapperSRGBPassName = Name{ "DisplayMapperSRGB" };
             const Name m_outputTransformPassName = Name{ "OutputTransform" };
 
             RHI::Format m_displayBufferFormat = RHI::Format::Unknown;

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
@@ -149,11 +149,11 @@ namespace AZ
                 inputPass = m_displayMapperPassthroughPassName;
                 inputPassAttachment = outputName;
             }
-            else if (m_displayMapperOnlyGammaCorrectionPass)
+            else if (m_displayMapperSRGBPass)
             {
-                m_displayMapperOnlyGammaCorrectionPass->SetInputReferencePassName(inputPass);
-                m_displayMapperOnlyGammaCorrectionPass->SetInputReferenceAttachmentName(inputPassAttachment);
-                inputPass = m_displayMapperOnlyGammaCorrectionPassName;
+                m_displayMapperSRGBPass->SetInputReferencePassName(inputPass);
+                m_displayMapperSRGBPass->SetInputReferenceAttachmentName(inputPassAttachment);
+                inputPass = m_displayMapperSRGBPassName;
                 inputPassAttachment = outputName;
             }
             else if (m_outputTransformPass)
@@ -319,7 +319,7 @@ namespace AZ
             const Name acesOutputTransformLutTemplateName = Name{ "AcesOutputTransformLutTemplate" };
             const Name bakeAcesOutputTransformLutTemplateName = Name{ "BakeAcesOutputTransformLutTemplate" };
             const Name displayMapperPassthroughTemplateName = Name{ "DisplayMapperPassthroughTemplate" };
-            const Name displayMapperOnlyGammaCorrectionTemplateName = Name{ "DisplayMapperOnlyGammaCorrectionTemplate" };
+            const Name displayMapperSRGBTemplateName = Name{ "DisplayMapperSRGBTemplate" };
             const Name hdrGradingLutTemplateName = Name{ "HdrGradingLutTemplate" };
             const Name ldrGradingLutTemplateName = Name{ "LdrGradingLutTemplate" };
             const Name outputTransformTemplateName = Name{ "OutputTransformTemplate" };
@@ -340,7 +340,7 @@ namespace AZ
             const char* acesOuputTransformLutShaderPath = "Shaders/PostProcessing/AcesOutputTransformLut.azshader";
             const char* bakeAcesOuputTransformLutShaderPath = "Shaders/PostProcessing/BakeAcesOutputTransformLutCS.azshader";
             const char* passthroughShaderPath = "Shaders/PostProcessing/FullscreenCopy.azshader";
-            const char* gammaCorrectionShaderPath = "Shaders/PostProcessing/DisplayMapperOnlyGammaCorrection.azshader";
+            const char* sRGBShaderPath = "Shaders/PostProcessing/DisplayMapperSRGB.azshader";
             const char* applyShaperLookupTableShaderFilePath = "Shaders/PostProcessing/ApplyShaperLookupTable.azshader";
             const char* outputTransformShaderPath = "Shaders/PostProcessing/OutputTransform.azshader";
 
@@ -366,11 +366,11 @@ namespace AZ
             m_passthroughTemplate = CreatePassTemplateHelper(
                 displayMapperPassthroughTemplateName, displayMapperFullScreenPassClassName,
                 m_displayMapperConfigurationDescriptor.m_ldrGradingLutEnabled, outputTransformImageName, passthroughShaderPath);
-            // Gamma Correction
-            m_gammaCorrectionTemplate.reset();
-            m_gammaCorrectionTemplate = CreatePassTemplateHelper(
-                displayMapperOnlyGammaCorrectionTemplateName, displayMapperFullScreenPassClassName,
-                m_displayMapperConfigurationDescriptor.m_ldrGradingLutEnabled, outputTransformImageName, gammaCorrectionShaderPath);
+            // sRGB
+            m_sRGBTemplate.reset();
+            m_sRGBTemplate = CreatePassTemplateHelper(
+                displayMapperSRGBTemplateName, displayMapperFullScreenPassClassName,
+                m_displayMapperConfigurationDescriptor.m_ldrGradingLutEnabled, outputTransformImageName, sRGBShaderPath);
             // Output Transform
             m_outputTransformTemplate.reset();
             m_outputTransformTemplate = CreatePassTemplateHelper(
@@ -425,8 +425,7 @@ namespace AZ
             }
             else if (m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::GammaSRGB)
             {
-                // Gamma 2.2
-                m_displayMapperOnlyGammaCorrectionPass = CreatePassHelper<DisplayMapperFullScreenPass>(passSystem, m_gammaCorrectionTemplate, m_displayMapperOnlyGammaCorrectionPassName);
+                m_displayMapperSRGBPass = CreatePassHelper<DisplayMapperFullScreenPass>(passSystem, m_sRGBTemplate, m_displayMapperSRGBPassName);
             }
             else if (m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Reinhard)
             {
@@ -462,9 +461,9 @@ namespace AZ
             {
                 AddChild(m_displayMapperPassthroughPass);
             }
-            if (m_displayMapperOnlyGammaCorrectionPass)
+            if (m_displayMapperSRGBPass)
             {
-                AddChild(m_displayMapperOnlyGammaCorrectionPass);
+                AddChild(m_displayMapperSRGBPass);
             }
             if (m_outputTransformPass)
             {
@@ -522,7 +521,7 @@ namespace AZ
             m_bakeAcesOutputTransformLutPass = nullptr;
             m_acesOutputTransformLutPass = nullptr;
             m_displayMapperPassthroughPass = nullptr;
-            m_displayMapperOnlyGammaCorrectionPass = nullptr;
+            m_displayMapperSRGBPass = nullptr;
             m_ldrGradingLookupTablePass = nullptr;
             m_outputTransformPass = nullptr;
         }


### PR DESCRIPTION
## What does this PR do?

The GammaSRGB Display Mapper simply applied a fixed-gamma 2.2 curve on top of the internal AcesCG color space, whereas its name suggests that it should output to the (non-linear) sRGB color space. This is now fixed by first transforming to the correct sRGB color primaries and using the sRGB transfer curve.

All occurences of DisplayMapperOnlyGammaCorrection* have been renamed to DisplayMapperSRGB* to clearly reflect this change. The only functional change is in DisplayMapperSRGB.azsl (used to be called DisplayMapperOnlyGammaCorrection.azsl).

Note: this rename also affects the o3de-atom-sampleviewer project in one location: ToneMappingExampleComponent.cpp:300.
I'll add a PR there if this PR gets approved.

## How was this PR tested?
- A synthetic test scene where a diffuse square is illuminated such that a pure white albedo maps to an output of 1 (or 255). A texture encoded as sRGB should then be identically reproduced if the output color space is set to sRGB.
When using this texture (each row up halves the values in sRGB space):
![texture](https://user-images.githubusercontent.com/251349/179007372-fc392042-7d93-499a-bebe-4259a611d0b1.png)
The old result was:
![oldGammaSRGB](https://user-images.githubusercontent.com/251349/179007323-2a9d9631-bbec-49b1-af2a-8435a5294aa3.png)
which shows undersaturation/color mixing due to the AcesCG color primaries and an incorrect grayscale ramp due to the difference between gamma 2.2 and the sRGB transfer curve. The new result is the expected identical reproduction of the texture:
![newGammaSRGB](https://user-images.githubusercontent.com/251349/179007336-222839ab-6019-4231-bdcd-beb7cf0d4e93.png)

- Running the full test suite of o3de-atom-sampleviewer (with the rename in one location as mentioned above) did not yield additional errors compared to the dev branch parent of f23a6667783739d797ff1a972a264d0bbd5b3873 (the common errors were a deviation in the upper edge of the cube in materialscreenshottests tile.png and failures of brdf.png and albedo.png in the passtree test)