### PR TITLE
bugfix(Whitebox): fix crash where default_shapes.py is run with invalid arguments

### DIFF
--- a/Gems/WhiteBox/Code/Source/WhiteBoxToolApiReflection.cpp
+++ b/Gems/WhiteBox/Code/Source/WhiteBoxToolApiReflection.cpp
@@ -81,8 +81,9 @@ namespace WhiteBox
             behaviorContext->Class<WhiteBoxMeshHandle>("WhiteBoxMeshHandle")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
                 ->Attribute(AZ::Script::Attributes::Module, "whitebox.api")
-                ->Method("IsValid", [](WhiteBoxMeshHandle* whiteBoxMeshHandle) {
-                    return (WhiteBoxMeshFromHandle(*whiteBoxMeshHandle) != nullptr);
+                ->Method("IsValid", [](WhiteBoxMeshHandle* whiteBoxMeshHandle) 
+                {
+                    return WhiteBoxMeshFromHandle(*whiteBoxMeshHandle) != nullptr;
                 })
                 ->Method(
                     "InitializeAsUnitCube",
@@ -90,11 +91,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if (whiteboxMesh)
-                        {
-                            return Api::InitializeAsUnitCube(*whiteboxMesh);
-                        }
-                        return Api::PolygonHandles {};
+                        return Api::InitializeAsUnitCube(*whiteboxMesh);
                     })
                 ->Method(
                     "MeshFaceCount",
@@ -102,11 +99,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if (whiteboxMesh)
-                        {
-                            return Api::MeshFaceCount(*whiteboxMesh);
-                        }
-                        return std::numeric_limits<size_t>::min();
+                        return Api::MeshFaceCount(*whiteboxMesh);
                     })
                 ->Method(
                     "MeshVertexCount",
@@ -120,11 +113,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if (whiteboxMesh)
-                        {
-                            return Api::FacePolygonHandle(*whiteboxMesh, faceHandle);
-                        }
-                        return Api::PolygonHandle {};
+                        return Api::FacePolygonHandle(*whiteboxMesh, faceHandle);
                     })
                 ->Method(
                     "FaceVertexHandles",
@@ -138,11 +127,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if (whiteboxMesh)
-                        {
-                            return Api::AddVertex(*whiteboxMesh, vertex);
-                        }
-                        return Api::VertexHandle{};
+                        return Api::AddVertex(*whiteboxMesh, vertex);
                     })
                 ->Method(
                     "VertexPosition",
@@ -150,11 +135,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if (whiteboxMesh) 
-                        {
-                            return Api::VertexPosition(*whiteboxMesh, vertexHandle);
-                        }
-                        return AZ::Vector3::CreateZero();
+                        return Api::VertexPosition(*whiteboxMesh, vertexHandle);
                     })
                 ->Method(
                     "VertexPositions",
@@ -162,11 +143,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if(whiteboxMesh) 
-                        {
-                            return Api::VertexPositions(*whiteboxMesh, vertexHandles);
-                        }
-                        return AZStd::vector<AZ::Vector3>{};
+                        return Api::VertexPositions(*whiteboxMesh, vertexHandles);
                     })
                 ->Method(
                     "TranslatePolygonAppend",
@@ -174,11 +151,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if(whiteboxMesh) 
-                        {
-                            return Api::TranslatePolygonAppend(*whiteboxMesh, polygonHandle, distance);
-                        }
-                        return Api::PolygonHandle {};
+                        return Api::TranslatePolygonAppend(*whiteboxMesh, polygonHandle, distance);
                     })
                 ->Method(
                     "TranslatePolygon",
@@ -186,10 +159,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if(whiteboxMesh) 
-                        {
-                            Api::TranslatePolygon(*whiteboxMesh, polygonHandle, distance);
-                        }
+                        Api::TranslatePolygon(*whiteboxMesh, polygonHandle, distance);
                     })
                 ->Method(
                     "CalculateNormals",
@@ -197,10 +167,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if(whiteboxMesh) 
-                        {
-                            Api::CalculateNormals(*whiteboxMesh);
-                        }
+                        Api::CalculateNormals(*whiteboxMesh);
                     })
                 ->Method(
                     "CalculatePlanarUVs",
@@ -208,10 +175,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if(whiteboxMesh) 
-                        {
-                            Api::CalculatePlanarUVs(*whiteboxMesh);
-                        }
+                        Api::CalculatePlanarUVs(*whiteboxMesh);
                     })
                 ->Method(
                     "HideEdge",
@@ -219,11 +183,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if(whiteboxMesh) 
-                        {
-                            return Api::HideEdge(*whiteboxMesh, edgeHandle);
-                        }
-                        return Api::PolygonHandle{};
+                        return Api::HideEdge(*whiteboxMesh, edgeHandle);
                     })
                 ->Method(
                     "FlipEdge",
@@ -231,11 +191,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if(whiteboxMesh) 
-                        {
-                            return Api::FlipEdge(*whiteboxMesh, edgeHandle);
-                        }
-                        return false;
+                        return Api::FlipEdge(*whiteboxMesh, edgeHandle);
                     })
                 ->Method(
                     "AddPolygon",
@@ -243,11 +199,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if(whiteboxMesh) 
-                        {
-                            return Api::AddPolygon(*whiteboxMesh, faceVertHandles);
-                        }
-                        return Api::PolygonHandle {};
+                        return Api::AddPolygon(*whiteboxMesh, faceVertHandles);
                     })
                 ->Method(
                     "AddTriPolygon",
@@ -255,11 +207,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if(whiteboxMesh) 
-                        {
-                            return Api::AddTriPolygon(*whiteboxMesh, v0, v1, v2);
-                        }
-                        return Api::PolygonHandle {};
+                        return Api::AddTriPolygon(*whiteboxMesh, v0, v1, v2);
                     })
                 ->Method(
                     "AddQuadPolygon",
@@ -271,11 +219,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        if(whiteboxMesh) 
-                        {
-                            return Api::AddQuadPolygon(*whiteboxMesh, v0, v1, v2, v3);
-                        }
-                        return Api::PolygonHandle {};
+                        return Api::AddQuadPolygon(*whiteboxMesh, v0, v1, v2, v3);
                     })
                 ->Method(
                     "Clear",
@@ -283,10 +227,7 @@ namespace WhiteBox
                     {
                         WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
                         AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.")
-                        if(whiteboxMesh) 
-                        {
-                            Api::Clear(*whiteboxMesh);
-                        }
+                        Api::Clear(*whiteboxMesh);
                     });
 
             behaviorContext->EnumProperty<(int)DefaultShapeType::Cube>("CUBE")

