### PR TITLE
Material Canvas: Added several math function test nodes

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ExamplePBR/MaterialGraphName_ForwardPass.azsl.template
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ExamplePBR/MaterialGraphName_ForwardPass.azsl.template
@@ -67,6 +67,7 @@ ForwardPassOutput MaterialGraphName_MainPassPS(VSOutput IN)
 {
     // GENERATED_INSTRUCTIONS_BEGIN
     float4 inBaseColor = float4(1.0, 1.0, 1.0, 1.0);
+    float4 inEmissive = float4(0.0, 0.0, 0.0, 0.0);
     float inMetallic = 1.0;
     float inRoughness = 0.5;
     float inSpecularF0Factor = 0.5;
@@ -90,6 +91,7 @@ ForwardPassOutput MaterialGraphName_MainPassPS(VSOutput IN)
     lightingData.Init(surface.position, surface.normal, surface.roughnessLinear);
     lightingData.specularResponse = FresnelSchlickWithRoughness(lightingData.NdotV, surface.specularF0, surface.roughnessLinear);
     lightingData.diffuseResponse = 1.0f - lightingData.specularResponse;
+    lightingData.emissiveLighting = inEmissive;
 
     // ------- Lighting Calculation -------
 

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ExamplePBR/example_pbr.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ExamplePBR/example_pbr.materialcanvasnode.azasset
@@ -3,7 +3,7 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "category": "Lighting Model",
+        "category": "Material Templates",
         "title": "Example PBR",
         "settings": {
             "templatePaths": [

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/abs.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/abs.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "abs",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = abs(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/acos.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/acos.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "acos",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = acos(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/add.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/add.materialcanvasnode.azasset
@@ -3,8 +3,8 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "category": "Math Operations",
-        "title": "Add",
+        "category": "Math Functions",
+        "title": "add",
         "inputSlots": [
             {
                 "name": "inValue1",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/asfloat.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/asfloat.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "asfloat",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = asfloat(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/asin.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/asin.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "asin",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = asin(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/atan.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/atan.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "atan",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = atan(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/atan2.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/atan2.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "atan2",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -73,7 +73,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = atan2(NODEID_inValue1, NODEID_inValue2);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ceil.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ceil.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "ceil",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = ceil(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/clamp.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/clamp.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "clamp",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -53,6 +53,30 @@
                 "settings": {
                     "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
                 }
+            },
+            {
+                "name": "inValue3",
+                "displayName": "Value3",
+                "description": "Value3",
+                "supportedDataTypes": [
+                    "float",
+                    "float2",
+                    "float3",
+                    "float4",
+                    "color"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
+                }
             }
         ],
         "outputSlots": [
@@ -73,7 +97,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = clamp(NODEID_inValue1, NODEID_inValue2, NODEID_inValue3);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/clip.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/clip.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "clip",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = clip(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/clip.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/clip.materialcanvasnode.azasset
@@ -5,6 +5,9 @@
     "ClassData": {
         "category": "Math Functions",
         "title": "clip",
+        "settings": {
+            "instructions": [ "clip(NODEID_inValue);" ]
+        },
         "inputSlots": [
             {
                 "name": "inValue",
@@ -47,9 +50,6 @@
                         0.0,
                         0.0
                     ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = clip(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/combine.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/combine.materialcanvasnode.azasset
@@ -3,8 +3,8 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "category": "Math Operations",
-        "title": "Combine",
+        "category": "Math Functions",
+        "title": "combine",
         "inputSlots": [
             {
                 "name": "inX",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/cos.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/cos.materialcanvasnode.azasset
@@ -3,8 +3,8 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "category": "Math Operations",
-        "title": "Cosine",
+        "category": "Math Functions",
+        "title": "cos",
         "inputSlots": [
             {
                 "name": "inValue",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/cosh.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/cosh.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "cosh",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = cosh(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/cross.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/cross.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "cross",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -73,7 +73,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = cross(NODEID_inValue1, NODEID_inValue2);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddx.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddx.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "ddx",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = ddx(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddx_coarse.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddx_coarse.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "ddx_coarse",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = ddx_coarse(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddx_fine.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddx_fine.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "ddx_fine",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = ddx_fine(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddy.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddy.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "ddy",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = ddy(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddy_coarse.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddy_coarse.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "ddy_coarse",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = ddy_coarse(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddy_fine.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddy_fine.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "ddy_fine",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = ddy_fine(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/degrees.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/degrees.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "degrees",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = degrees(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/distance.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/distance.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "distance",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -73,7 +73,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = distance(NODEID_inValue1, NODEID_inValue2);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/divide.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/divide.materialcanvasnode.azasset
@@ -3,8 +3,8 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "category": "Math Operations",
-        "title": "Divide",
+        "category": "Math Functions",
+        "title": "divide",
         "inputSlots": [
             {
                 "name": "inValue1",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/dot.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/dot.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "dot",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -73,7 +73,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = dot(NODEID_inValue1, NODEID_inValue2);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/exp.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/exp.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "exp",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = exp(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/exp2.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/exp2.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "exp2",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = exp2(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/floor.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/floor.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "floor",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = floor(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/fmod.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/fmod.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "fmod",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -73,7 +73,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = fmod(NODEID_inValue1, NODEID_inValue2);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/frac.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/frac.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "frac",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = frac(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/frexp.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/frexp.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "frexp",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -73,7 +73,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = frexp(NODEID_inValue1, NODEID_inValue2);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/fwidth.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/fwidth.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "fwidth",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = fwidth(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ldexp.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ldexp.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "ldexp",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -73,7 +73,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = ldexp(NODEID_inValue1, NODEID_inValue2);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/length.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/length.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "length",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = length(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/lerp.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/lerp.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "lerp",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -53,6 +53,30 @@
                 "settings": {
                     "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
                 }
+            },
+            {
+                "name": "inValue3",
+                "displayName": "Value3",
+                "description": "Value3",
+                "supportedDataTypes": [
+                    "float",
+                    "float2",
+                    "float3",
+                    "float4",
+                    "color"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
+                }
             }
         ],
         "outputSlots": [
@@ -73,7 +97,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = lerp(NODEID_inValue1, NODEID_inValue2, NODEID_inValue3);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/lit.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/lit.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "lit",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -53,6 +53,30 @@
                 "settings": {
                     "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
                 }
+            },
+            {
+                "name": "inValue3",
+                "displayName": "Value3",
+                "description": "Value3",
+                "supportedDataTypes": [
+                    "float",
+                    "float2",
+                    "float3",
+                    "float4",
+                    "color"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
+                }
             }
         ],
         "outputSlots": [
@@ -73,7 +97,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = lit(NODEID_inValue1, NODEID_inValue2, NODEID_inValue3);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/log.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/log.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "log",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = log(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/log10.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/log10.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "log10",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = log10(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/log2.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/log2.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "log2",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = log2(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/mad.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/mad.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "mad",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -53,6 +53,30 @@
                 "settings": {
                     "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
                 }
+            },
+            {
+                "name": "inValue3",
+                "displayName": "Value3",
+                "description": "Value3",
+                "supportedDataTypes": [
+                    "float",
+                    "float2",
+                    "float3",
+                    "float4",
+                    "color"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
+                }
             }
         ],
         "outputSlots": [
@@ -73,7 +97,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = mad(NODEID_inValue1, NODEID_inValue2, NODEID_inValue3);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/max.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/max.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "max",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -73,7 +73,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = max(NODEID_inValue1, NODEID_inValue2);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/min.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/min.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "min",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -73,7 +73,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = min(NODEID_inValue1, NODEID_inValue2);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/mul.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/mul.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "mul",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -73,7 +73,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = mul(NODEID_inValue1, NODEID_inValue2);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/multiply.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/multiply.materialcanvasnode.azasset
@@ -3,8 +3,8 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "category": "Math Operations",
-        "title": "Multiply",
+        "category": "Math Functions",
+        "title": "multiply",
         "inputSlots": [
             {
                 "name": "inValue1",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/noise.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/noise.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "noise",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = noise(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/normalize.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/normalize.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "normalize",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = normalize(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/pow.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/pow.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "pow",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -73,7 +73,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = pow(NODEID_inValue1, NODEID_inValue2);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/radians.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/radians.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "radians",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = radians(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/rcp.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/rcp.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "rcp",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = rcp(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/reflect.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/reflect.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "reflect",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -73,7 +73,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = reflect(NODEID_inValue1, NODEID_inValue2);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/refract.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/refract.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "refract",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -53,6 +53,30 @@
                 "settings": {
                     "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
                 }
+            },
+            {
+                "name": "inValue3",
+                "displayName": "Value3",
+                "description": "Value3",
+                "supportedDataTypes": [
+                    "float",
+                    "float2",
+                    "float3",
+                    "float4",
+                    "color"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
+                }
             }
         ],
         "outputSlots": [
@@ -73,7 +97,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = refract(NODEID_inValue1, NODEID_inValue2, NODEID_inValue3);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/round.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/round.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "round",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = round(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/rsqrt.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/rsqrt.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "rsqrt",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = rsqrt(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/saturate.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/saturate.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "saturate",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = saturate(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sign.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sign.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "sign",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = sign(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sin.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sin.materialcanvasnode.azasset
@@ -3,8 +3,8 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "category": "Math Operations",
-        "title": "Sine",
+        "category": "Math Functions",
+        "title": "sin",
         "inputSlots": [
             {
                 "name": "inValue",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sincos.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sincos.materialcanvasnode.azasset
@@ -4,36 +4,19 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "sincos",
+        "settings": {
+            "instructions": [
+                "float4 NODEID_outValue1 = float4(0, 0, 0, 0);",
+                "float4 NODEID_outValue2 = float4(0, 0, 0, 0);",
+                "sincos(NODEID_inValue, NODEID_outValue1, NODEID_outValue2);"
+            ]
+        },
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -57,9 +40,9 @@
         ],
         "outputSlots": [
             {
-                "name": "outValue",
-                "displayName": "Value",
-                "description": "Value",
+                "name": "outValue1",
+                "displayName": "Value1",
+                "description": "Value1",
                 "supportedDataTypes": [
                     "float4"
                 ],
@@ -71,9 +54,23 @@
                         0.0,
                         0.0
                     ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                }
+            },
+            {
+                "name": "outValue2",
+                "displayName": "Value2",
+                "description": "Value2",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sinh.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sinh.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "sinh",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = sinh(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/smoothstep.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/smoothstep.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "smoothstep",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -53,6 +53,30 @@
                 "settings": {
                     "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
                 }
+            },
+            {
+                "name": "inValue3",
+                "displayName": "Value3",
+                "description": "Value3",
+                "supportedDataTypes": [
+                    "float",
+                    "float2",
+                    "float3",
+                    "float4",
+                    "color"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
+                }
             }
         ],
         "outputSlots": [
@@ -73,7 +97,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = smoothstep(NODEID_inValue1, NODEID_inValue2, NODEID_inValue3);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/split.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/split.materialcanvasnode.azasset
@@ -3,8 +3,8 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "category": "Math Operations",
-        "title": "Split",
+        "category": "Math Functions",
+        "title": "split",
         "inputSlots": [
             {
                 "name": "inValue",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sqrt.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sqrt.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "sqrt",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = sqrt(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/step.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/step.materialcanvasnode.azasset
@@ -4,7 +4,7 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "step",
         "inputSlots": [
             {
                 "name": "inValue1",
@@ -73,7 +73,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = step(NODEID_inValue1, NODEID_inValue2);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/tan.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/tan.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "tan",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = tan(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/tanh.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/tanh.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "tanh",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = tanh(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/time.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/time.materialcanvasnode.azasset
@@ -3,8 +3,8 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "category": "Math Operations",
-        "title": "Time",
+        "category": "Math Functions",
+        "title": "time",
         "outputSlots": [
             {
                 "name": "outTime",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/trunc.materialcanvasnode.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/trunc.materialcanvasnode.azasset
@@ -4,36 +4,12 @@
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
         "category": "Math Functions",
-        "title": "subtract",
+        "title": "trunc",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
-                "supportedDataTypes": [
-                    "float",
-                    "float2",
-                    "float3",
-                    "float4",
-                    "color"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                },
-                "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;" ]
-                }
-            },
-            {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -73,7 +49,7 @@
                     ]
                 },
                 "settings": {
-                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;" ]
+                    "instructions": [ "SLOTTYPE NODEID_SLOTNAME = trunc(NODEID_inValue);" ]
                 }
             }
         ]

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -621,6 +621,13 @@ namespace MaterialCanvas
                         updateAndAddSlotInstructions(node, slot, instructionsForSlot);
                     }
                 }
+
+                // Gather and insert instructions provided by the node.
+                // We might need separate blocks of instructions that can be processed before or after the slots are processed.
+                AZStd::vector<AZStd::string> instructionsForNode;
+                collectSettingsAsVec(nodeConfig.m_settings, "instructions", instructionsForNode);
+                replaceStringsInVec("NODEID", AZStd::string::format("node%u", node->GetId()), instructionsForNode);
+                instructions.insert(instructions.end(), instructionsForNode.begin(), instructionsForNode.end());
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

This PR is almost entirely data, adding node configuration files for several math related functions to experiment with and help validate generated shaders. Once the data is hardened and these are more final, more descriptive node and slot names and tooltips will be added.

Updated the code that collects instructions to also get instructions from the node configurations. This was always planned, needed for sincos and functions with multiple outputs where we don't want to duplicate the generated code for each output.

Updating the example template to enable emissive color.

https://github.com/o3de/sig-graphics-audio/issues/51

_Please add links to any issues, RFCs or other items that are relevant to this PR._

## How was this PR tested?
The purpose of this change is to generate data for testing.
Manually tested some, but not all of the nodes by using them in graphs.
Automated tests will be written for material canvas features and data.

https://user-images.githubusercontent.com/82461473/180621539-b499609f-632b-4af0-bd2e-985fe644e5e1.mp4


