### PR TITLE
Change Recast to use the optional AABB with GetGeometry.

### DIFF
--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.cpp
@@ -213,9 +213,13 @@ namespace RecastNavigation
                 continue;
             }
 
-            overlapHit.m_shape->GetGeometry(vertices, indices, nullptr);
+            // Create an AABB for the Recast tile in local space and pass it in to GetGeometry so that large geometry sets
+            // (like heightfields) can just return the subset of geometry that overlaps the AABB.
             auto pose = overlapHit.m_shape->GetLocalPose();
-            // Note: geometry data is in local space
+            AZ::Aabb localScanBounds = geometry.m_scanBounds.GetTranslated(-pose.first);
+            overlapHit.m_shape->GetGeometry(vertices, indices, &localScanBounds);
+
+            // Note: returned geometry data is also in local space
             AZ::Transform tBody = AZ::Transform::CreateFromQuaternionAndTranslation(body->GetOrientation(), body->GetPosition());
             AZ::Transform t = tBody * AZ::Transform::CreateTranslation(pose.first);
 


### PR DESCRIPTION
## What does this PR do?

This gives heightfields the ability to just return the subset of the heightfield that overlaps the Recast tile instead of the entire heightfield.

## How was this PR tested?

Tried the fix out on a level with a large terrain and tiny Recast area, and verified that the debug drawing of the Recast mesh looked correct, and used breakpoints to verify the heightfield was only returning ~15000 points instead of 51 million.

![image](https://user-images.githubusercontent.com/82224783/180044896-7b2a9e39-5de1-4975-8c9e-70cb4c56d1a1.png)
