### PR TITLE
Limit SystemTick updates when Editor is backgrounded

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -2309,15 +2309,15 @@ int CCryEditApp::IdleProcessing(bool bBackgroundUpdate)
         // If we're backgrounded and not fully background updating, idle to rate limit SystemTick
         const float safeMarginFPS = 0.5f; // safe margin to not drop below idle fps
         const int maxEditorFPS = gEnv->pConsole->GetCVar("ed_backgroundSystemTickFPS")->GetIVal();
-        static AZ::TimeMs sTimeLast = AZ::GetRealElapsedTimeMs();
-        const AZ::TimeMs timeFrameMax(static_cast<AZ::TimeMs>((int64)(1000.f / ((float)maxEditorFPS + safeMarginFPS))));
-        const AZ::TimeMs timeLast = timeFrameMax + sTimeLast;
+        static AZ::TimeMs sTimeLastMs = AZ::GetRealElapsedTimeMs();
+        const AZ::TimeMs maxFrameTimeMs(static_cast<AZ::TimeMs>((int64)(1000.f / ((float)maxEditorFPS + safeMarginFPS))));
+        const AZ::TimeMs maxElapsedTimeMs = maxFrameTimeMs + sTimeLastMs;
         const AZ::TimeMs realElapsedTimeMs = AZ::GetRealElapsedTimeMs();
-        if (timeLast > realElapsedTimeMs)
+        if (maxElapsedTimeMs > realElapsedTimeMs)
         {
-            CrySleep(static_cast<uint64_t>(timeLast - realElapsedTimeMs));
+            CrySleep(static_cast<uint64_t>(maxElapsedTimeMs - realElapsedTimeMs));
         }
-        sTimeLast = AZ::GetRealElapsedTimeMs();
+        sTimeLastMs = AZ::GetRealElapsedTimeMs();
     }
 
     DisplayLevelLoadErrors();

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -2308,18 +2308,15 @@ int CCryEditApp::IdleProcessing(bool bBackgroundUpdate)
 
         // If we're backgrounded and not fully background updating, idle to rate limit SystemTick
         static AZ::TimeMs sTimeLastMs = AZ::GetRealElapsedTimeMs();
+        const int64_t maxFrameTimeMs = ed_backgroundSystemTickCap;
 
-        const auto console = AZ::Interface<AZ::IConsole>::Get();
-        AZ::TimeMs maxFrameTimeMs = AZ::TimeMs{ 1 };
-        console->GetCvarValue("ed_backgroundSystemTickCap", maxFrameTimeMs);
-
-        if (maxFrameTimeMs > AZ::TimeMs{ 0 })
+        if (maxFrameTimeMs > 0)
         {
-            const AZ::TimeMs maxElapsedTimeMs = maxFrameTimeMs + sTimeLastMs;
-            const AZ::TimeMs realElapsedTimeMs = AZ::GetRealElapsedTimeMs();
+            const int64_t maxElapsedTimeMs = maxFrameTimeMs + static_cast<int64_t>(sTimeLastMs);
+            const int64_t realElapsedTimeMs = static_cast<int64_t>(AZ::GetRealElapsedTimeMs());
             if (maxElapsedTimeMs > realElapsedTimeMs)
             {
-                CrySleep(static_cast<unsigned int>(maxElapsedTimeMs - realElapsedTimeMs));
+                CrySleep(aznumeric_cast<unsigned int>(maxElapsedTimeMs - realElapsedTimeMs));
             }
         }
         sTimeLastMs = AZ::GetRealElapsedTimeMs();

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -228,6 +228,7 @@ SEditorSettings::SEditorSettings()
     gui.hSystemFontItalic = QFont("Ms Shell Dlg 2", lfHeight, QFont::Normal, true);
 
     backgroundUpdatePeriod = 0;
+    backgroundSystemTickFPS = 30;
     g_TemporaryLevelName = nullptr;
 
     sliceSettings.dynamicByDefault = false;