--- a/Gems/WhiteBox/Code/Source/WhiteBoxToolApiReflection.cpp
+++ b/Gems/WhiteBox/Code/Source/WhiteBoxToolApiReflection.cpp
@@ -89,17 +89,13 @@ namespace WhiteBox
                     "InitializeAsUnitCube",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        return Api::InitializeAsUnitCube(*whiteboxMesh);
+                        return Api::InitializeAsUnitCube(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle));
                     })
                 ->Method(
                     "MeshFaceCount",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        return Api::MeshFaceCount(*whiteboxMesh);
+                        return Api::MeshFaceCount(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle));
                     })
                 ->Method(
                     "MeshVertexCount",
@@ -111,9 +107,7 @@ namespace WhiteBox
                     "FacePolygonHandle",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::FaceHandle faceHandle)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        return Api::FacePolygonHandle(*whiteboxMesh, faceHandle);
+                        return Api::FacePolygonHandle(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), faceHandle);
                     })
                 ->Method(
                     "FaceVertexHandles",
@@ -125,109 +119,85 @@ namespace WhiteBox
                     "AddVertex",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const AZ::Vector3& vertex)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        return Api::AddVertex(*whiteboxMesh, vertex);
+                        return Api::AddVertex(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), vertex);
                     })
                 ->Method(
                     "VertexPosition",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, Api::VertexHandle vertexHandle)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        return Api::VertexPosition(*whiteboxMesh, vertexHandle);
