### PR TITLE
Add set world rotation node to scriptcanvas

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -736,6 +736,7 @@ namespace AzFramework
                 ->Event("GetLocalX", &AZ::TransformBus::Events::GetLocalX)
                 ->Event("GetLocalY", &AZ::TransformBus::Events::GetLocalY)
                 ->Event("GetLocalZ", &AZ::TransformBus::Events::GetLocalZ)
+                ->Event("SetWorldRotation", &AZ::TransformBus::Events::SetWorldRotation)
                 ->Event("SetWorldRotationQuaternion", &AZ::TransformBus::Events::SetWorldRotationQuaternion)
                 ->Event("GetWorldRotation", &AZ::TransformBus::Events::GetWorldRotation)
                 ->Event("GetWorldRotationQuaternion", &AZ::TransformBus::Events::GetWorldRotationQuaternion)

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/TransformBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/TransformBus.names
@@ -503,6 +503,28 @@
                     ]
                 },
                 {
+                    "base": "SetWorldRotation",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Set World Rotation"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after SetWorldRotation is invoked"
+                    },
+                    "details": {
+                        "name": "Set World Rotation"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "details": {
+                                "name": "Euler Angles (Radians)"
+                            }
+                        }
+                    ]
+                },
+                {
                     "base": "SetWorldRotationQuaternion",
                     "entry": {
                         "name": "In",

--- a/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.cpp
@@ -130,11 +130,13 @@ namespace ScriptCanvasEditor::TranslationHelper
                     searchResult = fileIO->FindFiles(folderName.c_str(), "*",
                         [&](const char* path)
                         {
+                            AZ::IO::Path currentPath = path;
                             if (fileIO->IsDirectory(path))
                             {
                                 foldersToSearch.push_back(path);
                             }
-                            else if (AZStd::string(path).ends_with(fileNameWithExtension))
+                            else if (currentPath.HasFilename()
+                                && strcmp(currentPath.Filename().LexicallyNormal().c_str(), fileNameWithExtension.c_str()) == 0)
                             {
                                 filesFound.push_back(path);
                                 foldersToSearch.clear();


### PR DESCRIPTION
## What does this PR do?
As requested by https://github.com/o3de/o3de/issues/10647, add SetWorldRotation Node

PS. fix the translation file look up bug, which previously only look for file name end with (it leads to return back wrong file having same suffix name)

## How was this PR tested?
Using script canvas to set world rotation and local rotation respectively

https://user-images.githubusercontent.com/5900509/180097145-fa3dcbbe-d865-428c-b374-f4f045ae360c.mp4


SetWorldRotation node
![worldrotation](https://user-images.githubusercontent.com/5900509/180097191-1db3bd99-e09f-490c-a4ec-67fafdc76320.PNG)

Signed-off-by: onecent1101 <liug@amazon.com>