### PR TITLE
[Terrain] Simple unit tests for terrain level components

### DIFF
--- a/Gems/Atom/RPI/Code/CMakeLists.txt
+++ b/Gems/Atom/RPI/Code/CMakeLists.txt
@@ -154,12 +154,8 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 AZ::AzTest
                 AZ::AzTestShared
                 AZ::AzFramework
-                AZ::AzToolsFramework
-                Legacy::CryCommon
                 Gem::Atom_RPI.Public
                 Gem::Atom_RHI.Public
-                Gem::Atom_RPI.Edit
-                Gem::Atom_Utils.TestUtils.Static
     )
 endif()
 

--- a/Gems/Atom/RPI/Code/CMakeLists.txt
+++ b/Gems/Atom/RPI/Code/CMakeLists.txt
@@ -138,7 +138,7 @@ endif()
 ################################################################################
 # Tests
 ################################################################################
-if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
+if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
 
     ly_add_target(
         NAME Atom_RPI.TestUtils.Static STATIC
@@ -161,7 +161,9 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::Atom_RPI.Edit
                 Gem::Atom_Utils.TestUtils.Static
     )
+endif()
 
+if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME Atom_RPI.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
         NAMESPACE Gem

--- a/Gems/Atom/RPI/Code/CMakeLists.txt
+++ b/Gems/Atom/RPI/Code/CMakeLists.txt
@@ -141,6 +141,28 @@ endif()
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
 
     ly_add_target(
+        NAME Atom_RPI.TestUtils.Static STATIC
+        NAMESPACE Gem
+        FILES_CMAKE
+            atom_rpi_test_utils_files.cmake
+        INCLUDE_DIRECTORIES
+            PUBLIC
+                Tests
+        BUILD_DEPENDENCIES
+            PRIVATE
+                AZ::AtomCore
+                AZ::AzTest
+                AZ::AzTestShared
+                AZ::AzFramework
+                AZ::AzToolsFramework
+                Legacy::CryCommon
+                Gem::Atom_RPI.Public
+                Gem::Atom_RHI.Public
+                Gem::Atom_RPI.Edit
+                Gem::Atom_Utils.TestUtils.Static
+    )
+
+    ly_add_target(
         NAME Atom_RPI.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
         NAMESPACE Gem
         FILES_CMAKE
@@ -160,6 +182,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::Atom_RPI.Public
                 Gem::Atom_RHI.Public
                 Gem::Atom_RPI.Edit
+                Gem::Atom_RPI.TestUtils.Static
                 Gem::Atom_Utils.TestUtils.Static
     )
     ly_add_googletest(

--- a/Gems/Atom/RPI/Code/atom_rpi_test_utils_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_test_utils_files.cmake
@@ -1,0 +1,14 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Tests/Common/RHI/Factory.cpp
+    Tests/Common/RHI/Factory.h
+    Tests/Common/RHI/Stubs.cpp
+    Tests/Common/RHI/Stubs.h
+)

