### PR TITLE
Android LY_NDK_DIR env detection fix

### DIFF
--- a/cmake/Platform/Android/Toolchain_android.cmake
+++ b/cmake/Platform/Android/Toolchain_android.cmake
@@ -11,8 +11,8 @@ if(LY_TOOLCHAIN_NDK_API_LEVEL)
 endif()
 
 # Verify that the NDK environment is set and points to the support NDK
-if(NOT ${LY_NDK_DIR})
-    if($ENV{LY_NDK_DIR})
+if(NOT LY_NDK_DIR)
+    if(DEFINED ENV{LY_NDK_DIR})
         set(LY_NDK_DIR $ENV{LY_NDK_DIR})
     endif()
 endif()
@@ -86,7 +86,7 @@ endif()
 list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES LY_NDK_DIR)
 
 
-# The Native Activity Glue source file needs to be included in any project that will be loaded 
+# The Native Activity Glue source file needs to be included in any project that will be loaded
 # through the android launcher APK. This source file resides directly in the NDK source folder structure
 # based on the configured NDK Path set with ${LY_NDK_DIR}
 


### PR DESCRIPTION
When LY_NDK_DIR was set as an environment variable, it wasn't being properly detected by the Android toolchain file

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Configured android with `LY_NDK_DIR` set as an environment variable that pointed to the NDK.
