### PR TITLE
Fixed crash when heightfield baking is requested for a non-existing heightfield

### DIFF
--- a/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.h
@@ -68,6 +68,7 @@ namespace PhysX
         AZ::u32 OnConfigurationChanged();
         AZ::u32 OnToggleBakedHeightfield();
         AZ::u32 GetBakedHeightfieldVisibilitySetting() const;
+        bool IsHeightfieldInvalid() const;
 
         // Utility functions for heightfield baking
         void StartHeightfieldBakingJob();


### PR DESCRIPTION

Signed-off-by: Sergey Pereslavtsev <pereslav@amazon.com>

## What does this PR do?

Fixes #10792 - a crash when heightfield baking is requested for a component that has no heightfield. There was no TerrainSystem in the level, hence no physics heightfield was created.

Made the checkbox to be disabled in the UI in this case and added a safety check in the baking function.

## How was this PR tested?

Various manual testing
