### PR TITLE
Adding implementation of C++23 ranges::to

### DIFF
--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -178,7 +178,8 @@ namespace AZ
     {
         auto DeferredCommandCallable = [this](const DeferredCommand& deferredCommand)
         {
-            return this->DispatchCommand(deferredCommand.m_command, deferredCommand.m_arguments, deferredCommand.m_silentMode,
+            return this->DispatchCommand(deferredCommand.m_command,
+                ConsoleCommandContainer(AZStd::from_range, deferredCommand.m_arguments), deferredCommand.m_silentMode,
                 deferredCommand.m_invokedFrom, deferredCommand.m_requiredSet, deferredCommand.m_requiredClear);
         };
         // Attempt to invoke the deferred command and remove it from the queue if successful

--- a/Code/Framework/AzCore/AzCore/EBus/Internal/StoragePolicies.h
+++ b/Code/Framework/AzCore/AzCore/EBus/Internal/StoragePolicies.h
@@ -38,7 +38,7 @@ namespace AZ
             struct hash_table_traits
             {
                 using key_type = IdType;
-                using key_eq = AZStd::equal_to<key_type>;
+                using key_equal = AZStd::equal_to<key_type>;
                 using value_type = HandlerStorage;
                 using allocator_type = typename Traits::AllocatorType;
                 enum
@@ -68,7 +68,7 @@ namespace AZ
                 using base_type = AZStd::hash_table<hash_table_traits>;
 
                 StorageType()
-                    : base_type(typename base_type::hasher(), typename base_type::key_eq(), typename base_type::allocator_type())
+                    : base_type(typename base_type::hasher(), typename base_type::key_equal(), typename base_type::allocator_type())
                 { }
 
                 // EBus extension: Assert on insert
@@ -101,7 +101,7 @@ namespace AZ
             struct rbtree_traits
             {
                 using key_type = IdType;
-                using key_eq = typename Traits::BusIdOrderCompare;
+                using key_equal = typename Traits::BusIdOrderCompare;
                 using value_type = HandlerStorage;
                 using allocator_type = typename Traits::AllocatorType;
                 static const key_type& key_from_value(const value_type& value) { return value.m_busId; }

--- a/Code/Framework/AzCore/AzCore/Memory/BestFitExternalMapSchema.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/BestFitExternalMapSchema.cpp
@@ -23,7 +23,7 @@ namespace AZ
               AZStdIAllocator(desc.m_mapAllocator != nullptr ? desc.m_mapAllocator : &AllocatorInstance<SystemAllocator>::Get()))
         , m_allocChunksMap(
               AllocMapType::hasher(),
-              AllocMapType::key_eq(),
+              AllocMapType::key_equal(),
               AZStdIAllocator(desc.m_mapAllocator != nullptr ? desc.m_mapAllocator : &AllocatorInstance<SystemAllocator>::Get()))
     {
         if (m_desc.m_mapAllocator == nullptr)

--- a/Code/Framework/AzCore/AzCore/Module/Environment.cpp
+++ b/Code/Framework/AzCore/AzCore/Module/Environment.cpp
@@ -124,7 +124,7 @@ namespace AZ
             static EnvironmentInterface* Get();
 
             EnvironmentImpl(Environment::AllocatorInterface* allocator)
-                : m_variableMap(MapType::hasher(), MapType::key_eq(), OSStdAllocator(allocator))
+                : m_variableMap(MapType::hasher(), MapType::key_equal(), OSStdAllocator(allocator))
                 , m_numAttached(0)
                 , m_fallback(nullptr)
                 , m_allocator(allocator)

--- a/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
+++ b/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
@@ -52,6 +52,7 @@ set(FILES
     ranges/ranges_adaptor.h
     ranges/ranges_algorithm.h
     ranges/ranges_functional.h
+    ranges/ranges_to.h
     ranges/ref_view.h
     ranges/reverse_view.h
     ranges/single_view.h

--- a/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
+++ b/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
@@ -32,6 +32,7 @@ set(FILES
     hash.cpp
     hash.h
     hash_table.h
+    iterator/common_iterator.h
     iterator/iterator_primitives.h
     iterator.h
     limits.h
@@ -77,6 +78,7 @@ set(FILES
     containers/bitset.h
     containers/compressed_pair.h
     containers/compressed_pair.inl
+    containers/containers_concepts.h
     containers/deque.h
     containers/fixed_forward_list.h
     containers/fixed_list.h

--- a/Code/Framework/AzCore/AzCore/std/concepts/concepts.h
+++ b/Code/Framework/AzCore/AzCore/std/concepts/concepts.h
@@ -572,6 +572,121 @@ namespace AZStd
 
 namespace AZStd::Internal
 {
+    // cpp17 iterator concepts
+    // https://eel.is/c++draft/iterator.traits#2
+    template<class I, class = void>
+    constexpr bool cpp17_iterator_impl = false;
+    template<class I>
+    constexpr bool cpp17_iterator_impl<I, enable_if_t<conjunction_v<
+        bool_constant<can_reference<decltype(*declval<I&>())>>,
+        bool_constant<same_as<decltype(++declval<I&>()), I&>>,
+        bool_constant<can_reference<decltype(*declval<I&>()++)>>,
+        bool_constant<copyable<I>>
+        >>> = true;
+}
+
+namespace AZStd
+{
+    // cpp17-iterator concept
+    template<class I>
+    /*concept*/ constexpr bool cpp17_iterator = Internal::cpp17_iterator_impl<I>;
+}
+
+namespace AZStd::Internal
+{
+    template<class I, class = void>
+    constexpr bool cpp17_input_iterator_impl = false;
+    template<class I>
+    constexpr bool cpp17_input_iterator_impl<I, enable_if_t<conjunction_v<
+        bool_constant<cpp17_iterator<I>>,
+        bool_constant<equality_comparable<I>>,
+        sfinae_trigger<typename incrementable_traits<I>::difference_type>,
+        sfinae_trigger<typename indirectly_readable_traits<I>::value_type>,
+        sfinae_trigger<typename incrementable_traits<I>::difference_type>,
+        sfinae_trigger<typename common_reference_t<iter_reference_t<I>&&,
+            typename indirectly_readable_traits<I>::value_type&>>,
+        sfinae_trigger<typename common_reference_t<decltype(*declval<I&>()++)&&,
+            typename indirectly_readable_traits<I>::value_type&>>,
+        bool_constant<signed_integral<typename incrementable_traits<I>::difference_type>>
+        >>> = true;
+}
+
+namespace AZStd
+{
+    // cpp17-input-iterator concept
+    template<class I>
+    /*concept*/ constexpr bool cpp17_input_iterator = Internal::cpp17_input_iterator_impl<I>;
+}
+
+namespace AZStd::Internal
+{
+    template<class I, class = void>
+    constexpr bool cpp17_forward_iterator_impl = false;
+    template<class I>
+    constexpr bool cpp17_forward_iterator_impl<I, enable_if_t<conjunction_v<
+        bool_constant<cpp17_input_iterator<I>>,
+        bool_constant<constructible_from<I>>,
+        bool_constant<is_lvalue_reference_v<iter_reference_t<I>>>,
+        bool_constant<same_as<remove_cvref_t<iter_reference_t<I>>, typename indirectly_readable_traits<I>::value_type>>,
+        bool_constant<convertible_to<decltype(declval<I&>()++), const I&>>,
+        bool_constant<same_as<decltype(*declval<I&>()++), iter_reference_t<I>>>
+        >>> = true;
+}
+
+namespace AZStd
+{
+    // cpp17-forward-iterator concept
+    template<class I>
+    /*concept*/ constexpr bool cpp17_forward_iterator = Internal::cpp17_forward_iterator_impl<I>;
+}
+
+namespace AZStd::Internal
+{
+    template<class I, class = void>
+    constexpr bool cpp17_bidirectional_iterator_impl = false;
+    template<class I>
+    constexpr bool cpp17_bidirectional_iterator_impl<I, enable_if_t<conjunction_v<
+        bool_constant<cpp17_forward_iterator<I>>,
+        bool_constant<same_as<decltype(--declval<I&>()), I&>>,
+        bool_constant<convertible_to<decltype(declval<I&>()--), const I&>>,
+        bool_constant<same_as<decltype(*declval<I&>()--), iter_reference_t<I>>>
+        >>> = true;
+}
+
+namespace AZStd
+{
+    // cpp17-bidirectional-iterator concept
+    template<class I>
+    /*concept*/ constexpr bool cpp17_bidirectional_iterator = Internal::cpp17_bidirectional_iterator_impl<I>;
+}
+
+namespace AZStd::Internal
+{
+    template<class I, class = void>
+    constexpr bool cpp17_random_access_iterator_impl = false;
+    template<class I>
+    constexpr bool cpp17_random_access_iterator_impl<I, enable_if_t<conjunction_v<
+        bool_constant<cpp17_bidirectional_iterator<I>>,
+        bool_constant<totally_ordered<I>>,
+        bool_constant<same_as<decltype(declval<I&>() += declval<typename incrementable_traits<I>::difference_type>()), I&>>,
+        bool_constant<same_as<decltype(declval<I&>() -= declval<typename incrementable_traits<I>::difference_type>()), I&>>,
+        bool_constant<same_as<decltype(declval<I>() + declval<typename incrementable_traits<I>::difference_type>()), I>>,
+        bool_constant<same_as<decltype(declval<typename incrementable_traits<I>::difference_type>() + declval<I>()), I>>,
+        bool_constant<same_as<decltype(declval<I>() - declval<typename incrementable_traits<I>::difference_type>()), I>>,
+        bool_constant<same_as<decltype(declval<I>() - declval<I>()), typename incrementable_traits<I>::difference_type>>,
+        bool_constant<same_as<decltype(declval<I&>()[declval<typename incrementable_traits<I>::difference_type>()]), iter_reference_t<I>>>
+        >>> = true;
+}
+
+namespace AZStd
+{
+    // cpp17-random_access-iterator concept
+    template<class I>
+    /*concept*/ constexpr bool cpp17_random_access_iterator = Internal::cpp17_random_access_iterator_impl<I>;
+}
+
+namespace AZStd::Internal
+{
     // models the predicate concept
     template <bool, class F, class... Args>
     constexpr bool predicate_impl = false;

--- a/Code/Framework/AzCore/AzCore/std/containers/containers_concepts.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/containers_concepts.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/ranges/ranges.h>
+
+namespace AZStd::Internal
+{
+    // Exposition only concept for determining if the reference type being stored in a range
+    // is convertible to T
+    // https://eel.is/c++draft/container.requirements#container.alloc.reqmts-3
+    template<class R, class T, class = void>
+    /*concept*/ constexpr bool container_compatible_range = false;
+
+    template<class R, class T>
+    constexpr bool container_compatible_range<R, T,
+        enable_if_t<ranges::input_range<R> && convertible_to<conditional_t<
+        is_lvalue_reference_v<R>, ranges::range_reference_t<R>, ranges::range_rvalue_reference_t<R>>, T>>
+        > = true;
+}

--- a/Code/Framework/AzCore/AzCore/std/containers/node_handle.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/node_handle.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AzCore/std/allocator_traits.h>
+#include <AzCore/std/ranges/ranges.h>
 #include <AzCore/std/iterator.h>
 #include <AzCore/std/optional.h>
 #include <AzCore/std/utils.h>
@@ -201,18 +202,29 @@ namespace AZStd
     {
         // deduction guide helpers
         template<class InputIterator>
-        using iter_value_type = typename iterator_traits<InputIterator>::value_type::second_type;
+        using iter_value_type = typename iter_value_t<InputIterator>::second_type;
 
         template<class InputIterator>
-        using iter_key_type = remove_const_t<typename iterator_traits<InputIterator>::value_type::first_type>;
+        using iter_key_type = remove_const_t<typename iter_value_t<InputIterator>::first_type>;
 
         template<class InputIterator>
-        using iter_mapped_type = typename iterator_traits<InputIterator>::value_type::second_type;
+        using iter_mapped_type = typename iter_value_t<InputIterator>::second_type;
 
         template<class InputIterator>
         using iter_to_alloc_type = pair<
-            add_const_t<typename iterator_traits<InputIterator>::value_type::first_type>,
-            typename iterator_traits<InputIterator>::value_type::second_type
+            add_const_t<typename iter_value_t<InputIterator>::first_type>,
+            typename iter_value_t<InputIterator>::second_type
+        >;
+
+        // range deduction guide helpers
+        template<class Range, class = enable_if_t<ranges::input_range<Range>>>
+        using range_key_type = remove_const_t<typename ranges::range_value_t<Range>::first_type>;
+        template<class Range, class = enable_if_t<ranges::input_range<Range>>>
+        using range_mapped_type = typename ranges::range_value_t<Range>::second_type;
+        template<class Range, class = enable_if_t<ranges::input_range<Range>>>
+        using range_to_alloc_type = pair<
+            add_const_t<typename ranges::range_value_t<Range>::first_type>,
+            typename ranges::range_value_t<Range>::second_type
         >;
     }
 }

--- a/Code/Framework/AzCore/AzCore/std/containers/rbtree.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/rbtree.h
@@ -302,7 +302,7 @@ namespace AZStd
      *
      * Traits should have the following members
      * typedef xxx  key_type;
-     * typedef xxx  key_eq;
+     * typedef xxx  key_equal;
      * typedef xxx  value_type;
      * typedef xxx  allocator_type;
      * enum
@@ -328,7 +328,7 @@ namespace AZStd
         typedef Traits                          traits_type;
 
         typedef typename Traits::key_type       key_type;
-        typedef typename Traits::key_eq         key_eq;
+        typedef typename Traits::key_equal         key_equal;
         typedef typename Traits::allocator_type allocator_type;
         typedef typename allocator_type::size_type size_type;
         typedef typename allocator_type::difference_type difference_type;
@@ -364,7 +364,7 @@ namespace AZStd
     public:
         AZ_FORCE_INLINE rbtree()
             : m_numElements(0)
-            , m_keyEq(key_eq())
+            , m_keyEq(key_equal())
             , m_allocator(allocator_type())
         {
             m_head.set_color(AZSTD_RBTREE_RED); // used to distinguish header from root, in iterator.operator++
@@ -372,7 +372,7 @@ namespace AZStd
             m_head.m_left = &m_head;
             m_head.m_right = &m_head;
         }
-        explicit rbtree(const key_eq& keyEq)
+        explicit rbtree(const key_equal& keyEq)
             : m_numElements(0)
             , m_keyEq(keyEq)
             , m_allocator(allocator_type())
@@ -392,7 +392,7 @@ namespace AZStd
             m_head.m_left = &m_head;
             m_head.m_right = &m_head;
         }
-        AZ_FORCE_INLINE rbtree(const key_eq& keyEq, const allocator_type& allocator)
+        AZ_FORCE_INLINE rbtree(const key_equal& keyEq, const allocator_type& allocator)
             : m_numElements(0)
             , m_keyEq(keyEq)
             , m_allocator(allocator)
@@ -470,7 +470,7 @@ namespace AZStd
         }
 
         // accessors:
-        AZ_FORCE_INLINE key_eq  key_comp() const                { return m_keyEq; }
+        AZ_FORCE_INLINE key_equal  key_comp() const                { return m_keyEq; }
 
         AZ_FORCE_INLINE iterator begin()                        { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, m_head.m_left)); }
         AZ_FORCE_INLINE const_iterator begin() const            { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, m_head.m_left)); }
@@ -875,7 +875,7 @@ namespace AZStd
 
         template<class ComparableToKey>
         auto find(const ComparableToKey& key)
-            -> enable_if_t<Internal::is_transparent<key_eq, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, iterator>
+            -> enable_if_t<Internal::is_transparent<key_equal, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, iterator>
         {
             base_node_ptr_type y = &m_head;
             base_node_ptr_type x = m_head.get_parent();
@@ -904,21 +904,21 @@ namespace AZStd
 
         template<class ComparableToKey>
         auto find(const ComparableToKey& key) const
-            -> enable_if_t<Internal::is_transparent<key_eq, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, const_iterator>
+            -> enable_if_t<Internal::is_transparent<key_equal, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, const_iterator>
         {
             return const_iterator(const_cast<rbtree*>(this)->find(key));
         }
 
         template<class ComparableToKey>
         auto contains(const ComparableToKey& key) const
-            -> enable_if_t<Internal::is_transparent<key_eq, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, bool>
+            -> enable_if_t<Internal::is_transparent<key_equal, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, bool>
         {
             return find(key) != end();
         }
 
         template<class ComparableToKey>
         auto lower_bound(const ComparableToKey& key)
-            -> enable_if_t<Internal::is_transparent<key_eq, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, iterator>
+            -> enable_if_t<Internal::is_transparent<key_equal, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, iterator>
         {
             base_node_ptr_type y = &m_head;
             base_node_ptr_type x = m_head.get_parent();
@@ -940,14 +940,14 @@ namespace AZStd
 
         template<class ComparableToKey>
         auto lower_bound(const ComparableToKey& key) const
-            -> enable_if_t<Internal::is_transparent<key_eq, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, const_iterator>
+            -> enable_if_t<Internal::is_transparent<key_equal, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, const_iterator>
         {
             return const_iterator(const_cast<rbtree*>(this)->lower_bound(key));
         }
 
         template<class ComparableToKey>
         auto upper_bound(const ComparableToKey& key)
-            -> enable_if_t<Internal::is_transparent<key_eq, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, iterator>
+            -> enable_if_t<Internal::is_transparent<key_equal, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, iterator>
         {
             base_node_ptr_type y = &m_head;
             base_node_ptr_type x = m_head.get_parent();
@@ -969,14 +969,14 @@ namespace AZStd
 
         template<class ComparableToKey>
         auto upper_bound(const ComparableToKey& key) const
-            -> enable_if_t<Internal::is_transparent<key_eq, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, const_iterator>
+            -> enable_if_t<Internal::is_transparent<key_equal, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, const_iterator>
         {
             return const_iterator(const_cast<rbtree*>(this)->upper_bound(key));
         }
 
         template<class ComparableToKey>
         auto count(const ComparableToKey& key) const
-            -> enable_if_t<Internal::is_transparent<key_eq, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, size_type>
+            -> enable_if_t<Internal::is_transparent<key_equal, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, size_type>
         {
             AZStd::pair<const_iterator, const_iterator> p = equal_range(key);
             return AZStd::distance(p.first, p.second);
@@ -984,20 +984,20 @@ namespace AZStd
 
         template<class ComparableToKey>
         auto equal_range(const ComparableToKey& key)
-            -> enable_if_t<Internal::is_transparent<key_eq, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, AZStd::pair<iterator, iterator>>
+            -> enable_if_t<Internal::is_transparent<key_equal, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, AZStd::pair<iterator, iterator>>
         {
             return { lower_bound(key), upper_bound(key) };
         }
         template<class ComparableToKey>
         auto equal_range(const ComparableToKey& key) const
-            -> enable_if_t<Internal::is_transparent<key_eq, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, AZStd::pair<const_iterator, const_iterator>>
+            -> enable_if_t<Internal::is_transparent<key_equal, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, AZStd::pair<const_iterator, const_iterator>>
         {
             return { lower_bound(key), upper_bound(key) };
         }
 
         template<class ComparableToKey>
         auto equal_range_unique(const ComparableToKey& key)
-            -> enable_if_t<Internal::is_transparent<key_eq, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, AZStd::pair<iterator, iterator>>
+            -> enable_if_t<Internal::is_transparent<key_equal, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, AZStd::pair<iterator, iterator>>
         {
             AZStd::pair<iterator, iterator> p;
             p.second = lower_bound(key);
@@ -1014,7 +1014,7 @@ namespace AZStd
         }
         template<class ComparableToKey>
         auto equal_range_unique(const ComparableToKey& key) const
-            -> enable_if_t<Internal::is_transparent<key_eq, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, AZStd::pair<const_iterator, const_iterator>>
+            -> enable_if_t<Internal::is_transparent<key_equal, ComparableToKey>::value || AZStd::is_convertible_v<ComparableToKey, key_type>, AZStd::pair<const_iterator, const_iterator>>
         {
             AZStd::pair<iterator, iterator> non_const_range(const_cast<rbtree*>(this)->equal_range_unique(key));
             return { const_iterator(non_const_range.first), const_iterator(non_const_range.second) };
@@ -1942,7 +1942,7 @@ namespace AZStd
 
         Internal::rbtree_node_base  m_head;
         size_type                   m_numElements;
-        key_eq                      m_keyEq;
+        key_equal                      m_keyEq;
         allocator_type              m_allocator;
 
         // Debug
@@ -2005,7 +2005,7 @@ namespace AZStd
             result.node = AZStd::move(nodeHandle);
         }
         nodeHandle.release_node();
-        
+
         return result;
     }
 

--- a/Code/Framework/AzCore/AzCore/std/iterator.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator.h
@@ -136,7 +136,7 @@ namespace AZStd
     // to work with the range algorithms which require a weakly_incrementable iterator
     // the difference_type type alias must not be void as it is in C++17
     // https://en.cppreference.com/w/cpp/iterator/back_insert_iterator
-    // This is being workaround by specializing AZStd::iterator_traits for these types
+    // We workaround this by specializing AZStd::iterator_traits for these types
     // to provide a difference_type type alias
     template<class Container>
     struct iterator_traits<back_insert_iterator<Container>>

--- a/Code/Framework/AzCore/AzCore/std/iterator.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator.h
@@ -131,6 +131,32 @@ namespace AZStd
     using std::insert_iterator;
     using std::inserter;
 
+#if !defined(__cpp_lib_concepts)
+    // In order for pre C++20 back_inserter_iterator, front_inseter_iterator and insert_iterator
+    // to work with the range algorithms which require a weakly_incrementable iterator
+    // the difference_type type alias must not be void as it is in C++17
+    // https://en.cppreference.com/w/cpp/iterator/back_insert_iterator
+    // This is being workaround by specializing AZStd::iterator_traits for these types
+    // to provide a difference_type type alias
+    template<class Container>
+    struct iterator_traits<back_insert_iterator<Container>>
+    {
+        using difference_type = ptrdiff_t;
+    };
+
+    template<class Container>
+    struct iterator_traits<front_insert_iterator<Container>>
+    {
+        using difference_type = ptrdiff_t;
+    };
+    template<class Container>
+    struct iterator_traits<insert_iterator<Container>>
+    {
+        using difference_type = ptrdiff_t;
+    };
+
+#endif
+
     enum iterator_status_flag
     {
         isf_none = 0x00,     ///< Iterator is invalid.

--- a/Code/Framework/AzCore/AzCore/std/parallel/containers/concurrent_fixed_unordered_map.h
+++ b/Code/Framework/AzCore/AzCore/std/parallel/containers/concurrent_fixed_unordered_map.h
@@ -18,7 +18,7 @@ namespace AZStd
         struct ConcurrentUnorderedFixedMapTableTraits
         {
             typedef Key                             key_type;
-            typedef EqualKey                        key_eq;
+            typedef EqualKey                        key_equal;
             typedef Hasher                          hasher;
             typedef AZStd::pair<Key, MappedType>     value_type;
             typedef AZStd::no_default_allocator     allocator_type;
@@ -51,7 +51,7 @@ namespace AZStd
         typedef Internal::concurrent_hash_table< Internal::ConcurrentUnorderedFixedMapTableTraits<Key, MappedType, Hasher, EqualKey, false, FixedNumBuckets, FixedNumElements, NumLocks> > base_type;
     public:
         typedef typename base_type::key_type    key_type;
-        typedef typename base_type::key_eq      key_eq;
+        typedef typename base_type::key_equal   key_equal;
         typedef typename base_type::hasher      hasher;
         typedef MappedType                      mapped_type;
 
@@ -66,12 +66,12 @@ namespace AZStd
         typedef typename base_type::value_type                  value_type;
 
         AZ_FORCE_INLINE concurrent_fixed_unordered_map()
-            : base_type(hasher(), key_eq()) {}
-        AZ_FORCE_INLINE concurrent_fixed_unordered_map(const hasher& hash, const key_eq& keyEqual)
+            : base_type(hasher(), key_equal()) {}
+        AZ_FORCE_INLINE concurrent_fixed_unordered_map(const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual) {}
         template<class Iterator>
         AZ_FORCE_INLINE concurrent_fixed_unordered_map(Iterator first, Iterator last)
-            : base_type(hasher(), key_eq())
+            : base_type(hasher(), key_equal())
         {
             for (; first != last; ++first)
             {
@@ -79,7 +79,7 @@ namespace AZStd
             }
         }
         template<class Iterator>
-        AZ_FORCE_INLINE concurrent_fixed_unordered_map(Iterator first, Iterator last, const hasher& hash, const key_eq& keyEqual)
+        AZ_FORCE_INLINE concurrent_fixed_unordered_map(Iterator first, Iterator last, const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual, allocator_type())
         {
             for (; first != last; ++first)
@@ -128,7 +128,7 @@ namespace AZStd
         typedef Internal::concurrent_hash_table< Internal::ConcurrentUnorderedFixedMapTableTraits<Key, MappedType, Hasher, EqualKey, true, FixedNumBuckets, FixedNumElements, NumLocks> > base_type;
     public:
         typedef typename base_type::key_type    key_type;
-        typedef typename base_type::key_eq      key_eq;
+        typedef typename base_type::key_equal   key_equal;
         typedef typename base_type::hasher      hasher;
         typedef MappedType                      mapped_type;
 
@@ -143,12 +143,12 @@ namespace AZStd
         typedef typename base_type::value_type                  value_type;
 
         AZ_FORCE_INLINE concurrent_fixed_unordered_multimap()
-            : base_type(hasher(), key_eq()) {}
-        AZ_FORCE_INLINE concurrent_fixed_unordered_multimap(const hasher& hash, const key_eq& keyEqual)
+            : base_type(hasher(), key_equal()) {}
+        AZ_FORCE_INLINE concurrent_fixed_unordered_multimap(const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual) {}
         template<class Iterator>
         AZ_FORCE_INLINE concurrent_fixed_unordered_multimap(Iterator first, Iterator last)
-            : base_type(hasher(), key_eq())
+            : base_type(hasher(), key_equal())
         {
             for (; first != last; ++first)
             {
@@ -156,7 +156,7 @@ namespace AZStd
             }
         }
         template<class Iterator>
-        AZ_FORCE_INLINE concurrent_fixed_unordered_multimap(Iterator first, Iterator last, const hasher& hash, const key_eq& keyEqual)
+        AZ_FORCE_INLINE concurrent_fixed_unordered_multimap(Iterator first, Iterator last, const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual)
         {
             for (; first != last; ++first)

--- a/Code/Framework/AzCore/AzCore/std/parallel/containers/concurrent_fixed_unordered_set.h
+++ b/Code/Framework/AzCore/AzCore/std/parallel/containers/concurrent_fixed_unordered_set.h
@@ -18,7 +18,7 @@ namespace AZStd
         struct ConcurrentUnorderedFixedSetTableTraits
         {
             typedef Key         key_type;
-            typedef EqualKey    key_eq;
+            typedef EqualKey    key_equal;
             typedef Hasher      hasher;
             typedef Key         value_type;
             typedef AZStd::no_default_allocator allocator_type;
@@ -51,7 +51,7 @@ namespace AZStd
         typedef Internal::concurrent_hash_table< Internal::ConcurrentUnorderedFixedSetTableTraits<Key, Hasher, EqualKey, false, FixedNumBuckets, FixedNumElements, NumLocks> > base_type;
     public:
         typedef typename base_type::key_type    key_type;
-        typedef typename base_type::key_eq      key_eq;
+        typedef typename base_type::key_equal   key_equal;
         typedef typename base_type::hasher      hasher;
 
         typedef typename base_type::allocator_type              allocator_type;
@@ -65,13 +65,13 @@ namespace AZStd
         typedef typename base_type::value_type                  value_type;
 
         AZ_FORCE_INLINE concurrent_fixed_unordered_set()
-            : base_type(hasher(), key_eq()) {}
-        AZ_FORCE_INLINE concurrent_fixed_unordered_set(const hasher& hash, const key_eq& keyEqual)
+            : base_type(hasher(), key_equal()) {}
+        AZ_FORCE_INLINE concurrent_fixed_unordered_set(const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual)
         {}
         template<class Iterator>
         AZ_FORCE_INLINE concurrent_fixed_unordered_set(Iterator first, Iterator last)
-            : base_type(hasher(), key_eq())
+            : base_type(hasher(), key_equal())
         {
             for (; first != last; ++first)
             {
@@ -79,7 +79,7 @@ namespace AZStd
             }
         }
         template<class Iterator>
-        AZ_FORCE_INLINE concurrent_fixed_unordered_set(Iterator first, Iterator last, const hasher& hash, const key_eq& keyEqual)
+        AZ_FORCE_INLINE concurrent_fixed_unordered_set(Iterator first, Iterator last, const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual)
         {
             for (; first != last; ++first)
@@ -112,7 +112,7 @@ namespace AZStd
         typedef Internal::concurrent_hash_table< Internal::ConcurrentUnorderedFixedSetTableTraits<Key, Hasher, EqualKey, true, FixedNumBuckets, FixedNumElements, NumLocks> > base_type;
     public:
         typedef typename base_type::key_type    key_type;
-        typedef typename base_type::key_eq      key_eq;
+        typedef typename base_type::key_equal   key_equal;
         typedef typename base_type::hasher      hasher;
 
         typedef typename base_type::allocator_type              allocator_type;
@@ -126,13 +126,13 @@ namespace AZStd
         typedef typename base_type::value_type                  value_type;
 
         AZ_FORCE_INLINE concurrent_fixed_unordered_multiset()
-            : base_type(hasher(), key_eq()) {}
-        AZ_FORCE_INLINE concurrent_fixed_unordered_multiset(const hasher& hash, const key_eq& keyEqual)
+            : base_type(hasher(), key_equal()) {}
+        AZ_FORCE_INLINE concurrent_fixed_unordered_multiset(const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual)
         {}
         template<class Iterator>
         AZ_FORCE_INLINE concurrent_fixed_unordered_multiset(Iterator first, Iterator last)
-            : base_type(hasher(), key_eq())
+            : base_type(hasher(), key_equal())
         {
             for (; first != last; ++first)
             {
@@ -140,7 +140,7 @@ namespace AZStd
             }
         }
         template<class Iterator>
-        AZ_FORCE_INLINE concurrent_fixed_unordered_multiset(Iterator first, Iterator last, const hasher& hash, const key_eq& keyEqual)
+        AZ_FORCE_INLINE concurrent_fixed_unordered_multiset(Iterator first, Iterator last, const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual)
         {
             for (; first != last; ++first)

--- a/Code/Framework/AzCore/AzCore/std/parallel/containers/concurrent_unordered_map.h
+++ b/Code/Framework/AzCore/AzCore/std/parallel/containers/concurrent_unordered_map.h
@@ -18,7 +18,7 @@ namespace AZStd
         struct ConcurrentUnorderedMapTableTraits
         {
             typedef Key                             key_type;
-            typedef EqualKey                        key_eq;
+            typedef EqualKey                        key_equal;
             typedef Hasher                          hasher;
             typedef AZStd::pair<Key, MappedType>     value_type;
             typedef Allocator                       allocator_type;
@@ -51,7 +51,7 @@ namespace AZStd
         typedef Internal::concurrent_hash_table< Internal::ConcurrentUnorderedMapTableTraits<Key, MappedType, Hasher, EqualKey, Allocator, false, NumLocks> > base_type;
     public:
         typedef typename base_type::key_type    key_type;
-        typedef typename base_type::key_eq      key_eq;
+        typedef typename base_type::key_equal   key_equal;
         typedef typename base_type::hasher      hasher;
         typedef MappedType                      mapped_type;
 
@@ -66,27 +66,27 @@ namespace AZStd
         typedef typename base_type::value_type                  value_type;
 
         AZ_FORCE_INLINE concurrent_unordered_map()
-            : base_type(hasher(), key_eq(), allocator_type()) {}
-        AZ_FORCE_INLINE concurrent_unordered_map(const hasher& hash, const key_eq& keyEqual, const allocator_type& allocator)
+            : base_type(hasher(), key_equal(), allocator_type()) {}
+        AZ_FORCE_INLINE concurrent_unordered_map(const hasher& hash, const key_equal& keyEqual, const allocator_type& allocator)
             : base_type(hash, keyEqual, allocator) {}
         AZ_FORCE_INLINE concurrent_unordered_map(size_type numBucketsHint)
-            : base_type(hasher(), key_eq(), allocator_type())
+            : base_type(hasher(), key_equal(), allocator_type())
         {
             rehash(numBucketsHint);
         }
-        AZ_FORCE_INLINE concurrent_unordered_map(size_type numBucketsHint, const hasher& hash, const key_eq& keyEqual)
+        AZ_FORCE_INLINE concurrent_unordered_map(size_type numBucketsHint, const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual, allocator_type())
         {
             rehash(numBucketsHint);
         }
-        AZ_FORCE_INLINE concurrent_unordered_map(size_type numBucketsHint, const hasher& hash, const key_eq& keyEqual, const allocator_type& allocator)
+        AZ_FORCE_INLINE concurrent_unordered_map(size_type numBucketsHint, const hasher& hash, const key_equal& keyEqual, const allocator_type& allocator)
             : base_type(hash, keyEqual, allocator)
         {
             rehash(numBucketsHint);
         }
         template<class Iterator>
         AZ_FORCE_INLINE concurrent_unordered_map(Iterator first, Iterator last)
-            : base_type(hasher(), key_eq(), allocator_type())
+            : base_type(hasher(), key_equal(), allocator_type())
         {
             for (; first != last; ++first)
             {
@@ -95,7 +95,7 @@ namespace AZStd
         }
         template<class Iterator>
         AZ_FORCE_INLINE concurrent_unordered_map(Iterator first, Iterator last, size_type numBucketsHint)
-            : base_type(hasher(), key_eq(), allocator_type())
+            : base_type(hasher(), key_equal(), allocator_type())
         {
             rehash(numBucketsHint);
             for (; first != last; ++first)
@@ -104,7 +104,7 @@ namespace AZStd
             }
         }
         template<class Iterator>
-        AZ_FORCE_INLINE concurrent_unordered_map(Iterator first, Iterator last, size_type numBucketsHint, const hasher& hash, const key_eq& keyEqual)
+        AZ_FORCE_INLINE concurrent_unordered_map(Iterator first, Iterator last, size_type numBucketsHint, const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual, allocator_type())
         {
             rehash(numBucketsHint);
@@ -114,7 +114,7 @@ namespace AZStd
             }
         }
         template<class Iterator>
-        AZ_FORCE_INLINE concurrent_unordered_map(Iterator first, Iterator last, size_type numBucketsHint, const hasher& hash, const key_eq& keyEqual, const allocator_type& allocator)
+        AZ_FORCE_INLINE concurrent_unordered_map(Iterator first, Iterator last, size_type numBucketsHint, const hasher& hash, const key_equal& keyEqual, const allocator_type& allocator)
             : base_type(hash, keyEqual, allocator)
         {
             rehash(numBucketsHint);
@@ -164,7 +164,7 @@ namespace AZStd
         typedef Internal::concurrent_hash_table< Internal::ConcurrentUnorderedMapTableTraits<Key, MappedType, Hasher, EqualKey, Allocator, true, NumLocks> > base_type;
     public:
         typedef typename base_type::key_type    key_type;
-        typedef typename base_type::key_eq      key_eq;
+        typedef typename base_type::key_equal   key_equal;
         typedef typename base_type::hasher      hasher;
         typedef MappedType                      mapped_type;
 
@@ -179,27 +179,27 @@ namespace AZStd
         typedef typename base_type::value_type                  value_type;
 
         AZ_FORCE_INLINE concurrent_unordered_multimap()
-            : base_type(hasher(), key_eq(), allocator_type()) {}
-        AZ_FORCE_INLINE concurrent_unordered_multimap(const hasher& hash, const key_eq& keyEqual, const allocator_type& allocator)
+            : base_type(hasher(), key_equal(), allocator_type()) {}
+        AZ_FORCE_INLINE concurrent_unordered_multimap(const hasher& hash, const key_equal& keyEqual, const allocator_type& allocator)
             : base_type(hash, keyEqual, allocator) {}
         AZ_FORCE_INLINE concurrent_unordered_multimap(size_type numBuckets)
-            : base_type(hasher(), key_eq(), allocator_type())
+            : base_type(hasher(), key_equal(), allocator_type())
         {
             rehash(numBuckets);
         }
-        AZ_FORCE_INLINE concurrent_unordered_multimap(size_type numBuckets, const hasher& hash, const key_eq& keyEqual)
+        AZ_FORCE_INLINE concurrent_unordered_multimap(size_type numBuckets, const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual, allocator_type())
         {
             rehash(numBuckets);
         }
-        AZ_FORCE_INLINE concurrent_unordered_multimap(size_type numBuckets, const hasher& hash, const key_eq& keyEqual, const allocator_type& allocator)
+        AZ_FORCE_INLINE concurrent_unordered_multimap(size_type numBuckets, const hasher& hash, const key_equal& keyEqual, const allocator_type& allocator)
             : base_type(hash, keyEqual, allocator)
         {
             rehash(numBuckets);
         }
         template<class Iterator>
         AZ_FORCE_INLINE concurrent_unordered_multimap(Iterator first, Iterator last)
-            : base_type(hasher(), key_eq(), allocator_type())
+            : base_type(hasher(), key_equal(), allocator_type())
         {
             for (; first != last; ++first)
             {
@@ -208,7 +208,7 @@ namespace AZStd
         }
         template<class Iterator>
         AZ_FORCE_INLINE concurrent_unordered_multimap(Iterator first, Iterator last, size_type numBuckets)
-            : base_type(hasher(), key_eq(), allocator_type())
+            : base_type(hasher(), key_equal(), allocator_type())
         {
             rehash(numBuckets);
             for (; first != last; ++first)
@@ -217,7 +217,7 @@ namespace AZStd
             }
         }
         template<class Iterator>
-        AZ_FORCE_INLINE concurrent_unordered_multimap(Iterator first, Iterator last, size_type numBuckets, const hasher& hash, const key_eq& keyEqual)
+        AZ_FORCE_INLINE concurrent_unordered_multimap(Iterator first, Iterator last, size_type numBuckets, const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual, allocator_type())
         {
             rehash(numBuckets);
@@ -227,7 +227,7 @@ namespace AZStd
             }
         }
         template<class Iterator>
-        AZ_FORCE_INLINE concurrent_unordered_multimap(Iterator first, Iterator last, size_type numBuckets, const hasher& hash, const key_eq& keyEqual, const allocator_type& allocator)
+        AZ_FORCE_INLINE concurrent_unordered_multimap(Iterator first, Iterator last, size_type numBuckets, const hasher& hash, const key_equal& keyEqual, const allocator_type& allocator)
             : base_type(hash, keyEqual, allocator)
         {
             rehash(numBuckets);

--- a/Code/Framework/AzCore/AzCore/std/parallel/containers/concurrent_unordered_set.h
+++ b/Code/Framework/AzCore/AzCore/std/parallel/containers/concurrent_unordered_set.h
@@ -18,7 +18,7 @@ namespace AZStd
         struct ConcurrentUnorderedSetTableTraits
         {
             typedef Key         key_type;
-            typedef EqualKey    key_eq;
+            typedef EqualKey    key_equal;
             typedef Hasher      hasher;
             typedef Key         value_type;
             typedef Allocator   allocator_type;
@@ -51,7 +51,7 @@ namespace AZStd
         typedef Internal::concurrent_hash_table< Internal::ConcurrentUnorderedSetTableTraits<Key, Hasher, EqualKey, Allocator, false, NumLocks> > base_type;
     public:
         typedef typename base_type::key_type    key_type;
-        typedef typename base_type::key_eq      key_eq;
+        typedef typename base_type::key_equal   key_equal;
         typedef typename base_type::hasher      hasher;
 
         typedef typename base_type::allocator_type              allocator_type;
@@ -65,25 +65,25 @@ namespace AZStd
         typedef typename base_type::value_type                  value_type;
 
         AZ_FORCE_INLINE concurrent_unordered_set()
-            : base_type(hasher(), key_eq(), allocator_type()) {}
+            : base_type(hasher(), key_equal(), allocator_type()) {}
         AZ_FORCE_INLINE concurrent_unordered_set(size_type numBucketsHint)
-            : base_type(hasher(), key_eq(), allocator_type())
+            : base_type(hasher(), key_equal(), allocator_type())
         {
             rehash(numBucketsHint);
         }
-        AZ_FORCE_INLINE concurrent_unordered_set(size_type numBucketsHint, const hasher& hash, const key_eq& keyEqual)
+        AZ_FORCE_INLINE concurrent_unordered_set(size_type numBucketsHint, const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual, allocator_type())
         {
             rehash(numBucketsHint);
         }
-        AZ_FORCE_INLINE concurrent_unordered_set(size_type numBucketsHint, const hasher& hash, const key_eq& keyEqual, const allocator_type& allocator)
+        AZ_FORCE_INLINE concurrent_unordered_set(size_type numBucketsHint, const hasher& hash, const key_equal& keyEqual, const allocator_type& allocator)
             : base_type(hash, keyEqual, allocator)
         {
             rehash(numBucketsHint);
         }
         template<class Iterator>
         AZ_FORCE_INLINE concurrent_unordered_set(Iterator first, Iterator last)
-            : base_type(hasher(), key_eq(), allocator_type())
+            : base_type(hasher(), key_equal(), allocator_type())
         {
             for (; first != last; ++first)
             {
@@ -92,7 +92,7 @@ namespace AZStd
         }
         template<class Iterator>
         AZ_FORCE_INLINE concurrent_unordered_set(Iterator first, Iterator last, size_type numBucketsHint)
-            : base_type(hasher(), key_eq(), allocator_type())
+            : base_type(hasher(), key_equal(), allocator_type())
         {
             rehash(numBucketsHint);
             for (; first != last; ++first)
@@ -101,7 +101,7 @@ namespace AZStd
             }
         }
         template<class Iterator>
-        AZ_FORCE_INLINE concurrent_unordered_set(Iterator first, Iterator last, size_type numBucketsHint, const hasher& hash, const key_eq& keyEqual)
+        AZ_FORCE_INLINE concurrent_unordered_set(Iterator first, Iterator last, size_type numBucketsHint, const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual, allocator_type())
         {
             rehash(numBucketsHint);
@@ -111,7 +111,7 @@ namespace AZStd
             }
         }
         template<class Iterator>
-        AZ_FORCE_INLINE concurrent_unordered_set(Iterator first, Iterator last, size_type numBucketsHint, const hasher& hash, const key_eq& keyEqual, const allocator_type& allocator)
+        AZ_FORCE_INLINE concurrent_unordered_set(Iterator first, Iterator last, size_type numBucketsHint, const hasher& hash, const key_equal& keyEqual, const allocator_type& allocator)
             : base_type(hash, keyEqual, allocator)
         {
             rehash(numBucketsHint);
@@ -145,7 +145,7 @@ namespace AZStd
         typedef Internal::concurrent_hash_table< Internal::ConcurrentUnorderedSetTableTraits<Key, Hasher, EqualKey, Allocator, true, NumLocks> > base_type;
     public:
         typedef typename base_type::key_type    key_type;
-        typedef typename base_type::key_eq      key_eq;
+        typedef typename base_type::key_equal   key_equal;
         typedef typename base_type::hasher      hasher;
 
         typedef typename base_type::allocator_type              allocator_type;
@@ -159,25 +159,25 @@ namespace AZStd
         typedef typename base_type::value_type                  value_type;
 
         AZ_FORCE_INLINE concurrent_unordered_multiset()
-            : base_type(hasher(), key_eq(), allocator_type()) {}
+            : base_type(hasher(), key_equal(), allocator_type()) {}
         AZ_FORCE_INLINE concurrent_unordered_multiset(size_type numBuckets)
-            : base_type(hasher(), key_eq(), allocator_type())
+            : base_type(hasher(), key_equal(), allocator_type())
         {
             rehash(numBuckets);
         }
-        AZ_FORCE_INLINE concurrent_unordered_multiset(size_type numBuckets, const hasher& hash, const key_eq& keyEqual)
+        AZ_FORCE_INLINE concurrent_unordered_multiset(size_type numBuckets, const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual, allocator_type())
         {
             rehash(numBuckets);
         }
-        AZ_FORCE_INLINE concurrent_unordered_multiset(size_type numBuckets, const hasher& hash, const key_eq& keyEqual, const allocator_type& allocator)
+        AZ_FORCE_INLINE concurrent_unordered_multiset(size_type numBuckets, const hasher& hash, const key_equal& keyEqual, const allocator_type& allocator)
             : base_type(hash, keyEqual, allocator)
         {
             rehash(numBuckets);
         }
         template<class Iterator>
         AZ_FORCE_INLINE concurrent_unordered_multiset(Iterator first, Iterator last)
-            : base_type(hasher(), key_eq(), allocator_type())
+            : base_type(hasher(), key_equal(), allocator_type())
         {
             for (; first != last; ++first)
             {
@@ -186,7 +186,7 @@ namespace AZStd
         }
         template<class Iterator>
         AZ_FORCE_INLINE concurrent_unordered_multiset(Iterator first, Iterator last, size_type numBuckets)
-            : base_type(hasher(), key_eq(), allocator_type())
+            : base_type(hasher(), key_equal(), allocator_type())
         {
             rehash(numBuckets);
             for (; first != last; ++first)
@@ -195,7 +195,7 @@ namespace AZStd
             }
         }
         template<class Iterator>
-        AZ_FORCE_INLINE concurrent_unordered_multiset(Iterator first, Iterator last, size_type numBuckets, const hasher& hash, const key_eq& keyEqual)
+        AZ_FORCE_INLINE concurrent_unordered_multiset(Iterator first, Iterator last, size_type numBuckets, const hasher& hash, const key_equal& keyEqual)
             : base_type(hash, keyEqual, allocator_type())
         {
             rehash(numBuckets);
@@ -205,7 +205,7 @@ namespace AZStd
             }
         }
         template<class Iterator>
-        AZ_FORCE_INLINE concurrent_unordered_multiset(Iterator first, Iterator last, size_type numBuckets, const hasher& hash, const key_eq& keyEqual, const allocator_type& allocator)
+        AZ_FORCE_INLINE concurrent_unordered_multiset(Iterator first, Iterator last, size_type numBuckets, const hasher& hash, const key_equal& keyEqual, const allocator_type& allocator)
             : base_type(hash, keyEqual, allocator)
         {
             rehash(numBuckets);

--- a/Code/Framework/AzCore/AzCore/std/parallel/containers/internal/concurrent_hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/parallel/containers/internal/concurrent_hash_table.h
@@ -220,7 +220,7 @@ namespace AZStd
             friend class Internal::concurrent_hash_table_storage<Traits>;
         public:
             typedef typename Traits::key_type       key_type;
-            typedef typename Traits::key_eq         key_eq;
+            typedef typename Traits::key_equal      key_equal;
             typedef typename Traits::hasher         hasher;
 
             typedef typename Traits::allocator_type                 allocator_type;
@@ -238,7 +238,7 @@ namespace AZStd
             typedef typename storage_type::vector_value_type        vector_value_type;
             typedef typename storage_type::vector_type              vector_type;
 
-            AZ_FORCE_INLINE explicit concurrent_hash_table(const hasher& hash, const key_eq& keyEqual, const allocator_type& alloc = allocator_type())
+            AZ_FORCE_INLINE explicit concurrent_hash_table(const hasher& hash, const key_equal& keyEqual, const allocator_type& alloc = allocator_type())
                 : m_storage(alloc)
                 , m_keyEqual(keyEqual)
                 , m_hasher(hash)
@@ -266,7 +266,7 @@ namespace AZStd
             size_type size() const { return m_numElements.load(memory_order_acquire); }
             bool empty() const     { return (size() == 0); }
 
-            key_eq key_equal() const  { return m_keyEqual; }
+            key_equal key_eq() const  { return m_keyEqual; }
             hasher get_hasher() const { return m_hasher; }
 
             float max_load_factor() const                { return m_storage.max_load_factor(); }
@@ -541,7 +541,7 @@ namespace AZStd
             static_assert((num_locks & (num_locks - 1)) == 0, "must be power of 2");
 
             storage_type m_storage;
-            key_eq m_keyEqual;
+            key_equal m_keyEqual;
             hasher m_hasher;
             atomic<size_type> m_numElements;
             mutex m_locks[num_locks];

--- a/Code/Framework/AzCore/AzCore/std/ranges/ranges.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/ranges.h
@@ -1218,14 +1218,6 @@ namespace AZStd::ranges
 
 namespace AZStd::ranges
 {
-    //! Adding C++23 from_range_t tag type
-    //! https://eel.is/c++draft/range.utility.conv
-    struct from_range_t {};
-    inline constexpr from_range_t from_range;
-}
-
-namespace AZStd::ranges
-{
     template<class I1, class I2>
     struct in_in_result
     {
@@ -1313,4 +1305,9 @@ namespace AZStd::ranges::views{}
 namespace AZStd
 {
       namespace views = ranges::views;
+
+      //! Adding C++23 from_range_t tag type
+      //! https://eel.is/c++draft/range.utility.conv
+      struct from_range_t {};
+      inline constexpr from_range_t from_range;
 }

--- a/Code/Framework/AzCore/AzCore/std/ranges/ranges.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/ranges.h
@@ -1216,6 +1216,13 @@ namespace AZStd::ranges
     }
 }
 
+namespace AZStd::ranges
+{
+    //! Adding C++23 from_range_t tag type
+    //! https://eel.is/c++draft/range.utility.conv
+    struct from_range_t {};
+    inline constexpr from_range_t from_range;
+}
 
 namespace AZStd::ranges
 {

--- a/Code/Framework/AzCore/AzCore/std/ranges/ranges_algorithm.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/ranges_algorithm.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AzCore/std/function/identity.h>
+#include <AzCore/std/ranges/iter_move.h>
 #include <AzCore/std/ranges/ranges.h>
 #include <AzCore/std/ranges/ranges_functional.h>
 #include <AzCore/std/ranges/subrange.h>
@@ -15,6 +16,8 @@
 
 namespace AZStd::ranges
 {
+    // Algorithm result types
+    // https://eel.is/c++draft/algorithms#results
     template<class T>
     struct min_max_result
     {
@@ -45,18 +48,39 @@ namespace AZStd::ranges
         AZ_NO_UNIQUE_ADDRESS I in;
         AZ_NO_UNIQUE_ADDRESS F fun;
 
-        template<class I2, class F2, class = enable_if_t<convertible_to<const I&, I2>&& convertible_to<const F&, F2>>>
+        template<class I2, class F2, class = enable_if_t<convertible_to<const I&, I2> && convertible_to<const F&, F2>>>
         constexpr operator in_fun_result<I2, F2>() const&
         {
             return { in, fun };
         }
 
-        template<class I2, class F2, enable_if_t<convertible_to<I, I2>&& convertible_to<F, F2>>>
+        template<class I2, class F2, enable_if_t<convertible_to<I, I2> && convertible_to<F, F2>>>
         constexpr operator in_fun_result<I2, F2>() &&
         {
             return { AZStd::move(in), AZStd::move(fun) };
         }
     };
+
+
+    template<class I, class O>
+    struct in_out_result
+    {
+        AZ_NO_UNIQUE_ADDRESS I in;
+        AZ_NO_UNIQUE_ADDRESS O out;
+
+        template<class I2, class O2, class = enable_if_t<convertible_to<const I&, I2> && convertible_to<const O&, O2>>>
+        constexpr operator in_out_result<I2, O2>() const&
+        {
+            return { in, out };
+        }
+
+        template<class I2, class O2, class = enable_if_t<convertible_to<I, I2> && convertible_to<O, O2>>>
+        constexpr operator in_out_result<I2, O2>()&&
+        {
+            return { AZStd::move(in), AZStd::move(out) };
+        }
+    };
+
 
     namespace Internal
     {
@@ -1217,5 +1241,228 @@ namespace AZStd::ranges
     {
         constexpr Internal::count_fn count{};
         constexpr Internal::count_if_fn count_if{};
+    }
+
+    // Mutating Sequence Operations
+    // https://eel.is/c++draft/algorithms#alg.modifying.operations
+
+    // ranges::copy
+    // ranges::copy_if
+    // ranges::copy_n
+    // ranges::copy_backward
+    template<class I, class O>
+    using copy_result = in_out_result<I, O>;
+    template<class I, class O>
+    using copy_if_result = in_out_result<I, O>;
+    template<class I, class O>
+    using copy_n_result = in_out_result<I, O>;
+    template<class I1, class I2>
+    using copy_backward_result = in_out_result<I1, I2>;
+
+    namespace Internal
+    {
+        struct copy_fn
+        {
+            template<class I, class S, class O>
+            constexpr auto operator()(I first, S last, O result) const
+                -> enable_if_t<conjunction_v<
+                bool_constant<input_iterator<I>>,
+                bool_constant<sentinel_for<S, I>>,
+                bool_constant<weakly_incrementable<O>>,
+                bool_constant<indirectly_copyable<I, O>>
+                >, copy_result<I, O>>
+            {
+                for (; first != last; ++first, ++result)
+                {
+                    *result = *first;
+                }
+
+                return { AZStd::move(last), AZStd::move(result) };
+            }
+
+            template<class R, class O>
+            constexpr auto operator()(R&& r, O result) const
+                -> enable_if_t<conjunction_v<
+                bool_constant<input_range<R>>,
+                bool_constant<weakly_incrementable<O>>,
+                bool_constant<indirectly_copyable<iterator_t<R>, O>>
+                >, copy_result<borrowed_iterator_t<R>, O>>
+            {
+                return operator()(AZStd::ranges::begin(r), AZStd::ranges::end(r), AZStd::move(result));
+            }
+        };
+
+        struct copy_if_fn
+        {
+            template<class I, class S, class O, class Proj = identity, class Pred>
+            constexpr auto operator()(I first, S last, O result, Pred pred, Proj proj = {}) const
+                -> enable_if_t<conjunction_v<
+                bool_constant<input_iterator<I>>,
+                bool_constant<sentinel_for<S, I>>,
+                bool_constant<weakly_incrementable<O>>,
+                bool_constant<indirect_unary_predicate<Pred, projected<I, Proj>>>,
+                bool_constant<indirectly_copyable<I, O>>
+                >, copy_if_result<I, O>>
+            {
+                for (; first != last; ++first)
+                {
+                    if (AZStd::invoke(pred, AZStd::invoke(proj, *first)))
+                    {
+                        *result = *first;
+                        ++result;
+                    }
+                }
+
+                return { AZStd::move(last), AZStd::move(result) };
+            }
+
+            template<class R, class O, class Proj = identity, class Pred>
+            constexpr auto operator()(R&& r, O result, Pred pred, Proj proj = {}) const
+                -> enable_if_t<conjunction_v<
+                bool_constant<input_range<R>>,
+                bool_constant<weakly_incrementable<O>>,
+                bool_constant<indirect_unary_predicate<Pred, projected<iterator_t<R>, Proj>>>,
+                bool_constant<indirectly_copyable<iterator_t<R>, O>>
+                >, copy_if_result<borrowed_iterator_t<R>, O>>
+            {
+                return operator()(AZStd::ranges::begin(r), AZStd::ranges::end(r), AZStd::move(result),
+                    AZStd::move(pred), AZStd::move(proj));
+            }
+        };
+
+        struct copy_n_fn
+        {
+            template<class I, class O>
+            constexpr auto operator()(I first, iter_difference_t<I> n, O result) const
+                -> enable_if_t<conjunction_v<
+                bool_constant<input_iterator<I>>,
+                bool_constant<weakly_incrementable<O>>,
+                bool_constant<indirectly_copyable<I, O>>
+                >, copy_n_result<I, O>>
+            {
+                for (; n > 0; --n, ++first, ++result)
+                {
+                    *result = *first;
+                }
+
+                return { AZStd::move(first), AZStd::move(result) };
+            }
+        };
+
+        struct copy_backward_fn
+        {
+            template<class I1, class S1, class O>
+            constexpr auto operator()(I1 first, S1 last, O result) const
+                -> enable_if_t<conjunction_v<
+                bool_constant<bidirectional_iterator<I1>>,
+                bool_constant<sentinel_for<S1, I1>>,
+                bool_constant<bidirectional_iterator<O>>,
+                bool_constant<indirectly_copyable<I1, O>>
+                >, copy_backward_result<I1, O>>
+            {
+                for (I1 iter{ last }; iter != first;)
+                {
+                    *--result = *--iter;
+                }
+
+                return { AZStd::move(last), AZStd::move(result) };
+            }
+
+            template<class R, class O>
+            constexpr auto operator()(R&& r, O result) const
+                -> enable_if_t<conjunction_v<
+                bool_constant<bidirectional_range<R>>,
+                bool_constant<bidirectional_iterator<O>>,
+                bool_constant<indirectly_copyable<iterator_t<R>, O>>
+                >, copy_backward_result<borrowed_iterator_t<R>, O>>
+            {
+                return operator()(AZStd::ranges::begin(r), AZStd::ranges::end(r), AZStd::move(result));
+            }
+        };
+    }
+    inline namespace customization_point_object
+    {
+        constexpr Internal::copy_fn copy{};
+        constexpr Internal::copy_if_fn copy_if{};
+        constexpr Internal::copy_n_fn copy_n{};
+        constexpr Internal::copy_backward_fn copy_backward{};
+    }
+
+    // ranges::move
+
+    // ranges::copy_backward
+    template<class I, class O>
+    using move_result = in_out_result<I, O>;
+    template<class I1, class I2>
+    using move_backward_result = in_out_result<I1, I2>;
+
+    namespace Internal
+    {
+        struct move_fn
+        {
+            template<class I, class S, class O>
+                constexpr auto operator()(I first, S last, O result) const
+                -> enable_if_t<conjunction_v<
+                bool_constant<input_iterator<I>>,
+                bool_constant<sentinel_for<S, I>>,
+                bool_constant<weakly_incrementable<O>>,
+                bool_constant<indirectly_movable<I, O>>
+                >, move_result<I, O>>
+            {
+                for (; first != last; ++first, ++result)
+                {
+                    *result = AZStd::ranges::iter_move(first);
+                }
+
+                return { AZStd::move(first), AZStd::move(result) };
+            }
+
+            template<class R, class O>
+            constexpr auto operator()(R&& r, O result) const
+                -> enable_if_t<conjunction_v<
+                bool_constant<input_range<R>>,
+                bool_constant<weakly_incrementable<O>>,
+                bool_constant<indirectly_movable<iterator_t<R>, O>>
+                >, move_result<borrowed_iterator_t<R>, O>>
+            {
+                return operator()(AZStd::ranges::begin(r), AZStd::ranges::end(r), AZStd::move(result));
+            }
+        };
+
+        struct move_backward_fn
+        {
+            template<class I1, class S1, class O>
+            constexpr auto operator()(I1 first, S1 last, O result) const
+                -> enable_if_t<conjunction_v<
+                bool_constant<bidirectional_iterator<I1>>,
+                bool_constant<sentinel_for<S1, I1>>,
+                bool_constant<bidirectional_iterator<O>>,
+                bool_constant<indirectly_movable<I1, O>>
+                >, move_backward_result<I1, O>>
+            {
+                for (I1 iter{ last }; iter != first;)
+                {
+                    *--result = AZStd::ranges::iter_move(--iter);
+                }
+
+                return { AZStd::move(last), AZStd::move(result) };
+            }
+
+            template<class R, class O>
+            constexpr auto operator()(R&& r, O result) const
+                -> enable_if_t<conjunction_v<
+                bool_constant<bidirectional_range<R>>,
+                bool_constant<bidirectional_iterator<O>>,
+                bool_constant<indirectly_movable<iterator_t<R>, O>>
+                >, move_backward_result<borrowed_iterator_t<R>, O>>
+            {
+                return operator()(AZStd::ranges::begin(r), AZStd::ranges::end(r), AZStd::move(result));
+            }
+        };
+    }
+    inline namespace customization_point_object
+    {
+        constexpr Internal::move_fn move{};
+        constexpr Internal::move_backward_fn move_backward{};
     }
 } // namespace AZStd::ranges

--- a/Code/Framework/AzCore/AzCore/std/ranges/ranges_to.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/ranges_to.h
@@ -86,174 +86,182 @@ namespace AZStd::ranges
         }
 
 
-        template<template<class...> class C, class R, class... Args>
         struct container_range_direct_constructible
         {
-            static constexpr false_type ValidExpr(...);
-            template<bool Enable = sfinae_trigger_v<decltype(C(declval<R>(), declval<Args>()...))>>
-            static constexpr true_type ValidExpr(int);
-
-            static constexpr bool value = ValidExpr(0);
+            template<template<class...> class C, class R, class... Args>
+            constexpr false_type operator()(...);
+            
+            template<template<class...> class C, class R, class... Args>
+            constexpr auto operator()(int) -> enable_if_t<
+                sfinae_trigger_v<decltype(C(declval<R>(), declval<Args>()...))>,
+                true_type>;
         };
-
         template<template<class...> class C, class R, class... Args>
-        constexpr bool container_range_direct_constructible_v = container_range_direct_constructible<C, R, Args...>::value;
+        constexpr bool container_range_direct_constructible_v =
+            decltype(container_range_direct_constructible{}.operator()<C, R, Args...>(0))::value;
 
-        template<template<class...> class C, class R, class... Args>
         struct container_range_tag_type_constructible
         {
-            static constexpr false_type ValidExpr(...);
-            template<bool Enable = sfinae_trigger_v<decltype(C(from_range, declval<R>(), declval<Args>()...))>>
-            static constexpr true_type ValidExpr(int);
-
-            static constexpr bool value = ValidExpr(0);
+            template<template<class...> class C, class R, class... Args>
+            constexpr false_type operator()(...);
+            template<template<class...> class C, class R, class... Args>
+            constexpr auto operator()(int) -> enable_if_t<
+                sfinae_trigger_v<decltype(C(from_range, declval<R>(), declval<Args>()...))>,
+                true_type>;
         };
         template<template<class...> class C, class R, class... Args>
-        constexpr bool container_range_tag_type_constructible_v = container_range_tag_type_constructible<C, R, Args...>::value;
+        constexpr bool container_range_tag_type_constructible_v =
+            decltype(container_range_tag_type_constructible{}.operator()<C, R, Args...>(0))::value;
         
-        template<template<class...> class C, class R, class... Args>
         struct container_range_common_iterator_constructible
         {
-            static constexpr false_type ValidExpr(...);
-            template<bool Enable = sfinae_trigger_v<decltype(C(declval<I>(), declval<I>(), declval<Args>()...))>>
-            static constexpr true_type ValidExpr(int);
+            template<template<class...> class C, class I, class... Args>
+            constexpr false_type operator()(...);
+            template<template<class...> class C, class I, class... Args>
+            constexpr auto operator()(int) -> enable_if_t<
+                sfinae_trigger_v<decltype(C(declval<I>(), declval<I>(), declval<Args>()...))>,
+                true_type>;
 
-            static constexpr bool value = ValidExpr(0);
         };
         template<template<class...> class C, class I, class... Args>
-        constexpr bool container_range_common_iterator_constructible_v = container_range_common_iterator_constructible<C, I, Args...>::value;
-
+        constexpr bool container_range_common_iterator_constructible_v =
+            decltype(container_range_common_iterator_constructible{}.operator()<C, I, Args...>(0))::value;
         
 
-        template<template<class...> class C, class R, class... Args>
-        inline auto DEDUCE_EXPR()
+        // Exposition only type for deducing the template argument for the container template C
+        // https://eel.is/c++draft/range.utility.conv#to-2
+        template<class R>
+        struct range_input_iterator
         {
-            // Exposition only type for deducing the template argument for the container template C
-            // https://eel.is/c++draft/range.utility.conv#to-2
-            struct range_input_iterator
+            using iterator_category = input_iterator_tag;
+            using value_type = range_value_t<R>;
+            using difference_type = ptrdiff_t;
+            using reference = range_reference_t<R>;
+            using pointer = add_pointer_t<reference>;
+            reference operator*() const;
+            pointer operator->() const;
+            range_input_iterator& operator++();
+            range_input_iterator operator++(int);
+            bool operator==(const range_input_iterator&) const;
+            bool operator!=(const range_input_iterator&) const;
+        };
+
+        struct deduce_expr_impl
+        {
+            template<template<class...> class C, class R, class... Args>
+            constexpr auto operator()() const -> enable_if_t<container_range_direct_constructible_v<C, R>,
+                decltype(C(declval<R>(), declval<Args>()...))>;
+
+            template<template<class...> class C, class R, class... Args>
+            constexpr auto operator()() const ->enable_if_t<
+                container_range_tag_type_constructible_v<C, R, Args...>
+                && !container_range_direct_constructible_v<C, R>,
+                decltype(C(from_range, declval<R>(), declval<Args>()...))>;
+
+            template<template<class...> class C, class R, class... Args>
+            constexpr auto operator()() const ->enable_if_t<
+                container_range_common_iterator_constructible_v<C, range_input_iterator<R>, Args...>
+                && !container_range_direct_constructible_v<C, R>
+                && !container_range_tag_type_constructible_v<C, R, Args...>,
+                decltype(C(declval<range_input_iterator<R>>(), declval<range_input_iterator<R>>(), declval<Args>()...))>;
+        };
+
+        template<template<class...> class C, class R, class... Args>
+        using DEDUCE_EXPR = decltype(deduce_expr_impl{}.operator()< C, R, Args... >());
+    }
+
+    // ranges::to conversion function
+    //https://eel.is/c++draft/range.utility.conv#to
+    template<class C, class R, class... Args>
+    [[nodiscard]] constexpr auto to(R&& r, Args&&... args)
+        -> enable_if_t<conjunction_v<
+        bool_constant<input_range<R>>,
+        bool_constant<!view<C>>
+        >, C>
+    {
+        if constexpr (convertible_to<range_reference_t<R>, range_value_t<C>>)
+        {
+            // Container C contains supports a constructor that can accept the range directly
+            if constexpr (constructible_from<C, R, Args...>)
             {
-                using iterator_category = input_iterator_tag;
-                using value_type = range_value_t<R>;
-                using difference_type = ptrdiff_t;
-                using reference = range_reference_t<R>;
-                using pointer = add_pointer_t<reference>;
-                reference* operator*() const;
-                pointer operator->() const;
-                range_input_iterator& operator++();
-                range_input_iterator operator++(int);
-                bool operator==(const range_input_iterator&) const;
-                bool operator!=(const range_input_iterator&) const;
-            };
-            if constexpr (container_range_direct_constructible_v<C, R>)
-            {
-                return C(declval<R>(), declval<Args>()...);
+                return C(AZStd::forward<R>(r), AZStd::forward<Args>(args)...);
             }
-            else if constexpr (container_range_tag_type_constructible_v<C, R, Args...>)
+            // Container C contains supports from_range_t tagged constructor that can construct
+            // the C using the range
+            else if constexpr (constructible_from<C, from_range_t, R, Args...>)
             {
-                return C(from_range, declval<R>(), declval<Args>()...);
+                return C(from_range, AZStd::forward<R>(r), AZStd::forward<Args>(args)...);
             }
-            else if constexpr (container_range_common_iterator_constructible_v<C, range_input_iterator, Args...>)
+            // The Range is a common range(i.e has the same iterator and sentinel type)
+            // and the Container C has a legacy iterator constructor that construct C
+            // from begin and end iterators
+            else if constexpr (common_range<R> && cpp17_input_iterator<iterator_t<R>>
+                && constructible_from<C, iterator_t<R>, sentinel_t<R>, Args...>)
             {
-                return C(declval<range_input_iterator>(), declval<range_input_iterator>(), declval<Args>()...);
+                return C(ranges::begin(r), ranges::end(r), AZStd::forward<Args>(args)...);
+            }
+            // Construct an empty container and then use the inserter adapter to forward arguments
+            else if constexpr (constructible_from<C, Args...> && Internal::container_insertable<C, range_reference_t<R>>)
+            {
+                C c(AZStd::forward<Args>(args)...);
+                // If the range is a sized_range(i.e supports a constant Big-O call to ranges::size(R)
+                // and the new container supports the reserve function for reserving spaces for elements
+                // Then use reserve to reserve the total number of elements needed
+                if constexpr (sized_range<R> && Internal::reservable_container<C>)
+                {
+                    c.reserve(ranges::size(r));
+                }
+
+                ranges::copy(r, Internal::container_inserter<range_reference_t<R>>(c));
+                return c;
+            }
+            // Otherwise the construct is ill-formed
+            else
+            {
+                constexpr bool IllFormedCondition = (constructible_from<C, Args...> && Internal::container_insertable<C, range_reference_t<R>>);
+                static_assert(IllFormedCondition, "The reference type of range R is not convertible to the value type of container C");
             }
         }
-
-        struct to_fn
+        else if constexpr (input_range<range_reference_t<R>>)
         {
-            template<class C, class R, class... Args>
-            [[nodiscard]] constexpr auto operator()(R&& r, Args&&... args) const
-                -> enable_if_t<conjunction_v<
-                bool_constant<input_range<R>>,
-                bool_constant<!view<C>>
-                >, C>
+            auto recursive_to = [](auto&& elem)
             {
-                if constexpr (convertible_to<range_reference_t<R>, range_value_t<C>>)
-                {
-                    // Container C contains supports a constructor that can accept the range directly
-                    if constexpr (constructible_from<C, R, Args...>)
-                    {
-                        return C(AZStd::forward<R>(r), AZStd::forward<Args>(args)...);
-                    }
-                    // Container C contains supports from_range_t tagged constructor that can construct
-                    // the C using the range
-                    else if constexpr (constructible_from<C, from_range_t, R, Args...>)
-                    {
-                        return C(from_range, AZStd::forward<R>(r), AZStd::forward<Args>(args)...);
-                    }
-                    // The Range is a common range(i.e has the same iterator and sentinel type)
-                    // and the Container C has a legacy iterator constructor that construct C
-                    // from begin and end iterators
-                    else if constexpr (common_range<R> && input_iterator<iterator_t<R>>
-                        && constructible_from<C, iterator_t<R>, sentinel_t<R>, Args...>)
-                    {
-                        return C(ranges::begin(r), ranges::end(r), AZStd::forward<Args>(args)...);
-                    }
-                    // Construct an empty container and then use the inserter adapter to forward arguments
-                    else if constexpr (constructible_from<C, Args...> && container_insertable<C, range_reference_t<R>>)
-                    {
-                        C c(AZStd::forward<Args>(args)...);
-                        // If the range is a sized_range(i.e supports a constant Big-O call to ranges::size(R)
-                        // and the new container supports the reserve function for reserving spaces for elements
-                        // Then use reserve to reserve the total number of elements needed
-                        if constexpr (sized_range<R> && reservable_container<C>)
-                        {
-                            c.reserve(ranges::size(r));
-                        }
-
-                        ranges::copy(r, container_inserter<range_reference_t<R>>(C));
-
-                    }
-                    // Otherwise the construct is ill-formed
-                    else
-                    {
-                        constexpr bool IllFormedCondition = !(constructible_from<C, Args...> && container_insertable<C, range_reference_t<R>>);
-                        static_assert(IllFormedCondition, "The reference type of range R is not convertible to the value type of container C");
-                    }
-                }
-                else if constexpr (input_range<range_reference_t<R>>)
-                {
-                    auto recursive_to = [](auto&& elem)
-                    {
-                        return to_fn{}.operator()<range_value_t<C>>(AZStd::forward<decltype(elem)>(elem));
-                    };
-                    operator()<C>(r | views::transform(recursive_to), AZStd::forward<Args>(args)...);
-                }
-                else
-                {
-                    constexpr bool IllFormedCondition = !input_range<range_reference_t<R>>;
-                    static_assert(IllFormedCondition, "The reference type of range R is not convertible to the value type of container C");
-                }
-            }
-
-            template<template<class...> class C, class R, class... Args,
-                class = enable_if_t<input_range<R>>>
-            [[nodiscard]] constexpr auto operator()(R&& r, Args&&... args) const
-            {
-                return C<decltype(DEDUCE_EXPR<C, R, Args...>())>(AZStd::forward<R>(r), AZStd::forward<Args>(args)...);
-            }
-
-            template<class C, class... Args, class = enable_if_t<!view<C>>>
-            constexpr auto operator()(Args&&... args) const
-            {
-                auto to_forwarder = [](auto&& r, auto&&... boundArgs) constexpr
-                {
-                    return to_fn{}.operator()<C>(AZStd::forward<decltype(r)>(r), AZStd::forward<decltype(boundArgs)>(boundArgs)...);
-                };
-                return ::AZStd::ranges::views::Internal::range_adaptor_argument_forwarder{ to_forwarder, AZStd::forward<Args>(args)... };
-            }
-            template<template<class...> class C, class... Args>
-            constexpr auto operator()(Args&&... args) const
-            {
-                auto to_forwarder = [](auto&& r, auto&&... boundArgs) constexpr
-                {
-                    return to_fn{}.operator()<C>(AZStd::forward<decltype(r)>(r), AZStd::forward<decltype(boundArgs)>(boundArgs)...);
-                };
-                return ::AZStd::ranges::views::Internal::range_adaptor_argument_forwarder{ to_forwarder, AZStd::forward<Args>(args)... };
-            }
-        };
+                return to<range_value_t<C>>(AZStd::forward<decltype(elem)>(elem));
+            };
+            return to<C>(r | views::transform(recursive_to), AZStd::forward<Args>(args)...);
+        }
+        else
+        {
+            constexpr bool IllFormedCondition = input_range<range_reference_t<R>>;
+            static_assert(IllFormedCondition, "The reference type of range R is not convertible to the value type of container C");
+        }
     }
-    inline namespace customization_point_object
+
+    template<template<class...> class C, class R, class... Args,
+        class = enable_if_t<input_range<R>>>
+    [[nodiscard]] constexpr auto to(R&& r, Args&&... args)
     {
-        constexpr Internal::to_fn to{};
+        return to<Internal::DEDUCE_EXPR<C, R, Args...>>(AZStd::forward<R>(r), AZStd::forward<Args>(args)...);
+    }
+
+    // ranges::to adapators
+    // https://eel.is/c++draft/range.utility.conv#adaptors
+    template<class C, class... Args, class = enable_if_t<!view<C>>>
+    constexpr auto to(Args&&... args)
+    {
+        auto to_forwarder = [](auto&& r, auto&&... boundArgs) constexpr
+        {
+            return to<C>(AZStd::forward<decltype(r)>(r), AZStd::forward<decltype(boundArgs)>(boundArgs)...);
+        };
+        return ::AZStd::ranges::views::Internal::range_adaptor_argument_forwarder{ to_forwarder, AZStd::forward<Args>(args)... };
+    }
+    template<template<class...> class C, class... Args>
+    constexpr auto to(Args&&... args)
+    {
+        auto to_forwarder = [](auto&& r, auto&&... boundArgs) constexpr
+        {
+            return to<C>(AZStd::forward<decltype(r)>(r), AZStd::forward<decltype(boundArgs)>(boundArgs)...);
+        };
+        return ::AZStd::ranges::views::Internal::range_adaptor_argument_forwarder{ to_forwarder, AZStd::forward<Args>(args)... };
     }
 } // namespace AZStd::ranges

--- a/Code/Framework/AzCore/AzCore/std/ranges/transform_view.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/transform_view.h
@@ -225,14 +225,12 @@ namespace AZStd::ranges
     // which requires that the iterator type has the aliases
     // of difference_type, value_type, pointer, reference, iterator_category,
     // With C++20, the iterator concept support is used to deduce the traits
-    // needed, therefore alleviating the need to special std::iterator_traits
+    // needed, therefore alleviating the need to specialize std::iterator_traits
     // The following code allows std::reverse_iterator(which is aliased into AZStd namespace)
     // to work with the AZStd range views
     #if !__cpp_lib_concepts
         using pointer = void;
-        using reference = conditional_t<is_reference_v<invoke_result_t<Func&, range_reference_t<Base>>>,
-            invoke_result_t<Func&, range_reference_t<Base>>,
-            dangling>;
+        using reference = invoke_result_t<Func&, range_reference_t<Base>>;
     #endif
 
         template<bool Enable = default_initializable<iterator_t<Base>>, class = enable_if_t<Enable>>

--- a/Code/Framework/AzCore/AzCore/std/string/fixed_string.h
+++ b/Code/Framework/AzCore/AzCore/std/string/fixed_string.h
@@ -10,6 +10,7 @@
 #include <wchar.h>
 
 #include <AzCore/std/base.h>
+#include <AzCore/std/containers/containers_concepts.h>
 #include <AzCore/std/iterator.h>
 
 #include <AzCore/std/string/string_view.h>
@@ -76,6 +77,10 @@ namespace AZStd
         // #6
         template<class InputIt, typename = enable_if_t<input_iterator<InputIt> && !is_convertible_v<InputIt, size_t>>>
         constexpr basic_fixed_string(InputIt first, InputIt last);
+
+        // https://eel.is/c++draft/strings#string.cons-18
+        template<class R, class = enable_if_t<Internal::container_compatible_range<R, value_type>>>
+        constexpr basic_fixed_string(from_range_t, R&& rg);
 
         // #7
         constexpr basic_fixed_string(const basic_fixed_string& rhs);
@@ -144,9 +149,15 @@ namespace AZStd
             && !is_convertible_v<const T&, const Element*>, basic_fixed_string&>;
         constexpr auto append(const_pointer ptr) -> basic_fixed_string&;
         constexpr auto append(size_type count, Element ch) -> basic_fixed_string&;
+
         template<class InputIt>
         constexpr auto append(InputIt first, InputIt last)
             -> enable_if_t<input_iterator<InputIt> && !is_convertible_v<InputIt, size_type>, basic_fixed_string&>;
+
+        template<class R>
+        constexpr auto append_range(R&& rg)
+            -> enable_if_t<Internal::container_compatible_range<R, value_type>, basic_fixed_string&>;
+
         constexpr auto append(AZStd::initializer_list<Element> ilist) -> basic_fixed_string&;
 
         constexpr auto assign(const basic_fixed_string& rhs) -> basic_fixed_string&;
@@ -159,9 +170,14 @@ namespace AZStd
             && !is_convertible_v<const T&, const Element*>, basic_fixed_string&>;
         constexpr auto assign(const_pointer ptr) -> basic_fixed_string&;
         constexpr auto assign(size_type count, Element ch) -> basic_fixed_string&;
+
         template<class InputIt>
         constexpr auto assign(InputIt first, InputIt last)
             ->enable_if_t<input_iterator<InputIt> && !is_convertible_v<InputIt, size_type>, basic_fixed_string&>;
+
+        template<class R>
+        constexpr auto assign_range(R&& rg)
+            -> enable_if_t<Internal::container_compatible_range<R, value_type>, basic_fixed_string&>;
 
         constexpr auto assign(AZStd::initializer_list<Element> ilist) -> basic_fixed_string&;
 
@@ -177,9 +193,14 @@ namespace AZStd
         constexpr auto insert(const_iterator insertPos) -> iterator;
         constexpr auto insert(const_iterator insertPos, Element ch) -> iterator;
         constexpr auto insert(const_iterator insertPos, size_type count, Element ch) -> iterator;
+
         template<class InputIt>
         constexpr auto insert(const_iterator insertPos, InputIt first, InputIt last)
         -> enable_if_t<input_iterator<InputIt> && !is_convertible_v<InputIt, size_type>, iterator>;
+
+        template<class R>
+        constexpr auto insert_range(const_iterator insertPos, R&& rg)
+            -> enable_if_t<Internal::container_compatible_range<R, value_type>, iterator>;
 
         constexpr auto insert(const_iterator insertPos, AZStd::initializer_list<Element> ilist) -> iterator;
 
@@ -213,9 +234,15 @@ namespace AZStd
             -> AZStd::enable_if_t<is_convertible_v<const T&, basic_string_view<Element, Traits>>
             && !is_convertible_v<const T&, const Element*>, basic_fixed_string&>;
         constexpr auto replace(const_iterator first, const_iterator last, size_type count, Element ch) -> basic_fixed_string&;
+
         template<class InputIt>
         constexpr auto replace(const_iterator first, const_iterator last, InputIt first2, InputIt last2)
             -> enable_if_t<input_iterator<InputIt> && !is_convertible_v<InputIt, size_type>, basic_fixed_string&>;
+
+        template<class R>
+        constexpr auto replace_with_range(const_iterator first, const_iterator last, R&& rg)
+            -> enable_if_t<Internal::container_compatible_range<R, value_type>, basic_fixed_string&>;
+
         constexpr auto replace(const_iterator first, const_iterator last, AZStd::initializer_list<Element> ilist) -> basic_fixed_string&;
 
         constexpr auto at(size_type offset) -> reference;

--- a/Code/Framework/AzCore/AzCore/std/string/fixed_string.inl
+++ b/Code/Framework/AzCore/AzCore/std/string/fixed_string.inl
@@ -72,6 +72,14 @@ namespace AZStd
         assign(first, last);
     }
 
+    // https://eel.is/c++draft/strings#string.cons-18
+    template<class Element, size_t MaxElementCount, class Traits>
+    template<class R, typename>
+    inline constexpr basic_fixed_string<Element, MaxElementCount, Traits>::basic_fixed_string(from_range_t, R&& rg)
+    {
+        assign_range(AZStd::forward<R>(rg));
+    }
+
     // #7
     template<class Element, size_t MaxElementCount, class Traits>
     inline constexpr basic_fixed_string<Element, MaxElementCount, Traits>::basic_fixed_string(const basic_fixed_string& rhs)
@@ -328,7 +336,7 @@ namespace AZStd
         -> enable_if_t<input_iterator<InputIt> && !is_convertible_v<InputIt, size_type>, basic_fixed_string&>
     {
         if constexpr (contiguous_iterator<InputIt>
-            && is_same_v<typename AZStd::iterator_traits<InputIt>::value_type, value_type>)
+            && is_same_v<iter_value_t<InputIt>, value_type>)
         {
             return append(AZStd::to_address(first), AZStd::distance(first, last));
         }
@@ -363,6 +371,15 @@ namespace AZStd
             return append(inputCopy.c_str(), inputCopy.size());
         }
     }
+
+    template<class Element, size_t MaxElementCount, class Traits>
+    template<class R>
+    inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::append_range(R&& rg)
+        -> enable_if_t<Internal::container_compatible_range<R, value_type>, basic_fixed_string&>
+    {
+        return append(basic_fixed_string(from_range, AZStd::forward<R>(rg)));
+    }
+
     template<class Element, size_t MaxElementCount, class Traits>
     inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::append(AZStd::initializer_list<Element> ilist) -> basic_fixed_string&
     {
@@ -464,7 +481,7 @@ namespace AZStd
         -> enable_if_t<input_iterator<InputIt> && !is_convertible_v<InputIt, size_type>, basic_fixed_string&>
     {
         if constexpr (contiguous_iterator<InputIt>
-            && is_same_v<typename AZStd::iterator_traits<InputIt>::value_type, value_type>)
+            && is_same_v<iter_value_t<InputIt>, value_type>)
         {
             return assign(AZStd::to_address(first), AZStd::distance(first, last));
         }
@@ -499,6 +516,15 @@ namespace AZStd
             return assign(inputCopy.c_str(), inputCopy.size());
         }
     }
+
+    template<class Element, size_t MaxElementCount, class Traits>
+    template<class R>
+    inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::assign_range(R&& rg)
+        -> enable_if_t<Internal::container_compatible_range<R, value_type>, basic_fixed_string&>
+    {
+        return assign(ranges::begin(rg), ranges::end(rg));
+    }
+
     template<class Element, size_t MaxElementCount, class Traits>
     inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::assign(AZStd::initializer_list<Element> ilist) -> basic_fixed_string&
     {
@@ -631,7 +657,7 @@ namespace AZStd
     {   // insert [_First, _Last) at _Where
         size_type insertOffset = AZStd::distance(cbegin(), insertPos);
         if constexpr (contiguous_iterator<InputIt>
-            && is_same_v<typename AZStd::iterator_traits<InputIt>::value_type, value_type>)
+            && is_same_v<iter_value_t<InputIt>, value_type>)
         {
             insert(insertOffset, AZStd::to_address(first), AZStd::distance(first, last));
         }
@@ -667,6 +693,16 @@ namespace AZStd
             insert(insertOffset, inputCopy.c_str(), inputCopy.size());
         }
         return begin() + insertOffset;
+    }
+
+    template<class Element, size_t MaxElementCount, class Traits>
+    template<class R>
+    inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::insert_range(const_iterator insertPos, R&& rg)
+        -> enable_if_t<Internal::container_compatible_range<R, value_type>, iterator>
+    {
+        size_t offset = insertPos - begin();
+        insert(insertPos - begin(), basic_fixed_string(from_range, AZStd::forward<R>(rg)));
+        return begin() + offset;
     }
 
     template<class Element, size_t MaxElementCount, class Traits>
@@ -930,7 +966,7 @@ namespace AZStd
         InputIt replaceFirst, InputIt replaceLast) -> enable_if_t<input_iterator<InputIt> && !is_convertible_v<InputIt, size_type>, basic_fixed_string&>
     {   // replace [first, last) with [replaceFirst,replaceLast)
         if constexpr (contiguous_iterator<InputIt>
-            && is_same_v<typename AZStd::iterator_traits<InputIt>::value_type, value_type>)
+            && is_same_v<iter_value_t<InputIt>, value_type>)
         {
             return replace(first, last, AZStd::to_address(replaceFirst), AZStd::distance(replaceFirst, replaceLast));
         }
@@ -970,6 +1006,16 @@ namespace AZStd
             return replace(first, last, inputCopy.c_str(), inputCopy.size());
         }
     }
+
+    template<class Element, size_t MaxElementCount, class Traits>
+    template<class R>
+    inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::replace_with_range(
+        const_iterator first, const_iterator last, R&& rg)
+        -> enable_if_t<Internal::container_compatible_range<R, value_type>, basic_fixed_string&>
+    {
+        return replace(first, last, basic_fixed_string(from_range, AZStd::forward<R>(rg)));
+    }
+
     template<class Element, size_t MaxElementCount, class Traits>
     inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::replace(const_iterator first, const_iterator last,
         AZStd::initializer_list<Element> ilist) -> basic_fixed_string&

--- a/Code/Framework/AzCore/AzCore/std/string/string.h
+++ b/Code/Framework/AzCore/AzCore/std/string/string.h
@@ -13,6 +13,7 @@
 #include <cstring>
 
 #include <AzCore/std/containers/compressed_pair.h>
+#include <AzCore/std/containers/containers_concepts.h>
 #include <AzCore/std/base.h>
 #include <AzCore/std/iterator.h>
 #include <AzCore/std/allocator.h>
@@ -122,6 +123,16 @@ namespace AZStd
             : m_storage{ skip_element_tag{}, alloc }
         {   // construct from [first, last)
             assign(first, last);
+        }
+        template<class R, class = enable_if_t<Internal::container_compatible_range<R, value_type>>>
+        basic_string(from_range_t, R&& rg, const Allocator& alloc = Allocator())
+            : m_storage{ skip_element_tag{}, alloc }
+        {
+            assign_range(AZStd::forward<R>(rg));
+        }
+        basic_string(initializer_list<Element> ilist, const Allocator& alloc = Allocator())
+            : basic_string(ilist.begin(), ilist.end(), alloc)
+        {
         }
 
         inline basic_string(const this_type& rhs)
@@ -257,7 +268,7 @@ namespace AZStd
             -> enable_if_t<input_iterator<InputIt> && !is_convertible_v<InputIt, size_type>, this_type&>
         {   // append [first, last)
             if constexpr (contiguous_iterator<InputIt>
-                && is_same_v<typename AZStd::iterator_traits<InputIt>::value_type, value_type>)
+                && is_same_v<iter_value_t<InputIt>, value_type>)
             {
                 return append(AZStd::to_address(first), AZStd::distance(first, last));
             }
@@ -298,6 +309,16 @@ namespace AZStd
         inline this_type& append(const_pointer first, const_pointer last)
         {   // append [first, last), const pointers
             return replace(end(), end(), first, last);
+        }
+        template<class R>
+        auto append_range(R&& rg) -> enable_if_t<Internal::container_compatible_range<R, value_type>, basic_string&>
+        {
+            return append(basic_string(from_range, AZStd::forward<R>(rg), get_allocator()));
+        }
+
+        basic_string& append(initializer_list<Element> iList)
+        {
+            return append(iList.begin(), iList.end());
         }
 
         inline this_type& assign(const this_type& rhs)
@@ -402,7 +423,7 @@ namespace AZStd
             -> enable_if_t<input_iterator<InputIt> && !is_convertible_v<InputIt, size_type>, this_type&>
         {
             if constexpr (contiguous_iterator<InputIt>
-                && is_same_v<typename AZStd::iterator_traits<InputIt>::value_type, value_type>)
+                && is_same_v<iter_value_t<InputIt>, value_type>)
             {
                 return assign(AZStd::to_address(first), AZStd::distance(first, last));
             }
@@ -438,6 +459,17 @@ namespace AZStd
                 return assign(AZStd::move(inputCopy));
             }
         }
