### PR TITLE
Motion Matching: Optimize memory usage in KD-tree + use median instead of average

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/algorithm.h
+++ b/Code/Framework/AzCore/AzCore/std/algorithm.h
@@ -566,6 +566,9 @@ namespace AZStd
     // Since AZStd code doesn't need it constexpr at the moment, the std:: version will be used
     using std::rotate;
 
+    // nth-element
+    using std::nth_element;
+
     //////////////////////////////////////////////////////////////////////////
     // Heap
     // \todo move to heap.h

--- a/Gems/EMotionFX/Code/EMotionFX/Source/TransformData.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/TransformData.h
@@ -13,7 +13,6 @@
 #include "BaseObject.h"
 #include "Pose.h"
 
-
 namespace EMotionFX
 {
     // forward declarations

--- a/Gems/MotionMatching/Code/Source/KdTree.cpp
+++ b/Gems/MotionMatching/Code/Source/KdTree.cpp
@@ -6,15 +6,17 @@
  *
  */
 
+#include <AzCore/std/algorithm.h>
+#include <AzCore/Debug/Timer.h>
+
 #include <KdTree.h>
 #include <Feature.h>
 #include <Allocators.h>
 
-#include <AzCore/Debug/Timer.h>
-
 namespace EMotionFX::MotionMatching
 {
-    AZ_CLASS_ALLOCATOR_IMPL(KdTree, MotionMatchAllocator, 0)
+    AZ_CLASS_ALLOCATOR_IMPL(KdTree, MotionMatchAllocator, 0);
+    AZ_CLASS_ALLOCATOR_IMPL(KdTree::Node, MotionMatchAllocator, 0);
 
     KdTree::~KdTree()
     {
@@ -64,7 +66,7 @@ namespace EMotionFX::MotionMatching
 
         if (minFramesPerLeaf > 100000)
         {
-            AZ_Error("Motion Matching", false, "KdTree minFramesPerLeaf (%d) cannot be smaller than 100000.", minFramesPerLeaf);
+            AZ_Error("Motion Matching", false, "KdTree minFramesPerLeaf (%d) cannot be bigger than 100000.", minFramesPerLeaf);
             return false;
         }
 
@@ -83,9 +85,12 @@ namespace EMotionFX::MotionMatching
         m_maxDepth = maxDepth;
         m_minFramesPerLeaf = minFramesPerLeaf;
 
+        // Not all features are present in the KD-tree, thus we need to remap KD-tree local feature columns to the
+        // feature schema global feature columns.
+        const AZStd::vector<size_t> localToSchemaFeatureColumns = CalcLocalToSchemaFeatureColumns(features);
+
         // Build the tree.
-        m_featureValues.resize(m_numDimensions);
-        BuildTreeNodes(frameDatabase, featureMatrix, features, new Node(), nullptr, 0);
+        BuildTreeNodes(frameDatabase, featureMatrix, localToSchemaFeatureColumns, aznew Node(), nullptr, 0);
         MergeSmallLeafNodesToParents();
         ClearFramesForNonEssentialNodes();
         RemoveZeroFrameLeafNodes();
@@ -103,6 +108,27 @@ namespace EMotionFX::MotionMatching
         return true;
     }
 
+    AZStd::vector<size_t> KdTree::CalcLocalToSchemaFeatureColumns(const AZStd::vector<Feature*>& features) const
+    {
+        AZStd::vector<size_t> localToSchemaFeatureColumns;
+        localToSchemaFeatureColumns.resize(m_numDimensions);
+
+        size_t currentColumn = 0;
+        for (const Feature* feature : features)
+        {
+            const size_t numDimensions = feature->GetNumDimensions();
+            const size_t featureColumnOffset = feature->GetColumnOffset();
+            for (size_t i = 0; i < numDimensions; ++i)
+            {
+                localToSchemaFeatureColumns[currentColumn] = featureColumnOffset + i;
+                currentColumn++;
+            }
+        }
+
+        AZ_Assert(m_numDimensions == currentColumn, "There should be a column index mapping for each of the available dimensions.");
+        return localToSchemaFeatureColumns;
+    }
+
     void KdTree::Clear()
     {
         // delete all nodes
@@ -112,7 +138,6 @@ namespace EMotionFX::MotionMatching
         }
 
         m_nodes.clear();
-        m_featureValues.clear();
         m_numDimensions = 0;
     }
 
@@ -126,7 +151,6 @@ namespace EMotionFX::MotionMatching
             totalBytes += node->m_frames.capacity() * sizeof(size_t);
         }
 
-        totalBytes += m_featureValues.capacity() * sizeof(float);
         totalBytes += sizeof(KdTree);
         return totalBytes;
     }
