### PR TITLE
Making non fatal if vulkan validation libs are not found.

### DIFF
--- a/cmake/3rdParty/Platform/Android/VkValidation_android.cmake
+++ b/cmake/3rdParty/Platform/Android/VkValidation_android.cmake
@@ -8,10 +8,11 @@
 
 set(LY_ANDROID_VULKAN_VALIDATION_PATH "${LY_NDK_DIR}/sources/third_party/vulkan/src/build-android/jniLibs" CACHE PATH "Path to the Vulkan Validation Layers libs for Android")
 
-if(NOT EXISTS ${LY_ANDROID_VULKAN_VALIDATION_PATH})
-    message(FATAL_ERROR
-        "Unable to locate the Android Vulkan validation layer libs at ${LY_ANDROID_VULKAN_VALIDATION_PATH}.  "
-        "If using NDK r23 or above, these libs are distributed separately via https://github.com/KhronosGroup/Vulkan-ValidationLayers")
+if(EXISTS ${LY_ANDROID_VULKAN_VALIDATION_PATH})
+    set(VKVALIDATION_RUNTIME_DEPENDENCIES $<$<NOT:$<CONFIG:Release>>:${LY_ANDROID_VULKAN_VALIDATION_PATH}/arm64-v8a/libVkLayer_khronos_validation.so>)
+else()
+    message(WARNING
+        "Android Vulkan validation layer libs not found at ${LY_ANDROID_VULKAN_VALIDATION_PATH}. "
+        "If using Android NDK r23 or above, these libs are distributed separately via https://github.com/KhronosGroup/Vulkan-ValidationLayers. "
+        "Vulkan validation will not be availble.")
 endif()
-
-set(VKVALIDATION_RUNTIME_DEPENDENCIES $<$<NOT:$<CONFIG:Release>>:${LY_ANDROID_VULKAN_VALIDATION_PATH}/arm64-v8a/libVkLayer_khronos_validation.so>)

--- a/cmake/3rdParty/Platform/Android/VkValidation_android.cmake
+++ b/cmake/3rdParty/Platform/Android/VkValidation_android.cmake
@@ -14,5 +14,5 @@ else()
     message(WARNING
         "Android Vulkan validation layer libs not found at ${LY_ANDROID_VULKAN_VALIDATION_PATH}. "
         "If using Android NDK r23 or above, these libs are distributed separately via https://github.com/KhronosGroup/Vulkan-ValidationLayers. "
-        "Vulkan validation will not be availble.")
+        "Vulkan validation will not be available.")
 endif()


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Vulkan validation libs are optional and shouldn't stop from building.

Changed the script so it warns the user that it couldn't locate the libs and that validation will be disabled.

## How was this PR tested?

After the fix I was able to build with android without having the validation libs present.
