### PR TITLE
Adding C++17 deduction guides for AZStd container types

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/containers/deque.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/deque.h
@@ -1135,6 +1135,10 @@ namespace AZStd
         allocator_type      m_allocator{};    ///< Instance of the allocator.
     };
 
+    // AZStd::deque deduction guides
+    template <class InputIt, class Alloc = allocator>
+    deque(InputIt, InputIt, Alloc = Alloc()) -> deque<typename iterator_traits<InputIt>::value_type, Alloc>;
+
     template <class T, class Allocator, AZStd::size_t NumElementsPerBlock, AZStd::size_t MinMapSize>
     AZ_FORCE_INLINE bool operator==(const deque<T, Allocator, NumElementsPerBlock, MinMapSize>& left, const deque<T, Allocator, NumElementsPerBlock, MinMapSize>& right)
     {

--- a/Code/Framework/AzCore/AzCore/std/containers/forward_list.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/forward_list.h
@@ -1303,6 +1303,10 @@ namespace AZStd
 #endif
     };
 
+    // AZStd::forward_list deduction guides
+    template <class InputIt, class Alloc = allocator>
+    forward_list(InputIt, InputIt, Alloc = Alloc()) -> forward_list<typename iterator_traits<InputIt>::value_type, Alloc>;
+
     template<class T, class Allocator, class U>
     decltype(auto) erase(forward_list<T, Allocator>& container, const U& value)
     {

--- a/Code/Framework/AzCore/AzCore/std/containers/list.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/list.h
@@ -1292,6 +1292,10 @@ namespace AZStd
 #endif
     };
 
+    // AZStd::list deduction guides
+    template <class InputIt, class Alloc = allocator>
+    list(InputIt, InputIt, Alloc = Alloc()) -> list<typename iterator_traits<InputIt>::value_type, Alloc>;
+
     template< class T, class Allocator >
     AZ_FORCE_INLINE bool operator==(const list<T, Allocator>& left, const list<T, Allocator>& right)
     {

--- a/Code/Framework/AzCore/AzCore/std/containers/vector.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/vector.h
@@ -1324,6 +1324,10 @@ namespace AZStd
 #endif
     };
 
+    // AZStd::vector deduction guides
+    template <class InputIt, class Alloc = allocator>
+    vector(InputIt, InputIt, Alloc = Alloc()) -> vector<typename iterator_traits<InputIt>::value_type, Alloc>;
+
     //#pragma region Vector equality/inequality
     template <class T, class Allocator>
     AZ_FORCE_INLINE bool operator==(const vector<T, Allocator>& a, const vector<T, Allocator>& b)

--- a/Code/Framework/AzCore/AzCore/std/function/function_template.h
+++ b/Code/Framework/AzCore/AzCore/std/function/function_template.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AzCore/std/function/function_base.h>
+#include <AzCore/std/typetraits/function_traits.h>
 #include <AzCore/std/function/invoke.h>
 #include <AzCore/std/typetraits/is_integral.h>
 #include <AzCore/std/typetraits/remove_cvref.h>
@@ -683,4 +684,11 @@ namespace AZStd
             return base_type::operator()(AZStd::forward<Args>(args)...);
         }
     };
+
+    // AZStd::function deduction guides
+    template<class R, class... ArgTypes>
+    function(R(*)(ArgTypes...)) -> function<R(ArgTypes...)>;
+
+    template<class F, class = enable_if_t<AZStd::Internal::has_call_operator_v<F>>>
+    function(F) -> function<typename AZStd::Internal::function_object<F>::function_type>;
 } // end namespace AZStd

--- a/Code/Framework/AzCore/AzCore/std/smart_ptr/shared_ptr.h
+++ b/Code/Framework/AzCore/AzCore/std/smart_ptr/shared_ptr.h
@@ -404,6 +404,13 @@ namespace AZStd
         AZStd::Internal::shared_count pn;    // reference counter
     };  // shared_ptr
 
+    // AZStd::shared_ptr deduction guides
+    template <class T>
+    shared_ptr(AZStd::weak_ptr<T>) -> shared_ptr<T>;
+
+    template <class T, class D>
+    shared_ptr(AZStd::unique_ptr<T, D>) -> shared_ptr<T>;
+
     template<class T, class U>
     inline bool operator==(shared_ptr<T> const& a, shared_ptr<U> const& b) { return a.get() == b.get(); }
     template<class T, class U>

--- a/Code/Framework/AzCore/AzCore/std/string/regex.h
+++ b/Code/Framework/AzCore/AzCore/std/string/regex.h
@@ -1912,6 +1912,11 @@ namespace AZStd
         }
     };
 
+    // AZStd::basic_regex deduction guides
+    template <class ForwardIt>
+    basic_regex(ForwardIt, ForwardIt, AZStd::regex_constants::syntax_option_type = AZStd::regex_constants::ECMAScript)
+        -> basic_regex<typename iterator_traits<ForwardIt>::value_type>;
+
     // exchange contents of left with right
     template<class Element, class RegExTraits>
     void swap(basic_regex<Element, RegExTraits>& left, basic_regex<Element, RegExTraits>& right)

--- a/Code/Framework/AzCore/AzCore/std/string/string.h
+++ b/Code/Framework/AzCore/AzCore/std/string/string.h
@@ -91,7 +91,9 @@ namespace AZStd
 
         inline static constexpr size_type npos = size_type(-1);
 
-        inline basic_string(const Allocator& alloc = Allocator())
+        // Constructors and Assignment operators
+        // https://eel.is/c++draft/strings#string.cons
+        inline constexpr basic_string(const Allocator& alloc = Allocator())
             : m_storage{ skip_element_tag{}, alloc }
         {
             Traits::assign(m_storage.first().GetData()[0], Element());
@@ -150,6 +152,11 @@ namespace AZStd
         {
         }
 
+        basic_string(AZStd::basic_string_view<Element, Traits> view, size_type pos, size_type n, const Allocator& alloc = Allocator())
+            : basic_string(view.substr(pos, n), alloc)
+        {
+        }
+
         // C++23 overload to prevent initializing a string_view via a nullptr or integer type
         constexpr basic_string(AZStd::nullptr_t) = delete;
 
@@ -159,7 +166,7 @@ namespace AZStd
             deallocate_memory(m_storage.first().GetData(), 0, typename allocator_type::allow_memory_leaks());
         }
 
-        operator AZStd::basic_string_view<Element, Traits>() const
+        constexpr operator AZStd::basic_string_view<Element, Traits>() const
         {
             return AZStd::basic_string_view<Element, Traits>(data(), size());
         }
@@ -1877,6 +1884,21 @@ namespace AZStd
         }
 #endif
     };
+
+    // AZStd::basic_string deduction guides
+    template<class InputIt, class Alloc = allocator>
+    basic_string(InputIt, InputIt, Alloc = Alloc())-> basic_string<typename iterator_traits<InputIt>::value_type,
+        AZStd::char_traits<typename iterator_traits<InputIt>::value_type>,
+        Alloc>;
+
+    template<class CharT, class Traits, class Alloc = allocator>
+    explicit basic_string(AZStd::basic_string_view<CharT, Traits>, const Alloc& = Alloc()) ->
+        basic_string<CharT,Traits, Alloc>;
+
+    template<class CharT, class Traits, class Alloc = allocator>
+    explicit basic_string(AZStd::basic_string_view<CharT, Traits>, typename allocator_traits<Alloc>::size_type,
+        typename allocator_traits<Alloc>::size_type, const Alloc& = Alloc()) ->
+        basic_string<CharT, Traits, Alloc>;
 
     template<class Element, class Traits, class Allocator>
     inline void swap(basic_string<Element, Traits, Allocator>& left, basic_string<Element, Traits, Allocator>& right)

--- a/Code/Framework/AzCore/AzCore/std/string/string_view.h
+++ b/Code/Framework/AzCore/AzCore/std/string/string_view.h
@@ -1018,6 +1018,7 @@ namespace AZStd
         size_type m_size{};
     };
 
+    // AZStd::basic_string_view deduction guides
     template<class It, class End>
     basic_string_view(It, End)->basic_string_view<iter_value_t<It>>;
     template<class R>

--- a/Code/Framework/AzCore/AzCore/std/utils.h
+++ b/Code/Framework/AzCore/AzCore/std/utils.h
@@ -210,6 +210,10 @@ namespace AZStd
         T2 second;  // the second stored value
     };
 
