### PR TITLE
Removed push_back/push_front/insert extensions which took no parameters.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/Entity.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/Entity.cpp
@@ -1101,8 +1101,7 @@ namespace AZ
                 return FailureCode(DependencySortResult::DescriptorNotRegistered, "No descriptor registered for Component class '%s'.", component->RTTI_GetTypeName());
             }
 
-            componentInfos.push_back();
-            ComponentInfo& componentInfo = componentInfos.back();
+            ComponentInfo& componentInfo = componentInfos.emplace_back();
             componentInfo.m_component = component;
             componentInfo.m_componentId = component->GetId();
             componentInfo.m_descriptor = componentDescriptor;
@@ -1209,8 +1208,7 @@ namespace AZ
 
                     // put new entry into "linked-list" of components that depend upon this service
                     size_t newEntryIndex = dependentComponentBuffer.size();
-                    dependentComponentBuffer.push_back();
-                    DependentComponentEntry& dependentEntry = dependentComponentBuffer.back();
+                    DependentComponentEntry& dependentEntry = dependentComponentBuffer.emplace_back();
                     dependentEntry.m_dependentComponentInfo = &componentInfo;
 
                     if (serviceInfo.m_firstDependentComponentEntry == InvalidEntry)

--- a/Code/Framework/AzCore/AzCore/DOM/DomValue.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomValue.cpp
@@ -1196,8 +1196,7 @@ namespace AZ::Dom
         if (entry.IsEndOfArray())
         {
             Array::ContainerType& array = GetArrayInternal();
-            array.push_back();
-            return array[array.size() - 1];
+            return array.emplace_back();
         }
         return entry.IsIndex() ? operator[](entry.GetIndex()) : operator[](entry.GetKey());
     }
