### PR TITLE
Simplify autogen usage by using environment variable

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -1321,9 +1321,13 @@ namespace AZ
 
         }
 
-        // All dynamic modules have been gathered at this point
-        for (ModuleInitializationSteps lastStepToPerform :
-             { ModuleInitializationSteps::CreateClass, ModuleInitializationSteps::RegisterComponentDescriptors })
+        // All dynamic modules have been gathered at this point, and each dynamic module will be up until follow two phases:
+        // 1. Load - the first call is to load ensure all dynamic modules are loaded
+        // 1. CreateClass - the second call is to created specific AZ::Module class instances for each dynamic module after its loaded
+        // 2. RegisterComponentDescriptors - the third call is to perform a horizontal register step for each module component descriptos after
+        //    module has been loaded and created
+        for (ModuleInitializationSteps lastStepToPerform : { ModuleInitializationSteps::Load,
+            ModuleInitializationSteps::CreateClass, ModuleInitializationSteps::RegisterComponentDescriptors })
         {
             AZ::ModuleManagerRequests::LoadModulesResult loadModuleOutcomes;
             ModuleManagerRequestBus::BroadcastResult(

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -1322,15 +1322,20 @@ namespace AZ
         }
 
         // All dynamic modules have been gathered at this point
-        AZ::ModuleManagerRequests::LoadModulesResult loadModuleOutcomes;
-        ModuleManagerRequestBus::BroadcastResult(loadModuleOutcomes, &ModuleManagerRequests::LoadDynamicModules, gemModules, ModuleInitializationSteps::RegisterComponentDescriptors, true);
+        for (ModuleInitializationSteps lastStepToPerform :
+             { ModuleInitializationSteps::CreateClass, ModuleInitializationSteps::RegisterComponentDescriptors })
+        {
+            AZ::ModuleManagerRequests::LoadModulesResult loadModuleOutcomes;
+            ModuleManagerRequestBus::BroadcastResult(
+                loadModuleOutcomes, &ModuleManagerRequests::LoadDynamicModules, gemModules, lastStepToPerform, true);
 
 #if defined(AZ_ENABLE_TRACING)
-        for (const auto& loadModuleOutcome : loadModuleOutcomes)
-        {
-            AZ_Error("ComponentApplication", loadModuleOutcome.IsSuccess(), "%s", loadModuleOutcome.GetError().c_str());
-        }
+            for (const auto& loadModuleOutcome : loadModuleOutcomes)
+            {
+                AZ_Error("ComponentApplication", loadModuleOutcome.IsSuccess(), "%s", loadModuleOutcome.GetError().c_str());
+            }
 #endif
+        }
     }
 
     void ComponentApplication::Tick()

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -1321,10 +1321,10 @@ namespace AZ
 
         }
 
-        // All dynamic modules have been gathered at this point, and each dynamic module will be up until follow two phases:
-        // 1. Load - the first call is to load ensure all dynamic modules are loaded
-        // 1. CreateClass - the second call is to created specific AZ::Module class instances for each dynamic module after its loaded
-        // 2. RegisterComponentDescriptors - the third call is to perform a horizontal register step for each module component descriptos after
+        // All dynamic modules have been gathered at this point, and each dynamic module will be up until follow three phases:
+        // 1. Load - the first call is to ensure all dynamic modules are loaded
+        // 2. CreateClass - the second call is to create specific AZ::Module class instances for each dynamic module after its loaded
+        // 3. RegisterComponentDescriptors - the third call is to perform a horizontal register step for each module component descriptos after
         //    module has been loaded and created
         for (ModuleInitializationSteps lastStepToPerform : { ModuleInitializationSteps::Load,
             ModuleInitializationSteps::CreateClass, ModuleInitializationSteps::RegisterComponentDescriptors })

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
@@ -21,6 +21,8 @@ namespace ScriptCanvas
     static constexpr int MaxMessageLength = 4096;
     static constexpr const char ScriptCanvasAutoGenRegistrationWarningMessage[] = "[Warning] Registry name %s is occupied already, ignore AutoGen registry registration.\n";
 
