### PR TITLE
Fix bug template to remove mac os typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -35,7 +35,7 @@ Name of or link to the branch where the issue occurs.
 **Desktop/Device (please complete the following information):**
  - Device: [e.g. PC, Mac, iPhone, Samsung] 
  - OS: [e.g. Windows, macOS, iOS, Android]
- - Version [e.g. 10, Bug Sur, Oreo]
+ - Version [e.g. 10, Monterey, Oreo]
  - CPU [e.g. Intel I9-9900k , Ryzen 5900x, ]
  - GPU [AMD 6800 XT, NVidia RTX 3090]
  - Memory [e.g. 16GB]


### PR DESCRIPTION
## What does this PR do?

Fixes typo in big sur name, updates to latest Mac OS codename in bug template.

## How was this PR tested?

N/A - Change is for a process file, confirmed text change through visual inspection.

Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>