@@ -1259,8 +1258,7 @@ namespace AZ::Dom
         if (entry.IsEndOfArray())
         {
             Array::ContainerType& array = GetArrayInternal();
-            array.push_back();
-            return &array[array.size() - 1];
+            return &array.emplace_back();
         }
         else if (entry.IsIndex())
         {

--- a/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
@@ -3855,8 +3855,7 @@ LUA_API const Node* lua_getDummyNode()
                             const BehaviorEBusHandler::BusForwarderEvent& e = events[iEvent];
                             if (strcmp(fieldName, e.m_name) == 0)
                             {
-                                m_hooks.push_back();
-                                HookUserData* userData = &m_hooks.back();
+                                HookUserData* userData = &m_hooks.emplace_back();
 
                                 // make the object, cache the function, find the pushers for each argument
                                 userData->m_luaHandler = this;

--- a/Code/Framework/AzCore/AzCore/Script/ScriptContextDebug.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptContextDebug.cpp
@@ -510,8 +510,7 @@ ScriptContextDebug::PushCodeCallstack(int stackSuppressCount, int numStackLevels
     // TODO: Move this function to a common ScriptContextDebug.cpp there is no lua dependency here
     if (m_isRecordCallstack && numStackLevels > 0)
     {
-        m_callstack.push_back();
-        CallstackLine& cl = m_callstack.back();
+        CallstackLine& cl = m_callstack.emplace_back();
         cl.m_codeNumStackFrames = numStackLevels; // set non 0 number to indicate a C++ code on the callstack
         if (m_isRecordCodeCallstack)
         {
@@ -616,8 +615,7 @@ void LuaHook(lua_State* l, lua_Debug* ar)
         // add to callstack
         if (context->m_isRecordCallstack)
         {
-            context->m_callstack.push_back();
-            ScriptContextDebug::CallstackLine& cl = context->m_callstack.back();
+            ScriptContextDebug::CallstackLine& cl = context->m_callstack.emplace_back();
             cl.m_sourceName = ar->source;
             cl.m_functionType = ar->what;
             if (strcmp(ar->what, "main") != 0)
@@ -922,8 +920,7 @@ ScriptContextDebug::ReadValue(DebugValue& value, VoidPtrArray& tablesVisited, bo
             lua_pushnil(l);
             while (lua_next(l, -2))
             {
-                value.m_elements.push_back();
-                DebugValue& subValue = value.m_elements.back();
+                DebugValue& subValue = value.m_elements.emplace_back();
                 if (lua_type(l, -2) == LUA_TSTRING)
                 {
                     subValue.m_name = lua_tostring(l, -2);
@@ -999,8 +996,7 @@ ScriptContextDebug::ReadValue(DebugValue& value, VoidPtrArray& tablesVisited, bo
                     const char* subValueName = lua_tostring(l, -2);
                     if (lua_tocfunction(l, -1) == &Internal::LuaPropertyTagHelper)     // if it's a property
                     {
-                        value.m_elements.push_back();
-                        DebugValue& subValue = value.m_elements.back();
+                        DebugValue& subValue = value.m_elements.emplace_back();
                         subValue.m_name = subValueName;
 
                         //bool isRead = true;
@@ -1032,13 +1028,6 @@ ScriptContextDebug::ReadValue(DebugValue& value, VoidPtrArray& tablesVisited, bo
                             subValue.m_flags |= DebugValue::FLAG_READ_ONLY;     // it's ready only
                         }
                     }
-                    /*else if (lua_iscfunction(l, -1) && strncmp(subValueName, "__", 2) != 0)
-                    {
-                        value.m_elements.push_back();
-                        DebugValue& subValue = value.m_elements.back();
-                        subValue.m_name = subValueName;
-                        ReadValue(subValue, tablesVisited, isReadOnly);
-                    }*/
                 }
                 lua_pop(l, 1);    // pop the value and leave the key for next iteration
             }
@@ -1064,8 +1053,7 @@ ScriptContextDebug::ReadValue(DebugValue& value, VoidPtrArray& tablesVisited, bo
     // add the metatable if we have one
     if (showMetatable && lua_getmetatable(l, -1))
     {
-        value.m_elements.push_back();
-        DebugValue& subValue = value.m_elements.back();
+        DebugValue& subValue = value.m_elements.emplace_back();
         subValue.m_flags = DebugValue::FLAG_READ_ONLY; // we should NOT allow any modification of the metatable field.
         subValue.m_name = "__metatable__";
         ReadValue(subValue, tablesVisited, true);
@@ -1479,8 +1467,7 @@ ScriptContextDebug::SetValue(const DebugValue& sourceValue)
 
         for (AZ::OSString& token : tokens)
         {
-            current->m_elements.push_back();
-            current = &(current->m_elements.back());
+            current = &(current->m_elements.emplace_back());
             current->m_name = token;
             current->m_type = LUA_TTABLE;
         }

--- a/Code/Framework/AzCore/AzCore/Serialization/DataOverlayProviderMsgs.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/DataOverlayProviderMsgs.cpp
@@ -40,8 +40,7 @@ namespace AZ
     //-------------------------------------------------------------------------
     bool DataOverlayTarget::ElementBegin(NodeStack* nodeStack, const void* elemPtr, const SerializeContext::ClassData* classData, const SerializeContext::ClassElement* elementData)
     {
-        nodeStack->back()->m_subElements.push_back();
-        SerializeContext::DataElementNode* node = &nodeStack->back()->m_subElements.back();
+        SerializeContext::DataElementNode* node = &nodeStack->back()->m_subElements.emplace_back();
         nodeStack->push_back(node);
 
         node->m_classData = classData;

--- a/Code/Framework/AzCore/AzCore/Serialization/DataPatch.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/DataPatch.cpp
@@ -184,8 +184,7 @@ namespace AZ
         DataNode* newNode;
         if (m_currentNode)
         {
-            m_currentNode->m_children.push_back();
-            newNode = &m_currentNode->m_children.back();
+            newNode = &m_currentNode->m_children.emplace_back();
         }
         else
         {

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
@@ -507,8 +507,7 @@ namespace AZ
             }
             AZ_Assert(serializeClassData, "Class %s is not reflected in the serializer yet! Edit context can be set after the class is reflected!", AzTypeInfo<T>::Name());
 
-            m_classData.push_back();
-            Edit::ClassData& editClassData = m_classData.back();
+            Edit::ClassData& editClassData = m_classData.emplace_back();
             editClassData.m_name = displayName;
             editClassData.m_description = description;
             editClassData.m_editDataProvider = nullptr;
@@ -556,8 +555,7 @@ namespace AZ
     {
         if (IsValid())
         {
-            m_classElement->m_elements.push_back();
-            Edit::ElementData& ed = m_classElement->m_elements.back();
+            Edit::ElementData& ed = m_classElement->m_elements.emplace_back();
             ed.m_elementId = elementIdCrc;
             ed.m_description = description;
             m_editElement = &ed;
@@ -674,8 +672,7 @@ namespace AZ
         // We cannot continue past this point, we must alert the user to fix their serialization config and crash
         AZ_Assert(classElement, "Class element for editor data element reflection '%s' was NOT found in the serialize context! This member MUST be serializable to be editable!", name);
 
-        m_classElement->m_elements.push_back();
-        Edit::ElementData* ed = &m_classElement->m_elements.back();
+        Edit::ElementData* ed = &m_classElement->m_elements.emplace_back();
         
         classElement->m_editData = ed;
         m_editElement = ed;

--- a/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
@@ -273,8 +273,7 @@ namespace AZ
 
                 nextLevel = false;
 
-                elementNode.m_subElements.push_back();
-                SerializeContext::DataElementNode& childNode = elementNode.m_subElements.back();
+                SerializeContext::DataElementNode& childNode = elementNode.m_subElements.emplace_back();
                 // we might need to copy the element name, if it's deleted after the read element
                 // otherwise it will be left dangling
                 childNode.m_element = AZStd::move(childElement);
@@ -1764,8 +1763,7 @@ namespace AZ
             }
             else if (GetType() == ST_JSON)
             {
-                m_jsonWriteValues.push_back();
-                rapidjson::Value& classObject = m_jsonWriteValues.back();
+                rapidjson::Value& classObject = m_jsonWriteValues.emplace_back();
                 classObject.SetObject();
                 // element name
                 if (element.m_name)
@@ -1800,8 +1798,7 @@ namespace AZ
                     AZ_Assert(element.m_dataSize == 0, "We can't serialize values for %s(0x%x), value=%s without a serializer to do DataToText()!", element.m_name ? element.m_name : "NULL", element.m_nameCrc, idBuffer);
                 }
                 // Add child fields array
-                m_jsonWriteValues.push_back();
-                m_jsonWriteValues.back().SetArray();
+                m_jsonWriteValues.emplace_back().SetArray();
             }
             else /*ST_BINARY*/
             {
@@ -1972,8 +1969,7 @@ namespace AZ
                     m_jsonDoc->SetObject();
                     m_jsonDoc->AddMember("name", "ObjectStream", m_jsonDoc->GetAllocator());
                     m_jsonDoc->AddMember("version", m_version, m_jsonDoc->GetAllocator());
-                    m_jsonWriteValues.push_back();
-                    m_jsonWriteValues.back().SetArray();
+                    m_jsonWriteValues.emplace_back().SetArray();
                 }
                 else
                 {

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
@@ -2314,8 +2314,7 @@ namespace AZ
                 AZ_Assert(false, "A deprecated element with a data converter was passed to CloneObject, this is not supported.");
             }
             // push a dummy node in the stack
-            cloneData->m_parentStack.push_back();
-            ObjectCloneData::ParentInfo& parentInfo = cloneData->m_parentStack.back();
+            ObjectCloneData::ParentInfo& parentInfo = cloneData->m_parentStack.emplace_back();
             parentInfo.m_ptr = destPtr;
             parentInfo.m_reservePtr = reservePtr;
             parentInfo.m_classData = classData;
@@ -2376,8 +2375,7 @@ namespace AZ
             // There is no valid destination pointer so a dummy node is added to the clone data parent stack
             // and further descendent type iteration is halted
             // An error has been reported to the supplied errorHandler in the code above
-            cloneData->m_parentStack.push_back();
-            ObjectCloneData::ParentInfo& parentInfo = cloneData->m_parentStack.back();
+            ObjectCloneData::ParentInfo& parentInfo = cloneData->m_parentStack.emplace_back();
             parentInfo.m_ptr = destPtr;
             parentInfo.m_reservePtr = reservePtr;
             parentInfo.m_classData = classData;
@@ -2429,8 +2427,7 @@ namespace AZ
         }
 
         // push this node in the stack
-        cloneData->m_parentStack.push_back();
-        ObjectCloneData::ParentInfo& parentInfo = cloneData->m_parentStack.back();
+        ObjectCloneData::ParentInfo& parentInfo = cloneData->m_parentStack.emplace_back();
         parentInfo.m_ptr = destPtr;
         parentInfo.m_reservePtr = reservePtr;
         parentInfo.m_classData = classData;

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
@@ -821,8 +821,7 @@ namespace AZ
                         return false;
                     }
 
-                    fileList.push_back();
-                    RegistryFile& registryFile = fileList.back();
+                    RegistryFile& registryFile = fileList.emplace_back();
                     if (ExtractFileDescription(registryFile, filename, specializations))
                     {
                         registryFile.m_isPlatformFile = isPlatformFile;

--- a/Code/Framework/AzCore/AzCore/Slice/SliceComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Slice/SliceComponent.cpp
@@ -2116,8 +2116,7 @@ namespace AZ
             if (!newReference)
             {
                 Data::AssetBus::MultiHandler::BusConnect(sliceReference->m_asset.GetId());
-                m_slices.push_back();
-                newReference = &m_slices.back();
+                newReference = &m_slices.emplace_back();
                 newReference->m_component = this;
                 newReference->m_asset = sliceReference->m_asset;
                 newReference->m_isInstantiated = m_slicesAreInstantiated;
@@ -3394,8 +3393,7 @@ namespace AZ
         if (!reference)
         {
             Data::AssetBus::MultiHandler::BusConnect(sliceAsset.GetId());
-            m_slices.push_back();
-            reference = &m_slices.back();
+            reference = &m_slices.emplace_back();
 
             auto loadBehavior = reference->m_asset.GetAutoLoadBehavior();
 
@@ -3873,8 +3871,7 @@ namespace AZ
         // Anything left in the instance list are references that haven't been loaded yet, so load them.
         for (AZStd::pair<Data::Asset<SliceAsset>, SliceInstancePtrSet> refToAdd : sliceInstances)
         {
-            m_slices.push_back();
-            SliceReference *newReference = &m_slices.back();
+            SliceReference *newReference = &m_slices.emplace_back();
             newReference->m_component = this;
             newReference->m_asset = refToAdd.first;
 

--- a/Code/Framework/AzCore/AzCore/std/containers/deque.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/deque.h
@@ -474,13 +474,13 @@ namespace AZStd
 
         iterator insert(const_iterator insertPos, const value_type& value)
         {
-            iterator last, first = begin();
+            iterator first = begin();
             if (insertPos == first)
             {
                 push_front(value);
                 return begin();
             }
-            else if (insertPos == (last = end()))
+            else if (iterator last = end(); insertPos == last)
             {
                 push_back(value);
                 return end() - 1;
@@ -510,10 +510,10 @@ namespace AZStd
             }
         }
 
-        void insert(const_iterator insertPos, size_type numElements, const value_type& value)
+        iterator insert(const_iterator insertPos, size_type numElements, const value_type& value)
         {
             iterator  mid;
-            size_type offset = insertPos - begin();
+            const size_type offset = insertPos - begin();
             size_type rem = m_size - offset;
             //          size_type size = m_size;
             size_type i;
@@ -573,17 +573,19 @@ namespace AZStd
                     Internal::fill(mid, mid + numElements, valueCopy, Internal::is_fast_fill<iterator>());
                 }
             }
-        }
 
-        AZ_FORCE_INLINE void insert(const_iterator insertPos, std::initializer_list<value_type> list)
-        {
-            insert(insertPos, list.begin(), list.end());
+            return AZStd::ranges::next(begin(), offset);
         }
 
         template<class InputIterator>
-        AZ_FORCE_INLINE void insert(const_iterator insertPos, InputIterator first, InputIterator last)
+        iterator insert(const_iterator insertPos, InputIterator first, InputIterator last)
         {
-            insert_iter(insertPos, first, last, is_integral<InputIterator>());
+            return insert_iter(insertPos, first, last, is_integral<InputIterator>());
+        }
+
+        iterator insert(const_iterator insertPos, initializer_list<value_type> list)
+        {
+            return insert(insertPos, list.begin(), list.end());
         }
 
         AZ_FORCE_INLINE iterator erase(iterator erasePos)
@@ -685,11 +687,11 @@ namespace AZStd
             , m_size(0)
             , m_allocator(rhs.m_allocator)
         {
-            assign_rv(AZStd::forward<this_type>(rhs));
+            assign_rv(AZStd::move(rhs));
         }
         this_type& operator=(this_type&& rhs)
         {
-            assign_rv(AZStd::forward<this_type>(rhs));
+            assign_rv(AZStd::move(rhs));
             return *this;
         }
 
@@ -704,7 +706,7 @@ namespace AZStd
                 clear();
                 for (iterator iter = rhs.begin(); iter != rhs.end(); ++iter)
                 {
-                    push_back(AZStd::forward<T>(*iter));
+                    push_back(AZStd::move(*iter));
                 }
             }
             else
@@ -742,7 +744,7 @@ namespace AZStd
             }
 
             map_node_type ptr = m_map[block] + newOffset % NumElementsPerBlock;
-            Internal::construct<map_node_type>::single(ptr, AZStd::forward<value_type>(value));
+            Internal::construct<map_node_type>::single(ptr, AZStd::move(value));
 
             m_firstOffset = newOffset;
             ++m_size;
@@ -769,7 +771,7 @@ namespace AZStd
             }
 
             map_node_type ptr = m_map[block] + newOffset % NumElementsPerBlock;
-            Internal::construct<map_node_type>::single(ptr, AZStd::forward<value_type>(value));
+            Internal::construct<map_node_type>::single(ptr, AZStd::move(value));
             ++m_size;
         }
 
@@ -798,7 +800,7 @@ namespace AZStd
         }
 
         template<class... Args>
-        void emplace_back(Args&&... args)
+        reference emplace_back(Args&&... args)
         {
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
             orphan_all();
@@ -821,6 +823,7 @@ namespace AZStd
             map_node_type ptr = m_map[block] + newOffset % NumElementsPerBlock;
             Internal::construct<map_node_type>::single(ptr, AZStd::forward<Args>(args)...);
             ++m_size;
+            return *ptr;
         }
 
         template<class Args>
@@ -848,7 +851,7 @@ namespace AZStd
 
         void swap(this_type&& rhs)
         {
-            assign_rv(AZStd::forward<this_type>(rhs));
+            assign_rv(AZStd::move(rhs));
         }
 
         /**
@@ -915,63 +918,6 @@ namespace AZStd
 
             return isf_valid | isf_can_dereference;
         }
-
-        /**
-        *  Pushes an element at the front of the deque without a provided instance. This can be used for value types
-        *  with expensive constructors so we don't want to create temporary one.
-        */
-        inline void push_front()
-        {
-#ifdef AZSTD_HAS_CHECKED_ITERATORS
-            orphan_all();
-#endif
-            if (m_firstOffset % NumElementsPerBlock == 0 && m_mapSize <= (m_size + NumElementsPerBlock) / NumElementsPerBlock)
-            {
-                grow_map(1);
-            }
-            size_type newOffset = m_firstOffset != 0 ? m_firstOffset : m_mapSize * NumElementsPerBlock;
-            size_type block = --newOffset / NumElementsPerBlock;
-            if (m_map[block] == 0)
-            {
-                m_map[block] = reinterpret_cast<pointer>(m_allocator.allocate(sizeof(block_node_type), alignment_of<block_node_type>::value));
-            }
-
-            pointer toCreate = m_map[block] + newOffset % NumElementsPerBlock;
-            Internal::construct<pointer>::single(toCreate);
-
-            m_firstOffset = newOffset;
-            ++m_size;
-        }
-
-        /**
-        *  Pushes an element at the back of the deque without a provided instance. This can be used for value types
-        *  with expensive constructors so we don't want to create temporary one.
-        */
-        inline void push_back()
-        {
-#ifdef AZSTD_HAS_CHECKED_ITERATORS
-            orphan_all();
-#endif
-            if ((m_firstOffset + m_size) % NumElementsPerBlock == 0 && m_mapSize <= (m_size + NumElementsPerBlock) / NumElementsPerBlock)
-            {
-                grow_map(1);
-            }
-            size_type newOffset = m_firstOffset + m_size;
-            size_type block = newOffset / NumElementsPerBlock;
-            if (m_mapSize <= block)
-            {
-                block  -= m_mapSize;
-            }
-            if (m_map[block] == 0)
-            {
-                m_map[block] = reinterpret_cast<pointer>(m_allocator.allocate(sizeof(block_node_type), alignment_of<block_node_type>::value));
-            }
-
-            pointer toCreate = m_map[block] + newOffset % NumElementsPerBlock;
-            Internal::construct<pointer>::single(toCreate);
-            ++m_size;
-        }
-
 
         /**
         * Resets the container without deallocating any memory or calling any destructor.
@@ -1074,16 +1020,15 @@ namespace AZStd
             insert(begin(), first, last);
         }
         template<class InputIterator>
-        AZ_FORCE_INLINE void insert_iter(const_iterator insertPos, const InputIterator& first, const InputIterator& last, const true_type& /* is_intergral<InputIterator>()*/)
+        AZ_FORCE_INLINE iterator insert_iter(const_iterator insertPos, const InputIterator& first, const InputIterator& last, const true_type& /* is_intergral<InputIterator>()*/)
         {
-            insert(insertPos, (size_type)first, (value_type)last);
+            return insert(insertPos, (size_type)first, (value_type)last);
         }
 
         template<class InputIterator>
-        void insert_iter(const_iterator insertPos, const InputIterator& first, const InputIterator& last, const false_type& /* !is_intergral<InputIterator>()*/)
+        iterator insert_iter(const_iterator insertPos, const InputIterator& first, const InputIterator& last, const false_type& /* !is_intergral<InputIterator>()*/)
         {
-            AZSTD_CONTAINER_ASSERT(first != last, "AZStd::deque::insert_iter - first and last iterator are the same!");
-            size_type offset = insertPos - begin();
+            size_type offset = AZStd::ranges::distance(begin(), insertPos);
             size_type rem = m_size - offset;
             size_type size = m_size;
             if (offset < rem)
@@ -1122,6 +1067,8 @@ namespace AZStd
                     reverse(offset, m_size);
                 }
             }
+
+            return AZStd::ranges::next(begin(), offset);
         }
 
         inline void reverse(size_type first, size_type last)
@@ -1181,11 +1128,11 @@ namespace AZStd
 #endif // AZSTD_HAS_CHECKED_ITERATORS
 
     protected:
-        map_node_ptr_type   m_map;          ///< Pointer to array of pointers to blocks.
-        size_type           m_mapSize;      ///< Size of map array.
-        size_type           m_firstOffset;  ///< Offset of initial element.
-        size_type           m_size;         ///< Number of elements in the deque.
-        allocator_type      m_allocator;    ///< Instance of the allocator.
+        map_node_ptr_type   m_map{};          ///< Pointer to array of pointers to blocks.
+        size_type           m_mapSize{};      ///< Size of map array.
+        size_type           m_firstOffset{};  ///< Offset of initial element.
+        size_type           m_size{};         ///< Number of elements in the deque.
+        allocator_type      m_allocator{};    ///< Instance of the allocator.
     };
 
     template <class T, class Allocator, AZStd::size_t NumElementsPerBlock, AZStd::size_t MinMapSize>
@@ -1198,45 +1145,12 @@ namespace AZStd
     {
         return !(left.size() == right.size() && AZStd::equal(left.begin(), left.end(), right.begin()));
     }
-    /*template <class T, class Allocator, AZStd::size_t NumElementsPerBlock, AZStd::size_t MinMapSize>
-    AZ_FORCE_INLINE bool operator< (const deque<T,Allocator,NumElementsPerBlock,MinMapSize>& left,const deque<T,Allocator,NumElementsPerBlock,MinMapSize>& right)
-    {
 
-    }
-    template <class T, class Allocator, AZStd::size_t NumElementsPerBlock, AZStd::size_t MinMapSize>
-    AZ_FORCE_INLINE bool operator> (const deque<T,Allocator,NumElementsPerBlock,MinMapSize>& left,const deque<T,Allocator,NumElementsPerBlock,MinMapSize>& right)
-    {
-
-    }
-    template <class T, class Allocator, AZStd::size_t NumElementsPerBlock, AZStd::size_t MinMapSize>
-    AZ_FORCE_INLINE bool operator>=(const deque<T,Allocator,NumElementsPerBlock,MinMapSize>& left,const deque<T,Allocator,NumElementsPerBlock,MinMapSize>& right)
-    {
-
-    }
-    template <class T, class Allocator, AZStd::size_t NumElementsPerBlock, AZStd::size_t MinMapSize>
-    AZ_FORCE_INLINE bool operator<=(const deque<T,Allocator,NumElementsPerBlock,MinMapSize>& left,const deque<T,Allocator,NumElementsPerBlock,MinMapSize>& right)
-    {
-
-    }*/
     // specialized algorithms:
     template <class T, class Allocator, AZStd::size_t NumElementsPerBlock, AZStd::size_t MinMapSize>
     AZ_FORCE_INLINE void swap(deque<T, Allocator, NumElementsPerBlock, MinMapSize>& left, deque<T, Allocator, NumElementsPerBlock, MinMapSize>& right)
     {
         left.swap(right);
-    }
-
-    template <class T, class Allocator, AZStd::size_t NumElementsPerBlock, AZStd::size_t MinMapSize>
-    inline void swap(deque<T, Allocator, NumElementsPerBlock, MinMapSize>& left, deque<T, Allocator, NumElementsPerBlock, MinMapSize>&& right)
-    {
-        typedef deque<T, Allocator, NumElementsPerBlock, MinMapSize> this_type;
-        left.swap(AZStd::forward<this_type>(right));
-    }
-
-    template <class T, class Allocator, AZStd::size_t NumElementsPerBlock, AZStd::size_t MinMapSize>
-    inline void swap(deque<T, Allocator, NumElementsPerBlock, MinMapSize>&& left, deque<T, Allocator, NumElementsPerBlock, MinMapSize>& right)
-    {
-        typedef deque<T, Allocator, NumElementsPerBlock, MinMapSize> this_type;
-        right.swap(AZStd::forward<this_type>(left));
     }
 
     template<class T, class Allocator, AZStd::size_t NumElementsPerBlock, AZStd::size_t MinMapSize, class U>

--- a/Code/Framework/AzCore/AzCore/std/containers/fixed_forward_list.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/fixed_forward_list.h
@@ -5,8 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#ifndef AZSTD_FIXED_SLIST_H
-#define AZSTD_FIXED_SLIST_H 1
+#pragma once
 
 #include <AzCore/std/containers/forward_list.h>
 #include <AzCore/std/allocator_static.h>
@@ -23,55 +22,25 @@ namespace AZStd
     */
     template< class T, AZStd::size_t NumberOfNodes>
     class fixed_forward_list
-        : public forward_list<T, static_pool_allocator<typename Internal::forward_list_node<T>, NumberOfNodes > >
+        : public forward_list<T, static_pool_allocator<Internal::forward_list_node<T>, NumberOfNodes > >
     {
-        enum
-        {
-            CONTAINER_VERSION = 1
-        };
-
-        typedef fixed_forward_list<T, NumberOfNodes> this_type;
-        typedef forward_list<T, static_pool_allocator<typename Internal::forward_list_node<T>, NumberOfNodes> > base_type;
+        using base_type = forward_list<T, static_pool_allocator<Internal::forward_list_node<T>, NumberOfNodes>>;
     public:
-        //////////////////////////////////////////////////////////////////////////
-        // 23.2.2 construct/copy/destroy
-        AZ_FORCE_INLINE explicit fixed_forward_list() {}
-        AZ_FORCE_INLINE explicit fixed_forward_list(typename base_type::size_type numElements, typename base_type::const_reference value = typename base_type::value_type())
-            : base_type(numElements, value) {}
-        template<class InputIterator>
-        AZ_FORCE_INLINE fixed_forward_list(const InputIterator& first, const InputIterator& last)
-            : base_type(first, last)   {}
-        AZ_FORCE_INLINE fixed_forward_list(const this_type& rhs)
-            : base_type(rhs)   {}
-        AZ_FORCE_INLINE fixed_forward_list(std::initializer_list<T> list)
-            : base_type(list) {}
-        AZ_FORCE_INLINE this_type& operator=(const this_type& rhs)
+        using base_type::base_type;
+        friend bool operator==(const fixed_forward_list& x, const fixed_forward_list& y)
         {
-            if (this != &rhs)
-            {
-                base_type::assign(rhs.begin(), rhs.end());
-            }
-            return *this;
+            return static_cast<const base_type&>(x) == static_cast<const base_type&>(y);
         }
 
-        //AZ_FORCE_INLINE void * data() const ...
-    private:
-        // You are not allowed to change the allocator type.
-        void                        set_allocator(const typename base_type::allocator_type& allocator) { (void)allocator; }
+        friend bool operator!=(const fixed_forward_list& x, const fixed_forward_list& y)
+        {
+            return !operator==(x, y);
+        }
+
+        friend void swap(fixed_forward_list& x, fixed_forward_list& y)
+            noexcept(noexcept(x.swap(y)))
+        {
+            static_cast<base_type&>(x).swap(static_cast<base_type&>(y));
+        }
     };
-
-    template< class T, AZStd::size_t NumberOfNodes >
-    AZ_FORCE_INLINE bool operator==(const fixed_forward_list<T, NumberOfNodes>& left, const fixed_forward_list<T, NumberOfNodes>& right)
-    {
-        return (left.size() == right.size() && equal(left.begin(), left.end(), right.begin()));
-    }
-
-    template< class T, AZStd::size_t NumberOfNodes >
-    AZ_FORCE_INLINE bool operator!=(const fixed_forward_list<T, NumberOfNodes>& left, const fixed_forward_list<T, NumberOfNodes>& right)
-    {
-        return !(left == right);
-    }
 }
-
-#endif // AZSTD_FIXED_SLIST_H
-#pragma once

--- a/Code/Framework/AzCore/AzCore/std/containers/forward_list.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/forward_list.h
@@ -5,12 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#ifndef AZSTD_SLIST_H
-#define AZSTD_SLIST_H 1
 
-#include <AzCore/std/allocator.h>
+#pragma once
+
 #include <AzCore/std/algorithm.h>
+#include <AzCore/std/allocator_traits.h>
 #include <AzCore/std/createdestroy.h>
+#include <AzCore/std/ranges/ranges_algorithm.h>
 
 namespace AZStd
 {
@@ -131,13 +132,12 @@ namespace AZStd
 
 
     /**
-    * The list container (double linked list) is complaint with \ref CStd (23.2.2). In addition we introduce the following \ref ListExtensions "extensions".
+    * The list container (single linked list) is complaint with \ref CStd (23.2.2). In addition we introduce the following \ref ListExtensions "extensions".
     *
     * \par
-    * The list keep the values in nodes (with prev and next element pointers).
+    * The forward_list keep the values in nodes (next element pointers).
     * Each node is allocated separately, so adding 100 elements will cause 100 allocations,
     * that's why it's generally good idea (when speed is important), to either use \ref fixed_list or pool allocator like \ref static_pool_allocator.
-    * To find the node size and alignment use AZStd::forward_list::node_type.
     * You can see examples of all that \ref AZStdExamples.
     * \todo We should change the forward_list default allocator to be pool allocator based on the default allocator. This will reduce the number of allocations
     * in the general case.
@@ -153,36 +153,42 @@ namespace AZStd
             CONTAINER_VERSION = 1
         };
 
-        typedef forward_list<T, Allocator>               this_type;
+        using this_type = forward_list<T, Allocator>;
     public:
-        typedef T*                                      pointer;
-        typedef const T*                                const_pointer;
+        using value_type = T;
+        using pointer = T*;
+        using const_pointer = const T*;
 
-        typedef T&                                      reference;
-        typedef const T&                                const_reference;
-        typedef typename Allocator::difference_type     difference_type;
-        typedef typename Allocator::size_type           size_type;
-        typedef Allocator                               allocator_type;
+        using reference = T&;
+        using const_reference = const T&;
+    private:
+        using node_type = Internal::forward_list_node<T>;
 
+    public:
+        using allocator_type = Allocator;
+        using difference_type = typename AZStd::allocator_traits<allocator_type>::difference_type;
+        using size_type = typename AZStd::allocator_traits<allocator_type>::size_type;
+
+    private:
         // AZSTD extension.
-        typedef T                                       value_type;
-        typedef Internal::forward_list_node<T>          node_type;
-        typedef node_type*                              node_ptr_type;
-        typedef Internal::forward_list_node_base        base_node_type;
-        typedef base_node_type*                         base_node_ptr_type;
+        using node_ptr_type = node_type*;
+        using base_node_type = Internal::forward_list_node_base;
+        using base_node_ptr_type = base_node_type*;
 
-        typedef forward_list_const_iterator<T>          const_iterator_impl;
-        typedef forward_list_iterator<T>                iterator_impl;
+        using const_iterator_impl = forward_list_const_iterator<T>;
+        using iterator_impl = forward_list_iterator<T>;
 
+    public:
+        // Non-extension type aliases
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
-        typedef Debug::checked_forward_iterator<iterator_impl, this_type>        iterator;
-        typedef Debug::checked_forward_iterator<const_iterator_impl, this_type>  const_iterator;
+        using iterator = Debug::checked_forward_iterator<iterator_impl, this_type>;
+        using const_iterator = Debug::checked_forward_iterator<const_iterator_impl, this_type>;
 #else
-        typedef iterator_impl                           iterator;
-        typedef const_iterator_impl                     const_iterator;
+        using iterator = iterator_impl;
+        using const_iterator = const_iterator_impl;
 #endif
 
-        AZ_FORCE_INLINE explicit forward_list()
+        AZ_FORCE_INLINE forward_list()
             : m_numElements(0)
         {
             m_head.m_next = m_lastNode = &m_head;
@@ -200,48 +206,39 @@ namespace AZStd
             m_head.m_next = m_lastNode = &m_head;
             insert_after(before_begin(), numElements, value);
         }
-        AZ_FORCE_INLINE explicit forward_list(size_type numElements, const_reference value, const allocator_type& allocator)
+        AZ_FORCE_INLINE forward_list(size_type numElements, const_reference value, const allocator_type& allocator)
             : m_numElements(0)
             , m_allocator(allocator)
         {
             m_head.m_next = m_lastNode = &m_head;
             insert_after(before_begin(), numElements, value);
         }
-        template<class InputIterator>
-        AZ_FORCE_INLINE forward_list(const InputIterator& first, const InputIterator& last)
-            : m_numElements(0)
-        {
-            m_head.m_next = m_lastNode = &m_head;
-            insert_after_iter(before_begin(), first, last, is_integral<InputIterator>());
-        }
-        template<class InputIterator>
-        AZ_FORCE_INLINE forward_list(const InputIterator& first, const InputIterator& last, const allocator_type& allocator)
-            : m_numElements(0)
-            , m_allocator(allocator)
-        {
-            m_head.m_next = m_lastNode = &m_head;
-            insert_after_iter(before_begin(), first, last, is_integral<InputIterator>());
-        }
-        AZ_FORCE_INLINE forward_list(const this_type& rhs)
-            : m_numElements(0)
-            , m_allocator(rhs.m_allocator)
+
+        forward_list(const forward_list& rhs)
+            : m_allocator(rhs.m_allocator)
         {
             m_head.m_next = m_lastNode = &m_head;
             insert_after(before_begin(), rhs.begin(), rhs.end());
         }
 
-        AZ_FORCE_INLINE forward_list(std::initializer_list<T> list)
-            : m_numElements(0)
+        forward_list(forward_list&& rhs)
+            : m_allocator(rhs.m_allocator)
         {
             m_head.m_next = m_lastNode = &m_head;
-            insert_after_iter(before_begin(), list.begin(), list.end(), is_integral<std::initializer_list<T>>());
+            swap(rhs);
         }
-        AZ_FORCE_INLINE forward_list(std::initializer_list<T> list, const allocator_type& allocator)
-            : m_numElements(0)
-            , m_allocator(allocator)
+
+        template<class InputIterator>
+        AZ_FORCE_INLINE forward_list(InputIterator first, InputIterator last, const allocator_type& allocator = allocator_type())
+            : m_allocator(allocator)
         {
             m_head.m_next = m_lastNode = &m_head;
-            insert_after_iter(before_begin(), list.begin(), list.end(), is_integral<std::initializer_list<T>>());
+            insert_after_iter(before_begin(), first, last, is_integral<InputIterator>());
+        }
+
+        forward_list(initializer_list<T> list, const allocator_type& allocator = allocator_type())
+            : forward_list(list.begin(), list.end(), allocator)
+        {
         }
 
         AZ_FORCE_INLINE ~forward_list()
@@ -249,7 +246,7 @@ namespace AZStd
             clear();
         }
 
-        AZ_FORCE_INLINE this_type& operator=(const this_type& rhs)
+        AZ_FORCE_INLINE forward_list& operator=(const forward_list& rhs)
         {
             if (this == &rhs)
             {
@@ -257,6 +254,16 @@ namespace AZStd
             }
             assign(rhs.begin(), rhs.end());
             return (*this);
+        }
+
+        forward_list& operator=(forward_list&& rhs)
+        {
+            if (this == &rhs)
+            {
+                return *this;
+            }
+            swap(rhs);
+            return *this;
         }
         inline void assign(size_type numElements, const_reference value)
         {
@@ -272,7 +279,7 @@ namespace AZStd
 
             if (numToInsert > 0)
             {
-                insert_after(last(), numToInsert, value);
+                insert_after(before_end(), numToInsert, value);
             }
             else
             {
@@ -280,21 +287,36 @@ namespace AZStd
             }
         }
         template <class InputIterator>
-        AZ_FORCE_INLINE void assign(const InputIterator& first, const InputIterator& last)
+        AZ_FORCE_INLINE void assign(InputIterator first, InputIterator last)
         {
             assign_iter(first, last, is_integral<InputIterator>());
         }
 
-        AZ_FORCE_INLINE size_type   size() const            { return m_numElements; }
-        AZ_FORCE_INLINE size_type   max_size() const        { return AZStd::allocator_traits<allocator_type>::max_size(m_allocator) / sizeof(node_type); }
-        AZ_FORCE_INLINE bool    empty() const               { return (m_numElements == 0); }
+        void assign(initializer_list<T> ilist)
+        {
+            assign(ilist.begin(), ilist.end());
+        }
 
-        AZ_FORCE_INLINE iterator begin()                    { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, m_head.m_next)); }
-        AZ_FORCE_INLINE const_iterator begin() const        { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, m_head.m_next)); }
-        AZ_FORCE_INLINE iterator end()                      { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, &m_head)); }
-        AZ_FORCE_INLINE const_iterator end() const          { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, const_cast<base_node_ptr_type>(&m_head))); }
-        AZ_FORCE_INLINE iterator before_begin()             { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, &m_head)); }
+        // AZStd Extensions - std::forward_list minimizes size as much as possible
+        // so it doesn't store the size of the container.
+        // The extension here is to store off size in a member variable
+        AZ_FORCE_INLINE size_type   size() const { return m_numElements; }
+
+        // Non-extension members
+        AZ_FORCE_INLINE size_type   max_size() const { return AZStd::allocator_traits<allocator_type>::max_size(m_allocator) / sizeof(node_type); }
+        [[nodiscard]] bool    empty() const { return (m_numElements == 0); }
+
+        AZ_FORCE_INLINE iterator begin() { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, m_head.m_next)); }
+        AZ_FORCE_INLINE const_iterator begin() const { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, m_head.m_next)); }
+        AZ_FORCE_INLINE iterator end() { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, &m_head)); }
+        AZ_FORCE_INLINE const_iterator end() const { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, const_cast<base_node_ptr_type>(&m_head))); }
+        AZ_FORCE_INLINE iterator before_begin() { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, &m_head)); }
         AZ_FORCE_INLINE const_iterator before_begin() const { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, const_cast<base_node_ptr_type>(&m_head))); }
+
+        // AZStd Extensions for tracking the last node within the forward_list
+        // This isn't a fast function, as it involves traversing the list from the beginning
+        // until until the spuplied iter in order to find the previous entry
+        // This gives it a big-O run time of O(n)(as opposed to a double linked list where it is O(1))
         AZ_FORCE_INLINE iterator previous(iterator iter)
         {
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
@@ -313,8 +335,8 @@ namespace AZStd
 #endif
             return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, previous(iNode)));
         }
-        AZ_FORCE_INLINE iterator last()                     { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, m_lastNode)); }
-        AZ_FORCE_INLINE const_iterator last() const         { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, const_cast<base_node_ptr_type>(m_lastNode))); }
+        AZ_FORCE_INLINE iterator before_end() { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, m_lastNode)); }
+        AZ_FORCE_INLINE const_iterator before_end() const { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, const_cast<base_node_ptr_type>(m_lastNode))); }
 
         inline void resize(size_type newNumElements, const_reference value = value_type())
         {
@@ -334,43 +356,82 @@ namespace AZStd
             }
         }
 
-        AZ_FORCE_INLINE reference front()                   { return *begin(); }
-        AZ_FORCE_INLINE const_reference front() const       { return *begin(); }
-        AZ_FORCE_INLINE reference back()                    { return *last(); }
-        AZ_FORCE_INLINE const_reference back() const        { return *last(); }
+        AZ_FORCE_INLINE reference front() { return *begin(); }
+        AZ_FORCE_INLINE const_reference front() const { return *begin(); }
 
-        AZ_FORCE_INLINE void push_front(const_reference value)  { insert_after(before_begin(), value); }
-        AZ_FORCE_INLINE void pop_front()                        { erase_after(before_begin()); }
-        AZ_FORCE_INLINE void push_back(const_reference value)   { insert_after(last(), value);  }
+        void push_front(const_reference value) { emplace_front(value); }
+        void push_front(value_type&& value) { emplace_front(AZStd::move(value)); }
+        template<class... Args>
+        reference emplace_front(Args&&... args)
+        {
+            return *emplace_after(before_begin(), AZStd::forward<Args>(args)...);
+        }
+        void pop_front() { erase_after(before_begin()); }
 
-        AZ_FORCE_INLINE iterator insert(iterator insertPos, const_reference value)
+        // AZStd extension - back operations
+        // std::forward_list doesn't keep track of the last dereference node within the list
+        // so operations such as back/push_back/emplace_back/append_range aren't implemented in the standard
+        // since it would involve traversing the entire list to find the end.
+        reference back() { return *before_end(); }
+        const_reference back() const { return *before_end(); }
+        void push_back(const_reference value) { emplace_back(value); }
+        void push_back(value_type&& value) { emplace_back(AZStd::move(value)); }
+        template<class... Args>
+        reference emplace_back(Args&&... args)
+        {
+            return *emplace_after(before_end(), AZStd::forward<Args>(args)...);
+        }
+
+        // AZStd extension - insert operations
+        // It has performance characteristics of O(n)
+        // If this function is needed, then it is preferred to use a doubly linked list(AZStd::list)
+        // 
+        // In order for insert to work with a forward_list the list has to be traversed
+        // from the beginning to the specified iterator position in order to find the previous node
+        // since it each node only has pointers to the next node(reverse iteration can't be done)
+        AZ_FORCE_INLINE iterator insert(const_iterator insertPos, const_reference value)
         {
             return insert_after(previous(insertPos), value);
         }
 
-        AZ_FORCE_INLINE void insert(iterator insertPos, size_type numElements, const_reference value)
+        AZ_FORCE_INLINE iterator insert(const_iterator insertPos, size_type numElements, const_reference value)
         {
-            insert_after(previous(insertPos), numElements, value);
+            return insert_after(previous(insertPos), numElements, value);
         }
 
         template <class InputIterator>
-        AZ_FORCE_INLINE void insert(iterator insertPos, InputIterator first, InputIterator last)
+        AZ_FORCE_INLINE iterator insert(const_iterator insertPos, InputIterator first, InputIterator last)
         {
-            insert_after_iter(previous(insertPos), first, last, is_integral<InputIterator>());
+            return insert_after_iter(previous(insertPos), first, last, is_integral<InputIterator>());
         }
+
         template <class InputIterator>
-        AZ_FORCE_INLINE void insert_after(iterator insertPos, InputIterator first, InputIterator last)
+        iterator insert_after(const_iterator insertPos, InputIterator first, InputIterator last)
         {
-            insert_after_iter(insertPos, first, last, is_integral<InputIterator>());
+            return insert_after_iter(insertPos, first, last, is_integral<InputIterator>());
         }
 
-        inline iterator insert_after(iterator insertPos, const_reference value)
+        iterator insert_after(const_iterator insertPos, initializer_list<T> ilist)
         {
-            node_ptr_type newNode = reinterpret_cast<node_ptr_type>(m_allocator.allocate(sizeof(node_type), alignment_of<node_type>::value));
+            return insert_after(insertPos, ilist.begin(), ilist.end());
+        }
 
-            // copy construct
+        iterator insert_after(const_iterator insertPos, const_reference value)
+        {
+            return emplace_after(insertPos, value);
+        }
+        iterator insert_after(const_iterator insertPos, value_type&& value)
+        {
+            return emplace_after(insertPos, AZStd::move(value));
+        }
+        template<class... Args>
+        iterator emplace_after(const_iterator insertPos, Args&&... args)
+        {
+            node_ptr_type newNode = reinterpret_cast<node_ptr_type>(m_allocator.allocate(sizeof(node_type), alignof(node_type)));
+
+            // forward to the constructor 
             pointer ptr = &newNode->m_value;
-            Internal::construct<pointer>::single(ptr, value);
+            construct_at(ptr, AZStd::forward<Args>(args)...);
 
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
             base_node_ptr_type prevNode = insertPos.get_iterator().m_node;
@@ -385,13 +446,13 @@ namespace AZStd
                 m_lastNode = newNode;
             }
 
-            newNode->m_next     = prevNode->m_next;
-            prevNode->m_next    = newNode;
+            newNode->m_next = prevNode->m_next;
+            prevNode->m_next = newNode;
 
             return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, newNode));
         }
 
-        inline void insert_after(iterator insertPos, size_type numElements, const_reference value)
+        iterator insert_after(const_iterator insertPos, size_type numElements, const_reference value)
         {
             m_numElements += numElements;
 
@@ -400,12 +461,19 @@ namespace AZStd
 #else
             base_node_ptr_type prevNode = insertPos.m_node;
 #endif
+            // Tracks the first insert node to return as the iterator value
+            iterator returnIter(insertPos.m_node);
             base_node_ptr_type insNode = prevNode->m_next;
 
-            for (; 0  < numElements; --numElements)
+            for (bool firstIteration = true; 0 < numElements; --numElements, firstIteration = false)
             {
                 node_ptr_type newNode = reinterpret_cast<node_ptr_type>(m_allocator.allocate(sizeof(node_type), alignment_of<node_type>::value));
-                AZSTD_CONTAINER_ASSERT(newNode != NULL, "AZSTD::forward_list::insert - failed to allocate node!");
+                AZSTD_CONTAINER_ASSERT(newNode != nullptr, "AZSTD::forward_list::insert - failed to allocate node!");
+
+                if (firstIteration)
+                {
+                    returnIter = iterator(newNode);
+                }
 
                 if (m_lastNode == prevNode)
                 {
@@ -416,11 +484,13 @@ namespace AZStd
                 pointer ptr = &newNode->m_value;
                 Internal::construct<pointer>::single(ptr, value);
 
-                newNode->m_next     = insNode;
+                newNode->m_next = insNode;
                 insNode = newNode;
             }
 
             prevNode->m_next = insNode;
+
+            return returnIter;
         }
 
         inline iterator erase_after(const_iterator toEraseNext)
@@ -464,6 +534,13 @@ namespace AZStd
             return last;
         }
 
+        // AZStd extension - erase operations
+        // It has performance characteristics of O(n)
+        // If this function is needed, then it is preferred to use a doubly linked list(AZStd::list)
+        // 
+        // In order for eraseto work with a forward_list the list has to be traversed
+        // from the beginning to the specified iterator position in order to find the previous node
+        // since it each node only has pointers to the next node(reverse iteration can't be done)
         AZ_FORCE_INLINE iterator erase(const_iterator toErase)
         {
             return erase_after(previous(toErase));
@@ -494,6 +571,18 @@ namespace AZStd
             m_head.m_next = m_lastNode = &m_head;
             m_numElements = 0;
         }
+
+        friend bool operator==(const forward_list& left, const forward_list& right)
+        {
+            // test for list equality
+            return ranges::equal(left, right);
+        }
+
+        friend bool operator!=(const forward_list& left, const forward_list& right)
+        {
+            return !(left == right);
+        }
+
         void swap(this_type& rhs)
         {
             AZSTD_CONTAINER_ASSERT(this != &rhs, "AZStd::forward_list::swap - it's pointless to swap the vector itself!");
@@ -586,6 +675,13 @@ namespace AZStd
             }
         }
 
+        // AZStd extension - splice operations
+        // It has performance characteristics of O(n)
+        // If this function is needed, then it is preferred to use a doubly linked list(AZStd::list)
+        // 
+        // In order for splice to work with a forward_list the list has to be traversed
+        // from the beginning to the specified iterator position in order to find the previous node
+        // to splice onto
         AZ_FORCE_INLINE void splice(iterator splicePos, this_type& rhs)
         {
             splice_after(previous(splicePos), rhs);
@@ -1066,67 +1162,6 @@ namespace AZStd
             return isf_valid | isf_can_dereference;
         }
 
-        //////////////////////////////////////////////////////////////////////////
-        // Insert methods without provided src value.
-        /**
-        *  Pushes an element at the back of the list, without a provided instance. This can be used for value types
-        *  with expensive constructors so we don't want to create temporary one.
-        */
-        AZ_FORCE_INLINE void                        push_back()
-        {
-            node_ptr_type newNode = reinterpret_cast<node_ptr_type>(m_allocator.allocate(sizeof(node_type), alignment_of<node_type>::value));
-
-            Internal::construct<node_ptr_type>::single(newNode);
-            ++m_numElements;
-
-            newNode->m_next = m_lastNode->m_next;
-            m_lastNode->m_next = newNode;
-            m_lastNode = newNode;
-        }
-        /**
-        *  Pushes an element at the front of the list, without a provided instance. This can be used for value types
-        *  with expensive constructors so we don't want to create temporary one.
-        */
-        AZ_FORCE_INLINE void                        push_front()
-        {
-            node_ptr_type newNode = reinterpret_cast<node_ptr_type>(m_allocator.allocate(sizeof(node_type), alignment_of<node_type>::value));
-
-            Internal::construct<node_ptr_type>::single(newNode);
-            ++m_numElements;
-
-            base_node_ptr_type insertNode = m_head.m_next;
-            newNode->m_next = insertNode;
-            m_head.m_next = newNode;
-        }
-
-        /**
-        *  Inserts an element at the user position in the list without a provided instance. This can be used for value types
-        *  with expensive constructors so we don't want to create temporary one.
-        */
-        inline iterator insert(iterator insertPos)
-        {
-            node_ptr_type newNode = reinterpret_cast<node_ptr_type>(m_allocator.allocate(sizeof(node_type), alignment_of<node_type>::value));
-
-            // construct
-            pointer ptr = &newNode->m_value;
-            Internal::construct<pointer>::single(ptr);
-
-#ifdef AZSTD_HAS_CHECKED_ITERATORS
-            base_node_ptr_type insNode = insertPos.get_iterator().m_node;
-#else
-            base_node_ptr_type insNode = insertPos.m_node;
-#endif
-            base_node_ptr_type prevInsNode = previous(insNode);
-            ++m_numElements;
-
-            newNode->m_next = insNode;
-            prevInsNode->m_next = newNode;
-
-            return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, newNode));
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-
         /**
         * Resets the container without deallocating any memory or calling any destructor.
         * This function should be used when we need very quick tear down. Generally it's used for temporary vectors and we can just nuke them that way.
@@ -1177,19 +1212,25 @@ namespace AZStd
         }
 
         template <class InputIterator>
-        AZ_FORCE_INLINE void    insert_after_iter(iterator insertPos, const InputIterator& first, const InputIterator& last, const true_type& /* is_integral<InputIterator> */)
+        iterator insert_after_iter(const_iterator insertPos, const InputIterator& first, const InputIterator& last, const true_type& /* is_integral<InputIterator> */)
         {
-            insert_after(insertPos, (size_type)first, (value_type)last);
+            return insert_after(insertPos, (size_type)first, (value_type)last);
         }
 
         template <class InputIterator>