+    // AZStd::pair deduction guides
+    template <class T1, class T2>
+    pair(T1, T2) -> pair<T1, T2>;
+
     // pair
     template<class T1, class T2>
     constexpr void swap(AZStd::pair<T1, T2>& left, AZStd::pair<T1, T2>& _Right)

--- a/Code/Framework/AzCore/Tests/AZStd/DequeAndSimilar.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/DequeAndSimilar.cpp
@@ -30,9 +30,6 @@
 
 namespace UnitTest
 {
-    using namespace AZStd;
-    using namespace UnitTestInternal;
-
     class Containers
         : public AllocatorsFixture
     {
@@ -45,7 +42,7 @@ namespace UnitTest
     {
         // DequeContainerTest-Begin
 
-        typedef deque<int> int_deque_type;
+        using int_deque_type = AZStd::deque<int>;
 
         int_deque_type int_deque;
         AZ_TEST_VALIDATE_EMPTY_DEQUE(int_deque);
@@ -112,7 +109,7 @@ namespace UnitTest
         int_deque1.assign(5, 333);
         AZ_TEST_VALIDATE_DEQUE(int_deque1, 5);
 
-        array<int, 7> elements = {
+        AZStd::array<int, 7> elements = {
             {1, 2, 3, 4, 5, 6, 7}
         };
         int_deque1.assign(elements.begin(), elements.end());
@@ -142,11 +139,11 @@ namespace UnitTest
         AZ_TEST_VALIDATE_DEQUE(int_deque1, 20);
         AZ_TEST_ASSERT(int_deque1[3] == 601);
 
-        int_deque1.insert(int_deque1.begin(), elements.begin(), next(elements.begin()));
+        int_deque1.insert(int_deque1.begin(), elements.begin(), AZStd::next(elements.begin()));
         AZ_TEST_VALIDATE_DEQUE(int_deque1, 21);
         AZ_TEST_ASSERT(int_deque1.front() == 1);
 
-        int_deque1.insert(int_deque1.end(), prev(elements.end()), elements.end());
+        int_deque1.insert(int_deque1.end(), AZStd::prev(elements.end()), elements.end());
         AZ_TEST_VALIDATE_DEQUE(int_deque1, 22);
         AZ_TEST_ASSERT(int_deque1.back() == 7);
 
@@ -163,7 +160,6 @@ namespace UnitTest
         AZ_TEST_ASSERT(int_deque1.front() == 1);
         AZ_TEST_ASSERT(int_deque1[3] == 3);
 
-        int_deque1.insert(int_deque1.begin(), {});
         AZ_TEST_VALIDATE_DEQUE(int_deque1, 37);
         int_deque1.erase(int_deque1.begin(), int_deque1.begin() + 8);
         AZ_TEST_VALIDATE_DEQUE(int_deque1, 29);
@@ -207,21 +203,21 @@ namespace UnitTest
         AZ_TEST_ASSERT(int_deque2[1] == 401);
 
         // alignment
-        deque<MyClass> aligned_deque(5, 99);
+        AZStd::deque<UnitTestInternal::MyClass> aligned_deque(5, 99);
         for (AZStd::size_t i = 0; i < aligned_deque.size(); ++i)
         {
-            AZ_TEST_ASSERT(((AZStd::size_t)&aligned_deque[i] & (alignment_of<MyClass>::value - 1)) == 0);
+            AZ_TEST_ASSERT(((AZStd::size_t)&aligned_deque[i] & (AZStd::alignment_of<UnitTestInternal::MyClass>::value - 1)) == 0);
         }
 
         // different allocators
-        typedef static_buffer_allocator<16*1024, 1> static_buffer_16KB_type;
+        using static_buffer_16KB_type = AZStd::static_buffer_allocator<16 * 1024, 1>;
         static_buffer_16KB_type myMemoryManager1;
         static_buffer_16KB_type myMemoryManager2;
-        typedef allocator_ref<static_buffer_16KB_type> static_allocator_ref_type;
+        using static_allocator_ref_type = AZStd::allocator_ref<static_buffer_16KB_type>;
         static_allocator_ref_type allocator1(myMemoryManager1, "Mystack allocator 1");
         static_allocator_ref_type allocator2(myMemoryManager2, "Mystack allocator 2");
 
-        typedef deque<int, static_allocator_ref_type> int_deque_myalloc_type;
+        using int_deque_myalloc_type = AZStd::deque<int, static_allocator_ref_type>;
         int_deque_myalloc_type int_deque10(100, 13, allocator1); /// Allocate 100 elements using memory manager 1
         AZ_TEST_VALIDATE_DEQUE(int_deque10, 100);
         AZ_TEST_ASSERT(myMemoryManager1.get_allocated_size() >= 100 * sizeof(int));
@@ -285,19 +281,26 @@ namespace UnitTest
         // DequeContainerTest-End
     }
 
+    TEST_F(Containers, Deque_DeductionGuide_Compiles)
+    {
+        constexpr AZStd::string_view testView;
+        AZStd::deque testDeque(testView.begin(), testView.end());
+        EXPECT_TRUE(testDeque.empty());
+    }
+
     /**
     * Queue container test.
     */
     TEST_F(Containers, Queue)
     {
         // QueueContainerTest-Begin
-        typedef queue<int> int_queue_type;
+        using int_queue_type = AZStd::queue<int>;
         int_queue_type int_queue;
         AZ_TEST_ASSERT(int_queue.empty());
         AZ_TEST_ASSERT(int_queue.size() == 0);
 
         // Queue uses deque as default container, so try to construct to queue from a deque.
-        deque<int> container(40, 10);
+        AZStd::deque<int> container(40, 10);
         int_queue_type int_queue2(container);
         AZ_TEST_ASSERT(!int_queue2.empty());
         AZ_TEST_ASSERT(int_queue2.size() == 40);
@@ -334,7 +337,7 @@ namespace UnitTest
         AZ_TEST_ASSERT(int_queue.size() == 40);
         AZ_TEST_ASSERT(int_queue.back() == 20);
 
-        queue<MyClass> class_queue;
+        AZStd::queue<UnitTestInternal::MyClass> class_queue;
         class_queue.emplace(3, false, 1.0f);
 
         // QueueContainerTest-End
@@ -346,12 +349,12 @@ namespace UnitTest
     TEST_F(Containers, PriorityQueue)
     {
         // PriorityQueueContainerTest-Begin
-        typedef priority_queue<int> int_priority_queue_type;
+        using int_priority_queue_type = AZStd::priority_queue<int>;
         int_priority_queue_type int_queue;
         AZ_TEST_ASSERT(int_queue.empty());
         AZ_TEST_ASSERT(int_queue.size() == 0);
 
-        array<int, 10> elements = {
+        AZStd::array<int, 10> elements = {
             {10, 2, 6, 3, 5, 8, 7, 9, 1, 4}
         };
         int_priority_queue_type int_queue2(elements.begin(), elements.end());
@@ -366,7 +369,7 @@ namespace UnitTest
         }
         AZ_TEST_ASSERT(int_queue2.size() == 0);
 
-        priority_queue<int, vector<int>, AZStd::greater<int> > int_queue3(elements.begin(), elements.end());
+        AZStd::priority_queue<int, AZStd::vector<int>, AZStd::greater<int> > int_queue3(elements.begin(), elements.end());
         AZ_TEST_ASSERT(!int_queue3.empty());
         AZ_TEST_ASSERT(int_queue3.size() == 10);
         lastValue = 0;
@@ -392,12 +395,12 @@ namespace UnitTest
     TEST_F(Containers, Stack)
     {
         // StackContainerTest-Begin
-        typedef stack<int> int_stack_type;
+        using int_stack_type = AZStd::stack<int>;
         int_stack_type int_stack;
         AZ_TEST_ASSERT(int_stack.empty());
         AZ_TEST_ASSERT(int_stack.size() == 0);
 
-        deque<int> container(40, 10);
+        AZStd::deque<int> container(40, 10);
         int_stack_type int_stack2(container);
         AZ_TEST_ASSERT(!int_stack2.empty());
         AZ_TEST_ASSERT(int_stack2.size() == 40);
@@ -453,8 +456,8 @@ namespace UnitTest
      */
     TEST_F(Containers, RingBuffer)
     {
-        typedef ring_buffer<int> int_ringbuffer_type;
-        typedef ring_buffer<MyClass> class_ringbuffer_type;
+        using int_ringbuffer_type = AZStd::ring_buffer<int>;
+        using class_ringbuffer_type = AZStd::ring_buffer<UnitTestInternal::MyClass>;
 
         // Test empty  buffer with intergral type.
         int_ringbuffer_type int_buffer;

--- a/Code/Framework/AzCore/Tests/AZStd/FunctionalBasic.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/FunctionalBasic.cpp
@@ -202,6 +202,8 @@ namespace UnitTest
         {
             return ~lhs.m_value;
         }
+
+        void RawTestFunc(int) {};
     }
 
     TEST_F(FunctionalBasicTest, FunctionalOperators_ReturnsExpectedValue)
@@ -216,5 +218,11 @@ namespace UnitTest
         Internal::FunctionalOperatorConfig::PerformOperation<void>(7, Internal::IntWrapper{ 11 }, AZStd::make_tuple(18, -4, 77, 0, 7, -7, false, true, false, true, false, true, true, true, false, 3, 15, 12, ~7));
         Internal::FunctionalOperatorConfig::PerformOperation<void>(Internal::IntWrapper{ 45 }, 34, AZStd::make_tuple(79, 11, 1530, 1, 11, -45, false, true, true, false, true, false, true, true, false, 32, 47, 15, ~45));
         Internal::FunctionalOperatorConfig::PerformOperation<void>(24, Internal::IntWrapper{ 24 }, AZStd::make_tuple(48, 0, 576, 1, 0, -24, true, false, false, false, true, true, true, true, false, 24, 24, 0, ~24));
+    }
+
+    TEST_F(FunctionalBasicTest, DeductionGuide_Compiles)
+    {
+        AZStd::function rawFuncDeduce(&Internal::RawTestFunc);
+        AZStd::function functionObjectDeduce([](int) -> double { return {}; });
     }
 }

--- a/Code/Framework/AzCore/Tests/AZStd/Lists.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Lists.cpp
@@ -29,8 +29,6 @@
 
 namespace UnitTest
 {
-    using namespace AZStd;
-    using namespace UnitTestInternal;
     /**
      * Tests AZSTD::list container.
      */
@@ -52,38 +50,38 @@ namespace UnitTest
 
     TEST_F(ListContainers, InitializerListCtor)
     {
-        list<int> intList({ 1, 2, 3, 4, 5, 6 });
+        AZStd::list<int> intList({ 1, 2, 3, 4, 5, 6 });
         EXPECT_EQ(6, intList.size());
     }
 
     TEST_F(ListContainers, ListCtorAssign)
     {
-        list<int>   int_list;
-        list<int>   int_list1;
-        list<int>   int_list2;
-        list<int>   int_list3;
+        AZStd::list<int>   int_list;
+        AZStd::list<int>   int_list1;
+        AZStd::list<int>   int_list2;
+        AZStd::list<int>   int_list3;
 
         // default ctor
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list);
 
         // 10 int elements, value 33
-        int_list1 = list<int>(10, 33);
+        int_list1 = AZStd::list<int>(10, 33);
         AZ_TEST_VALIDATE_LIST(int_list1, 10);
-        for (list<int>::iterator iter = int_list1.begin(); iter != int_list1.end(); ++iter)
+        for (AZStd::list<int>::iterator iter = int_list1.begin(); iter != int_list1.end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter == 33);
         }
 
         // copy list 1 using, first,last,allocator.
-        int_list2 = list<int>(int_list1.begin(), int_list1.end());
+        int_list2 = AZStd::list<int>(int_list1.begin(), int_list1.end());
         AZ_TEST_VALIDATE_LIST(int_list2, 10);
-        for (list<int>::iterator iter = int_list2.begin(); iter != int_list2.end(); ++iter)
+        for (AZStd::list<int>::iterator iter = int_list2.begin(); iter != int_list2.end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter == 33);
         }
 
         // copy construct
-        int_list3 = list<int>(int_list1);
+        int_list3 = AZStd::list<int>(int_list1);
         AZ_TEST_ASSERT(int_list1 == int_list3);
 
         // assign
@@ -106,7 +104,7 @@ namespace UnitTest
         // assign a fixed value
         int_list.assign(5, 55);
         AZ_TEST_VALIDATE_LIST(int_list, 5);
-        for (list<int>::iterator iter = int_list.begin(); iter != int_list.end(); ++iter)
+        for (AZStd::list<int>::iterator iter = int_list.begin(); iter != int_list.end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter == 55);
         }
@@ -114,14 +112,14 @@ namespace UnitTest
 
     TEST_F(ListContainers, ListResizeInsertEraseClear)
     {
-        list<int>   int_list;
-        list<int>   int_list1;
-        list<int>   int_list2;
-        list<int>   int_list3;
-        list<int>::iterator list_it;
+        AZStd::list<int>   int_list;
+        AZStd::list<int>   int_list1;
+        AZStd::list<int>   int_list2;
+        AZStd::list<int>   int_list3;
+        AZStd::list<int>::iterator list_it;
 
         int_list.assign(5, 55);
-        int_list1 = list<int>(10, 33);
+        int_list1 = AZStd::list<int>(10, 33);
 
         // resize to bigger
         int_list.resize(6, 43);
@@ -167,7 +165,7 @@ namespace UnitTest
 
         // Ensure that parallel iterating over int_list1 and int_list
         // from the returned iterator result in the same elements.
-        list<int>::iterator list1_it = int_list1.begin();
+        AZStd::list<int>::iterator list1_it = int_list1.begin();
         for (; list1_it != int_list1.end(); ++list_it, ++list1_it)
         {
             AZ_TEST_ASSERT(list_it != int_list.end());
@@ -194,11 +192,11 @@ namespace UnitTest
 
     TEST_F(ListContainers, SwapSplice)
     {
-        list<int>   int_list;
-        list<int>   int_list1;
-        list<int>   int_list2;
+        AZStd::list<int>   int_list;
+        AZStd::list<int>   int_list1;
+        AZStd::list<int>   int_list2;
 
-        int_list2 = list<int>(10, 33);
+        int_list2 = AZStd::list<int>(10, 33);
 
         // list operations with container with the same allocator.
         // swap
@@ -249,7 +247,7 @@ namespace UnitTest
 
     TEST_F(ListContainers, RemoveUniqueSort)
     {
-        list<int>   int_list;
+        AZStd::list<int>   int_list;
 
         // remove
         int_list.assign(5, 101);
@@ -292,7 +290,7 @@ namespace UnitTest
         int_list.push_back(1);
         int_list.sort();
         AZ_TEST_VALIDATE_LIST(int_list, 4);
-        for (list<int>::iterator iter = int_list.begin(); iter != --int_list.end(); ++iter)
+        for (AZStd::list<int>::iterator iter = int_list.begin(); iter != --int_list.end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter <= *next(iter));
         }
@@ -302,7 +300,7 @@ namespace UnitTest
         int_list.push_back(1);
         int_list.sort(AZStd::greater<int>());
         AZ_TEST_VALIDATE_LIST(int_list, 4);
-        for (list<int>::iterator iter = int_list.begin(); iter != --int_list.end(); ++iter)
+        for (AZStd::list<int>::iterator iter = int_list.begin(); iter != --int_list.end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter >= *next(iter));
         }
@@ -310,10 +308,10 @@ namespace UnitTest
 
     TEST_F(ListContainers, ReverseMerge)
     {
-        list<int>   int_list;
-        list<int>   int_list1;
-        list<int>   int_list2;
-        list<int>   int_list3;
+        AZStd::list<int>   int_list;
+        AZStd::list<int>   int_list1;
+        AZStd::list<int>   int_list2;
+        AZStd::list<int>   int_list3;
 
         int_list.push_back(201);
         int_list.push_back(1);
@@ -321,7 +319,7 @@ namespace UnitTest
 
         // reverse
         int_list.reverse();
-        for (list<int>::iterator iter = int_list.begin(); iter != --int_list.end(); ++iter)
+        for (AZStd::list<int>::iterator iter = int_list.begin(); iter != --int_list.end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter <= *next(iter));
         }
@@ -343,7 +341,7 @@ namespace UnitTest
         int_list2.merge(int_list3);
         AZ_TEST_VALIDATE_LIST(int_list2, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list3);
-        for (list<int>::iterator iter = int_list2.begin(); iter != --int_list2.end(); ++iter)
+        for (AZStd::list<int>::iterator iter = int_list2.begin(); iter != --int_list2.end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter < *next(iter));
         }
@@ -356,7 +354,7 @@ namespace UnitTest
         int_list2.merge(int_list3, AZStd::greater<int>());
         AZ_TEST_VALIDATE_LIST(int_list2, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list3);
-        for (list<int>::iterator iter = int_list2.begin(); iter != --int_list2.end(); ++iter)
+        for (AZStd::list<int>::iterator iter = int_list2.begin(); iter != --int_list2.end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter > *next(iter));
         }
@@ -364,7 +362,7 @@ namespace UnitTest
 
     TEST_F(ListContainers, Extensions)
     {
-        list<int>   int_list;
+        AZStd::list<int>   int_list;
         // Extensions.
         int_list.clear();
 
@@ -386,8 +384,8 @@ namespace UnitTest
         AZ_TEST_ASSERT(((AZStd::size_t)&int_list.front() % 4) == 0); // default int alignment
 
         // make sure every allocation is aligned.
-        list<MyClass> aligned_list(5, MyClass(99));
-        AZ_TEST_ASSERT(((AZStd::size_t)&aligned_list.front() & (alignment_of<MyClass>::value - 1)) == 0);
+        AZStd::list<UnitTestInternal::MyClass> aligned_list(5, UnitTestInternal::MyClass(99));
+        AZ_TEST_ASSERT(((AZStd::size_t)&aligned_list.front() & (AZStd::alignment_of<UnitTestInternal::MyClass>::value - 1)) == 0);
     }
 
     TEST_F(ListContainers, StaticBufferAllocator)
@@ -395,18 +393,18 @@ namespace UnitTest
         /////////////////////////////////////////////////////////////////////////
         // Test swap, splice, merge, etc. of containers with different allocators.
         // list operations with container with the same allocator.
-        typedef static_buffer_allocator<16*1024, 1> static_buffer_16KB_type;
+        using static_buffer_16KB_type = AZStd::static_buffer_allocator<16 * 1024, 1>;
         static_buffer_16KB_type myMemoryManager1;
         static_buffer_16KB_type myMemoryManager2;
-        typedef allocator_ref<static_buffer_16KB_type> static_allocator_ref_type;
+        using static_allocator_ref_type = AZStd::allocator_ref<static_buffer_16KB_type>;
         static_allocator_ref_type allocator1(myMemoryManager1, "Mystack allocator 1");
         static_allocator_ref_type allocator2(myMemoryManager2, "Mystack allocator 2");
 
-        typedef list<MyClass, static_allocator_ref_type> stack_myclass_list_type;
+        using stack_myclass_list_type = AZStd::list<UnitTestInternal::MyClass, static_allocator_ref_type>;
         stack_myclass_list_type int_list10(allocator1);
         stack_myclass_list_type int_list20(allocator2);
 
-        int_list20.assign(10, MyClass(33));
+        int_list20.assign(10, UnitTestInternal::MyClass(33));
         AZ_TEST_VALIDATE_LIST(int_list20, 10);
         AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 10 * sizeof(stack_myclass_list_type::value_type));
 
@@ -415,7 +413,7 @@ namespace UnitTest
         myMemoryManager2.reset(); // free all memory
 
         // set allocator
-        int_list20.assign(20, MyClass(22));
+        int_list20.assign(20, UnitTestInternal::MyClass(22));
         int_list20.set_allocator(allocator1);
         AZ_TEST_VALIDATE_LIST(int_list20, 20);
         AZ_TEST_ASSERT(myMemoryManager1.get_allocated_size() >= 20 * sizeof(stack_myclass_list_type::value_type));
@@ -425,7 +423,7 @@ namespace UnitTest
         myMemoryManager1.reset();
         myMemoryManager2.reset();
 
-        int_list20.assign(10, MyClass(11));
+        int_list20.assign(10, UnitTestInternal::MyClass(11));
 
         // swap
         int_list10.swap(int_list20);
@@ -442,30 +440,30 @@ namespace UnitTest
         int_list10.swap(int_list20);
         AZ_TEST_VALIDATE_LIST(int_list10, 10);
         AZ_TEST_VALIDATE_LIST(int_list20, 5);
-        AZ_TEST_ASSERT(int_list10.front() == MyClass(11));
-        AZ_TEST_ASSERT(int_list20.front() == MyClass(55));
+        AZ_TEST_ASSERT(int_list10.front() == UnitTestInternal::MyClass(11));
+        AZ_TEST_ASSERT(int_list20.front() == UnitTestInternal::MyClass(55));
 
         // splice
         // splice(iterator splicePos, this_type& rhs)
         int_list10.splice(int_list10.end(), int_list20);
         AZ_TEST_VALIDATE_LIST(int_list10, 15);
-        AZ_TEST_ASSERT(int_list10.front() == MyClass(11));
-        AZ_TEST_ASSERT(int_list10.back() == MyClass(55));
+        AZ_TEST_ASSERT(int_list10.front() == UnitTestInternal::MyClass(11));
+        AZ_TEST_ASSERT(int_list10.back() == UnitTestInternal::MyClass(55));
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list20);
 
         // splice(iterator splicePos, this_type& rhs, iterator first)