+                        return Api::VertexPosition(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), vertexHandle);
                     })
                 ->Method(
                     "VertexPositions",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::VertexHandles& vertexHandles)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        return Api::VertexPositions(*whiteboxMesh, vertexHandles);
+                        return Api::VertexPositions(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), vertexHandles);
                     })
                 ->Method(
                     "TranslatePolygonAppend",
-                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::PolygonHandle& polygonHandle, const float distance)
+                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::PolygonHandle& polygonHandle,
+                       const float distance)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        return Api::TranslatePolygonAppend(*whiteboxMesh, polygonHandle, distance);
+                        return Api::TranslatePolygonAppend(
+                            *WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), polygonHandle, distance);
                     })
                 ->Method(
                     "TranslatePolygon",
-                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::PolygonHandle& polygonHandle, const float distance)
+                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::PolygonHandle& polygonHandle,
+                       const float distance)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        Api::TranslatePolygon(*whiteboxMesh, polygonHandle, distance);
+                        return Api::TranslatePolygon(
+                            *WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), polygonHandle, distance);
                     })
                 ->Method(
                     "CalculateNormals",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        Api::CalculateNormals(*whiteboxMesh);
+                        return Api::CalculateNormals(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle));
                     })
                 ->Method(
                     "CalculatePlanarUVs",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        Api::CalculatePlanarUVs(*whiteboxMesh);
+                        return Api::CalculatePlanarUVs(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle));
                     })
                 ->Method(
                     "HideEdge",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, Api::EdgeHandle edgeHandle)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        return Api::HideEdge(*whiteboxMesh, edgeHandle);
+                        return Api::HideEdge(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), edgeHandle);
                     })
                 ->Method(
                     "FlipEdge",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, Api::EdgeHandle edgeHandle)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        return Api::FlipEdge(*whiteboxMesh, edgeHandle);
+                        return Api::FlipEdge(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), edgeHandle);
                     })
                 ->Method(
                     "AddPolygon",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::FaceVertHandlesList& faceVertHandles)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        return Api::AddPolygon(*whiteboxMesh, faceVertHandles);
+                        return Api::AddPolygon(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), faceVertHandles);
                     })
                 ->Method(
                     "AddTriPolygon",
-                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, Api::VertexHandle v0, Api::VertexHandle v1, Api::VertexHandle v2)
+                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, Api::VertexHandle v0, Api::VertexHandle v1,
+                       Api::VertexHandle v2)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        return Api::AddTriPolygon(*whiteboxMesh, v0, v1, v2);
+                        return Api::AddTriPolygon(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), v0, v1, v2);
                     })
                 ->Method(
                     "AddQuadPolygon",
-                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle,
-                       Api::VertexHandle v0,
-                       Api::VertexHandle v1,
-                       Api::VertexHandle v2,
-                       Api::VertexHandle v3)
+                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, Api::VertexHandle v0, Api::VertexHandle v1,
+                       Api::VertexHandle v2, Api::VertexHandle v3)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
-                        return Api::AddQuadPolygon(*whiteboxMesh, v0, v1, v2, v3);
+                        return Api::AddQuadPolygon(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), v0, v1, v2, v3);
                     })
                 ->Method(
                     "Clear",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle)
                     {
-                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
-                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.")
-                        Api::Clear(*whiteboxMesh);
+                        return Api::Clear(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle));
                     });
 
             behaviorContext->EnumProperty<(int)DefaultShapeType::Cube>("CUBE")

--- a/Gems/WhiteBox/Code/Source/WhiteBoxToolApiReflection.cpp
+++ b/Gems/WhiteBox/Code/Source/WhiteBoxToolApiReflection.cpp
@@ -81,17 +81,32 @@ namespace WhiteBox
             behaviorContext->Class<WhiteBoxMeshHandle>("WhiteBoxMeshHandle")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
                 ->Attribute(AZ::Script::Attributes::Module, "whitebox.api")