+    static AZ::EnvironmentVariable<AutoGenRegistryManager> g_autogenRegistry;
+
     AutoGenRegistryManager::~AutoGenRegistryManager()
     {
         m_registries.clear();
@@ -28,10 +30,20 @@ namespace ScriptCanvas
 
     AutoGenRegistryManager* AutoGenRegistryManager::GetInstance()
     {
-        // Use static object so each module will keep its own registry collection
-        static AutoGenRegistryManager s_autogenRegistry;
+        // Look up variable in AZ::Environment first
+        // This is need if the Environment variable was already created
+        if (!g_autogenRegistry)
+        {
+            g_autogenRegistry = AZ::Environment::FindVariable<AutoGenRegistryManager>(ScriptCanvasAutoGenRegistryName);
+        }
 
-        return &s_autogenRegistry;
+        // Create the environment variable in this memory space if it has not been found
+        if (!g_autogenRegistry)
+        {
+            g_autogenRegistry = AZ::Environment::CreateVariable<AutoGenRegistryManager>(ScriptCanvasAutoGenRegistryName);
+        }
+
+        return &(g_autogenRegistry.Get());
     }
 
     AZStd::vector<AZStd::string> AutoGenRegistryManager::GetRegistryNames(const char* registryName)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
@@ -37,7 +37,7 @@ namespace ScriptCanvas
             g_autogenRegistry = AZ::Environment::FindVariable<AutoGenRegistryManager>(ScriptCanvasAutoGenRegistryName);
         }
 