-        int_list20.push_back(MyClass(101));
+        int_list20.push_back(UnitTestInternal::MyClass(101));
         int_list10.splice(int_list10.begin(), int_list20, int_list20.begin());
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list20);
         AZ_TEST_VALIDATE_LIST(int_list10, 16);
-        AZ_TEST_ASSERT(int_list10.front() == MyClass(101));
+        AZ_TEST_ASSERT(int_list10.front() == UnitTestInternal::MyClass(101));
 
         // splice(iterator splicePos, this_type& rhs, iterator first, iterator last)
-        int_list20.assign(5, MyClass(201));
+        int_list20.assign(5, UnitTestInternal::MyClass(201));
         int_list10.splice(int_list10.end(), int_list20, ++int_list20.begin(), int_list20.end());
         AZ_TEST_VALIDATE_LIST(int_list20, 1);
         AZ_TEST_VALIDATE_LIST(int_list10, 20);
-        AZ_TEST_ASSERT(int_list10.back() == MyClass(201));
+        AZ_TEST_ASSERT(int_list10.back() == UnitTestInternal::MyClass(201));
 
         int_list10.leak_and_reset();
         int_list20.leak_and_reset();
@@ -475,14 +473,14 @@ namespace UnitTest
         // merge
         stack_myclass_list_type int_list30(allocator1);
         stack_myclass_list_type int_list40(allocator2);
