### PR TITLE
{lny13480} Updated Shared Cached interface based on feedback from UX

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/CacheServerData.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/CacheServerData.cpp
@@ -112,13 +112,15 @@ namespace AssetProcessor
             stream.setCodec("UTF-8");
             stream << buffer.GetString();
 
-            m_errorLevel = ErrorLevel::Notice;
-            m_errorMessage = AZStd::string::format("Updated settings file (%s)", fullpath.c_str());
+            m_statusLevel = StatusLevel::Notice;
+            m_statusMessage = AZStd::string::format("Updated settings file (%s)", fullpath.c_str());
+            m_updateStatus = true;
         }
         else
         {
-            m_errorLevel = ErrorLevel::Error;
-            m_errorMessage = AZStd::string::format("**Error**: Could not write settings file (%s)", fullpath.c_str());
+            m_statusLevel = StatusLevel::Error;
+            m_statusMessage = AZStd::string::format("**Error**: Could not write settings file (%s)", fullpath.c_str());
+            m_updateStatus = false;
         }
         file.close();
         return result;

--- a/Code/Tools/AssetProcessor/native/ui/CacheServerData.h
+++ b/Code/Tools/AssetProcessor/native/ui/CacheServerData.h
@@ -19,10 +19,10 @@ namespace AssetProcessor
     {
         enum class StatusLevel
         {
-            None,   // uninitalized or no state
+            None,   // uninitialized or no state
             Notice, // a notification to inform the user about state changes
             Error,  // system is configured wrong
-            Active  // the sysetm is active as a Client or Server
+            Active  // the system is active as a Client or Server
         };
 
         bool m_dirty = false;

--- a/Code/Tools/AssetProcessor/native/ui/CacheServerData.h
+++ b/Code/Tools/AssetProcessor/native/ui/CacheServerData.h
@@ -17,20 +17,21 @@ namespace AssetProcessor
 {
     struct CacheServerData
     {
-        enum class ErrorLevel
+        enum class StatusLevel
         {
-            None,
-            Notice,
-            Warning,
-            Error
+            None,   // uninitalized or no state
+            Notice, // a notification to inform the user about state changes
+            Error,  // system is configured wrong
+            Active  // the sysetm is active as a Client or Server
         };
 
         bool m_dirty = false;
         AssetServerMode m_cachingMode = AssetServerMode::Inactive;
         AZStd::string m_serverAddress = "";
         RecognizerContainer m_patternContainer;
-        ErrorLevel m_errorLevel = ErrorLevel::None;
-        AZStd::string m_errorMessage;
+        StatusLevel m_statusLevel = StatusLevel::None;
+        AZStd::string m_statusMessage;
+        bool m_updateStatus = false;
 
         void Reset();
         bool Save(const AZ::IO::Path& projectPath);

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -631,8 +631,7 @@ void MainWindow::SetupAssetServerTab()
         });
 
     // serverAddressToolButton
-    ui->serverAddressToolButton->setIcon(QIcon(":/PropertyEditor/Resources/Browse_on.png"));
-    AzQtComponents::PushButton::applySmallIconStyle(ui->serverAddressToolButton);
+    ui->serverAddressToolButton->setIcon(QIcon(":Browse_on.png"));
     QObject::connect(ui->serverAddressToolButton, &QToolButton::clicked, this,
         [this]()
         {

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -613,9 +613,6 @@ void MainWindow::SetupAssetServerTab()
                 QStringLiteral("https://o3de.org/docs/user-guide/assets/asset-processor/asset-cache-server/"));
 
         });
-    ui->sharedCacheSupport->setStyleSheet(
-        ui->sharedCacheSupport->styleSheet() +
-        "qproperty-icon: url(:/stylesheet/img/help.svg); qproperty-iconSize: 24px 24px;");
 
     QObject::connect(ui->serverCacheModeOptions,
         static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
@@ -628,6 +625,7 @@ void MainWindow::SetupAssetServerTab()
             {
                 this->m_cacheServerData.m_dirty = true;
                 this->m_cacheServerData.m_cachingMode = inputAssetServerMode;
+                this->m_cacheServerData.m_updateStatus = false;
                 this->CheckAssetServerStates();
             }
         });
@@ -690,6 +688,7 @@ void MainWindow::SetupAssetServerTab()
         {
             AddPatternRow("New Name", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard, "", true);
             this->m_cacheServerData.m_dirty = true;
+            this->m_cacheServerData.m_updateStatus = false;
             this->CheckAssetServerStates();
         });
 
