### PR TITLE
Fixing omitted EditorSharedTest import

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Sandbox.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Sandbox.py
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 import pytest
 
-from ly_test_tools.o3de.editor_test import EditorSingleTest, EditorSingleTest, EditorParallelTest, EditorTestSuite
+from ly_test_tools.o3de.editor_test import EditorSingleTest, EditorSharedTest, EditorParallelTest, EditorTestSuite
 
 
 @pytest.mark.SUITE_sandbox


### PR DESCRIPTION
Signed-off-by: jckand-amzn <82226555+jckand-amzn@users.noreply.github.com>

Fixing omitted EditorSharedTest import so shared tests can run successfully in Sandbox. Fixes the error below:

```
[2022-07-20T05:52:10.974Z] =================================== ERRORS ====================================

[2022-07-20T05:52:10.974Z] _ ERROR collecting AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Sandbox.py _

[2022-07-20T05:52:10.974Z] D:\workspace\o3de\AutomatedTesting\Gem\PythonTests\Prefab\TestSuite_Sandbox.py:16: in <module>

[2022-07-20T05:52:10.974Z]     class TestAutomationAutoTestMode(EditorTestSuite):

[2022-07-20T05:52:10.974Z] D:\workspace\o3de\AutomatedTesting\Gem\PythonTests\Prefab\TestSuite_Sandbox.py:21: in TestAutomationAutoTestMode

[2022-07-20T05:52:10.974Z]     class test_SC_Spawnables_SimpleSpawnAndDespawn(EditorSharedTest):

[2022-07-20T05:52:10.974Z] E   NameError: name 'EditorSharedTest' is not defined

```

## How was this PR tested?

Ran tests locally and verified PyTest picks the tests up.
