### PR TITLE
Add cstr labels to all task graphs and events

### DIFF
--- a/Code/Framework/AzCore/AzCore/Task/TaskExecutor.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskExecutor.cpp
@@ -29,8 +29,10 @@ namespace AZ
             AZStd::vector<Task>&& tasks,
             AZStd::unordered_map<uint32_t, AZStd::vector<uint32_t>>& links,
             size_t linkCount,
-            TaskGraph* parent)
+            TaskGraph* parent,
+            const char* parentLabel)
             : m_parent{ parent }
+            , m_parentLabel{ parentLabel }
         {
             m_tasks = AZStd::move(tasks);
             m_successors.resize(linkCount);

--- a/Code/Framework/AzCore/AzCore/Task/TaskExecutor.h
+++ b/Code/Framework/AzCore/AzCore/Task/TaskExecutor.h
@@ -32,7 +32,8 @@ namespace AZ
                 AZStd::vector<Task>&& tasks,
                 AZStd::unordered_map<uint32_t, AZStd::vector<uint32_t>>& links,
                 size_t linkCount,
-                TaskGraph* parent);
+                TaskGraph* parent,
+                const char* parentLabel);
 
             AZStd::vector<Task>& Tasks() noexcept
             {
@@ -53,6 +54,7 @@ namespace AZ
             // The pointer to the parent graph is set only if it is retained
             TaskGraph* m_parent = nullptr;
             AZStd::atomic<uint32_t> m_remaining;
+            const char* m_parentLabel;
         };
 
         class TaskWorker;

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
@@ -16,7 +16,7 @@ namespace AZ
 
     void TaskGraphEvent::Wait()
     {
-        AZ_Assert(m_executor->GetTaskWorker() == nullptr, "Waiting in a task is unsupported");
+        AZ_Assert(m_executor->GetTaskWorker() == nullptr, "Event %s waiting in a task is unsupported", m_label);
         m_semaphore.acquire();
     }
 
