### PR TITLE
chore: update for unused variable in PlatformConfiguration

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -2124,7 +2124,7 @@ namespace AssetProcessor
                 addedEntries = true;
             }
         }
-        return true;
+        return addedEntries;
     }
 
     // AssetProcessor


### PR DESCRIPTION
## What does this PR do?
build failed locally with unused variable. I'm guessing this boolean is returned if anything was added. This function is only called in one location `AssetServerHandler.cpp` and the return result is discarded. 

