### PR TITLE
Fixing crash with skinned meshes when baking reflection probes

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetComputePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetComputePass.cpp
@@ -51,7 +51,7 @@ namespace AZ
         {
             if (m_skinnedMeshFeatureProcessor)
             {
-                frameGraph.SetEstimatedItemCount(m_skinnedMeshFeatureProcessor->GetMorphTargetDispatchCount());
+                m_skinnedMeshFeatureProcessor->SetupMorphTargetScope(frameGraph);
             }
 
             ComputePass::SetupFrameGraphDependencies(frameGraph);

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshComputePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshComputePass.cpp
@@ -44,7 +44,7 @@ namespace AZ
         {
             if (m_skinnedMeshFeatureProcessor)
             {
-                frameGraph.SetEstimatedItemCount(m_skinnedMeshFeatureProcessor->GetSkinningDispatchCount());
+                m_skinnedMeshFeatureProcessor->SetupSkinningScope(frameGraph);
             }
 
             ComputePass::SetupFrameGraphDependencies(frameGraph);

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
@@ -309,6 +309,9 @@ namespace AZ
             // because they execute at a lower frequency
             m_skinningDispatches.clear();
             m_morphTargetDispatches.clear();
+
+            m_alreadyCreatedSkinningScopeThisFrame = false;
+            m_alreadyCreatedMorphTargetScopeThisFrame = false;
         }
 
         SkinnedMeshFeatureProcessor::SkinnedMeshHandle SkinnedMeshFeatureProcessor::AcquireSkinnedMesh(const SkinnedMeshHandleDescriptor& desc)
@@ -417,6 +420,32 @@ namespace AZ
             m_cachedSkinningShaderOptions.SetShader(m_skinningShader);
         }
 
+        void SkinnedMeshFeatureProcessor::SetupSkinningScope(RHI::FrameGraphInterface frameGraph)
+        {
+            if (m_alreadyCreatedSkinningScopeThisFrame)
+            {
+                frameGraph.SetEstimatedItemCount(0);
+            }
+            else
+            {
+                frameGraph.SetEstimatedItemCount((u32)m_skinningDispatches.size());
+                m_alreadyCreatedSkinningScopeThisFrame = true;
+            }
+        }
+
+        void SkinnedMeshFeatureProcessor::SetupMorphTargetScope(RHI::FrameGraphInterface frameGraph)
+        {
+            if (m_alreadyCreatedMorphTargetScopeThisFrame)
+            {
+                frameGraph.SetEstimatedItemCount(0);
+            }
+            else
+            {
+                frameGraph.SetEstimatedItemCount((u32)m_morphTargetDispatches.size());
+                m_alreadyCreatedMorphTargetScopeThisFrame = true;
+            }
+        }
+
         void SkinnedMeshFeatureProcessor::SubmitSkinningDispatchItems(RHI::CommandList* commandList, uint32_t startIndex, uint32_t endIndex)
         {
             AZStd::lock_guard lock(m_dispatchItemMutex);
@@ -429,7 +458,6 @@ namespace AZ
                 dispatchItem->m_submitIndex = index;
                 commandList->Submit(*dispatchItem);
             }
-            m_skinningDispatches.clear();
         }
 
         void SkinnedMeshFeatureProcessor::SubmitMorphTargetDispatchItems(RHI::CommandList* commandList, uint32_t startIndex, uint32_t endIndex)
@@ -444,7 +472,6 @@ namespace AZ
                 dispatchItem->m_submitIndex = index;
                 commandList->Submit(*dispatchItem);
             }
-            m_morphTargetDispatches.clear();
         }
 
         Data::Instance<RPI::Shader> SkinnedMeshFeatureProcessor::GetSkinningShader() const

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.h
@@ -12,6 +12,8 @@
 #include <SkinnedMesh/SkinnedMeshStatsCollector.h>
 #include <Atom/Feature/SkinnedMesh/SkinnedMeshFeatureProcessorInterface.h>
 
+#include <Atom/RHI/FrameGraphInterface.h>
+
 #include <Atom/RPI.Public/Culling.h>
 #include <Atom/RPI.Public/FeatureProcessor.h>
 #include <Atom/Utils/StableDynamicArray.h>
@@ -64,12 +66,13 @@ namespace AZ
             Data::Instance<RPI::Shader> GetSkinningShader() const;
             RPI::ShaderOptionGroup CreateSkinningShaderOptionGroup(const SkinnedMeshShaderOptions shaderOptions, SkinnedMeshShaderOptionNotificationBus::Handler& shaderReinitializedHandler);
             void OnSkinningShaderReinitialized(const Data::Instance<RPI::Shader> skinningShader);
-            uint32_t GetSkinningDispatchCount() const { return aznumeric_cast<uint32_t>(m_skinningDispatches.size()); }
             void SubmitSkinningDispatchItems(RHI::CommandList* commandList, uint32_t startIndex, uint32_t endIndex);
+            void SetupSkinningScope(RHI::FrameGraphInterface frameGraph);
 
             Data::Instance<RPI::Shader> GetMorphTargetShader() const;
-            uint32_t GetMorphTargetDispatchCount() const { return aznumeric_cast<uint32_t>(m_morphTargetDispatches.size()); }
             void SubmitMorphTargetDispatchItems(RHI::CommandList* commandList, uint32_t startIndex, uint32_t endIndex);
+            void SetupMorphTargetScope(RHI::FrameGraphInterface frameGraph);
+
         private:
             AZ_DISABLE_COPY_MOVE(SkinnedMeshFeatureProcessor);
 
@@ -87,8 +90,13 @@ namespace AZ
             AZStd::unique_ptr<SkinnedMeshStatsCollector> m_statsCollector;
 
             MeshFeatureProcessor* m_meshFeatureProcessor = nullptr;
+
             AZStd::unordered_set<const RHI::DispatchItem*> m_skinningDispatches;
+            bool m_alreadyCreatedSkinningScopeThisFrame = false;
+
             AZStd::unordered_set<const RHI::DispatchItem*> m_morphTargetDispatches;
+            bool m_alreadyCreatedMorphTargetScopeThisFrame = false;
+
             AZStd::mutex m_dispatchItemMutex;
 
         };


### PR DESCRIPTION
Skinned mesh FP and passes would delete the dispatch list after it submits it in the command list. This would break with the recent estimate item count changes since the skinning dispatch submission now using the provided range. If there are two passes, that range will be the same for both passes, but the first pass will delete the dispatch list after submitting it, so the second pass will try to access an empty list using the provided ranges and crash.
Changed the behavior so that only one skinning pass will get the full item count and subsequent skinning passes will receive a count of zero to avoid duplicate work (this duplicate work would also break motion vectors since it would update the previous position buffer twice in the same frame, so motion vectors would be zero).
In the future we need to add support for "Per Scene" passes so things like skinning can render once per scene instead of per-view as is the case with the current render pipelines.