+        template<class R>
+        auto assign_range(R&& rg) -> enable_if_t<Internal::container_compatible_range<R, value_type>, basic_string&>
+        {
+            return assign(ranges::begin(rg), ranges::end(rg));
+        }
+
+        basic_string& assign(initializer_list<Element> iList)
+        {
+            return assign(iList.begin(), iList.end());
+        }
+
         inline this_type& insert(size_type offset, const this_type& rhs) { return insert(offset, rhs, 0, npos); }
         this_type& insert(size_type offset, const this_type& rhs, size_type rhsOffset, size_type count)
         {
@@ -547,7 +579,7 @@ namespace AZStd
         {   // insert [_First, _Last) at _Where
             size_type insertOffset = AZStd::distance(cbegin(), insertPos);
             if constexpr (contiguous_iterator<InputIt>
-                && is_same_v<typename AZStd::iterator_traits<InputIt>::value_type, value_type>)
+                && is_same_v<iter_value_t<InputIt>, value_type>)
             {
                 insert(insertOffset, AZStd::to_address(first), AZStd::distance(first, last));
             }
@@ -587,6 +619,19 @@ namespace AZStd
             return begin() + insertOffset;
         }
 
+        template<class R>
+        auto insert_range(const_iterator insertPos, R&& rg) -> enable_if_t<Internal::container_compatible_range<R, value_type>, iterator>
+        {
+            size_t offset = insertPos - begin();
+            insert(offset, basic_string(from_range, AZStd::forward<R>(rg), get_allocator()));
+            return begin() + offset;
+        }
+
+        iterator insert(const_iterator insertPos, initializer_list<Element> iList)
+        {
+            return insert(insertPos, iList.begin(), iList.end());
+        }
+
         this_type& erase(size_type offset = 0, size_type count = npos)
         {   // erase elements [offset, offset + count)
             AZSTD_CONTAINER_ASSERT(size() >= offset, "Invalid offset");
@@ -604,7 +649,7 @@ namespace AZStd
                 Traits::move(data + offset, data + offset + count, size() - offset - count);
                 m_storage.first().SetSize(size() - count);
                 Traits::assign(data[size()], Element());  // terminate
-        }
+            }
             return *this;
         }
 