@@ -712,6 +711,7 @@ void MainWindow::AddPatternRow(AZStd::string_view name, AssetBuilderSDK::AssetBu
     auto updateStatus = [this](int)
     {
         this->m_cacheServerData.m_dirty = true;
+        this->m_cacheServerData.m_updateStatus = false;
         this->CheckAssetServerStates();
     };
 
@@ -814,31 +814,37 @@ void MainWindow::CheckAssetServerStates()
         case CacheServerData::StatusLevel::None:
         {
             m_cacheServerData.m_updateStatus = true;
-            ui->sharedCacheStatus->setStyleSheet("background-color: transparent; color : white;");
+            ui->sharedCacheStatus->setStyleSheet("QLabel#sharedCacheStatus");
             ui->sharedCacheStatus->setText("");
             break;
         }
         case CacheServerData::StatusLevel::Notice:
         {
-            // blue
-            ui->sharedCacheStatus->setStyleSheet("font-weight: normal; color: white; background-color: rgba(88, 140, 188, 0.1); border: 1px solid #4285F4;");
             ui->sharedCacheStatus->setText(m_cacheServerData.m_statusMessage.c_str());
+            ui->sharedCacheStatus->setProperty("highlight", "blue");
+            ui->sharedCacheStatus->style()->unpolish(ui->sharedCacheStatus);
+            ui->sharedCacheStatus->style()->polish(ui->sharedCacheStatus);
+            ui->sharedCacheStatus->update();
             break;
         }
         case CacheServerData::StatusLevel::Active:
         {
-            // green
             m_cacheServerData.m_updateStatus = false;
-            ui->sharedCacheStatus->setStyleSheet("font-weight: medium; color: white; background-color: rgba(88, 188, 97, 0.1); border: 1px solid #58BC61;");
             ui->sharedCacheStatus->setText(m_cacheServerData.m_statusMessage.c_str());
+            ui->sharedCacheStatus->setProperty("highlight", "green");
+            ui->sharedCacheStatus->style()->unpolish(ui->sharedCacheStatus);
+            ui->sharedCacheStatus->style()->polish(ui->sharedCacheStatus);
+            ui->sharedCacheStatus->update();
             break;
         }
         case CacheServerData::StatusLevel::Error:
         {
-            // red
             m_cacheServerData.m_updateStatus = false;
-            ui->sharedCacheStatus->setStyleSheet("font-weight: bold; color: white; background-color: rgba(255, 0, 0, 0.1); border: 1px solid #FA2727;");
             ui->sharedCacheStatus->setText(m_cacheServerData.m_statusMessage.c_str());
+            ui->sharedCacheStatus->setProperty("highlight", "red");
+            ui->sharedCacheStatus->style()->unpolish(ui->sharedCacheStatus);
+            ui->sharedCacheStatus->style()->polish(ui->sharedCacheStatus);
+            ui->sharedCacheStatus->update();
             break;
         }
         default:

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -1665,17 +1665,6 @@
                <property name="text">
                 <string>Choose a remote folder.</string>
                </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>style/Browse.png</normaloff>
-                 <selectedon>style/Browse_on.png</selectedon>style/Browse.png</iconset>
-               </property>
-               <property name="popupMode">
-                <enum>QToolButton::DelayedPopup</enum>
-               </property>
-               <property name="toolButtonStyle">
-                <enum>Qt::ToolButtonIconOnly</enum>
-               </property>
               </widget>
              </item>
              <item row="1" column="0" colspan="4">

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -1478,7 +1478,7 @@
           </item>
          </layout>
         </widget>
-        <widget class="QWidget" name="page">
+        <widget class="QWidget" name="SharedCachePage">
          <layout class="QGridLayout" name="gridLayout_2">
           <property name="leftMargin">
            <number>0</number>
@@ -1493,7 +1493,7 @@
            <number>0</number>
           </property>
           <item row="0" column="0">
-           <widget class="QWidget" name="widget" native="true">
+           <widget class="QWidget" name="widget_sharedCache" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
               <horstretch>0</horstretch>
@@ -1513,30 +1513,43 @@
              <property name="bottomMargin">
               <number>10</number>
              </property>
-             <item row="5" column="4">
-              <widget class="QPushButton" name="serverAddressButton">
-               <property name="maximumSize">
-                <size>
-                 <width>16</width>
-                 <height>16777215</height>
-                </size>
+             <item row="0" column="0" colspan="2">
+              <widget class="QLabel" name="sharedCacheTitle">
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
                </property>
                <property name="text">
-                <string/>
+                <string># Shared Cache Settings</string>
+               </property>
+               <property name="textFormat">
+                <enum>Qt::MarkdownText</enum>
                </property>
               </widget>
              </item>
-             <item row="1" column="0">
-              <widget class="Line" name="line">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+             <item row="9" column="3">
+              <widget class="QPushButton" name="sharedCacheSubmitButton">
+               <property name="text">
+                <string>Save Changes</string>
+               </property>
+               <property name="autoDefault">
+                <bool>true</bool>
+               </property>
+               <property name="default">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
-             <item row="4" column="0">
-              <widget class="QLabel" name="label_3">
+             <item row="5" column="0" colspan="4">
+              <widget class="QLineEdit" name="serverAddressLineEdit"/>
+             </item>
+             <item row="9" column="4">
+              <widget class="QPushButton" name="sharedCacheDiscardButton">
                <property name="text">
-                <string>Step 2: Select a remote folder</string>
+                <string>Discard</string>
                </property>
               </widget>
              </item>
@@ -1603,64 +1616,24 @@
                </column>
               </widget>
              </item>
-             <item row="5" column="0" colspan="4">
-              <widget class="QPlainTextEdit" name="serverAddressText">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>32</height>
-                </size>
-               </property>
-               <property name="font">
-                <font>
-                 <family>Amazon Ember Mono</family>
-                 <pointsize>9</pointsize>
-                </font>
-               </property>
-               <property name="toolTip">
-                <string>The remote folder should be accessible to the entire team.</string>
-               </property>
-               <property name="inputMethodHints">
-                <set>Qt::ImhNone</set>
-               </property>
-               <property name="plainText">
-                <string>c:/transfer/stuff</string>
+             <item row="4" column="0">
+              <widget class="QLabel" name="label_3">
+               <property name="text">
+                <string>Step 2: Select a remote folder</string>
                </property>
               </widget>
              </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="sharedCacheTitle">
-               <property name="font">
-                <font>
-                 <pointsize>10</pointsize>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string># Shared Cache Settings</string>
-               </property>
-               <property name="textFormat">
-                <enum>Qt::MarkdownText</enum>
+             <item row="1" column="0">
+              <widget class="Line" name="line">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
                </property>
               </widget>
              </item>
-             <item row="9" column="4">
-              <widget class="QPushButton" name="sharedCacheDiscardButton">
-               <property name="maximumSize">
-                <size>
-                 <width>64</width>
-                 <height>16777215</height>
-                </size>
-               </property>
+             <item row="6" column="0">
+              <widget class="QLabel" name="label_4">
                <property name="text">
-                <string>Discard</string>
+                <string>Step 3: Manage shared cache asset patterns</string>
                </property>
               </widget>
              </item>
@@ -1674,41 +1647,8 @@
                </property>
               </widget>
              </item>
-             <item row="6" column="0">
-              <widget class="QLabel" name="label_4">
-               <property name="text">
-                <string>Step 3: Manage shared cache asset patterns</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="label_2">
-               <property name="text">
-                <string>Step 1: Set shared cache mode</string>
-               </property>
-              </widget>
-             </item>
-             <item row="9" column="3">
-              <widget class="QPushButton" name="sharedCacheSubmitButton">
-               <property name="maximumSize">
-                <size>
-                 <width>128</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="text">
-                <string>Save Changes</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
+             <item row="3" column="0" colspan="4">
               <widget class="QComboBox" name="serverCacheModeOptions">
-               <property name="maximumSize">
-                <size>
-                 <width>128</width>
-                 <height>16777215</height>
-                </size>
-               </property>
                <property name="toolTip">
                 <string>Select the mode the project should use to cache asset products.</string>
                </property>
@@ -1720,7 +1660,32 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="2" colspan="3">
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>Step 1: Set shared cache mode</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="4">
+              <widget class="QToolButton" name="serverAddressToolButton">
+               <property name="text">
+                <string>Choose a remote folder.</string>
+               </property>
+               <property name="icon">
+                <iconset>
+                 <normaloff>style/Browse.png</normaloff>
+                 <selectedon>style/Browse_on.png</selectedon>style/Browse.png</iconset>
+               </property>
+               <property name="popupMode">
+                <enum>QToolButton::DelayedPopup</enum>
+               </property>
+               <property name="toolButtonStyle">
+                <enum>Qt::ToolButtonIconOnly</enum>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0" colspan="4">
               <widget class="QLabel" name="sharedCacheStatus">
                <property name="font">
                 <font>
@@ -1741,6 +1706,16 @@
                </property>
                <property name="margin">
                 <number>5</number>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="4">
+              <widget class="QPushButton" name="sharedCacheSupport">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="flat">
+                <bool>true</bool>
                </property>
               </widget>
              </item>

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -1623,13 +1623,6 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="0">
-              <widget class="Line" name="line">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-              </widget>
-             </item>
              <item row="6" column="0">
               <widget class="QLabel" name="label_4">
                <property name="text">

--- a/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qrc
+++ b/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qrc
@@ -18,5 +18,7 @@
         <file>AssetProcessor_refresh.png</file>
         <file>o3de_assetprocessor.png</file>
         <file>o3de_assetprocessor_taskbar.svg</file>
-    </qresource>
+		<file>Browse.png</file>
+		<file>Browse_on.png</file>
+	</qresource>
 </RCC>

--- a/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qss
+++ b/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qss
@@ -182,3 +182,11 @@ QLabel#sharedCacheStatus[highlight = "red"] {
     background-color: rgba(255, 0, 0, 0.1);
     border: 1px solid #FA2727;
 }