-        AZ_FORCE_INLINE void    insert_after_iter(iterator insertPos, const InputIterator& first, const InputIterator& last, const false_type& /* !is_integral<InputIterator> */)
+        iterator insert_after_iter(const_iterator insertPos, InputIterator first, InputIterator last, const false_type& /* !is_integral<InputIterator> */)
         {
-            InputIterator iter(first);
-            for (; iter != last; ++iter, ++insertPos)
+            iterator returnIter(insertPos.m_node);
+            for (bool firstIteration = true; first != last; ++first, ++insertPos, firstIteration = false)
             {
-                insert_after(insertPos, *iter);
+                // The first iteration of the loop sets the iterator to the beginning of the inserted elements
+                if (iterator insertIter = insert_after(insertPos, *first); firstIteration)
+                {
+                    returnIter = insertIter;
+                }
             }
+
+            return returnIter;
         }
 
         template <class InputIterator>
@@ -1219,8 +1260,8 @@ namespace AZStd
         }
 
         base_node_type      m_head;             ///< Node header.
-        base_node_ptr_type  m_lastNode;         ///< Cached last valid node.
-        size_type           m_numElements;      ///< Number of elements so size() is O(1).
+        base_node_ptr_type  m_lastNode{};         ///< Cached last valid node.
+        size_type           m_numElements{};      ///< Number of elements so size() is O(1).
         allocator_type      m_allocator;        ///< Instance of the allocator.
 
         // Debug
@@ -1262,19 +1303,6 @@ namespace AZStd
 #endif
     };
 
-    template< class T, class Allocator >
-    AZ_FORCE_INLINE bool operator==(const forward_list<T, Allocator>& left, const forward_list<T, Allocator>& right)
-    {
-        // test for list equality
-        return (left.size() == right.size() && equal(left.begin(), left.end(), right.begin()));
-    }
-
-    template< class T, class Allocator >
-    AZ_FORCE_INLINE bool operator!=(const forward_list<T, Allocator>& left, const forward_list<T, Allocator>& right)
-    {
-        return !(left == right);
-    }
-
     template<class T, class Allocator, class U>
     decltype(auto) erase(forward_list<T, Allocator>& container, const U& value)
     {
@@ -1286,6 +1314,3 @@ namespace AZStd
         return container.remove_if(predicate);
     }
 }
-
-#endif // AZSTD_SLIST_H
-#pragma once

--- a/Code/Framework/AzCore/AzCore/std/containers/list.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/list.h
@@ -220,8 +220,7 @@ namespace AZStd
 
         //////////////////////////////////////////////////////////////////////////
         // 23.2.2 construct/copy/destroy
-        AZ_FORCE_INLINE explicit list()
-            : m_numElements(0)
+        list()
         {
             m_head.m_next = m_head.m_prev = &m_head;
         }
@@ -238,28 +237,14 @@ namespace AZStd
             m_head.m_next = m_head.m_prev = &m_head;
             insert(begin(), numElements, value);
         }
-        AZ_FORCE_INLINE explicit list(size_type numElements, const_reference value, const allocator_type& allocator)
+        AZ_FORCE_INLINE list(size_type numElements, const_reference value, const allocator_type& allocator)
             : m_numElements(0)
             , m_allocator(allocator)
         {
             m_head.m_next = m_head.m_prev = static_cast<node_ptr_type>(&m_head);
             insert(begin(), numElements, value);
         }
-        template<class InputIterator>
-        AZ_FORCE_INLINE list(const InputIterator& first, const InputIterator& last)
-            : m_numElements(0)
-        {
-            m_head.m_next = m_head.m_prev = &m_head;
-            insert_iter(begin(), first, last, is_integral<InputIterator>());
-        }
-        template<class InputIterator>
-        AZ_FORCE_INLINE list(const InputIterator& first, const InputIterator& last, const allocator_type& allocator)
-            : m_numElements(0)
-            , m_allocator(allocator)
-        {
-            m_head.m_next = m_head.m_prev = &m_head;
-            insert_iter(begin(), first, last, is_integral<InputIterator>());
-        }
+
         AZ_FORCE_INLINE list(const this_type& rhs)
             : m_numElements(0)
             , m_allocator(rhs.m_allocator)
@@ -269,11 +254,18 @@ namespace AZStd
             insert(begin(), rhs.begin(), rhs.end());
         }
 
-        AZ_FORCE_INLINE list(std::initializer_list<T> list)
-            : m_numElements(0)
+        template<class InputIterator>
+        AZ_FORCE_INLINE list(InputIterator first, InputIterator last, const allocator_type& allocator = allocator_type())
+            : m_allocator(allocator)
         {
             m_head.m_next = m_head.m_prev = &m_head;
-            insert(begin(), list.begin(), list.end());
+            insert_iter(begin(), first, last, is_integral<InputIterator>());
+        }
+
+
+        AZ_FORCE_INLINE list(initializer_list<T> ilist, const allocator_type& alloc = allocator_type())
+            : list(ilist.begin(), ilist.end(), alloc)
+        {
         }
 
         AZ_FORCE_INLINE ~list()
@@ -313,6 +305,11 @@ namespace AZStd
         AZ_FORCE_INLINE void assign(const InputIterator& first, const InputIterator& last)
         {
             assign_iter(first, last, is_integral<InputIterator>());
+        }
+
+        void assign(initializer_list<T> iList)
+        {
+            assign(iList.begin(), iList.end());
         }
 
         AZ_FORCE_INLINE size_type   size() const            { return m_numElements; }
@@ -383,39 +380,39 @@ namespace AZStd
 
         void push_front(T&& value)
         {
-            insert_element(begin(), AZStd::forward<T>(value));
+            insert_element(begin(), AZStd::move(value));
         }
 
         void push_back(T&& value)
         {
-            insert_element(end(), AZStd::forward<T>(value));
+            insert_element(end(), AZStd::move(value));
         }
 
         iterator insert(const_iterator inserPos, T&& value)
         {
-            return emplace(inserPos, AZStd::forward<T>(value));
+            return emplace(inserPos, AZStd::move(value));
         }
 
         template<class ... ArgumentsInputs>
-        void emplace_front(ArgumentsInputs&& ... agruments)
+        reference emplace_front(ArgumentsInputs&& ... arguments)
         {
-            insert_element(begin(), AZStd::forward<ArgumentsInputs>(agruments) ...);
+            return insert_element(begin(), AZStd::forward<ArgumentsInputs>(arguments) ...);
         }
 
         template<class ... ArgumentsInputs>
-        void emplace_back(ArgumentsInputs&& ... agruments)
+        reference emplace_back(ArgumentsInputs&& ... arguments)
         {
-            insert_element(end(), AZStd::forward<ArgumentsInputs>(agruments) ...);
+            return insert_element(end(), AZStd::forward<ArgumentsInputs>(arguments) ...);
         }
 
         template<class ... ArgumentsInputs>
-        iterator emplace(const_iterator insertPos, ArgumentsInputs&& ... agruments)
+        iterator emplace(const_iterator insertPos, ArgumentsInputs&& ... arguments)
         {
-            insert_element(insertPos, AZStd::forward<ArgumentsInputs>(agruments) ...);
+            insert_element(insertPos, AZStd::forward<ArgumentsInputs>(arguments) ...);
             return iterator((--insertPos).m_node);
         }
 
-        iterator insert(const_iterator insertPos, std::initializer_list<T> ilist)
+        iterator insert(const_iterator insertPos, initializer_list<T> ilist)
         {
             return insert(insertPos, ilist.begin(), ilist.end());
         }
@@ -1043,40 +1040,6 @@ namespace AZStd
 
         //////////////////////////////////////////////////////////////////////////
         // Insert methods without provided src value.
