### PR TITLE
VS2022 build node support

### DIFF
--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -345,6 +345,25 @@
       "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo"
     }
   },
+  "release_vs2022": {
+    "TAGS": [
+      "default",
+      "weekly-build-metrics",
+      "snapshot"
+    ],
+    "PIPELINE_ENV":{
+      "NODE_LABEL":"windows-vs2022"
+    },
+    "COMMAND": "build_windows.cmd",
+    "PARAMETERS": {
+      "CONFIGURATION": "release",
+      "OUTPUT_DIRECTORY": "build\\windows",
+      "CMAKE_OPTIONS": "-G \"Visual Studio 17 2022\" -DCMAKE_SYSTEM_VERSION=10.0",
+      "CMAKE_LY_PROJECTS": "AutomatedTesting",
+      "CMAKE_TARGET": "ALL_BUILD",
+      "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo"
+    }
+  },
   "monolithic_release": {
     "TAGS": [
       "periodic-incremental-daily",

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -103,6 +103,24 @@
       "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo"
     }
   },
+  "profile_vs2022": {
+    "TAGS": [
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal",
+    ],
+    "PIPELINE_ENV":{
+      "NODE_LABEL":"windows-vs2022"
+    },
+    "COMMAND": "build_windows.cmd",
+    "PARAMETERS": {
+      "CONFIGURATION": "profile",
+      "OUTPUT_DIRECTORY": "build\\windows",
+      "CMAKE_OPTIONS": "-G \"Visual Studio 17 2022\" -DCMAKE_SYSTEM_VERSION=10.0 -DLY_TEST_IMPACT_INSTRUMENTATION_BIN=%TEST_IMPACT_WIN_BINARY%",
+      "CMAKE_LY_PROJECTS": "AutomatedTesting",
+      "CMAKE_TARGET": "ALL_BUILD",
+      "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo"
+    }
+  },
   "profile_nounity": {
     "TAGS": [
       "periodic-incremental-daily",

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -106,7 +106,7 @@
   "profile_vs2022": {
     "TAGS": [
       "periodic-incremental-daily",
-      "periodic-clean-weekly-internal",
+      "periodic-clean-weekly-internal"
     ],
     "PIPELINE_ENV":{
       "NODE_LABEL":"windows-vs2022"

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -347,7 +347,7 @@
   },
   "release_vs2022": {
     "TAGS": [
-      "default",
+      "periodic-incremental-daily",
       "weekly-build-metrics",
       "snapshot"
     ],

--- a/scripts/build/build_node/Platform/Windows/install_utiltools.ps1
+++ b/scripts/build/build_node/Platform/Windows/install_utiltools.ps1
@@ -24,7 +24,7 @@ git config --global "credential.UseHttpPath" "true"
 choco install corretto8jdk -y --ia INSTALLDIR="c:\jdk8" # Custom directory to handle cases where whitespace in the path is not quote wrapped
 
 # Install CMake
-choco install cmake -y --installargs 'ADD_CMAKE_TO_PATH=System'
+choco install cmake --version=3.23.2 -y --installargs 'ADD_CMAKE_TO_PATH=System'
 
 # Install Windows Installer XML toolkit (WiX)
 choco install wixtoolset -y

--- a/scripts/build/build_node/Platform/Windows/install_vsbuildtools.ps1
+++ b/scripts/build/build_node/Platform/Windows/install_vsbuildtools.ps1
@@ -5,7 +5,7 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 #>
 
-choco install visualstudio2022buildtools --version=17.1.6 --package-parameters "--config .\vs2022bt.vsconfig" -y
+choco install visualstudio2022buildtools --version=17.2.6 --package-parameters "--config .\vs2022bt.vsconfig" -y
 choco install visualstudio2019buildtools --version=16.8.2 --package-parameters "--config .\vs2019bt.vsconfig" -y
 choco install visualstudio2017buildtools --version=15.9.29 --package-parameters "--config .\vs2017bt.vsconfig" -y
 

--- a/scripts/build/build_node/Platform/Windows/install_vsbuildtools.ps1
+++ b/scripts/build/build_node/Platform/Windows/install_vsbuildtools.ps1
@@ -5,6 +5,7 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 #>
 
+choco install visualstudio2022buildtools --version=17.1.6 --package-parameters "--config .\vs2022bt.vsconfig" -y
 choco install visualstudio2019buildtools --version=16.8.2 --package-parameters "--config .\vs2019bt.vsconfig" -y
 choco install visualstudio2017buildtools --version=15.9.29 --package-parameters "--config .\vs2017bt.vsconfig" -y
 

--- a/scripts/build/build_node/Platform/Windows/vs2022bt.vsconfig
+++ b/scripts/build/build_node/Platform/Windows/vs2022bt.vsconfig
@@ -1,0 +1,30 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.Component.MSBuild",
+    "Microsoft.Component.NetFX.Native",
+    "Microsoft.Net.Component.4.8.SDK",
+    "Microsoft.NetCore.Component.Runtime.3.1",
+    "Microsoft.NetCore.Component.Runtime.5.0",
+    "Microsoft.NetCore.Component.SDK",
+    "Microsoft.VisualStudio.Component.CoreBuildTools",
+    "Microsoft.VisualStudio.Component.NuGet.BuildTools",
+    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+    "Microsoft.VisualStudio.Component.TestTools.BuildTools",
+    "Microsoft.VisualStudio.Component.TextTemplating",
+    "Microsoft.VisualStudio.Component.VC.ASAN",
+    "Microsoft.VisualStudio.Component.VC.ATL",
+    "Microsoft.VisualStudio.Component.VC.CMake.Project",
+    "Microsoft.VisualStudio.Component.VC.CoreBuildTools",
+    "Microsoft.VisualStudio.Component.VC.CoreIde",
+    "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+    "Microsoft.VisualStudio.Component.Windows10SDK",
+    "Microsoft.VisualStudio.Component.Windows10SDK.18362",
+    "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
+    "Microsoft.VisualStudio.ComponentGroup.UWP.BuildTools",
+    "Microsoft.VisualStudio.Workload.MSBuildTools",
+    "Microsoft.VisualStudio.Workload.UniversalBuildTools",
+    "Microsoft.VisualStudio.Workload.VCTools"
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Addresses https://github.com/o3de/o3de/issues/10680 and https://github.com/o3de/o3de/issues/10681

- Adds the installer and vs.config workloads for VS2022 17.2.6. 
- Adds CMake 3.23.2, which supports "Visual Studio 17 2022" generators (Introduced in 3.21)
- Add profile and release jobs on build nodes specific to VS2022, and sets them to run in the nightly builds

## How was this PR tested?

Tested in a sandbox Jenkins instance