-        int_list10.push_back(MyClass(1)); // 2 sorted lists for merge
-        int_list10.push_back(MyClass(10));
-        int_list10.push_back(MyClass(50));
-        int_list10.push_back(MyClass(200));
-        int_list20.push_back(MyClass(2));
-        int_list20.push_back(MyClass(8));
-        int_list20.push_back(MyClass(60));
-        int_list20.push_back(MyClass(180));
+        int_list10.push_back(UnitTestInternal::MyClass(1)); // 2 sorted lists for merge
+        int_list10.push_back(UnitTestInternal::MyClass(10));
+        int_list10.push_back(UnitTestInternal::MyClass(50));
+        int_list10.push_back(UnitTestInternal::MyClass(200));
+        int_list20.push_back(UnitTestInternal::MyClass(2));
+        int_list20.push_back(UnitTestInternal::MyClass(8));
+        int_list20.push_back(UnitTestInternal::MyClass(60));
+        int_list20.push_back(UnitTestInternal::MyClass(180));
 
         int_list30 = int_list10;
         int_list40 = int_list20;
@@ -499,7 +497,7 @@ namespace UnitTest
 
         int_list30 = int_list10;
         int_list40 = int_list20;
-        int_list30.merge(int_list40, AZStd::greater<MyClass>());
+        int_list30.merge(int_list40, AZStd::greater<UnitTestInternal::MyClass>());
         AZ_TEST_VALIDATE_LIST(int_list30, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list40);
         for (stack_myclass_list_type::iterator iter = int_list30.begin(); iter != --int_list30.end(); ++iter)
