### PR TITLE
chore: cleanup Vector4Tests

### DIFF
--- a/Code/Framework/AzCore/Tests/Math/Vector4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector4Tests.cpp
@@ -13,12 +13,12 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AZTestShared/Math/MathTestHelpers.h>
 #include <AzCore/Math/SimdMath.h>
+#include <gtest/gtest.h>
 
 using namespace AZ;
 
 namespace UnitTest
 {
-    float values[4] = { 10.0f, 20.0f, 30.0f, 40.0f };
 
     TEST(MATH_Vector4, TestConstructors)
     {
@@ -46,26 +46,27 @@ namespace UnitTest
 
     TEST(MATH_Vector4, TestCreateFrom)
     {
+        const float values[4] = { 10.0f, 20.0f, 30.0f, 40.0f };
         Vector4 v4 = Vector4::CreateFromFloat4(values);
-        AZ_TEST_ASSERT((v4.GetX() == 10.0f) && (v4.GetY() == 20.0f) && (v4.GetZ() == 30.0f) && (v4.GetW() == 40.0f));
+        EXPECT_THAT(v4, IsClose(Vector4(10.0f, 20.0f, 30.0f, 40.0f)));
         Vector4 v5 = Vector4::CreateFromVector3(Vector3(2.0f, 3.0f, 4.0f));
-        AZ_TEST_ASSERT((v5.GetX() == 2.0f) && (v5.GetY() == 3.0f) && (v5.GetZ() == 4.0f) && (v5.GetW() == 1.0f));
+        EXPECT_THAT(v5, IsClose(Vector4(2.0f, 3.0f, 4.0f, 1.0f)));
         Vector4 v6 = Vector4::CreateFromVector3AndFloat(Vector3(2.0f, 3.0f, 4.0f), 5.0f);
-        AZ_TEST_ASSERT((v6.GetX() == 2.0f) && (v6.GetY() == 3.0f) && (v6.GetZ() == 4.0f) && (v6.GetW() == 5.0f));
+        EXPECT_THAT(v6, IsClose(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
     }
 
     TEST(MATH_Vector4, TestCreate)
     {
-        AZ_TEST_ASSERT(Vector4::CreateOne() == Vector4(1.0f, 1.0f, 1.0f, 1.0f));
-        AZ_TEST_ASSERT(Vector4::CreateZero() == Vector4(0.0f));
+        EXPECT_THAT(Vector4::CreateOne(), IsClose(Vector4(1.0f, 1.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(Vector4::CreateZero(), IsClose(Vector4(0.0f)));
     }
 
     TEST(MATH_Vector4, TestCreateAxis)
     {
-        AZ_TEST_ASSERT(Vector4::CreateAxisX() == Vector4(1.0f, 0.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(Vector4::CreateAxisY() == Vector4(0.0f, 1.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(Vector4::CreateAxisZ() == Vector4(0.0f, 0.0f, 1.0f, 0.0f));
-        AZ_TEST_ASSERT(Vector4::CreateAxisW() == Vector4(0.0f, 0.0f, 0.0f, 1.0f));
+        EXPECT_THAT(Vector4::CreateAxisX(), IsClose(Vector4(1.0f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(Vector4::CreateAxisY(), IsClose(Vector4(0.0f, 1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(Vector4::CreateAxisZ(), IsClose(Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(Vector4::CreateAxisW(), IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
     }
 
     TEST(MATH_Vector4, TestCompareEqual)
@@ -76,9 +77,9 @@ namespace UnitTest
 
         // operation r.x = (cmp1.x == cmp2.x) ? vA.x : vB.x per component
         Vector4 compareEqualAB = Vector4::CreateSelectCmpEqual(vA, vB, Vector4(1.0f), Vector4(0.0f));
-        AZ_TEST_ASSERT(compareEqualAB.IsClose(Vector4(0.0f, 1.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(compareEqualAB, IsClose(Vector4(0.0f, 1.0f, 0.0f, 1.0f)));
         Vector4 compareEqualBC = Vector4::CreateSelectCmpEqual(vB, vC, Vector4(1.0f), Vector4(0.0f));
-        AZ_TEST_ASSERT(compareEqualBC.IsClose(Vector4(1.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(compareEqualBC, IsClose(Vector4(1.0f, 0.0f, 0.0f, 1.0f)));
     }
 
     TEST(MATH_Vector4, TestCompareGreaterEqual)
@@ -89,9 +90,9 @@ namespace UnitTest
 
         // operation ( r.x = (cmp1.x >= cmp2.x) ? vA.x : vB.x ) per component
         Vector4 compareGreaterEqualAB = Vector4::CreateSelectCmpGreaterEqual(vA, vB, Vector4(1.0f), Vector4(0.0f));
-        AZ_TEST_ASSERT(compareGreaterEqualAB.IsClose(Vector4(0.0f, 1.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(compareGreaterEqualAB, IsClose(Vector4(0.0f, 1.0f, 1.0f, 1.0f)));
         Vector4 compareGreaterEqualBD = Vector4::CreateSelectCmpGreaterEqual(vB, vD, Vector4(1.0f), Vector4(0.0f));
-        AZ_TEST_ASSERT(compareGreaterEqualBD.IsClose(Vector4(1.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(compareGreaterEqualBD, IsClose(Vector4(1.0f, 0.0f, 0.0f, 1.0f)));
     }
 
     TEST(MATH_Vector4, TestCompareGreater)
@@ -102,44 +103,45 @@ namespace UnitTest
 
         // operation ( r.x = (cmp1.x > cmp2.x) ? vA.x : vB.x ) per component
         Vector4 compareGreaterAB = Vector4::CreateSelectCmpGreater(vA, vB, Vector4(1.0f), Vector4(0.0f));
-        AZ_TEST_ASSERT(compareGreaterAB.IsClose(Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(compareGreaterAB, IsClose(Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
         Vector4 compareGreaterCA = Vector4::CreateSelectCmpGreater(vC, vA, Vector4(1.0f), Vector4(0.0f));
-        AZ_TEST_ASSERT(compareGreaterCA.IsClose(Vector4(1.0f, 1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(compareGreaterCA, IsClose(Vector4(1.0f, 1.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestGetSet)
     {
         Vector4 v1(2.0f, 3.0f, 4.0f, 5.0f);
-        AZ_TEST_ASSERT(v1 == Vector4(2.0f, 3.0f, 4.0f, 5.0f));
+        EXPECT_THAT(v1, IsClose(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
         v1.SetX(10.0f);
-        AZ_TEST_ASSERT(v1 == Vector4(10.0f, 3.0f, 4.0f, 5.0f));
+        EXPECT_THAT(v1, IsClose(Vector4(10.0f, 3.0f, 4.0f, 5.0f)));
         v1.SetY(11.0f);
-        AZ_TEST_ASSERT(v1 == Vector4(10.0f, 11.0f, 4.0f, 5.0f));
+        EXPECT_THAT(v1, IsClose(Vector4(10.0f, 11.0f, 4.0f, 5.0f)));
         v1.SetZ(12.0f);
-        AZ_TEST_ASSERT(v1 == Vector4(10.0f, 11.0f, 12.0f, 5.0f));
+        EXPECT_THAT(v1, IsClose(Vector4(10.0f, 11.0f, 12.0f, 5.0f)));
         v1.SetW(13.0f);
-        AZ_TEST_ASSERT(v1 == Vector4(10.0f, 11.0f, 12.0f, 13.0f));
+        EXPECT_THAT(v1, IsClose(Vector4(10.0f, 11.0f, 12.0f, 13.0f)));
         v1.Set(15.0f);
-        AZ_TEST_ASSERT(v1 == Vector4(15.0f));
+        EXPECT_THAT(v1, IsClose(Vector4(15.0f)));
+        const float values[4] = { 10.0f, 20.0f, 30.0f, 40.0f };
         v1.Set(values);
-        AZ_TEST_ASSERT((v1.GetX() == 10.0f) && (v1.GetY() == 20.0f) && (v1.GetZ() == 30.0f) && (v1.GetW() == 40.0f));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(10.0f, 20.0f, 30.0f, 40.0f)));
         v1.Set(Vector3(2.0f, 3.0f, 4.0f));
-        AZ_TEST_ASSERT((v1.GetX() == 2.0f) && (v1.GetY() == 3.0f) && (v1.GetZ() == 4.0f) && (v1.GetW() == 1.0f));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(2.0f, 3.0f, 4.0f, 1.0f)));
         v1.Set(Vector3(2.0f, 3.0f, 4.0f), 5.0f);
-        AZ_TEST_ASSERT((v1.GetX() == 2.0f) && (v1.GetY() == 3.0f) && (v1.GetZ() == 4.0f) && (v1.GetW() == 5.0f));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
     }
 
     TEST(MATH_Vector4, TestIndexOperators)
     {
         Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
-        AZ_TEST_ASSERT(v1.GetElement(0) == 1.0f);
-        AZ_TEST_ASSERT(v1.GetElement(1) == 2.0f);
-        AZ_TEST_ASSERT(v1.GetElement(2) == 3.0f);
-        AZ_TEST_ASSERT(v1.GetElement(3) == 4.0f);
-        AZ_TEST_ASSERT(v1(0) == 1.0f);
-        AZ_TEST_ASSERT(v1(1) == 2.0f);
-        AZ_TEST_ASSERT(v1(2) == 3.0f);
-        AZ_TEST_ASSERT(v1(3) == 4.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(0), 1.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(1), 2.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(2), 3.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(3), 4.0f);
+        EXPECT_FLOAT_EQ(v1(0), 1.0f);
+        EXPECT_FLOAT_EQ(v1(1), 2.0f);
+        EXPECT_FLOAT_EQ(v1(2), 3.0f);
+        EXPECT_FLOAT_EQ(v1(3), 4.0f);
     }
 
     TEST(MATH_Vector4, TestGetElementSetElement)
@@ -149,313 +151,349 @@ namespace UnitTest
         v1.SetElement(1, 6.0f);
         v1.SetElement(2, 7.0f);
         v1.SetElement(3, 8.0f);
-        AZ_TEST_ASSERT(v1.GetElement(0) == 5.0f);
-        AZ_TEST_ASSERT(v1.GetElement(1) == 6.0f);
-        AZ_TEST_ASSERT(v1.GetElement(2) == 7.0f);
-        AZ_TEST_ASSERT(v1.GetElement(3) == 8.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(0), 5.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(1), 6.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(2), 7.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(3), 8.0f);
     }
 
     TEST(MATH_Vector4, TestEquality)
     {
         Vector4 v3(1.0f, 2.0f, 3.0f, 4.0f);
-        AZ_TEST_ASSERT(v3 == Vector4(1.0f, 2.0f, 3.0f, 4.0));
-        AZ_TEST_ASSERT(!(v3 == Vector4(1.0f, 2.0f, 3.0f, 5.0f)));
-        AZ_TEST_ASSERT(v3 != Vector4(1.0f, 2.0f, 3.0f, 5.0f));
-        AZ_TEST_ASSERT(!(v3 != Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
+        EXPECT_TRUE(v3 == Vector4(1.0f, 2.0f, 3.0f, 4.0));
+        EXPECT_FALSE((v3 == Vector4(1.0f, 2.0f, 3.0f, 5.0f)));
+        EXPECT_TRUE(v3 != Vector4(1.0f, 2.0f, 3.0f, 5.0f));
+        EXPECT_FALSE((v3 != Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
     }
 
     TEST(MATH_Vector4, TestGetLength)
     {
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector4(0.0f, 3.0f, 4.0f, 0.0f).GetLengthSq(), 25.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLength(), 5.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLengthEstimate(), 5.0f);
+        EXPECT_FLOAT_EQ(Vector4(0.0f, 3.0f, 4.0f, 0.0f).GetLengthSq(), 25.0f);
+        EXPECT_FLOAT_EQ(Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLength(), 5.0f);
+        EXPECT_FLOAT_EQ(Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLengthEstimate(), 5.0f);
     }
 
     TEST(MATH_Vector4, TestGetLengthReciprocal)
     {
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLengthReciprocal(), 0.2f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLengthReciprocalEstimate(), 0.2f);
+        EXPECT_NEAR(Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLengthReciprocal(), 0.2f, 0.01f);
+        EXPECT_NEAR(Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLengthReciprocalEstimate(), 0.2f, 0.01f);
     }
 
     TEST(MATH_Vector4, TestGetNormalized)
     {
-        AZ_TEST_ASSERT(Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalized().IsClose(Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
-        AZ_TEST_ASSERT(Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalizedEstimate().IsClose(Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalized(), IsClose(Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalizedEstimate(), IsClose(Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestGetNormalizedSafe)
     {
-        AZ_TEST_ASSERT(Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalizedSafe().IsClose(Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
-        AZ_TEST_ASSERT(Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalizedSafeEstimate().IsClose(Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
-        AZ_TEST_ASSERT(Vector4(0.0f).GetNormalizedSafe() == Vector4(0.0f, 0.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(Vector4(0.0f).GetNormalizedSafeEstimate() == Vector4(0.0f, 0.0f, 0.0f, 0.0f));
+        EXPECT_THAT(Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalizedSafe(), IsClose(Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalizedSafeEstimate(), IsClose(Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(Vector4(0.0f).GetNormalizedSafe(), IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(Vector4(0.0f).GetNormalizedSafeEstimate(), IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestNormalize)
     {
         Vector4 v1(4.0f, 3.0f, 0.0f, 0.0f);
         v1.Normalize();
-        AZ_TEST_ASSERT(v1.IsClose(Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
         v1.Set(4.0f, 3.0f, 0.0f, 0.0f);
         v1.NormalizeEstimate();
-        AZ_TEST_ASSERT(v1.IsClose(Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestNormalizeWithLength)
     {
         Vector4 v1(4.0f, 3.0f, 0.0f, 0.0f);
         float length = v1.NormalizeWithLength();
-        AZ_TEST_ASSERT_FLOAT_CLOSE(length, 5.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
+        ASSERT_FLOAT_EQ(length, 5.0f);
+        EXPECT_THAT(v1, IsClose(Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
         v1.Set(4.0f, 3.0f, 0.0f, 0.0f);
         length = v1.NormalizeWithLengthEstimate();
-        AZ_TEST_ASSERT_FLOAT_CLOSE(length, 5.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
+        ASSERT_FLOAT_EQ(length, 5.0f);
+        EXPECT_THAT(v1, IsClose(Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestNormalizeSafe)
     {
         Vector4 v1(0.0f, 3.0f, 4.0f, 0.0f);
         v1.NormalizeSafe();
-        AZ_TEST_ASSERT(v1.IsClose(Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
         v1.Set(0.0f);
         v1.NormalizeSafe();
-        AZ_TEST_ASSERT(v1 == Vector4(0.0f, 0.0f, 0.0f, 0.0f));
+        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
         v1.Set(0.0f, 3.0f, 4.0f, 0.0f);
         v1.NormalizeSafeEstimate();
-        AZ_TEST_ASSERT(v1.IsClose(Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
         v1.Set(0.0f);
         v1.NormalizeSafeEstimate();
-        AZ_TEST_ASSERT(v1 == Vector4(0.0f, 0.0f, 0.0f, 0.0f));
+        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestNormalizeSafeWithLength)
     {
         Vector4 v1(0.0f, 3.0f, 4.0f, 0.0f);
         float length = v1.NormalizeSafeWithLength();
-        AZ_TEST_ASSERT_FLOAT_CLOSE(length, 5.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_FLOAT_EQ(length, 5.0f);
+        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
         v1.Set(0.0f);
         length = v1.NormalizeSafeWithLength();
-        AZ_TEST_ASSERT(length == 0.0f);
-        AZ_TEST_ASSERT(v1 == Vector4(0.0f, 0.0f, 0.0f, 0.0f));
+        EXPECT_FLOAT_EQ(length, 0.0f);
+        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
         v1.Set(0.0f, 3.0f, 4.0f, 0.0f);
         length = v1.NormalizeSafeWithLengthEstimate();
-        AZ_TEST_ASSERT_FLOAT_CLOSE(length, 5.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_FLOAT_EQ(length, 5.0f);
+        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
         v1.Set(0.0f);
         length = v1.NormalizeSafeWithLengthEstimate();
-        AZ_TEST_ASSERT(length == 0.0f);
-        AZ_TEST_ASSERT(v1 == Vector4(0.0f, 0.0f, 0.0f, 0.0f));
+        EXPECT_FLOAT_EQ(length, 0.0f);
+        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestIsNormalized)
     {
-        AZ_TEST_ASSERT(Vector4(1.0f, 0.0f, 0.0f, 0.0f).IsNormalized());
-        AZ_TEST_ASSERT(Vector4(0.7071f, 0.7071f, 0.0f, 0.0f).IsNormalized());
-        AZ_TEST_ASSERT(!Vector4(1.0f, 1.0f, 0.0f, 0.0f).IsNormalized());
+        EXPECT_TRUE(Vector4(1.0f, 0.0f, 0.0f, 0.0f).IsNormalized());
+        EXPECT_TRUE(Vector4(0.7071f, 0.7071f, 0.0f, 0.0f).IsNormalized());
+        EXPECT_FALSE(Vector4(1.0f, 1.0f, 0.0f, 0.0f).IsNormalized());
     }
 
     TEST(MATH_Vector4, TestSetLength)
     {
         Vector4 v1(3.0f, 4.0f, 0.0f, 0.0f);
         v1.SetLength(10.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector4(6.0f, 8.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(Vector4(6.0f, 8.0f, 0.0f, 0.0f)));
         v1.Set(3.0f, 4.0f, 0.0f, 0.0f);
         v1.SetLengthEstimate(10.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector4(6.0f, 8.0f, 0.0f, 0.0f), 1e-3f));
+        EXPECT_THAT(v1, IsCloseTolerance(Vector4(6.0f, 8.0f, 0.0f, 0.0f), 1e-3f));
     }
 
     TEST(MATH_Vector4, TestDistance)
     {
         Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(v1.GetDistanceSq(Vector4(-2.0f, 6.0f, 3.0f, 4.0f)), 25.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(v1.GetDistance(Vector4(-2.0f, 2.0f, -1.0f, 4.0f)), 5.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(v1.GetDistanceEstimate(Vector4(-2.0f, 2.0f, -1.0f, 4.0f)), 5.0f);
+        EXPECT_FLOAT_EQ(v1.GetDistanceSq(Vector4(-2.0f, 6.0f, 3.0f, 4.0f)), 25.0f);
+        EXPECT_FLOAT_EQ(v1.GetDistance(Vector4(-2.0f, 2.0f, -1.0f, 4.0f)), 5.0f);
+        EXPECT_FLOAT_EQ(v1.GetDistanceEstimate(Vector4(-2.0f, 2.0f, -1.0f, 4.0f)), 5.0f);
     }
 
     TEST(MATH_Vector4, TestIsLessThan)
     {
-        AZ_TEST_ASSERT(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessThan(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
-        AZ_TEST_ASSERT(!Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessThan(Vector4(0.0f, 3.0f, 4.0f, 5.0f)));
-        AZ_TEST_ASSERT(!Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessThan(Vector4(1.0f, 2.0f, 4.0f, 5.0f)));
+        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessThan(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
+        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessThan(Vector4(0.0f, 3.0f, 4.0f, 5.0f)));
+        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessThan(Vector4(1.0f, 2.0f, 4.0f, 5.0f)));
     }
 
     TEST(MATH_Vector4, TestIsLessEqualThan)
     {
-        AZ_TEST_ASSERT(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessEqualThan(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
-        AZ_TEST_ASSERT(!Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessEqualThan(Vector4(0.0f, 3.0f, 4.0f, 5.0f)));
-        AZ_TEST_ASSERT(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessEqualThan(Vector4(2.0f, 2.0f, 4.0f, 5.0f)));
+        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessEqualThan(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
+        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessEqualThan(Vector4(0.0f, 3.0f, 4.0f, 5.0f)));
+        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessEqualThan(Vector4(2.0f, 2.0f, 4.0f, 5.0f)));
     }
 
     TEST(MATH_Vector4, TestIsGreaterThan)
     {
-        AZ_TEST_ASSERT(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterThan(Vector4(0.0f, 1.0f, 2.0f, 3.0f)));
-        AZ_TEST_ASSERT(!Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterThan(Vector4(0.0f, 3.0f, 2.0f, 3.0f)));
-        AZ_TEST_ASSERT(!Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterThan(Vector4(0.0f, 2.0f, 2.0f, 3.0f)));
+        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterThan(Vector4(0.0f, 1.0f, 2.0f, 3.0f)));
+        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterThan(Vector4(0.0f, 3.0f, 2.0f, 3.0f)));
+        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterThan(Vector4(0.0f, 2.0f, 2.0f, 3.0f)));
     }
 
     TEST(MATH_Vector4, TestIsGreaterEqualThan)
     {
-        AZ_TEST_ASSERT(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterEqualThan(Vector4(0.0f, 1.0f, 2.0f, 3.0f)));
-        AZ_TEST_ASSERT(!Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterEqualThan(Vector4(0.0f, 3.0f, 2.0f, 3.0f)));
-        AZ_TEST_ASSERT(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterEqualThan(Vector4(0.0f, 2.0f, 2.0f, 3.0f)));
+        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterEqualThan(Vector4(0.0f, 1.0f, 2.0f, 3.0f)));
+        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterEqualThan(Vector4(0.0f, 3.0f, 2.0f, 3.0f)));
+        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterEqualThan(Vector4(0.0f, 2.0f, 2.0f, 3.0f)));
     }
 
     TEST(MATH_Vector4, TestLerpSlerpNLerp)
     {
-        AZ_TEST_ASSERT(Vector4(4.0f, 5.0f, 6.0f, 7.0f).Lerp(Vector4(5.0f, 10.0f, 2.0f, 1.0f), 0.5f).IsClose(Vector4(4.5f, 7.5f, 4.0f, 4.0f)));
-        AZ_TEST_ASSERT(Vector4(1.0f, 0.0f, 0.0f, 0.0f).Slerp(Vector4(0.0f, 1.0f, 0.0f, 0.0f), 0.5f).IsClose(Vector4(0.7071f, 0.7071f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(Vector4(1.0f, 0.0f, 0.0f, 0.0f).Nlerp(Vector4(0.0f, 1.0f, 0.0f, 0.0f), 0.5f).IsClose(Vector4(0.7071f, 0.7071f, 0.0f, 0.0f)));
+        EXPECT_TRUE(Vector4(4.0f, 5.0f, 6.0f, 7.0f).Lerp(Vector4(5.0f, 10.0f, 2.0f, 1.0f), 0.5f).IsClose(Vector4(4.5f, 7.5f, 4.0f, 4.0f)));
+        EXPECT_TRUE(Vector4(1.0f, 0.0f, 0.0f, 0.0f).Slerp(Vector4(0.0f, 1.0f, 0.0f, 0.0f), 0.5f).IsClose(Vector4(0.7071f, 0.7071f, 0.0f, 0.0f)));
+        EXPECT_TRUE(Vector4(1.0f, 0.0f, 0.0f, 0.0f).Nlerp(Vector4(0.0f, 1.0f, 0.0f, 0.0f), 0.5f).IsClose(Vector4(0.7071f, 0.7071f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestDot)
     {
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).Dot(Vector4(-1.0f, 5.0f, 3.0f, 2.0f)), 26.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).Dot3(Vector3(-1.0f, 5.0f, 3.0f)), 18.0f);
+        EXPECT_FLOAT_EQ(Vector4(1.0f, 2.0f, 3.0f, 4.0f).Dot(Vector4(-1.0f, 5.0f, 3.0f, 2.0f)), 26.0f);
+        EXPECT_FLOAT_EQ(Vector4(1.0f, 2.0f, 3.0f, 4.0f).Dot3(Vector3(-1.0f, 5.0f, 3.0f)), 18.0f);
     }
 
     TEST(MATH_Vector4, TestIsClose)
     {
-        AZ_TEST_ASSERT(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
-        AZ_TEST_ASSERT(!Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsClose(Vector4(1.0f, 2.0f, 3.0f, 5.0f)));
-        AZ_TEST_ASSERT(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.4f), 0.5f));
+        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
+        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsClose(Vector4(1.0f, 2.0f, 3.0f, 5.0f)));
+        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.4f), 0.5f));
     }
 
     TEST(MATH_Vector4, TestHomogenize)
     {
         Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
-        AZ_TEST_ASSERT(v1.GetHomogenized().IsClose(Vector3(0.25f, 0.5f, 0.75f)));
+        EXPECT_THAT(v1.GetHomogenized(), IsClose(Vector3(0.25f, 0.5f, 0.75f)));
         v1.Homogenize();
-        AZ_TEST_ASSERT(v1.IsClose(Vector4(0.25f, 0.5f, 0.75f, 1.0f)));
+        EXPECT_THAT(v1, IsClose(Vector4(0.25f, 0.5f, 0.75f, 1.0f)));
     }
 
     TEST(MATH_Vector4, TestMinMax)
     {
-        AZ_TEST_ASSERT(Vector4(2.0f, 5.0f, 6.0f, 7.0f).GetMin(Vector4(1.0f, 6.0f, 5.0f, 4.0f)) == Vector4(1.0f, 5.0f, 5.0f, 4.0f));
-        AZ_TEST_ASSERT(Vector4(2.0f, 5.0f, 6.0f, 7.0f).GetMax(Vector4(1.0f, 6.0f, 5.0f, 4.0f)) == Vector4(2.0f, 6.0f, 6.0f, 7.0f));
+        EXPECT_THAT(Vector4(2.0f, 5.0f, 6.0f, 7.0f).GetMin(Vector4(1.0f, 6.0f, 5.0f, 4.0f)), IsClose(Vector4(1.0f, 5.0f, 5.0f, 4.0f)));
+        EXPECT_THAT(Vector4(2.0f, 5.0f, 6.0f, 7.0f).GetMax(Vector4(1.0f, 6.0f, 5.0f, 4.0f)), IsClose(Vector4(2.0f, 6.0f, 6.0f, 7.0f)));
     }
 
     TEST(MATH_Vector4, TestClamp)
     {
-        AZ_TEST_ASSERT(Vector4(1.0f, 2.0f, 3.0f, 4.0f).GetClamp(Vector4(0.0f, -1.0f, 4.0f, 4.0f), Vector4(2.0f, 1.0f, 10.0f, 4.0f)) == Vector4(1.0f, 1.0f, 4.0f, 4.0f));
+        EXPECT_THAT(Vector4(1.0f, 2.0f, 3.0f, 4.0f).GetClamp(Vector4(0.0f, -1.0f, 4.0f, 4.0f), Vector4(2.0f, 1.0f, 10.0f, 4.0f)), IsClose(Vector4(1.0f, 1.0f, 4.0f, 4.0f)));
     }
 
     TEST(MATH_Vector4, TestTrig)
     {
-        AZ_TEST_ASSERT(Vector4(DegToRad( 78.0f), DegToRad(-150.0f), DegToRad( 190.0f), DegToRad( 78.0f)).GetAngleMod().IsClose(Vector4(DegToRad(78.0f), DegToRad(-150.0f), DegToRad(-170.0f), DegToRad(78.0f))));
-        AZ_TEST_ASSERT(Vector4(DegToRad(390.0f), DegToRad(-190.0f), DegToRad(-400.0f), DegToRad(390.0f)).GetAngleMod().IsClose(Vector4(DegToRad(30.0f), DegToRad(170.0f), DegToRad(-40.0f), DegToRad(30.0f))));
-        AZ_TEST_ASSERT(Vector4(DegToRad( 60.0f), DegToRad( 105.0f), DegToRad(-174.0f), DegToRad( 60.0f)).GetSin().IsClose(Vector4(0.866f, 0.966f, -0.105f, 0.866f), 0.005f));
-        AZ_TEST_ASSERT(Vector4(DegToRad( 60.0f), DegToRad( 105.0f), DegToRad(-174.0f), DegToRad( 60.0f)).GetCos().IsClose(Vector4(0.5f, -0.259f, -0.995f, 0.5f), 0.005f));
+        EXPECT_THAT(Vector4(DegToRad( 78.0f), DegToRad(-150.0f), DegToRad( 190.0f), DegToRad( 78.0f)).GetAngleMod(), IsClose(Vector4(DegToRad(78.0f), DegToRad(-150.0f), DegToRad(-170.0f), DegToRad(78.0f))));
+        EXPECT_THAT(Vector4(DegToRad(390.0f), DegToRad(-190.0f), DegToRad(-400.0f), DegToRad(390.0f)).GetAngleMod(), IsClose(Vector4(DegToRad(30.0f), DegToRad(170.0f), DegToRad(-40.0f), DegToRad(30.0f))));
+        EXPECT_THAT(Vector4(DegToRad( 60.0f), DegToRad( 105.0f), DegToRad(-174.0f), DegToRad( 60.0f)).GetSin(), IsCloseTolerance(Vector4(0.866f, 0.966f, -0.105f, 0.866f), 0.005f));
+        EXPECT_THAT(Vector4(DegToRad( 60.0f), DegToRad( 105.0f), DegToRad(-174.0f), DegToRad( 60.0f)).GetCos(), IsCloseTolerance(Vector4(0.5f, -0.259f, -0.995f, 0.5f), 0.005f));
         Vector4 sin, cos;
         Vector4 v1(DegToRad(60.0f), DegToRad(105.0f), DegToRad(-174.0f), DegToRad(60.0f));
         v1.GetSinCos(sin, cos);
-        AZ_TEST_ASSERT(sin.IsClose(Vector4(0.866f, 0.966f, -0.105f, 0.866f), 0.005f));
-        AZ_TEST_ASSERT(cos.IsClose(Vector4(0.5f, -0.259f, -0.995f, 0.5f), 0.005f));
+        EXPECT_THAT(sin, IsCloseTolerance(Vector4(0.866f, 0.966f, -0.105f, 0.866f), 0.005f));
+        EXPECT_THAT(cos, IsCloseTolerance(Vector4(0.5f, -0.259f, -0.995f, 0.5f), 0.005f));
     }
 
     TEST(MATH_Vector4, TestAbs)
     {
-        AZ_TEST_ASSERT(Vector4(-1.0f, 2.0f, -5.0f, 1.0f).GetAbs() == Vector4(1.0f, 2.0f, 5.0f, 1.0f));
-        AZ_TEST_ASSERT(Vector4(1.0f, -2.0f, 5.0f, -1.0f).GetAbs() == Vector4(1.0f, 2.0f, 5.0f, 1.0f));
+        EXPECT_THAT(Vector4(-1.0f, 2.0f, -5.0f, 1.0f).GetAbs(), IsClose(Vector4(1.0f, 2.0f, 5.0f, 1.0f)));
+        EXPECT_THAT(Vector4(1.0f, -2.0f, 5.0f, -1.0f).GetAbs(), IsClose(Vector4(1.0f, 2.0f, 5.0f, 1.0f)));
     }
 
     TEST(MATH_Vector4, TestReciprocal)
     {
-        AZ_TEST_ASSERT(Vector4(2.0f, 4.0f, 5.0f, 10.0f).GetReciprocal().IsClose(Vector4(0.5f, 0.25f, 0.2f, 0.1f)));
-        AZ_TEST_ASSERT(Vector4(2.0f, 4.0f, 5.0f, 10.0f).GetReciprocalEstimate().IsClose(Vector4(0.5f, 0.25f, 0.2f, 0.1f), 1e-3f));
+        EXPECT_THAT(Vector4(2.0f, 4.0f, 5.0f, 10.0f).GetReciprocal(), IsClose(Vector4(0.5f, 0.25f, 0.2f, 0.1f)));
+        EXPECT_THAT(Vector4(2.0f, 4.0f, 5.0f, 10.0f).GetReciprocalEstimate(), IsCloseTolerance(Vector4(0.5f, 0.25f, 0.2f, 0.1f), 1e-3f));
     }
 
     TEST(MATH_Vector4, TestNegate)
     {
-        AZ_TEST_ASSERT((-Vector4(1.0f, 2.0f, -3.0f, -1.0f)) == Vector4(-1.0f, -2.0f, 3.0f, 1.0f));
+        EXPECT_THAT((-Vector4(1.0f, 2.0f, -3.0f, -1.0f)), IsClose(Vector4(-1.0f, -2.0f, 3.0f, 1.0f)));
     }
 
     TEST(MATH_Vector4, TestAdd)
     {
-        AZ_TEST_ASSERT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) + Vector4(-1.0f, 4.0f, 5.0f, 2.0f)) == Vector4(0.0f, 6.0f, 8.0f, 6.0f));
+        EXPECT_THAT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) + Vector4(-1.0f, 4.0f, 5.0f, 2.0f)), IsClose(Vector4(0.0f, 6.0f, 8.0f, 6.0f)));
 
         Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
         v1 += Vector4(5.0f, 3.0f, -1.0f, 2.0f);
-        AZ_TEST_ASSERT(v1 == Vector4(6.0f, 5.0f, 2.0f, 6.0f));
+        EXPECT_THAT(v1, IsClose(Vector4(6.0f, 5.0f, 2.0f, 6.0f)));
     }
 
     TEST(MATH_Vector4, TestSub)
     {
-        AZ_TEST_ASSERT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) - Vector4(-1.0f, 4.0f, 5.0f, 2.0f)) == Vector4(2.0f, -2.0f, -2.0f, 2.0f));
+        EXPECT_THAT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) - Vector4(-1.0f, 4.0f, 5.0f, 2.0f)), IsClose(Vector4(2.0f, -2.0f, -2.0f, 2.0f)));
 
         Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
         v1 += Vector4(5.0f, 3.0f, -1.0f, 2.0f);
         v1 -= Vector4(2.0f, -1.0f, 3.0f, 1.0f);
-        AZ_TEST_ASSERT(v1 == Vector4(4.0f, 6.0f, -1.0f, 5.0f));
+        EXPECT_THAT(v1, IsClose(Vector4(4.0f, 6.0f, -1.0f, 5.0f)));
     }
 
     TEST(MATH_Vector4, TestMultiply)
     {
-        AZ_TEST_ASSERT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) * Vector4(-1.0f, 4.0f, 5.0f, 2.0f)) == Vector4(-1.0f, 8.0f, 15.0f, 8.0f));
-        AZ_TEST_ASSERT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) * 2.0f) == Vector4(2.0f, 4.0f, 6.0f, 8.0f));
-        AZ_TEST_ASSERT((2.0f * Vector4(1.0f, 2.0f, 3.0f, 4.0f)) == Vector4(2.0f, 4.0f, 6.0f, 8.0f));
+        EXPECT_THAT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) * Vector4(-1.0f, 4.0f, 5.0f, 2.0f)), IsClose(Vector4(-1.0f, 8.0f, 15.0f, 8.0f)));
+        EXPECT_THAT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) * 2.0f), IsClose(Vector4(2.0f, 4.0f, 6.0f, 8.0f)));
+        EXPECT_THAT((2.0f * Vector4(1.0f, 2.0f, 3.0f, 4.0f)), IsClose(Vector4(2.0f, 4.0f, 6.0f, 8.0f)));
 
         Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
         v1 += Vector4(5.0f, 3.0f, -1.0f, 2.0f);
         v1 -= Vector4(2.0f, -1.0f, 3.0f, 1.0f);
         v1 *= 3.0f;
-        AZ_TEST_ASSERT(v1 == Vector4(12.0f, 18.0f, -3.0f, 15.0f));
+        EXPECT_THAT(v1, IsClose(Vector4(12.0f, 18.0f, -3.0f, 15.0f)));
     }
 
     TEST(MATH_Vector4, TestDivide)
     {
-        AZ_TEST_ASSERT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) / Vector4(-1.0f, 4.0f, 5.0f, 2.0f)).IsClose(Vector4(-1.0f, 0.5f, 3.0f / 5.0f, 2.0f)));
-        AZ_TEST_ASSERT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) / 2.0f).IsClose(Vector4(0.5f, 1.0f, 1.5f, 2.0f)));
+        EXPECT_THAT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) / Vector4(-1.0f, 4.0f, 5.0f, 2.0f)), IsClose(Vector4(-1.0f, 0.5f, 3.0f / 5.0f, 2.0f)));
+        EXPECT_THAT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) / 2.0f), IsClose(Vector4(0.5f, 1.0f, 1.5f, 2.0f)));
 
         Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
         v1 += Vector4(5.0f, 3.0f, -1.0f, 2.0f);
         v1 -= Vector4(2.0f, -1.0f, 3.0f, 1.0f);
         v1 *= 3.0f;
         v1 /= 2.0f;
-        AZ_TEST_ASSERT(v1.IsClose(Vector4(6.0f, 9.0f, -1.5f, 7.5f)));
+        EXPECT_THAT(v1, IsClose(Vector4(6.0f, 9.0f, -1.5f, 7.5f)));
     }
 
-    TEST(MATH_Vector4, TestAngles)
+    struct AngleTestArgs
     {
-        using Vec4CalcFunc = float(Vector4::*)(const Vector4&) const;
-        auto angleTest = [](Vec4CalcFunc func, const Vector4& self, const Vector4& other, float target)
-        {
-            const float epsilon = 0.01f;
-            float value = (self.*func)(other);
-            AZ_TEST_ASSERT(AZ::IsClose(value, target, epsilon));
-        };
+        AZ::Vector4 current;
+        AZ::Vector4 target;
+        float angle;
+    };
 
-        const Vec4CalcFunc angleFuncs[2] = { &Vector4::Angle, &Vector4::AngleSafe };
-        for (Vec4CalcFunc angleFunc : angleFuncs)
-        {
-            angleTest(angleFunc, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, AZ::Constants::HalfPi);
-            angleTest(angleFunc, Vector4{ 42.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 23.0f, 0.0f, 0.0f }, AZ::Constants::HalfPi);
-            angleTest(angleFunc, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ -1.0f, 0.0f, 0.0f, 0.0f }, AZ::Constants::Pi);
-            angleTest(angleFunc, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, AZ::Constants::QuarterPi);
-            angleTest(angleFunc, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, 0.f);
-            angleTest(angleFunc, Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, Vector4{ -1.0f, -1.0f, 0.0f, 0.0f }, AZ::Constants::Pi);
-        }
+    using AngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
 
-        const Vec4CalcFunc angleDegFuncs[2] = { &Vector4::AngleDeg, &Vector4::AngleSafeDeg };
-        for (Vec4CalcFunc angleDegFunc : angleDegFuncs)
-        {
-            angleTest(angleDegFunc, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, 90.f);
-            angleTest(angleDegFunc, Vector4{ 42.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 23.0f, 0.0f, 0.0f }, 90.f);
-            angleTest(angleDegFunc, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ -1.0f, 0.0f, 0.0f, 0.0f }, 180.f);
-            angleTest(angleDegFunc, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, 45.f);
-            angleTest(angleDegFunc, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, 0.f);
-            angleTest(angleDegFunc, Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, Vector4{ -1.0f, -1.0f, 0.0f, 0.0f }, 180.f);
-        }
-
-        const Vec4CalcFunc angleSafeFuncs[2] = { &Vector4::AngleSafe, &Vector4::AngleSafeDeg };
-        for (Vec4CalcFunc angleSafeFunc : angleSafeFuncs)
-        {
-            angleTest(angleSafeFunc, Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, 0.f);
-            angleTest(angleSafeFunc, Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f);
-            angleTest(angleSafeFunc, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f);
-            angleTest(angleSafeFunc, Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 323432.0f, 0.0f, 0.0f }, 0.f);
-            angleTest(angleSafeFunc, Vector4{ 323432.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f);
-        }
+    TEST_P(AngleTestFixture, TestAngle)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.Angle(param.target), param.angle);
     }
-}
+
+    TEST_P(AngleTestFixture, TestAngleSafe)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleSafe(param.target), param.angle);
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        MATH_Vector4,
+        AngleTestFixture,
+        ::testing::Values(
+            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, AZ::Constants::HalfPi },
+            AngleTestArgs{ Vector4{ 42.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 23.0f, 0.0f, 0.0f }, AZ::Constants::HalfPi },
+            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ -1.0f, 0.0f, 0.0f, 0.0f }, AZ::Constants::Pi },
+            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, AZ::Constants::QuarterPi },
+            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, Vector4{ -1.0f, -1.0f, 0.0f, 0.0f }, AZ::Constants::Pi }));
+
+    using AngleDegTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+
+    TEST_P(AngleDegTestFixture, TestAngleDeg)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleDeg(param.target), param.angle);
+    }
+
+    TEST_P(AngleDegTestFixture, TestAngleDegSafe)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
+    }
+    INSTANTIATE_TEST_CASE_P(
+        MATH_Vector4,
+        AngleDegTestFixture,
+        ::testing::Values(
+            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, 90.f },
+            AngleTestArgs{ Vector4{ 42.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 23.0f, 0.0f, 0.0f }, 90.f },
+            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ -1.0f, 0.0f, 0.0f, 0.0f }, 180.f },
+            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, 45.f },
+            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, Vector4{ -1.0f, -1.0f, 0.0f, 0.0f }, 180.f }));
+
+    using AngleSafeInvalidAngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+    TEST_P(AngleSafeInvalidAngleTestFixture, TestInvalidAngle)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleSafe(param.target), param.angle);
+    }
+
+    TEST_P(AngleSafeInvalidAngleTestFixture, TestInvalidAngleDeg)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        MATH_Vector4,
+        AngleSafeInvalidAngleTestFixture,
+        ::testing::Values(
+            AngleTestArgs{ Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 323432.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector4{ 323432.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f }));
+} // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Math/Vector4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector4Tests.cpp
@@ -13,127 +13,124 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AZTestShared/Math/MathTestHelpers.h>
 #include <AzCore/Math/SimdMath.h>
-#include <gtest/gtest.h>
-
-using namespace AZ;
 
 namespace UnitTest
 {
 
     TEST(MATH_Vector4, TestConstructors)
     {
-        Vector4 v1(0.0f);
+        AZ::Vector4 v1(0.0f);
         EXPECT_FLOAT_EQ(v1.GetX(), 0.0f);
         EXPECT_FLOAT_EQ(v1.GetY(), 0.0f);
         EXPECT_FLOAT_EQ(v1.GetZ(), 0.0f);
         EXPECT_FLOAT_EQ(v1.GetW(), 0.0f);
-        Vector4 v2(5.0f);
+        AZ::Vector4 v2(5.0f);
         EXPECT_FLOAT_EQ(v2.GetX(), 5.0f);
         EXPECT_FLOAT_EQ(v2.GetY(), 5.0f);
         EXPECT_FLOAT_EQ(v2.GetZ(), 5.0f);
         EXPECT_FLOAT_EQ(v2.GetW(), 5.0f);
-        Vector4 v3(1.0f, 2.0f, 3.0f, 4.0f);
+        AZ::Vector4 v3(1.0f, 2.0f, 3.0f, 4.0f);
         EXPECT_FLOAT_EQ(v3.GetX(), 1.0f);
         EXPECT_FLOAT_EQ(v3.GetY(), 2.0f);
         EXPECT_FLOAT_EQ(v3.GetZ(), 3.0f);
         EXPECT_FLOAT_EQ(v3.GetW(), 4.0f);
-        EXPECT_THAT(Vector4(Vector3(10.0f, 3.0f, 2.0f)), IsClose(Vector4(10.0f, 3.0f, 2.0f, 1.0f)));
-        EXPECT_THAT(Vector4(Vector3(10.0f, 3.0f, 2.0f), 5.0f), IsClose(Vector4(10.0f, 3.0f, 2.0f, 5.0f)));
-        EXPECT_THAT(Vector4(Vector2(10.0f, 3.0f)), IsClose(Vector4(10.0f, 3.0f, 0.0f, 1.0f)));
-        EXPECT_THAT(Vector4(Vector2(10.0f, 3.0f), 5.0f), IsClose(Vector4(10.0f, 3.0f, 5.0f, 1.0f)));
-        EXPECT_THAT(Vector4(Vector2(10.0f, 3.0f), 5.0f, 6.0f), IsClose(Vector4(10.0f, 3.0f, 5.0f, 6.0f)));
+        EXPECT_THAT(AZ::Vector4(AZ::Vector3(10.0f, 3.0f, 2.0f)), IsClose(AZ::Vector4(10.0f, 3.0f, 2.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector4(AZ::Vector3(10.0f, 3.0f, 2.0f), 5.0f), IsClose(AZ::Vector4(10.0f, 3.0f, 2.0f, 5.0f)));
+        EXPECT_THAT(AZ::Vector4(AZ::Vector2(10.0f, 3.0f)), IsClose(AZ::Vector4(10.0f, 3.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector4(AZ::Vector2(10.0f, 3.0f), 5.0f), IsClose(AZ::Vector4(10.0f, 3.0f, 5.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector4(AZ::Vector2(10.0f, 3.0f), 5.0f, 6.0f), IsClose(AZ::Vector4(10.0f, 3.0f, 5.0f, 6.0f)));
     }
 
     TEST(MATH_Vector4, TestCreateFrom)
     {
         const float values[4] = { 10.0f, 20.0f, 30.0f, 40.0f };
-        Vector4 v4 = Vector4::CreateFromFloat4(values);
-        EXPECT_THAT(v4, IsClose(Vector4(10.0f, 20.0f, 30.0f, 40.0f)));
-        Vector4 v5 = Vector4::CreateFromVector3(Vector3(2.0f, 3.0f, 4.0f));
-        EXPECT_THAT(v5, IsClose(Vector4(2.0f, 3.0f, 4.0f, 1.0f)));
-        Vector4 v6 = Vector4::CreateFromVector3AndFloat(Vector3(2.0f, 3.0f, 4.0f), 5.0f);
-        EXPECT_THAT(v6, IsClose(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
+        AZ::Vector4 v4 = AZ::Vector4::CreateFromFloat4(values);
+        EXPECT_THAT(v4, IsClose(AZ::Vector4(10.0f, 20.0f, 30.0f, 40.0f)));
+        AZ::Vector4 v5 = AZ::Vector4::CreateFromVector3(AZ::Vector3(2.0f, 3.0f, 4.0f));
+        EXPECT_THAT(v5, IsClose(AZ::Vector4(2.0f, 3.0f, 4.0f, 1.0f)));
+        AZ::Vector4 v6 = AZ::Vector4::CreateFromVector3AndFloat(AZ::Vector3(2.0f, 3.0f, 4.0f), 5.0f);
+        EXPECT_THAT(v6, IsClose(AZ::Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
     }
 
     TEST(MATH_Vector4, TestCreate)
     {
-        EXPECT_THAT(Vector4::CreateOne(), IsClose(Vector4(1.0f, 1.0f, 1.0f, 1.0f)));
-        EXPECT_THAT(Vector4::CreateZero(), IsClose(Vector4(0.0f)));
+        EXPECT_THAT(AZ::Vector4::CreateOne(), IsClose(AZ::Vector4(1.0f, 1.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector4::CreateZero(), IsClose(AZ::Vector4(0.0f)));
     }
 
     TEST(MATH_Vector4, TestCreateAxis)
     {
-        EXPECT_THAT(Vector4::CreateAxisX(), IsClose(Vector4(1.0f, 0.0f, 0.0f, 0.0f)));
-        EXPECT_THAT(Vector4::CreateAxisY(), IsClose(Vector4(0.0f, 1.0f, 0.0f, 0.0f)));
-        EXPECT_THAT(Vector4::CreateAxisZ(), IsClose(Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
-        EXPECT_THAT(Vector4::CreateAxisW(), IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector4::CreateAxisX(), IsClose(AZ::Vector4(1.0f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector4::CreateAxisY(), IsClose(AZ::Vector4(0.0f, 1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector4::CreateAxisZ(), IsClose(AZ::Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector4::CreateAxisW(), IsClose(AZ::Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
     }
 
     TEST(MATH_Vector4, TestCompareEqual)
     {
-        Vector4 vA(-100.0f, 10.0f, -1.0f, 0.0f);
-        Vector4 vB(35.0f, 10.0f, -5.0f, 0.0f);
-        Vector4 vC(35.0f, 20.0f, -1.0f, 0.0f);
+        AZ::Vector4 vA(-100.0f, 10.0f, -1.0f, 0.0f);
+        AZ::Vector4 vB(35.0f, 10.0f, -5.0f, 0.0f);
+        AZ::Vector4 vC(35.0f, 20.0f, -1.0f, 0.0f);
 
         // operation r.x = (cmp1.x == cmp2.x) ? vA.x : vB.x per component
-        Vector4 compareEqualAB = Vector4::CreateSelectCmpEqual(vA, vB, Vector4(1.0f), Vector4(0.0f));
-        EXPECT_THAT(compareEqualAB, IsClose(Vector4(0.0f, 1.0f, 0.0f, 1.0f)));
-        Vector4 compareEqualBC = Vector4::CreateSelectCmpEqual(vB, vC, Vector4(1.0f), Vector4(0.0f));
-        EXPECT_THAT(compareEqualBC, IsClose(Vector4(1.0f, 0.0f, 0.0f, 1.0f)));
+        AZ::Vector4 compareEqualAB = AZ::Vector4::CreateSelectCmpEqual(vA, vB, AZ::Vector4(1.0f), AZ::Vector4(0.0f));
+        EXPECT_THAT(compareEqualAB, IsClose(AZ::Vector4(0.0f, 1.0f, 0.0f, 1.0f)));
+        AZ::Vector4 compareEqualBC = AZ::Vector4::CreateSelectCmpEqual(vB, vC, AZ::Vector4(1.0f), AZ::Vector4(0.0f));
+        EXPECT_THAT(compareEqualBC, IsClose(AZ::Vector4(1.0f, 0.0f, 0.0f, 1.0f)));
     }
 
     TEST(MATH_Vector4, TestCompareGreaterEqual)
     {
-        Vector4 vA(-100.0f, 10.0f, -1.0f, 0.0f);
-        Vector4 vB(35.0f, 10.0f, -5.0f, 0.0f);
-        Vector4 vD(15.0f, 30.0f, 45.0f, 0.0f);
+        AZ::Vector4 vA(-100.0f, 10.0f, -1.0f, 0.0f);
+        AZ::Vector4 vB(35.0f, 10.0f, -5.0f, 0.0f);
+        AZ::Vector4 vD(15.0f, 30.0f, 45.0f, 0.0f);
 
         // operation ( r.x = (cmp1.x >= cmp2.x) ? vA.x : vB.x ) per component
-        Vector4 compareGreaterEqualAB = Vector4::CreateSelectCmpGreaterEqual(vA, vB, Vector4(1.0f), Vector4(0.0f));
-        EXPECT_THAT(compareGreaterEqualAB, IsClose(Vector4(0.0f, 1.0f, 1.0f, 1.0f)));
-        Vector4 compareGreaterEqualBD = Vector4::CreateSelectCmpGreaterEqual(vB, vD, Vector4(1.0f), Vector4(0.0f));
-        EXPECT_THAT(compareGreaterEqualBD, IsClose(Vector4(1.0f, 0.0f, 0.0f, 1.0f)));
+        AZ::Vector4 compareGreaterEqualAB = AZ::Vector4::CreateSelectCmpGreaterEqual(vA, vB, AZ::Vector4(1.0f), AZ::Vector4(0.0f));
+        EXPECT_THAT(compareGreaterEqualAB, IsClose(AZ::Vector4(0.0f, 1.0f, 1.0f, 1.0f)));
+        AZ::Vector4 compareGreaterEqualBD = AZ::Vector4::CreateSelectCmpGreaterEqual(vB, vD, AZ::Vector4(1.0f), AZ::Vector4(0.0f));
+        EXPECT_THAT(compareGreaterEqualBD, IsClose(AZ::Vector4(1.0f, 0.0f, 0.0f, 1.0f)));
     }
 
     TEST(MATH_Vector4, TestCompareGreater)
     {
-        Vector4 vA(-100.0f, 10.0f, -1.0f, 0.0f);
-        Vector4 vB(35.0f, 10.0f, -5.0f, 0.0f);
-        Vector4 vC(35.0f, 20.0f, -1.0f, 0.0f);
+        AZ::Vector4 vA(-100.0f, 10.0f, -1.0f, 0.0f);
+        AZ::Vector4 vB(35.0f, 10.0f, -5.0f, 0.0f);
+        AZ::Vector4 vC(35.0f, 20.0f, -1.0f, 0.0f);
 
         // operation ( r.x = (cmp1.x > cmp2.x) ? vA.x : vB.x ) per component
-        Vector4 compareGreaterAB = Vector4::CreateSelectCmpGreater(vA, vB, Vector4(1.0f), Vector4(0.0f));
-        EXPECT_THAT(compareGreaterAB, IsClose(Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
-        Vector4 compareGreaterCA = Vector4::CreateSelectCmpGreater(vC, vA, Vector4(1.0f), Vector4(0.0f));
-        EXPECT_THAT(compareGreaterCA, IsClose(Vector4(1.0f, 1.0f, 0.0f, 0.0f)));
+        AZ::Vector4 compareGreaterAB = AZ::Vector4::CreateSelectCmpGreater(vA, vB, AZ::Vector4(1.0f), AZ::Vector4(0.0f));
+        EXPECT_THAT(compareGreaterAB, IsClose(AZ::Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
+        AZ::Vector4 compareGreaterCA = AZ::Vector4::CreateSelectCmpGreater(vC, vA, AZ::Vector4(1.0f), AZ::Vector4(0.0f));
+        EXPECT_THAT(compareGreaterCA, IsClose(AZ::Vector4(1.0f, 1.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestGetSet)
     {
-        Vector4 v1(2.0f, 3.0f, 4.0f, 5.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
+        AZ::Vector4 v1(2.0f, 3.0f, 4.0f, 5.0f);
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
         v1.SetX(10.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(10.0f, 3.0f, 4.0f, 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(10.0f, 3.0f, 4.0f, 5.0f)));
         v1.SetY(11.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(10.0f, 11.0f, 4.0f, 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(10.0f, 11.0f, 4.0f, 5.0f)));
         v1.SetZ(12.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(10.0f, 11.0f, 12.0f, 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(10.0f, 11.0f, 12.0f, 5.0f)));
         v1.SetW(13.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(10.0f, 11.0f, 12.0f, 13.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(10.0f, 11.0f, 12.0f, 13.0f)));
         v1.Set(15.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(15.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(15.0f)));
         const float values[4] = { 10.0f, 20.0f, 30.0f, 40.0f };
         v1.Set(values);
         EXPECT_THAT(v1, IsClose(AZ::Vector4(10.0f, 20.0f, 30.0f, 40.0f)));
-        v1.Set(Vector3(2.0f, 3.0f, 4.0f));
+        v1.Set(AZ::Vector3(2.0f, 3.0f, 4.0f));
         EXPECT_THAT(v1, IsClose(AZ::Vector4(2.0f, 3.0f, 4.0f, 1.0f)));
-        v1.Set(Vector3(2.0f, 3.0f, 4.0f), 5.0f);
+        v1.Set(AZ::Vector3(2.0f, 3.0f, 4.0f), 5.0f);
         EXPECT_THAT(v1, IsClose(AZ::Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
     }
 
     TEST(MATH_Vector4, TestIndexOperators)
     {
-        Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
+        AZ::Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
         EXPECT_FLOAT_EQ(v1.GetElement(0), 1.0f);
         EXPECT_FLOAT_EQ(v1.GetElement(1), 2.0f);
         EXPECT_FLOAT_EQ(v1.GetElement(2), 3.0f);
@@ -146,7 +143,7 @@ namespace UnitTest
 
     TEST(MATH_Vector4, TestGetElementSetElement)
     {
-        Vector4 v1;
+        AZ::Vector4 v1;
         v1.SetElement(0, 5.0f);
         v1.SetElement(1, 6.0f);
         v1.SetElement(2, 7.0f);
@@ -159,263 +156,263 @@ namespace UnitTest
 
     TEST(MATH_Vector4, TestEquality)
     {
-        Vector4 v3(1.0f, 2.0f, 3.0f, 4.0f);
-        EXPECT_TRUE(v3 == Vector4(1.0f, 2.0f, 3.0f, 4.0));
-        EXPECT_FALSE((v3 == Vector4(1.0f, 2.0f, 3.0f, 5.0f)));
-        EXPECT_TRUE(v3 != Vector4(1.0f, 2.0f, 3.0f, 5.0f));
-        EXPECT_FALSE((v3 != Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
+        AZ::Vector4 v3(1.0f, 2.0f, 3.0f, 4.0f);
+        EXPECT_TRUE(v3 == AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0));
+        EXPECT_FALSE((v3 == AZ::Vector4(1.0f, 2.0f, 3.0f, 5.0f)));
+        EXPECT_TRUE(v3 != AZ::Vector4(1.0f, 2.0f, 3.0f, 5.0f));
+        EXPECT_FALSE((v3 != AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
     }
 
     TEST(MATH_Vector4, TestGetLength)
     {
-        EXPECT_FLOAT_EQ(Vector4(0.0f, 3.0f, 4.0f, 0.0f).GetLengthSq(), 25.0f);
-        EXPECT_FLOAT_EQ(Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLength(), 5.0f);
-        EXPECT_FLOAT_EQ(Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLengthEstimate(), 5.0f);
+        EXPECT_FLOAT_EQ(AZ::Vector4(0.0f, 3.0f, 4.0f, 0.0f).GetLengthSq(), 25.0f);
+        EXPECT_FLOAT_EQ(AZ::Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLength(), 5.0f);
+        EXPECT_FLOAT_EQ(AZ::Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLengthEstimate(), 5.0f);
     }
 
     TEST(MATH_Vector4, TestGetLengthReciprocal)
     {
-        EXPECT_NEAR(Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLengthReciprocal(), 0.2f, 0.01f);
-        EXPECT_NEAR(Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLengthReciprocalEstimate(), 0.2f, 0.01f);
+        EXPECT_NEAR(AZ::Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLengthReciprocal(), 0.2f, 0.01f);
+        EXPECT_NEAR(AZ::Vector4(0.0f, 0.0f, 4.0f, -3.0f).GetLengthReciprocalEstimate(), 0.2f, 0.01f);
     }
 
     TEST(MATH_Vector4, TestGetNormalized)
     {
-        EXPECT_THAT(Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalized(), IsClose(Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
-        EXPECT_THAT(Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalizedEstimate(), IsClose(Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalized(), IsClose(AZ::Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalizedEstimate(), IsClose(AZ::Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestGetNormalizedSafe)
     {
-        EXPECT_THAT(Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalizedSafe(), IsClose(Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
-        EXPECT_THAT(Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalizedSafeEstimate(), IsClose(Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
-        EXPECT_THAT(Vector4(0.0f).GetNormalizedSafe(), IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
-        EXPECT_THAT(Vector4(0.0f).GetNormalizedSafeEstimate(), IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalizedSafe(), IsClose(AZ::Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector4(3.0f, 0.0f, 4.0f, 0.0f).GetNormalizedSafeEstimate(), IsClose(AZ::Vector4(3.0f / 5.0f, 0.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector4(0.0f).GetNormalizedSafe(), IsClose(AZ::Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector4(0.0f).GetNormalizedSafeEstimate(), IsClose(AZ::Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestNormalize)
     {
-        Vector4 v1(4.0f, 3.0f, 0.0f, 0.0f);
+        AZ::Vector4 v1(4.0f, 3.0f, 0.0f, 0.0f);
         v1.Normalize();
-        EXPECT_THAT(v1, IsClose(Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
         v1.Set(4.0f, 3.0f, 0.0f, 0.0f);
         v1.NormalizeEstimate();
-        EXPECT_THAT(v1, IsClose(Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestNormalizeWithLength)
     {
-        Vector4 v1(4.0f, 3.0f, 0.0f, 0.0f);
+        AZ::Vector4 v1(4.0f, 3.0f, 0.0f, 0.0f);
         float length = v1.NormalizeWithLength();
         ASSERT_FLOAT_EQ(length, 5.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
         v1.Set(4.0f, 3.0f, 0.0f, 0.0f);
         length = v1.NormalizeWithLengthEstimate();
         ASSERT_FLOAT_EQ(length, 5.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(4.0f / 5.0f, 3.0f / 5.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestNormalizeSafe)
     {
-        Vector4 v1(0.0f, 3.0f, 4.0f, 0.0f);
+        AZ::Vector4 v1(0.0f, 3.0f, 4.0f, 0.0f);
         v1.NormalizeSafe();
-        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
         v1.Set(0.0f);
         v1.NormalizeSafe();
-        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
         v1.Set(0.0f, 3.0f, 4.0f, 0.0f);
         v1.NormalizeSafeEstimate();
-        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
         v1.Set(0.0f);
         v1.NormalizeSafeEstimate();
-        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestNormalizeSafeWithLength)
     {
-        Vector4 v1(0.0f, 3.0f, 4.0f, 0.0f);
+        AZ::Vector4 v1(0.0f, 3.0f, 4.0f, 0.0f);
         float length = v1.NormalizeSafeWithLength();
         EXPECT_FLOAT_EQ(length, 5.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
         v1.Set(0.0f);
         length = v1.NormalizeSafeWithLength();
         EXPECT_FLOAT_EQ(length, 0.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
         v1.Set(0.0f, 3.0f, 4.0f, 0.0f);
         length = v1.NormalizeSafeWithLengthEstimate();
         EXPECT_FLOAT_EQ(length, 5.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(0.0f, 3.0f / 5.0f, 4.0f / 5.0f, 0.0f)));
         v1.Set(0.0f);
         length = v1.NormalizeSafeWithLengthEstimate();
         EXPECT_FLOAT_EQ(length, 0.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestIsNormalized)
     {
-        EXPECT_TRUE(Vector4(1.0f, 0.0f, 0.0f, 0.0f).IsNormalized());
-        EXPECT_TRUE(Vector4(0.7071f, 0.7071f, 0.0f, 0.0f).IsNormalized());
-        EXPECT_FALSE(Vector4(1.0f, 1.0f, 0.0f, 0.0f).IsNormalized());
+        EXPECT_TRUE(AZ::Vector4(1.0f, 0.0f, 0.0f, 0.0f).IsNormalized());
+        EXPECT_TRUE(AZ::Vector4(0.7071f, 0.7071f, 0.0f, 0.0f).IsNormalized());
+        EXPECT_FALSE(AZ::Vector4(1.0f, 1.0f, 0.0f, 0.0f).IsNormalized());
     }
 
     TEST(MATH_Vector4, TestSetLength)
     {
-        Vector4 v1(3.0f, 4.0f, 0.0f, 0.0f);
+        AZ::Vector4 v1(3.0f, 4.0f, 0.0f, 0.0f);
         v1.SetLength(10.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(6.0f, 8.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(6.0f, 8.0f, 0.0f, 0.0f)));
         v1.Set(3.0f, 4.0f, 0.0f, 0.0f);
         v1.SetLengthEstimate(10.0f);
-        EXPECT_THAT(v1, IsCloseTolerance(Vector4(6.0f, 8.0f, 0.0f, 0.0f), 1e-3f));
+        EXPECT_THAT(v1, IsCloseTolerance(AZ::Vector4(6.0f, 8.0f, 0.0f, 0.0f), 1e-3f));
     }
 
     TEST(MATH_Vector4, TestDistance)
     {
-        Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
-        EXPECT_FLOAT_EQ(v1.GetDistanceSq(Vector4(-2.0f, 6.0f, 3.0f, 4.0f)), 25.0f);
-        EXPECT_FLOAT_EQ(v1.GetDistance(Vector4(-2.0f, 2.0f, -1.0f, 4.0f)), 5.0f);
-        EXPECT_FLOAT_EQ(v1.GetDistanceEstimate(Vector4(-2.0f, 2.0f, -1.0f, 4.0f)), 5.0f);
+        AZ::Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
+        EXPECT_FLOAT_EQ(v1.GetDistanceSq(AZ::Vector4(-2.0f, 6.0f, 3.0f, 4.0f)), 25.0f);
+        EXPECT_FLOAT_EQ(v1.GetDistance(AZ::Vector4(-2.0f, 2.0f, -1.0f, 4.0f)), 5.0f);
+        EXPECT_FLOAT_EQ(v1.GetDistanceEstimate(AZ::Vector4(-2.0f, 2.0f, -1.0f, 4.0f)), 5.0f);
     }
 
     TEST(MATH_Vector4, TestIsLessThan)
     {
-        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessThan(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
-        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessThan(Vector4(0.0f, 3.0f, 4.0f, 5.0f)));
-        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessThan(Vector4(1.0f, 2.0f, 4.0f, 5.0f)));
+        EXPECT_TRUE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessThan(AZ::Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
+        EXPECT_FALSE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessThan(AZ::Vector4(0.0f, 3.0f, 4.0f, 5.0f)));
+        EXPECT_FALSE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessThan(AZ::Vector4(1.0f, 2.0f, 4.0f, 5.0f)));
     }
 
     TEST(MATH_Vector4, TestIsLessEqualThan)
     {
-        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessEqualThan(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
-        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessEqualThan(Vector4(0.0f, 3.0f, 4.0f, 5.0f)));
-        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessEqualThan(Vector4(2.0f, 2.0f, 4.0f, 5.0f)));
+        EXPECT_TRUE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessEqualThan(AZ::Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
+        EXPECT_FALSE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessEqualThan(AZ::Vector4(0.0f, 3.0f, 4.0f, 5.0f)));
+        EXPECT_TRUE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsLessEqualThan(AZ::Vector4(2.0f, 2.0f, 4.0f, 5.0f)));
     }
 
     TEST(MATH_Vector4, TestIsGreaterThan)
     {
-        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterThan(Vector4(0.0f, 1.0f, 2.0f, 3.0f)));
-        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterThan(Vector4(0.0f, 3.0f, 2.0f, 3.0f)));
-        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterThan(Vector4(0.0f, 2.0f, 2.0f, 3.0f)));
+        EXPECT_TRUE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterThan(AZ::Vector4(0.0f, 1.0f, 2.0f, 3.0f)));
+        EXPECT_FALSE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterThan(AZ::Vector4(0.0f, 3.0f, 2.0f, 3.0f)));
+        EXPECT_FALSE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterThan(AZ::Vector4(0.0f, 2.0f, 2.0f, 3.0f)));
     }
 
     TEST(MATH_Vector4, TestIsGreaterEqualThan)
     {
-        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterEqualThan(Vector4(0.0f, 1.0f, 2.0f, 3.0f)));
-        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterEqualThan(Vector4(0.0f, 3.0f, 2.0f, 3.0f)));
-        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterEqualThan(Vector4(0.0f, 2.0f, 2.0f, 3.0f)));
+        EXPECT_TRUE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterEqualThan(AZ::Vector4(0.0f, 1.0f, 2.0f, 3.0f)));
+        EXPECT_FALSE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterEqualThan(AZ::Vector4(0.0f, 3.0f, 2.0f, 3.0f)));
+        EXPECT_TRUE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsGreaterEqualThan(AZ::Vector4(0.0f, 2.0f, 2.0f, 3.0f)));
     }
 
     TEST(MATH_Vector4, TestLerpSlerpNLerp)
     {
-        EXPECT_TRUE(Vector4(4.0f, 5.0f, 6.0f, 7.0f).Lerp(Vector4(5.0f, 10.0f, 2.0f, 1.0f), 0.5f).IsClose(Vector4(4.5f, 7.5f, 4.0f, 4.0f)));
-        EXPECT_TRUE(Vector4(1.0f, 0.0f, 0.0f, 0.0f).Slerp(Vector4(0.0f, 1.0f, 0.0f, 0.0f), 0.5f).IsClose(Vector4(0.7071f, 0.7071f, 0.0f, 0.0f)));
-        EXPECT_TRUE(Vector4(1.0f, 0.0f, 0.0f, 0.0f).Nlerp(Vector4(0.0f, 1.0f, 0.0f, 0.0f), 0.5f).IsClose(Vector4(0.7071f, 0.7071f, 0.0f, 0.0f)));
+        EXPECT_TRUE(AZ::Vector4(4.0f, 5.0f, 6.0f, 7.0f).Lerp(AZ::Vector4(5.0f, 10.0f, 2.0f, 1.0f), 0.5f).IsClose(AZ::Vector4(4.5f, 7.5f, 4.0f, 4.0f)));
+        EXPECT_TRUE(AZ::Vector4(1.0f, 0.0f, 0.0f, 0.0f).Slerp(AZ::Vector4(0.0f, 1.0f, 0.0f, 0.0f), 0.5f).IsClose(AZ::Vector4(0.7071f, 0.7071f, 0.0f, 0.0f)));
+        EXPECT_TRUE(AZ::Vector4(1.0f, 0.0f, 0.0f, 0.0f).Nlerp(AZ::Vector4(0.0f, 1.0f, 0.0f, 0.0f), 0.5f).IsClose(AZ::Vector4(0.7071f, 0.7071f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestDot)
     {
-        EXPECT_FLOAT_EQ(Vector4(1.0f, 2.0f, 3.0f, 4.0f).Dot(Vector4(-1.0f, 5.0f, 3.0f, 2.0f)), 26.0f);
-        EXPECT_FLOAT_EQ(Vector4(1.0f, 2.0f, 3.0f, 4.0f).Dot3(Vector3(-1.0f, 5.0f, 3.0f)), 18.0f);
+        EXPECT_FLOAT_EQ(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).Dot(AZ::Vector4(-1.0f, 5.0f, 3.0f, 2.0f)), 26.0f);
+        EXPECT_FLOAT_EQ(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).Dot3(AZ::Vector3(-1.0f, 5.0f, 3.0f)), 18.0f);
     }
 
     TEST(MATH_Vector4, TestIsClose)
     {
-        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
-        EXPECT_FALSE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsClose(Vector4(1.0f, 2.0f, 3.0f, 5.0f)));
-        EXPECT_TRUE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.4f), 0.5f));
+        EXPECT_TRUE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsClose(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
+        EXPECT_FALSE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsClose(AZ::Vector4(1.0f, 2.0f, 3.0f, 5.0f)));
+        EXPECT_TRUE(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).IsClose(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.4f), 0.5f));
     }
 
     TEST(MATH_Vector4, TestHomogenize)
     {
-        Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
-        EXPECT_THAT(v1.GetHomogenized(), IsClose(Vector3(0.25f, 0.5f, 0.75f)));
+        AZ::Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
+        EXPECT_THAT(v1.GetHomogenized(), IsClose(AZ::Vector3(0.25f, 0.5f, 0.75f)));
         v1.Homogenize();
-        EXPECT_THAT(v1, IsClose(Vector4(0.25f, 0.5f, 0.75f, 1.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(0.25f, 0.5f, 0.75f, 1.0f)));
     }
 
     TEST(MATH_Vector4, TestMinMax)
     {
-        EXPECT_THAT(Vector4(2.0f, 5.0f, 6.0f, 7.0f).GetMin(Vector4(1.0f, 6.0f, 5.0f, 4.0f)), IsClose(Vector4(1.0f, 5.0f, 5.0f, 4.0f)));
-        EXPECT_THAT(Vector4(2.0f, 5.0f, 6.0f, 7.0f).GetMax(Vector4(1.0f, 6.0f, 5.0f, 4.0f)), IsClose(Vector4(2.0f, 6.0f, 6.0f, 7.0f)));
+        EXPECT_THAT(AZ::Vector4(2.0f, 5.0f, 6.0f, 7.0f).GetMin(AZ::Vector4(1.0f, 6.0f, 5.0f, 4.0f)), IsClose(AZ::Vector4(1.0f, 5.0f, 5.0f, 4.0f)));
+        EXPECT_THAT(AZ::Vector4(2.0f, 5.0f, 6.0f, 7.0f).GetMax(AZ::Vector4(1.0f, 6.0f, 5.0f, 4.0f)), IsClose(AZ::Vector4(2.0f, 6.0f, 6.0f, 7.0f)));
     }
 
     TEST(MATH_Vector4, TestClamp)
     {
-        EXPECT_THAT(Vector4(1.0f, 2.0f, 3.0f, 4.0f).GetClamp(Vector4(0.0f, -1.0f, 4.0f, 4.0f), Vector4(2.0f, 1.0f, 10.0f, 4.0f)), IsClose(Vector4(1.0f, 1.0f, 4.0f, 4.0f)));
+        EXPECT_THAT(AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f).GetClamp(AZ::Vector4(0.0f, -1.0f, 4.0f, 4.0f), AZ::Vector4(2.0f, 1.0f, 10.0f, 4.0f)), IsClose(AZ::Vector4(1.0f, 1.0f, 4.0f, 4.0f)));
     }
 
     TEST(MATH_Vector4, TestTrig)
     {
-        EXPECT_THAT(Vector4(DegToRad( 78.0f), DegToRad(-150.0f), DegToRad( 190.0f), DegToRad( 78.0f)).GetAngleMod(), IsClose(Vector4(DegToRad(78.0f), DegToRad(-150.0f), DegToRad(-170.0f), DegToRad(78.0f))));
-        EXPECT_THAT(Vector4(DegToRad(390.0f), DegToRad(-190.0f), DegToRad(-400.0f), DegToRad(390.0f)).GetAngleMod(), IsClose(Vector4(DegToRad(30.0f), DegToRad(170.0f), DegToRad(-40.0f), DegToRad(30.0f))));
-        EXPECT_THAT(Vector4(DegToRad( 60.0f), DegToRad( 105.0f), DegToRad(-174.0f), DegToRad( 60.0f)).GetSin(), IsCloseTolerance(Vector4(0.866f, 0.966f, -0.105f, 0.866f), 0.005f));
-        EXPECT_THAT(Vector4(DegToRad( 60.0f), DegToRad( 105.0f), DegToRad(-174.0f), DegToRad( 60.0f)).GetCos(), IsCloseTolerance(Vector4(0.5f, -0.259f, -0.995f, 0.5f), 0.005f));
-        Vector4 sin, cos;
-        Vector4 v1(DegToRad(60.0f), DegToRad(105.0f), DegToRad(-174.0f), DegToRad(60.0f));
+        EXPECT_THAT(AZ::Vector4(AZ::DegToRad( 78.0f), AZ::DegToRad(-150.0f), AZ::DegToRad( 190.0f), AZ::DegToRad( 78.0f)).GetAngleMod(), IsClose(AZ::Vector4(AZ::DegToRad(78.0f), AZ::DegToRad(-150.0f), AZ::DegToRad(-170.0f), AZ::DegToRad(78.0f))));
+        EXPECT_THAT(AZ::Vector4(AZ::DegToRad(390.0f), AZ::DegToRad(-190.0f), AZ::DegToRad(-400.0f), AZ::DegToRad(390.0f)).GetAngleMod(), IsClose(AZ::Vector4(AZ::DegToRad(30.0f), AZ::DegToRad(170.0f), AZ::DegToRad(-40.0f), AZ::DegToRad(30.0f))));
+        EXPECT_THAT(AZ::Vector4(AZ::DegToRad( 60.0f), AZ::DegToRad( 105.0f), AZ::DegToRad(-174.0f), AZ::DegToRad( 60.0f)).GetSin(), IsCloseTolerance(AZ::Vector4(0.866f, 0.966f, -0.105f, 0.866f), 0.005f));
+        EXPECT_THAT(AZ::Vector4(AZ::DegToRad( 60.0f), AZ::DegToRad( 105.0f), AZ::DegToRad(-174.0f), AZ::DegToRad( 60.0f)).GetCos(), IsCloseTolerance(AZ::Vector4(0.5f, -0.259f, -0.995f, 0.5f), 0.005f));
+        AZ::Vector4 sin, cos;
+        AZ::Vector4 v1(AZ::DegToRad(60.0f), AZ::DegToRad(105.0f), AZ::DegToRad(-174.0f), AZ::DegToRad(60.0f));
         v1.GetSinCos(sin, cos);
-        EXPECT_THAT(sin, IsCloseTolerance(Vector4(0.866f, 0.966f, -0.105f, 0.866f), 0.005f));
-        EXPECT_THAT(cos, IsCloseTolerance(Vector4(0.5f, -0.259f, -0.995f, 0.5f), 0.005f));
+        EXPECT_THAT(sin, IsCloseTolerance(AZ::Vector4(0.866f, 0.966f, -0.105f, 0.866f), 0.005f));
+        EXPECT_THAT(cos, IsCloseTolerance(AZ::Vector4(0.5f, -0.259f, -0.995f, 0.5f), 0.005f));
     }
 
     TEST(MATH_Vector4, TestAbs)
     {
-        EXPECT_THAT(Vector4(-1.0f, 2.0f, -5.0f, 1.0f).GetAbs(), IsClose(Vector4(1.0f, 2.0f, 5.0f, 1.0f)));
-        EXPECT_THAT(Vector4(1.0f, -2.0f, 5.0f, -1.0f).GetAbs(), IsClose(Vector4(1.0f, 2.0f, 5.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector4(-1.0f, 2.0f, -5.0f, 1.0f).GetAbs(), IsClose(AZ::Vector4(1.0f, 2.0f, 5.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector4(1.0f, -2.0f, 5.0f, -1.0f).GetAbs(), IsClose(AZ::Vector4(1.0f, 2.0f, 5.0f, 1.0f)));
     }
 
     TEST(MATH_Vector4, TestReciprocal)
     {
-        EXPECT_THAT(Vector4(2.0f, 4.0f, 5.0f, 10.0f).GetReciprocal(), IsClose(Vector4(0.5f, 0.25f, 0.2f, 0.1f)));
-        EXPECT_THAT(Vector4(2.0f, 4.0f, 5.0f, 10.0f).GetReciprocalEstimate(), IsCloseTolerance(Vector4(0.5f, 0.25f, 0.2f, 0.1f), 1e-3f));
+        EXPECT_THAT(AZ::Vector4(2.0f, 4.0f, 5.0f, 10.0f).GetReciprocal(), IsClose(AZ::Vector4(0.5f, 0.25f, 0.2f, 0.1f)));
+        EXPECT_THAT(AZ::Vector4(2.0f, 4.0f, 5.0f, 10.0f).GetReciprocalEstimate(), IsCloseTolerance(AZ::Vector4(0.5f, 0.25f, 0.2f, 0.1f), 1e-3f));
     }
 
     TEST(MATH_Vector4, TestNegate)
     {
-        EXPECT_THAT((-Vector4(1.0f, 2.0f, -3.0f, -1.0f)), IsClose(Vector4(-1.0f, -2.0f, 3.0f, 1.0f)));
+        EXPECT_THAT((-AZ::Vector4(1.0f, 2.0f, -3.0f, -1.0f)), IsClose(AZ::Vector4(-1.0f, -2.0f, 3.0f, 1.0f)));
     }
 
     TEST(MATH_Vector4, TestAdd)
     {
-        EXPECT_THAT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) + Vector4(-1.0f, 4.0f, 5.0f, 2.0f)), IsClose(Vector4(0.0f, 6.0f, 8.0f, 6.0f)));
+        EXPECT_THAT((AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f) + AZ::Vector4(-1.0f, 4.0f, 5.0f, 2.0f)), IsClose(AZ::Vector4(0.0f, 6.0f, 8.0f, 6.0f)));
 
-        Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
-        v1 += Vector4(5.0f, 3.0f, -1.0f, 2.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(6.0f, 5.0f, 2.0f, 6.0f)));
+        AZ::Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
+        v1 += AZ::Vector4(5.0f, 3.0f, -1.0f, 2.0f);
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(6.0f, 5.0f, 2.0f, 6.0f)));
     }
 
     TEST(MATH_Vector4, TestSub)
     {
-        EXPECT_THAT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) - Vector4(-1.0f, 4.0f, 5.0f, 2.0f)), IsClose(Vector4(2.0f, -2.0f, -2.0f, 2.0f)));
+        EXPECT_THAT((AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f) - AZ::Vector4(-1.0f, 4.0f, 5.0f, 2.0f)), IsClose(AZ::Vector4(2.0f, -2.0f, -2.0f, 2.0f)));
 
-        Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
-        v1 += Vector4(5.0f, 3.0f, -1.0f, 2.0f);
-        v1 -= Vector4(2.0f, -1.0f, 3.0f, 1.0f);
-        EXPECT_THAT(v1, IsClose(Vector4(4.0f, 6.0f, -1.0f, 5.0f)));
+        AZ::Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
+        v1 += AZ::Vector4(5.0f, 3.0f, -1.0f, 2.0f);
+        v1 -= AZ::Vector4(2.0f, -1.0f, 3.0f, 1.0f);
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(4.0f, 6.0f, -1.0f, 5.0f)));
     }
 
     TEST(MATH_Vector4, TestMultiply)
     {
-        EXPECT_THAT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) * Vector4(-1.0f, 4.0f, 5.0f, 2.0f)), IsClose(Vector4(-1.0f, 8.0f, 15.0f, 8.0f)));
-        EXPECT_THAT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) * 2.0f), IsClose(Vector4(2.0f, 4.0f, 6.0f, 8.0f)));
-        EXPECT_THAT((2.0f * Vector4(1.0f, 2.0f, 3.0f, 4.0f)), IsClose(Vector4(2.0f, 4.0f, 6.0f, 8.0f)));
+        EXPECT_THAT((AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f) * AZ::Vector4(-1.0f, 4.0f, 5.0f, 2.0f)), IsClose(AZ::Vector4(-1.0f, 8.0f, 15.0f, 8.0f)));
+        EXPECT_THAT((AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f) * 2.0f), IsClose(AZ::Vector4(2.0f, 4.0f, 6.0f, 8.0f)));
+        EXPECT_THAT((2.0f * AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f)), IsClose(AZ::Vector4(2.0f, 4.0f, 6.0f, 8.0f)));
 
-        Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
-        v1 += Vector4(5.0f, 3.0f, -1.0f, 2.0f);
-        v1 -= Vector4(2.0f, -1.0f, 3.0f, 1.0f);
+        AZ::Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
+        v1 += AZ::Vector4(5.0f, 3.0f, -1.0f, 2.0f);
+        v1 -= AZ::Vector4(2.0f, -1.0f, 3.0f, 1.0f);
         v1 *= 3.0f;
-        EXPECT_THAT(v1, IsClose(Vector4(12.0f, 18.0f, -3.0f, 15.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(12.0f, 18.0f, -3.0f, 15.0f)));
     }
 
     TEST(MATH_Vector4, TestDivide)
     {
-        EXPECT_THAT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) / Vector4(-1.0f, 4.0f, 5.0f, 2.0f)), IsClose(Vector4(-1.0f, 0.5f, 3.0f / 5.0f, 2.0f)));
-        EXPECT_THAT((Vector4(1.0f, 2.0f, 3.0f, 4.0f) / 2.0f), IsClose(Vector4(0.5f, 1.0f, 1.5f, 2.0f)));
+        EXPECT_THAT((AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f) / AZ::Vector4(-1.0f, 4.0f, 5.0f, 2.0f)), IsClose(AZ::Vector4(-1.0f, 0.5f, 3.0f / 5.0f, 2.0f)));
+        EXPECT_THAT((AZ::Vector4(1.0f, 2.0f, 3.0f, 4.0f) / 2.0f), IsClose(AZ::Vector4(0.5f, 1.0f, 1.5f, 2.0f)));
 
-        Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
-        v1 += Vector4(5.0f, 3.0f, -1.0f, 2.0f);
-        v1 -= Vector4(2.0f, -1.0f, 3.0f, 1.0f);
+        AZ::Vector4 v1(1.0f, 2.0f, 3.0f, 4.0f);
+        v1 += AZ::Vector4(5.0f, 3.0f, -1.0f, 2.0f);
+        v1 -= AZ::Vector4(2.0f, -1.0f, 3.0f, 1.0f);
         v1 *= 3.0f;
         v1 /= 2.0f;
-        EXPECT_THAT(v1, IsClose(Vector4(6.0f, 9.0f, -1.5f, 7.5f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector4(6.0f, 9.0f, -1.5f, 7.5f)));
     }
 
     struct AngleTestArgs
@@ -443,12 +440,12 @@ namespace UnitTest
         MATH_Vector4,
         AngleTestFixture,
         ::testing::Values(
-            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, AZ::Constants::HalfPi },
-            AngleTestArgs{ Vector4{ 42.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 23.0f, 0.0f, 0.0f }, AZ::Constants::HalfPi },
-            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ -1.0f, 0.0f, 0.0f, 0.0f }, AZ::Constants::Pi },
-            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, AZ::Constants::QuarterPi },
-            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, Vector4{ -1.0f, -1.0f, 0.0f, 0.0f }, AZ::Constants::Pi }));
+            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, AZ::Constants::HalfPi },
+            AngleTestArgs{ AZ::Vector4{ 42.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 23.0f, 0.0f, 0.0f }, AZ::Constants::HalfPi },
+            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ -1.0f, 0.0f, 0.0f, 0.0f }, AZ::Constants::Pi },
+            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, AZ::Constants::QuarterPi },
+            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, AZ::Vector4{ -1.0f, -1.0f, 0.0f, 0.0f }, AZ::Constants::Pi }));
 
     using AngleDegTestFixture = ::testing::TestWithParam<AngleTestArgs>;
 
@@ -467,12 +464,12 @@ namespace UnitTest
         MATH_Vector4,
         AngleDegTestFixture,
         ::testing::Values(
-            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, 90.f },
-            AngleTestArgs{ Vector4{ 42.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 23.0f, 0.0f, 0.0f }, 90.f },
-            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ -1.0f, 0.0f, 0.0f, 0.0f }, 180.f },
-            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, 45.f },
-            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, Vector4{ -1.0f, -1.0f, 0.0f, 0.0f }, 180.f }));
+            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, 90.f },
+            AngleTestArgs{ AZ::Vector4{ 42.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 23.0f, 0.0f, 0.0f }, 90.f },
+            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ -1.0f, 0.0f, 0.0f, 0.0f }, 180.f },
+            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, 45.f },
+            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, AZ::Vector4{ -1.0f, -1.0f, 0.0f, 0.0f }, 180.f }));
 
     using AngleSafeInvalidAngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
     TEST_P(AngleSafeInvalidAngleTestFixture, TestInvalidAngle)
@@ -491,9 +488,9 @@ namespace UnitTest
         MATH_Vector4,
         AngleSafeInvalidAngleTestFixture,
         ::testing::Values(
-            AngleTestArgs{ Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 323432.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector4{ 323432.0f, 0.0f, 0.0f, 0.0f }, Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f }));
+            AngleTestArgs{ AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 323432.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector4{ 323432.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f }));
 } // namespace UnitTest


### PR DESCRIPTION
## What does this PR do?

this just cleans up the existing test cases for Vector4Tests. 

- replace usage of == used with Vector4 with EXPECT_THAT
- replace TestAngles with separate parameterized tests, avoids a lot of the custom logic with parametrized test cases. 

## How was this PR tested?

run
```
./AzTestRunner ./libAzCore.Tests.so AzRunUnitTests --gtest_filter="*MATH_Vector4*"
```