+                ->Method("IsValid", [](WhiteBoxMeshHandle* whiteBoxMeshHandle) {
+                    return (WhiteBoxMeshFromHandle(*whiteBoxMeshHandle) != nullptr);
+                })
                 ->Method(
                     "InitializeAsUnitCube",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle)
                     {
-                        return Api::InitializeAsUnitCube(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle));
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if (whiteboxMesh)
+                        {
+                            return Api::InitializeAsUnitCube(*whiteboxMesh);
+                        }
+                        return Api::PolygonHandles {};
                     })
                 ->Method(
                     "MeshFaceCount",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle)
                     {
-                        return Api::MeshFaceCount(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle));
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if (whiteboxMesh)
+                        {
+                            return Api::MeshFaceCount(*whiteboxMesh);
+                        }
+                        return std::numeric_limits<size_t>::min();
                     })
                 ->Method(
                     "MeshVertexCount",
@@ -103,7 +118,13 @@ namespace WhiteBox
                     "FacePolygonHandle",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::FaceHandle faceHandle)
                     {
-                        return Api::FacePolygonHandle(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), faceHandle);
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if (whiteboxMesh)
+                        {
+                            return Api::FacePolygonHandle(*whiteboxMesh, faceHandle);
+                        }
+                        return Api::PolygonHandle {};
                     })
                 ->Method(
                     "FaceVertexHandles",
@@ -115,85 +136,157 @@ namespace WhiteBox
                     "AddVertex",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const AZ::Vector3& vertex)
                     {
-                        return Api::AddVertex(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), vertex);
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if (whiteboxMesh)
+                        {
+                            return Api::AddVertex(*whiteboxMesh, vertex);
+                        }
+                        return Api::VertexHandle{};
                     })
                 ->Method(
                     "VertexPosition",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, Api::VertexHandle vertexHandle)
                     {
-                        return Api::VertexPosition(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), vertexHandle);
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if (whiteboxMesh) 
+                        {
+                            return Api::VertexPosition(*whiteboxMesh, vertexHandle);
+                        }
+                        return AZ::Vector3::CreateZero();
                     })
                 ->Method(
                     "VertexPositions",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::VertexHandles& vertexHandles)
                     {
-                        return Api::VertexPositions(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), vertexHandles);
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if(whiteboxMesh) 
+                        {
+                            return Api::VertexPositions(*whiteboxMesh, vertexHandles);
+                        }
+                        return AZStd::vector<AZ::Vector3>{};
                     })
                 ->Method(
                     "TranslatePolygonAppend",
-                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::PolygonHandle& polygonHandle,
-                       const float distance)
+                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::PolygonHandle& polygonHandle, const float distance)
                     {
-                        return Api::TranslatePolygonAppend(
-                            *WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), polygonHandle, distance);
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if(whiteboxMesh) 
+                        {
+                            return Api::TranslatePolygonAppend(*whiteboxMesh, polygonHandle, distance);
+                        }
+                        return Api::PolygonHandle {};
                     })
                 ->Method(
                     "TranslatePolygon",
-                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::PolygonHandle& polygonHandle,
-                       const float distance)
+                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::PolygonHandle& polygonHandle, const float distance)
                     {
-                        return Api::TranslatePolygon(
-                            *WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), polygonHandle, distance);
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if(whiteboxMesh) 
+                        {
+                            Api::TranslatePolygon(*whiteboxMesh, polygonHandle, distance);
+                        }
                     })
                 ->Method(
                     "CalculateNormals",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle)
                     {
-                        return Api::CalculateNormals(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle));
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if(whiteboxMesh) 
+                        {
+                            Api::CalculateNormals(*whiteboxMesh);
+                        }
                     })
                 ->Method(
                     "CalculatePlanarUVs",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle)
                     {
-                        return Api::CalculatePlanarUVs(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle));
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if(whiteboxMesh) 
+                        {
+                            Api::CalculatePlanarUVs(*whiteboxMesh);
+                        }
                     })
                 ->Method(
                     "HideEdge",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, Api::EdgeHandle edgeHandle)
                     {
-                        return Api::HideEdge(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), edgeHandle);
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if(whiteboxMesh) 
+                        {
+                            return Api::HideEdge(*whiteboxMesh, edgeHandle);
+                        }
+                        return Api::PolygonHandle{};
                     })
                 ->Method(
                     "FlipEdge",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, Api::EdgeHandle edgeHandle)
                     {
-                        return Api::FlipEdge(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), edgeHandle);
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if(whiteboxMesh) 
+                        {
+                            return Api::FlipEdge(*whiteboxMesh, edgeHandle);
+                        }
+                        return false;
                     })
                 ->Method(
                     "AddPolygon",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::FaceVertHandlesList& faceVertHandles)
                     {
-                        return Api::AddPolygon(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), faceVertHandles);
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if(whiteboxMesh) 
+                        {
+                            return Api::AddPolygon(*whiteboxMesh, faceVertHandles);
+                        }
+                        return Api::PolygonHandle {};
                     })
                 ->Method(
                     "AddTriPolygon",
-                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, Api::VertexHandle v0, Api::VertexHandle v1,
-                       Api::VertexHandle v2)
+                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, Api::VertexHandle v0, Api::VertexHandle v1, Api::VertexHandle v2)
                     {
-                        return Api::AddTriPolygon(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), v0, v1, v2);
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if(whiteboxMesh) 
+                        {
+                            return Api::AddTriPolygon(*whiteboxMesh, v0, v1, v2);
+                        }
+                        return Api::PolygonHandle {};
                     })
                 ->Method(
                     "AddQuadPolygon",
-                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, Api::VertexHandle v0, Api::VertexHandle v1,
-                       Api::VertexHandle v2, Api::VertexHandle v3)
+                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle,
+                       Api::VertexHandle v0,
+                       Api::VertexHandle v1,
+                       Api::VertexHandle v2,
+                       Api::VertexHandle v3)
                     {
-                        return Api::AddQuadPolygon(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), v0, v1, v2, v3);
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.");
+                        if(whiteboxMesh) 
+                        {
+                            return Api::AddQuadPolygon(*whiteboxMesh, v0, v1, v2, v3);
+                        }
+                        return Api::PolygonHandle {};
                     })
                 ->Method(
                     "Clear",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle)
                     {
-                        return Api::Clear(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle));
+                        WhiteBoxMesh* whiteboxMesh = WhiteBoxMeshFromHandle(*whiteBoxMeshHandle);
+                        AZ_Assert(whiteboxMesh, "WhiteBoxMesh is not found.")
+                        if(whiteboxMesh) 
+                        {
+                            Api::Clear(*whiteboxMesh);
+                        }
                     });
 
             behaviorContext->EnumProperty<(int)DefaultShapeType::Cube>("CUBE")

--- a/Gems/WhiteBox/Editor/Scripts/default_shapes.py
+++ b/Gems/WhiteBox/Editor/Scripts/default_shapes.py
@@ -36,6 +36,10 @@ def on_change_default_shape_type(whiteBoxMeshComponent, defaultShapeType):
 
     # get the white box mesh handle
     whiteBoxMesh = azlmbr.whitebox.request.bus.EditorWhiteBoxComponentRequestBus(bus.Event, 'GetWhiteBoxMeshHandle', whiteBoxMeshComponent)
+    
+    if not whiteBoxMesh.IsValid():
+        print('Could not resolve White Box Mesh')
+        return
 
     # clear whiteBoxMesh
     whiteBoxMesh.Clear()


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/8263

## What does this PR do?

add null checking to avoid a crash in whitebox when running from python. 

## How was this PR tested?

run this is the command line window
```
PyRunFile <project>/o3de/Gems/WhiteBox/Editor/Scripts/default_shapes.py 1 1 1
```

Signed-off-by: Michael Pollind <mpollind@gmail.com>