@@ -841,7 +886,7 @@ namespace AZStd
             -> enable_if_t<input_iterator<InputIt> && !is_convertible_v<InputIt, size_type>, this_type&>
         {
             if constexpr (contiguous_iterator<InputIt>
-                && is_same_v<typename AZStd::iterator_traits<InputIt>::value_type, value_type>)
+                && is_same_v<iter_value_t<InputIt>, value_type>)
             {
                 return replace(first, last, AZStd::to_address(replaceFirst), AZStd::distance(replaceFirst, replaceLast));
             }
@@ -882,6 +927,18 @@ namespace AZStd
 
                 return replace(first, last, inputCopy.c_str(), inputCopy.size());
             }
+        }
+
+        template<class R>
+        auto replace_with_range(const_iterator first, const_iterator last, R&& rg)
+            -> enable_if_t<Internal::container_compatible_range<R, value_type>, basic_string&>
+        {
+            return replace(first, last, basic_string(from_range, AZStd::forward<R>(rg), get_allocator()));
+        }
+
+        basic_string& replace(const_iterator first, const_iterator last, initializer_list<Element> iList)
+        {
+            return replace(first, last, iList.begin(), iList.end());
         }
 
         inline reference at(size_type offset)
@@ -1887,9 +1944,13 @@ namespace AZStd
 
     // AZStd::basic_string deduction guides
     template<class InputIt, class Alloc = allocator>
