### PR TITLE
Editorsv_print_server_logs to Turn On/Off Seeing Server Logs in the Editor Console

### DIFF
--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -40,6 +40,9 @@ namespace Multiplayer
     AZ_CVAR(AZ::CVarFixedString, editorsv_serveraddr, AZ::CVarFixedString(LocalHost), nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "The address of the server to connect to");
     AZ_CVAR(AZ::CVarFixedString, editorsv_rhi_override, "", nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
         "Override the default rendering hardware interface (rhi) when launching the Editor server. For example, you may be running an Editor using 'dx12', but want to launch a headless server using 'null'. If empty the server will launch using the same rhi as the Editor.");
+    AZ_CVAR(bool, editorsv_print_server_logs, true, nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
+        "Whether Editor should print its server's logs to the Editor console. Useful for seeing server prints, warnings, and errors without having to open up the server console or server.log file.");
+
     AZ_CVAR_EXTERNED(uint16_t, editorsv_port);
     
     //////////////////////////////////////////////////////////////////////////
@@ -295,8 +298,12 @@ namespace Multiplayer
                 m_serverProcessWatcher->TerminateProcess(0);
             }
             m_serverProcessWatcher.reset(outProcess);
-            m_serverProcessTracePrinter = AZStd::make_unique<ProcessCommunicatorTracePrinter>(m_serverProcessWatcher->GetCommunicator(), "EditorServer");
-            AZ::TickBus::Handler::BusConnect();
+
+            if (editorsv_print_server_logs)
+            {
+                m_serverProcessTracePrinter = AZStd::make_unique<ProcessCommunicatorTracePrinter>(m_serverProcessWatcher->GetCommunicator(), "EditorServer");
+                AZ::TickBus::Handler::BusConnect();
+            }
         }
         else
         {
@@ -388,7 +395,7 @@ namespace Multiplayer
 
     void MultiplayerEditorSystemComponent::OnTick(float, AZ::ScriptTimePoint)
     {
-        if (m_serverProcessTracePrinter)
+        if (editorsv_print_server_logs && m_serverProcessTracePrinter)
         {
             m_serverProcessTracePrinter->Pump();
         }

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -41,7 +41,7 @@ namespace Multiplayer
     AZ_CVAR(AZ::CVarFixedString, editorsv_rhi_override, "", nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
         "Override the default rendering hardware interface (rhi) when launching the Editor server. For example, you may be running an Editor using 'dx12', but want to launch a headless server using 'null'. If empty the server will launch using the same rhi as the Editor.");
     AZ_CVAR(bool, editorsv_print_server_logs, true, nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
-        "Whether Editor should print its server's logs to the Editor console. Useful for seeing server prints, warnings, and errors without having to open up the server console or server.log file.");
+        "Whether Editor should print its server's logs to the Editor console. Useful for seeing server prints, warnings, and errors without having to open up the server console or server.log file. Note: Must be set before entering the editor play mode.");
 
     AZ_CVAR_EXTERNED(uint16_t, editorsv_port);
     
@@ -395,7 +395,7 @@ namespace Multiplayer
 
     void MultiplayerEditorSystemComponent::OnTick(float, AZ::ScriptTimePoint)
     {
-        if (editorsv_print_server_logs && m_serverProcessTracePrinter)
+        if (m_serverProcessTracePrinter)
         {
             m_serverProcessTracePrinter->Pump();
         }


### PR DESCRIPTION
## What does this PR do?
Adding editorsv_print_server_logs. Useful flag for seeing server prin…ts, warnings, and errors without having to open up the server console or server.log file. 

Fixes part 1 #10774. Doesn't actually remove server spam, but at least you can turn off seeing it in the editor.

## How was this PR tested?
Run the editor with multiplayer enabled with editorsv_print_server_logs enabled and disabled and making sure the logs do and dont appear respectively.