-        /**
-        *  Pushes an element at the back of the list, without a provided instance. This can be used for value types
-        *  with expensive constructors so we don't want to create temporary one.
-        */
-        inline void                     push_back()
-        {
-            node_ptr_type newNode = reinterpret_cast<node_ptr_type>(m_allocator.allocate(sizeof(node_type), alignment_of<node_type>::value));
-
-            Internal::construct<node_ptr_type>::single(newNode);
-            ++m_numElements;
-
-            base_node_ptr_type insertNode = &m_head;
-            newNode->m_next = insertNode;
-            newNode->m_prev = insertNode->m_prev;
-            insertNode->m_prev = newNode;
-            newNode->m_prev->m_next = newNode;
-        }
-        /**
-        *  Pushes an element at the front of the list, without a provided instance. This can be used for value types
-        *  with expensive constructors so we don't want to create temporary one.
-        */
-        inline void                     push_front()
-        {
-            node_ptr_type newNode = reinterpret_cast<node_ptr_type>(m_allocator.allocate(sizeof(node_type), alignment_of<node_type>::value));
-
-            Internal::construct<node_ptr_type>::single(newNode);
-            ++m_numElements;
-
-            base_node_ptr_type insertNode = m_head.m_next;
-            newNode->m_next = insertNode;
-            newNode->m_prev = insertNode->m_prev;
-            insertNode->m_prev = newNode;
-            newNode->m_prev->m_next = newNode;
-        }
 
         /**
         *  Inserts an element at the user position in the list without a provided instance. This can be used for value types
@@ -1263,13 +1226,13 @@ namespace AZStd
         }
 
         template<class ... ArgumentsInputs>
-        void insert_element(const_iterator insertPos, ArgumentsInputs&& ... agruments)
+        reference insert_element(const_iterator insertPos, ArgumentsInputs&& ... arguments)
         {
             node_ptr_type newNode = reinterpret_cast<node_ptr_type>(m_allocator.allocate(sizeof(node_type), alignment_of<node_type>::value));
 
             // construct
             pointer ptr = &newNode->m_value;
-            Internal::construct<pointer>::single(ptr, AZStd::forward<ArgumentsInputs>(agruments) ...);
+            Internal::construct<pointer>::single(ptr, AZStd::forward<ArgumentsInputs>(arguments) ...);
 
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
             base_node_ptr_type insNode = insertPos.get_iterator().m_node;
@@ -1282,10 +1245,12 @@ namespace AZStd
             newNode->m_prev = insNode->m_prev;
             insNode->m_prev = newNode;
             newNode->m_prev->m_next = newNode;
+
+            return *ptr;
         }
 
         base_node_type      m_head;
-        size_type           m_numElements;
+        size_type           m_numElements{};
         allocator_type      m_allocator;        ///< Instance of the allocator.
 
         // Debug

--- a/Code/Framework/AzCore/AzCore/std/containers/ring_buffer.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/ring_buffer.h
@@ -483,83 +483,67 @@ namespace AZStd
 
         inline void push_back(const_reference value)
         {
-            if (full())
-            {
-                if (m_size == 0)
-                {
-                    return;
-                }
-                replace(m_last, value);
-                increment(m_last);
-                m_first = m_last;
-            }
-            else
-            {
-                Internal::construct<pointer>::single(m_last, value);
-                increment(m_last);
-                ++m_size;
-            }
+            emplace_back(value);
         }
 
-        inline void push_back()
+        inline void push_back(value_type&& value)
+        {
+            emplace_back(AZStd::move(value));
+        }
+
+        template<class... Args>
+        inline reference emplace_back(Args&&... args)
         {
             if (full())
             {
-                if (m_size == 0)
-                {
-                    return;
-                }
+                AZSTD_CONTAINER_ASSERT(m_size > 0, "Cannot replaces last element in a ring buffer of zero capacity");
                 Internal::destroy<pointer>::single(m_last);
-                Internal::construct<pointer>::single(m_last);
+                Internal::construct<pointer>::single(m_last, AZStd::forward<Args>(args)...);
+                reference emplaceRef = *m_last;
                 increment(m_last);
                 m_first = m_last;
+                return emplaceRef;
             }
             else
             {
-                Internal::construct<pointer>::single(m_last);
+                Internal::construct<pointer>::single(m_last, AZStd::forward<Args>(args)...);
+                reference emplaceRef = *m_last;
                 increment(m_last);
                 ++m_size;
+                return emplaceRef;
             }
         }
 
         inline void push_front(const_reference value)
         {
-            if (full())
-            {
-                if (m_size == 0)
-                {
-                    return;
-                }
-                decrement(m_first);
-                replace(m_first, value);
-                m_last = m_first;
-            }
-            else
-            {
-                decrement(m_first);
-                Internal::construct<pointer>::single(m_first, value);
-                ++m_size;
-            }
+            emplace_front(value);
         }
 
-        inline void push_front()
+        inline void push_front(value_type&& value)
+        {
+            emplace_front(AZStd::move(value));
+        }
+
+        template<class... Args>
+        inline reference emplace_front(Args&&... args)
         {
             if (full())
             {
-                if (m_size == 0)
-                {
-                    return;
-                }
+                AZSTD_CONTAINER_ASSERT(m_size > 0, "Cannot replaces first element in a ring buffer of zero capacity");
                 decrement(m_first);
                 Internal::destroy<pointer>::single(m_first);
-                Internal::construct<pointer>::single(m_first);
+                Internal::construct<pointer>::single(m_first, AZStd::forward<Args>(args)...);
+                reference emplaceRef = *m_first;
                 m_last = m_first;
+                return emplaceRef;
             }
             else
             {
                 decrement(m_first);
-                Internal::construct<pointer>::single(m_first);
+                Internal::construct<pointer>::single(m_first, AZStd::forward<Args>(args)...);
+                reference emplaceRef = *m_first;
                 ++m_size;
+                return emplaceRef;
             }
         }
         AZ_FORCE_INLINE void pop_back()

--- a/Code/Framework/AzCore/AzCore/std/containers/vector.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/vector.h
@@ -132,33 +132,16 @@ namespace AZStd
         }
 
         template <class InputIterator>
-        vector(const InputIterator& first, const InputIterator& last)
-            : m_start(0)
-            , m_last(0)
-            , m_end(0)
+        vector(InputIterator first, InputIterator last, const allocator_type& allocator = allocator_type())
+            : m_allocator(allocator)
         {
             // We need some help here, since this function can be mistaken with the vector(size_type, const_reference value, const allocator_type&) one...
             // so we need to handle this case.
             construct_iter(first, last, is_integral<InputIterator>());
         }
-        template <class InputIterator>
-        vector(const InputIterator& first, const InputIterator& last, const allocator_type& allocator)
-            : m_start(0)
-            , m_last(0)
-            , m_end(0)
-            , m_allocator(allocator)
+        vector(initializer_list<T> list, const allocator_type& allocator = allocator_type())
+            : vector(list.begin(), list.end(), allocator)
         {
-            // We need some help here, since this function can be mistaken with the vector(size_type, const_reference value, const allocator_type&) one...
-            // so we need to handle this case.
-            construct_iter(first, last, is_integral<InputIterator>());
-        }
-        vector(std::initializer_list<T> list, const allocator_type& allocator = allocator_type())
-            : m_start(0)
-            , m_last(0)
-            , m_end(0)
-            , m_allocator(allocator)
-        {
-            construct_iter(list.begin(), list.end(), is_integral<std::initializer_list<T> >());
         }
 
         vector(const this_type& rhs)
@@ -184,7 +167,7 @@ namespace AZStd
             , m_end(0)
             , m_allocator(rhs.m_allocator)
         {
-            assign_rv(AZStd::forward<this_type>(rhs));
+            assign_rv(AZStd::move(rhs));
         }
         vector(this_type&& rhs, const allocator_type& allocator)
             :  m_start(0)
@@ -192,11 +175,11 @@ namespace AZStd
             , m_end(0)
             , m_allocator(allocator)
         {
-            assign_rv(AZStd::forward<this_type>(rhs));
+            assign_rv(AZStd::move(rhs));
         }
         this_type& operator=(this_type&& rhs)
         {
-            assign_rv(AZStd::forward<this_type>(rhs));
+            assign_rv(AZStd::move(rhs));
             return *this;
         }
 
@@ -211,7 +194,7 @@ namespace AZStd
                 clear();
                 for (iterator iter = rhs.begin(); iter != rhs.end(); ++iter)
                 {
-                    push_back(AZStd::forward<T>(*iter));
+                    push_back(AZStd::move(*iter));
                 }
             }
             else
@@ -258,7 +241,7 @@ namespace AZStd
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
                 orphan_range(m_last, m_last);
 #endif
-                Internal::construct<pointer>::single(m_last, AZStd::forward<value_type>(m_start[index]));
+                Internal::construct<pointer>::single(m_last, AZStd::move(m_start[index]));
                 ++m_last;
             }
             else
@@ -278,7 +261,7 @@ namespace AZStd
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
                 orphan_range(m_last, m_last);
 #endif
-                Internal::construct<pointer>::single(m_last, AZStd::forward<value_type>(value));
+                Internal::construct<pointer>::single(m_last, AZStd::move(value));
                 ++m_last;
             }
         }
@@ -310,7 +293,7 @@ namespace AZStd
 
         inline iterator insert(const_iterator pos, value_type&& value)
         {
-            return emplace(pos, AZStd::forward<value_type>(value));
+            return emplace(pos, AZStd::move(value));
         }
 
         template<class ... Args>
@@ -327,10 +310,6 @@ namespace AZStd
             emplace_back(AZStd::forward<Args>(args) ...);
             AZStd::rotate(m_start + offset, m_last - 1, m_last);
             return iterator(AZSTD_POINTER_ITERATOR_PARAMS(m_start + offset));
-        }
-        void swap(this_type&& rhs)
-        {
-            assign_rv(AZStd::forward<this_type>(rhs));
         }
 
         ~vector()
@@ -630,6 +609,11 @@ namespace AZStd
             assign_iter(first, last, is_integral<InputIterator>());
         }
 
+        void assign(initializer_list<T> iList)
+        {
+            assign(iList.begin(), iList.end());
+        }
+
         inline iterator insert(const_iterator insertPos, const_reference value)
         {
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
@@ -653,11 +637,11 @@ namespace AZStd
             return iterator(AZSTD_POINTER_ITERATOR_PARAMS(m_start)) + offset;
         }
 
-        void    insert(const_iterator insertPos, size_type numElements, const_reference value)
+        iterator insert(const_iterator insertPos, size_type numElements, const_reference value)
         {
             if (numElements == 0)
             {
-                return;
+                return begin() + ranges::distance(begin(), insertPos);
             }
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
             pointer insertPosPtr;
@@ -674,6 +658,7 @@ namespace AZStd
 #else
             pointer insertPosPtr = const_cast<pointer>(insertPos);
 #endif
+            const size_type offset = AZStd::ranges::distance(cbegin(), insertPos);
             size_type capacity   = m_end - m_start;
             size_type size       = m_last - m_start;
             size_type newSize    = size + numElements;
@@ -807,17 +792,19 @@ namespace AZStd
                 orphan_range(insertPosPtr, m_last);
 #endif
             }
+
+            return AZStd::ranges::next(begin(), offset);
         }
 
         template<class InputIterator>
-        AZ_FORCE_INLINE void        insert(const_iterator insertPos, const InputIterator& first, const InputIterator& last)
+        iterator insert(const_iterator insertPos, InputIterator first, InputIterator last)
         {
-            insert_impl(insertPos, first, last, is_integral<InputIterator>());
+            return insert_impl(insertPos, first, last, is_integral<InputIterator>());
         }
 
-        AZ_FORCE_INLINE void insert(const_iterator insertPos, std::initializer_list<T> ilist)
+        iterator insert(const_iterator insertPos, initializer_list<T> ilist)
         {
-            insert_impl(insertPos, ilist.begin(), ilist.end(), is_integral<std::initializer_list<T> >());
+            return insert(insertPos, ilist.begin(), ilist.end());
         }
 
         inline iterator erase(const_iterator elementIter)
@@ -979,30 +966,6 @@ namespace AZStd
         AZ_FORCE_INLINE int     validate_iterator(const const_reverse_iterator& iter) const { return validate_iterator(iter.base()); }
 
         /**
-         *  Pushes an element at the end of the vector without a provided instance. This can be used for value types
-         *  with expensive constructors so we don't want to create temporary one.
-         */
-        inline void push_back()
-        {
-            size_type size      = m_last - m_start;
-            size_type capacity  = m_end - m_start;
-            if (size >= capacity)
-            {
-                // Reallocate - this is so expensive that I rather just call regular push, with a copy of a default object;
-                push_back(value_type());
-            }
-            else
-            {
-#ifdef AZSTD_HAS_CHECKED_ITERATORS
-                orphan_range(m_last, m_last);
-#endif
-                Internal::construct<pointer>::single(m_last);
-                ++m_last;
-            }
-        }
-
-
-        /**
         * Resets the container without deallocating any memory or calling any destructor.
         * This function should be used when we need very quick tear down. Generally it's used for temporary vectors and we can just nuke them that way.
         * In addition the provided \ref Allocators, has leak and reset flag which will enable automatically this behavior. So this function should be used in
@@ -1109,21 +1072,21 @@ namespace AZStd
 
         //#pragma region Insert iterator specializations
         template<class Iterator>
-        AZ_FORCE_INLINE void insert_impl(const_iterator insertPos, const Iterator& first, const Iterator& last, const true_type& /* is_integral<Iterator> */)
+        AZ_FORCE_INLINE iterator insert_impl(const_iterator insertPos, const Iterator& first, const Iterator& last, const true_type& /* is_integral<Iterator> */)
         {
             // we actually are calling this with integral types.
-            insert(insertPos, (size_type)first, (const_reference)last);
+            return insert(insertPos, (size_type)first, (const_reference)last);
         }
 
         template<class Iterator>
-        AZ_FORCE_INLINE void insert_impl(const_iterator insertPos, const Iterator& first, const Iterator& last, const false_type& /* is_integral<Iterator> */)
+        AZ_FORCE_INLINE iterator insert_impl(const_iterator insertPos, const Iterator& first, const Iterator& last, const false_type& /* is_integral<Iterator> */)
         {
             // specialize for specific interators.
-            insert_iter(insertPos, first, last, typename iterator_traits<Iterator>::iterator_category());
+            return insert_iter(insertPos, first, last, typename iterator_traits<Iterator>::iterator_category());
         }
 
         template<class Iterator>
-        void insert_iter(const_iterator insertPos, const Iterator& first, const Iterator& last, const forward_iterator_tag&)
+        iterator insert_iter(const_iterator insertPos, const Iterator& first, const Iterator& last, const forward_iterator_tag&)
         {
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
             // We can template this func if we want to check if first and last belong to the same container. It's possible
@@ -1142,11 +1105,12 @@ namespace AZStd
 #else
             pointer insertPosPtr = const_cast<pointer>(insertPos);
 #endif
+            const size_type offset = AZStd::ranges::distance(begin(), insertPos);
 
             size_type numElements = distance(first, last);
             if (numElements == 0)
             {
-                return;
+                return AZStd::ranges::next(begin(), offset);
             }
             //AZSTD_CONTAINER_ASSERT(numElements>0,("AZStd::vector<T>::insert<Iterator> - No point to insert 0 elements!"));
 
@@ -1252,11 +1216,13 @@ namespace AZStd
                 orphan_range(insertPosPtr, m_last);
 #endif
             }
+
+            return AZStd::ranges::next(begin(), offset);
         }
 
 
         template<class Iterator>
-        inline void insert_iter(const_iterator insertPos, const Iterator& first, const Iterator& last, const input_iterator_tag&)
+        inline iterator insert_iter(const_iterator insertPos, const Iterator& first, const Iterator& last, const input_iterator_tag&)
         {
             const_iterator start(AZSTD_POINTER_ITERATOR_PARAMS(m_start));
             size_type offset = AZStd::distance(start, insertPos);
@@ -1266,6 +1232,8 @@ namespace AZStd
             {
                 insert(start + offset, *iter);
             }
+
+            return AZStd::ranges::next(begin(), offset);
         }
         //#pragma endregion
 
@@ -1312,9 +1280,9 @@ namespace AZStd
         //#pragma endregion
 
     protected:
-        pointer         m_start;            ///< Pointer to the first allocated element of the array.
-        pointer         m_last;             ///< Pointer after the last used element.
-        pointer         m_end;              ///< Pointer after the last allocated element.
+        pointer         m_start{};            ///< Pointer to the first allocated element of the array.
+        pointer         m_last{};             ///< Pointer after the last used element.
+        pointer         m_end{};              ///< Pointer after the last allocated element.
         allocator_type  m_allocator;        ///< Instance of the allocator.
 
         // Debug

--- a/Code/Framework/AzCore/AzCore/std/createdestroy.h
+++ b/Code/Framework/AzCore/AzCore/std/createdestroy.h
@@ -128,7 +128,10 @@ namespace AZStd::Internal
         bool = is_trivially_constructible_v<ValueType>>
         struct construct
     {
-        static constexpr void range(InputIterator first, InputIterator last) { (void)first; (void)last; }
+        static constexpr void range(InputIterator first, InputIterator last)
+        {
+            range(first, last, ValueType());
+        }
         static constexpr void range(InputIterator first, InputIterator last, const ValueType& value)
         {
             for (; first != last; ++first)
@@ -136,7 +139,10 @@ namespace AZStd::Internal
                 *first = value;
             }
         }
-        static constexpr void single(InputIterator iter) { (void)iter; }
+        static constexpr void single(InputIterator iter)
+        {
+            single(iter, ValueType());
+        }
         static constexpr void single(InputIterator iter, const ValueType& value)
         {
             *iter = value;
@@ -166,11 +172,6 @@ namespace AZStd::Internal
             {
                 ::new (&*first) ValueType(value);
             }
-        }
-
-        static void single(InputIterator iter)
-        {
-            ::new (&*iter) ValueType();
         }
 
         template<class ... InputArguments>

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/Debug/StackTracer_Windows.cpp
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/Debug/StackTracer_Windows.cpp
@@ -627,8 +627,7 @@ namespace AZ {
                 // find insert position
                 if (g_moduleInfo.size() <  g_moduleInfo.capacity())
                 {
-                    g_moduleInfo.push_back();
-                    SymbolStorage::ModuleInfo& modInfo = g_moduleInfo.back();
+                    SymbolStorage::ModuleInfo& modInfo = g_moduleInfo.emplace_back();
                     modInfo.m_baseAddress = (u64)baseAddr;
                     azstrcpy(modInfo.m_modName, AZ_ARRAY_SIZE(modInfo.m_modName), szMod);
                     azstrcpy(modInfo.m_fileName, AZ_ARRAY_SIZE(modInfo.m_fileName), img);

--- a/Code/Framework/AzCore/Tests/AZStd/DequeAndSimilar.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/DequeAndSimilar.cpp
@@ -163,9 +163,7 @@ namespace UnitTest
         AZ_TEST_ASSERT(int_deque1.front() == 1);
         AZ_TEST_ASSERT(int_deque1[3] == 3);
 
-        AZ_TEST_START_TRACE_SUPPRESSION;
         int_deque1.insert(int_deque1.begin(), {});
-        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         AZ_TEST_VALIDATE_DEQUE(int_deque1, 37);
         int_deque1.erase(int_deque1.begin(), int_deque1.begin() + 8);
         AZ_TEST_VALIDATE_DEQUE(int_deque1, 29);
@@ -200,11 +198,11 @@ namespace UnitTest
         }
 
         // extensions
-        int_deque2.push_back();
+        int_deque2.emplace_back();
         AZ_TEST_VALIDATE_DEQUE(int_deque2, 2);
         AZ_TEST_ASSERT(int_deque2.front() == 401);
 
-        int_deque2.push_front();
+        int_deque2.emplace_front();
         AZ_TEST_VALIDATE_DEQUE(int_deque2, 3);
         AZ_TEST_ASSERT(int_deque2[1] == 401);
 
@@ -620,13 +618,13 @@ namespace UnitTest
         int_buffer5.push_back(101);
         AZ_TEST_VALIDATE_RINGBUFFER(int_buffer5, myArr.size() + 1);
         AZ_TEST_ASSERT(int_buffer5.back() == 101);
-        int_buffer5.push_back();
+        int_buffer5.emplace_back();
         AZ_TEST_VALIDATE_RINGBUFFER(int_buffer5, myArr.size() + 2);
 
         int_buffer5.push_front(201);
         AZ_TEST_VALIDATE_RINGBUFFER(int_buffer5, myArr.size() + 3);
         AZ_TEST_ASSERT(int_buffer5.front() == 201);
-        int_buffer5.push_front();
+        int_buffer5.emplace_front();
         AZ_TEST_VALIDATE_RINGBUFFER(int_buffer5, myArr.size() + 4);
 
         // pop

--- a/Code/Framework/AzCore/Tests/AZStd/Lists.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Lists.cpp
@@ -369,12 +369,12 @@ namespace UnitTest
         int_list.clear();
 
         // Push_back()
-        int_list.push_back();
+        int_list.emplace_back();
         AZ_TEST_VALIDATE_LIST(int_list, 1);
         int_list.front() = 100;
 
         // Push_front()
-        int_list.push_front();
+        int_list.emplace_front();
         AZ_TEST_VALIDATE_LIST(int_list, 2);
         AZ_TEST_ASSERT(int_list.back() == 100);
 
@@ -408,7 +408,7 @@ namespace UnitTest
 
         int_list20.assign(10, MyClass(33));
         AZ_TEST_VALIDATE_LIST(int_list20, 10);
-        AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 10 * sizeof(stack_myclass_list_type::node_type));
+        AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 10 * sizeof(stack_myclass_list_type::value_type));
 
         int_list20.leak_and_reset();
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list20);
@@ -418,8 +418,8 @@ namespace UnitTest
         int_list20.assign(20, MyClass(22));
         int_list20.set_allocator(allocator1);
         AZ_TEST_VALIDATE_LIST(int_list20, 20);
