### PR TITLE
Reflect MarkForRemoval and ClearAllEntities from appropriate net components

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetBindComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetBindComponent.h
@@ -50,7 +50,7 @@ namespace Multiplayer
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
 
         NetBindComponent();
-        ~NetBindComponent() override;
+        ~NetBindComponent() override = default;
 
         //! AZ::Component overrides.
         //! @{

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetBindComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetBindComponent.h
@@ -50,7 +50,7 @@ namespace Multiplayer
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
 
         NetBindComponent();
-        ~NetBindComponent() override = default;
+        ~NetBindComponent() override;
 
         //! AZ::Component overrides.
         //! @{

--- a/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
@@ -112,7 +112,7 @@ namespace Multiplayer
                     return netBindComponent->IsNetEntityRoleClient();
                 })
 
-            ->Method("IsNetEntityRoleServer", [](AZ::EntityId id) -> bool {
+                ->Method("IsNetEntityRoleServer", [](AZ::EntityId id) -> bool {
                     AZ::Entity* entity = AZ::Interface<AZ::ComponentApplicationRequests>::Get()->FindEntity(id);
                     if (!entity)
                     {
@@ -128,7 +128,24 @@ namespace Multiplayer
                     }
                     return netBindComponent->IsNetEntityRoleServer();
                 })
-            ;
+
+                ->Method("MarkForRemoval", [](AZ::EntityId id) {
+                    AZ::Entity* entity = AZ::Interface<AZ::ComponentApplicationRequests>::Get()->FindEntity(id);
+                    if (!entity)
+                    {
+                        AZ_Warning("NetBindComponent", false, "NetBindComponent MarkForRemoval failed. The entity with id %s doesn't exist, please provide a valid entity id.", id.ToString().c_str());
+                        return;
+                    }
+
+                    NetBindComponent* netBindComponent = GetNetworkEntityTracker()->GetNetBindComponent(entity);
+                    if (!netBindComponent)
+                    {
+                        AZ_Warning("NetBindComponent", false, "NetBindComponent MarkForRemoval failed. Entity '%s' (id: %s) is missing a NetBindComponent, make sure this entity contains a component which derives from NetBindComponent.", entity->GetName().c_str(), id.ToString().c_str())
+                        return;
+                    }
+
+                    AZ::Interface<IMultiplayer>::Get()->GetNetworkEntityManager()->MarkForRemoval(netBindComponent->GetEntityHandle());
+                });
         }
     }
 

--- a/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
@@ -168,6 +168,14 @@ namespace Multiplayer
         ;
     }
 
+    NetBindComponent::~NetBindComponent()
+    {
+        if (m_needsToBeStopped)
+        {
+            AZ_Warning("NetBindComponent", false, "NetBindComponent destructed without being stopped. Ensure MarkForRemoval is called before destroying a networked entity or disconnect is called before exiting.")                       
+        }
+    }
+
     void NetBindComponent::Init()
     {
         auto* netEntityManager = AZ::Interface<INetworkEntityManager>::Get();

--- a/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
@@ -168,14 +168,6 @@ namespace Multiplayer
         ;
     }
 
-    NetBindComponent::~NetBindComponent()
-    {
-        if (m_needsToBeStopped)
-        {
-            AZ_Warning("NetBindComponent", false, "NetBindComponent destructed without being stopped. Ensure MarkForRemoval is called before destroying a networked entity or disconnect is called before exiting.")                       
-        }
-    }
-
     void NetBindComponent::Init()
     {
         auto* netEntityManager = AZ::Interface<INetworkEntityManager>::Get();

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -143,7 +143,7 @@ namespace Multiplayer
                         AZ_Warning("Multiplayer Property", false,
                             "MultiplayerSystemComponent GetOnEndpointDisonnectedEvent failed."
                             "The entity with id %s doesn't exist, please provide a valid entity id.",
-                            id.ToString().c_str())
+                            id.ToString().c_str());
                         return nullptr;
                     }
 
@@ -153,11 +153,36 @@ namespace Multiplayer
                         AZ_Warning("Multiplayer Property", false,
                             "MultiplayerSystemComponent GetOnEndpointDisonnectedEvent failed."
                             "Entity '%s' (id: %s) is missing MultiplayerSystemComponent, be sure to add MultiplayerSystemComponent to this entity.",
-                            entity->GetName().c_str(), id.ToString().c_str())
+                            entity->GetName().c_str(), id.ToString().c_str());
                         return nullptr;
                     }
 
                     return &mpComponent->m_endpointDisonnectedEvent;
+                })
+                ->Method("ClearAllEntities", [](AZ::EntityId id)
+                {
+                    AZ::Entity* entity = AZ::Interface<AZ::ComponentApplicationRequests>::Get()->FindEntity(id);
+                    if (!entity)
+                    {
+                        AZ_Warning("Multiplayer Property", false,
+                            "MultiplayerSystemComponent MarkForRemoval failed."
+                            "The entity with id %s doesn't exist, please provide a valid entity id.",
+                            id.ToString().c_str());
+                        return;
+                    }
+
+                    MultiplayerSystemComponent* mpComponent = entity->FindComponent<MultiplayerSystemComponent>();
+                    if (!mpComponent)
+                    {
+                        AZ_Warning("Multiplayer Property", false,
+                            "MultiplayerSystemComponent MarkForRemoval failed."
+                            "Entity '%s' (id: %s) is missing MultiplayerSystemComponent, be sure to add MultiplayerSystemComponent to "
+                            "this entity.",
+                            entity->GetName().c_str(), id.ToString().c_str());
+                        return;
+                    }
+
+                    mpComponent->GetNetworkEntityManager()->ClearAllEntities();
                 })
                 ->Attribute(
                     AZ::Script::Attributes::AzEventDescription,


### PR DESCRIPTION
Signed-off-by: puvvadar <puvvadar@amazon.com>

## What does this PR do?

Per https://github.com/o3de/o3de/issues/10006, this change reflects MarkForRemoval from NetBindComponent and ClearAllEntities from MultiplayerSystemComponent.

## How was this PR tested?

This was tested by using the repro steps in https://github.com/o3de/o3de/issues/9999. Fix was confirmed by replacing the DestroyEntity call with MarkForRemoval and confirming efficacy.