@@ -148,7 +172,7 @@ namespace EMotionFX::MotionMatching
 
     void KdTree::BuildTreeNodes(const FrameDatabase& frameDatabase,
         const FeatureMatrix& featureMatrix,
-        const AZStd::vector<Feature*>& features,
+        const AZStd::vector<size_t>& localToSchemaFeatureColumns,
         Node* node,
         Node* parent,
         size_t dimension,
@@ -159,7 +183,8 @@ namespace EMotionFX::MotionMatching
         m_nodes.emplace_back(node);
 
         // Fill the frames array and calculate the median.
-        FillFramesForNode(node, frameDatabase, featureMatrix, features, parent, leftSide);
+        AZStd::vector<float> frameFeatureValues;
+        FillFramesForNode(node, frameDatabase, featureMatrix, localToSchemaFeatureColumns, frameFeatureValues, parent, leftSide);
 
         // Prevent splitting further when we don't want to.
         const size_t maxDimensions = AZ::GetMin(m_numDimensions, m_maxDepth);
@@ -170,16 +195,16 @@ namespace EMotionFX::MotionMatching
         }
 
         // Create the left node.
-        Node* leftNode = new Node();
+        Node* leftNode = aznew Node();
         AZ_Assert(!node->m_leftNode, "Expected the parent left node to be a nullptr");
         node->m_leftNode = leftNode;
-        BuildTreeNodes(frameDatabase, featureMatrix, features, leftNode, node, dimension + 1, true);
+        BuildTreeNodes(frameDatabase, featureMatrix, localToSchemaFeatureColumns, leftNode, node, dimension + 1, true);
 
         // Create the right node.
-        Node* rightNode = new Node();
+        Node* rightNode = aznew Node();
         AZ_Assert(!node->m_rightNode, "Expected the parent right node to be a nullptr");
         node->m_rightNode = rightNode;
-        BuildTreeNodes(frameDatabase, featureMatrix, features, rightNode, node, dimension + 1, false);
+        BuildTreeNodes(frameDatabase, featureMatrix, localToSchemaFeatureColumns, rightNode, node, dimension + 1, false);
     }
 
     void KdTree::ClearFramesForNonEssentialNodes()
@@ -267,38 +292,41 @@ namespace EMotionFX::MotionMatching
     void KdTree::FillFramesForNode(Node* node,
         const FrameDatabase& frameDatabase,
         const FeatureMatrix& featureMatrix,
-        const AZStd::vector<Feature*>& features,
+        const AZStd::vector<size_t>& localToSchemaFeatureColumns,
+        AZStd::vector<float>& frameFeatureValues,
         Node* parent,
         bool leftSide)
     {
-        float median = 0.0f;
+        frameFeatureValues.clear();
+
         if (parent)
         {
             // Assume half of the parent frames are in this node.
-            node->m_frames.reserve((parent->m_frames.size() / 2) + 1);
+            const size_t numExpectedFrames = (parent->m_frames.size() / 2) + 1;
+            frameFeatureValues.reserve(numExpectedFrames);
+            node->m_frames.reserve(numExpectedFrames);
 
             // Add parent frames to this node, but only ones that should be on this side.
             for (const size_t frameIndex : parent->m_frames)
             {
-                FillFeatureValues(featureMatrix, features, frameIndex);
+                // Remap local to the KD-tree feature column to the feature schema global column and read the value directly from the feature matrix.
+                const float featureValue = featureMatrix(frameIndex, localToSchemaFeatureColumns[parent->m_dimension]);
+                frameFeatureValues.push_back(featureValue);
 
-                const float value = m_featureValues[parent->m_dimension];
                 if (leftSide)
                 {
-                    if (value <= parent->m_median)
+                    if (featureValue <= parent->m_median)
                     {
                         node->m_frames.emplace_back(frameIndex);
                     }
                 }
                 else
                 {
-                    if (value > parent->m_median)
+                    if (featureValue > parent->m_median)
                     {
                         node->m_frames.emplace_back(frameIndex);
                     }
                 }
-
-                median += value;
             }
         }
         else // We're the root node.
@@ -308,35 +336,20 @@ namespace EMotionFX::MotionMatching
             {
                 const size_t frameIndex = frame.GetFrameIndex();
                 node->m_frames.emplace_back(frameIndex);
-                FillFeatureValues(featureMatrix, features, frameIndex);
-                median += m_featureValues[node->m_dimension];
+
+                // Remap local to the KD-tree feature column to the feature schema global column and read the value directly from the feature matrix.
+                const float featureValue = featureMatrix(frameIndex, localToSchemaFeatureColumns[node->m_dimension]);
+                frameFeatureValues.push_back(featureValue);
             }
         }
 