@@ -848,6 +849,7 @@ void SEditorSettings::PostInitApply()
     REGISTER_CVAR2_CB("ed_toolbarIconSize", &gui.nToolbarIconSize, gui.nToolbarIconSize, VF_NULL, "Override size of the toolbar icons 0-default, 16,32,...", ToolbarIconSizeChanged);
 
     REGISTER_CVAR2("ed_backgroundUpdatePeriod", &backgroundUpdatePeriod, backgroundUpdatePeriod, 0, "Delay between frame updates (ms) when window is out of focus but not minimized. 0 = disable background update. -1 = update with no delay.");
+    REGISTER_CVAR2("ed_backgroundSystemTickFPS", &backgroundSystemTickFPS, backgroundSystemTickFPS, 30, "FPS at which SystemTick occurs when Editor is backgrounded and frame updates are disabled.");
     REGISTER_CVAR2("ed_showErrorDialogOnLoad", &showErrorDialogOnLoad, showErrorDialogOnLoad, 0, "Show error dialog on level load");
     REGISTER_CVAR2_CB("ed_keepEditorActive", &keepEditorActive, 0, VF_NULL, "Keep the editor active, even if no focus is set", KeepEditorActiveChanged);
     REGISTER_CVAR2("g_TemporaryLevelName", &g_TemporaryLevelName, "temp_level", VF_NULL, "Temporary level named used for experimental levels.");

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -22,9 +22,7 @@
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/StringFunc/StringFunc.h>
-#include <AzCore/Time/ITime.h>
 #include <AzCore/Utils/Utils.h>
-#include <AzCore/Console/IConsole.h>
 
 
 // AzFramework