@@ -27,7 +27,7 @@ namespace AZ
         while(!m_waitCount.compare_exchange_weak(expectedValue, expectedValue + 1))
         {
              // value will be negative once event is ready to signal or has been signaled. Shouldn't happen.
-            AZ_Assert(expectedValue >= 0, "Called TaskGraphEvent::IncWaitCount on a signalled event");
+            AZ_Assert(expectedValue >= 0, "Called TaskGraphEvent::IncWaitCount on a signalled event %s", m_label);
             if (expectedValue < 0) // event already signaled, skip
             {
                 return;
@@ -42,7 +42,7 @@ namespace AZ
         while(!m_waitCount.compare_exchange_weak(expectedValue, expectedValue - 1))
         {
             // It's an error for Signal to be called if no one is waiting, or the event has already been signaled
-            AZ_Assert(expectedValue > 0, "Called TaskGraphEvent::Signal when event is either signaled or unused");
+            AZ_Assert(expectedValue > 0, "Called %s TaskGraphEvent::Signal when event is either signaled or unused", m_label);
             if (expectedValue < 0) // return if already signaled
             {
                 return;
@@ -62,7 +62,7 @@ namespace AZ
 
     void TaskToken::PrecedesInternal(TaskToken& comesAfter)
     {
-        AZ_Assert(!m_parent.m_submitted, "Cannot mutate a TaskGraph that was previously submitted.");
+        AZ_Assert(!m_parent.m_submitted, "Cannot mutate a TaskGraph %s that was previously submitted.", m_parent.m_label);
 
         // Increment inbound/outbound edge counts
         m_parent.m_tasks[m_index].Link(m_parent.m_tasks[comesAfter.m_index]);
@@ -70,6 +70,11 @@ namespace AZ
         m_parent.m_links[m_index].emplace_back(comesAfter.m_index);
 
         ++m_parent.m_linkCount;
+    }
+
+    TaskGraph::TaskGraph(const char* label)
+        : m_label{ label }
+    {
     }
 
     TaskGraph::~TaskGraph()
@@ -86,7 +91,7 @@ namespace AZ
 
     void TaskGraph::Reset()
     {
-        AZ_Assert(!m_submitted, "Cannot reset a job graph while it is in flight");
+        AZ_Assert(!m_submitted, "Cannot reset task graph %s while it is in flight", m_label);
         if (m_compiledTaskGraph)
         {
             azdestroy(m_compiledTaskGraph);
@@ -118,7 +123,7 @@ namespace AZ
     {
         if (!m_compiledTaskGraph)
         {
-            m_compiledTaskGraph = aznew CompiledTaskGraph(AZStd::move(m_tasks), m_links, m_linkCount, m_retained ? this : nullptr);
+            m_compiledTaskGraph = aznew CompiledTaskGraph(AZStd::move(m_tasks), m_links, m_linkCount, m_retained ? this : nullptr, m_label);
         }
 
         m_compiledTaskGraph->m_waitEvent = waitEvent;

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
@@ -74,6 +74,7 @@ namespace AZ
     class TaskGraphEvent
     {
     public:
+        // ! The supplied string label is expected to be a string literal or otherwise outlive the lifetime of this TG event.
         explicit TaskGraphEvent(const char* label);
         bool IsSignaled();
         void Wait();
@@ -101,6 +102,7 @@ namespace AZ
     class TaskGraph final
     {
     public:
+        // ! The supplied string label is expected to be a string literal or otherwise outlive the lifetime of this TG.
         explicit TaskGraph(const char* graphlabel);
         ~TaskGraph();
 

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
@@ -74,6 +74,7 @@ namespace AZ
     class TaskGraphEvent
     {
     public:
+        explicit TaskGraphEvent(const char* label);
         bool IsSignaled();
         void Wait();
 
@@ -88,6 +89,7 @@ namespace AZ
         AZStd::binary_semaphore m_semaphore;
         AZStd::atomic_int       m_waitCount = 0;
         TaskExecutor*           m_executor = nullptr;
+        const char* m_label;
     };
 
     // The TaskGraph encapsulates a set of tasks and their interdependencies. After adding
@@ -99,6 +101,7 @@ namespace AZ
     class TaskGraph final
     {
     public:
+        explicit TaskGraph(const char* graphlabel);
         ~TaskGraph();
 
         // Reset the state of the task graph to begin recording tasks and edges again
@@ -160,6 +163,7 @@ namespace AZ
         // Task index |-> Dependent task indices
         AZStd::unordered_map<uint32_t, AZStd::vector<uint32_t>> m_links;
 
+        char const* m_label;
         uint32_t m_linkCount = 0;
         bool m_retained = true;
         AZStd::atomic<bool> m_submitted = false;

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
@@ -104,6 +104,7 @@ namespace AZ
     public:
         // ! The supplied string label is expected to be a string literal or otherwise outlive the lifetime of this TG.
         explicit TaskGraph(const char* graphlabel);
+        TaskGraph(AZStd::nullptr_t) = delete;
         ~TaskGraph();
 
         // Reset the state of the task graph to begin recording tasks and edges again

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.inl
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.inl
@@ -28,6 +28,11 @@ namespace AZ
         (tokens.PrecedesInternal(*this), ...);
     }
 
+    inline TaskGraphEvent::TaskGraphEvent(const char* label)
+        : m_label{ label }
+    {
+    }
+
     inline bool TaskGraphEvent::IsSignaled()
     {
         return m_semaphore.try_acquire_for(AZStd::chrono::milliseconds{ 0 });

--- a/Code/Framework/AzCore/Tests/TaskTests.cpp
+++ b/Code/Framework/AzCore/Tests/TaskTests.cpp
@@ -240,7 +240,7 @@ namespace UnitTest
     {
         AZStd::atomic_int32_t x = 0;
 
-        TaskGraph graph;
+        TaskGraph graph{ "SingleTask" };
         graph.AddTask(
             defaultTD,
             [&x]
@@ -248,7 +248,7 @@ namespace UnitTest
                 x = 1;
             });
 
-        TaskGraphEvent ev;
+        TaskGraphEvent ev{ "ev" };
         graph.SubmitOnExecutor(*m_executor, &ev);
         ev.Wait();
 
@@ -260,7 +260,7 @@ namespace UnitTest
     {
         AZStd::atomic_int32_t x = 0;
 
-        TaskGraph graph;
+        TaskGraph graph{ "SingleTaskChain" };
         auto a = graph.AddTask(
             defaultTD,
             [&x]
@@ -275,7 +275,7 @@ namespace UnitTest
             });
         b.Precedes(a);
 
-        TaskGraphEvent ev;
+        TaskGraphEvent ev{ "ev" };
         graph.SubmitOnExecutor(*m_executor, &ev);
         ev.Wait();
 
@@ -287,7 +287,7 @@ namespace UnitTest
         AZStd::atomic_int32_t x = 0;
         constexpr int numChains = 5;
 
-        TaskGraph graph;
+        TaskGraph graph{ "MultipleIndependentTaskChains" };
         for( int i = 0; i < numChains; ++i)
         {
             auto a = graph.AddTask(
@@ -305,7 +305,7 @@ namespace UnitTest
             b.Precedes(a);
         }
 
-        TaskGraphEvent ev;
+        TaskGraphEvent ev{ "ev" };
         graph.SubmitOnExecutor(*m_executor, &ev);
         ev.Wait();
 
@@ -316,7 +316,7 @@ namespace UnitTest
     {
         int x = 0;
 
-        TaskGraph graph;
+        TaskGraph graph{ "VariadicInterface" };
         auto [a, b, c] = graph.AddTasks(
             defaultTD,
             [&]
@@ -335,7 +335,7 @@ namespace UnitTest
         a.Precedes(b);
         b.Precedes(c);
 
-        TaskGraphEvent ev;
+        TaskGraphEvent ev{ "ev" };
         graph.SubmitOnExecutor(*m_executor, &ev);
         ev.Wait();
 
@@ -346,7 +346,7 @@ namespace UnitTest
     {
         int x = 0;
 
-        TaskGraph graph;
+        TaskGraph graph{ "SerialGraph" };
         auto a = graph.AddTask(
             defaultTD,
             [&]
@@ -369,7 +369,7 @@ namespace UnitTest
         a.Precedes(b);
         b.Precedes(c);
 
-        TaskGraphEvent ev;
+        TaskGraphEvent ev{ "ev" };
         graph.SubmitOnExecutor(*m_executor, &ev);
         ev.Wait();
 
@@ -380,10 +380,10 @@ namespace UnitTest
     {
         int x = 0;
 
-        TaskGraphEvent ev;
+        TaskGraphEvent ev{ "ev" };
 
         {
-            TaskGraph graph;
+            TaskGraph graph{ "DetachedGraph" };
             auto a = graph.AddTask(
                 defaultTD,
                 [&]
@@ -422,7 +422,7 @@ namespace UnitTest
         // Task b and c toggles the lowest two bits atomically
         // Task d decrements x
 
-        TaskGraph graph;
+        TaskGraph graph{ "ForkJoin" };
         auto a = graph.AddTask(
             defaultTD,
             [&]
@@ -457,7 +457,7 @@ namespace UnitTest
         a.Precedes(b, c);
         d.Follows(b, c);
 
-        TaskGraphEvent ev;
+        TaskGraphEvent ev{ "ev" };
         graph.SubmitOnExecutor(*m_executor, &ev);
         ev.Wait();
 
@@ -469,7 +469,7 @@ namespace UnitTest
     {
         AZStd::atomic<int> x = 0;
 
-        TaskGraph graph;
+        TaskGraph graph{ "SpawnSubgraph" };
         auto a = graph.AddTask(
             defaultTD,
             [&]
@@ -488,7 +488,7 @@ namespace UnitTest
             {
                 x ^= 2;
 
-                TaskGraph subgraph;
+                TaskGraph subgraph{ "InnerSubgraph" };
                 auto e = subgraph.AddTask(
                     defaultTD,
                     [&]
@@ -509,7 +509,7 @@ namespace UnitTest
                     });
                 e.Precedes(g);
                 f.Precedes(g);
-                TaskGraphEvent ev;
+                TaskGraphEvent ev{ "ev" };
                 subgraph.SubmitOnExecutor(*m_executor, &ev);
                 // TaskGraphEvent::Wait asserts if called on a worker thread, suppress & validate assert
                 AZ_TEST_START_TRACE_SUPPRESSION;
@@ -541,7 +541,7 @@ namespace UnitTest
         b.Precedes(d);
         c.Precedes(d);
 
-        TaskGraphEvent ev;
+        TaskGraphEvent ev{ "ev" };
         graph.SubmitOnExecutor(*m_executor, &ev);
         ev.Wait();
     }
@@ -550,7 +550,7 @@ namespace UnitTest
     {
         AZStd::atomic<int> x = 0;
 
-        TaskGraph graph;
+        TaskGraph graph{ "RetainedGraph" };
         auto a = graph.AddTask(
             defaultTD,
             [&]
@@ -610,14 +610,14 @@ namespace UnitTest
         g.Follows(e, f);
         g.Precedes(d);
 
-        TaskGraphEvent ev1;
+        TaskGraphEvent ev1{ "ev1" };
         graph.SubmitOnExecutor(*m_executor, &ev1);
         ev1.Wait();
 
         EXPECT_EQ(3 | 0b100000, x);
         x = 0;
 
-        TaskGraphEvent ev2;
+        TaskGraphEvent ev2{ "ev2" };
         graph.SubmitOnExecutor(*m_executor, &ev2);
         ev2.Wait();
 
@@ -633,7 +633,7 @@ namespace Benchmark
         void internalSetUp()
         {
             executor = new TaskExecutor;
-            graph = new TaskGraph;
+            graph = new TaskGraph{ "BenchmarkFixture" };
         }
 
         void internalTearDown()
@@ -679,7 +679,7 @@ namespace Benchmark
             });
         for ([[maybe_unused]] auto _ : state)
         {
-            TaskGraphEvent ev;
+            TaskGraphEvent ev{ "ev" };
             graph->SubmitOnExecutor(*executor, &ev);
             ev.Wait();
         }
@@ -701,7 +701,7 @@ namespace Benchmark
 
         for ([[maybe_unused]] auto _ : state)
         {
-            TaskGraphEvent ev;
+            TaskGraphEvent ev{ "ev" };
             graph->SubmitOnExecutor(*executor, &ev);
             ev.Wait();
         }
@@ -731,7 +731,7 @@ namespace Benchmark
 
         for ([[maybe_unused]] auto _ : state)
         {
-            TaskGraphEvent ev;
+            TaskGraphEvent ev{ "ev" };
             graph->SubmitOnExecutor(*executor, &ev);
             ev.Wait();
         }

--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
@@ -88,7 +88,7 @@ namespace AZ
                 if (taskGraphActive)
                 {
                     static const AZ::TaskDescriptor pngTaskDescriptor{"PngWriteOutChannelSwap", "Graphics"};
-                    AZ::TaskGraph taskGraph;
+                    AZ::TaskGraph taskGraph{ "FrameCapturePngWriteOut" };
                     for (int i = 0; i < numThreads; ++i)
                     {
                         int startPixel = i * numPixelsPerThread;
@@ -109,7 +109,7 @@ namespace AZ
                                 }
                             });
                     }
-                    AZ::TaskGraphEvent taskGraphFinishedEvent;
+                    AZ::TaskGraphEvent taskGraphFinishedEvent{ "FrameCapturePngWriteOutWait" };
                     taskGraph.Submit(&taskGraphFinishedEvent);
                     taskGraphFinishedEvent.Wait();
                 }

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
@@ -275,7 +275,7 @@ namespace AZ
                 const uint32_t compilesPerJob = m_compileRequest.m_shaderResourceGroupCompilesPerJob;
                 if (m_taskGraphActive && m_taskGraphActive->IsTaskGraphActive())
                 {
-                    AZ::TaskGraph taskGraph;
+                    AZ::TaskGraph taskGraph{ "SRG Compilation" };
 
                     const auto compileIntervalsFunction = [compilesPerJob, &taskGraph](ShaderResourceGroupPool* srgPool)
                     {
@@ -312,7 +312,7 @@ namespace AZ
                     resourcePoolDatabase.ForEachShaderResourceGroupPool<decltype(compileIntervalsFunction)>(AZStd::move(compileIntervalsFunction));
                     if (!taskGraph.IsEmpty())
                     {
-                        AZ::TaskGraphEvent finishedEvent;
+                        AZ::TaskGraphEvent finishedEvent{ "SRG Compile Wait" };
                         taskGraph.Submit(&finishedEvent);
                         finishedEvent.Wait();
                     }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
@@ -831,7 +831,7 @@ namespace AZ
 
         void CullingScene::BeginCullingTaskGraph(const AZStd::vector<ViewPtr>& views)
         {
-            AZ::TaskGraph taskGraph;
+            AZ::TaskGraph taskGraph{ "RPI::Culling" };
             AZ::TaskDescriptor beginCullingDescriptor{"RPI_CullingScene_BeginCullingView", "Graphics"};
             for (auto& view : views)
             {
@@ -846,7 +846,7 @@ namespace AZ
 
             if (!taskGraph.IsEmpty())
             {
-                AZ::TaskGraphEvent waitForCompletion;
+                AZ::TaskGraphEvent waitForCompletion{ "RPI::Culling Wait" };
                 taskGraph.Submit(&waitForCompletion);
                 waitForCompletion.Wait();
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -272,7 +272,7 @@ namespace AZ
             AZ_PROFILE_SCOPE(RPI, "View: SortFinalizedDrawLists");
             RHI::DrawListsByTag& drawListsByTag = m_drawListContext.GetMergedDrawListsByTag();
 
-            AZ::TaskGraph drawListSortTG;
+            AZ::TaskGraph drawListSortTG{ "DrawList Sort" };
             AZ::TaskDescriptor drawListSortTGDescriptor{"RPI_View_SortFinalizedDrawLists", "Graphics"};
             for (size_t idx = 0; idx < drawListsByTag.size(); ++idx)
             {

--- a/Gems/EMotionFX/Code/EMotionFX/Source/DualQuatSkinDeformer.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/DualQuatSkinDeformer.cpp
@@ -79,7 +79,7 @@ namespace EMotionFX
         if (m_useTaskGraph)
         {
             // Skin the vertices by executing the task graph.
-            AZ::TaskGraphEvent finishedEvent;
+            AZ::TaskGraphEvent finishedEvent{ "DualQuatSkinning Wait" };
             m_taskGraph.Submit(&finishedEvent);
             finishedEvent.Wait();
         }

--- a/Gems/EMotionFX/Code/EMotionFX/Source/DualQuatSkinDeformer.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/DualQuatSkinDeformer.h
@@ -139,7 +139,7 @@ namespace EMotionFX
 
         //! Number of vertices per batch/job used for multi-threaded software skinning.
         static constexpr AZ::u32 s_numVerticesPerBatch = 10000;
-        AZ::TaskGraph m_taskGraph;
+        AZ::TaskGraph m_taskGraph{ "DualQuatSkinDeformer" };
         bool m_useTaskGraph = true;
 
         /**

--- a/Gems/MotionMatching/Code/Source/MotionMatchingData.cpp
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingData.cpp
@@ -84,7 +84,7 @@ namespace EMotionFX::MotionMatching
             const bool useTaskGraph = taskGraphActiveInterface && taskGraphActiveInterface->IsTaskGraphActive();
             if (useTaskGraph)
             {
-                AZ::TaskGraph m_taskGraph;
+                AZ::TaskGraph m_taskGraph{ "MotionMatching FeatureExtraction" };
 
                 // Split-up the motion database into batches of frames and extract the feature values for each batch simultaneously.
                 for (size_t batchIndex = 0; batchIndex < numBatches; ++batchIndex)
@@ -102,7 +102,7 @@ namespace EMotionFX::MotionMatching
                         });
                 }
 
-                AZ::TaskGraphEvent finishedEvent;
+                AZ::TaskGraphEvent finishedEvent{ "MotionMatching FeatureExtraction Wait" };
                 m_taskGraph.Submit(&finishedEvent);
                 finishedEvent.Wait();
             }

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshComponentController.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshComponentController.cpp
@@ -397,7 +397,7 @@ namespace RecastNavigation
         {
             AZ_PROFILE_SCOPE(Navigation, "Navigation: OnReceivedAllNewTiles");
 
-            m_taskGraphEvent = AZStd::make_unique<AZ::TaskGraphEvent>();
+            m_taskGraphEvent = AZStd::make_unique<AZ::TaskGraphEvent>("RecastNavigation Tile Processing Wait");
             m_taskGraph.Reset();
 
             AZStd::vector<AZ::TaskToken> tileTaskTokens;

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshComponentController.h
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshComponentController.h
@@ -119,7 +119,7 @@ namespace RecastNavigation
         AZStd::atomic<bool> m_shouldProcessTiles{ true };
 
         //! Task graph objects to process tile geometry into Recast tiles.
-        AZ::TaskGraph m_taskGraph;
+        AZ::TaskGraph m_taskGraph{ "RecastNavigation Tile Processing" };
         AZ::TaskExecutor m_taskExecutor;
         AZStd::unique_ptr<AZ::TaskGraphEvent> m_taskGraphEvent;
         AZ::TaskDescriptor m_taskDescriptor{ "Processing Tiles", "Recast Navigation" };

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.cpp
@@ -365,7 +365,7 @@ namespace RecastNavigation
         {
             AZ_PROFILE_SCOPE(Navigation, "Navigation: CollectGeometryAsync");
 
-            m_taskGraphEvent = AZStd::make_unique<AZ::TaskGraphEvent>();
+            m_taskGraphEvent = AZStd::make_unique<AZ::TaskGraphEvent>("RecastNavigation PhysX Wait");
             m_taskGraph.Reset();
 
             AZStd::vector<AZStd::shared_ptr<TileGeometry>> tiles;

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.h
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.h
@@ -113,7 +113,7 @@ namespace RecastNavigation
         AZStd::atomic<bool> m_updateInProgress{ false };
 
         //! Task graph objects to collect geometry data in tiles over a grid.
-        AZ::TaskGraph m_taskGraph;
+        AZ::TaskGraph m_taskGraph{ "RecastNavigation PhysX" };
         AZ::TaskExecutor m_taskExecutor;
         AZStd::unique_ptr<AZ::TaskGraphEvent> m_taskGraphEvent;
         AZ::TaskDescriptor m_taskDescriptor{ "Collect Geometry", "Recast Navigation" };


### PR DESCRIPTION
All TaskGraph events and graphs now have a required cstr label as a
constructor argument to aid debugging.