### PR TITLE
Fixed parallax correction for OOBB reflection probes

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/LightingUtils.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/LightingUtils.azsli
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <Atom/RPI/Math.azsli>
+
 //! Transform cubemap coordinates to the expected cubemap orientation
 float3 GetCubemapCoords(float3 original)
 {
@@ -67,6 +69,16 @@ float3 ApplyParallaxCorrectionAABB(float3 aabbMin, float3 aabbMax, float3 aabbPo
 // compute parallax corrected reflection vector, OBB version
 float3 ApplyParallaxCorrectionOBB(float4x4 obbTransformInverse, float3 obbHalfExtents, float3 positionWS, float3 reflectDir)
 {
+    // Convert point and reflection direction to object space (object here being the reflection probe)
     float3 p = mul(obbTransformInverse, float4(positionWS, 1.0f)).xyz;
-    return ApplyParallaxCorrectionAABB(-obbHalfExtents, obbHalfExtents, float3(0.0f, 0.0f, 0.0f), p, reflectDir);
+    float3 r = mul(obbTransformInverse, float4(reflectDir, 0.0f)).xyz;
+
+    // Apply parallax correction in object aligned space
+    r = ApplyParallaxCorrectionAABB(-obbHalfExtents, obbHalfExtents, float3(0.0f, 0.0f, 0.0f), p, r);
+
+    // Rotate the result back to world space
+    float3x3 probeToWorldRotation = transpose(ExtractFloat3x3(obbTransformInverse));
+    r = mul(probeToWorldRotation, r);
+
+    return normalize(r);
 }

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -1384,7 +1384,7 @@ namespace AZ
                         // take the last handle from the list, which will be the smallest (most influential) probe
                         ReflectionProbeHandle handle = reflectionProbeHandles.back();
 
-                        objectSrg->SetConstant(modelToWorldConstantIndex, reflectionProbeFeatureProcessor->GetTransform(handle));
+                        objectSrg->SetConstant(modelToWorldConstantIndex, Matrix3x4::CreateFromTransform(reflectionProbeFeatureProcessor->GetTransform(handle)));
                         objectSrg->SetConstant(modelToWorldInverseConstantIndex, Matrix3x4::CreateFromTransform(reflectionProbeFeatureProcessor->GetTransform(handle)).GetInverseFull());
                         objectSrg->SetConstant(outerObbHalfLengthsConstantIndex, reflectionProbeFeatureProcessor->GetOuterObbWs(handle).GetHalfLengths());
                         objectSrg->SetConstant(innerObbHalfLengthsConstantIndex, reflectionProbeFeatureProcessor->GetInnerObbWs(handle).GetHalfLengths());

--- a/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/Math.azsli
+++ b/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/Math.azsli
@@ -87,6 +87,17 @@ float max4(float4 abcd)
     return max4(abcd.x, abcd.y, abcd.z, abcd.w);
 }
 
+// ---------- Matrix ----------
+
+float3x3 ExtractFloat3x3(float3x4 input)
+{
+    return float3x3(input[0].xyz, input[1].xyz, input[2].xyz);
+}
+
+float3x3 ExtractFloat3x3(float4x4 input)
+{
+    return float3x3(input[0].xyz, input[1].xyz, input[2].xyz);
+}
 
 // ---------- Intersection -----------
 
@@ -298,6 +309,7 @@ float PerspectiveDepthToLinear(float clipDepth, float3 coefficients)
 }
 
 // ---------- Random number generators -----------
+
 // George Marsaglia's Xorshift RNGs
 // https://www.jstatsoft.org/article/view/v008i14/xorshift.pdf
 uint Xorshift(in uint value) 
@@ -333,7 +345,9 @@ float LerpInverse(float a, float b, float value)
         return (value - a) / (b - a);
     }
 }
-//-------- Gaussinan distribution functions ---------
+
+// -------- Gaussinan distribution functions ---------
+
 // https://en.wikipedia.org/wiki/Gaussian_function
 // Parameter:
 // amplitude - the height of the curve's peak


### PR DESCRIPTION
OOBB reflection probes were transforming point to object space but not the reflection vector.
