### PR TITLE
Bug fix for updating nav mesh tiles when all physical colliders were removed within that tile's volume

### DIFF
--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshComponentController.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshComponentController.cpp
@@ -82,6 +82,15 @@ namespace RecastNavigation
         {
             for (AZStd::shared_ptr<TileGeometry>& tile : tiles)
             {
+                {
+                    NavMeshQuery::LockGuard lock(*m_navObject);
+                    // If a tile at the location already exists, remove it before updating the data.
+                    if (const dtTileRef tileRef = lock.GetNavMesh()->getTileRefAt(tile->m_tileX, tile->m_tileY, 0))
+                    {
+                        lock.GetNavMesh()->removeTile(tileRef, nullptr, nullptr);
+                    }
+                }
+
                 if (tile->IsEmpty())
                 {
                     continue;
@@ -90,15 +99,6 @@ namespace RecastNavigation
                 // Given geometry create Recast tile structure.
                 NavigationTileData navigationTileData = CreateNavigationTile(tile.get(),
                     m_configuration, m_context.get());
-
-                {
-                    NavMeshQuery::LockGuard lock(*m_navObject);
-                    // If a tile at the location already exists, remove it before update the data.
-                    if (const dtTileRef tileRef = lock.GetNavMesh()->getTileRefAt(tile->m_tileX, tile->m_tileY, 0))
-                    {
-                        lock.GetNavMesh()->removeTile(tileRef, nullptr, nullptr);
-                    }
-                }
 
                 // A tile might have no geometry at all if no objects were found there.
                 if (navigationTileData.IsValid())

--- a/Gems/RecastNavigation/Code/Tests/NavigationMeshTest.cpp
+++ b/Gems/RecastNavigation/Code/Tests/NavigationMeshTest.cpp
@@ -24,8 +24,6 @@
 #include <PhysX/MockSceneInterface.h>
 #include <PhysX/MockSimulatedBody.h>
 
-#pragma optimize("", off)
-
 namespace RecastNavigationTests
 {
     using testing::_;
@@ -931,5 +929,3 @@ namespace RecastNavigationTests
         EXPECT_EQ(waypoints.size(), 0);
     }
 }
-
-#pragma optimize("", on)

--- a/Gems/RecastNavigation/Code/Tests/NavigationMeshTest.cpp
+++ b/Gems/RecastNavigation/Code/Tests/NavigationMeshTest.cpp
@@ -24,6 +24,8 @@
 #include <PhysX/MockSceneInterface.h>
 #include <PhysX/MockSimulatedBody.h>
 
+#pragma optimize("", off)
+
 namespace RecastNavigationTests
 {
     using testing::_;
@@ -890,4 +892,44 @@ namespace RecastNavigationTests
         waypoints = detour->FindPathBetweenPositions(AZ::Vector3(0.f, 0.f, 0.f), AZ::Vector3(2.f, 2.f, 0.f));
         EXPECT_GE(waypoints.size(), 1);
     }
+
+    TEST_F(NavigationTest, NavUpdateThenDeleteCollidersThenUpdateAgainThenFindPathShouldFail)
+    {
+        Entity e;
+        PopulateEntity(e);
+        e.CreateComponent<DetourNavigationComponent>(e.GetId(), 3.f);
+        ActivateEntity(e);
+        SetupNavigationMesh();
+
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
+            {
+                AddTestGeometry(vertices, indices, true);
+            }));
+        
+        RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
+
+        AZStd::vector<AZ::Vector3> waypoints;
+        DetourNavigationRequestBus::EventResult(waypoints, AZ::EntityId(1), &DetourNavigationRequests::FindPathBetweenPositions,
+            AZ::Vector3(0.f, 0.f, 0.f), AZ::Vector3(2.f, 2.f, 0.f));
+        EXPECT_GT(waypoints.size(), 1);
+
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([]
+        (
+            [[maybe_unused]] AZStd::vector<AZ::Vector3>& vertices,
+            [[maybe_unused]] AZStd::vector<AZ::u32>& indices,
+            [[maybe_unused]] const AZ::Aabb*)
+            {
+                // Act as if there colliders are gone.
+            }));
+        
+        RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
+
+        waypoints.clear();
+        DetourNavigationRequestBus::EventResult(waypoints, AZ::EntityId(1), &DetourNavigationRequests::FindPathBetweenPositions,
+            AZ::Vector3(0.f, 0.f, 0.f), AZ::Vector3(2.f, 2.f, 0.f));
+        EXPECT_EQ(waypoints.size(), 0);
+    }
 }
+
+#pragma optimize("", on)


### PR DESCRIPTION
## What does this PR do?