-        // Create the environment variable in this memory space if it has not been found
+        // Create the environment variable in O3DEKernel memory space if it has not been found
         if (!g_autogenRegistry)
         {
             g_autogenRegistry = AZ::Environment::CreateVariable<AutoGenRegistryManager>(ScriptCanvasAutoGenRegistryName);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
@@ -28,13 +28,10 @@ namespace AZ
 #define REGISTER_SCRIPTCANVAS_AUTOGEN_GRAMMAR(LIBRARY)\
     static ScriptCanvas::LIBRARY##GrammarRegistry s_AutoGenGrammarRegistry;
 
-//! AutoGen registry util macros
-#define INIT_SCRIPTCANVAS_AUTOGEN(LIBRARY)\
-    ScriptCanvas::AutoGenRegistryManager::Init(#LIBRARY);
-#define REFLECT_SCRIPTCANVAS_AUTOGEN(LIBRARY, CONTEXT)\
-    ScriptCanvas::AutoGenRegistryManager::Reflect(CONTEXT, #LIBRARY);
-#define GET_SCRIPTCANVAS_AUTOGEN_COMPONENT_DESCRIPTORS(LIBRARY)\
-    ScriptCanvas::AutoGenRegistryManager::GetComponentDescriptors(#LIBRARY)
+//! Not used anymore, keep it for backward compatibility
+#define INIT_SCRIPTCANVAS_AUTOGEN(LIBRARY)
+#define REFLECT_SCRIPTCANVAS_AUTOGEN(LIBRARY, CONTEXT)
+#define GET_SCRIPTCANVAS_AUTOGEN_COMPONENT_DESCRIPTORS(LIBRARY)
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Source/ScriptCanvasCommonGem.cpp
+++ b/Gems/ScriptCanvas/Code/Source/ScriptCanvasCommonGem.cpp
@@ -10,6 +10,7 @@
 #include <SystemComponent.h>
 
 #include <Asset/RuntimeAssetSystemComponent.h>
+#include <ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h>
 #include <ScriptCanvas/Core/Graph.h>
 #include <ScriptCanvas/Core/Connection.h>
 
@@ -54,6 +55,15 @@ namespace ScriptCanvas
 
         MathNodeUtilities::RandomEngineInit();
         InitDataRegistry();
+
+        ScriptCanvas::AutoGenRegistryManager::Init();
+        if (auto componentApplication = AZ::Interface<AZ::ComponentApplicationRequests>::Get())
+        {
+            for (auto descriptor : ScriptCanvas::AutoGenRegistryManager::GetComponentDescriptors())
+            {
+                componentApplication->RegisterComponentDescriptor(descriptor);
+            }
+        }
     }
 
     ScriptCanvasModuleCommon::~ScriptCanvasModuleCommon()

--- a/Gems/ScriptCanvas/Code/Source/ScriptCanvasCommonGem.cpp
+++ b/Gems/ScriptCanvas/Code/Source/ScriptCanvasCommonGem.cpp
@@ -21,7 +21,6 @@
 #include <ScriptCanvas/Libraries/Libraries.h>
 #include <ScriptCanvas/Libraries/Math/MathNodeUtilities.h>
 #include <ScriptCanvas/Variable/GraphVariableManagerComponent.h>
-#include <AutoGenNodeableRegistry.generated.h>
 
 namespace ScriptCanvas
 {
@@ -55,10 +54,6 @@ namespace ScriptCanvas
 
         MathNodeUtilities::RandomEngineInit();
         InitDataRegistry();
-
-        INIT_SCRIPTCANVAS_AUTOGEN(ScriptCanvasStatic)
-        auto autogenDescriptors = GET_SCRIPTCANVAS_AUTOGEN_COMPONENT_DESCRIPTORS(ScriptCanvasStatic);
-        m_descriptors.insert(m_descriptors.end(), autogenDescriptors.begin(), autogenDescriptors.end());
     }
 
     ScriptCanvasModuleCommon::~ScriptCanvasModuleCommon()

--- a/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
@@ -152,15 +152,6 @@ namespace ScriptCanvas
 
         m_infiniteLoopDetectionMaxIterations = ScriptCanvasSystemComponentCpp::k_infiniteLoopDetectionMaxIterations;
         m_maxHandlerStackDepth = ScriptCanvasSystemComponentCpp::k_maxHandlerStackDepth;
-
-        ScriptCanvas::AutoGenRegistryManager::Init();
-        if (auto componentApplication = AZ::Interface<AZ::ComponentApplicationRequests>::Get())
-        {
-            for (auto descriptor : ScriptCanvas::AutoGenRegistryManager::GetComponentDescriptors())
-            {
-                componentApplication->RegisterComponentDescriptor(descriptor);
-            }
-        }
     }
 
     void SystemComponent::Activate()

--- a/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
@@ -82,7 +82,7 @@ namespace ScriptCanvas
 
     void SystemComponent::Reflect(AZ::ReflectContext* context)
     {
-        REFLECT_SCRIPTCANVAS_AUTOGEN(ScriptCanvasStatic, context);
+        ScriptCanvas::AutoGenRegistryManager::Reflect(context);
         VersionData::Reflect(context);
         Nodeable::Reflect(context);
         SourceHandle::Reflect(context);
@@ -152,6 +152,15 @@ namespace ScriptCanvas
 
         m_infiniteLoopDetectionMaxIterations = ScriptCanvasSystemComponentCpp::k_infiniteLoopDetectionMaxIterations;
         m_maxHandlerStackDepth = ScriptCanvasSystemComponentCpp::k_maxHandlerStackDepth;
+
+        ScriptCanvas::AutoGenRegistryManager::Init();
+        if (auto componentApplication = AZ::Interface<AZ::ComponentApplicationRequests>::Get())
+        {
+            for (auto descriptor : ScriptCanvas::AutoGenRegistryManager::GetComponentDescriptors())
+            {
+                componentApplication->RegisterComponentDescriptor(descriptor);
+            }
+        }
     }
 
     void SystemComponent::Activate()

--- a/Gems/ScriptCanvasPhysics/Code/Source/ScriptCanvasPhysicsSystemComponent.cpp
+++ b/Gems/ScriptCanvasPhysics/Code/Source/ScriptCanvasPhysicsSystemComponent.cpp
@@ -19,8 +19,6 @@ namespace ScriptCanvasPhysics
 {
     void ScriptCanvasPhysicsSystemComponent::Reflect(AZ::ReflectContext* context)
     {
-        REFLECT_SCRIPTCANVAS_AUTOGEN(ScriptCanvasPhysicsStatic, context);
-
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<ScriptCanvasPhysicsSystemComponent, AZ::Component>()

--- a/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
@@ -38,6 +38,9 @@
 #define SC_EXPECT_DOUBLE_EQ(candidate, reference) EXPECT_NEAR(candidate, reference, 0.001)
 #define SC_EXPECT_FLOAT_EQ(candidate, reference) EXPECT_NEAR(candidate, reference, 0.001f)
 
+REGISTER_SCRIPTCANVAS_AUTOGEN_FUNCTION(ScriptCanvasTestingEditorStatic);
+REGISTER_SCRIPTCANVAS_AUTOGEN_NODEABLE(ScriptCanvasTestingEditorStatic);
+
 namespace ScriptCanvasTests
 {
 
@@ -116,10 +119,6 @@ namespace ScriptCanvasTests
             TestNodeableObject::Reflect(m_behaviorContext);
             ScriptUnitTestEventHandler::Reflect(m_serializeContext);
             ScriptUnitTestEventHandler::Reflect(m_behaviorContext);
-
-            REGISTER_SCRIPTCANVAS_AUTOGEN_FUNCTION(ScriptCanvasTestingEditorStatic);
-            REGISTER_SCRIPTCANVAS_AUTOGEN_NODEABLE(ScriptCanvasTestingEditorStatic);
-            REFLECT_SCRIPTCANVAS_AUTOGEN(ScriptCanvasTestingEditorStatic, m_behaviorContext);
         }
 
         static void TearDownTestCase()
@@ -159,11 +158,6 @@ namespace ScriptCanvasTests
 
             RegisterComponentDescriptor<TestNodes::TestResult>();
             RegisterComponentDescriptor<TestNodes::ConfigurableUnitTestNode>();
-            auto autogenDescriptors = GET_SCRIPTCANVAS_AUTOGEN_COMPONENT_DESCRIPTORS(ScriptCanvasTestingEditorStatic);
-            for (auto descriptor : autogenDescriptors)
-            {
-                GetApplication()->RegisterComponentDescriptor(descriptor);
-            }
 
             m_numericVectorType = ScriptCanvas::Data::Type::BehaviorContextObject(azrtti_typeid<AZStd::vector<ScriptCanvas::Data::NumberType>>());
             m_stringToNumberMapType = ScriptCanvas::Data::Type::BehaviorContextObject(azrtti_typeid<AZStd::unordered_map<ScriptCanvas::Data::StringType, ScriptCanvas::Data::NumberType>>());

--- a/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingEditorModule.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingEditorModule.cpp
@@ -30,10 +30,6 @@ namespace ScriptCanvasTesting
                 ScriptCanvasTestingSystemComponent::CreateDescriptor(),
                 TraceMessageComponent::CreateDescriptor(),
             });
-
-            AZStd::vector<AZ::ComponentDescriptor*> componentDescriptors(
-                GET_SCRIPTCANVAS_AUTOGEN_COMPONENT_DESCRIPTORS(ScriptCanvasTestingEditorStatic));
-            m_descriptors.insert(m_descriptors.end(), componentDescriptors.begin(), componentDescriptors.end());
         }
 
         /**

--- a/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingSystemComponent.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingSystemComponent.cpp
@@ -42,7 +42,6 @@ namespace ScriptCanvasTesting
 
         ScriptCanvasTestingNodes::BehaviorContextObjectTest::Reflect(context);
         ScriptCanvasTesting::Reflect(context);
-        REFLECT_SCRIPTCANVAS_AUTOGEN(ScriptCanvasTestingEditorStatic, context);
     }
 
     void ScriptCanvasTestingSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
@@ -67,7 +66,6 @@ namespace ScriptCanvasTesting
 
     void ScriptCanvasTestingSystemComponent::Init()
     {
-        INIT_SCRIPTCANVAS_AUTOGEN(ScriptCanvasTestingEditorStatic);
     }
 
     void ScriptCanvasTestingSystemComponent::Activate()

--- a/Gems/StartingPointInput/Code/Source/StartingPointInputGem.cpp
+++ b/Gems/StartingPointInput/Code/Source/StartingPointInputGem.cpp
@@ -115,7 +115,6 @@ namespace StartingPointInput
 
         static void Reflect(AZ::ReflectContext* context)
         {
-            REFLECT_SCRIPTCANVAS_AUTOGEN(StartingPointInputStatic, context);
             InputEventBindingsAsset::Reflect(context);
             InputEventBindings::Reflect(context);
             InputEventGroup::Reflect(context);
@@ -175,7 +174,6 @@ namespace StartingPointInput
 
         void Init() override
         {
-            INIT_SCRIPTCANVAS_AUTOGEN(StartingPointInputStatic);
         }
 
         void Activate() override
@@ -210,9 +208,6 @@ namespace StartingPointInput
                 InputConfigurationComponent::CreateDescriptor(),
                 StartingPointInputSystemComponent::CreateDescriptor(),
             });
-
-            AZStd::vector<AZ::ComponentDescriptor*> autogenDescriptors(GET_SCRIPTCANVAS_AUTOGEN_COMPONENT_DESCRIPTORS(StartingPointInputStatic));
-            m_descriptors.insert(m_descriptors.end(), autogenDescriptors.begin(), autogenDescriptors.end());
         }
 
         AZ::ComponentTypeList GetRequiredSystemComponents() const override

--- a/cmake/AzAutoGen.py
+++ b/cmake/AzAutoGen.py
@@ -37,15 +37,7 @@ class AutoGenConfig:
         self.pythonPaths = pythonPaths
 
 def SanitizeTargetName(targetName):
-    targetNameList = list(targetName)
-    firstAlphabetIndex = -1
-    for i, ch in enumerate(targetNameList):
-        if ch.isalpha() and firstAlphabetIndex == -1:
-            firstAlphabetIndex = i
-        if not ch.isalnum():
-            targetNameList[i] = ""
-
-    return ''.join(targetNameList[firstAlphabetIndex:]) if 0 <= firstAlphabetIndex < len(targetNameList) else ""
+    return re.sub(r'[^\w]', '', targetName.lstrip('0123456789'))
 
 def ParseInputFile(inputFilePath):
     result = []

--- a/cmake/AzAutoGen.py
+++ b/cmake/AzAutoGen.py
@@ -37,7 +37,15 @@ class AutoGenConfig:
         self.pythonPaths = pythonPaths
 
 def SanitizeTargetName(targetName):
-    return ''.join(ch for ch in targetName if ch.isalnum())
+    targetNameList = list(targetName)
+    firstAlphabetIndex = -1
+    for i, ch in enumerate(targetNameList):
+        if ch.isalpha() and firstAlphabetIndex == -1:
+            firstAlphabetIndex = i
+        if not ch.isalnum():
+            targetNameList[i] = ""
+
+    return ''.join(targetNameList[firstAlphabetIndex:]) if 0 <= firstAlphabetIndex < len(targetNameList) else ""
 
 def ParseInputFile(inputFilePath):
     result = []

--- a/cmake/AzAutoGen.py
+++ b/cmake/AzAutoGen.py
@@ -37,7 +37,7 @@ class AutoGenConfig:
         self.pythonPaths = pythonPaths
 
 def SanitizeTargetName(targetName):
-    return targetName.replace('.', '').replace('::', '')
+    return ''.join(ch for ch in targetName if ch.isalnum())
 
 def ParseInputFile(inputFilePath):
     result = []


### PR DESCRIPTION
## What does this PR do?
Because of this change https://github.com/o3de/o3de/pull/8790, we can utilize Environment variable to store static object across modules, which hugely simply ScriptCanvas autogen use case.

Extra:
1. In order to support this change, have to change module load workflow by breaking CreateClass and RegisterComponentDescriptors into separate loop. So all static objects from Gems can be created in CreateClass step, then when invoke RegisterComponentDescriptors step, all required static objects can be found. (module loading process is idempotent, it should be safe to break into separate loop) 
2. During game jam, find out user can give random informal project name, update current sanitized target name logic by taking alphabetic letter and number only

## How was this PR tested?
All ScriptCanvas nodes can be registered correctly.
Unit Test pass.

Signed-off-by: onecent1101 <liug@amazon.com>