@@ -510,12 +508,12 @@ namespace UnitTest
 
     TEST_F(ListContainers, UniquePtr)
     {
-        list<unique_ptr<MyNoCopyClass>> nocopy_list;
-        nocopy_list.emplace_back(new MyNoCopyClass(1, true, 3.0f));
-        nocopy_list.emplace_front(new MyNoCopyClass(2, true, 4.0f));
-        nocopy_list.emplace(nocopy_list.end(), new MyNoCopyClass(3, true, 5.0f));
+        AZStd::list<AZStd::unique_ptr<UnitTestInternal::MyNoCopyClass>> nocopy_list;
+        nocopy_list.emplace_back(new UnitTestInternal::MyNoCopyClass(1, true, 3.0f));
+        nocopy_list.emplace_front(new UnitTestInternal::MyNoCopyClass(2, true, 4.0f));
+        nocopy_list.emplace(nocopy_list.end(), new UnitTestInternal::MyNoCopyClass(3, true, 5.0f));
 
-        nocopy_list.insert(nocopy_list.end(), AZStd::unique_ptr<MyNoCopyClass>(new MyNoCopyClass(4, true, 6.0f)));
+        nocopy_list.insert(nocopy_list.end(), AZStd::unique_ptr<UnitTestInternal::MyNoCopyClass>(new UnitTestInternal::MyNoCopyClass(4, true, 6.0f)));
 
         for (const auto& ptr : nocopy_list)
         {
@@ -525,33 +523,33 @@ namespace UnitTest
 
     TEST_F(ListContainers, ForwardListAssign)
     {
-        forward_list<int> int_slist;
-        forward_list<int> int_slist1;
-        forward_list<int> int_slist2;
-        forward_list<int> int_slist3;
-        forward_list<int> int_slist4;
+        AZStd::forward_list<int> int_slist;
+        AZStd::forward_list<int> int_slist1;
+        AZStd::forward_list<int> int_slist2;
+        AZStd::forward_list<int> int_slist3;
+        AZStd::forward_list<int> int_slist4;
 
         // default ctor
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist);
 
         // 10 int elements, value 33
-        int_slist1 = forward_list<int>(10, 33);
+        int_slist1 = AZStd::forward_list<int>(10, 33);
         AZ_TEST_VALIDATE_LIST(int_slist1, 10);
-        for (forward_list<int>::iterator iter = int_slist1.begin(); iter != int_slist1.end(); ++iter)
+        for (AZStd::forward_list<int>::iterator iter = int_slist1.begin(); iter != int_slist1.end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter == 33);
         }
 
         // copy list 1 using, first,last,allocator.
-        int_slist2 = forward_list<int>(int_slist1.begin(), int_slist1.end());
+        int_slist2 = AZStd::forward_list<int>(int_slist1.begin(), int_slist1.end());
         AZ_TEST_VALIDATE_LIST(int_slist2, 10);
-        for (forward_list<int>::iterator iter = int_slist2.begin(); iter != int_slist2.end(); ++iter)
+        for (AZStd::forward_list<int>::iterator iter = int_slist2.begin(); iter != int_slist2.end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter == 33);
         }
 
         // copy construct
-        int_slist3 = forward_list<int>(int_slist1);
+        int_slist3 = AZStd::forward_list<int>(int_slist1);
         AZ_TEST_ASSERT(int_slist1 == int_slist3);
 
         // initializer_list construct
@@ -578,7 +576,7 @@ namespace UnitTest
         // assign a fixed value
         int_slist.assign(5, 55);
         AZ_TEST_VALIDATE_LIST(int_slist, 5);
-        for (forward_list<int>::iterator iter = int_slist.begin(); iter != int_slist.end(); ++iter)
+        for (AZStd::forward_list<int>::iterator iter = int_slist.begin(); iter != int_slist.end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter == 55);
         }
@@ -586,12 +584,12 @@ namespace UnitTest
 
     TEST_F(ListContainers, ForwardListInsertEraseClear)
     {
-        forward_list<int> int_slist;
-        forward_list<int> int_slist1;
+        AZStd::forward_list<int> int_slist;
+        AZStd::forward_list<int> int_slist1;
 
         int_slist.assign(5, 55);
-        int_slist1 = forward_list<int>(10, 33);
-        
+        int_slist1 = AZStd::forward_list<int>(10, 33);
+
         // resize to bigger
         int_slist.resize(6, 43);
         AZ_TEST_VALIDATE_LIST(int_slist, 6);
@@ -644,11 +642,11 @@ namespace UnitTest
 
     TEST_F(ListContainers, ForwardListSwapSplice)
     {
-        forward_list<int> int_slist;
-        forward_list<int> int_slist1;
-        forward_list<int> int_slist2;
+        AZStd::forward_list<int> int_slist;
+        AZStd::forward_list<int> int_slist1;
+        AZStd::forward_list<int> int_slist2;
 
-        int_slist2 = forward_list<int>(10, 33);
+        int_slist2 = AZStd::forward_list<int>(10, 33);
 
         // list operations with container with the same allocator.
         // swap
@@ -699,8 +697,8 @@ namespace UnitTest
 
     TEST_F(ListContainers, ForwardListRemoveUniqueSort)
     {
-        forward_list<int> int_slist;
-        
+        AZStd::forward_list<int> int_slist;
+
         // remove
         int_slist.assign(5, 101);
         int_slist.push_back(201);
@@ -742,7 +740,7 @@ namespace UnitTest
         int_slist.push_back(1);
         int_slist.sort();
         AZ_TEST_VALIDATE_LIST(int_slist, 4);
-        for (forward_list<int>::iterator iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
+        for (auto iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter <= *next(iter));
         }
@@ -752,7 +750,7 @@ namespace UnitTest
         int_slist.push_back(1);
         int_slist.sort(AZStd::greater<int>());
         AZ_TEST_VALIDATE_LIST(int_slist, 4);
-        for (forward_list<int>::iterator iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
+        for (auto iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter >= *next(iter));
         }
@@ -760,10 +758,10 @@ namespace UnitTest
 
     TEST_F(ListContainers, ForwardListReverseMerge)
     {
-        forward_list<int> int_slist;
-        forward_list<int> int_slist1;
-        forward_list<int> int_slist2;
-        forward_list<int> int_slist3;
+        AZStd::forward_list<int> int_slist;
+        AZStd::forward_list<int> int_slist1;
+        AZStd::forward_list<int> int_slist2;
+        AZStd::forward_list<int> int_slist3;
 
         int_slist.assign(2, 101);
         int_slist.push_back(201);
@@ -772,7 +770,7 @@ namespace UnitTest
 
         // reverse
         int_slist.reverse();
-        for (forward_list<int>::iterator iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
+        for (auto iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter <= *next(iter));
         }
@@ -794,7 +792,7 @@ namespace UnitTest
         int_slist2.merge(int_slist3);
         AZ_TEST_VALIDATE_LIST(int_slist2, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist3);
-        for (forward_list<int>::iterator iter = int_slist2.begin(); iter != int_slist2.before_end(); ++iter)
+        for (auto iter = int_slist2.begin(); iter != int_slist2.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter < *next(iter));
         }
@@ -807,7 +805,7 @@ namespace UnitTest
         int_slist2.merge(int_slist3, AZStd::greater<int>());
         AZ_TEST_VALIDATE_LIST(int_slist2, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist3);
-        for (forward_list<int>::iterator iter = int_slist2.begin(); iter != int_slist2.before_end(); ++iter)
+        for (auto iter = int_slist2.begin(); iter != int_slist2.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter > *next(iter));
         }
@@ -815,7 +813,7 @@ namespace UnitTest
 
     TEST_F(ListContainers, ForwardListExtensions)
     {
-        forward_list<int> int_slist;
+        AZStd::forward_list<int> int_slist;
 
         // Extensions.
         int_slist.clear();
@@ -834,26 +832,26 @@ namespace UnitTest
         AZ_TEST_ASSERT(((AZStd::size_t)&int_slist.front() % 4) == 0); // default int alignment
 
         // make sure every allocation is aligned.
-        forward_list<MyClass> aligned_list(5, MyClass(99));
-        AZ_TEST_ASSERT(((AZStd::size_t)&aligned_list.front() & (alignment_of<MyClass>::value - 1)) == 0);
+        AZStd::forward_list<UnitTestInternal::MyClass> aligned_list(5, UnitTestInternal::MyClass(99));
+        AZ_TEST_ASSERT(((AZStd::size_t)&aligned_list.front() & (AZStd::alignment_of<UnitTestInternal::MyClass>::value - 1)) == 0);
     }
 
     TEST_F(ListContainers, ForwardListStaticBuffer)
     {
         // Test swap, splice, merge, etc. of containers with different allocators.
         // list operations with container with the same allocator.
-        typedef static_buffer_allocator<16*1024, 1> static_buffer_16KB_type;
+        using static_buffer_16KB_type = AZStd::static_buffer_allocator<16 * 1024, 1>;
         static_buffer_16KB_type myMemoryManager1;
         static_buffer_16KB_type myMemoryManager2;
-        typedef allocator_ref<static_buffer_16KB_type> static_allocator_ref_type;
+        using static_allocator_ref_type = AZStd::allocator_ref<static_buffer_16KB_type>;
         static_allocator_ref_type allocator1(myMemoryManager1, "Mystack allocator 1");
         static_allocator_ref_type allocator2(myMemoryManager2, "Mystack allocator 2");
 
-        typedef forward_list<MyClass, static_allocator_ref_type> stack_myclass_slist_type;
+        using stack_myclass_slist_type = AZStd::forward_list<UnitTestInternal::MyClass, static_allocator_ref_type>;
         stack_myclass_slist_type   int_slist10(allocator1);
         stack_myclass_slist_type   int_slist20(allocator2);
 
-        int_slist20.assign(10, MyClass(33));
+        int_slist20.assign(10, UnitTestInternal::MyClass(33));
         AZ_TEST_VALIDATE_LIST(int_slist20, 10);
         AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 10 * sizeof(stack_myclass_slist_type::value_type));
 
@@ -862,7 +860,7 @@ namespace UnitTest
         myMemoryManager2.reset();  // free all memory
 
         // set allocator
-        int_slist20.assign(20, MyClass(22));
+        int_slist20.assign(20, UnitTestInternal::MyClass(22));
         int_slist20.set_allocator(allocator1);
         AZ_TEST_VALIDATE_LIST(int_slist20, 20);
         AZ_TEST_ASSERT(myMemoryManager1.get_allocated_size() >= 20 * sizeof(stack_myclass_slist_type::value_type));
@@ -872,7 +870,7 @@ namespace UnitTest
         myMemoryManager1.reset();
         myMemoryManager2.reset();
 
-        int_slist20.assign(10, MyClass(11));
+        int_slist20.assign(10, UnitTestInternal::MyClass(11));
 
         // swap
         int_slist10.swap(int_slist20);
@@ -889,30 +887,30 @@ namespace UnitTest
         int_slist10.swap(int_slist20);
         AZ_TEST_VALIDATE_LIST(int_slist10, 10);
         AZ_TEST_VALIDATE_LIST(int_slist20, 5);
-        AZ_TEST_ASSERT(int_slist10.front() == MyClass(11));
-        AZ_TEST_ASSERT(int_slist20.front() == MyClass(55));
+        AZ_TEST_ASSERT(int_slist10.front() == UnitTestInternal::MyClass(11));
+        AZ_TEST_ASSERT(int_slist20.front() == UnitTestInternal::MyClass(55));
 
         // splice
         // splice(iterator splicePos, this_type& rhs)
         int_slist10.splice(int_slist10.end(), int_slist20);
         AZ_TEST_VALIDATE_LIST(int_slist10, 15);
-        AZ_TEST_ASSERT(int_slist10.front() == MyClass(11));
-        AZ_TEST_ASSERT(int_slist10.back() == MyClass(55));
+        AZ_TEST_ASSERT(int_slist10.front() == UnitTestInternal::MyClass(11));
+        AZ_TEST_ASSERT(int_slist10.back() == UnitTestInternal::MyClass(55));
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist20);
 
         // splice(iterator splicePos, this_type& rhs, iterator first)
-        int_slist20.push_back(MyClass(101));
+        int_slist20.push_back(UnitTestInternal::MyClass(101));
         int_slist10.splice(int_slist10.begin(), int_slist20, int_slist20.begin());
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist20);
         AZ_TEST_VALIDATE_LIST(int_slist10, 16);