-        AZ_TEST_ASSERT(myMemoryManager1.get_allocated_size() >= 20 * sizeof(stack_myclass_list_type::node_type));
-        AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 20 * sizeof(stack_myclass_list_type::node_type));
+        AZ_TEST_ASSERT(myMemoryManager1.get_allocated_size() >= 20 * sizeof(stack_myclass_list_type::value_type));
+        AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 20 * sizeof(stack_myclass_list_type::value_type));
         int_list20.leak_and_reset();
         int_list20.set_allocator(allocator2);
         myMemoryManager1.reset();
@@ -431,8 +431,8 @@ namespace UnitTest
         int_list10.swap(int_list20);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list20);
         AZ_TEST_VALIDATE_LIST(int_list10, 10);
-        AZ_TEST_ASSERT(myMemoryManager1.get_allocated_size() >= 10 * sizeof(stack_myclass_list_type::node_type));
-        AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 10 * sizeof(stack_myclass_list_type::node_type));
+        AZ_TEST_ASSERT(myMemoryManager1.get_allocated_size() >= 10 * sizeof(stack_myclass_list_type::value_type));
+        AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 10 * sizeof(stack_myclass_list_type::value_type));
 
         int_list10.swap(int_list20);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_list10);
@@ -619,7 +619,7 @@ namespace UnitTest
         int_slist.insert(int_slist.end(), 2, 22);
         AZ_TEST_VALIDATE_LIST(int_slist, 9);
         AZ_TEST_ASSERT(int_slist.back() == 22);
-        AZ_TEST_ASSERT(*int_slist.previous(int_slist.last()) == 22);
+        AZ_TEST_ASSERT(*int_slist.previous(int_slist.before_end()) == 22);
 
         int_slist.insert(int_slist.end(), int_slist1.begin(), int_slist1.end());
         AZ_TEST_VALIDATE_LIST(int_slist, 9 + int_slist1.size());
@@ -628,12 +628,12 @@ namespace UnitTest
         // erase
         int_slist.assign(2, 10);
         int_slist.push_back(20);
-        int_slist.erase(int_slist.last());
+        int_slist.erase(int_slist.before_end());
         AZ_TEST_VALIDATE_LIST(int_slist, 2);
         AZ_TEST_ASSERT(int_slist.back() == 10);
 
         int_slist.insert(int_slist.end(), 3, 44);
-        int_slist.erase(int_slist.previous(int_slist.last()), int_slist.end());
+        int_slist.erase(int_slist.previous(int_slist.before_end()), int_slist.end());
         AZ_TEST_VALIDATE_LIST(int_slist, 3);
         AZ_TEST_ASSERT(int_slist.back() == 44);
 
@@ -742,7 +742,7 @@ namespace UnitTest
         int_slist.push_back(1);
         int_slist.sort();
         AZ_TEST_VALIDATE_LIST(int_slist, 4);
-        for (forward_list<int>::iterator iter = int_slist.begin(); iter != int_slist.last(); ++iter)
+        for (forward_list<int>::iterator iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter <= *next(iter));
         }
@@ -752,7 +752,7 @@ namespace UnitTest
         int_slist.push_back(1);
         int_slist.sort(AZStd::greater<int>());
         AZ_TEST_VALIDATE_LIST(int_slist, 4);
-        for (forward_list<int>::iterator iter = int_slist.begin(); iter != int_slist.last(); ++iter)
+        for (forward_list<int>::iterator iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter >= *next(iter));
         }
@@ -772,7 +772,7 @@ namespace UnitTest
 
         // reverse
         int_slist.reverse();
-        for (forward_list<int>::iterator iter = int_slist.begin(); iter != int_slist.last(); ++iter)
+        for (forward_list<int>::iterator iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter <= *next(iter));
         }
@@ -794,7 +794,7 @@ namespace UnitTest
         int_slist2.merge(int_slist3);
         AZ_TEST_VALIDATE_LIST(int_slist2, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist3);
-        for (forward_list<int>::iterator iter = int_slist2.begin(); iter != int_slist2.last(); ++iter)
+        for (forward_list<int>::iterator iter = int_slist2.begin(); iter != int_slist2.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter < *next(iter));
         }
@@ -807,7 +807,7 @@ namespace UnitTest
         int_slist2.merge(int_slist3, AZStd::greater<int>());
         AZ_TEST_VALIDATE_LIST(int_slist2, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist3);
-        for (forward_list<int>::iterator iter = int_slist2.begin(); iter != int_slist2.last(); ++iter)
+        for (forward_list<int>::iterator iter = int_slist2.begin(); iter != int_slist2.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter > *next(iter));
         }
@@ -821,18 +821,14 @@ namespace UnitTest
         int_slist.clear();
 
         // Push_back()
-        int_slist.push_back();
+        int_slist.emplace_back();
         AZ_TEST_VALIDATE_LIST(int_slist, 1);
         int_slist.front() = 100;
 
         // Push_front()
-        int_slist.push_front();
+        int_slist.emplace_front();
         AZ_TEST_VALIDATE_LIST(int_slist, 2);
         AZ_TEST_ASSERT(int_slist.back() == 100);
-
-        // Insert without value to copy from.
-        int_slist.insert(int_slist.begin());
-        AZ_TEST_VALIDATE_LIST(int_slist, 3);
 
         // default int alignment
         AZ_TEST_ASSERT(((AZStd::size_t)&int_slist.front() % 4) == 0); // default int alignment
@@ -859,7 +855,7 @@ namespace UnitTest
 
         int_slist20.assign(10, MyClass(33));
         AZ_TEST_VALIDATE_LIST(int_slist20, 10);
-        AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 10 * sizeof(stack_myclass_slist_type::node_type));
+        AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 10 * sizeof(stack_myclass_slist_type::value_type));
 
         int_slist20.leak_and_reset();
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist20);
@@ -869,8 +865,8 @@ namespace UnitTest
         int_slist20.assign(20, MyClass(22));
         int_slist20.set_allocator(allocator1);
         AZ_TEST_VALIDATE_LIST(int_slist20, 20);
-        AZ_TEST_ASSERT(myMemoryManager1.get_allocated_size() >= 20 * sizeof(stack_myclass_slist_type::node_type));
-        AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 20 * sizeof(stack_myclass_slist_type::node_type));
+        AZ_TEST_ASSERT(myMemoryManager1.get_allocated_size() >= 20 * sizeof(stack_myclass_slist_type::value_type));
+        AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 20 * sizeof(stack_myclass_slist_type::value_type));
         int_slist20.leak_and_reset();
         int_slist20.set_allocator(allocator2);
         myMemoryManager1.reset();
@@ -882,8 +878,8 @@ namespace UnitTest
         int_slist10.swap(int_slist20);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist20);
         AZ_TEST_VALIDATE_LIST(int_slist10, 10);
-        AZ_TEST_ASSERT(myMemoryManager1.get_allocated_size() >= 10 * sizeof(stack_myclass_slist_type::node_type));
-        AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 10 * sizeof(stack_myclass_slist_type::node_type));
+        AZ_TEST_ASSERT(myMemoryManager1.get_allocated_size() >= 10 * sizeof(stack_myclass_slist_type::value_type));
+        AZ_TEST_ASSERT(myMemoryManager2.get_allocated_size() >= 10 * sizeof(stack_myclass_slist_type::value_type));
 
         int_slist10.swap(int_slist20);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist10);
@@ -940,7 +936,7 @@ namespace UnitTest
         int_slist30.merge(int_slist40);
         AZ_TEST_VALIDATE_LIST(int_slist30, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist40);
-        for (stack_myclass_slist_type::iterator iter = int_slist30.begin(); iter != int_slist30.last(); ++iter)
+        for (stack_myclass_slist_type::iterator iter = int_slist30.begin(); iter != int_slist30.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter < *next(iter));
         }
@@ -953,7 +949,7 @@ namespace UnitTest
         int_slist30.merge(int_slist40, AZStd::greater<MyClass>());
         AZ_TEST_VALIDATE_LIST(int_slist30, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist40);
-        for (stack_myclass_slist_type::iterator iter = int_slist30.begin(); iter != int_slist30.last(); ++iter)
+        for (stack_myclass_slist_type::iterator iter = int_slist30.begin(); iter != int_slist30.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter > *next(iter));
         }

--- a/Code/Framework/AzCore/Tests/AZStd/ListsFixed.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/ListsFixed.cpp
@@ -342,12 +342,12 @@ namespace UnitTest
         fixed_list<int, 100> int_list;
 
         // Push_back()
-        int_list.push_back();
+        int_list.emplace_back();
         AZ_TEST_VALIDATE_LIST(int_list, 1);
         int_list.front() = 100;
 
         // Push_front()
-        int_list.push_front();
+        int_list.emplace_front();
         AZ_TEST_VALIDATE_LIST(int_list, 2);
         AZ_TEST_ASSERT(int_list.back() == 100);
 
@@ -459,7 +459,7 @@ namespace UnitTest
         int_slist.insert(int_slist.end(), 2, 22);
         AZ_TEST_VALIDATE_LIST(int_slist, 9);
         AZ_TEST_ASSERT(int_slist.back() == 22);
-        AZ_TEST_ASSERT(*int_slist.previous(int_slist.last()) == 22);
+        AZ_TEST_ASSERT(*int_slist.previous(int_slist.before_end()) == 22);
 
         int_slist.insert(int_slist.end(), int_slist1.begin(), int_slist1.end());
         AZ_TEST_VALIDATE_LIST(int_slist, 9 + int_slist1.size());
@@ -468,12 +468,12 @@ namespace UnitTest
         // erase
         int_slist.assign(2, 10);
         int_slist.push_back(20);
-        int_slist.erase(int_slist.last());
+        int_slist.erase(int_slist.before_end());
         AZ_TEST_VALIDATE_LIST(int_slist, 2);
         AZ_TEST_ASSERT(int_slist.back() == 10);
 
         int_slist.insert(int_slist.end(), 3, 44);
-        int_slist.erase(int_slist.previous(int_slist.last()), int_slist.end());
+        int_slist.erase(int_slist.previous(int_slist.before_end()), int_slist.end());
         AZ_TEST_VALIDATE_LIST(int_slist, 3);
         AZ_TEST_ASSERT(int_slist.back() == 44);
 
@@ -582,7 +582,7 @@ namespace UnitTest
         int_slist.push_back(1);
         int_slist.sort();
         AZ_TEST_VALIDATE_LIST(int_slist, 4);
-        for (fixed_forward_list<int, 100>::iterator iter = int_slist.begin(); iter != int_slist.last(); ++iter)
+        for (fixed_forward_list<int, 100>::iterator iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter <= *next(iter));
         }
@@ -592,7 +592,7 @@ namespace UnitTest
         int_slist.push_back(1);
         int_slist.sort(AZStd::greater<int>());
         AZ_TEST_VALIDATE_LIST(int_slist, 4);
-        for (fixed_forward_list<int, 100>::iterator iter = int_slist.begin(); iter != int_slist.last(); ++iter)
+        for (fixed_forward_list<int, 100>::iterator iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter >= *next(iter));
         }
@@ -612,7 +612,7 @@ namespace UnitTest
 
         // reverse
         int_slist.reverse();
-        for (fixed_forward_list<int, 100>::iterator iter = int_slist.begin(); iter != int_slist.last(); ++iter)
+        for (fixed_forward_list<int, 100>::iterator iter = int_slist.begin(); iter != int_slist.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter <= *next(iter));
         }
@@ -634,7 +634,7 @@ namespace UnitTest
         int_slist2.merge(int_slist3);
         AZ_TEST_VALIDATE_LIST(int_slist2, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist3);
-        for (fixed_forward_list<int, 100>::iterator iter = int_slist2.begin(); iter != int_slist2.last(); ++iter)
+        for (fixed_forward_list<int, 100>::iterator iter = int_slist2.begin(); iter != int_slist2.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter < *next(iter));
         }
@@ -647,7 +647,7 @@ namespace UnitTest
         int_slist2.merge(int_slist3, AZStd::greater<int>());
         AZ_TEST_VALIDATE_LIST(int_slist2, 8);
         AZ_TEST_VALIDATE_EMPTY_LIST(int_slist3);
-        for (fixed_forward_list<int, 100>::iterator iter = int_slist2.begin(); iter != int_slist2.last(); ++iter)
+        for (fixed_forward_list<int, 100>::iterator iter = int_slist2.begin(); iter != int_slist2.before_end(); ++iter)
         {
             AZ_TEST_ASSERT(*iter > *next(iter));
         }
@@ -658,18 +658,14 @@ namespace UnitTest
         fixed_forward_list<int, 100> int_slist;
 
         // Push_back()
-        int_slist.push_back();
+        int_slist.emplace_back();
         AZ_TEST_VALIDATE_LIST(int_slist, 1);
         int_slist.front() = 100;
 
         // Push_front()
-        int_slist.push_front();
+        int_slist.emplace_front();
         AZ_TEST_VALIDATE_LIST(int_slist, 2);
         AZ_TEST_ASSERT(int_slist.back() == 100);
-
-        // Insert without value to copy from.
-        int_slist.insert(int_slist.begin());
-        AZ_TEST_VALIDATE_LIST(int_slist, 3);
 
         // default int alignment
         AZ_TEST_ASSERT(((AZStd::size_t)&int_slist.front() % 4) == 0); // default int alignment

--- a/Code/Framework/AzCore/Tests/AZStd/VectorAndArray.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/VectorAndArray.cpp
@@ -254,7 +254,7 @@ namespace UnitTest
         AZ_TEST_ASSERT(int_vector1.back() == 55);
 
         // push back
-        int_vector1.push_back();
+        int_vector1.emplace_back();
         AZ_TEST_VALIDATE_VECTOR(int_vector1, 11);
 
         // pop back
@@ -273,7 +273,7 @@ namespace UnitTest
         AZ_TEST_ASSERT(int_vector1.back() == 100);
 
         // push back with capacity and change capacity!
-        int_vector1.push_back();
+        int_vector1.emplace_back();
         AZ_TEST_VALIDATE_VECTOR(int_vector1, 12);
         AZ_TEST_ASSERT(int_vector1.capacity() >= 12);
 
@@ -343,8 +343,8 @@ namespace UnitTest
         AZ_TEST_VALIDATE_VECTOR(int_vector1, 33);
         AZ_TEST_ASSERT(int_vector1.front() == 55);
 
-        // swap rvalue reference binding to temporary
-        int_vector1.swap(vector_int_type());
+        // empty variable via default constructor
+        int_vector1 = {};
         AZ_TEST_VALIDATE_EMPTY_VECTOR(int_vector1);
 
 
@@ -510,7 +510,7 @@ namespace UnitTest
         move_only_vector.push_back(4);
 
         AZStd::vector<VectorMoveOnly> result_move_only_vector{ AZStd::make_move_iterator(move_only_vector.begin()), AZStd::make_move_iterator(move_only_vector.end()) };