-    basic_string(InputIt, InputIt, Alloc = Alloc())-> basic_string<typename iterator_traits<InputIt>::value_type,
-        AZStd::char_traits<typename iterator_traits<InputIt>::value_type>,
+    basic_string(InputIt, InputIt, Alloc = Alloc()) -> basic_string<iter_value_t<InputIt>,
+        AZStd::char_traits<iter_value_t<InputIt>>,
         Alloc>;
+
+    template<class R, class Alloc = allocator, class = enable_if_t<ranges::input_range<R>>>
+    basic_string(from_range_t, R&&, Alloc = Alloc())
+        -> basic_string<ranges::range_value_t<R>, char_traits<ranges::range_value_t<R>>, Alloc>;
 
     template<class CharT, class Traits, class Alloc = allocator>
     explicit basic_string(AZStd::basic_string_view<CharT, Traits>, const Alloc& = Alloc()) ->

--- a/Code/Framework/AzCore/Tests/AZStd/DequeAndSimilar.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/DequeAndSimilar.cpp
@@ -7,14 +7,16 @@
  */
 #include "UserTypes.h"
 
+#include <AzCore/std/allocator_ref.h>
+#include <AzCore/std/allocator_static.h>
 #include <AzCore/std/containers/array.h>
 #include <AzCore/std/containers/deque.h>
 #include <AzCore/std/containers/queue.h>