+
+QToolButton#serverAddressToolButton {
+    min-width: -1px;
+    border-width: 0px;
+    border-radius: 0px;
+    border-image: url(":/Browse_on.png") 0 0 0 0 stretch stretch;
+    padding: 0 0 0 0;
+}

--- a/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qss
+++ b/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qss
@@ -102,6 +102,7 @@ QTableWidget#incomingSourceDependenciesTable:item:selected:!active {
     selection-color: rgb(192, 192, 192);
 }
 
+QPushButton#sharedCacheSupport,
 QPushButton#supportButton,
 QPushButton#MissingProductDependenciesSupport {
     min-height: 24px; /* We have to set the min- and max-height otherwise the margins are not respected. */
@@ -154,4 +155,30 @@ QListWidget::item:hover {
 
 QListWidget QHeaderView::section {
     background-color: rgb(34,34,34);
+}
+
+QLabel#sharedCacheStatus {
+    background-color: transparent;
+    color : white;
+}
+
+QLabel#sharedCacheStatus[highlight = "blue"] {
+    color : white;
+    font-weight: normal; 
+    background-color: rgba(88, 140, 188, 0.1);
+    border: 1px solid #4285F4;
+}
+
+QLabel#sharedCacheStatus[highlight = "green"] {
+    color : white;
+    font-weight: normal;
+    background-color: rgba(88, 188, 97, 0.1);
+    border: 1px solid #58BC61;
+}
+
+QLabel#sharedCacheStatus[highlight = "red"] {
+    color : white;
+    font-weight: normal;
+    background-color: rgba(255, 0, 0, 0.1);
+    border: 1px solid #FA2727;
 }

