### PR TITLE
fix github issue #10732

### DIFF
--- a/Gems/WhiteBox/Code/Tests/WhiteBoxPhysicsTest.cpp
+++ b/Gems/WhiteBox/Code/Tests/WhiteBoxPhysicsTest.cpp
@@ -29,6 +29,7 @@ namespace UnitTest
         // AZ::Test::GemTestEnvironment overrides ...
         void AddGemsAndComponents() override;
         AZ::ComponentApplication* CreateApplicationInstance() override;
+        void PostSystemEntityActivate() override;
 
     public:
         EditorWhiteBoxPhysicsTestEnvironment() = default;
@@ -49,6 +50,11 @@ namespace UnitTest
     {
         // Using ToolsTestApplication to have AzFramework and AzToolsFramework components.
         return aznew UnitTest::ToolsTestApplication("EditorWhiteBoxPhysics");
+    }
+
+    void EditorWhiteBoxPhysicsTestEnvironment::PostSystemEntityActivate()
+    {
+        AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
     }
 
     class WhiteBoxPhysicsFixture : public ::testing::Test


### PR DESCRIPTION
Signed-off-by: Tom Hulton-Harrop <82228511+hultonha@users.noreply.github.com>

## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/10732

## How was this PR tested?

Ran local tests for `WhiteBoxPhysicsFixture`

```
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from WhiteBoxPhysicsFixture
[ RUN      ] WhiteBoxPhysicsFixture.EditorWhiteBoxColliderComponentCanBeAddedToAnEmptyWhiteBoxComponent
[       OK ] WhiteBoxPhysicsFixture.EditorWhiteBoxColliderComponentCanBeAddedToAnEmptyWhiteBoxComponent (6 ms)
[----------] 1 test from WhiteBoxPhysicsFixture (6 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (3015 ms total)
[  PASSED  ] 1 test.
```