-        AZ_TEST_ASSERT(int_slist10.front() == MyClass(101));
+        AZ_TEST_ASSERT(int_slist10.front() == UnitTestInternal::MyClass(101));
 
         // splice(iterator splicePos, this_type& rhs, iterator first, iterator last)
-        int_slist20.assign(5, MyClass(201));
+        int_slist20.assign(5, UnitTestInternal::MyClass(201));
         int_slist10.splice(int_slist10.end(), int_slist20, ++int_slist20.begin(), int_slist20.end());
         AZ_TEST_VALIDATE_LIST(int_slist20, 1);
         AZ_TEST_VALIDATE_LIST(int_slist10, 20);
-        AZ_TEST_ASSERT(int_slist10.back() == MyClass(201));
+        AZ_TEST_ASSERT(int_slist10.back() == UnitTestInternal::MyClass(201));
 
         int_slist10.leak_and_reset();
         int_slist20.leak_and_reset();
@@ -922,14 +920,14 @@ namespace UnitTest
         // merge
         stack_myclass_slist_type   int_slist30(allocator1);
         stack_myclass_slist_type   int_slist40(allocator2);
-        int_slist10.push_back(MyClass(1));  // 2 sorted lists for merge
-        int_slist10.push_back(MyClass(10));
-        int_slist10.push_back(MyClass(50));
-        int_slist10.push_back(MyClass(200));
-        int_slist20.push_back(MyClass(2));
-        int_slist20.push_back(MyClass(8));
-        int_slist20.push_back(MyClass(60));
-        int_slist20.push_back(MyClass(180));
+        int_slist10.push_back(UnitTestInternal::MyClass(1));  // 2 sorted lists for merge
+        int_slist10.push_back(UnitTestInternal::MyClass(10));
+        int_slist10.push_back(UnitTestInternal::MyClass(50));
+        int_slist10.push_back(UnitTestInternal::MyClass(200));
+        int_slist20.push_back(UnitTestInternal::MyClass(2));
+        int_slist20.push_back(UnitTestInternal::MyClass(8));
+        int_slist20.push_back(UnitTestInternal::MyClass(60));
+        int_slist20.push_back(UnitTestInternal::MyClass(180));
 
         int_slist30 = int_slist10;
         int_slist40 = int_slist20;
@@ -946,13 +944,26 @@ namespace UnitTest
 
         int_slist30 = int_slist10;
         int_slist40 = int_slist20;
-        int_slist30.merge(int_slist40, AZStd::greater<MyClass>());
+        int_slist30.merge(int_slist40, AZStd::greater<UnitTestInternal::MyClass>());
         AZ_TEST_VALIDATE_LIST(int_slist30, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist40);
         for (stack_myclass_slist_type::iterator iter = int_slist30.begin(); iter != int_slist30.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter > *next(iter));
         }
+    }
+
+    TEST_F(ListContainers, List_DeductionGuide_Compiles)
+    {
+        constexpr AZStd::string_view testView;
+        AZStd::list testList(testView.begin(), testView.end());
+        EXPECT_TRUE(testList.empty());
+    }
+    TEST_F(ListContainers, ForwardList_DeductionGuide_Compiles)
+    {
+        constexpr AZStd::string_view testView;
+        AZStd::forward_list testList(testView.begin(), testView.end());
+        EXPECT_TRUE(testList.empty());
     }
 }
 

--- a/Code/Framework/AzCore/Tests/AZStd/String.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/String.cpp
@@ -2482,6 +2482,26 @@ namespace UnitTest
         EXPECT_EQ("Hello", testString);
     }
 
+    TEST_F(String, AZStdString_DeductionGuide_Compiles)
+    {
+        constexpr AZStd::string_view testView{ "Hello" };
+        {
+            // legacy common iterator deduction guide
+            AZStd::basic_string testString(testView.begin(), testView.end());
+            EXPECT_EQ("Hello", testString);
+        }
+        {
+            // basic_string_view deduction guide
+            AZStd::basic_string testString(testView);
+            EXPECT_EQ("Hello", testString);
+        }
+        {
+            // basic_string_view with position and size deduction guide
+            AZStd::basic_string testString(testView, 1, 3);
+            EXPECT_EQ("ell", testString);
+        }
+    }
+
     template <typename StringType>
     class ImmutableStringFunctionsFixture
         : public ScopedAllocatorSetupFixture