-        
+
         for (const auto& move_only1 : move_only_vector)
         {
             EXPECT_EQ(0, move_only1.m_num);
@@ -606,7 +606,7 @@ namespace UnitTest
         AZ_TEST_ASSERT(int_vector1.back() == 55);
 
         // push back
-        int_vector1.push_back();
+        int_vector1.emplace_back();
         AZ_TEST_VALIDATE_VECTOR(int_vector1, 11);
 
         // pop back

--- a/Code/Framework/AzCore/Tests/Module.cpp
+++ b/Code/Framework/AzCore/Tests/Module.cpp
@@ -133,8 +133,7 @@ namespace UnitTest
             appDesc.m_recordingMode = Debug::AllocationRecords::RECORD_FULL;
 
             // AZCoreTestDLL will load as a dynamic module
-            appDesc.m_modules.push_back();
-            DynamicModuleDescriptor& dynamicModuleDescriptor = appDesc.m_modules.back();
+            DynamicModuleDescriptor& dynamicModuleDescriptor = appDesc.m_modules.emplace_back();
             dynamicModuleDescriptor.m_dynamicLibraryPath = "AzCoreTestDLL";
 
             // StaticModule will load via AZCreateStaticModule(...)

--- a/Code/Framework/AzCore/Tests/Patching.cpp
+++ b/Code/Framework/AzCore/Tests/Patching.cpp
@@ -676,15 +676,15 @@ namespace UnitTest
         {
             ObjectToPatch sourceObj;
             sourceObj.m_intValue = 101;
-            sourceObj.m_objectArray.push_back();
-            sourceObj.m_objectArray.push_back();
-            sourceObj.m_objectArray.push_back();
+            sourceObj.m_objectArray.emplace_back();
+            sourceObj.m_objectArray.emplace_back();
+            sourceObj.m_objectArray.emplace_back();
             sourceObj.m_dynamicField.Set(aznew ContainedObjectNoPersistentId(40));
             {
                 // derived
-                sourceObj.m_derivedObjectArray.push_back();
-                sourceObj.m_derivedObjectArray.push_back();
-                sourceObj.m_derivedObjectArray.push_back();
+                sourceObj.m_derivedObjectArray.emplace_back();
+                sourceObj.m_derivedObjectArray.emplace_back();
+                sourceObj.m_derivedObjectArray.emplace_back();
             }
 
             // test generic containers with persistent ID
@@ -706,17 +706,17 @@ namespace UnitTest
 
             ObjectToPatch targetObj;
             targetObj.m_intValue = 121;
-            targetObj.m_objectArray.push_back();
-            targetObj.m_objectArray.push_back();
-            targetObj.m_objectArray.push_back();
+            targetObj.m_objectArray.emplace_back();
+            targetObj.m_objectArray.emplace_back();
+            targetObj.m_objectArray.emplace_back();
             targetObj.m_objectArray[0].m_persistentId = 1;
             targetObj.m_objectArray[0].m_data = 301;
             targetObj.m_dynamicField.Set(aznew ContainedObjectNoPersistentId(50));
             {
                 // derived
-                targetObj.m_derivedObjectArray.push_back();
-                targetObj.m_derivedObjectArray.push_back();
-                targetObj.m_derivedObjectArray.push_back();
+                targetObj.m_derivedObjectArray.emplace_back();
+                targetObj.m_derivedObjectArray.emplace_back();
+                targetObj.m_derivedObjectArray.emplace_back();
                 targetObj.m_derivedObjectArray[0].m_persistentId = 1;
                 targetObj.m_derivedObjectArray[0].m_data = 3010;
             }

--- a/Code/Framework/AzCore/Tests/Script.cpp
+++ b/Code/Framework/AzCore/Tests/Script.cpp
@@ -3436,8 +3436,7 @@ namespace UnitTest
             AZ_TEST_ASSERT(values[2].m_elements.size() == valueCheck.m_elements.size());
 
             // set a table value with metatable
-            values[3].m_elements.push_back();
-            ScriptContextDebug::DebugValue& subValue = values[3].m_elements.back();
+            ScriptContextDebug::DebugValue& subValue = values[3].m_elements.emplace_back();
             subValue.m_name = "valueA";
             subValue.m_type = LUA_TNUMBER;
             subValue.m_value = "16";

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -637,7 +637,7 @@ namespace SerializeTestClasses {
             m_textData = "Random Text";
             m_vectorInt.push_back(1);
             m_vectorInt.push_back(2);
-            m_vectorIntVector.push_back();
+            m_vectorIntVector.emplace_back();
             m_vectorIntVector.back().push_back(5);
             m_vectorEnum.push_back(GenericEnum::Value3);
             m_vectorEnum.push_back(GenericEnum::Value1);
@@ -649,7 +649,7 @@ namespace SerializeTestClasses {
             m_fixedVectorInt.push_back(4000);
             m_fixedVectorInt.push_back(5000);
             m_listInt.push_back(10);
-            m_forwardListInt.push_back(15);
+            m_forwardListInt.push_front(15);
             m_setInt.insert(20);
             m_usetInt.insert(20);
             m_umultisetInt.insert(20);
@@ -922,7 +922,7 @@ namespace SerializeTestClasses
             m_string = "Random Text";
             m_vectorInt2.push_back(1 * 2);
             m_vectorInt2.push_back(2 * 2);
-            m_listIntList.push_back();
+            m_listIntList.emplace_back();
             m_listIntList.back().push_back(5);
             m_umapPolymorphic.insert(AZStd::make_pair(1, aznew MyClassMixNew)).first->second->Set(100.f);
             m_umapPolymorphic.insert(AZStd::make_pair(2, aznew MyClassMix2)).first->second->Set(200.f);
@@ -1084,7 +1084,7 @@ namespace ContainerElementDeprecationTestData
             {
                 delete base;
             }
-            m_vectorOfBaseClasses.swap(AZStd::vector<BaseClass*>());
+            m_vectorOfBaseClasses = {};
         }
 
         static void Reflect(ReflectContext* context)
@@ -2009,8 +2009,8 @@ TEST_F(SerializeBasicTest, BasicTypeTest_Succeed)
                 testData.m_array[1] = 6;
                 testData.m_list.push_back(7);
                 testData.m_list.push_back(8);
-                testData.m_forwardList.push_back(9);
-                testData.m_forwardList.push_back(10);
+                auto forwardListIt = testData.m_forwardList.emplace_after(testData.m_forwardList.before_begin(), 9);
+                testData.m_forwardList.emplace_after(forwardListIt, 10);
                 testData.m_unorderedSet.insert(11);
                 testData.m_unorderedSet.insert(12);
                 testData.m_unorderedMap.insert(AZStd::make_pair(13, 13.f));
@@ -3841,8 +3841,8 @@ TEST_F(SerializeBasicTest, BasicTypeTest_Succeed)
                 , m_childOfUnregisteredBase(&m_childOfUnregisteredRttiBase)
                 , m_basePtrToGenericChild(&m_unserializableGeneric)
             {
-                m_vectorUnregisteredClass.push_back();
-                m_vectorUnregisteredRttiClass.push_back();
+                m_vectorUnregisteredClass.emplace_back();
+                m_vectorUnregisteredRttiClass.emplace_back();
                 m_vectorUnregisteredRttiBase.push_back(&m_unregisteredRttiMember);
                 m_vectorGenericChildPtr.push_back(&m_unserializableGeneric);
                 sc.Class<UnserializableMembers>()->
@@ -7820,9 +7820,21 @@ namespace UnitTest
         DataType::Reflect(*this->GetSerializeContext());
 
         // Add 3 items to the container
+        typename TypeParam::iterator insertIter{};
+        if constexpr (AZStd::same_as<TypeParam, AZStd::forward_list<int>>)
+        {
+            insertIter = this->m_holder.m_data.before_begin();
+        }
         for (int i = 0; i < 3; ++i)
         {
-            this->m_holder.m_data.insert(this->m_holder.m_data.end(), i);
+            if constexpr (AZStd::same_as<TypeParam, AZStd::forward_list<int>>)
+            {
+                insertIter = this->m_holder.m_data.insert_after(insertIter, i);
+            }
+            else
+            {
+                this->m_holder.m_data.insert(this->m_holder.m_data.end(), i);
+            }
         }
 
         // Serialize the container
@@ -7837,9 +7849,20 @@ namespace UnitTest
 
         // Put different data in a different instance
         DataType got;
+        if constexpr (AZStd::same_as<TypeParam, AZStd::forward_list<int>>)
+        {
+            insertIter = got.m_data.before_begin();
+        }
         for (int i = 3; i < 6; ++i)
         {
-            got.m_data.insert(got.m_data.end(), i);
+            if constexpr (AZStd::same_as<TypeParam, AZStd::forward_list<int>>)
+            {
+                insertIter = got.m_data.insert_after(insertIter, i);
+            }
+            else
+            {
+                got.m_data.insert(got.m_data.end(), i);
+            }
         }
 
         // Verify that the two containers are different

--- a/Code/Framework/AzCore/Tests/Serialization/Json/BasicContainerSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/BasicContainerSerializerTests.cpp
@@ -143,7 +143,7 @@ namespace JsonSerializationTests
 
         bool AreEqual(const Container& lhs, const Container& rhs) override
         {
-            if (lhs.size() != rhs.size())
+            if (AZStd::ranges::distance(lhs) != AZStd::ranges::distance(rhs))
             {
                 return false;
             }
@@ -237,7 +237,7 @@ namespace JsonSerializationTests
 
         bool AreEqual(const Container& lhs, const Container& rhs) override
         {
-            if (lhs.size() != rhs.size())
+            if (AZStd::ranges::distance(lhs) != AZStd::ranges::distance(rhs))
             {
                 return false;
             }

--- a/Code/Framework/AzCore/Tests/TickBusTest.cpp
+++ b/Code/Framework/AzCore/Tests/TickBusTest.cpp
@@ -49,8 +49,7 @@ TEST_F(OrderedTickBus, OnTick_HandlersFireInSortedOrder)
     AZStd::list<OrderedTicker> tickers;
     for (int order : unsortedHandlerOrder)
     {
-        tickers.push_back();
-        OrderedTicker& ticker = tickers.back();
+        OrderedTicker& ticker = tickers.emplace_back();
         ticker.m_order = order;
         ticker.m_targetList = &actualTickOrder;
         ticker.TickBus::Handler::BusConnect();

--- a/Code/Framework/AzFramework/AzFramework/Script/ScriptRemoteDebugging.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Script/ScriptRemoteDebugging.cpp
@@ -34,8 +34,7 @@ namespace AzFramework
         static bool EnumClass(const char* name, const AZ::Uuid& typeId, void* userData)
         {
             ScriptUserClassList& output = *reinterpret_cast<ScriptUserClassList*>(userData);
-            output.push_back();
-            output.back().m_name = name;
+            output.emplace_back().m_name = name;
             output.back().m_typeId = typeId;
             return true;
         }
@@ -44,8 +43,7 @@ namespace AzFramework
         {
             (void)classTypeId;
             ScriptUserMethodList& output = *reinterpret_cast<ScriptUserMethodList*>(userData);
-            output.push_back();
-            output.back().m_name = name;
+            output.emplace_back().m_name = name;
             output.back().m_dbgParamInfo = dbgParamInfo ? dbgParamInfo : "null";
             return true;
         }
@@ -54,8 +52,7 @@ namespace AzFramework
         {
             (void)classTypeId;
             ScriptUserPropertyList& output = *reinterpret_cast<ScriptUserPropertyList*>(userData);
-            output.push_back();
-            output.back().m_name = name;
+            output.emplace_back().m_name = name;
             output.back().m_isRead = isRead;
             output.back().m_isWrite = isWrite;
             return true;
@@ -79,8 +76,7 @@ namespace AzFramework
 
             if (!found)
             {
-                output.push_back();
-                auto& ebus = output.back();
+                auto& ebus = output.emplace_back();
                 ebus.m_name = name;
                 ebus.m_canBroadcast = canBroadcast;
                 ebus.m_canQueue = canQueue;
@@ -98,8 +94,7 @@ namespace AzFramework
             {
                 if (ebusName == it->m_name)
                 {
-                    it->m_events.push_back();
-                    auto& event = it->m_events.back();
+                    auto& event = it->m_events.emplace_back();
                     event.m_name = senderName;
                     event.m_dbgParamInfo = dbgParamInfo;
                     event.m_category = category;
@@ -297,8 +292,7 @@ namespace AzFramework
                 return;
             }
         }
-        m_availableContexts.push_back();
-        m_availableContexts.back().m_context = sc;
+        m_availableContexts.emplace_back().m_context = sc;
         m_availableContexts.back().m_name = name;
     }
     //-------------------------------------------------------------------------

--- a/Code/Framework/AzFramework/AzFramework/TargetManagement/TargetManagementComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/TargetManagement/TargetManagementComponent.cpp
@@ -640,8 +640,7 @@ namespace AzFramework
         }
 
         m_outboxMutex.lock();
-        m_outbox.push_back();
-        m_outbox.back().first = target.m_persistentId;
+        m_outbox.emplace_back().first = target.m_persistentId;
         m_outbox.back().second.swap(msgBuffer);
         m_outboxMutex.unlock();
     }

--- a/Code/Framework/AzFramework/Tests/GenAppDescriptors.cpp
+++ b/Code/Framework/AzFramework/Tests/GenAppDescriptors.cpp
@@ -30,8 +30,7 @@ namespace UnitTest
             {
                 for (const char* module : modules)
                 {
-                    desc.m_modules.push_back();
-                    desc.m_modules.back().m_dynamicLibraryPath = module;
+                    desc.m_modules.emplace_back().m_dynamicLibraryPath = module;
                     desc.m_modules.back().m_dynamicLibraryPath += libSuffix;
                 }
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/LocalFileSCComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/LocalFileSCComponent.cpp
@@ -82,8 +82,7 @@ namespace AzToolsFramework
                 {
                     for (QString file : GetFiles(fullFilePath.c_str()))
                     {
-                        fileInfo.push_back();
-                        fileInfo.back().m_filePath = file.toUtf8().constData();
+                        fileInfo.emplace_back().m_filePath = file.toUtf8().constData();
 
                         RefreshInfoFromFileSystem(fileInfo.back());
                     }
@@ -121,8 +120,7 @@ namespace AzToolsFramework
 
                 for (const auto& filePath : fullFilePaths)
                 {
-                    info.push_back();
-                    auto& fileInfo = info.back();
+                    auto& fileInfo = info.emplace_back();
 
                     fileInfo.m_filePath = filePath;
                     RefreshInfoFromFileSystem(fileInfo);
@@ -346,8 +344,7 @@ namespace AzToolsFramework
 
                 for (QString file : files)
                 {
-                    info.push_back();
-                    auto& fileInfo = info.back();
+                    auto& fileInfo = info.emplace_back();
 
                     fileInfo.m_filePath = file.toUtf8().constData();
                     RefreshInfoFromFileSystem(fileInfo);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/MainWindowSavedState.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/MainWindowSavedState.cpp
@@ -27,8 +27,7 @@ namespace AzToolsFramework
         while (remaining > 0)
         {
             AZStd::size_t bytes_this_gulp = AZStd::min((AZStd::size_t)2000, remaining);
-            m_serializableWindowState.push_back();
-            m_serializableWindowState.back().assign((AZ::u8*)windowState.begin() + pos, (AZ::u8*)windowState.begin() + pos + bytes_this_gulp);
+            m_serializableWindowState.emplace_back((AZ::u8*)windowState.begin() + pos, (AZ::u8*)windowState.begin() + pos + bytes_this_gulp);
             pos += bytes_this_gulp;
             remaining -= bytes_this_gulp;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogPanel_Panel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogPanel_Panel.cpp
@@ -322,8 +322,7 @@ namespace AzToolsFramework
             {
                 m_numLinesRemoved++; // this line will cause a line to be removed.
             }
-            m_lines.push_back();
-            m_lines.back() = AZStd::move(source);
+            m_lines.emplace_back() = AZStd::move(source);
             ++m_numLinesAdded;
         }
 
@@ -446,8 +445,7 @@ namespace AzToolsFramework
                 m_linesAdded = 0;
             }
 
-            m_lines.push_back();
-            m_lines.back() = AZStd::move(source);
+            m_lines.emplace_back() = AZStd::move(source);
             ++m_linesAdded;
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/InstanceDataHierarchy.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/InstanceDataHierarchy.cpp
@@ -580,8 +580,7 @@ namespace AzToolsFramework
                         // For every UIElement, generate an InstanceDataNode pointed at our instance with the corresponding attributes
                         for (size_t i = 0; i < numInstances; ++i)
                         {
-                            m_supplementalElementData.push_back();
-                            auto& serializeFieldElement = m_supplementalElementData.back();
+                            auto& serializeFieldElement = m_supplementalElementData.emplace_back();
 
                             serializeFieldElement.m_name = element.m_description;
                             serializeFieldElement.m_nameCrc = AZ::Crc32(element.m_description);
@@ -814,8 +813,7 @@ namespace AzToolsFramework
                     for (auto it = node->m_children.begin(); it != node->m_children.end(); ++it, ++i)
                     {
                         InstanceDataNode& childNode = *it;
-                        m_supplementalEditData.push_back();
-                        AZ::Edit::ElementData* editData = &m_supplementalEditData.back().m_editElementData;
+                        AZ::Edit::ElementData* editData = &m_supplementalEditData.emplace_back().m_editElementData;
                         if (childNode.GetElementEditMetadata())
                         {
                             *editData = *node->GetElementEditMetadata();
@@ -838,8 +836,7 @@ namespace AzToolsFramework
                 }
             }
 
-            m_supplementalEditData.push_back();
-            AZ::Edit::ElementData* editData = &m_supplementalEditData.back().m_editElementData;
+            AZ::Edit::ElementData* editData = &m_supplementalEditData.emplace_back().m_editElementData;
             if (node->GetElementEditMetadata())
             {
                 *editData = *node->GetElementEditMetadata();
@@ -1046,8 +1043,7 @@ namespace AzToolsFramework
                 }
                 else
                 {
-                    m_curParentNode->m_children.push_back();
-                    node = &m_curParentNode->m_children.back();
+                    node = &m_curParentNode->m_children.emplace_back();
                 }
             }
             node->m_instances.push_back(ptr);
@@ -1105,8 +1101,7 @@ namespace AzToolsFramework
         // if our data contains dynamic edit data handler, push it on the stack
         if (classData && classData->m_editData && classData->m_editData->m_editDataProvider)
         {
-            m_editDataOverrides.push_back();
-            m_editDataOverrides.back().m_override = classData->m_editData->m_editDataProvider;
+            m_editDataOverrides.emplace_back().m_override = classData->m_editData->m_editDataProvider;
             m_editDataOverrides.back().m_overridingInstance = ptr;
             m_editDataOverrides.back().m_overridingNode = node;
         }
@@ -1258,8 +1253,7 @@ namespace AzToolsFramework
                         if (targetNodeParent)
                         {
                             // Insert a node to mark the removed element, with no data, but relating to the node in the source hierarchy.
-                            targetNodeParent->m_children.push_back();
-                            InstanceDataNode& removedMarker = targetNodeParent->m_children.back();
+                            InstanceDataNode& removedMarker = targetNodeParent->m_children.emplace_back();
                             removedMarker = *sourceNode;
                             removedMarker.m_instances.clear();
                             removedMarker.m_children.clear();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
@@ -431,8 +431,7 @@ namespace AzToolsFramework
         }
         else
         {
-            m_impl->m_instances.push_back();
-            m_impl->m_instances.back().SetValueComparisonFunction(m_impl->m_valueComparisonFunction);
+            m_impl->m_instances.emplace_back().SetValueComparisonFunction(m_impl->m_valueComparisonFunction);
             m_impl->m_instances.back().AddRootInstance(instance, classId);
 
             if (compareInstance)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SlicePushWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SlicePushWidget.cpp
@@ -2885,8 +2885,7 @@ namespace AzToolsFramework
     //=========================================================================
     void SlicePushWidget::AddStatusMessage(StatusMessageType messageType, const QString& messageText)
     {
-        m_statusMessages.push_back();
-        AzToolsFramework::SlicePushWidget::StatusMessage& newMessage = m_statusMessages.back();
+        AzToolsFramework::SlicePushWidget::StatusMessage& newMessage = m_statusMessages.emplace_back();
         newMessage.m_type = messageType;
         newMessage.m_text = messageText;
     }

--- a/Code/Framework/AzToolsFramework/Tests/InstanceDataHierarchy.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/InstanceDataHierarchy.cpp
@@ -1460,8 +1460,7 @@ namespace UnitTest
             AZStd::list<AggregatedContainer> containers;
             for (int i = 0; i < 5; ++i)
             {
-                containers.push_back();
-                AggregatedContainer& container = containers.back();
+                AggregatedContainer& container = containers.emplace_back();
                 idh.AddRootInstance(&container, azrtti_typeid<AggregatedContainer>());
                 idh.Build(&serializeContext, 0);
 

--- a/Code/Tools/AssetBundler/source/utils/utils.cpp
+++ b/Code/Tools/AssetBundler/source/utils/utils.cpp
@@ -684,8 +684,7 @@ namespace AssetBundler
 
     void ScopedTraceHandler::ClearErrors()
     {
-        m_errors.clear();
-        m_errors.swap(AZStd::vector<AZStd::string>());
+        m_errors = {};
     }
 
     AZ::Outcome<AzToolsFramework::AssetFileInfoListComparison::ComparisonType, AZStd::string> ParseComparisonType(

--- a/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
@@ -1496,8 +1496,7 @@ namespace AssetProcessor
             [&](ScanFolderDatabaseEntry& scanFolder)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(scanFolder);
+                container.emplace_back() = AZStd::move(scanFolder);
                 return true;  // return true to collect more rows since we are filling a container
             });
         return found && succeeded;
@@ -1610,8 +1609,7 @@ namespace AssetProcessor
             [&](SourceDatabaseEntry& source)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(source);
+                container.emplace_back() = AZStd::move(source);
                 return true; // return true to continue iterating over additional results, we are populating a container
             });
         return  found && succeeded;
@@ -1635,12 +1633,11 @@ namespace AssetProcessor
         bool found = false;
         bool succeeded = QuerySourceBySourceName(AssetUtilities::NormalizeFilePath(exactSourceName).toUtf8().constData(),
             [&](SourceDatabaseEntry& source)
-        {
-            found = true;
-            container.push_back();
-            container.back() = AZStd::move(source);
-            return true;  // return true to continue iterating over additional results, we are populating a container
-        });
+            {
+                found = true;
+                container.emplace_back() = AZStd::move(source);
+                return true;  // return true to continue iterating over additional results, we are populating a container
+            });
         return  found && succeeded;
     }
 
@@ -1650,12 +1647,11 @@ namespace AssetProcessor
         bool succeeded = QuerySourceBySourceNameScanFolderID(exactSourceName.toUtf8().constData(),
             scanFolderID,
             [&](SourceDatabaseEntry& source)
-        {
-            found = true;
-            container.push_back();
-            container.back() = AZStd::move(source);
-            return true;  // return true to continue iterating over additional results, we are populating a container
-        });
+            {
+                found = true;
+                container.emplace_back() = AZStd::move(source);
+                return true;  // return true to continue iterating over additional results, we are populating a container
+            });
         return  found && succeeded;
     }
 
@@ -1671,8 +1667,7 @@ namespace AssetProcessor
             [&](SourceDatabaseEntry& source)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(source);
+                container.emplace_back() = AZStd::move(source);
                 return true;  // return true to continue iterating over additional results, we are populating a container
             });
         return  found && succeeded;
@@ -1695,8 +1690,7 @@ namespace AssetProcessor
             [&](SourceDatabaseEntry& source)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(source);
+                container.emplace_back() = AZStd::move(source);
                 return true; // return true to continue iterating over additional results, we are populating a container
             });
         return found && succeeded;
@@ -1707,11 +1701,11 @@ namespace AssetProcessor
         bool found = false;
         QuerySourceByJobID( jobID,
             [&](SourceDatabaseEntry& source)
-        {
-            found = true;
-            entry = AZStd::move(source);
-            return false; // stop after the first result
-        });
+            {
+                found = true;
+                entry = AZStd::move(source);
+                return false; // stop after the first result
+            });
         return found;
     }
 
@@ -1720,11 +1714,11 @@ namespace AssetProcessor
         bool found = false;
         QuerySourceByProductID( productID,
             [&](SourceDatabaseEntry& source)
-        {
-            found = true;
-            entry = AZStd::move(source);
-            return false; // stop after the first result
-        });
+            {
+                found = true;
+                entry = AZStd::move(source);
+                return false; // stop after the first result
+            });
         return found;
     }
 
@@ -1732,13 +1726,12 @@ namespace AssetProcessor
     {
         bool found = false;
         bool succeeded = QueryCombinedByProductName(exactProductName.toUtf8().constData(),
-                [&](CombinedDatabaseEntry& combined)
-                {
-                    found = true;
-                    container.push_back();
-                    container.back() = AZStd::move(combined);
-                    return true; // return true to continue collecting all
-                });
+            [&](CombinedDatabaseEntry& combined)
+            {
+                found = true;
+                container.emplace_back() = AZStd::move(combined);
+                return true; // return true to continue collecting all
+            });
         return found && succeeded;
     }
 
