### PR TITLE
bugfix(graphics): fix winding for debug sphere to render faces outward (GHI-6773)

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
@@ -473,12 +473,12 @@ namespace AZ
                     for (uint32_t section = 0; section < numSections; ++section)
                     {
                         uint32_t nextSection = (section + 1) % numSections;
-                        indices.push_back(static_cast<uint16_t>(firstVertOfThisRing + nextSection));
                         indices.push_back(static_cast<uint16_t>(firstVertOfThisRing + section));
+                        indices.push_back(static_cast<uint16_t>(firstVertOfThisRing + nextSection));
                         indices.push_back(static_cast<uint16_t>(firstVertOfNextRing + nextSection));
 
-                        indices.push_back(static_cast<uint16_t>(firstVertOfNextRing + section));
                         indices.push_back(static_cast<uint16_t>(firstVertOfNextRing + nextSection));
+                        indices.push_back(static_cast<uint16_t>(firstVertOfNextRing + section));
                         indices.push_back(static_cast<uint16_t>(firstVertOfThisRing + section));
                     }
                 }
@@ -489,8 +489,8 @@ namespace AZ
                 for (uint32_t section = 0; section < numSections; ++section)
                 {
                     uint32_t nextSection = (section + 1) % numSections;
-                    indices.push_back(static_cast<uint16_t>(firstVertOfFirstRing + section));
                     indices.push_back(static_cast<uint16_t>(firstVertOfFirstRing + nextSection));
+                    indices.push_back(static_cast<uint16_t>(firstVertOfFirstRing + section));
                     indices.push_back(static_cast<uint16_t>(firstPoleVert));
                 }
 
@@ -501,8 +501,8 @@ namespace AZ
                     for (uint32_t section = 0; section < numSections; ++section)
                     {
                         uint32_t nextSection = (section + 1) % numSections;
-                        indices.push_back(static_cast<uint16_t>(firstVertOfLastRing + nextSection));
                         indices.push_back(static_cast<uint16_t>(firstVertOfLastRing + section));
+                        indices.push_back(static_cast<uint16_t>(firstVertOfLastRing + nextSection));
                         indices.push_back(static_cast<uint16_t>(lastPoleVert));
                     }
                 }


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

The winding for the debug sphere is reversed so the surfaces would render inward. this just flips the windings so they face outward.

## How was this PR tested?

![image](https://user-images.githubusercontent.com/854359/179384378-292e8d83-d0be-4c02-82ee-634975d54850.png)
![image](https://user-images.githubusercontent.com/854359/179384379-ec6a416e-4edf-43e6-9b40-52113b795a94.png)

run whitebox gem and set
```
cl_whiteBoxVertexManipulatorSize 5
```

verify both the top and bottom poles of the sphere and also the outer surfaces. 

ref: https://github.com/o3de/o3de/issues/6773

additional discussion here: https://github.com/o3de/o3de/pull/9925