--- a/Code/Framework/AzCore/Tests/AZStd/VectorAndArray.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/VectorAndArray.cpp
@@ -54,9 +54,6 @@
 
 namespace UnitTest
 {
-    using namespace AZStd;
-    using namespace UnitTestInternal;
-
 #if !AZ_UNIT_TEST_SKIP_STD_VECTOR_AND_ARRAY_TESTS
 
     struct MyCtorClass
@@ -175,7 +172,7 @@ namespace UnitTest
     {
         // VectorContainerTest-Begin
 
-        typedef vector<int> vector_int_type;
+        using vector_int_type = AZStd::vector<int>;
         //////////////////////////////////////////////////////////////////////////////////////////
         // Vector functionality
 
@@ -184,13 +181,13 @@ namespace UnitTest
         AZ_TEST_VALIDATE_EMPTY_VECTOR(int_vector_default);
 
         // Default vector (non-integral type).
-        vector<MyClass> myclass_vector_default;
+        AZStd::vector<UnitTestInternal::MyClass> myclass_vector_default;
         AZ_TEST_VALIDATE_EMPTY_VECTOR(myclass_vector_default);
 
         // Create a vector (using fill ctor, with memset optimization to set the values)
-        vector<char> char_vector(10, 'A');
+        AZStd::vector<char> char_vector(10, 'A');
         AZ_TEST_VALIDATE_VECTOR(char_vector, 10);
-        for (vector<char>::iterator iter = char_vector.begin(); iter != char_vector.end(); ++iter)
+        for (AZStd::vector<char>::iterator iter = char_vector.begin(); iter != char_vector.end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter == 'A');
         }
@@ -203,12 +200,12 @@ namespace UnitTest
             AZ_TEST_ASSERT(int_vector.validate_iterator(iter));
             AZ_TEST_ASSERT(*iter == 55);
         }
-        AZ_TEST_ASSERT(int_vector.validate_iterator(int_vector.end()) == isf_valid);
+        AZ_TEST_ASSERT(int_vector.validate_iterator(int_vector.end()) == AZStd::isf_valid);
 
         // Fill ctor non-intergral type
-        vector<MyClass> myclass_vector(22, MyClass(11));
+        AZStd::vector<UnitTestInternal::MyClass> myclass_vector(22, UnitTestInternal::MyClass(11));
         AZ_TEST_VALIDATE_VECTOR(myclass_vector, 22);
-        for (vector<MyClass>::iterator iter = myclass_vector.begin(); iter != myclass_vector.end(); ++iter)
+        for (AZStd::vector<UnitTestInternal::MyClass>::iterator iter = myclass_vector.begin(); iter != myclass_vector.end(); ++iter)
         {
             AZ_TEST_ASSERT(iter->m_data == 11);
         }
@@ -362,9 +359,9 @@ namespace UnitTest
         AZ_TEST_ASSERT(((AZStd::size_t)int_vector.data() % 4) == 0); // default int alignment
 
         // make sure every vector allocation is aligned.
-        vector<MyClass> aligned_vector(5, 99);
-        AZ_TEST_ASSERT(((AZStd::size_t)aligned_vector.data() & (alignment_of<MyClass>::value - 1)) == 0);
-        AZ_TEST_ASSERT(((AZStd::size_t)&aligned_vector[0] & (alignment_of<MyClass>::value - 1)) == 0);
+        AZStd::vector<UnitTestInternal::MyClass> aligned_vector(5, 99);
+        AZ_TEST_ASSERT(((AZStd::size_t)aligned_vector.data() & (AZStd::alignment_of<UnitTestInternal::MyClass>::value - 1)) == 0);
+        AZ_TEST_ASSERT(((AZStd::size_t)&aligned_vector[0] & (AZStd::alignment_of<UnitTestInternal::MyClass>::value - 1)) == 0);
 
         // reverse iterators
         int_vector.clear();
@@ -386,7 +383,7 @@ namespace UnitTest
         }
 
         // resize_no_construct test (it technically behaves like reserve that updates the size of the container)
-        vector<MyCtorClass> myCtorClassArray;
+        AZStd::vector<MyCtorClass> myCtorClassArray;
         AZ_TEST_ASSERT(MyCtorClass::s_numConstructedObjects == 0);
         myCtorClassArray.resize_no_construct(10);
         AZ_TEST_ASSERT(myCtorClassArray.size() == 10);
@@ -403,14 +400,14 @@ namespace UnitTest
 
         //////////////////////////////////////////////////////////////////////////////////////////
         // Vector allocator tests
-        typedef static_buffer_allocator<16*1024, 1> static_buffer_16KB;
+        using static_buffer_16KB = AZStd::static_buffer_allocator<16 * 1024, 1>;
         static_buffer_16KB myMemoryManager1;
         static_buffer_16KB myMemoryManager2;
-        typedef allocator_ref<static_buffer_16KB> static_allocator_ref_type;
+        using static_allocator_ref_type = AZStd::allocator_ref<static_buffer_16KB>;
         static_allocator_ref_type allocator1(myMemoryManager1, "Mystack allocator 1");
         static_allocator_ref_type allocator2(myMemoryManager2, "Mystack allocator 2");
 
-        typedef vector<int, static_allocator_ref_type > IntVectorMyAllocator;
+        using IntVectorMyAllocator = AZStd::vector<int, static_allocator_ref_type >;
         IntVectorMyAllocator int_vector10(100, 13, allocator1); /// Allocate 100 elements using memory manager 1
         AZ_TEST_VALIDATE_VECTOR(int_vector10, 100);
         AZ_TEST_ASSERT(myMemoryManager1.get_allocated_size() == 100 * sizeof(int));
@@ -480,7 +477,7 @@ namespace UnitTest
         AZ_TEST_ASSERT(int_moved_vector.data() == data);
 
         myclass_vector.clear();
-        myclass_vector.push_back(MyClass(23));
+        myclass_vector.push_back(UnitTestInternal::MyClass(23));
         AZ_TEST_ASSERT(myclass_vector.size() == 1);
         AZ_TEST_ASSERT(myclass_vector[0].m_data == 23);
         AZ_TEST_ASSERT(myclass_vector[0].m_isMoved == true); // the compiler should move the class automatically
@@ -534,15 +531,15 @@ namespace UnitTest
         // Fixed Vector functionality
 
         // Default vector (integral type).
-        fixed_vector<int, 50> int_vector_default;
+        AZStd::fixed_vector<int, 50> int_vector_default;
         AZ_TEST_VALIDATE_VECTOR_0(int_vector_default);
 
         // Default vector (non-integral type).
-        fixed_vector<MyClass, 10> myclass_vector_default;
+        AZStd::fixed_vector<UnitTestInternal::MyClass, 10> myclass_vector_default;
         AZ_TEST_VALIDATE_VECTOR_0(myclass_vector_default);
 
         // Create a vector (using fill ctor, with memset optimization to set the values)
-        typedef fixed_vector<char, 10> char_10_type;
+        using char_10_type = AZStd::fixed_vector<char, 10>;
         char_10_type char_vector(10, 'A');
         AZ_TEST_VALIDATE_VECTOR(char_vector, 10);
         for (char_10_type::iterator iter = char_vector.begin(); iter != char_vector.end(); ++iter)
@@ -551,7 +548,7 @@ namespace UnitTest
         }
 
         // Fill ctor with out memset optimization. validate iterators too.
-        typedef fixed_vector<int, 50> int_50_t;
+        using int_50_t = AZStd::fixed_vector<int, 50>;
         int_50_t int_vector(33, 55);
         AZ_TEST_VALIDATE_VECTOR(int_vector, 33);
         for (int_50_t::iterator iter = int_vector.begin(); iter != int_vector.end(); ++iter)
@@ -559,11 +556,11 @@ namespace UnitTest
             AZ_TEST_ASSERT(int_vector.validate_iterator(iter));
             AZ_TEST_ASSERT(*iter == 55);
         }
-        AZ_TEST_ASSERT(int_vector.validate_iterator(int_vector.end()) == isf_valid);
+        AZ_TEST_ASSERT(int_vector.validate_iterator(int_vector.end()) == AZStd::isf_valid);
 
         // Fill ctor non-intergral type