@@ -1746,13 +1739,12 @@ namespace AssetProcessor
     {
         bool found = false;
         bool succeeded = QueryCombinedLikeProductName(likeProductName.toUtf8().constData(), likeType,
-                [&](CombinedDatabaseEntry& combined)
-                {
-                    found = true;
-                    container.push_back();
-                    container.back() = AZStd::move(combined);
-                    return true;//all
-                });
+            [&](CombinedDatabaseEntry& combined)
+            {
+                found = true;
+                container.emplace_back() = AZStd::move(combined);
+                return true;//all
+            });
         return found && succeeded;
     }
 
@@ -1899,8 +1891,7 @@ namespace AssetProcessor
                 [&](JobDatabaseEntry& job)
                 {
                     found = true;
-                    container.push_back();
-                    container.back() = AZStd::move(job);
+                    container.emplace_back() = AZStd::move(job);
                     return true;//all
                 },  builderGuid,
                 jobKey.isEmpty() ? nullptr : jobKey.toUtf8().constData(),
@@ -1942,8 +1933,7 @@ namespace AssetProcessor
             [&](JobDatabaseEntry& job)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(job);
+            container.emplace_back() = AZStd::move(job);
             return true; // continue to fetch more rows.
         },  builderGuid,
             jobKey.isEmpty() ? nullptr : jobKey.toUtf8().constData(),
@@ -1962,8 +1952,7 @@ namespace AssetProcessor
                 [&](JobDatabaseEntry& job)
                 {
                     found = true;
-                    container.push_back();
-                    container.back() = AZStd::move(job);
+                    container.emplace_back() = AZStd::move(job);
                     return true;//all
                 },  builderGuid,
                     jobKey.isEmpty() ? nullptr : jobKey.toUtf8().constData(),
@@ -1989,8 +1978,7 @@ namespace AssetProcessor
                 [&](JobDatabaseEntry& job)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(job);
+                container.emplace_back() = AZStd::move(job);
                 return true;//all
             },  builderGuid,
                 jobKey.isEmpty() ? nullptr : jobKey.toUtf8().constData(),
@@ -2011,8 +1999,7 @@ namespace AssetProcessor
                 [&](JobDatabaseEntry& job)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(job);
+                container.emplace_back() = AZStd::move(job);
                 return true;//all
             });
             return true; // continue to fetch more rows.
@@ -2033,8 +2020,7 @@ namespace AssetProcessor
                 [&](JobDatabaseEntry& job)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(job);
+                container.emplace_back() = AZStd::move(job);
                 return true; // continue to fetch more rows for the QueryJobByProductId call
             });
             return true; // continue to fetch more rows for the QueryProductLikeProductName call
@@ -2182,8 +2168,7 @@ namespace AssetProcessor
                 [&](ProductDatabaseEntry& product)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(product);
+                container.emplace_back() = AZStd::move(product);
                 return true; // continue fetching more results.
             }, builderGuid,
                jobKey.isEmpty() ? nullptr : jobKey.toUtf8().constData(),
@@ -2199,8 +2184,7 @@ namespace AssetProcessor
             [&](ProductDatabaseEntry& product)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(product);
+            container.emplace_back() = AZStd::move(product);
             return true; // continue fetching more results.
         }, builderGuid,
            jobKey.isEmpty() ? nullptr : jobKey.toUtf8().constData(),
@@ -2222,8 +2206,7 @@ namespace AssetProcessor
                 [&](ProductDatabaseEntry& product)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(product);
+                container.emplace_back() = AZStd::move(product);
                 return true; // continue fetching more results.
             }, builderGuid,
                jobKey.isEmpty() ? nullptr : jobKey.toUtf8().constData(),
@@ -2239,8 +2222,7 @@ namespace AssetProcessor
                 [&](ProductDatabaseEntry& product)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(product);
+                container.emplace_back() = AZStd::move(product);
                 return true; // continue fetching more results.
             }, builderGuid,
                jobKey.isEmpty() ? nullptr : jobKey.toUtf8().constData(),
@@ -2261,8 +2243,7 @@ namespace AssetProcessor
             [&](ProductDatabaseEntry& product)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(product);
+            container.emplace_back() = AZStd::move(product);
             return true; // continue fetching more results.
         }, builderGuid,
             jobKey.isEmpty() ? nullptr : jobKey.toUtf8().constData(),
@@ -2278,8 +2259,7 @@ namespace AssetProcessor
             [&](CombinedDatabaseEntry& combined)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(combined);
+                container.emplace_back() = AZStd::move(combined);
                 return true; // continue fetching more results.
             }, builderGuid,
                jobKey.isEmpty() ? nullptr : jobKey.toUtf8().constData(),
@@ -2295,8 +2275,7 @@ namespace AssetProcessor
             [&](CombinedDatabaseEntry& combined)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(combined);
+                container.emplace_back() = AZStd::move(combined);
                 return true; // continue fetching more results.
             });
         return found && succeeded;
@@ -2565,8 +2544,7 @@ namespace AssetProcessor
             [&](JobInfo& jobInfo)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(jobInfo);
+            container.emplace_back() = AZStd::move(jobInfo);
             return true; // return true to keep iterating over further rows.
         });
         return found && succeeded;
@@ -2580,8 +2558,7 @@ namespace AssetProcessor
             [&](JobInfo& jobInfo)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(jobInfo);
+            container.emplace_back() = AZStd::move(jobInfo);
             return true; // return true to keep iterating over further rows.
         });
         return found && succeeded;
@@ -2594,8 +2571,7 @@ namespace AssetProcessor
             [&](JobInfo& jobInfo)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(jobInfo);
+            container.emplace_back() = AZStd::move(jobInfo);
             return true; // return true to keep iterating over further rows.
         }, builderGuid,
             jobKey.isEmpty() ? nullptr : jobKey.toUtf8().constData(),
@@ -2667,8 +2643,7 @@ namespace AssetProcessor
             if (builderGuid == entry.m_builderGuid)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(entry);
+                container.emplace_back() = AZStd::move(entry);
             }
             return true; // return true to keep iterating over further rows.
         });
@@ -2682,8 +2657,7 @@ namespace AssetProcessor
             [&](SourceFileDependencyEntry& entry)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(entry);
+            container.emplace_back() = AZStd::move(entry);
             return true; // return true to keep iterating over further rows.
         });
         return found && succeeded;
@@ -2699,8 +2673,7 @@ namespace AssetProcessor
             [&](SourceFileDependencyEntry& entry)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(entry);
+            container.emplace_back() = AZStd::move(entry);
             return true; // return true to keep iterating over further rows.
         });
         return found && succeeded;
@@ -2792,8 +2765,7 @@ namespace AssetProcessor
         bool succeeded = QueryProductDependenciesTable([&](AZ::Data::AssetId& /*assetId*/, ProductDependencyDatabaseEntry& entry)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(entry);
+            container.emplace_back() = AZStd::move(entry);
             return true; // return true to keep iterating over further rows.
         });
         return found && succeeded;
@@ -2819,8 +2791,7 @@ namespace AssetProcessor
             [&](ProductDependencyDatabaseEntry& entry)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(entry);
+            container.emplace_back() = AZStd::move(entry);
             return true; // return true to keep iterating over further rows.
         });
         return found && succeeded;
@@ -2833,8 +2804,7 @@ namespace AssetProcessor
             [&](ProductDatabaseEntry& entry)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(entry);
+            container.emplace_back() = AZStd::move(entry);
             return true; // return true to keep iterating over further rows.
         });
         return found && succeeded;
@@ -2847,8 +2817,7 @@ namespace AssetProcessor
             [&](ProductDatabaseEntry& entry)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(entry);
+            container.emplace_back() = AZStd::move(entry);
             return true;
         });
         return found && succeeded;
@@ -2872,8 +2841,7 @@ namespace AssetProcessor
             [&](ProductDatabaseEntry& entry)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(entry);
+            container.emplace_back() = AZStd::move(entry);
             return true; // return true to keep iterating over further rows.
         });
         return found && succeeded;
@@ -2887,8 +2855,7 @@ namespace AssetProcessor
             [&](ProductDependencyDatabaseEntry& entry)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(entry);
+            container.emplace_back() = AZStd::move(entry);
             return true; // return true to keep iterating over further rows.
         });
         return found && succeeded;
@@ -3056,8 +3023,7 @@ namespace AssetProcessor
             [&](MissingProductDependencyDatabaseEntry& entry)
         {
             found = true;
-            container.push_back();
-            container.back() = AZStd::move(entry);
+            container.emplace_back() = AZStd::move(entry);
             return true; // return true to keep iterating over further rows.
         });
         return found && succeeded;
@@ -3323,8 +3289,7 @@ namespace AssetProcessor
             [&](StatDatabaseEntry& stat)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(stat);
+                container.emplace_back() = AZStd::move(stat);
                 return true; // return true to continue iterating over additional results, we are populating a container
             });
         return found && succeeded;
@@ -3338,8 +3303,7 @@ namespace AssetProcessor
             [&](StatDatabaseEntry& stat)
             {
                 found = true;
-                container.push_back();
-                container.back() = AZStd::move(stat);
+                container.emplace_back() = AZStd::move(stat);
                 return true; // return true to continue iterating over additional results, we are populating a container
             });
         return found && succeeded;

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -5026,8 +5026,7 @@ namespace AssetProcessor
                         entry.m_productID,
                         [&](AzToolsFramework::AssetDatabase::ProductDependencyDatabaseEntry& entry)
                         {
-                            container.push_back();
-                            container.back() = AZStd::move(entry);
+                            container.emplace_back() = AZStd::move(entry);
                             return true; // return true to keep iterating over further rows.
                         });
 

--- a/Code/Tools/AssetProcessor/native/tests/utilities/StatsCaptureTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/utilities/StatsCaptureTest.cpp
@@ -256,8 +256,7 @@ TEST_F(StatsCaptureOutputTest, StatsCaptureTest_PersistToDb)
     AZStd::vector<AzToolsFramework::AssetDatabase::StatDatabaseEntry> statEntryContainer;
     auto getQueriedStatEntry = [&statEntryContainer]([[maybe_unused]] AzToolsFramework::AssetDatabase::StatDatabaseEntry& entry)
     {
-        statEntryContainer.push_back();
-        statEntryContainer.back() = AZStd::move(entry);
+        statEntryContainer.emplace_back() = AZStd::move(entry);
         return true;
     };
 

--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.cpp
@@ -446,8 +446,7 @@ namespace AssetProcessor
             productItemData->m_databaseInfo.m_productID,
             [&](AzToolsFramework::AssetDatabase::ProductDependencyDatabaseEntry& entry)
         {
-            existingDependencies.push_back();
-            existingDependencies.back() = AZStd::move(entry);
+            existingDependencies.emplace_back() = AZStd::move(entry);
             return true; // return true to keep iterating over further rows.
         });
 

--- a/Code/Tools/LuaIDE/Source/LUA/LUADebuggerComponent.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUADebuggerComponent.cpp
@@ -351,13 +351,11 @@ namespace LUADebugger
             {
                 if (*c2 == '\n')
                 {
-                    callstack.push_back();
-                    callstack.back().assign(c1, c2);
+                    callstack.emplace_back().assign(c1, c2);
                     c1 = c2 + 1;
                 }
             }
-            callstack.push_back();
-            callstack.back() = c1;
+            callstack.emplace_back() = c1;
             EBUS_EVENT(LUAEditor::Context_DebuggerManagement::Bus, OnReceivedCallstack, callstack);
         }
         else if (azrtti_istypeof<AzFramework::ScriptDebugRegisteredGlobalsResult*>(msg.get()))

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuilderUtility.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuilderUtility.cpp
@@ -680,8 +680,7 @@ namespace AZ
                         continue;
                     }
 
-                    contract.m_streamChannels.push_back();
-                    contract.m_streamChannels.back().m_semantic = streamChannelSemantic;
+                    contract.m_streamChannels.emplace_back().m_semantic = streamChannelSemantic;
 
                     if (member.m_variable.m_typeModifier == MatrixMajor::ColumnMajor)
                     {
@@ -763,9 +762,8 @@ namespace AZ
 
                     if (semantic.m_name.GetStringView() == "SV_Target")
                     {
-                        contract.m_requiredColorAttachments.push_back();
                         // Render targets only support 1-D vector types and those are always column-major (per DXC)
-                        contract.m_requiredColorAttachments.back().m_componentCount = member.m_variable.m_cols;
+                        contract.m_requiredColorAttachments.emplace_back().m_componentCount = member.m_variable.m_cols;
                     }
                     else if (
                         semantic.m_name.GetStringView() == "SV_Depth" || semantic.m_name.GetStringView() == "SV_DepthGreaterEqual" ||

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.cpp
@@ -708,8 +708,7 @@ namespace AZ
             }
             else
             {
-                primBuffer.m_primitiveBuffer.push_back();
-                auto& primitive = primBuffer.m_primitiveBuffer.back();
+                auto& primitive = primBuffer.m_primitiveBuffer.emplace_back();
                 primitive.m_primitiveType = primitiveType;
                 primitive.m_depthReadType = depthRead;
                 primitive.m_depthWriteType = depthWrite;
@@ -784,8 +783,7 @@ namespace AZ
             }
             else
             {
-                primBuffer.m_primitiveBuffer.push_back();
-                auto& primitive = primBuffer.m_primitiveBuffer.back();
+                auto& primitive = primBuffer.m_primitiveBuffer.emplace_back();
                 primitive.m_primitiveType = primitiveType;
                 primitive.m_depthReadType = depthRead;
                 primitive.m_depthWriteType = depthWrite;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
@@ -299,8 +299,8 @@ namespace AZ
                 else
                 {
                     // If kernel radius is 0 skip kernel calculation and buffer preparation
-                    m_weightData.push_back();
-                    m_offsetData.push_back();
+                    m_weightData.emplace_back();
+                    m_offsetData.emplace_back();
                     m_kernelRadiusData.push_back(0);
                 }
             }

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -423,8 +423,7 @@ namespace AZ::Render
                 uint16_t shadowIndex = shadowProperty.m_shadowId.GetIndex();
                 FilterParameter& filterData = m_shadowData.GetElement<FilterParamIndex>(shadowIndex);
 
-                shadowmapSizes.push_back();
-                ProjectedShadowmapsPass::ShadowmapSizeWithIndices& sizeWithIndices = shadowmapSizes.back();
+                ProjectedShadowmapsPass::ShadowmapSizeWithIndices& sizeWithIndices = shadowmapSizes.emplace_back();
                 sizeWithIndices.m_size = static_cast<ShadowmapSize>(filterData.m_shadowmapSize);
                 sizeWithIndices.m_shadowIndexInSrg = shadowIndex;
             }

--- a/Gems/Atom/Feature/Common/Code/Source/TransformService/TransformServiceFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/TransformService/TransformServiceFeatureProcessor.cpp
@@ -182,9 +182,9 @@ namespace AZ
             else
             {
                 modelIndex = aznumeric_cast<uint32_t>(m_objectToWorldTransforms.size());
-                m_objectToWorldTransforms.push_back();
-                m_objectToWorldInverseTransposeTransforms.push_back();
-                m_objectToWorldHistoryTransforms.push_back();
+                m_objectToWorldTransforms.emplace_back();
+                m_objectToWorldInverseTransposeTransforms.emplace_back();
+                m_objectToWorldHistoryTransforms.emplace_back();
             }
             return ObjectId(modelIndex);
         }

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/InputStreamLayoutBuilder.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/InputStreamLayoutBuilder.cpp
@@ -58,8 +58,7 @@ namespace AZ
             }
             else
             {
-                m_channelDescriptors.push_back();
-                StreamChannelDescriptor& channel = m_channelDescriptors.back();
+                StreamChannelDescriptor& channel = m_channelDescriptors.emplace_back();
 
                 channel.m_bufferIndex = m_bufferIndex;
                 channel.m_byteOffset = m_byteOffset;
@@ -94,9 +93,7 @@ namespace AZ
                 return &m_dummyBufferDescriptorBuilder;
             }
 
-            m_bufferDescriptorBuilders.push_back();
-
-            BufferDescriptorBuilder* builder = &m_bufferDescriptorBuilders.back();
+            BufferDescriptorBuilder* builder = &m_bufferDescriptorBuilders.emplace_back();
             builder->m_bufferIndex = static_cast<uint32_t>(m_bufferDescriptorBuilders.size() - 1);
             builder->m_bufferDescriptor.m_stepFunction = stepFunction;
             builder->m_bufferDescriptor.m_stepRate = stepRate;

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
@@ -103,7 +103,7 @@ namespace AZ
                 }
 
                 handle = PipelineLibraryHandle(m_globalLibrarySet.size());
-                m_globalLibrarySet.push_back();
+                m_globalLibrarySet.emplace_back();
             }
 
             AZ_Assert(m_globalLibraryActiveBits[handle.GetIndex()] == false, "Attempted to allocate active library entry!");

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAssetCreator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAssetCreator.h
@@ -33,7 +33,8 @@ namespace AZ
 
             //! Adds a shader to the built-in shader collection, which will be run for this material.
             //! shaderTag must be unique within the material type's list of shaders.
-            void AddShader(const AZ::Data::Asset<ShaderAsset>& shaderAsset, const ShaderVariantId& shaderVaraintId = ShaderVariantId{}, const AZ::Name& shaderTag = Uuid::CreateRandom().ToString<AZ::Name>());
+            void AddShader(const AZ::Data::Asset<ShaderAsset>& shaderAsset, const ShaderVariantId& shaderVariantId = ShaderVariantId{});
+            void AddShader(const AZ::Data::Asset<ShaderAsset>& shaderAsset, const ShaderVariantId& shaderVariantId, const AZ::Name& shaderTag);
             void AddShader(const AZ::Data::Asset<ShaderAsset>& shaderAsset, const AZ::Name& shaderTag);
 
             //! Sets the version of the MaterialTypeAsset

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPropertySerializer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPropertySerializer.cpp
@@ -269,7 +269,7 @@ namespace AZ
                 }
                 else
                 {
-                    property->m_outputConnections.push_back();
+                    property->m_outputConnections.emplace_back();
                     result.Combine(ContinueLoading(&property->m_outputConnections.back(), azrtti_typeid(property->m_outputConnections.back()), inputValue[Field::connection], context));
                 }
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -235,8 +235,7 @@ namespace AZ
                 const RHI::RenderStates& renderStatesOverlay = *shaderItem.GetRenderStatesOverlay();
                 RHI::MergeStateInto(renderStatesOverlay, pipelineStateDescriptor.m_renderStates);
 
-                streamBufferViewsPerShader.push_back();
-                auto& streamBufferViews = streamBufferViewsPerShader.back();
+                auto& streamBufferViews = streamBufferViewsPerShader.emplace_back();
 
                 UvStreamTangentBitmask uvStreamTangentBitmask;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
@@ -312,7 +312,7 @@ namespace AZ
             PassRequest clearRequest;
             clearRequest.m_templateName = Name("SlowClearPassTemplate");
             clearRequest.m_passData = AZStd::make_shared<SlowClearPassData>();
-            clearRequest.m_connections.push_back();
+            clearRequest.m_connections.emplace_back();
             clearRequest.m_connections[0].m_localSlot = Name("ClearInputOutput");
             clearRequest.m_connections[0].m_attachmentRef.m_pass = Name("Parent");
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -983,7 +983,7 @@ namespace AZ
 
                             if (pipelineStatesItr == m_pipelineStatesLookup.end())
                             {
-                                m_pipelineStatesLookup[drawListTag].push_back();
+                                m_pipelineStatesLookup[drawListTag].emplace_back();
                                 m_pipelineStatesLookup[drawListTag][0].m_multisampleState = rasterPass->GetMultisampleState();
                                 m_pipelineStatesLookup[drawListTag][0].m_renderAttachmentConfiguration = rasterPass->GetRenderAttachmentConfiguration();
                                 rasterPass->SetPipelineStateDataIndex(0);
@@ -1016,7 +1016,7 @@ namespace AZ
                                 else
                                 {
                                     // No match found, add new pipeline state data
-                                    pipelineStateList.push_back();
+                                    pipelineStateList.emplace_back();
                                     pipelineStateList[size].m_multisampleState = rasterPass->GetMultisampleState();
                                     pipelineStateList[size].m_renderAttachmentConfiguration = rasterPass->GetRenderAttachmentConfiguration();
                                     rasterPass->SetPipelineStateDataIndex(static_cast<AZ::u32>(size));

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAssetCreator.cpp
@@ -94,11 +94,11 @@ namespace AZ
                 [this](const char* message){ ReportError("%s", message); });
         }
 