Fixing a bug where a navigation mesh would not update a file if all the physical colliders were removed within that tile.
With these changes, that tile will now be updated to have no navigation data, instead of keeping the stale data before colliders were removed.

Added a unit test for this scenario as well: `NavigationTest.NavUpdateThenDeleteCollidersThenUpdateAgainThenFindPathShouldFail`

## How was this PR tested?

Unit tests.

```
[==========] Running 24 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 24 tests from NavigationTest
[ RUN      ] NavigationTest.GetNativeNavMesh
[       OK ] NavigationTest.GetNativeNavMesh (26 ms)
[ RUN      ] NavigationTest.TestAgainstEmptyPhysicalBody
[       OK ] NavigationTest.TestAgainstEmptyPhysicalBody (14 ms)
[ RUN      ] NavigationTest.BlockingTest
[       OK ] NavigationTest.BlockingTest (17 ms)
[ RUN      ] NavigationTest.BlockingTestWithDebugDraw
[       OK ] NavigationTest.BlockingTestWithDebugDraw (20 ms)
[ RUN      ] NavigationTest.BlockingNonIndexedWithDebugDraw
[       OK ] NavigationTest.BlockingNonIndexedWithDebugDraw (19 ms)
[ RUN      ] NavigationTest.BlockingTestRerun
[       OK ] NavigationTest.BlockingTestRerun (14 ms)
[ RUN      ] NavigationTest.BlockingOnEmptyRerun
[       OK ] NavigationTest.BlockingOnEmptyRerun (14 ms)
[ RUN      ] NavigationTest.BlockingTestNonIndexedGeometry
[       OK ] NavigationTest.BlockingTestNonIndexedGeometry (18 ms)
[ RUN      ] NavigationTest.TickingDebugDraw
[       OK ] NavigationTest.TickingDebugDraw (20 ms)
[ RUN      ] NavigationTest.DirectTestOnDebugDrawQuad
[       OK ] NavigationTest.DirectTestOnDebugDrawQuad (4 ms)
[ RUN      ] NavigationTest.DirectTestOnDebugDrawLines
[       OK ] NavigationTest.DirectTestOnDebugDrawLines (5 ms)
[ RUN      ] NavigationTest.DirectTestOnDebugDrawWithoutDebugDisplayRequests
[       OK ] NavigationTest.DirectTestOnDebugDrawWithoutDebugDisplayRequests (5 ms)
[ RUN      ] NavigationTest.FindPathTestDetaultDetourSettings
[       OK ] NavigationTest.FindPathTestDetaultDetourSettings (17 ms)
[ RUN      ] NavigationTest.FindPathTest
[       OK ] NavigationTest.FindPathTest (17 ms)
[ RUN      ] NavigationTest.FindPathToOutOfBoundsDestination
[       OK ] NavigationTest.FindPathToOutOfBoundsDestination (16 ms)
[ RUN      ] NavigationTest.FindPathOnEmptyNavMesh
[       OK ] NavigationTest.FindPathOnEmptyNavMesh (14 ms)
[ RUN      ] NavigationTest.FindPathBetweenInvalidEntities
[       OK ] NavigationTest.FindPathBetweenInvalidEntities (15 ms)
[ RUN      ] NavigationTest.FindPathBetweenEntitiesOnEmptyNavMesh
[       OK ] NavigationTest.FindPathBetweenEntitiesOnEmptyNavMesh (15 ms)
[ RUN      ] NavigationTest.RecastNavigationMeshComponentControllerTests
[       OK ] NavigationTest.RecastNavigationMeshComponentControllerTests (8 ms)
[ RUN      ] NavigationTest.RecastNavigationNotificationHandler
[       OK ] NavigationTest.RecastNavigationNotificationHandler (3 ms)
[ RUN      ] NavigationTest.RecastNavigationPhysXProviderComponentController
[       OK ] NavigationTest.RecastNavigationPhysXProviderComponentController (11 ms)
[ RUN      ] NavigationTest.CollectGeometryCornerCaseZeroTileSize
[       OK ] NavigationTest.CollectGeometryCornerCaseZeroTileSize (14 ms)
[ RUN      ] NavigationTest.DetourSetNavMeshEntity
[       OK ] NavigationTest.DetourSetNavMeshEntity (13 ms)
[ RUN      ] NavigationTest.NavUpdateThenDeleteCollidersThenUpdateAgainThenFindPathShouldFail
[       OK ] NavigationTest.NavUpdateThenDeleteCollidersThenUpdateAgainThenFindPathShouldFail (17 ms)
[----------] 24 tests from NavigationTest (347 ms total)

[----------] Global test environment tear-down
[==========] 24 tests from 1 test case ran. (349 ms total)
[  PASSED  ] 24 tests.
```