-#include <AzCore/std/containers/stack.h>
 #include <AzCore/std/containers/ring_buffer.h>
-
-#include <AzCore/std/allocator_static.h>
-#include <AzCore/std/allocator_ref.h>
+#include <AzCore/std/containers/set.h>
+#include <AzCore/std/containers/span.h>
+#include <AzCore/std/containers/stack.h>
+#include <AzCore/std/ranges/transform_view.h>
 
 #define AZ_TEST_VALIDATE_EMPTY_DEQUE(_Deque) \
     AZ_TEST_ASSERT(_Deque.validate());       \
@@ -624,7 +626,7 @@ namespace UnitTest
         int_buffer5.emplace_back();
         AZ_TEST_VALIDATE_RINGBUFFER(int_buffer5, myArr.size() + 2);
 
-        int_buffer5.push_front(201);
+        int_buffer5.emplace_front(201);
         AZ_TEST_VALIDATE_RINGBUFFER(int_buffer5, myArr.size() + 3);
         AZ_TEST_ASSERT(int_buffer5.front() == 201);
         int_buffer5.emplace_front();
@@ -684,5 +686,79 @@ namespace UnitTest
         using ContainerType = typename AZStd::stack<TestPairType>::container_type;
         AZStd::stack<TestPairType> expectedStack(ContainerType{ TestPairType{ 0, 0 }, TestPairType{ 1, 0 }, TestPairType{ 2, 3 } });
         EXPECT_EQ(expectedStack, testStack);
+    }
+
+
+    using DequeTestFixture = ScopedAllocatorSetupFixture;
+
+    TEST_F(DequeTestFixture, RangeConstructors_Succeeds)
+    {
+        constexpr AZStd::string_view testView = "abc";
+
+        AZStd::deque testDeque(AZStd::from_range, testView);
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c'));
+
+        testDeque = AZStd::deque(AZStd::from_range, AZStd::vector<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c'));
+        testDeque = AZStd::deque(AZStd::from_range, AZStd::list<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c'));
+        testDeque = AZStd::deque(AZStd::from_range, AZStd::deque<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c'));
+        testDeque = AZStd::deque(AZStd::from_range, AZStd::set<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c'));
+        testDeque = AZStd::deque(AZStd::from_range, AZStd::unordered_set<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c'));
+        testDeque = AZStd::deque(AZStd::from_range, AZStd::fixed_vector<char, 8>{testView.begin(), testView.end()});
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c'));
+        testDeque = AZStd::deque(AZStd::from_range, AZStd::array{ 'a', 'b', 'c' });
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c'));
+        testDeque = AZStd::deque(AZStd::from_range, AZStd::span(testView));
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c'));
+
+        AZStd::fixed_string<8> testValue(testView);
+        testDeque = AZStd::deque(AZStd::from_range, testValue);
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c'));
+        testDeque = AZStd::deque(AZStd::from_range, AZStd::string(testView));
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c'));
+
+        // Test Range views
+        testDeque = AZStd::deque(AZStd::from_range, testValue | AZStd::views::transform([](const char elem) -> char { return elem + 1; }));
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('b', 'c', 'd'));
+    }
+
+    TEST_F(DequeTestFixture, AssignRange_Succeeds)
+    {
+        constexpr AZStd::string_view testView = "def";
+        AZStd::deque testDev{ 'a', 'b', 'c' };
+        testDev.assign_range(AZStd::vector<char>{testView.begin(), testView.end()});
+        testDev.assign_range(AZStd::vector<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testDev, ::testing::ElementsAre('d', 'e', 'f'));
+    }
+
+    TEST_F(DequeTestFixture, InsertRange_Succeeds)
+    {
+        constexpr AZStd::string_view testView = "abc";
+        AZStd::deque testDeque{ 'd', 'e', 'f' };
+        testDeque.insert_range(testDeque.begin(), AZStd::vector<char>{testView.begin(), testView.end()});
+        testDeque.insert_range(testDeque.end(), testView | AZStd::views::transform([](const char elem) -> char { return elem + 6; }));
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'));
+    }
+
+    TEST_F(DequeTestFixture, AppendRange_Succeeds)
+    {
+        constexpr AZStd::string_view testView = "def";
+        AZStd::deque testDeque{ 'a', 'b', 'c' };
+        testDeque.append_range(AZStd::vector<char>{testView.begin(), testView.end()});
+        testDeque.append_range(testView | AZStd::views::transform([](const char elem) -> char { return elem + 3; }));
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'));
+    }
+
+    TEST_F(DequeTestFixture, PrependRange_Succeeds)
+    {
+        constexpr AZStd::string_view testView = "def";
+        AZStd::deque testDeque{ 'g', 'h', 'i' };
+        testDeque.prepend_range(AZStd::vector<char>{testView.begin(), testView.end()});
+        testDeque.prepend_range(testView | AZStd::views::transform([](const char elem) -> char { return elem + -3; }));
+        EXPECT_THAT(testDeque, ::testing::ElementsAre('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'));
     }
 }

--- a/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
@@ -12,6 +12,8 @@
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/containers/fixed_unordered_set.h>
 #include <AzCore/std/containers/fixed_unordered_map.h>
+#include <AzCore/std/containers/span.h>
+#include <AzCore/std/ranges/transform_view.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/typetraits/has_member_function.h>
 
@@ -141,7 +143,7 @@ namespace UnitTest
     struct HashTableSetTestTraits
     {
         typedef T                               key_type;
-        typedef typename AZStd::equal_to<T>     key_eq;
+        typedef typename AZStd::equal_to<T>     key_equal;
         typedef typename AZStd::hash<T>         hasher;
         typedef T                               value_type;
         typedef AZStd::allocator                allocator_type;
@@ -168,10 +170,10 @@ namespace UnitTest
         hash_set_traits::hasher set_hasher;
 
         //
-        hash_key_table_type hTable(set_hasher, hash_set_traits::key_eq(), hash_set_traits::allocator_type());
+        hash_key_table_type hTable(set_hasher, hash_set_traits::key_equal(), hash_set_traits::allocator_type());
         ValidateHash(hTable);
         //
-        hash_key_table_type hTable1(elements.begin(), elements.end(), set_hasher, hash_set_traits::key_eq(), hash_set_traits::allocator_type());
+        hash_key_table_type hTable1(elements.begin(), elements.end(), set_hasher, hash_set_traits::key_equal(), hash_set_traits::allocator_type());
         ValidateHash(hTable1, elements.size());
         //
         hash_key_table_type hTable2(hTable1);
@@ -266,7 +268,7 @@ namespace UnitTest
         typedef HashTableSetTestTraits< int, true, true > hash_multiset_traits;
         typedef hash_table< hash_multiset_traits >  hash_key_multitable_type;
 
-        hash_key_multitable_type hMultiTable(set_hasher, hash_set_traits::key_eq(), hash_set_traits::allocator_type());
+        hash_key_multitable_type hMultiTable(set_hasher, hash_set_traits::key_equal(), hash_set_traits::allocator_type());
 
         array<int, 7> toInsert2 = {
             { 17, 101, 27, 7, 501, 101, 101 }
@@ -348,10 +350,10 @@ namespace UnitTest
         hash_set_traits::hasher set_hasher;
 
         //
-        hash_key_table_type hTable(set_hasher, hash_set_traits::key_eq(), hash_set_traits::allocator_type());
+        hash_key_table_type hTable(set_hasher, hash_set_traits::key_equal(), hash_set_traits::allocator_type());
         ValidateHash(hTable);
         //
-        hash_key_table_type hTable1(elements.begin(), elements.end(), set_hasher, hash_set_traits::key_eq(), hash_set_traits::allocator_type());
+        hash_key_table_type hTable1(elements.begin(), elements.end(), set_hasher, hash_set_traits::key_equal(), hash_set_traits::allocator_type());
         ValidateHash(hTable1, elements.size());
         //
         hash_key_table_type hTable2(hTable1);
@@ -434,7 +436,7 @@ namespace UnitTest
         typedef HashTableSetTestTraits< int, true, false > hash_multiset_traits;
         typedef hash_table< hash_multiset_traits >  hash_key_multitable_type;
 
-        hash_key_multitable_type hMultiTable(set_hasher, hash_set_traits::key_eq(), hash_set_traits::allocator_type());
+        hash_key_multitable_type hMultiTable(set_hasher, hash_set_traits::key_equal(), hash_set_traits::allocator_type());
 
         array<int, 7> toInsert2 = {
             { 17, 101, 27, 7, 501, 101, 101 }
@@ -461,7 +463,7 @@ namespace UnitTest
         typedef unordered_set<int> int_set_type;
 
         int_set_type::hasher myHasher;
-        int_set_type::key_eq myKeyEqCmp;
+        int_set_type::key_equal myKeyEqCmp;
         int_set_type::allocator_type myAllocator;
 
         int_set_type int_set;
@@ -520,7 +522,7 @@ namespace UnitTest
         typedef fixed_unordered_set<int, 101, 300> int_set_type;
 
         int_set_type::hasher myHasher;
-        int_set_type::key_eq myKeyEqCmp;
+        int_set_type::key_equal myKeyEqCmp;
 
         int_set_type int_set;
         ValidateHash(int_set);
@@ -537,7 +539,7 @@ namespace UnitTest
         int_set_type int_set4(uniqueArray.begin(), uniqueArray.end());
         ValidateHash(int_set4, uniqueArray.size());
 
-        int_set_type int_set6(uniqueArray.begin(), uniqueArray.end(), myHasher, myKeyEqCmp);
+        int_set_type int_set6(uniqueArray.begin(), uniqueArray.end(), 0, myHasher, myKeyEqCmp);
         ValidateHash(int_set6, uniqueArray.size());
         EXPECT_EQ(101, int_set6.bucket_count());
     }
@@ -547,7 +549,7 @@ namespace UnitTest
         typedef unordered_multiset<int> int_multiset_type;
 
         int_multiset_type::hasher myHasher;
-        int_multiset_type::key_eq myKeyEqCmp;
+        int_multiset_type::key_equal myKeyEqCmp;
         int_multiset_type::allocator_type myAllocator;
 
         int_multiset_type int_set;
@@ -606,7 +608,7 @@ namespace UnitTest
         typedef fixed_unordered_multiset<int, 101, 300> int_multiset_type;
 
         int_multiset_type::hasher myHasher;
-        int_multiset_type::key_eq myKeyEqCmp;
+        int_multiset_type::key_equal myKeyEqCmp;
 
         int_multiset_type int_set;
         ValidateHash(int_set);
@@ -624,7 +626,7 @@ namespace UnitTest
         ValidateHash(int_set4, uniqueArray.size());
         EXPECT_EQ(101, int_set4.bucket_count());
 
-        int_multiset_type int_set6(uniqueArray.begin(), uniqueArray.end(), myHasher, myKeyEqCmp);
+        int_multiset_type int_set6(uniqueArray.begin(), uniqueArray.end(), 0, myHasher, myKeyEqCmp);
         ValidateHash(int_set6, uniqueArray.size());
         EXPECT_EQ(101, int_set6.bucket_count());
     }
@@ -634,7 +636,7 @@ namespace UnitTest
         typedef unordered_map<int, int> int_int_map_type;
 
         int_int_map_type::hasher myHasher;
-        int_int_map_type::key_eq myKeyEqCmp;
+        int_int_map_type::key_equal myKeyEqCmp;
         int_int_map_type::allocator_type myAllocator;
 
         int_int_map_type intint_map;
@@ -735,7 +737,7 @@ namespace UnitTest
         typedef unordered_map<int, MyClass> int_myclass_map_type;
 
         int_myclass_map_type::hasher myHasher;
-        int_myclass_map_type::key_eq myKeyEqCmp;
+        int_myclass_map_type::key_equal myKeyEqCmp;
         int_myclass_map_type::allocator_type myAllocator;
 
         int_myclass_map_type intclass_map;
@@ -855,7 +857,7 @@ namespace UnitTest
         typedef fixed_unordered_map<int, int, 101, 300> int_int_map_type;
 
         int_int_map_type::hasher myHasher;
-        int_int_map_type::key_eq myKeyEqCmp;
+        int_int_map_type::key_equal myKeyEqCmp;
 
         int_int_map_type intint_map;
         ValidateHash(intint_map);
@@ -892,7 +894,7 @@ namespace UnitTest
         ValidateHash(intint_map4, uniqueArray.size());
         EXPECT_EQ(101, intint_map4.bucket_count());
 
-        int_int_map_type intint_map6(uniqueArray.begin(), uniqueArray.end(), myHasher, myKeyEqCmp);
+        int_int_map_type intint_map6(uniqueArray.begin(), uniqueArray.end(), 0, myHasher, myKeyEqCmp);
         ValidateHash(intint_map6, uniqueArray.size());
         EXPECT_EQ(101, intint_map6.bucket_count());
     }
@@ -902,7 +904,7 @@ namespace UnitTest
         typedef fixed_unordered_map<int, MyClass, 101, 300> int_myclass_map_type;
 
         int_myclass_map_type::hasher myHasher;
-        int_myclass_map_type::key_eq myKeyEqCmp;
+        int_myclass_map_type::key_equal myKeyEqCmp;
 
         int_myclass_map_type intclass_map;
         ValidateHash(intclass_map);
@@ -938,7 +940,7 @@ namespace UnitTest
         ValidateHash(intclass_map4, uniqueArray.size());
         EXPECT_EQ(101, intclass_map4.bucket_count());
 
-        int_myclass_map_type intclass_map6(uniqueArray.begin(), uniqueArray.end(), myHasher, myKeyEqCmp);
+        int_myclass_map_type intclass_map6(uniqueArray.begin(), uniqueArray.end(), 0, myHasher, myKeyEqCmp);
         ValidateHash(intclass_map6, uniqueArray.size());
         EXPECT_EQ(101, intclass_map6.bucket_count());
     }
@@ -948,7 +950,7 @@ namespace UnitTest
         typedef unordered_multimap<int, int> int_int_multimap_type;
 
         int_int_multimap_type::hasher myHasher;
-        int_int_multimap_type::key_eq myKeyEqCmp;
+        int_int_multimap_type::key_equal myKeyEqCmp;
         int_int_multimap_type::allocator_type myAllocator;
 
         int_int_multimap_type intint_map;
@@ -1025,7 +1027,7 @@ namespace UnitTest
         typedef fixed_unordered_multimap<int, int, 101, 300> int_int_multimap_type;
 
         int_int_multimap_type::hasher myHasher;
-        int_int_multimap_type::key_eq myKeyEqCmp;
+        int_int_multimap_type::key_equal myKeyEqCmp;
 
         int_int_multimap_type intint_map;
         ValidateHash(intint_map);
@@ -1057,7 +1059,7 @@ namespace UnitTest
         ValidateHash(intint_map4, multiArray.size());
         EXPECT_EQ(101, intint_map4.bucket_count());
 
-        int_int_multimap_type intint_map6(multiArray.begin(), multiArray.end(), myHasher, myKeyEqCmp);
+        int_int_multimap_type intint_map6(multiArray.begin(), multiArray.end(), 0, myHasher, myKeyEqCmp);
         ValidateHash(intint_map6, multiArray.size());
         EXPECT_EQ(101, intint_map6.bucket_count());
     }
@@ -1291,6 +1293,8 @@ namespace UnitTest
         EXPECT_EQ(8, testContainer.size());
     }
 