--- a/Code/Tools/AssetProcessor/native/ui/style/Browse.png
+++ b/Code/Tools/AssetProcessor/native/ui/style/Browse.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e9e58d0c9bf1e2a69a9fa0a1f58b6745c75146cd49d352f9db9021d5addd1e4
+size 1016

--- a/Code/Tools/AssetProcessor/native/ui/style/Browse_on.png
+++ b/Code/Tools/AssetProcessor/native/ui/style/Browse_on.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:935193affffd5459e91e363ae40d02c3af1be4f9ee2df1a518633e56237fcfa8
+size 1014

--- a/Code/Tools/AssetProcessor/native/ui/style/Browse_on.png
+++ b/Code/Tools/AssetProcessor/native/ui/style/Browse_on.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:935193affffd5459e91e363ae40d02c3af1be4f9ee2df1a518633e56237fcfa8
-size 1014
+oid sha256:8cfddbab3991f53304b9e645cdce8ae3b609ee6bfab11fcd1927f5d66164b7b2
+size 1032


### PR DESCRIPTION
## What does this PR do?

This updates the user interface for the AP's Shared Cache tool page.

* Adds a support button
* Status field is easier to read
* The Save Changes button is now default blue

## How was this PR tested?

Manually tested to make sure the UX works as expected. 


![acs_image](https://user-images.githubusercontent.com/23512001/180326468-a93901d3-1e8f-409c-9ea1-ec36ab6e972b.png)

