### PR TITLE
PropertyTreeEditor | Change container set behavior to use destination type and circumvent issues with basic_string

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.cpp
@@ -365,10 +365,9 @@ namespace AzToolsFramework
 
         // Default handler
 
-        //A temporary conversion buffer in case the src and dst data types are different.
+        // A temporary conversion buffer in case the src and dst data types are different.
         AZStd::any convertedValue;
 
-        
         // Check if types match, or convert the value if its type supports it.
         const void* valuePtr = HandleTypeConversion(value.type(), pteNode.m_nodePtr->GetClassMetadata()->m_typeId, AZStd::any_cast<void>(&value), convertedValue);
         if (valuePtr)
@@ -601,7 +600,7 @@ namespace AzToolsFramework
                 if (keyAddress && valueAddress)
                 {
                     m_serializeContext->CloneObjectInplace(keyAddress, AZStd::any_cast<void>(&key), key.type());
-                    m_serializeContext->CloneObjectInplace(valueAddress, AZStd::any_cast<void>(&value), value.type());
+                    m_serializeContext->CloneObjectInplace(valueAddress, AZStd::any_cast<void>(&value), data.value().m_valueElement->m_typeId);
                     data.value().m_dataContainer->StoreElement(nodePtr->FirstInstance(), newEntry);
                     return { PropertyAccessOutcome::ValueType(true) };
                 }
@@ -617,7 +616,7 @@ namespace AzToolsFramework
             if (destination)
             {
                 const void* source = AZStd::any_cast<void>(&value);
-                m_serializeContext->CloneObjectInplace(destination, source, value.type());
+                m_serializeContext->CloneObjectInplace(destination, source, data.value().m_valueElement->m_typeId);
                 return { PropertyAccessOutcome::ValueType(true) };
             }
             else
@@ -691,7 +690,7 @@ namespace AzToolsFramework
             if (destination)
             {
                 const void* source = AZStd::any_cast<void>(&value);
-                m_serializeContext->CloneObjectInplace(destination, source, value.type());
+                m_serializeContext->CloneObjectInplace(destination, source, data.value().m_valueElement->m_typeId);
                 return { PropertyAccessOutcome::ValueType(true) };
             }
         }
@@ -708,7 +707,7 @@ namespace AzToolsFramework
             {
                 void* destination = keyPairInfo.value().m_pairClass->m_container->GetElementByIndex(keyPairValue, keyPairInfo.value().m_valueElement, 1);
                 const void* source = AZStd::any_cast<void>(&value);
-                m_serializeContext->CloneObjectInplace(destination, source, value.type());
+                m_serializeContext->CloneObjectInplace(destination, source, data.value().m_valueElement->m_typeId);
                 return { PropertyAccessOutcome::ValueType(true) };
             }
         }


### PR DESCRIPTION
## What does this PR do?
Changes the behavior of the PTE's container item setters to use the destination's type when cloning in place. Note that SetProperty in the PTE already uses the destination's type to determine how to convert the Any value passed to the function, but the container API that was added separately did not.

Fixes #10464 

## How was this PR tested?

This script was used to test the behavior. It was run via the Phyton Scripts interface inside the Editor:
```
import azlmbr.legacy.general as general
import azlmbr.bus as bus
import azlmbr.editor as editor
import azlmbr.entity as entity

def find_entity_by_name(entity_name):
    """
    Gets an entity ID from the entity with the given entity_name
    :param entity_name: String of entity name to search for
    :return entity ID
    """
    search_filter = entity.SearchFilter()
    search_filter.names = [entity_name]
    matching_entity_list = entity.SearchBus(bus.Broadcast, 'SearchEntities', search_filter)
    if matching_entity_list:
        matching_entity = matching_entity_list[0]
        if matching_entity.IsValid():
            print(f'{entity_name} entity found with ID {matching_entity.ToString()}')
            return matching_entity
    else:
        return matching_entity_list

entityId = find_entity_by_name("Entity1")

type_ids_list = editor.EditorComponentAPIBus(bus.Broadcast, 'FindComponentTypeIdsByEntityType', ["PostFX Layer"], entity.EntityType().Game)
postFxLayerTypeId = type_ids_list[0]

postFxLayerComponentOutcome = editor.EditorComponentAPIBus(bus.Broadcast, 'GetComponentOfType', entityId, postFxLayerTypeId)
postFxLayerComponent = postFxLayerComponentOutcome.GetValue()

build_prop_tree_outcome = editor.EditorComponentAPIBus(bus.Broadcast, "BuildComponentPropertyTreeEditor", postFxLayerComponent)
property_tree_editor = build_prop_tree_outcome.GetValue()

property_tree_editor.append_container_item('Controller|Configuration|Select Camera Tags Only', 'yes')
```

Before the change, this error would be printed:
```
[Error] (Serialize) - Element with class ID '{7114E998-A8B4-519B-9342-A86D1587B4F7}' is not registered with the serializer!

=== Serialize stack ===
[ Address: 000001F880719500 Uuid: {7114E998-A8B4-519B-9342-A86D1587B4F7} ]
```
(`{7114E998-A8B4-519B-9342-A86D1587B4F7}` is the typeId for the basic string)

After the change, no error is printed and the Component's value is updated as expected
![image](https://user-images.githubusercontent.com/82231674/179641157-abd8a177-d9b4-4505-b109-2d4d1a8277d2.png)
