### PR TITLE
Fixed native visualizers for the AZStd forward_list and fixed_list classes

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
+++ b/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
@@ -137,7 +137,7 @@
         <Size>m_numElements</Size>
         <HeadPointer>m_head.m_next</HeadPointer>
         <NextPointer>m_next</NextPointer>
-        <ValueNode>*($T1*)(this+1)</ValueNode>
+        <ValueNode>(*(Internal::forward_list_node&lt;$T1&gt;*)(this)).m_value</ValueNode>
       </LinkedListItems>
     </Expand>
   </Type>
@@ -150,7 +150,7 @@
         <Size>m_numElements</Size>
         <HeadPointer>m_head.m_next</HeadPointer>
         <NextPointer>m_next</NextPointer>
-        <ValueNode>*($T1*)(this+1)</ValueNode>
+        <ValueNode>(*(Internal::list_node&lt;$T1&gt;*)(this)).m_value</ValueNode>
       </LinkedListItems>
     </Expand>
   </Type>
@@ -163,7 +163,7 @@
         <Size>m_numElements</Size>
         <HeadPointer>m_head.m_next</HeadPointer>
         <NextPointer>m_next</NextPointer>
-        <ValueNode>*($T1*)(this+1)</ValueNode>
+        <ValueNode>(*(Internal::forward_list_node&lt;$T1&gt;*)(this)).m_value</ValueNode>
       </LinkedListItems>
     </Expand>
   </Type>
@@ -245,14 +245,24 @@
 
   <Type Name="AZStd::list_const_iterator&lt;*&gt;">
     <AlternativeType Name="AZStd::list_iterator&lt;*&gt;" />
-    <AlternativeType Name="AZStd::forward_list_iterator&lt;*&gt;" />
-    <AlternativeType Name="AZStd::forward_list_const_iterator&lt;*&gt;" />
     <DisplayString>{*((Internal::list_node&lt;$T1&gt;*)(m_node))}</DisplayString>
     <Expand>
       <Item Name="[ptr]">(void*)(m_node), x</Item>
       <Item Name="[value]">*((Internal::list_node&lt;$T1&gt;*)(m_node))</Item>
+      <Item Name="[next]">*(AZStd::list_const_iterator&lt;$T1&gt;*) (((Internal::list_node&lt;$T1&gt;*)(m_node))->m_next)</Item>
+      <Item Name="[prev]">*(AZStd::list_const_iterator&lt;$T1&gt;*) (((Internal::list_node&lt;$T1&gt;*)(m_node))->m_prev)</Item>
     </Expand>
   </Type>
+
+    <Type Name="AZStd::forward_list_const_iterator&lt;*&gt;">
+        <AlternativeType Name="AZStd::forward_list_iterator&lt;*&gt;" />
+        <DisplayString>{*((Internal::forward_list_node&lt;$T1&gt;*)(m_node))}</DisplayString>
+        <Expand>
+            <Item Name="[ptr]">(void*)(m_node), x</Item>
+            <Item Name="[value]">*((Internal::forward_list_node&lt;$T1&gt;*)(m_node))</Item>
+            <Item Name="[next]">*(AZStd::forward_list_const_iterator&lt;$T1&gt;*) (((Internal::forward_list_node&lt;$T1&gt;*)(m_node))->m_next)</Item>
+        </Expand>
+    </Type>
 
   <Type Name="AZStd::intrusive_list&lt;*&gt;::const_iterator_impl">
     <AlternativeType Name="AZStd::intrusive_list&lt;*&gt;::iterator_impl" />


### PR DESCRIPTION

This fixes the forward_list iterator types as well to be casted to the correct forward_list::iterator type.
Previously it was being cast to the list::iterator type which is not compatible.

Added a [next] entry in the forward_list iterator entry that allows traversing the iteratorxs entries in the debugger with the list node values shown
Also added a [next] and [prev] entry in list iterator netry that allows traversing the iterator entries

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Examined a forward_list_iterator and forward_list_const_iterator in the MSVC debugger to validate the entries were correct.