--- a/Gems/Atom/RPI/Code/atom_rpi_tests_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_tests_files.cmake
@@ -18,14 +18,10 @@ set(FILES
     Tests/Common/RPITestFixture.cpp
     Tests/Common/RPITestFixture.h
     Tests/Common/SerializeTester.h
-    Tests/Common/TestUtils.h
-    Tests/Common/TestFeatureProcessors.h
-    Tests/Common/RHI/Factory.cpp
-    Tests/Common/RHI/Factory.h
-    Tests/Common/RHI/Stubs.cpp
-    Tests/Common/RHI/Stubs.h
     Tests/Common/ShaderAssetTestUtils.cpp
     Tests/Common/ShaderAssetTestUtils.h
+    Tests/Common/TestUtils.h
+    Tests/Common/TestFeatureProcessors.h
     Tests/Image/StreamingImageTests.cpp
     Tests/Material/LuaMaterialFunctorTests.cpp
     Tests/Material/MaterialVersionUpdateTests.cpp

--- a/Gems/Terrain/Code/CMakeLists.txt
+++ b/Gems/Terrain/Code/CMakeLists.txt
@@ -106,6 +106,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         BUILD_DEPENDENCIES
             PRIVATE
                 AZ::AzTest
+                AZ::AzTestShared
                 AZ::AzFramework
                 Gem::LmbrCentral.Mocks
                 Gem::GradientSignal.Mocks

--- a/Gems/Terrain/Code/CMakeLists.txt
+++ b/Gems/Terrain/Code/CMakeLists.txt
@@ -106,8 +106,10 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         BUILD_DEPENDENCIES
             PRIVATE
                 AZ::AzTest
+                AZ::AzFrameworkTestShared
                 AZ::AzTestShared
                 AZ::AzFramework
+                Gem::Atom_RPI.TestUtils.Static
                 Gem::LmbrCentral.Mocks
                 Gem::GradientSignal.Mocks
                 Gem::Terrain.Mocks

--- a/Gems/Terrain/Code/Tests/TerrainTestFixtures.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainTestFixtures.cpp
@@ -11,7 +11,9 @@
 
 #include <Atom/RPI.Reflect/Image/ImageMipChainAsset.h>
 #include <Atom/RPI.Reflect/Image/StreamingImageAssetHandler.h>
+#include <Atom/RPI.Public/RPISystem.h>
 #include <AzFramework/Components/TransformComponent.h>
+#include <AzFramework/Scene/SceneSystemComponent.h>
 #include <GradientSignal/Components/GradientSurfaceDataComponent.h>
 #include <GradientSignal/Components/GradientTransformComponent.h>
 #include <GradientSignal/Components/RandomGradientComponent.h>
@@ -44,6 +46,7 @@ namespace UnitTest
         AddDynamicModulePaths({ "LmbrCentral", "SurfaceData", "GradientSignal" });
 
         AddComponentDescriptors({
+            AzFramework::SceneSystemComponent::CreateDescriptor(),
             AzFramework::TransformComponent::CreateDescriptor(),
 
             Terrain::TerrainHeightGradientListComponent::CreateDescriptor(),
@@ -78,6 +81,12 @@ namespace UnitTest
         SurfaceData::SurfaceDataProviderRequestBus::GetOrCreateContext();
         SurfaceData::SurfaceDataModifierRequestBus::GetOrCreateContext();
         LmbrCentral::ShapeComponentRequestsBus::GetOrCreateContext();
+
+        // Call the AZ::RPI::RPISystem reflection for use with the terrain rendering component unit tests.
+        auto serializeContext = AZ::ReflectionEnvironment::GetReflectionManager()
+            ? AZ::ReflectionEnvironment::GetReflectionManager()->GetReflectContext<AZ::SerializeContext>()
+            : nullptr;
+        AZ::RPI::RPISystem::Reflect(serializeContext);
     }
 
     void TerrainBaseFixture::SetupCoreSystems()

--- a/Gems/Terrain/Code/Tests/TerrainTestFixtures.h
+++ b/Gems/Terrain/Code/Tests/TerrainTestFixtures.h
@@ -89,7 +89,7 @@ namespace UnitTest
         void CreateTestTerrainSystemWithSurfaceGradients(const AZ::Aabb& worldBounds, float queryResolution);
         void DestroyTestTerrainSystem();
 
-    protected:
+    private:
         // State data for a full test terrain system setup.
         AZStd::vector<AZStd::unique_ptr<AZ::Entity>> m_heightGradientEntities;
         AZStd::vector<AZStd::unique_ptr<AZ::Entity>> m_surfaceGradientEntities;

--- a/Gems/Terrain/Code/Tests/TerrainWorldComponentTests.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainWorldComponentTests.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Components/TerrainWorldComponent.h>
+
+#include <AzTest/AzTest.h>
+
+#include <TerrainTestFixtures.h>
+
+class TerrainWorldComponentTest
+    : public UnitTest::TerrainTestFixture
+{
+};
+
+TEST_F(TerrainWorldComponentTest, ComponentActivatesSuccessfully)
+{
+    auto entity = CreateEntity();
+
+    entity->CreateComponent<Terrain::TerrainWorldComponent>();
+
+    ActivateEntity(entity.get());
+    EXPECT_EQ(entity->GetState(), AZ::Entity::State::Active);
+
+    entity.reset();
+}

--- a/Gems/Terrain/Code/Tests/TerrainWorldDebuggerComponentTests.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainWorldDebuggerComponentTests.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Components/TerrainWorldComponent.h>
+#include <Components/TerrainWorldDebuggerComponent.h>
+
+#include <AzTest/AzTest.h>
+
+#include <TerrainTestFixtures.h>
+
+class TerrainWorldDebuggerComponentTest
+    : public UnitTest::TerrainTestFixture
+{
+};
+
+TEST_F(TerrainWorldDebuggerComponentTest, MissingRequiredComponentsActivateFailure)
+{
+    auto entity = CreateEntity();
+
+    entity->CreateComponent<Terrain::TerrainWorldDebuggerComponent>();
+
+    // This should report failure because it depends on a missing TerrainWorldCmponent.
+    const AZ::Entity::DependencySortOutcome sortOutcome = entity->EvaluateDependenciesGetDetails();
+    EXPECT_FALSE(sortOutcome.IsSuccess());
+
+    entity.reset();
+}
+
+TEST_F(TerrainWorldDebuggerComponentTest, ComponentActivatesSuccessfully)
+{
+    auto entity = CreateEntity();
+
+    entity->CreateComponent<Terrain::TerrainWorldComponent>();
+    entity->CreateComponent<Terrain::TerrainWorldDebuggerComponent>();
+
+    ActivateEntity(entity.get());
+    EXPECT_EQ(entity->GetState(), AZ::Entity::State::Active);
+
+    entity.reset();
+}

--- a/Gems/Terrain/Code/Tests/TerrainWorldDebuggerComponentTests.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainWorldDebuggerComponentTests.cpp
@@ -18,19 +18,6 @@ class TerrainWorldDebuggerComponentTest
 {
 };
 
-TEST_F(TerrainWorldDebuggerComponentTest, MissingRequiredComponentsActivateFailure)
-{
-    auto entity = CreateEntity();
-
-    entity->CreateComponent<Terrain::TerrainWorldDebuggerComponent>();
-
-    // This should report failure because it depends on a missing TerrainWorldCmponent.
-    const AZ::Entity::DependencySortOutcome sortOutcome = entity->EvaluateDependenciesGetDetails();
-    EXPECT_FALSE(sortOutcome.IsSuccess());
-
-    entity.reset();
-}
-
 TEST_F(TerrainWorldDebuggerComponentTest, ComponentActivatesSuccessfully)
 {
     auto entity = CreateEntity();

--- a/Gems/Terrain/Code/Tests/TerrainWorldRendererComponentTests.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainWorldRendererComponentTests.cpp
@@ -71,19 +71,6 @@ private:
     AZStd::unique_ptr<AZ::Entity> m_sceneSystemEntity;
 };
 
-TEST_F(TerrainWorldRendererComponentTest, MissingRequiredComponentsActivateFailure)
-{
-    auto entity = CreateEntity();
-
-    entity->CreateComponent<Terrain::TerrainWorldRendererComponent>();
-
-    // This should report failure because it depends on a missing TerrainWorldComponent.
-    const AZ::Entity::DependencySortOutcome sortOutcome = entity->EvaluateDependenciesGetDetails();
-    EXPECT_FALSE(sortOutcome.IsSuccess());
-
-    entity.reset();
-}
-
 TEST_F(TerrainWorldRendererComponentTest, ComponentActivatesSuccessfully)
 {
     auto entity = CreateEntity();

--- a/Gems/Terrain/Code/Tests/TerrainWorldRendererComponentTests.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainWorldRendererComponentTests.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Components/TerrainWorldComponent.h>
+#include <Components/TerrainWorldRendererComponent.h>
+
+#include <Atom/RPI.Public/RPISystem.h>
+#include <Common/RHI/Stubs.h>
+#include <Common/RHI/Factory.h>
+#include <AzFramework/Scene/SceneSystemComponent.h>
+
+#include <AzCore/UnitTest/Mocks/MockFileIOBase.h>
+#include <Tests/FileIOBaseTestTypes.h>
+
+#include <AzTest/AzTest.h>
+
+#include <TerrainTestFixtures.h>
+
+class TerrainWorldRendererComponentTest
+    : public UnitTest::TerrainTestFixture
+{
+protected:
+    TerrainWorldRendererComponentTest()
+        : m_restoreFileIO(m_fileIOMock)
+    {
+        // Install Mock File IO, since the ShaderMetricsSystem inside of Atom's RPISystem will try to read/write a file.
+        AZ::IO::MockFileIOBase::InstallDefaultReturns(m_fileIOMock);
+    }
+
+    void SetUp() override
+    {
+        UnitTest::TerrainTestFixture::SetUp();
+
+        // Create the SceneSystemComponent for use by Atom
+        m_sceneSystemEntity = CreateEntity();
+        m_sceneSystemEntity->CreateComponent<AzFramework::SceneSystemComponent>();
+        ActivateEntity(m_sceneSystemEntity.get());
+
+        // Create a stub RHI for use by Atom
+        m_rhiFactory.reset(aznew UnitTest::StubRHI::Factory());
+
+        // Create the Atom RPISystem
+        AZ::RPI::RPISystemDescriptor rpiSystemDescriptor;
+        m_rpiSystem = AZStd::make_unique<AZ::RPI::RPISystem>();
+        m_rpiSystem->Initialize(rpiSystemDescriptor);
+    }
+
+    void TearDown() override
+    {
+        m_rpiSystem->Shutdown();
+        m_rpiSystem = nullptr;
+        m_rhiFactory = nullptr;
+
+        m_sceneSystemEntity.reset();
+
+        UnitTest::TerrainTestFixture::TearDown();
+    }
+
+private:
+    AZStd::unique_ptr<UnitTest::StubRHI::Factory> m_rhiFactory;
+    AZStd::unique_ptr<AZ::RPI::RPISystem> m_rpiSystem;
+
+    UnitTest::SetRestoreFileIOBaseRAII m_restoreFileIO;
+    ::testing::NiceMock<AZ::IO::MockFileIOBase> m_fileIOMock;
+
+    AZStd::unique_ptr<AZ::Entity> m_sceneSystemEntity;
+};
+
+TEST_F(TerrainWorldRendererComponentTest, MissingRequiredComponentsActivateFailure)
+{
+    auto entity = CreateEntity();
+
+    entity->CreateComponent<Terrain::TerrainWorldRendererComponent>();
+
+    // This should report failure because it depends on a missing TerrainWorldComponent.
+    const AZ::Entity::DependencySortOutcome sortOutcome = entity->EvaluateDependenciesGetDetails();
+    EXPECT_FALSE(sortOutcome.IsSuccess());
+
+    entity.reset();
+}
+
+TEST_F(TerrainWorldRendererComponentTest, ComponentActivatesSuccessfully)
+{
+    auto entity = CreateEntity();
+
+    entity->CreateComponent<Terrain::TerrainWorldComponent>();
+    entity->CreateComponent<Terrain::TerrainWorldRendererComponent>();
+
+    ActivateEntity(entity.get());
+    EXPECT_EQ(entity->GetState(), AZ::Entity::State::Active);
+
+    entity.reset();
+}

--- a/Gems/Terrain/Code/terrain_tests_files.cmake
+++ b/Gems/Terrain/Code/terrain_tests_files.cmake
@@ -18,6 +18,9 @@ set(FILES
     Tests/TerrainSurfaceGradientListTests.cpp
     Tests/TerrainSystemBenchmarks.cpp
     Tests/TerrainSystemTest.cpp
+    Tests/TerrainWorldComponentTests.cpp
+    Tests/TerrainWorldDebuggerComponentTests.cpp
+    Tests/TerrainWorldRendererComponentTests.cpp
     Tests/TerrainTest.cpp
     Tests/TerrainTestFixtures.cpp
     Tests/TerrainTestFixtures.h


### PR DESCRIPTION
## What does this PR do?

This adds unit tests that successfully activate/deactivate the Terrain World component, Terrain World Debugger component, and the Terrain World Renderer component. Even though the tests are simple, they at least raise the minimum bar of functionality for the components a few steps beyond "it compiles". For example, it will catch any memory leaks or unexpected system dependencies.

To make it possible to activate the Terrain World Renderer, I also needed to extract some of the Atom RPI test harness code into a separate build target so that I could use it from the Terrain tests as well, without needing to rewrite and maintain two versions of the test harness.

## How was this PR tested?

Ran the unit tests for Atom and Terrain and verified they all ran and passed.