@@ -834,7 +832,7 @@ void SEditorSettings::Load()
 //////////////////////////////////////////////////////////////////////////
 AZ_CVAR(bool, ed_previewGameInFullscreen_once, false, nullptr, AZ::ConsoleFunctorFlags::IsInvisible, "Preview the game (Ctrl+G, \"Play Game\", etc.) in fullscreen once");
 AZ_CVAR(bool, ed_lowercasepaths, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Convert CCryFile paths to lowercase on Open");
-AZ_CVAR(AZ::TimeMs, ed_backgroundSystemTickCap, AZ::TimeMs{ 33 }, nullptr, AZ::ConsoleFunctorFlags::Null,"Delay between frame updates (ms) when window is out of focus but not minimized AND background update is disabled.");
+AZ_CVAR(int64_t, ed_backgroundSystemTickCap, 33, nullptr, AZ::ConsoleFunctorFlags::Null,"Delay between frame updates (ms) when window is out of focus but not minimized AND background update is disabled.");
     
 void SEditorSettings::PostInitApply()
 {

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -22,8 +22,10 @@
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/StringFunc/StringFunc.h>
+#include <AzCore/Time/ITime.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzCore/Console/IConsole.h>
+
 
 // AzFramework
 #include <AzFramework/API/ApplicationAPI.h>
@@ -228,7 +230,6 @@ SEditorSettings::SEditorSettings()
     gui.hSystemFontItalic = QFont("Ms Shell Dlg 2", lfHeight, QFont::Normal, true);
 
     backgroundUpdatePeriod = 0;
-    backgroundSystemTickFPS = 30;
     g_TemporaryLevelName = nullptr;
 
     sliceSettings.dynamicByDefault = false;
@@ -833,7 +834,8 @@ void SEditorSettings::Load()
 //////////////////////////////////////////////////////////////////////////
 AZ_CVAR(bool, ed_previewGameInFullscreen_once, false, nullptr, AZ::ConsoleFunctorFlags::IsInvisible, "Preview the game (Ctrl+G, \"Play Game\", etc.) in fullscreen once");
 AZ_CVAR(bool, ed_lowercasepaths, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Convert CCryFile paths to lowercase on Open");
-
+AZ_CVAR(AZ::TimeMs, ed_backgroundSystemTickCap, AZ::TimeMs{ 33 }, nullptr, AZ::ConsoleFunctorFlags::Null,"Delay between frame updates (ms) when window is out of focus but not minimized AND background update is disabled.");
+    
 void SEditorSettings::PostInitApply()
 {
     if (!gEnv || !gEnv->pConsole)
@@ -849,7 +851,6 @@ void SEditorSettings::PostInitApply()
     REGISTER_CVAR2_CB("ed_toolbarIconSize", &gui.nToolbarIconSize, gui.nToolbarIconSize, VF_NULL, "Override size of the toolbar icons 0-default, 16,32,...", ToolbarIconSizeChanged);
 
     REGISTER_CVAR2("ed_backgroundUpdatePeriod", &backgroundUpdatePeriod, backgroundUpdatePeriod, 0, "Delay between frame updates (ms) when window is out of focus but not minimized. 0 = disable background update. -1 = update with no delay.");
-    REGISTER_CVAR2("ed_backgroundSystemTickFPS", &backgroundSystemTickFPS, backgroundSystemTickFPS, 30, "FPS at which SystemTick occurs when Editor is backgrounded and frame updates are disabled.");
     REGISTER_CVAR2("ed_showErrorDialogOnLoad", &showErrorDialogOnLoad, showErrorDialogOnLoad, 0, "Show error dialog on level load");
     REGISTER_CVAR2_CB("ed_keepEditorActive", &keepEditorActive, 0, VF_NULL, "Keep the editor active, even if no focus is set", KeepEditorActiveChanged);
     REGISTER_CVAR2("g_TemporaryLevelName", &g_TemporaryLevelName, "temp_level", VF_NULL, "Temporary level named used for experimental levels.");

--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -20,6 +20,7 @@
 #include <AzToolsFramework/Editor/EditorSettingsAPIBus.h>
 #include <AzToolsFramework/Prefab/PrefabLoaderInterface.h>
 #include <AzCore/JSON/document.h>
+#include <AzCore/Console/IConsole.h>
 
 #include <AzQtComponents/Components/Widgets/ToolBar.h>
 
@@ -253,6 +254,7 @@ struct SSmartOpenDialogSettings
 //////////////////////////////////////////////////////////////////////////
 /** Various editor settings.
 */
+AZ_CVAR_EXTERNED(int64_t, ed_backgroundSystemTickCap);
 AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 struct SANDBOX_API SEditorSettings
     : AzToolsFramework::EditorSettingsAPIBus::Handler

--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -426,6 +426,7 @@ AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     int  navigationDebugAgentType;
 
     int backgroundUpdatePeriod;
+    int backgroundSystemTickFPS;
     const char* g_TemporaryLevelName;
 
     SSliceSettings sliceSettings;

--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -426,7 +426,6 @@ AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     int  navigationDebugAgentType;
 
     int backgroundUpdatePeriod;
-    int backgroundSystemTickFPS;
     const char* g_TemporaryLevelName;
 
     SSliceSettings sliceSettings;


### PR DESCRIPTION
Signed-off-by: puvvadar <puvvadar@amazon.com>

## What does this PR do?

This change addresses SystemTick running uncapped when the Editor is in the background.

This change adds the cvar `ed_backgroundSystemTickFPS` with a default of 30 FPS. This cvar is used when the Editor is both in the background and is set to not fully update while in the background. When in this state it will cap Editor updates to a maximum of `ed_backgroundSystemTickFPS` FPS by sleeping any free time.

The logic used is very similar to logic used to limit FPS when VSync and Max FPS are specified in [`System.cpp`](https://github.com/o3de/o3de/blob/97d791bc9e46f3e18c8c12e981f12a6da225547d/Code/Legacy/CrySystem/System.cpp#L639).

## How was this PR tested?

Change was tested by comparing CPU/GPU utilization of Editor while fully active and while backgrounded. With this change, background utilization was reduced by a factor of 3-4x for CPU and 5-6x for GPU compared to fully active. (Local hardware so YMMV).