### PR TITLE
chore(RHI): use MinSwapChainImages from limits

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
@@ -29,9 +29,6 @@ namespace AZ
             AZ_RTTI(SwapChain, "{888B64A5-D956-406F-9C33-CF6A54FC41B0}", Object);
             virtual ~SwapChain();
 
-            // Due to restriction on DX12 we need to allocate at least a minimum of 2 swapChain images or the drivers will complain
-            static const uint32_t MinSwapChainImages = 2; 
-
             //! Initializes the swap chain, making it ready for attachment.
             ResultCode Init(RHI::Device& device, const SwapChainDescriptor& descriptor);
 

--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/SwapChain_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/SwapChain_Windows.cpp
@@ -40,7 +40,7 @@ namespace AZ
             {
                 *nativeDimensions = descriptor.m_dimensions;
             }
-            const uint32_t SwapBufferCount = AZStd::max(RHI::SwapChain::MinSwapChainImages, RHI::Limits::Device::FrameCountMax);
+            const uint32_t SwapBufferCount = AZStd::max(RHI::Limits::Device::MinSwapChainImages, RHI::Limits::Device::FrameCountMax);
 
             DXGI_SWAP_CHAIN_DESCX swapChainDesc = {};
             swapChainDesc.SampleDesc.Quality = 0;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
@@ -176,7 +176,7 @@ namespace AZ
             descriptor.m_verticalSyncInterval = syncInterval;
             descriptor.m_dimensions.m_imageWidth = width;
             descriptor.m_dimensions.m_imageHeight = height;
-            descriptor.m_dimensions.m_imageCount = AZStd::max(RHI::SwapChain::MinSwapChainImages, RHI::Limits::Device::FrameCountMax);
+            descriptor.m_dimensions.m_imageCount = AZStd::max(RHI::Limits::Device::MinSwapChainImages, RHI::Limits::Device::FrameCountMax);
             descriptor.m_dimensions.m_imageFormat = GetSwapChainFormat(device);
 
             AZStd::string attachmentName = AZStd::string::format("WindowContextAttachment_%p", m_windowHandle);


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

The RHI layer was failing to build on linux because of missing symbols. the same constant is already define in limits.h.

```
                // Due to the fact that D3D12 only supports the flip model we need to allocate at least
                // a minimum of 2 swapChain images or the drivers will complain.
                constexpr uint32_t MinSwapChainImages = 2;
```