-        void MaterialTypeAssetCreator::AddShader(const AZ::Data::Asset<ShaderAsset>& shaderAsset, const ShaderVariantId& shaderVaraintId, const AZ::Name& shaderTag)
+        void MaterialTypeAssetCreator::AddShader(const AZ::Data::Asset<ShaderAsset>& shaderAsset, const ShaderVariantId& shaderVariantId, const AZ::Name& shaderTag)
         {
             if (ValidateIsReady() && ValidateNotNull(shaderAsset, "ShaderAsset"))
             {
-                m_asset->m_shaderCollection.m_shaderItems.push_back(ShaderCollection::Item{shaderAsset, shaderTag, shaderVaraintId});
+                m_asset->m_shaderCollection.m_shaderItems.push_back(ShaderCollection::Item{shaderAsset, shaderTag, shaderVariantId});
                 if (!m_asset->m_shaderCollection.m_shaderTagIndexMap.Insert(shaderTag, RHI::Handle<uint32_t>(m_asset->m_shaderCollection.m_shaderItems.size() - 1)))
                 {
                     ReportError(AZStd::string::format("Failed to insert shader tag '%s'. Shader tag must be unique.", shaderTag.GetCStr()).c_str());
@@ -110,6 +110,11 @@ namespace AZ
 
                 CacheMaterialSrgLayout();
             }
+        }
+
+        void MaterialTypeAssetCreator::AddShader(const AZ::Data::Asset<ShaderAsset>& shaderAsset, const ShaderVariantId& shaderVariantId)
+        {
+            AddShader(shaderAsset, shaderVariantId, AZ::Name(AZ::Uuid::CreateRandom().ToFixedString()));
         }
 
         void MaterialTypeAssetCreator::AddShader(const AZ::Data::Asset<ShaderAsset>& shaderAsset, const AZ::Name& shaderTag)

--- a/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
+++ b/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
@@ -645,8 +645,7 @@ namespace AZ
                 }
                 if (row == sortedPassGrid.end())
                 {
-                    sortedPassGrid.push_back();
-                    sortedPassGrid.back().push_back(passEntry);
+                    sortedPassGrid.emplace_back().push_back(passEntry);
                 }
             }
 
@@ -1617,14 +1616,12 @@ namespace AZ
                     // add constiuent buffers and textures as sub-nodes in the corresponding treemap.
                     if (hostBytes > 0)
                     {
-                        hostNodes.push_back();
-                        poolNode = &hostNodes.back();
+                        poolNode = &hostNodes.emplace_back();
                         poolNode->m_name = pool.m_name;
                     }
                     else if (deviceBytes > 0)
                     {
-                        deviceNodes.push_back();
-                        poolNode = &deviceNodes.back();
+                        poolNode = &deviceNodes.emplace_back();
                         poolNode->m_name = pool.m_name;
                     }
                     else
@@ -1633,8 +1630,7 @@ namespace AZ
                     }
 
                     const AZ::Name unusedGroup{ "Unused" };
-                    poolNode->m_children.push_back();
-                    TreemapNode& unusedNode = poolNode->m_children.back();
+                    TreemapNode& unusedNode = poolNode->m_children.emplace_back();
                     unusedNode.m_name = "Unused";
                     unusedNode.m_group = unusedGroup;
                     if (hostBytes > 0)
@@ -1657,8 +1653,7 @@ namespace AZ
 
                     for (auto& buffer : pool.m_buffers)
                     {
-                        poolNode->m_children.push_back();
-                        TreemapNode& child = poolNode->m_children.back();
+                        TreemapNode& child = poolNode->m_children.emplace_back();
                         child.m_name = buffer.m_name;
                         child.m_weight = static_cast<float>(buffer.m_sizeInBytes) / GpuProfilerImGuiHelper::MB;
                         child.m_group = bufferGroup;
@@ -1666,8 +1661,7 @@ namespace AZ
 
                     for (auto& image : pool.m_images)
                     {
-                        poolNode->m_children.push_back();
-                        TreemapNode& child = poolNode->m_children.back();
+                        TreemapNode& child = poolNode->m_children.emplace_back();
                         child.m_name = image.m_name;
                         child.m_weight = static_cast<float>(image.m_sizeInBytes) / GpuProfilerImGuiHelper::MB;
                         child.m_group = textureGroup;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
@@ -263,7 +263,7 @@ namespace AZ
             // This is a bug with AssetManager [LYN-2249]
             auto temp = m_controller.m_configuration.m_modelAsset;
 
-            m_stats.m_meshStatsForLod.swap({});
+            m_stats.m_meshStatsForLod = {};
             SetDirty();
 
             return BaseClass::OnConfigurationChanged();

--- a/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
@@ -152,7 +152,7 @@ namespace Audio
             AudioRequestsQueue callbacksToProcess{};
             {
                 AZStd::scoped_lock lock(m_pendingCallbacksMutex);
-                callbacksToProcess.swap(AZStd::move(m_pendingCallbacksQueue));
+                callbacksToProcess = AZStd::move(m_pendingCallbacksQueue);
             }
 
             while (!callbacksToProcess.empty())
@@ -223,7 +223,7 @@ namespace Audio
             AudioRequestsQueue requestsToProcess{};
             {
                 AZStd::scoped_lock lock(m_pendingRequestsMutex);
-                requestsToProcess.swap(AZStd::move(m_pendingRequestsQueue));
+                requestsToProcess = AZStd::move(m_pendingRequestsQueue);
             }
 
             while (!requestsToProcess.empty())

--- a/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
+++ b/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
@@ -753,8 +753,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawAabb(const AZ::Aabb& aabb, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeAabbsMutex);
-        m_activeAabbs.push_back();
-        DebugDrawAabbElement& newElement = m_activeAabbs.back();
+        DebugDrawAabbElement& newElement = m_activeAabbs.emplace_back();
         newElement.m_aabb = aabb;
         newElement.m_color = color;
         newElement.m_duration = duration;
@@ -764,8 +763,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawAabbOnEntity(const AZ::EntityId& targetEntity, const AZ::Aabb& aabb, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeAabbsMutex);
-        m_activeAabbs.push_back();
-        DebugDrawAabbElement& newElement = m_activeAabbs.back();
+        DebugDrawAabbElement& newElement = m_activeAabbs.emplace_back();
         newElement.m_targetEntityId = targetEntity;
         newElement.m_aabb = aabb;
         newElement.m_color = color;
@@ -797,8 +795,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawLineLocationToLocation(const AZ::Vector3& startLocation, const AZ::Vector3& endLocation, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeLinesMutex);
-        m_activeLines.push_back();
-        DebugDrawLineElement& newElement = m_activeLines.back();
+        DebugDrawLineElement& newElement = m_activeLines.emplace_back();
 
         newElement.m_color = color;
         newElement.m_duration = duration;
@@ -810,8 +807,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawLineEntityToLocation(const AZ::EntityId& startEntity, const AZ::Vector3& endLocation, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeLinesMutex);
-        m_activeLines.push_back();
-        DebugDrawLineElement& newElement = m_activeLines.back();
+        DebugDrawLineElement& newElement = m_activeLines.emplace_back();
         newElement.m_color = color;
         newElement.m_duration = duration;
         newElement.m_startEntityId = startEntity; // Start of line is at this entity's location
@@ -822,8 +818,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawLineEntityToEntity(const AZ::EntityId& startEntity, const AZ::EntityId& endEntity, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeLinesMutex);
-        m_activeLines.push_back();
-        DebugDrawLineElement& newElement = m_activeLines.back();
+        DebugDrawLineElement& newElement = m_activeLines.emplace_back();
         newElement.m_color = color;
         newElement.m_duration = duration;
         newElement.m_startEntityId = startEntity; // Start of line is at start entity's location
@@ -849,8 +844,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawObb(const AZ::Obb& obb, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeObbsMutex);
-        m_activeObbs.push_back();
-        DebugDrawObbElement& newElement = m_activeObbs.back();
+        DebugDrawObbElement& newElement = m_activeObbs.emplace_back();
         newElement.m_obb = obb;
         newElement.m_color = color;
         newElement.m_duration = duration;
@@ -860,8 +854,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawObbOnEntity(const AZ::EntityId& targetEntity, const AZ::Obb& obb, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeObbsMutex);
-        m_activeObbs.push_back();
-        DebugDrawObbElement& newElement = m_activeObbs.back();
+        DebugDrawObbElement& newElement = m_activeObbs.emplace_back();
         newElement.m_targetEntityId = targetEntity;
         newElement.m_obb = obb;
         newElement.m_color = color;
@@ -887,8 +880,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawRayLocationToDirection(const AZ::Vector3& worldLocation, const AZ::Vector3& worldDirection, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeRaysMutex);
-        m_activeRays.push_back();
-        DebugDrawRayElement& newElement = m_activeRays.back();
+        DebugDrawRayElement& newElement = m_activeRays.emplace_back();
         newElement.m_color = color;
         newElement.m_duration = duration;
         newElement.m_worldLocation = worldLocation;
@@ -899,8 +891,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawRayEntityToDirection(const AZ::EntityId& startEntity, const AZ::Vector3& worldDirection, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeRaysMutex);
-        m_activeRays.push_back();
-        DebugDrawRayElement& newElement = m_activeRays.back();
+        DebugDrawRayElement& newElement = m_activeRays.emplace_back();
         newElement.m_color = color;
         newElement.m_duration = duration;
         newElement.m_startEntityId = startEntity;
@@ -911,8 +902,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawRayEntityToEntity(const AZ::EntityId& startEntity, const AZ::EntityId& endEntity, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeRaysMutex);
-        m_activeRays.push_back();
-        DebugDrawRayElement& newElement = m_activeRays.back();
+        DebugDrawRayElement& newElement = m_activeRays.emplace_back();
         newElement.m_color = color;
         newElement.m_duration = duration;
         newElement.m_startEntityId = startEntity;
@@ -938,8 +928,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawSphereAtLocation(const AZ::Vector3& worldLocation, float radius, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeSpheresMutex);
-        m_activeSpheres.push_back();
-        DebugDrawSphereElement& newElement = m_activeSpheres.back();
+        DebugDrawSphereElement& newElement = m_activeSpheres.emplace_back();
         newElement.m_worldLocation = worldLocation;
         newElement.m_radius = radius;
         newElement.m_color = color;
@@ -950,8 +939,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawSphereOnEntity(const AZ::EntityId& targetEntity, float radius, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeSpheresMutex);
-        m_activeSpheres.push_back();
-        DebugDrawSphereElement& newElement = m_activeSpheres.back();
+        DebugDrawSphereElement& newElement = m_activeSpheres.emplace_back();
         newElement.m_targetEntityId = targetEntity;
         newElement.m_radius = radius;
         newElement.m_color = color;
@@ -975,8 +963,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawTextAtLocation(const AZ::Vector3& worldLocation, const AZStd::string& text, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeTextsMutex);
-        m_activeTexts.push_back();
-        DebugDrawTextElement& newText = m_activeTexts.back();
+        DebugDrawTextElement& newText = m_activeTexts.emplace_back();
         newText.m_drawMode = DebugDrawTextElement::DrawMode::InWorld;
         newText.m_text = text;
         newText.m_color = color;
@@ -988,8 +975,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawTextOnEntity(const AZ::EntityId& targetEntity, const AZStd::string& text, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeTextsMutex);
-        m_activeTexts.push_back();
-        DebugDrawTextElement& newText = m_activeTexts.back();
+        DebugDrawTextElement& newText = m_activeTexts.emplace_back();
         newText.m_drawMode = DebugDrawTextElement::DrawMode::InWorld;
         newText.m_text = text;
         newText.m_color = color;
@@ -1001,8 +987,7 @@ namespace DebugDraw
     void DebugDrawSystemComponent::DrawTextOnScreen(const AZStd::string& text, const AZ::Color& color, float duration)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeTextsMutex);
-        m_activeTexts.push_back();
-        DebugDrawTextElement& newText = m_activeTexts.back();
+        DebugDrawTextElement& newText = m_activeTexts.emplace_back();
         newText.m_drawMode = DebugDrawTextElement::DrawMode::OnScreen;
         //newText.m_category = 0;
         newText.m_text = text;

--- a/Gems/GradientSignal/Code/Source/Editor/EditorMixedGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorMixedGradientComponent.cpp
@@ -38,7 +38,7 @@ namespace GradientSignal
     {
         if (m_configuration.m_layers.empty())
         {
-            m_configuration.m_layers.push_back();
+            m_configuration.m_layers.emplace_back();
             m_configuration.m_layers.front().m_operation = MixedGradientLayer::MixingOperation::Initialize;
             SetDirty();
         }

--- a/Gems/LyShine/Code/Editor/PropertyHandlerEntityIdComboBox.cpp
+++ b/Gems/LyShine/Code/Editor/PropertyHandlerEntityIdComboBox.cpp
@@ -86,8 +86,7 @@ void PropertyHandlerEntityIdComboBox::ConsumeAttribute(PropertyEntityIdComboBoxC
         {
             for (const AZ::Edit::EnumConstant<AZ::EntityId>& constantValue : enumConstantValues)
             {
-                guiEnumValues.push_back();
-                auto& enumValue = guiEnumValues.back();
+                auto& enumValue = guiEnumValues.emplace_back();
                 enumValue.first = constantValue.m_value;
                 enumValue.second = constantValue.m_description;
             }

--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
@@ -497,9 +497,9 @@ namespace PhysX
     {
         m_physicsSystemConfigChanged.Disconnect();
 
-        s_overlapBuffer.swap({});
-        s_rayCastBuffer.swap({});
-        s_sweepBuffer.swap({});
+        s_overlapBuffer = {};
+        s_rayCastBuffer = {};
+        s_sweepBuffer = {};
 
         for (auto& simulatedBody : m_simulatedBodies)
         {

--- a/Gems/PhysX/Code/Source/WindProvider.cpp
+++ b/Gems/PhysX/Code/Source/WindProvider.cpp
@@ -134,8 +134,7 @@ namespace PhysX
             m_entityTransformHandlers.emplace_back(entityId,
                 [this, entityId]()
                 {
-                    m_pendingAabbUpdates.push_back();
-                    ColliderShapeRequestBus::EventResult(m_pendingAabbUpdates.back()
+                    ColliderShapeRequestBus::EventResult(m_pendingAabbUpdates.emplace_back()
                         , entityId
                         , &ColliderShapeRequestBus::Events::GetColliderShapeAabb);
 
@@ -161,8 +160,7 @@ namespace PhysX
 
                 // When deleting entity from handler's m_entities, the AABB should be appended to m_pendingAabbUpdates
                 // for local wind handler to broadcast OnWindChanged to notify relative entities of wind changes in OnTick().  
-                m_pendingAabbUpdates.push_back();
-                ColliderShapeRequestBus::EventResult(m_pendingAabbUpdates.back(),
+                ColliderShapeRequestBus::EventResult(m_pendingAabbUpdates.emplace_back(),
                     entityId, &ColliderShapeRequestBus::Events::GetColliderShapeAabb);
 
                 m_changed = true;

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventBroadcast.cpp
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventBroadcast.cpp
@@ -56,7 +56,7 @@ namespace ScriptEvents
 
             SetArgumentName(index, argumentName);
 
-            m_behaviorParameters.push_back();
+            m_behaviorParameters.emplace_back();
             Internal::Utils::BehaviorParameterFromParameter(behaviorContext, parameter, m_argumentNames[index].c_str(), m_behaviorParameters.back());
 
             const AZStd::string& tooltip = parameter.GetTooltip();

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventMethod.cpp
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventMethod.cpp
@@ -65,7 +65,7 @@ namespace ScriptEvents
             const AZStd::string& argumentName = parameter.GetName();
             SetArgumentName(index, argumentName);
 
-            m_behaviorParameters.push_back();
+            m_behaviorParameters.emplace_back();
             Internal::Utils::BehaviorParameterFromParameter(behaviorContext, parameter, m_argumentNames[index].c_str(), m_behaviorParameters.back());
 
             const AZStd::string& tooltip = parameter.GetTooltip();

--- a/Gems/Terrain/Code/Source/TerrainRenderer/ClipmapBounds.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/ClipmapBounds.cpp
@@ -66,8 +66,7 @@ namespace Terrain
         // Calculate the vertical box
         if (updatedCenter.m_x != m_center.m_x)
         {
-            updateRegions.push_back();
-            Aabb2i& updateRegion = updateRegions.back();
+            Aabb2i& updateRegion = updateRegions.emplace_back();
             
             if (updatedCenter.m_x < m_center.m_x)
             {
@@ -86,8 +85,7 @@ namespace Terrain
         // Calculate the horizontal box
         if (updatedCenter.m_y != m_center.m_y && updateWidth < m_size)
         {
-            updateRegions.push_back();
-            Aabb2i& updateRegion = updateRegions.back();
+            Aabb2i& updateRegion = updateRegions.emplace_back();
             
             uint32_t updateHeight = AZStd::GetMin<uint32_t>(abs(updatedCenter.m_y - m_center.m_y), m_size);
             if (updatedCenter.m_y < m_center.m_y)

--- a/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
@@ -1128,8 +1128,7 @@ namespace Vegetation
         ([[maybe_unused]] size_t inPositionIndex, const AZ::Vector3& position,
             const AZ::Vector3& normal, const SurfaceData::SurfaceTagWeights& masks) -> bool
             {
-                sectorInfo.m_baseContext.m_availablePoints.push_back();
-                ClaimPoint& claimPoint = sectorInfo.m_baseContext.m_availablePoints.back();
+                ClaimPoint& claimPoint = sectorInfo.m_baseContext.m_availablePoints.emplace_back();
                 claimPoint.m_handle = CreateClaimHandle(sectorInfo, ++claimIndex);
                 claimPoint.m_position = position;
                 claimPoint.m_normal = normal;

--- a/Gems/Vegetation/Code/Source/Editor/EditorAreaBlenderComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Editor/EditorAreaBlenderComponent.cpp
@@ -44,7 +44,7 @@ namespace Vegetation
     {
         if (m_configuration.m_vegetationAreaIds.empty())
         {
-            m_configuration.m_vegetationAreaIds.push_back();
+            m_configuration.m_vegetationAreaIds.emplace_back();
             SetDirty();
         }
     }

--- a/Gems/Vegetation/Code/Source/Editor/EditorDescriptorListComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Editor/EditorDescriptorListComponent.cpp
@@ -40,7 +40,7 @@ namespace Vegetation
     {
         if (m_configuration.m_descriptors.empty())
         {
-            m_configuration.m_descriptors.push_back();
+            m_configuration.m_descriptors.emplace_back();
             SetDirty();
         }
     }

--- a/Gems/Vegetation/Code/Source/InstanceSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/InstanceSystemComponent.cpp
@@ -523,8 +523,7 @@ namespace Vegetation
         AZStd::lock_guard<decltype(m_mainThreadTaskMutex)> mainThreadTaskLock(m_mainThreadTaskMutex);
         if (m_mainThreadTaskQueue.empty() || m_mainThreadTaskQueue.back().size() >= m_configuration.m_maxInstanceTaskBatchSize)
         {
-            m_mainThreadTaskQueue.push_back();
-            m_mainThreadTaskQueue.back().reserve(m_configuration.m_maxInstanceTaskBatchSize);
+            m_mainThreadTaskQueue.emplace_back().reserve(m_configuration.m_maxInstanceTaskBatchSize);
         }
         m_mainThreadTaskQueue.back().emplace_back(task);
     }


### PR DESCRIPTION
The call sites have been replaced with calls to emplace_back or emplace_front.

Corrected return types for AZStd insert() functions to return an `iterator` instance for every insert function which accepts a `const_iterator` position parameter as many of those functions were incorrectly returning void.

Updated AZStd::deque emplace_back/emplace_front function to correctly return a reference instead of void.
Updated AZStd::ring_buffer extension to support emplace_front and emplace_back functions.
Updated AZStd::forward_list to support rvalues and emplace_front/emplace_front functions. AZStd::forward_list previously didn't support any rvalue functions for move.

Since AZStd::forward_list is only used in unit test it is not much of a problem.
It is also has a lot of limitations as compared to AZStd::list which makes it not quite useful to ever use in the codebase.

Finally removed the swap() function extensions which accepted an rvalue reference.
They have been replaced with assignment to a default constructed instance, which what the swap function was swapping with it anyway.
The operation to swap with an rvalue is really just a move operation since it is stealing the values from a temporary.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Ran automated test suite.
