### PR TITLE
displaymapper null-render test update

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
@@ -164,11 +164,8 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
 
         for operation_type in DISPLAY_MAPPER_OPERATION_TYPE.keys():
             # 5. Set the Display Mapper Operation Type enumerated in DISPLAY_MAPPER_OPERATION_TYPE for each type
-            # Type property cannot be set currently. as a workaround we are calling an ebus to set the operation type
-            # display_mapper_component.set_component_property_value(
-            #     AtomComponentProperties.display_mapper('Type'), DISPLAY_MAPPER_OPERATION_TYPE[operation_type])
-            render.DisplayMapperComponentRequestBus(
-                bus.Broadcast, "SetDisplayMapperOperationType", DISPLAY_MAPPER_OPERATION_TYPE[operation_type])
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Type'), DISPLAY_MAPPER_OPERATION_TYPE[operation_type])
             general.idle_wait_frames(3)
             set_type = render.DisplayMapperComponentRequestBus(bus.Broadcast, "GetDisplayMapperOperationType")
             Report.info(f"DiplayMapperOperationType: {set_type}")
@@ -371,11 +368,14 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
         cinema_limit_white_presets = [48.0, 184.3200073, 368.6400146, 737.2800293]
         for preset in DISPLAY_MAPPER_PRESET.keys():
             # 19. Select and load each preset
