### PR TITLE
SerializeContextTools `dumpsc` support for loading project gems

### DIFF
--- a/Code/Tools/SerializeContextTools/Application.cpp
+++ b/Code/Tools/SerializeContextTools/Application.cpp
@@ -85,7 +85,8 @@ namespace AZ::SerializeContextTools
 
                 // If the "dumptypes" or "createtype" supplied attempt to load the editor gem dependencies
                 if (m_commandLine.GetNumMiscValues() > 0 &&
-                    (m_commandLine.GetMiscValue(0) == "dumptypes" || m_commandLine.GetMiscValue(0) == "createtype"))
+                    (m_commandLine.GetMiscValue(0) == "dumptypes" || m_commandLine.GetMiscValue(0) == "createtype"
+                        || m_commandLine.GetMiscValue(0) == "dumpsc"))
                 {
                     projectSpecializations.Append("editor");
                 }

--- a/Code/Tools/SerializeContextTools/Dumper.cpp
+++ b/Code/Tools/SerializeContextTools/Dumper.cpp
@@ -681,8 +681,10 @@ namespace AZ::SerializeContextTools
             rapidjson::Value(rapidjson::StringRef("Deprecated")) : rapidjson::Value(classData->m_version), document.GetAllocator());
 
         auto systemComponentIt = AZStd::lower_bound(systemComponents.begin(), systemComponents.end(), classData->m_typeId);
-        bool isSystemComponent = systemComponentIt != systemComponents.end() && *systemComponentIt == classData->m_typeId;
+        const bool isSystemComponent = systemComponentIt != systemComponents.end() && *systemComponentIt == classData->m_typeId;
         classNode.AddMember("IsSystemComponent", isSystemComponent, document.GetAllocator());
+        const bool isComponent = isSystemComponent || (classData->m_azRtti != nullptr && classData->m_azRtti->IsTypeOf<AZ::Component>());
+        classNode.AddMember("IsComponent", isComponent, document.GetAllocator());
         classNode.AddMember("IsPrimitive", Utilities::IsSerializationPrimitive(genericClassInfo ? genericClassInfo->GetGenericTypeId() : classData->m_typeId), document.GetAllocator());
         classNode.AddMember("IsContainer", classData->m_container != nullptr, document.GetAllocator());
         if (genericClassInfo)

--- a/Code/Tools/SerializeContextTools/Utilities.cpp
+++ b/Code/Tools/SerializeContextTools/Utilities.cpp
@@ -29,26 +29,16 @@ namespace AZ::SerializeContextTools
 {
     AZStd::string Utilities::ReadOutputTargetFromCommandLine(Application& application, const char* defaultFileOrFolder)
     {
-        AZ::IO::Path sourceGameFolder;
-        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
-        {
-            settingsRegistry->Get(sourceGameFolder.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath);
-        }
-
         AZ::IO::Path outputPath;
         if (application.GetAzCommandLine()->HasSwitch("output"))
         {
             outputPath.Native() = application.GetAzCommandLine()->GetSwitchValue("output", 0);
-            if (outputPath.IsRelative())
-            {
-                outputPath = sourceGameFolder / outputPath;
-            }
         }
         else
         {
-            outputPath = sourceGameFolder / defaultFileOrFolder;
+            outputPath = defaultFileOrFolder;
         }
-        return outputPath.Native();
+        return AZStd::move(outputPath.Native());
     }
 
     AZStd::vector<AZStd::string> Utilities::ReadFileListFromCommandLine(Application& application, AZStd::string_view switchName)
@@ -69,12 +59,6 @@ namespace AZ::SerializeContextTools
             return result;
         }
 
-        AZ::IO::Path sourceGameFolder;
-        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
-        {
-            settingsRegistry->Get(sourceGameFolder.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath);
-        }
-
         AZStd::vector<AZStd::string_view> fileList;
         auto AppendFileList = [&fileList](AZStd::string_view filename)
         {
@@ -84,7 +68,7 @@ namespace AZ::SerializeContextTools
         {
             AZ::StringFunc::TokenizeVisitor(commandLine->GetSwitchValue(switchName, switchIndex), AppendFileList, ";");
         }
-        return Utilities::ExpandFileList(sourceGameFolder.c_str(), fileList);
+        return Utilities::ExpandFileList(".", fileList);
     }
 
     AZStd::vector<AZStd::string> Utilities::ExpandFileList(const char* root, const AZStd::vector<AZStd::string_view>& fileList)


### PR DESCRIPTION
The `dumpsc` command for the SerializeContextTools has been updated to support loading a project's Editor gem modules if the --project-path parameter is supplied.

Changed the --output argument for the `dumpsc` command to output relative to the current working directory, instead of relative to the project path.
When the project path wasn't specified this would output files within the executable directory instead of the current working directory.

Added an "IsComponent" field to the dumped SerializeContext content.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Ran the `dumpsc` command with the project path pointing to the AutomatedTesting project.
Here are the results of that `dumpsc` command
[serialize-and-edit.txt](https://github.com/o3de/o3de/files/9154819/serialize-and-edit.txt)

