### PR TITLE
chore: AZCore replace usage of VectorConversions

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/VertexContainerInterface.h
+++ b/Code/Framework/AzCore/AzCore/Math/VertexContainerInterface.h
@@ -11,7 +11,6 @@
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
-#include <AzCore/Math/VectorConversions.h>
 #include <AzCore/std/containers/vector.h>
 
 namespace AZ
@@ -155,7 +154,7 @@ namespace AZ
     inline AZ::Vector3 AdaptVertexIn<AZ::Vector3>(const AZ::Vector3& vector) { return vector; }
 
     template<>
-    inline AZ::Vector2 AdaptVertexIn<AZ::Vector2>(const AZ::Vector3& vector) { return Vector3ToVector2(vector); }
+    inline AZ::Vector2 AdaptVertexIn<AZ::Vector2>(const AZ::Vector3& vector) { return AZ::Vector2(vector); }
 
     // template helper to map a vertex (vector) from a vertex container to a local/world space position
     // depending on if the vertex container is storing Vector2s or Vector3s.
@@ -166,6 +165,6 @@ namespace AZ
     inline AZ::Vector3 AdaptVertexOut<AZ::Vector3>(const AZ::Vector3& vector) { return vector; }
 
     template<>
-    inline AZ::Vector3 AdaptVertexOut<AZ::Vector2>(const AZ::Vector2& vector) { return Vector2ToVector3(vector); }
+    inline AZ::Vector3 AdaptVertexOut<AZ::Vector2>(const AZ::Vector2& vector) { return AZ::Vector3(vector); }
 
 } // namespace AZ

--- a/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
@@ -10,8 +10,9 @@
 #include <AzCore/Math/Matrix3x4.h>
 #include <AzCore/Math/Matrix3x3.h>
 #include <AzCore/Math/Quaternion.h>
-#include <AzCore/Math/Vector4.h>
+#include <AzCore/Math/VectorConversions.h>
 #include <AZTestShared/Math/MathTestHelpers.h>
+#include <AzCore/Math/Vector4.h>
 #include "MathTestData.h"
 
 namespace UnitTest
@@ -403,7 +404,7 @@ namespace UnitTest
         const AZ::Vector3 vector(2.3f, -0.6, 1.8f);
         EXPECT_THAT(matrix3x4.TransformVector(vector), IsClose((matrix4x4 * AZ::Vector4(vector, 0.0f)).GetAsVector3()));
         const AZ::Vector3 point(12.3f, -5.6, 7.3f);
-        EXPECT_THAT(matrix3x4.TransformPoint(point), IsClose((matrix4x4 * AZ::Vector4(vector, 1.0f)).GetAsVector3()));
+        EXPECT_THAT(matrix3x4.TransformPoint(point), IsClose((matrix4x4 * AZ::Vector4(point, 1.0f)).GetAsVector3()));
     }
 
     INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4CreateFromMatrix4x4Fixture, ::testing::ValuesIn(MathTestData::Matrix4x4s));

--- a/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
@@ -10,7 +10,7 @@
 #include <AzCore/Math/Matrix3x4.h>
 #include <AzCore/Math/Matrix3x3.h>
 #include <AzCore/Math/Quaternion.h>
-#include <AzCore/Math/VectorConversions.h>
+#include <AzCore/Math/Vector4.h>
 #include <AZTestShared/Math/MathTestHelpers.h>
 #include "MathTestData.h"
 
@@ -401,9 +401,9 @@ namespace UnitTest
         const AZ::Matrix3x4 matrix3x4 = AZ::Matrix3x4::UnsafeCreateFromMatrix4x4(matrix4x4);
         EXPECT_THAT(matrix3x4.GetTranslation(), IsClose(matrix4x4.GetTranslation()));
         const AZ::Vector3 vector(2.3f, -0.6, 1.8f);
-        EXPECT_THAT(matrix3x4.TransformVector(vector), IsClose((matrix4x4 * AZ::Vector3ToVector4(vector, 0.0f)).GetAsVector3()));
+        EXPECT_THAT(matrix3x4.TransformVector(vector), IsClose((matrix4x4 * AZ::Vector4(vector, 0.0f)).GetAsVector3()));
         const AZ::Vector3 point(12.3f, -5.6, 7.3f);
-        EXPECT_THAT(matrix3x4.TransformPoint(point), IsClose((matrix4x4 * AZ::Vector3ToVector4(point, 1.0f)).GetAsVector3()));
+        EXPECT_THAT(matrix3x4.TransformPoint(point), IsClose((matrix4x4 * AZ::Vector4(vector, 1.0f)).GetAsVector3()));
     }
 
     INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4CreateFromMatrix4x4Fixture, ::testing::ValuesIn(MathTestData::Matrix4x4s));

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponentMode.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponentMode.cpp
@@ -13,6 +13,8 @@
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 
 #include <AzCore/Component/NonUniformScaleBus.h>
+#include <AzCore/Math/Vector2.h>
+#include <AzCore/Math/Vector3.h>
 
 namespace LmbrCentral
 {
@@ -27,7 +29,7 @@ namespace LmbrCentral
         AzToolsFramework::MidpointCalculator midpointCalculator;
         for (const AZ::Vector2& vertex : vertexContainer.GetVertices())
         {
-            midpointCalculator.AddPosition(AZ::Vector2ToVector3(vertex, height));
+            midpointCalculator.AddPosition(AZ::Vector3(vertex, height));
         }
 
         return midpointCalculator.CalculateMidpoint();
@@ -133,15 +135,17 @@ namespace LmbrCentral
         m_heightManipulator->SetViews(AZStd::move(views));
 
         // height manipulator callbacks
-        m_heightManipulator->InstallMouseMoveCallback([this, polygonPrism](
-            const LinearManipulator::Action& action)
-        {
-            polygonPrism->SetHeight(AZ::GetMax<float>(action.LocalPosition().GetZ(), 0.0f));
-            m_heightManipulator->SetLocalTransform(
-                AZ::Transform::CreateTranslation(Vector2ToVector3(Vector3ToVector2(
-                    action.LocalPosition()), AZ::GetMax<float>(0.0f, action.LocalPosition().GetZ()))));
-            m_heightManipulator->SetBoundsDirty();
-        });
+        m_heightManipulator->InstallMouseMoveCallback(
+            [this, polygonPrism](const LinearManipulator::Action& action)
+            {
+                polygonPrism->SetHeight(AZ::GetMax<float>(action.LocalPosition().GetZ(), 0.0f));
+
+                m_heightManipulator->SetLocalTransform(AZ::Transform::CreateTranslation(AZ::Vector3(
+                    action.LocalPosition().GetX(), 
+                    action.LocalPosition().GetY(), 
+                    AZ::GetMax<float>(0.0f, action.LocalPosition().GetZ()))));
+                m_heightManipulator->SetBoundsDirty();
+            });
 
         m_heightManipulator->Register(g_mainManipulatorManagerId);
     }


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

replace usage of deprecated VectorConversions