-            # Preset Selection cannot be set or loaded currently; as a workaround we are calling an ebus to load preset
-            # A fix is in progress
-            # display_mapper_component.set_component_property_value(
-            #     AtomComponentProperties.display_mapper('Preset Selection'), DISPLAY_MAPPER_PRESET[preset])
-            render.DisplayMapperComponentRequestBus(bus.Broadcast, "LoadPreset", DISPLAY_MAPPER_PRESET[preset])
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Preset Selection'), DISPLAY_MAPPER_PRESET[preset])
+            general.idle_wait_frames(1)
+            render.DisplayMapperComponentRequestBus(
+                bus.Broadcast,
+                "LoadPreset",
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Preset Selection')))
             general.idle_wait_frames(1)
             # check some value to confirm preset loaded
             test_preset = (f"Preset {preset} loaded expected value",

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DisplayMapperAdded.py
@@ -202,12 +202,8 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
 
         for operation_type in DISPLAY_MAPPER_OPERATION_TYPE.keys():
             # 6. Set the Display Mapper Operation Type enumerated in DISPLAY_MAPPER_OPERATION_TYPE for each type
-            # Type property cannot be set currently. as a workaround we are calling an ebus to set the operation type
-            # A fix is in progress
-            # display_mapper_component.set_component_property_value(
-            #     AtomComponentProperties.display_mapper('Type'), DISPLAY_MAPPER_OPERATION_TYPE[operation_type])
-            render.DisplayMapperComponentRequestBus(
-                bus.Broadcast, "SetDisplayMapperOperationType", DISPLAY_MAPPER_OPERATION_TYPE[operation_type])
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Type'), DISPLAY_MAPPER_OPERATION_TYPE[operation_type])
             general.idle_wait_frames(3)
             set_type = render.DisplayMapperComponentRequestBus(bus.Broadcast, "GetDisplayMapperOperationType")
             Report.info(f"DiplayMapperOperationType: {set_type}")
@@ -410,11 +406,14 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
         cinema_limit_white_presets = [48.0, 184.3200073, 368.6400146, 737.2800293]
         for preset in DISPLAY_MAPPER_PRESET.keys():
             # 20. Select and load each preset
-            # Preset Selection cannot be set or loaded currently; as a workaround we are calling an ebus to load preset
-            # A fix is in progress
-            # display_mapper_component.set_component_property_value(
-            #     AtomComponentProperties.display_mapper('Preset Selection'), DISPLAY_MAPPER_PRESET[preset])
-            render.DisplayMapperComponentRequestBus(bus.Broadcast, "LoadPreset", DISPLAY_MAPPER_PRESET[preset])
+            display_mapper_component.set_component_property_value(
+                AtomComponentProperties.display_mapper('Preset Selection'), DISPLAY_MAPPER_PRESET[preset])
+            general.idle_wait_frames(1)
+            render.DisplayMapperComponentRequestBus(
+                bus.Broadcast,
+                "LoadPreset",
+                display_mapper_component.get_component_property_value(
+                    AtomComponentProperties.display_mapper('Preset Selection')))
             general.idle_wait_frames(1)
             # check some value to confirm preset loaded
             test_preset = (f"Preset {preset} loaded expected value",


### PR DESCRIPTION
Signed-off-by: Scott Murray <scottmur@amazon.com>

## What does this PR do?
updates display mapper null-render AR tests to set/get previously unreachable properties.
while I can now set/get the preset, I am still calling the ebus to load the preset since the button isn't otherwise exposed to python automation.

https://github.com/o3de/o3de/issues/8348

## How was this PR tested?
this was run in editor for both test scripts with no failures
there was a warning in the output, but this was present before these changes
`[Warning] (AzToolsFramework) - GenericValue could not be found in the combo box`

```
    Start 164: AutomatedTesting::Atom_Main_Null_Render_02.main::TEST_RUN
1/4 Test #164: AutomatedTesting::Atom_Main_Null_Render_02.main::TEST_RUN ...   Passed   53.53 sec
    Start 165: AutomatedTesting::Atom_Main_Null_Render_03.main::TEST_RUN
2/4 Test #165: AutomatedTesting::Atom_Main_Null_Render_03.main::TEST_RUN ...   Passed   45.71 sec
    Start 162: AutomatedTesting::Atom_Main_Null_Render_00.main::TEST_RUN
3/4 Test #162: AutomatedTesting::Atom_Main_Null_Render_00.main::TEST_RUN ...   Passed   35.63 sec
    Start 163: AutomatedTesting::Atom_Main_Null_Render_01.main::TEST_RUN
4/4 Test #163: AutomatedTesting::Atom_Main_Null_Render_01.main::TEST_RUN ...   Passed   44.77 sec
```

```
(python_test) - Success: Level has a Display Mapper component
Undo (Undo:1,Redo:1)
(python_test) - Success: UNDO level component addition success
Redo (Undo:2,Redo:0)
(python_test) - Success: REDO Level component addition success
(python_test) - Success: LDR color Grading LUT asset set
(python_test) - Info: DiplayMapperOperationType: 0
(python_test) - Success: Display Mapper Operation Type is correctly set
(python_test) - Success: Enable LDR color grading LUT set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Cinema Limit (black) property set to maximum value
(python_test) - Success: Cinema Limit (black) property set to minimum value
(python_test) - Success: Cinema Limit (white) property set to maximum value
(python_test) - Success: Cinema Limit (white) property set to minimum value
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Info: Entering game mode
Disable Accelerators
Entered game mode
(python_test) - Success: Entered game mode
(python_test) - Info: Exiting game mode
Enable Accelerators
Exited game mode
(python_test) - Success: Exited game mode
(python_test) - Info: DiplayMapperOperationType: 1
(python_test) - Success: Display Mapper Operation Type is correctly set
(python_test) - Success: Enable LDR color grading LUT set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Cinema Limit (black) property set to maximum value
(python_test) - Success: Cinema Limit (black) property set to minimum value
(python_test) - Success: Cinema Limit (white) property set to maximum value
(python_test) - Success: Cinema Limit (white) property set to minimum value
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Info: Entering game mode
Disable Accelerators
Entered game mode
(python_test) - Success: Entered game mode
(python_test) - Info: Exiting game mode
Enable Accelerators
Exited game mode
(python_test) - Success: Exited game mode
(python_test) - Info: DiplayMapperOperationType: 2
(python_test) - Success: Display Mapper Operation Type is correctly set
(python_test) - Success: Enable LDR color grading LUT set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Cinema Limit (black) property set to maximum value
(python_test) - Success: Cinema Limit (black) property set to minimum value
(python_test) - Success: Cinema Limit (white) property set to maximum value
(python_test) - Success: Cinema Limit (white) property set to minimum value
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Info: Entering game mode
Disable Accelerators
Entered game mode
(python_test) - Success: Entered game mode
(python_test) - Info: Exiting game mode
Enable Accelerators
Exited game mode
(python_test) - Success: Exited game mode
(python_test) - Info: DiplayMapperOperationType: 3
(python_test) - Success: Display Mapper Operation Type is correctly set
(python_test) - Success: Enable LDR color grading LUT set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Cinema Limit (black) property set to maximum value
(python_test) - Success: Cinema Limit (black) property set to minimum value
(python_test) - Success: Cinema Limit (white) property set to maximum value
(python_test) - Success: Cinema Limit (white) property set to minimum value
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Info: Entering game mode
Disable Accelerators
Entered game mode
(python_test) - Success: Entered game mode
(python_test) - Info: Exiting game mode
Enable Accelerators
Exited game mode
(python_test) - Success: Exited game mode
(python_test) - Info: DiplayMapperOperationType: 4
(python_test) - Success: Display Mapper Operation Type is correctly set
(python_test) - Success: Enable LDR color grading LUT set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Cinema Limit (black) property set to maximum value
(python_test) - Success: Cinema Limit (black) property set to minimum value
(python_test) - Success: Cinema Limit (white) property set to maximum value
(python_test) - Success: Cinema Limit (white) property set to minimum value
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Info: Entering game mode
Disable Accelerators
Entered game mode
(python_test) - Success: Entered game mode
(python_test) - Info: Exiting game mode
Enable Accelerators
Exited game mode
(python_test) - Success: Exited game mode
(python_test) - Success: Preset 48Nits loaded expected value
(python_test) - Success: Preset 1000Nits loaded expected value
(python_test) - Success: Preset 2000Nits loaded expected value
(python_test) - Success: Preset 4000Nits loaded expected value
(python_test) - Test AtomEditorComponentsLevel_DisplayMapper_AddedToEntity finished.
```

```
(python_test) - Success: Display Mapper Entity successfully created
(python_test) - Success: Entity has a Display Mapper component
Undo (Undo:3,Redo:1)
Undo (Undo:2,Redo:2)
Undo (Undo:1,Redo:3)
Undo (Undo:0,Redo:4)
(python_test) - Success: UNDO Entity creation success
Redo (Undo:1,Redo:3)
Redo (Undo:2,Redo:2)
Redo (Undo:3,Redo:1)
Redo (Undo:4,Redo:0)
(python_test) - Success: REDO Entity creation success
(python_test) - Success: LDR color Grading LUT asset set
(python_test) - Info: DiplayMapperOperationType: 0
(python_test) - Success: Display Mapper Operation Type is correctly set
(python_test) - Success: Enable LDR color grading LUT set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Cinema Limit (black) property set to maximum value
(python_test) - Success: Cinema Limit (black) property set to minimum value
(python_test) - Success: Cinema Limit (white) property set to maximum value
(python_test) - Success: Cinema Limit (white) property set to minimum value
(python_test) - Info: 4.800000190734863
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Info: Entering game mode
Disable Accelerators
Entered game mode
(python_test) - Success: Entered game mode
(python_test) - Info: Exiting game mode
Enable Accelerators
Exited game mode
(python_test) - Success: Exited game mode
(python_test) - Info: DiplayMapperOperationType: 1
(python_test) - Success: Display Mapper Operation Type is correctly set
(python_test) - Success: Enable LDR color grading LUT set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Cinema Limit (black) property set to maximum value
(python_test) - Success: Cinema Limit (black) property set to minimum value
(python_test) - Success: Cinema Limit (white) property set to maximum value
(python_test) - Success: Cinema Limit (white) property set to minimum value
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Info: Entering game mode
Disable Accelerators
Entered game mode
(python_test) - Success: Entered game mode
(python_test) - Info: Exiting game mode
Enable Accelerators
Exited game mode
(python_test) - Success: Exited game mode
(python_test) - Info: DiplayMapperOperationType: 2
(python_test) - Success: Display Mapper Operation Type is correctly set
(python_test) - Success: Enable LDR color grading LUT set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Cinema Limit (black) property set to maximum value
(python_test) - Success: Cinema Limit (black) property set to minimum value
(python_test) - Success: Cinema Limit (white) property set to maximum value
(python_test) - Success: Cinema Limit (white) property set to minimum value
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Info: Entering game mode
Disable Accelerators
Entered game mode
(python_test) - Success: Entered game mode
(python_test) - Info: Exiting game mode
Enable Accelerators
Exited game mode
(python_test) - Success: Exited game mode
(python_test) - Info: DiplayMapperOperationType: 3
(python_test) - Success: Display Mapper Operation Type is correctly set
(python_test) - Success: Enable LDR color grading LUT set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Cinema Limit (black) property set to maximum value
(python_test) - Success: Cinema Limit (black) property set to minimum value
(python_test) - Success: Cinema Limit (white) property set to maximum value
(python_test) - Success: Cinema Limit (white) property set to minimum value
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Info: Entering game mode
Disable Accelerators
Entered game mode
(python_test) - Success: Entered game mode
(python_test) - Info: Exiting game mode
Enable Accelerators
Exited game mode
(python_test) - Success: Exited game mode
(python_test) - Info: DiplayMapperOperationType: 4
(python_test) - Success: Display Mapper Operation Type is correctly set
(python_test) - Success: Enable LDR color grading LUT set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Override Defaults property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Surround property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter Desaturation property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Alter CAT D60 to D65 property set
(python_test) - Success: Cinema Limit (black) property set to maximum value
(python_test) - Success: Cinema Limit (black) property set to minimum value
(python_test) - Success: Cinema Limit (white) property set to maximum value
(python_test) - Success: Cinema Limit (white) property set to minimum value
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Min Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Mid Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Max Point (luminance) property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Surround Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Success: Gamma property set
(python_test) - Info: Entering game mode
Disable Accelerators
Entered game mode
(python_test) - Success: Entered game mode
(python_test) - Info: Exiting game mode
Enable Accelerators
Exited game mode
(python_test) - Success: Exited game mode
(python_test) - Success: Preset 48Nits loaded expected value
(python_test) - Success: Preset 1000Nits loaded expected value
(python_test) - Success: Preset 2000Nits loaded expected value
(python_test) - Success: Preset 4000Nits loaded expected value
(python_test) - Success: Entity is hidden
(python_test) - Success: Entity is visible
(python_test) - Success: Entity deleted
Undo (Undo:49,Redo:1)
(python_test) - Success: UNDO deletion success
Redo (Undo:50,Redo:0)
(python_test) - Success: REDO deletion success
(python_test) - Test AtomEditorComponents_DisplayMapper_AddedToEntity finished.
```