+
+
     TEST_F(HashedContainers, UnorderedSetInsertNodeHandleSucceeds)
     {
         using SetType = AZStd::unordered_set<int32_t>;
@@ -1403,7 +1407,7 @@ namespace UnitTest
 
         static ContainerType Create(std::initializer_list<typename ContainerType::value_type> intList, AZ::IAllocator* allocatorInstance)
         {
-            ContainerType allocatorSet(intList, AZStd::hash<int32_t>{}, AZStd::equal_to<int32_t>{}, AZ::AZStdIAllocator{ allocatorInstance });
+            ContainerType allocatorSet(intList, 0, AZStd::hash<int32_t>{}, AZStd::equal_to<int32_t>{}, AZ::AZStdIAllocator{ allocatorInstance });
             return allocatorSet;
         }
     };
@@ -1788,6 +1792,104 @@ namespace UnitTest
         EXPECT_EQ(-6354, insertOrAssignPairIter.first->second.m_value);
     }
 
+    template<template<class...> class SetTemplate>
+    static void HashSetRangeConstructorSucceeds()
+    {
+        constexpr AZStd::string_view testView = "abc";
+
+        SetTemplate testSet(AZStd::from_range, testView);
+        EXPECT_THAT(testSet, ::testing::UnorderedElementsAre('a', 'b', 'c'));
+
+        testSet = SetTemplate(AZStd::from_range, AZStd::vector<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testSet, ::testing::UnorderedElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::list<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testSet, ::testing::UnorderedElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::deque<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testSet, ::testing::UnorderedElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::unordered_set<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testSet, ::testing::UnorderedElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::fixed_vector<char, 8>{testView.begin(), testView.end()});
+        EXPECT_THAT(testSet, ::testing::UnorderedElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::array{ 'a', 'b', 'c' });
+        EXPECT_THAT(testSet, ::testing::UnorderedElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::span(testView));
+        EXPECT_THAT(testSet, ::testing::UnorderedElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::span(testView));
+        EXPECT_THAT(testSet, ::testing::UnorderedElementsAre('a', 'b', 'c'));
+
+        AZStd::fixed_string<8> testValue(testView);
+        testSet = SetTemplate(AZStd::from_range, testValue);
+        EXPECT_THAT(testSet, ::testing::UnorderedElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::string(testView));
+        EXPECT_THAT(testSet, ::testing::UnorderedElementsAre('a', 'b', 'c'));
+
+        // Test Range views
+        testSet = SetTemplate(AZStd::from_range, testValue | AZStd::views::transform([](const char elem) -> char { return elem + 1; }));
+        EXPECT_THAT(testSet, ::testing::UnorderedElementsAre('b', 'c', 'd'));
+    }
+
+    template<template<class...> class MapTemplate>
+    static void HashMapRangeConstructorSucceeds()
+    {
+        using ValueType = AZStd::pair<char, int>;
+        constexpr AZStd::array testArray{ ValueType{'a', 1}, ValueType{'b', 2}, ValueType{'c', 3} };
+
+        MapTemplate testMap(AZStd::from_range, testArray);
+        EXPECT_THAT(testMap, ::testing::UnorderedElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+
+        testMap = MapTemplate(AZStd::from_range, AZStd::vector<ValueType>{testArray.begin(), testArray.end()});
+        EXPECT_THAT(testMap, ::testing::UnorderedElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+        testMap = MapTemplate(AZStd::from_range, AZStd::list<ValueType>{testArray.begin(), testArray.end()});
+        EXPECT_THAT(testMap, ::testing::UnorderedElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+        testMap = MapTemplate(AZStd::from_range, AZStd::deque<ValueType>{testArray.begin(), testArray.end()});
+        EXPECT_THAT(testMap, ::testing::UnorderedElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+        testMap = MapTemplate(AZStd::from_range, AZStd::unordered_set<ValueType>{testArray.begin(), testArray.end()});
+        EXPECT_THAT(testMap, ::testing::UnorderedElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+        testMap = MapTemplate(AZStd::from_range, AZStd::fixed_vector<ValueType, 8>{testArray.begin(), testArray.end()});
+        EXPECT_THAT(testMap, ::testing::UnorderedElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+        testMap = MapTemplate(AZStd::from_range, AZStd::span(testArray));
+        EXPECT_THAT(testMap, ::testing::UnorderedElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+    }
+
+    TEST_F(HashedContainers, RangeConstructor_Succeeds)
+    {
+        HashSetRangeConstructorSucceeds<AZStd::unordered_set>();
+        HashSetRangeConstructorSucceeds<AZStd::unordered_multiset>();
+        HashMapRangeConstructorSucceeds<AZStd::unordered_map>();
+        HashMapRangeConstructorSucceeds<AZStd::unordered_multimap>();
+    }
+
+    template<template<class...> class SetTemplate>
+    static void HashSetInsertRangeSucceeds()
+    {
+        constexpr AZStd::string_view testView = "abc";
+        SetTemplate testSet{ 'd', 'e', 'f' };
+        testSet.insert_range(AZStd::vector<char>{testView.begin(), testView.end()});
+        testSet.insert_range(testView | AZStd::views::transform([](const char elem) -> char { return elem + 6; }));
+        EXPECT_THAT(testSet, ::testing::UnorderedElementsAre('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'));
+    }
+
+    template<template<class...> class MapTemplate>
+    static void HashMapInsertRangeSucceeds()
+    {
+        using ValueType = AZStd::pair<char, int>;
+        constexpr AZStd::array testArray{ ValueType{'a', 1}, ValueType{'b', 2}, ValueType{'c', 3} };
+
+        MapTemplate testMap(AZStd::from_range, testArray);
+
+        testMap.insert_range(AZStd::vector<ValueType>{ValueType{ 'd', 4 }, ValueType{ 'e', 5 }, ValueType{ 'f', 6 }});
+        EXPECT_THAT(testMap, ::testing::UnorderedElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 },
+            ValueType{ 'd', 4 }, ValueType{ 'e', 5 }, ValueType{ 'f', 6 }));
+    }
+
+    TEST_F(HashedContainers, InsertRange_Succeeds)
+    {
+        HashSetInsertRangeSucceeds<AZStd::unordered_set>();
+        HashSetInsertRangeSucceeds<AZStd::unordered_multiset>();
+        HashMapInsertRangeSucceeds<AZStd::unordered_map>();
+        HashMapInsertRangeSucceeds<AZStd::unordered_multimap>();
+    }
+
     template <typename ContainerType>
     class HashedMapDifferentAllocatorFixture
         : public AllocatorsFixture
@@ -1801,7 +1903,7 @@ namespace UnitTest
 
         static ContainerType Create(std::initializer_list<typename ContainerType::value_type> intList, AZ::IAllocator* allocatorInstance)
         {
-            ContainerType allocatorMap(intList, AZStd::hash<int32_t>{}, AZStd::equal_to<int32_t>{}, AZ::AZStdIAllocator{ allocatorInstance });
+            ContainerType allocatorMap(intList, 0, AZStd::hash<int32_t>{}, AZStd::equal_to<int32_t>{}, AZ::AZStdIAllocator{ allocatorInstance });
             return allocatorMap;
         }
     };

--- a/Code/Framework/AzCore/Tests/AZStd/ListsFixed.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/ListsFixed.cpp
@@ -12,25 +12,41 @@
 
 #include <AzCore/std/containers/array.h>
 
-using namespace AZStd;
-using namespace UnitTestInternal;
-
 #define AZ_TEST_VALIDATE_EMPTY_LIST(_List)        \
-    AZ_TEST_ASSERT(_List.validate());             \
-    AZ_TEST_ASSERT(_List.size() == 0);            \
-    AZ_TEST_ASSERT(_List.begin() == _List.end()); \
-    AZ_TEST_ASSERT(_List.empty());
-
+    EXPECT_TRUE(_List.empty());
 
 #define AZ_TEST_VALIDATE_LIST(_List, _NumElements)                                                    \
-    AZ_TEST_ASSERT(_List.validate());                                                                 \
-    AZ_TEST_ASSERT(_List.size() == _NumElements);                                                     \
-    AZ_TEST_ASSERT((_NumElements > 0) ? !_List.empty() : _List.empty());                              \
-    AZ_TEST_ASSERT((_NumElements > 0) ? _List.begin() != _List.end() : _List.begin() == _List.end()); \
-    AZ_TEST_ASSERT(!_List.empty());
+    EXPECT_EQ(_NumElements, _List.size());                                                     \
+    AZ_PUSH_DISABLE_WARNING_MSVC(4127) \
+    if(_NumElements > 0) { EXPECT_FALSE(_List.empty()); } else { EXPECT_TRUE(_List.empty()); } \
+    if(_NumElements > 0) { EXPECT_NE(_List.end(),_List.begin()); } else { EXPECT_EQ(_List.end(),_List.begin()); } \
+    AZ_POP_DISABLE_WARNING_MSVC \
+    EXPECT_FALSE(_List.empty());
 
 namespace UnitTest
 {
+    template<class T, size_t NodeCount>
+    auto FindPrevValidElementBefore(const AZStd::fixed_forward_list<T, NodeCount>& forwardList,
+        typename AZStd::fixed_forward_list<T, NodeCount>::const_iterator last, int prevCount = 1)
+    {
+        // Find the previous valid element that is at least prevCount before
+        // the @last iterator
+        auto lastValidIter = forwardList.before_begin();
+        for (auto first = AZStd::ranges::next(lastValidIter, prevCount);
+            first != last; ++lastValidIter, ++first)
+        {
+        }
+
+        return lastValidIter;
+    };
+
+    template<class T, size_t NodeCount>
+    auto FindLastValidElementBefore(const AZStd::fixed_forward_list<T, NodeCount>& forwardList,
+        typename AZStd::fixed_forward_list<T, NodeCount>::const_iterator last)
+    {
+        return FindPrevValidElementBefore(forwardList, last, 1);
+    };
+
     class FixedListContainers
         : public AllocatorsFixture
     {
@@ -48,119 +64,119 @@ namespace UnitTest
 
     TEST_F(FixedListContainers, ListCtorAssign)
     {
-        fixed_list<int, 100> int_list;
-        fixed_list<int, 100> int_list1;
-        fixed_list<int, 100> int_list2;
-        fixed_list<int, 100> int_list3;
-        fixed_list<int, 100> int_list4;
+        AZStd::fixed_list<int, 100> int_list;
+        AZStd::fixed_list<int, 100> int_list1;
+        AZStd::fixed_list<int, 100> int_list2;
+        AZStd::fixed_list<int, 100> int_list3;
+        AZStd::fixed_list<int, 100> int_list4;
 
         // default ctor
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list);
 
         // 10 int elements, value 33
-        int_list1 = fixed_list<int, 100>(10, 33);
+        int_list1 = AZStd::fixed_list<int, 100>(10, 33);
         AZ_TEST_VALIDATE_LIST(int_list1, 10);
-        for (fixed_list<int, 100>::iterator iter = int_list1.begin(); iter != int_list1.end(); ++iter)
+        for (AZStd::fixed_list<int, 100>::iterator iter = int_list1.begin(); iter != int_list1.end(); ++iter)
         {
-            AZ_TEST_ASSERT(*iter == 33);
+            EXPECT_EQ(33, *iter);
         }
 
         // copy list 1 using, first,last,allocator.
-        int_list2 = fixed_list<int, 100>(int_list1.begin(), int_list1.end());
+        int_list2 = AZStd::fixed_list<int, 100>(int_list1.begin(), int_list1.end());
         AZ_TEST_VALIDATE_LIST(int_list2, 10);
-        for (fixed_list<int, 100>::iterator iter = int_list2.begin(); iter != int_list2.end(); ++iter)
+        for (AZStd::fixed_list<int, 100>::iterator iter = int_list2.begin(); iter != int_list2.end(); ++iter)
         {
-            AZ_TEST_ASSERT(*iter == 33);
+            EXPECT_EQ(33, *iter);
         }
 
         // copy construct
-        int_list3 = fixed_list<int, 100>(int_list1);
-        AZ_TEST_ASSERT(int_list1 == int_list3);
+        int_list3 = AZStd::fixed_list<int, 100>(int_list1);
+        EXPECT_EQ(int_list3, int_list1);
 
         // initializer_list construct
         int_list4 = { 33, 33, 33, 33, 33, 33, 33, 33, 33, 33 };
-        AZ_TEST_ASSERT(int_list1 == int_list4);
+        EXPECT_EQ(int_list4, int_list1);
 
         // assign
         int_list = int_list1;
-        AZ_TEST_ASSERT(int_list == int_list1);
+        EXPECT_EQ(int_list1, int_list);
 
         int_list2.push_back(60);
         int_list = int_list2;
-        AZ_TEST_ASSERT(int_list == int_list2);
+        EXPECT_EQ(int_list2, int_list);
 
         int_list2.pop_back();
         int_list2.pop_back();
         int_list = int_list2;
-        AZ_TEST_ASSERT(int_list == int_list2);
+        EXPECT_EQ(int_list2, int_list);
 
         // assign with iterators (at the moment this uses the function operator= calls)
         int_list2.assign(int_list1.begin(), int_list1.end());
-        AZ_TEST_ASSERT(int_list2 == int_list1);
+        EXPECT_EQ(int_list1, int_list2);
 
         // assign a fixed value
         int_list.assign(5, 55);
         AZ_TEST_VALIDATE_LIST(int_list, 5);
-        for (fixed_list<int, 100>::iterator iter = int_list.begin(); iter != int_list.end(); ++iter)
+        for (AZStd::fixed_list<int, 100>::iterator iter = int_list.begin(); iter != int_list.end(); ++iter)
         {
-            AZ_TEST_ASSERT(*iter == 55);
+            EXPECT_EQ(55, *iter);
         }
     }
 
     TEST_F(FixedListContainers, ListResizeInsertErase)
     {
-        fixed_list<int, 100> int_list;
-        fixed_list<int, 100> int_list1;
+        AZStd::fixed_list<int, 100> int_list;
+        AZStd::fixed_list<int, 100> int_list1;
 
         int_list.assign(5, 55);
-        int_list1 = fixed_list<int, 100>(10, 33);
+        int_list1 = AZStd::fixed_list<int, 100>(10, 33);
 
         // resize to bigger
         int_list.resize(6, 43);
         AZ_TEST_VALIDATE_LIST(int_list, 6);
-        AZ_TEST_ASSERT(int_list.back() == 43);
-        AZ_TEST_ASSERT(*prev(int_list.end(), 2) == 55);
-        AZ_TEST_ASSERT(*int_list.begin() == *prev(int_list.rend()));
+        EXPECT_EQ(43, int_list.back());
+        EXPECT_EQ(55, *prev(int_list.end(), 2));
+        EXPECT_EQ(*prev(int_list.rend()), *int_list.begin());
 
         // resize to smaller
         int_list.resize(3);
         AZ_TEST_VALIDATE_LIST(int_list, 3);
-        AZ_TEST_ASSERT(int_list.back() == 55);
+        EXPECT_EQ(55, int_list.back());
 
         // insert
         int_list.insert(int_list.begin(), 44);
         AZ_TEST_VALIDATE_LIST(int_list, 4);
-        AZ_TEST_ASSERT(int_list.front() == 44);
+        EXPECT_EQ(44, int_list.front());
 
         int_list.insert(int_list.end(), 66);
         AZ_TEST_VALIDATE_LIST(int_list, 5);
-        AZ_TEST_ASSERT(int_list.back() == 66);
+        EXPECT_EQ(66, int_list.back());
 
         int_list.insert(int_list.begin(), 2, 11);
         AZ_TEST_VALIDATE_LIST(int_list, 7);
-        AZ_TEST_ASSERT(int_list.front() == 11);
-        AZ_TEST_ASSERT(*next(int_list.begin()) == 11);
+        EXPECT_EQ(11, int_list.front());
+        EXPECT_EQ(11, *next(int_list.begin()));
 
         int_list.insert(int_list.end(), 2, 22);
         AZ_TEST_VALIDATE_LIST(int_list, 9);
-        AZ_TEST_ASSERT(int_list.back() == 22);
-        AZ_TEST_ASSERT(*prev(int_list.end(), 2) == 22);
+        EXPECT_EQ(22, int_list.back());
+        EXPECT_EQ(22, *prev(int_list.end(), 2));
 
         int_list.insert(int_list.end(), int_list1.begin(), int_list1.end());
         AZ_TEST_VALIDATE_LIST(int_list, 9 + int_list1.size());
-        AZ_TEST_ASSERT(int_list.back() == 33);
+        EXPECT_EQ(33, int_list.back());
 
         // erase
         int_list.assign(2, 10);
         int_list.push_back(20);
         int_list.erase(--int_list.end());
         AZ_TEST_VALIDATE_LIST(int_list, 2);
-        AZ_TEST_ASSERT(int_list.back() == 10);
+        EXPECT_EQ(10, int_list.back());
 
         int_list.insert(int_list.end(), 3, 44);
         int_list.erase(prev(int_list.end(), 2), int_list.end());
         AZ_TEST_VALIDATE_LIST(int_list, 3);
-        AZ_TEST_ASSERT(int_list.back() == 44);
+        EXPECT_EQ(44, int_list.back());
 
         // clear
         int_list.clear();
@@ -169,11 +185,11 @@ namespace UnitTest
 
     TEST_F(FixedListContainers, ListSwapSplice)
     {
-        fixed_list<int, 100> int_list;
-        fixed_list<int, 100> int_list1;
-        fixed_list<int, 100> int_list2;
+        AZStd::fixed_list<int, 100> int_list;
+        AZStd::fixed_list<int, 100> int_list1;
+        AZStd::fixed_list<int, 100> int_list2;
 
-        int_list2 = fixed_list<int, 100>(10, 33);
+        int_list2 = AZStd::fixed_list<int, 100>(10, 33);
 
         // list operations with container with the same allocator.
         // swap
@@ -189,15 +205,15 @@ namespace UnitTest
         int_list.swap(int_list2);
         AZ_TEST_VALIDATE_LIST(int_list, 10);
         AZ_TEST_VALIDATE_LIST(int_list2, 5);
-        AZ_TEST_ASSERT(int_list.front() == 33);
-        AZ_TEST_ASSERT(int_list2.front() == 55);
+        EXPECT_EQ(33, int_list.front());
+        EXPECT_EQ(55, int_list2.front());
 
         // splice
         // splice(iterator splicePos, this_type& rhs)
         int_list.splice(int_list.end(), int_list2);
         AZ_TEST_VALIDATE_LIST(int_list, 15);
-        AZ_TEST_ASSERT(int_list.front() == 33);
-        AZ_TEST_ASSERT(int_list.back() == 55);
+        EXPECT_EQ(33, int_list.front());
+        EXPECT_EQ(55, int_list.back());
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list2);
 
         // splice(iterator splicePos, this_type& rhs, iterator first)
@@ -205,26 +221,26 @@ namespace UnitTest
         int_list.splice(int_list.begin(), int_list2, int_list2.begin());
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list2);
         AZ_TEST_VALIDATE_LIST(int_list, 16);
-        AZ_TEST_ASSERT(int_list.front() == 101);
+        EXPECT_EQ(101, int_list.front());
 
         // splice(iterator splicePos, this_type& rhs, iterator first, iterator last)
         int_list2.assign(5, 201);
         int_list.splice(int_list.end(), int_list2, ++int_list2.begin(), int_list2.end());
         AZ_TEST_VALIDATE_LIST(int_list2, 1);
         AZ_TEST_VALIDATE_LIST(int_list, 20);
-        AZ_TEST_ASSERT(int_list.back() == 201);
+        EXPECT_EQ(201, int_list.back());
 
         // splice(iterator splicePos, this_type& rhs, iterator first, iterator last) the whole vector optimization.
         int_list2.push_back(301);
         int_list.splice(int_list.end(), int_list2, int_list2.begin(), int_list2.end());
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list2);
         AZ_TEST_VALIDATE_LIST(int_list, 22);
-        AZ_TEST_ASSERT(int_list.back() == 301);
+        EXPECT_EQ(301, int_list.back());
     }
 
     TEST_F(FixedListContainers, ListRemoveUniqueSort)
     {
-        fixed_list<int, 100> int_list;
+        AZStd::fixed_list<int, 100> int_list;
         
         // remove
         int_list.assign(5, 101);
@@ -233,12 +249,12 @@ namespace UnitTest
         int_list.push_back(401);
         int_list.remove(101);
         AZ_TEST_VALIDATE_LIST(int_list, 3);
-        AZ_TEST_ASSERT(int_list.front() == 201);
-        AZ_TEST_ASSERT(int_list.back() == 401);
+        EXPECT_EQ(201, int_list.front());
+        EXPECT_EQ(401, int_list.back());
 
         int_list.remove_if(RemoveLessThan401());
         AZ_TEST_VALIDATE_LIST(int_list, 1);
-        AZ_TEST_ASSERT(int_list.back() == 401);
+        EXPECT_EQ(401, int_list.back());
 
         // unique
         int_list.assign(2, 101);
@@ -247,8 +263,8 @@ namespace UnitTest
         int_list.push_back(301);
         int_list.unique();
         AZ_TEST_VALIDATE_LIST(int_list, 3);
-        AZ_TEST_ASSERT(int_list.front() == 101);
-        AZ_TEST_ASSERT(int_list.back() == 301);
+        EXPECT_EQ(101, int_list.front());
+        EXPECT_EQ(301, int_list.back());
 
         int_list.assign(2, 101);
         int_list.push_back(201);
@@ -258,17 +274,17 @@ namespace UnitTest
         int_list.push_back(501);
         int_list.unique(UniqueForLessThan401());
         AZ_TEST_VALIDATE_LIST(int_list, 5);
-        AZ_TEST_ASSERT(int_list.front() == 101);
-        AZ_TEST_ASSERT(int_list.back() == 501);
+        EXPECT_EQ(101, int_list.front());
+        EXPECT_EQ(501, int_list.back());
         // sort
         int_list.assign(2, 101);
         int_list.push_back(201);
         int_list.push_back(1);
         int_list.sort();
         AZ_TEST_VALIDATE_LIST(int_list, 4);
-        for (fixed_list<int, 100>::iterator iter = int_list.begin(); iter != --int_list.end(); ++iter)
+        for (AZStd::fixed_list<int, 100>::iterator iter = int_list.begin(); iter != --int_list.end(); ++iter)
         {
-            AZ_TEST_ASSERT(*iter <= *next(iter));
+            EXPECT_LE(*iter, *next(iter));
         }
 
         int_list.assign(2, 101);
@@ -276,18 +292,18 @@ namespace UnitTest
         int_list.push_back(1);
         int_list.sort(AZStd::greater<int>());
         AZ_TEST_VALIDATE_LIST(int_list, 4);
-        for (fixed_list<int, 100>::iterator iter = int_list.begin(); iter != --int_list.end(); ++iter)
+        for (AZStd::fixed_list<int, 100>::iterator iter = int_list.begin(); iter != --int_list.end(); ++iter)
         {
-            AZ_TEST_ASSERT(*iter >= *next(iter));
+            EXPECT_GE(*iter, *next(iter));
         }
     }
 
     TEST_F(FixedListContainers, ListReverseMerge)
     {
-        fixed_list<int, 100> int_list;
-        fixed_list<int, 100> int_list1;
-        fixed_list<int, 100> int_list2;
-        fixed_list<int, 100> int_list3;
+        AZStd::fixed_list<int, 100> int_list;
+        AZStd::fixed_list<int, 100> int_list1;
+        AZStd::fixed_list<int, 100> int_list2;
+        AZStd::fixed_list<int, 100> int_list3;
 
         int_list.assign(2, 101);
         int_list.push_back(201);
@@ -296,9 +312,9 @@ namespace UnitTest
 
         // reverse
         int_list.reverse();
-        for (fixed_list<int, 100>::iterator iter = int_list.begin(); iter != --int_list.end(); ++iter)
+        for (AZStd::fixed_list<int, 100>::iterator iter = int_list.begin(); iter != --int_list.end(); ++iter)
         {
-            AZ_TEST_ASSERT(*iter <= *next(iter));
+            EXPECT_LE(*iter, *next(iter));
         }
 
         // merge
@@ -318,9 +334,9 @@ namespace UnitTest
         int_list2.merge(int_list3);
         AZ_TEST_VALIDATE_LIST(int_list2, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list3);
-        for (fixed_list<int, 100>::iterator iter = int_list2.begin(); iter != --int_list2.end(); ++iter)
+        for (AZStd::fixed_list<int, 100>::iterator iter = int_list2.begin(); iter != --int_list2.end(); ++iter)
         {
-            AZ_TEST_ASSERT(*iter < *next(iter));
+            EXPECT_LT(*iter, *next(iter));
         }
 
         int_list.reverse();
@@ -331,15 +347,15 @@ namespace UnitTest
         int_list2.merge(int_list3, AZStd::greater<int>());
         AZ_TEST_VALIDATE_LIST(int_list2, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list3);
-        for (fixed_list<int, 100>::iterator iter = int_list2.begin(); iter != --int_list2.end(); ++iter)
+        for (AZStd::fixed_list<int, 100>::iterator iter = int_list2.begin(); iter != --int_list2.end(); ++iter)
         {
-            AZ_TEST_ASSERT(*iter > *next(iter));
+            EXPECT_GT(*iter, *next(iter));
         }
     }
 
     TEST_F(FixedListContainers, ListExtensions)
     {
-        fixed_list<int, 100> int_list;
+        AZStd::fixed_list<int, 100> int_list;
 
         // Push_back()
         int_list.emplace_back();
@@ -349,294 +365,269 @@ namespace UnitTest
         // Push_front()
         int_list.emplace_front();
         AZ_TEST_VALIDATE_LIST(int_list, 2);
-        AZ_TEST_ASSERT(int_list.back() == 100);
+        EXPECT_EQ(100, int_list.back());
 
         // Insert without value to copy from.
         int_list.insert(int_list.begin());
         AZ_TEST_VALIDATE_LIST(int_list, 3);
 
         // default int alignment
-        AZ_TEST_ASSERT(((AZStd::size_t)&int_list.front() % 4) == 0); // default int alignment
+        EXPECT_EQ(0, ((AZStd::size_t)&int_list.front() % 4)); // default int alignment
 
         // make sure every allocation is aligned.
-        fixed_list<MyClass, 100> aligned_list(5, MyClass(99));
-        AZ_TEST_ASSERT(((AZStd::size_t)&aligned_list.front() & (alignment_of<MyClass>::value - 1)) == 0);
+        AZStd::fixed_list<UnitTestInternal::MyClass, 100> aligned_list(5, UnitTestInternal::MyClass(99));
+        EXPECT_EQ(0, ((AZStd::size_t)&aligned_list.front() & (alignof(UnitTestInternal::MyClass) - 1)));
     }
 
     TEST_F(FixedListContainers, ForwardListCtorAssign)
     {
-        fixed_forward_list<int, 100> int_slist;
-        fixed_forward_list<int, 100> int_slist1;
-        fixed_forward_list<int, 100> int_slist2;
-        fixed_forward_list<int, 100> int_slist3;
-        fixed_forward_list<int, 100> int_slist4;
+        AZStd::fixed_forward_list<int, 100> int_slist;
+        AZStd::fixed_forward_list<int, 100> int_slist1;
+        AZStd::fixed_forward_list<int, 100> int_slist2;
+        AZStd::fixed_forward_list<int, 100> int_slist3;
+        AZStd::fixed_forward_list<int, 100> int_slist4;
 
         // default ctor
-        AZ_TEST_VALIDATE_EMPTY_LIST(int_slist);
 
         // 10 int elements, value 33
-        int_slist1 = fixed_forward_list<int, 100>(10, 33);
-        AZ_TEST_VALIDATE_LIST(int_slist1, 10);
-        for (fixed_forward_list<int, 100>::iterator iter = int_slist1.begin(); iter != int_slist1.end(); ++iter)
+        int_slist1 = AZStd::fixed_forward_list<int, 100>(10, 33);
+        for (AZStd::fixed_forward_list<int, 100>::iterator iter = int_slist1.begin(); iter != int_slist1.end(); ++iter)
         {
-            AZ_TEST_ASSERT(*iter == 33);
+            EXPECT_EQ(33, *iter);
         }
 
         // copy list 1 using, first,last,allocator.
-        int_slist2 = fixed_forward_list<int, 100>(int_slist1.begin(), int_slist1.end());
-        AZ_TEST_VALIDATE_LIST(int_slist2, 10);
-        for (fixed_forward_list<int, 100>::iterator iter = int_slist2.begin(); iter != int_slist2.end(); ++iter)
+        int_slist2 = AZStd::fixed_forward_list<int, 100>(int_slist1.begin(), int_slist1.end());
+        for (AZStd::fixed_forward_list<int, 100>::iterator iter = int_slist2.begin(); iter != int_slist2.end(); ++iter)
         {
-            AZ_TEST_ASSERT(*iter == 33);
+            EXPECT_EQ(33, *iter);
         }
 
         // copy construct
-        int_slist3 = fixed_forward_list<int, 100>(int_slist1);
-        AZ_TEST_ASSERT(int_slist1 == int_slist3);
+        int_slist3 = AZStd::fixed_forward_list<int, 100>(int_slist1);
+        EXPECT_EQ(int_slist3, int_slist1);
 
         // initializer_list construct
         int_slist4 = { 33, 33, 33, 33, 33, 33, 33, 33, 33, 33 };
-        AZ_TEST_ASSERT(int_slist1 == int_slist4);
+        EXPECT_EQ(int_slist4, int_slist1);
 
         // assign
         int_slist = int_slist1;
-        AZ_TEST_ASSERT(int_slist == int_slist1);
+        EXPECT_EQ(int_slist1, int_slist);
 
-        int_slist2.push_back(60);
+        int_slist2.emplace_after(FindLastValidElementBefore(int_slist2, int_slist2.end()), 60);
         int_slist = int_slist2;
-        AZ_TEST_ASSERT(int_slist == int_slist2);
+        EXPECT_EQ(int_slist2, int_slist);
 
         //int_slist2.pop_back();
         //int_slist2.pop_back();
         //int_slist = int_slist2;
-        //AZ_TEST_ASSERT(int_slist==int_slist2);
+        //EXPECT_EQ(int_slist2, int_slist);
 
         // assign with iterators (at the moment this uses the function operator= calls)
         int_slist2.assign(int_slist1.begin(), int_slist1.end());
-        AZ_TEST_ASSERT(int_slist2 == int_slist1);
+        EXPECT_EQ(int_slist1, int_slist2);
 
         // assign a fixed value
         int_slist.assign(5, 55);
-        AZ_TEST_VALIDATE_LIST(int_slist, 5);
-        for (fixed_forward_list<int, 100>::iterator iter = int_slist.begin(); iter != int_slist.end(); ++iter)
+        for (AZStd::fixed_forward_list<int, 100>::iterator iter = int_slist.begin(); iter != int_slist.end(); ++iter)
         {
-            AZ_TEST_ASSERT(*iter == 55);
+            EXPECT_EQ(55, *iter);
         }
     }
 
     TEST_F(FixedListContainers, ForwardListResizeInsertErase)
     {
-        fixed_forward_list<int, 100> int_slist;
-        fixed_forward_list<int, 100> int_slist1;
+        AZStd::fixed_forward_list<int, 100> int_slist;
+        AZStd::fixed_forward_list<int, 100> int_slist1;
        
         int_slist.assign(5, 55);
-        int_slist1 = fixed_forward_list<int, 100>(10, 33);
+        int_slist1 = AZStd::fixed_forward_list<int, 100>(10, 33);
 
         // resize to bigger
         int_slist.resize(6, 43);
-        AZ_TEST_VALIDATE_LIST(int_slist, 6);
-        AZ_TEST_ASSERT(int_slist.back() == 43);
+        EXPECT_EQ(43, *FindLastValidElementBefore(int_slist, int_slist.end()));
 
         // resize to smaller
         int_slist.resize(3);
-        AZ_TEST_VALIDATE_LIST(int_slist, 3);
-        AZ_TEST_ASSERT(int_slist.back() == 55);
+        EXPECT_EQ(55, *FindLastValidElementBefore(int_slist, int_slist.end()));
 
         // insert
-        int_slist.insert(int_slist.begin(), 44);
-        AZ_TEST_VALIDATE_LIST(int_slist, 4);
-        AZ_TEST_ASSERT(int_slist.front() == 44);
+        int_slist.insert_after(int_slist.before_begin(), 44);
+        EXPECT_EQ(44, int_slist.front());
 
-        int_slist.insert(int_slist.end(), 66);
-        AZ_TEST_VALIDATE_LIST(int_slist, 5);
-        AZ_TEST_ASSERT(int_slist.back() == 66);
+        int_slist.insert_after(FindLastValidElementBefore(int_slist, int_slist.end()), 66);
+        EXPECT_EQ(66, *FindLastValidElementBefore(int_slist, int_slist.end()));
 
-        int_slist.insert(int_slist.begin(), 2, 11);
-        AZ_TEST_VALIDATE_LIST(int_slist, 7);
-        AZ_TEST_ASSERT(int_slist.front() == 11);
-        AZ_TEST_ASSERT(*next(int_slist.begin()) == 11);
+        int_slist.insert_after(int_slist.before_begin(), 2, 11);
+        EXPECT_EQ(11, int_slist.front());
+        EXPECT_EQ(11, *next(int_slist.begin()));
 
-        int_slist.insert(int_slist.end(), 2, 22);
-        AZ_TEST_VALIDATE_LIST(int_slist, 9);
-        AZ_TEST_ASSERT(int_slist.back() == 22);
-        AZ_TEST_ASSERT(*int_slist.previous(int_slist.before_end()) == 22);
+        int_slist.insert_after(FindLastValidElementBefore(int_slist, int_slist.end()), 2, 22);
+        EXPECT_EQ(22, *FindLastValidElementBefore(int_slist, int_slist.end()));
+        EXPECT_EQ(22, *FindLastValidElementBefore(int_slist, FindLastValidElementBefore(int_slist, int_slist.end())));
 
-        int_slist.insert(int_slist.end(), int_slist1.begin(), int_slist1.end());
-        AZ_TEST_VALIDATE_LIST(int_slist, 9 + int_slist1.size());
-        AZ_TEST_ASSERT(int_slist.back() == 33);
+        int_slist.insert_after(int_slist.before_end(), int_slist1.begin(), int_slist1.end());
+        EXPECT_EQ(33, *FindLastValidElementBefore(int_slist, int_slist.end()));
 
         // erase
         int_slist.assign(2, 10);
-        int_slist.push_back(20);
-        int_slist.erase(int_slist.before_end());
-        AZ_TEST_VALIDATE_LIST(int_slist, 2);
-        AZ_TEST_ASSERT(int_slist.back() == 10);
+        int_slist.emplace_after(FindLastValidElementBefore(int_slist, int_slist.end()), 20);
+        auto secondToLastElementIter = FindPrevValidElementBefore(int_slist, int_slist.end(), 2);
+        int_slist.erase_after(secondToLastElementIter);
+        EXPECT_EQ(10, *FindLastValidElementBefore(int_slist, int_slist.end()));
 
-        int_slist.insert(int_slist.end(), 3, 44);
-        int_slist.erase(int_slist.previous(int_slist.before_end()), int_slist.end());
-        AZ_TEST_VALIDATE_LIST(int_slist, 3);
-        AZ_TEST_ASSERT(int_slist.back() == 44);
+        int_slist.insert_after(FindLastValidElementBefore(int_slist, int_slist.end()), 3, 44);
+        auto thirdToLastElementIter = FindPrevValidElementBefore(int_slist, int_slist.end(), 3);
+        int_slist.erase_after(thirdToLastElementIter);
+        EXPECT_EQ(44, *FindLastValidElementBefore(int_slist, int_slist.end()));
 
         // clear
         int_slist.clear();
-        AZ_TEST_VALIDATE_EMPTY_LIST(int_slist);
     }
 
     TEST_F(FixedListContainers, ForwardListSwapSplice)
     {
-        fixed_forward_list<int, 100> int_slist;
-        fixed_forward_list<int, 100> int_slist1;
-        fixed_forward_list<int, 100> int_slist2;
+        AZStd::fixed_forward_list<int, 100> int_slist;
+        AZStd::fixed_forward_list<int, 100> int_slist1;
+        AZStd::fixed_forward_list<int, 100> int_slist2;
 
-        int_slist2 = fixed_forward_list<int, 100>(10, 33);
+        int_slist2 = AZStd::fixed_forward_list<int, 100>(10, 33);
 
         // list operations with container with the same allocator.
         // swap
         int_slist.swap(int_slist2);
-        AZ_TEST_VALIDATE_EMPTY_LIST(int_slist2);
-        AZ_TEST_VALIDATE_LIST(int_slist, 10);
+        EXPECT_TRUE(int_slist2.empty());
 
         int_slist.swap(int_slist2);
-        AZ_TEST_VALIDATE_EMPTY_LIST(int_slist);
-        AZ_TEST_VALIDATE_LIST(int_slist2, 10);
+        EXPECT_TRUE(int_slist.empty());
+        EXPECT_FALSE(int_slist2.empty());
 
         int_slist.assign(5, 55);
         int_slist.swap(int_slist2);
-        AZ_TEST_VALIDATE_LIST(int_slist, 10);
-        AZ_TEST_VALIDATE_LIST(int_slist2, 5);
-        AZ_TEST_ASSERT(int_slist.front() == 33);
-        AZ_TEST_ASSERT(int_slist2.front() == 55);
+        EXPECT_EQ(33, int_slist.front());
+        EXPECT_EQ(55, int_slist2.front());
 
         // splice
         // splice(iterator splicePos, this_type& rhs)
-        int_slist.splice(int_slist.end(), int_slist2);
-        AZ_TEST_VALIDATE_LIST(int_slist, 15);
-        AZ_TEST_ASSERT(int_slist.front() == 33);
-        AZ_TEST_ASSERT(int_slist.back() == 55);
-        AZ_TEST_VALIDATE_EMPTY_LIST(int_slist2);
+        int_slist.splice_after(FindLastValidElementBefore(int_slist, int_slist.end()), int_slist2);
+        EXPECT_EQ(33, int_slist.front());
+        EXPECT_EQ(55, *FindLastValidElementBefore(int_slist, int_slist.end()));
+        EXPECT_TRUE(int_slist2.empty());
 
         // splice(iterator splicePos, this_type& rhs, iterator first)
-        int_slist2.push_back(101);
-        int_slist.splice(int_slist.begin(), int_slist2, int_slist2.begin());
-        AZ_TEST_VALIDATE_EMPTY_LIST(int_slist2);
-        AZ_TEST_VALIDATE_LIST(int_slist, 16);
-        AZ_TEST_ASSERT(int_slist.front() == 101);
+        int_slist2.emplace_after(FindLastValidElementBefore(int_slist2, int_slist2.end()), 101);
+        int_slist.splice_after(int_slist.before_begin(), int_slist2, int_slist2.before_begin());
+        EXPECT_EQ(101, int_slist.front());
 
         // splice(iterator splicePos, this_type& rhs, iterator first, iterator last)
         int_slist2.assign(5, 201);
-        int_slist.splice(int_slist.end(), int_slist2, ++int_slist2.begin(), int_slist2.end());
-        AZ_TEST_VALIDATE_LIST(int_slist2, 1);
-        AZ_TEST_VALIDATE_LIST(int_slist, 20);
-        AZ_TEST_ASSERT(int_slist.back() == 201);
+        int_slist.splice_after(FindLastValidElementBefore(int_slist, int_slist.end()), int_slist2, int_slist2.begin(), int_slist2.end());
+        EXPECT_EQ(201, *FindLastValidElementBefore(int_slist, int_slist.end()));
 
         // splice(iterator splicePos, this_type& rhs, iterator first, iterator last) the whole vector optimization.
-        int_slist2.push_back(301);
-        int_slist.splice(int_slist.end(), int_slist2, int_slist2.begin(), int_slist2.end());
-        AZ_TEST_VALIDATE_EMPTY_LIST(int_slist2);
-        AZ_TEST_VALIDATE_LIST(int_slist, 22);
-        AZ_TEST_ASSERT(int_slist.back() == 301);
+        int_slist2.emplace_after(FindLastValidElementBefore(int_slist2, int_slist2.end()), 301);
+        int_slist.splice_after(FindLastValidElementBefore(int_slist, int_slist.end()), int_slist2, int_slist2.before_begin(), int_slist2.end());
+        EXPECT_EQ(301, *FindLastValidElementBefore(int_slist, int_slist.end()));
     }
 
     TEST_F(FixedListContainers, ForwardListRemoveUniqueSort)
     {
-        fixed_forward_list<int, 100> int_slist;
+        AZStd::fixed_forward_list<int, 100> int_slist;
 
         // remove
         int_slist.assign(5, 101);
-        int_slist.push_back(201);
-        int_slist.push_back(301);
-        int_slist.push_back(401);
+        auto lastInsertIter = int_slist.emplace_after(FindLastValidElementBefore(int_slist, int_slist.end()), 201);
+        lastInsertIter = int_slist.emplace_after(lastInsertIter, 301);
+        lastInsertIter = int_slist.emplace_after(lastInsertIter, 401);
         int_slist.remove(101);
-        AZ_TEST_VALIDATE_LIST(int_slist, 3);
-        AZ_TEST_ASSERT(int_slist.front() == 201);
-        AZ_TEST_ASSERT(int_slist.back() == 401);
+        EXPECT_EQ(201, int_slist.front());
+        EXPECT_EQ(401, *FindLastValidElementBefore(int_slist, int_slist.end()));
 
         int_slist.remove_if(RemoveLessThan401());
-        AZ_TEST_VALIDATE_LIST(int_slist, 1);
-        AZ_TEST_ASSERT(int_slist.back() == 401);
+        EXPECT_EQ(401, *FindLastValidElementBefore(int_slist, int_slist.end()));
 
         // unique
         int_slist.assign(2, 101);
-        int_slist.push_back(201);
-        int_slist.push_back(201);
-        int_slist.push_back(301);
+        lastInsertIter = int_slist.emplace_after(FindLastValidElementBefore(int_slist, int_slist.end()), 201);
+        lastInsertIter = int_slist.emplace_after(lastInsertIter, 201);
+        lastInsertIter = int_slist.emplace_after(lastInsertIter, 301);
         int_slist.unique();
-        AZ_TEST_VALIDATE_LIST(int_slist, 3);
-        AZ_TEST_ASSERT(int_slist.front() == 101);
-        AZ_TEST_ASSERT(int_slist.back() == 301);
+        EXPECT_EQ(101, int_slist.front());
+        EXPECT_EQ(301, *FindLastValidElementBefore(int_slist, int_slist.end()));
 
         int_slist.assign(2, 101);
-        int_slist.push_back(201);
-        int_slist.push_back(201);
-        int_slist.push_back(401);
-        int_slist.push_back(401);
-        int_slist.push_back(501);
+        lastInsertIter = int_slist.emplace_after(FindLastValidElementBefore(int_slist, int_slist.end()), 201);
+        lastInsertIter = int_slist.emplace_after(lastInsertIter, 201);
+        lastInsertIter = int_slist.emplace_after(lastInsertIter, 401);
+        lastInsertIter = int_slist.emplace_after(lastInsertIter, 401);
+        lastInsertIter = int_slist.emplace_after(lastInsertIter, 501);
         int_slist.unique(UniqueForLessThan401());
-        AZ_TEST_VALIDATE_LIST(int_slist, 5);
-        AZ_TEST_ASSERT(int_slist.front() == 101);
-        AZ_TEST_ASSERT(int_slist.back() == 501);
+        EXPECT_EQ(101, int_slist.front());
+        EXPECT_EQ(501, *FindLastValidElementBefore(int_slist, int_slist.end()));
 
         // sort
         int_slist.assign(2, 101);
-        int_slist.push_back(201);
-        int_slist.push_back(1);
+        lastInsertIter = int_slist.emplace_after(FindLastValidElementBefore(int_slist, int_slist.end()), 201);
+        lastInsertIter = int_slist.emplace_after(lastInsertIter, 1);
         int_slist.sort();
-        AZ_TEST_VALIDATE_LIST(int_slist, 4);
-        for (fixed_forward_list<int, 100>::iterator iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
+        for (auto iter = int_slist.begin(); iter != FindLastValidElementBefore(int_slist, int_slist.end()); ++iter)
         {
-            AZ_TEST_ASSERT(*iter <= *next(iter));
+            EXPECT_LE(*iter, *next(iter));
         }
 
         int_slist.assign(2, 101);
-        int_slist.push_back(201);
-        int_slist.push_back(1);
+        lastInsertIter = int_slist.emplace_after(FindLastValidElementBefore(int_slist, int_slist.end()), 201);
+        lastInsertIter = int_slist.emplace_after(lastInsertIter, 1);
         int_slist.sort(AZStd::greater<int>());
-        AZ_TEST_VALIDATE_LIST(int_slist, 4);
-        for (fixed_forward_list<int, 100>::iterator iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
+        for (auto iter = int_slist.begin(); iter != FindLastValidElementBefore(int_slist, int_slist.end()); ++iter)
         {
-            AZ_TEST_ASSERT(*iter >= *next(iter));
+            EXPECT_GE(*iter, *next(iter));
         }
     }
 
     TEST_F(FixedListContainers, ForwardListReverseMerge)
     {
-        fixed_forward_list<int, 100> int_slist;
-        fixed_forward_list<int, 100> int_slist1;
-        fixed_forward_list<int, 100> int_slist2;
-        fixed_forward_list<int, 100> int_slist3;
+        AZStd::fixed_forward_list<int, 100> int_slist;
+        AZStd::fixed_forward_list<int, 100> int_slist1;
+        AZStd::fixed_forward_list<int, 100> int_slist2;
+        AZStd::fixed_forward_list<int, 100> int_slist3;
 
         int_slist.assign(2, 101);
-        int_slist.push_back(201);
-        int_slist.push_back(1);
+        auto lastInsertIter = int_slist.emplace_after(FindLastValidElementBefore(int_slist, int_slist.end()), 201);
+        lastInsertIter = int_slist.emplace_after(lastInsertIter, 1);
         int_slist.sort(AZStd::greater<int>());
 
         // reverse
         int_slist.reverse();
-        for (fixed_forward_list<int, 100>::iterator iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
+        for (auto iter = int_slist.begin(); iter != FindLastValidElementBefore(int_slist, int_slist.end()); ++iter)
         {
-            AZ_TEST_ASSERT(*iter <= *next(iter));
+            EXPECT_LE(*iter, *next(iter));
         }
 
         // merge
         int_slist.clear();
         int_slist1.clear();
-        int_slist.push_back(1); // 2 sorted lists for merge
-        int_slist.push_back(10);
-        int_slist.push_back(50);
-        int_slist.push_back(200);
-        int_slist1.push_back(2);
-        int_slist1.push_back(8);
-        int_slist1.push_back(60);
-        int_slist1.push_back(180);
+        // 2 sorted lists for merge
+        {
+            lastInsertIter = int_slist.emplace_after(int_slist.before_begin(), 1);
+            lastInsertIter = int_slist.emplace_after(lastInsertIter, 10);
+            lastInsertIter = int_slist.emplace_after(lastInsertIter, 50);
+            lastInsertIter = int_slist.emplace_after(lastInsertIter, 200);
+        }
+        {
+            lastInsertIter = int_slist1.emplace_after(int_slist1.before_begin(), 2);
+            lastInsertIter = int_slist1.emplace_after(lastInsertIter, 8);
+            lastInsertIter = int_slist1.emplace_after(lastInsertIter, 60);
+            lastInsertIter = int_slist1.emplace_after(lastInsertIter, 180);
+        }
 
         int_slist2 = int_slist;
         int_slist3 = int_slist1;
         int_slist2.merge(int_slist3);
-        AZ_TEST_VALIDATE_LIST(int_slist2, 8);
-        AZ_TEST_VALIDATE_EMPTY_LIST(int_slist3);
-        for (fixed_forward_list<int, 100>::iterator iter = int_slist2.begin(); iter != int_slist2.before_end(); ++iter)
+        for (auto iter = int_slist2.begin(); iter != FindLastValidElementBefore(int_slist2, int_slist2.end()); ++iter)
         {
-            AZ_TEST_ASSERT(*iter < *next(iter));
+            EXPECT_LT(*iter, *next(iter));
         }
 
         int_slist.reverse();
@@ -645,34 +636,10 @@ namespace UnitTest
         int_slist2 = int_slist;
         int_slist3 = int_slist1;
         int_slist2.merge(int_slist3, AZStd::greater<int>());
-        AZ_TEST_VALIDATE_LIST(int_slist2, 8);
-        AZ_TEST_VALIDATE_EMPTY_LIST(int_slist3);
-        for (fixed_forward_list<int, 100>::iterator iter = int_slist2.begin(); iter != int_slist2.before_end(); ++iter)
+        for (auto iter = int_slist2.begin(); iter != FindLastValidElementBefore(int_slist2, int_slist2.end()); ++iter)
         {
-            AZ_TEST_ASSERT(*iter > *next(iter));
+            EXPECT_GT(*iter, *next(iter));
         }
-    }
-
-    TEST_F(FixedListContainers, ForwardListExtensions)
-    {
-        fixed_forward_list<int, 100> int_slist;
-
-        // Push_back()
-        int_slist.emplace_back();
-        AZ_TEST_VALIDATE_LIST(int_slist, 1);
-        int_slist.front() = 100;
-
-        // Push_front()
-        int_slist.emplace_front();
-        AZ_TEST_VALIDATE_LIST(int_slist, 2);
-        AZ_TEST_ASSERT(int_slist.back() == 100);
-
-        // default int alignment
-        AZ_TEST_ASSERT(((AZStd::size_t)&int_slist.front() % 4) == 0); // default int alignment
-
-        // make sure every allocation is aligned.
-        fixed_forward_list<MyClass, 100> aligned_list(5, MyClass(99));
-        AZ_TEST_ASSERT(((AZStd::size_t)&aligned_list.front() & (alignment_of<MyClass>::value - 1)) == 0);
     }
 }
 

--- a/Code/Framework/AzCore/Tests/AZStd/Ordered.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Ordered.cpp
@@ -14,6 +14,8 @@
 
 #include <AzCore/std/containers/array.h>
 #include <AzCore/std/containers/fixed_vector.h>
+#include <AzCore/std/containers/span.h>
+#include <AzCore/std/ranges/transform_view.h>
 
 #define AZ_TEST_VALIDATE_EMPTY_TREE(_Tree_) \
     EXPECT_EQ(0, _Tree_.size());     \
@@ -39,7 +41,7 @@ namespace UnitTest
     struct RedBlackTree_SetTestTraits
     {
         typedef T                   key_type;
-        typedef KeyEq               key_eq;
+        typedef KeyEq               key_equal;
         typedef T                   value_type;
         typedef Allocator           allocator_type;
         static AZ_FORCE_INLINE const key_type& key_from_value(const value_type& value)  { return value; }
@@ -1071,6 +1073,66 @@ namespace UnitTest
         EXPECT_EQ(1, uniqueSet.count(4));
     }
 
+    template<template<class...> class SetTemplate>
+    static void TreeSetRangeConstructorSucceeds()
+    {
+        constexpr AZStd::string_view testView = "abc";
+
+        SetTemplate testSet(AZStd::from_range, testView);
+        EXPECT_THAT(testSet, ::testing::ElementsAre('a', 'b', 'c'));
+
+        testSet = SetTemplate(AZStd::from_range, AZStd::vector<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testSet, ::testing::ElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::list<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testSet, ::testing::ElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::deque<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testSet, ::testing::ElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::set<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testSet, ::testing::ElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::unordered_set<char>{testView.begin(), testView.end()});
+        EXPECT_THAT(testSet, ::testing::ElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::fixed_vector<char, 8>{testView.begin(), testView.end()});
+        EXPECT_THAT(testSet, ::testing::ElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::array{ 'a', 'b', 'c' });
+        EXPECT_THAT(testSet, ::testing::ElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::span(testView));
+        EXPECT_THAT(testSet, ::testing::ElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::span(testView));
+        EXPECT_THAT(testSet, ::testing::ElementsAre('a', 'b', 'c'));
+
+        AZStd::fixed_string<8> testValue(testView);
+        testSet = SetTemplate(AZStd::from_range, testValue);
+        EXPECT_THAT(testSet, ::testing::ElementsAre('a', 'b', 'c'));
+        testSet = SetTemplate(AZStd::from_range, AZStd::string(testView));
+        EXPECT_THAT(testSet, ::testing::ElementsAre('a', 'b', 'c'));
+
+        // Test Range views
+        testSet = SetTemplate(AZStd::from_range, testValue | AZStd::views::transform([](const char elem) -> char { return elem + 1; }));
+        EXPECT_THAT(testSet, ::testing::ElementsAre('b', 'c', 'd'));
+    }
+
+    TEST_F(Tree_Set, RangeConstructor_Succeeds)
+    {
+        TreeSetRangeConstructorSucceeds<AZStd::set>();
+        TreeSetRangeConstructorSucceeds<AZStd::multiset>();
+    }
+
+    template<template<class...> class SetTemplate>
+    static void TreeSetInsertRangeSucceeds()
+    {
+        constexpr AZStd::string_view testView = "abc";
+        SetTemplate testSet{ 'd', 'e', 'f' };
+        testSet.insert_range(AZStd::vector<char>{testView.begin(), testView.end()});
+        testSet.insert_range(testView | AZStd::views::transform([](const char elem) -> char { return elem + 6; }));
+        EXPECT_THAT(testSet, ::testing::ElementsAre('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'));
+    }
+
+    TEST_F(Tree_Set, InsertRange_Succeeds)
+    {
+        TreeSetInsertRangeSucceeds<AZStd::set>();
+        TreeSetInsertRangeSucceeds<AZStd::multiset>();
+    }
+
     template <typename ContainerType>
     class TreeSetDifferentAllocatorFixture
         : public AllocatorsFixture
@@ -1490,6 +1552,56 @@ namespace UnitTest
         EXPECT_EQ(1, s_tryInsertOrAssignAssignmentCalls);
         EXPECT_FALSE(insertOrAssignPairIter.second);
         EXPECT_EQ(-6354, insertOrAssignPairIter.first->second.m_value);
+    }
+
+    template<template<class...> class MapTemplate>
+    static void TreeMapRangeConstructorSucceeds()
+    {
+        using ValueType = AZStd::pair<char, int>;
+        constexpr AZStd::array testArray{ ValueType{'a', 1}, ValueType{'b', 2}, ValueType{'c', 3} };
+
+        MapTemplate testMap(AZStd::from_range, testArray);
+        EXPECT_THAT(testMap, ::testing::ElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+
+        testMap = MapTemplate(AZStd::from_range, AZStd::vector<ValueType>{testArray.begin(), testArray.end()});
+        EXPECT_THAT(testMap, ::testing::ElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+        testMap = MapTemplate(AZStd::from_range, AZStd::list<ValueType>{testArray.begin(), testArray.end()});
+        EXPECT_THAT(testMap, ::testing::ElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+        testMap = MapTemplate(AZStd::from_range, AZStd::deque<ValueType>{testArray.begin(), testArray.end()});
+        EXPECT_THAT(testMap, ::testing::ElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+        testMap = MapTemplate(AZStd::from_range, AZStd::set<ValueType>{testArray.begin(), testArray.end()});
+        EXPECT_THAT(testMap, ::testing::ElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+        testMap = MapTemplate(AZStd::from_range, AZStd::unordered_set<ValueType>{testArray.begin(), testArray.end()});
+        EXPECT_THAT(testMap, ::testing::ElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+        testMap = MapTemplate(AZStd::from_range, AZStd::fixed_vector<ValueType, 8>{testArray.begin(), testArray.end()});
+        EXPECT_THAT(testMap, ::testing::ElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+        testMap = MapTemplate(AZStd::from_range, AZStd::span(testArray));
+        EXPECT_THAT(testMap, ::testing::ElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 }));
+    }
+
+    TEST_F(Tree_Map, RangeConstructor_Succeeds)
+    {
+        TreeMapRangeConstructorSucceeds<AZStd::map>();
+        TreeMapRangeConstructorSucceeds<AZStd::multimap>();
+    }
+
+    template<template<class...> class MapTemplate>
+    static void TreeMapInsertRangeSucceeds()
+    {
+        using ValueType = AZStd::pair<char, int>;
+        constexpr AZStd::array testArray{ ValueType{'a', 1}, ValueType{'b', 2}, ValueType{'c', 3} };
+
+        MapTemplate testMap(AZStd::from_range, testArray);
+
+        testMap.insert_range(AZStd::vector<ValueType>{ValueType{ 'd', 4 }, ValueType{ 'e', 5 }, ValueType{ 'f', 6 }});
+        EXPECT_THAT(testMap, ::testing::ElementsAre(ValueType{ 'a', 1 }, ValueType{ 'b', 2 }, ValueType{ 'c', 3 },
+            ValueType{ 'd', 4 }, ValueType{ 'e', 5 }, ValueType{ 'f', 6 }));
+    }
+
+    TEST_F(Tree_Map, InsertRange_Succeeds)
+    {
+        TreeMapInsertRangeSucceeds<AZStd::map>();
+        TreeMapInsertRangeSucceeds<AZStd::multimap>();
     }
 
     template <typename ContainerType>

--- a/Code/Framework/AzCore/Tests/AZStd/RangesUtilityTests.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/RangesUtilityTests.cpp
@@ -7,6 +7,11 @@
  */
 
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/std/containers/array.h>
+#include <AzCore/std/containers/set.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
 #include <AzCore/std/ranges/ranges_to.h>
 
 namespace UnitTest
@@ -16,8 +21,51 @@ namespace UnitTest
     {};
 
 
-    TEST_F(RangesUtilityTestFixture, RangesTo_Succeeds)
+    TEST_F(RangesUtilityTestFixture, RangesTo_ConvertsContainer_To_Vector_AndBack_Succeeds)
     {
-        
+        AZStd::string testString{ "Hello World" };
+        {
+            // Test convert from AZStd::string -> AZStd::vector<char>
+            auto convertedVector = AZStd::ranges::to<AZStd::vector<char>>(testString);
+            EXPECT_THAT(convertedVector, ::testing::Pointwise(::testing::Eq(), testString));
+
+            // Test back from convert from AZStd::vector<char> -> AZStd::string
+            auto convertedString = AZStd::ranges::to<AZStd::string>(convertedVector);
+            EXPECT_EQ(testString, convertedString);
+        }
+    }
+
+    TEST_F(RangesUtilityTestFixture, RangesTo_TemplateTemplateOverload_Conversion_Succeeds)
+    {
+        AZStd::string testString{ "Hello World" };
+        {
+            // Test convert from AZStd::string -> AZStd::vector<char>
+            auto convertedVector = AZStd::ranges::to<AZStd::vector>(testString);
+            EXPECT_THAT(convertedVector, ::testing::Pointwise(::testing::Eq(), testString));
+
+            // Test back from convert from AZStd::vector<char> -> AZStd::string
+            auto convertedString = AZStd::ranges::to<AZStd::basic_string>(convertedVector);
+            EXPECT_EQ(testString, convertedString);
+        }
+    }
+
+    TEST_F(RangesUtilityTestFixture, RangesTo_ToAdaptor_Succeeds)
+    {
+        AZStd::string testString{ "Hello World" };
+        // Test adaptor container class overload
+        auto convertedClassVector = testString | AZStd::ranges::to<AZStd::vector<char>>();
+        EXPECT_THAT(convertedClassVector, ::testing::Pointwise(::testing::Eq(), testString));
+
+        // Test adaptor container template template overload
+        auto convertedTemplateVector = testString | AZStd::ranges::to<AZStd::vector>();
+        EXPECT_THAT(convertedTemplateVector, ::testing::Pointwise(::testing::Eq(), testString));
+
+        // Test adaptor container class overload with allocator argument
+        convertedClassVector = testString | AZStd::ranges::to<AZStd::vector<char>>(AZStd::allocator{});
+        EXPECT_THAT(convertedClassVector, ::testing::Pointwise(::testing::Eq(), testString));
+
+        // Test adaptor container template template overload with allocator argument
+        convertedTemplateVector = testString | AZStd::ranges::to<AZStd::vector>(AZStd::allocator{});
+        EXPECT_THAT(convertedTemplateVector, ::testing::Pointwise(::testing::Eq(), testString));
     }
 }

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -223,6 +223,7 @@ set(FILES
     AZStd/Parallel.cpp
     AZStd/RangesAlgorithmTests.cpp
     AZStd/RangesTests.cpp
+    AZStd/RangesUtilityTests.cpp
     AZStd/RangesViewTests.cpp
     AZStd/ScopedLockTests.cpp
     AZStd/SetsIntrusive.cpp

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/CvarAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/CvarAdapter.cpp
@@ -107,7 +107,7 @@ namespace AZ::DocumentPropertyEditor
                         {
                             newValue.push_back(ConsoleTypeHelpers::ToString(newContainer.GetElement(i)));
                         }
-                        (*functor)(ConsoleCommandContainer(newValue));
+                        (*functor)(ConsoleCommandContainer(AZStd::from_range, newValue));
                         m_adapter->OnContentsChanged(path, value);
                     });
                 builder.EndPropertyEditor();

--- a/Code/Tools/AssetBundler/source/ui/NewFileDialog.cpp
+++ b/Code/Tools/AssetBundler/source/ui/NewFileDialog.cpp
@@ -112,8 +112,8 @@ namespace AssetBundler
     {
         // Check to see if any of the selected platform-specific files already exist on-disk
         QString overwriteExistingFilesList;
-        AZStd::fixed_vector<AZStd::string, AzFramework::NumPlatforms> selectedPlatformNames =
-            AzFramework::PlatformHelper::GetPlatforms(GetPlatformFlags());
+        AZStd::fixed_vector<AZStd::string, AzFramework::NumPlatforms> selectedPlatformNames{ AZStd::from_range,
+            AzFramework::PlatformHelper::GetPlatforms(GetPlatformFlags()) };
         for (const AZStd::string& platformName : selectedPlatformNames)
         {
             FilePath platformSpecificFilePath(GetAbsoluteFilePath(), platformName);

--- a/Code/Tools/AssetBundler/source/ui/RulesTabWidget.cpp
+++ b/Code/Tools/AssetBundler/source/ui/RulesTabWidget.cpp
@@ -230,8 +230,8 @@ namespace AssetBundler
         AZStd::vector<AZStd::string> outputFilePaths;
         bool hasFileGenerationErrors = false;
 
-        AZStd::fixed_vector<AZStd::string, AzFramework::NumPlatforms> selectedPlatformNames =
-            AzFramework::PlatformHelper::GetPlatforms(runRuleDialog.GetPlatformFlags());
+        AZStd::fixed_vector<AZStd::string, AzFramework::NumPlatforms> selectedPlatformNames{ AZStd::from_range,
+            AzFramework::PlatformHelper::GetPlatforms(runRuleDialog.GetPlatformFlags()) };
         for (const AZStd::string& platformName : selectedPlatformNames)
         {
             // We do not want to modify the original Rules file, as we do not save Asset List file paths to disk


### PR DESCRIPTION
The [ranges::to](https://www.open-std.org/JTC1/SC22/WG21/docs/papers/2022/p1206r7.pdf) utility function allows conversion from a range to a container.

Added the C++23 ranges constructor and methods of `insert_range`, `append_range`, `prepend_range`, `assign_range` to the AZStd containers(`AZStd::list`, `AZStd::forward_list`, `AZStd::deque`, `AZStd::vector`, `AZStd::fixed_vector`, `AZStd::string`, `AZStd::fixed_string`, `AZStd::set`, `AZStd::multiset`, `AZStd::map`, `AZStd::multimap`, `AZStd::unordered_set`, `AZStd::unordered_multiset`, `AZStd::unordered_map`, `AZStd::unordered_multimap`) 

It allows such conversions such as `AZStd::string_view` -> `AZStd::vector<char>` or `AZStd::vector<AZStd::pair<int, AZStd::string>` <-> `AZStd::(unordered)_map<int, AZStd::string`

It also supports transforming ranges such as `AZStd::ranges::transform_view<FuncThatConvertsIntToString, AZStd::vector<int>` -> `AZStd::vector<AZStd::string>`

Adding implementation of C++20 `ranges::copy`, `ranges::copy_if`, `ranges::copy_n`, `ranges::copy_backward`, `ranges::move`, and `ranges::move_backward`.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