-        if (!node->m_frames.empty())
+        // Calculate the median in O(n).
+        node->m_median = 0.0f;
+        if (!frameFeatureValues.empty())
         {
-            median /= static_cast<float>(node->m_frames.size());
-        }
-        node->m_median = median;
-    }
-
-    void KdTree::FillFeatureValues(const FeatureMatrix& featureMatrix, const Feature* feature, size_t frameIndex, size_t startIndex)
-    {
-        const size_t numDimensions = feature->GetNumDimensions();
-        const size_t featureColumnOffset = feature->GetColumnOffset();
-        for (size_t i = 0; i < numDimensions; ++i)
-        {
-            m_featureValues[startIndex + i] = featureMatrix(frameIndex, featureColumnOffset + i);
-        }
-    }
-
-    void KdTree::FillFeatureValues(const FeatureMatrix& featureMatrix, const AZStd::vector<Feature*>& features, size_t frameIndex)
-    {
-        size_t startDimension = 0;
-        for (const Feature* feature : features)
-        {
-            FillFeatureValues(featureMatrix, feature, frameIndex, startDimension);
-            startDimension += feature->GetNumDimensions();
+            auto medianIterator = frameFeatureValues.begin() + frameFeatureValues.size() / 2;
+            AZStd::nth_element(frameFeatureValues.begin(), medianIterator, frameFeatureValues.end());
+            node->m_median = frameFeatureValues[frameFeatureValues.size() / 2];
         }
     }
 

--- a/Gems/MotionMatching/Code/Source/KdTree.h
+++ b/Gems/MotionMatching/Code/Source/KdTree.h
@@ -22,8 +22,8 @@ namespace EMotionFX::MotionMatching
     class KdTree
     {
     public:
-        AZ_RTTI(KdTree, "{CDA707EC-4150-463B-8157-90D98351ACED}")
-        AZ_CLASS_ALLOCATOR_DECL
+        AZ_RTTI(KdTree, "{CDA707EC-4150-463B-8157-90D98351ACED}");
+        AZ_CLASS_ALLOCATOR_DECL;
 
         KdTree() = default;
         virtual ~KdTree();
@@ -53,6 +53,10 @@ namespace EMotionFX::MotionMatching
     private:
         struct Node
         {
+            AZ_RTTI(KdTree::Node, "{8A7944B3-86F1-4A33-84BC-A3B6D599E0C9}");
+            AZ_CLASS_ALLOCATOR_DECL;
+            virtual ~Node() = default;
+
             Node* m_leftNode = nullptr;
             Node* m_rightNode = nullptr;
             Node* m_parent = nullptr;
@@ -63,17 +67,16 @@ namespace EMotionFX::MotionMatching
 
         void BuildTreeNodes(const FrameDatabase& frameDatabase,
             const FeatureMatrix& featureMatrix,
-            const AZStd::vector<Feature*>& features,
+            const AZStd::vector<size_t>& localToSchemaFeatureColumns,
             Node* node,
             Node* parent,
             size_t dimension = 0,
             bool leftSide = true);
-        void FillFeatureValues(const FeatureMatrix& featureMatrix, const Feature* feature, size_t frameIndex, size_t startIndex);
-        void FillFeatureValues(const FeatureMatrix& featureMatrix, const AZStd::vector<Feature*>& features, size_t frameIndex);
         void FillFramesForNode(Node* node,
             const FrameDatabase& frameDatabase,
             const FeatureMatrix& featureMatrix,
-            const AZStd::vector<Feature*>& features,
+            const AZStd::vector<size_t>& localToSchemaFeatureColumns,
+            AZStd::vector<float>& frameFeatureValues,
             Node* parent,
             bool leftSide);
         void RecursiveCalcNumFrames(Node* node, size_t& outNumFrames) const;
@@ -82,10 +85,10 @@ namespace EMotionFX::MotionMatching
         void RemoveZeroFrameLeafNodes();
         void RemoveLeafNode(Node* node);
         void FindNearestNeighbors(Node* node, const AZStd::vector<float>& frameFloats, AZStd::vector<size_t>& resultFrameIndices) const;
+        AZStd::vector<size_t> CalcLocalToSchemaFeatureColumns(const AZStd::vector<Feature*>& features) const;
 
     private:
         AZStd::vector<Node*> m_nodes;
-        AZStd::vector<float> m_featureValues;
         size_t m_numDimensions = 0;
         size_t m_maxDepth = 20;
         size_t m_minFramesPerLeaf = 1000;

--- a/Gems/MotionMatching/Code/Source/MotionMatchingEditorSystemComponent.cpp
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingEditorSystemComponent.cpp
@@ -40,7 +40,6 @@ namespace EMotionFX::MotionMatching
         }
     }
 
-
     void MotionMatchingEditorSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
     {
         BaseSystemComponent::GetProvidedServices(provided);


### PR DESCRIPTION
The KD-tree was storing feature values previously which was duplicated data from the feature matrix. With this change, we are reading the data directly from the feature matrix.

Additionally we're calculating the median now instead of just the average value to separate the data between the nodes.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>