-        typedef fixed_vector<MyClass, 22> myclass_22_t;
-        myclass_22_t myclass_vector(22, MyClass(11));
+        using myclass_22_t = AZStd::fixed_vector<UnitTestInternal::MyClass, 22>;
+        myclass_22_t myclass_vector(22, UnitTestInternal::MyClass(11));
         AZ_TEST_VALIDATE_VECTOR(myclass_vector, 22);
         for (myclass_22_t::iterator iter = myclass_vector.begin(); iter != myclass_vector.end(); ++iter)
         {
@@ -678,9 +675,9 @@ namespace UnitTest
         AZ_TEST_ASSERT(((AZStd::size_t)int_vector.data() % 4) == 0); // default int alignment
 
         // make sure every vector allocation is aligned. My class is aligned on 32 bytes.
-        myclass_vector_default.push_back(MyClass(10));
-        AZ_TEST_ASSERT(((AZStd::size_t)myclass_vector_default.data() & (alignment_of<MyClass>::value - 1)) == 0);
-        AZ_TEST_ASSERT(((AZStd::size_t)&myclass_vector_default[0] & (alignment_of<MyClass>::value - 1)) == 0);
+        myclass_vector_default.push_back(UnitTestInternal::MyClass(10));
+        AZ_TEST_ASSERT(((AZStd::size_t)myclass_vector_default.data() & (AZStd::alignment_of<UnitTestInternal::MyClass>::value - 1)) == 0);
+        AZ_TEST_ASSERT(((AZStd::size_t)&myclass_vector_default[0] & (AZStd::alignment_of<UnitTestInternal::MyClass>::value - 1)) == 0);
 
         // reverse iterators
 
@@ -716,8 +713,8 @@ namespace UnitTest
         // Test dealing with fixed_vectors with big sizes.
         // Have to heap allocated since they wont fit in the stack
         constexpr int bigFixedVectorSize = 10000000; // enough to make it fail without the fix
-        AZStd::unique_ptr<fixed_vector<char, bigFixedVectorSize>> big_fixed_vector0 = AZStd::make_unique<fixed_vector<char, bigFixedVectorSize>>();
-        AZStd::unique_ptr<fixed_vector<char, bigFixedVectorSize>> big_fixed_vector1 = AZStd::make_unique<fixed_vector<char, bigFixedVectorSize>>();
+        AZStd::unique_ptr<AZStd::fixed_vector<char, bigFixedVectorSize>> big_fixed_vector0 = AZStd::make_unique<AZStd::fixed_vector<char, bigFixedVectorSize>>();
+        AZStd::unique_ptr<AZStd::fixed_vector<char, bigFixedVectorSize>> big_fixed_vector1 = AZStd::make_unique<AZStd::fixed_vector<char, bigFixedVectorSize>>();
 
         big_fixed_vector0->insert(big_fixed_vector0->end(), bigFixedVectorSize, 0);
         big_fixed_vector1->insert(big_fixed_vector1->end(), bigFixedVectorSize, 1);
@@ -829,9 +826,9 @@ namespace UnitTest
 
     TEST_F(Arrays, VectorSwap)
     {
-        vector<void*> vec1(42, nullptr);
-        vector<void*> vec2(3, reinterpret_cast<void*>((intptr_t)0xdeadbeef));
-        vector<void*> vec3(3, reinterpret_cast<void*>((intptr_t)0xcdcdcdcd));
+        AZStd::vector<void*> vec1(42, nullptr);
+        AZStd::vector<void*> vec2(3, reinterpret_cast<void*>((intptr_t)0xdeadbeef));
+        AZStd::vector<void*> vec3(3, reinterpret_cast<void*>((intptr_t)0xcdcdcdcd));
 
         vec1.swap(vec2);
         EXPECT_EQ(3, vec1.size());
@@ -851,7 +848,7 @@ namespace UnitTest
     TEST_F(Arrays, Array)
     {
         // ArrayContainerTest-Begin
-        array<int, 10> myArr = {
+        AZStd::array<int, 10> myArr = {
             {1, 2, 3, 4}
         };
         AZ_TEST_ASSERT(myArr.empty() == false);
@@ -864,13 +861,13 @@ namespace UnitTest
 
         using iteratorType = int;
         auto testValue = myArr;
-        reverse_iterator<iteratorType*> rend = testValue.rend();
-        reverse_iterator<const iteratorType*> crend1 = testValue.rend();
-        reverse_iterator<const iteratorType*> crend2 = testValue.crend();
+        AZStd::reverse_iterator<iteratorType*> rend = testValue.rend();
+        AZStd::reverse_iterator<const iteratorType*> crend1 = testValue.rend();
+        AZStd::reverse_iterator<const iteratorType*> crend2 = testValue.crend();
 
-        reverse_iterator<iteratorType*> rbegin = testValue.rbegin();
-        reverse_iterator<const iteratorType*> crbegin1 = testValue.rbegin();
-        reverse_iterator<const iteratorType*> crbegin2 = testValue.crbegin();
+        AZStd::reverse_iterator<iteratorType*> rbegin = testValue.rbegin();
+        AZStd::reverse_iterator<const iteratorType*> crbegin1 = testValue.rbegin();
+        AZStd::reverse_iterator<const iteratorType*> crbegin2 = testValue.crbegin();
 
         AZ_TEST_ASSERT(rend == crend1);
         AZ_TEST_ASSERT(crend1 == crend2);
@@ -880,7 +877,7 @@ namespace UnitTest
 
         AZ_TEST_ASSERT(rbegin != rend);
 
-        array<int, 10> myArr1 = {
+        AZStd::array<int, 10> myArr1 = {
             {10, 11, 12, 13}
         };
         AZ_TEST_ASSERT(myArr != myArr1);
@@ -905,7 +902,7 @@ namespace UnitTest
     TEST_F(Arrays, ZeroLengthArray)
     {
         // ArrayContainerTest-Begin
-        array<int, 0> myArr;
+        AZStd::array<int, 0> myArr;
         EXPECT_TRUE(myArr.empty());
         EXPECT_EQ(0, myArr.size());
         EXPECT_EQ(0, myArr.max_size());
@@ -916,7 +913,7 @@ namespace UnitTest
         myArr[0];
         AZ_TEST_STOP_TRACE_SUPPRESSION(4);
 
-        array<int, 0> myArr2;
+        AZStd::array<int, 0> myArr2;
         EXPECT_EQ(myArr, myArr2);
 
         myArr.data();
@@ -961,10 +958,10 @@ namespace UnitTest
 
             bool m_moved;
             int m_data;
-            vector<int>     m_intVector;
+            AZStd::vector<int> m_intVector;
         };
 
-        typedef vector<MyDeepClass>  deep_vector_type;
+        using deep_vector_type = AZStd::vector<MyDeepClass>;
         deep_vector_type deep_vec_1;
         AZ_TEST_VALIDATE_EMPTY_VECTOR(deep_vec_1);
 
@@ -990,13 +987,13 @@ namespace UnitTest
         AZ_TEST_ASSERT(deep_vec_2.back().m_intVector.size() == 10);
 
         // insert with unitialized_copy
-        deep_vec_2.insert(prev(deep_vec_2.end()), MyDeepClass(200));
+        deep_vec_2.insert(AZStd::prev(deep_vec_2.end()), MyDeepClass(200));
         AZ_TEST_VALIDATE_VECTOR(deep_vec_2, 12);
         AZ_TEST_ASSERT(deep_vec_2.back().m_data == 100);
         AZ_TEST_ASSERT(deep_vec_2.back().m_intVector.size() == 10);
 
         // insert with uninitilized_copy and move
-        deep_vec_2.insert(prev(deep_vec_2.end(), 2), MyDeepClass(300));
+        deep_vec_2.insert(AZStd::prev(deep_vec_2.end(), 2), MyDeepClass(300));
         AZ_TEST_VALIDATE_VECTOR(deep_vec_2, 13);
         AZ_TEST_ASSERT(deep_vec_2.back().m_data == 100);
         AZ_TEST_ASSERT(deep_vec_2.back().m_intVector.size() == 10);
@@ -1009,4 +1006,10 @@ namespace UnitTest
     }
 #endif // AZ_UNIT_TEST_SKIP_STD_VECTOR_AND_ARRAY_TESTS
 
+    TEST_F(Arrays, Vector_DeductionGuide_Compiles)
+    {
+        constexpr AZStd::string_view testView;
+        AZStd::vector testVec(testView.begin(), testView.end());
+        EXPECT_TRUE(testVec.empty());
+    }
 }


### PR DESCRIPTION
Deduction guides were added for deque, forward_list, list, vector, function_template, shared_ptr, basic_regex, string, pair.

Removed `using namespace AZStd` calls at namespace scope in the deque, lists and vector UnitTest files.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
