### PR TITLE
chore: cleanup Vector3Tests

### DIFF
--- a/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
@@ -14,86 +14,84 @@
 #include <AZTestShared/Math/MathTestHelpers.h>
 #include <AzCore/Math/SimdMath.h>
 
-using namespace AZ;
-
 namespace UnitTest
 {
     TEST(MATH_Vector3, TestConstructors)
     {
-        Vector3 v1(0.0f);
+        AZ::Vector3 v1(0.0f);
         EXPECT_FLOAT_EQ(v1.GetX(), 0.0f);
         EXPECT_FLOAT_EQ(v1.GetY(), 0.0f);
         EXPECT_FLOAT_EQ(v1.GetZ(), 0.0f);
-        Vector3 v2(5.0f);
+        AZ::Vector3 v2(5.0f);
         EXPECT_FLOAT_EQ(v2.GetX(), 5.0f);
         EXPECT_FLOAT_EQ(v2.GetY(), 5.0f);
         EXPECT_FLOAT_EQ(v2.GetZ(), 5.0f);
-        Vector3 v3(1.0f, 2.0f, 3.0f);
+        AZ::Vector3 v3(1.0f, 2.0f, 3.0f);
         EXPECT_FLOAT_EQ(v3.GetX(), 1.0f);
         EXPECT_FLOAT_EQ(v3.GetY(), 2.0f);
         EXPECT_FLOAT_EQ(v3.GetZ(), 3.0f);
         
-        EXPECT_THAT(Vector3(Vector3(1.0f, 3.0f,2.0f)), IsClose(Vector3(1.0f, 3.0f,2.0f)));
-        EXPECT_THAT(Vector3(Vector2(1.0f, 3.0f)), IsClose(Vector3(1.0f, 3.0f,0.0f)));
-        EXPECT_THAT(Vector3(Vector2(1.0f, 3.0f), 6.0f), IsClose(Vector3(1.0f, 3.0f,6.0f)));
-        EXPECT_THAT(Vector3(Vector4(1.0f, 3.0f, 5.0f, 2.0f)), IsClose(Vector3(1.0f, 3.0f, 5.0f)));
-        EXPECT_THAT(Vector3(Simd::Vec3::LoadImmediate(1.0f, 2.0f, 4.0f)), IsClose(Vector3(1.0f, 2.0f, 4.0f)));
+        EXPECT_THAT(AZ::Vector3(AZ::Vector3(1.0f, 3.0f,2.0f)), IsClose(AZ::Vector3(1.0f, 3.0f,2.0f)));
+        EXPECT_THAT(AZ::Vector3(AZ::Vector2(1.0f, 3.0f)), IsClose(AZ::Vector3(1.0f, 3.0f,0.0f)));
+        EXPECT_THAT(AZ::Vector3(AZ::Vector2(1.0f, 3.0f), 6.0f), IsClose(AZ::Vector3(1.0f, 3.0f,6.0f)));
+        EXPECT_THAT(AZ::Vector3(AZ::Vector4(1.0f, 3.0f, 5.0f, 2.0f)), IsClose(AZ::Vector3(1.0f, 3.0f, 5.0f)));
+        EXPECT_THAT(AZ::Vector3(Simd::Vec3::LoadImmediate(1.0f, 2.0f, 4.0f)), IsClose(AZ::Vector3(1.0f, 2.0f, 4.0f)));
 
     }
 
     TEST(MATH_Vector3, TestCreateFunctions)
     {
-        EXPECT_THAT(Vector3::CreateOne(), IsClose(Vector3(1.0f, 1.0f, 1.0f)));
-        EXPECT_THAT(Vector3::CreateZero(), IsClose(Vector3(0.0f)));
+        EXPECT_THAT(AZ::Vector3::CreateOne(), IsClose(AZ::Vector3(1.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector3::CreateZero(), IsClose(AZ::Vector3(0.0f)));
         float values[3] = { 10.0f, 20.0f, 30.0f };
-        EXPECT_THAT(Vector3::CreateFromFloat3(values), IsClose(Vector3(10.0f, 20.0f, 30.0f)));
-        EXPECT_THAT(Vector3::CreateAxisX(), IsClose(Vector3(1.0f, 0.0f, 0.0f)));
-        EXPECT_THAT(Vector3::CreateAxisY(), IsClose(Vector3(0.0f, 1.0f, 0.0f)));
-        EXPECT_THAT(Vector3::CreateAxisZ(), IsClose(Vector3(0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector3::CreateFromFloat3(values), IsClose(AZ::Vector3(10.0f, 20.0f, 30.0f)));
+        EXPECT_THAT(AZ::Vector3::CreateAxisX(), IsClose(AZ::Vector3(1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector3::CreateAxisY(), IsClose(AZ::Vector3(0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector3::CreateAxisZ(), IsClose(AZ::Vector3(0.0f, 0.0f, 1.0f)));
     }
 
     TEST(MATH_Vector3, TestCompareEqual)
     {
-        Vector3 vA(-100.0f, 10.0f, -1.0f);
-        Vector3 vB(35.0f, 10.0f, -5.0f);
-        Vector3 vC(35.0f, 20.0f, -1.0f);
+        AZ::Vector3 vA(-100.0f, 10.0f, -1.0f);
+        AZ::Vector3 vB(35.0f, 10.0f, -5.0f);
+        AZ::Vector3 vC(35.0f, 20.0f, -1.0f);
 
         // operation r.x = (cmp1.x == cmp2.x) ? vA.x : vB.x per component
-        Vector3 compareEqualAB = Vector3::CreateSelectCmpEqual(vA, vB, Vector3(1.0f), Vector3(0.0f));
-        EXPECT_THAT(compareEqualAB, IsClose(Vector3(0.0f, 1.0f, 0.0f)));
-        Vector3 compareEqualBC = Vector3::CreateSelectCmpEqual(vB, vC, Vector3(1.0f), Vector3(0.0f));
-        EXPECT_THAT(compareEqualBC, IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+        AZ::Vector3 compareEqualAB = AZ::Vector3::CreateSelectCmpEqual(vA, vB, AZ::Vector3(1.0f), AZ::Vector3(0.0f));
+        EXPECT_THAT(compareEqualAB, IsClose(AZ::Vector3(0.0f, 1.0f, 0.0f)));
+        AZ::Vector3 compareEqualBC = AZ::Vector3::CreateSelectCmpEqual(vB, vC, AZ::Vector3(1.0f), AZ::Vector3(0.0f));
+        EXPECT_THAT(compareEqualBC, IsClose(AZ::Vector3(1.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestCompareGreaterEqual)
     {
-        Vector3 vA(-100.0f, 10.0f, -1.0f);
-        Vector3 vB(35.0f, 10.0f, -5.0f);
-        Vector3 vD(15.0f, 30.0f, 45.0f);
+        AZ::Vector3 vA(-100.0f, 10.0f, -1.0f);
+        AZ::Vector3 vB(35.0f, 10.0f, -5.0f);
+        AZ::Vector3 vD(15.0f, 30.0f, 45.0f);
 
         // operation ( r.x = (cmp1.x >= cmp2.x) ? vA.x : vB.x ) per component
-        Vector3 compareGreaterEqualAB = Vector3::CreateSelectCmpGreaterEqual(vA, vB, Vector3(1.0f), Vector3(0.0f));
-        EXPECT_THAT(compareGreaterEqualAB, IsClose(Vector3(0.0f, 1.0f, 1.0f)));
-        Vector3 compareGreaterEqualBD = Vector3::CreateSelectCmpGreaterEqual(vB, vD, Vector3(1.0f), Vector3(0.0f));
-        EXPECT_THAT(compareGreaterEqualBD, IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+        AZ::Vector3 compareGreaterEqualAB = AZ::Vector3::CreateSelectCmpGreaterEqual(vA, vB, AZ::Vector3(1.0f), AZ::Vector3(0.0f));
+        EXPECT_THAT(compareGreaterEqualAB, IsClose(AZ::Vector3(0.0f, 1.0f, 1.0f)));
+        AZ::Vector3 compareGreaterEqualBD = AZ::Vector3::CreateSelectCmpGreaterEqual(vB, vD, AZ::Vector3(1.0f), AZ::Vector3(0.0f));
+        EXPECT_THAT(compareGreaterEqualBD, IsClose(AZ::Vector3(1.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestCompareGreater)
     {
-        Vector3 vA(-100.0f, 10.0f, -1.0f);
-        Vector3 vB(35.0f, 10.0f, -5.0f);
-        Vector3 vC(35.0f, 20.0f, -1.0f);
+        AZ::Vector3 vA(-100.0f, 10.0f, -1.0f);
+        AZ::Vector3 vB(35.0f, 10.0f, -5.0f);
+        AZ::Vector3 vC(35.0f, 20.0f, -1.0f);
 
         // operation ( r.x = (cmp1.x > cmp2.x) ? vA.x : vB.x ) per component
-        Vector3 compareGreaterAB = Vector3::CreateSelectCmpGreater(vA, vB, Vector3(1.0f), Vector3(0.0f));
-        EXPECT_THAT(compareGreaterAB, IsClose(Vector3(0.0f, 0.0f, 1.0f)));
-        Vector3 compareGreaterCA = Vector3::CreateSelectCmpGreater(vC, vA, Vector3(1.0f), Vector3(0.0f));
-        EXPECT_THAT(compareGreaterCA, IsClose(Vector3(1.0f, 1.0f, 0.0f)));
+        AZ::Vector3 compareGreaterAB = AZ::Vector3::CreateSelectCmpGreater(vA, vB, AZ::Vector3(1.0f), AZ::Vector3(0.0f));
+        EXPECT_THAT(compareGreaterAB, IsClose(AZ::Vector3(0.0f, 0.0f, 1.0f)));
+        AZ::Vector3 compareGreaterCA = AZ::Vector3::CreateSelectCmpGreater(vC, vA, AZ::Vector3(1.0f), AZ::Vector3(0.0f));
+        EXPECT_THAT(compareGreaterCA, IsClose(AZ::Vector3(1.0f, 1.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestStoreFloat)
     {
-        Vector3 v1(1.0f, 2.0f, 3.0f);
+        AZ::Vector3 v1(1.0f, 2.0f, 3.0f);
         float values[3];
 
         v1.StoreToFloat3(values);
@@ -111,25 +109,25 @@ namespace UnitTest
 
     TEST(MATH_Vector3, TestGetSet)
     {
-        Vector3 v1(2.0f, 3.0f, 4.0f);
+        AZ::Vector3 v1(2.0f, 3.0f, 4.0f);
         const float values[3] = { 1.0f, 2.0f, 3.0f };
 
-        EXPECT_THAT(v1, IsClose(Vector3(2.0f, 3.0f, 4.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(2.0f, 3.0f, 4.0f)));
         v1.SetX(10.0f);
-        EXPECT_THAT(v1, IsClose(Vector3(10.0f, 3.0f, 4.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(10.0f, 3.0f, 4.0f)));
         v1.SetY(11.0f);
-        EXPECT_THAT(v1, IsClose(Vector3(10.0f, 11.0f, 4.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(10.0f, 11.0f, 4.0f)));
         v1.SetZ(12.0f);
-        EXPECT_THAT(v1, IsClose(Vector3(10.0f, 11.0f, 12.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(10.0f, 11.0f, 12.0f)));
         v1.Set(15.0f);
-        EXPECT_THAT(v1, IsClose(Vector3(15.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(15.0f)));
         v1.Set(values);
-        EXPECT_THAT(v1, IsClose(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(1.0f, 2.0f, 3.0f)));
     }
 
     TEST(MATH_Vector3, TestIndexElement)
     {
-        Vector3 v1(1.0f, 2.0f, 3.0f);
+        AZ::Vector3 v1(1.0f, 2.0f, 3.0f);
         EXPECT_FLOAT_EQ(v1(0), 1.0f);
         EXPECT_FLOAT_EQ(v1(1), 2.0f);
         EXPECT_FLOAT_EQ(v1(2), 3.0f);
@@ -146,268 +144,268 @@ namespace UnitTest
 
     TEST(MATH_Vector3, TestGetLength)
     {
-        EXPECT_NEAR(Vector3(3.0f, 4.0f, 0.0f).GetLengthSq(), 25.0f, .01f);
-        EXPECT_NEAR(Vector3(0.0f, 4.0f, -3.0f).GetLength(), 5.0f, .01f);
-        EXPECT_NEAR(Vector3(0.0f, 4.0f, -3.0f).GetLengthEstimate(), 5.0f, .01f);
+        EXPECT_NEAR(AZ::Vector3(3.0f, 4.0f, 0.0f).GetLengthSq(), 25.0f, .01f);
+        EXPECT_NEAR(AZ::Vector3(0.0f, 4.0f, -3.0f).GetLength(), 5.0f, .01f);
+        EXPECT_NEAR(AZ::Vector3(0.0f, 4.0f, -3.0f).GetLengthEstimate(), 5.0f, .01f);
     }
 
     TEST(MATH_Vector3, TestGetLengthReciprocal)
     {
-        EXPECT_NEAR(Vector3(0.0f, 4.0f, -3.0f).GetLengthReciprocal(), 0.2f, .01f);
-        EXPECT_NEAR(Vector3(0.0f, 4.0f, -3.0f).GetLengthReciprocalEstimate(), 0.2f, .01f);
+        EXPECT_NEAR(AZ::Vector3(0.0f, 4.0f, -3.0f).GetLengthReciprocal(), 0.2f, .01f);
+        EXPECT_NEAR(AZ::Vector3(0.0f, 4.0f, -3.0f).GetLengthReciprocalEstimate(), 0.2f, .01f);
     }
 
     TEST(MATH_Vector3, TestGetNormalized)
     {
-        EXPECT_THAT(Vector3(3.0f, 0.0f, 4.0f).GetNormalized(), IsClose(Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
-        EXPECT_THAT(Vector3(3.0f, 0.0f, 4.0f).GetNormalizedEstimate(), IsClose(Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(AZ::Vector3(3.0f, 0.0f, 4.0f).GetNormalized(), IsClose(AZ::Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(AZ::Vector3(3.0f, 0.0f, 4.0f).GetNormalizedEstimate(), IsClose(AZ::Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
     }
 
     TEST(MATH_Vector3, TestGetNormalizedSafe)
     {
-        EXPECT_THAT(Vector3(3.0f, 0.0f, 4.0f).GetNormalizedSafe(), IsClose(Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
-        EXPECT_THAT(Vector3(3.0f, 0.0f, 4.0f).GetNormalizedSafeEstimate(), IsClose(Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
-        EXPECT_THAT(Vector3(0.0f).GetNormalizedSafe(), Vector3(0.0f, 0.0f, 0.0f));
-        EXPECT_THAT(Vector3(0.0f).GetNormalizedSafeEstimate(), Vector3(0.0f, 0.0f, 0.0f));
+        EXPECT_THAT(AZ::Vector3(3.0f, 0.0f, 4.0f).GetNormalizedSafe(), IsClose(AZ::Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(AZ::Vector3(3.0f, 0.0f, 4.0f).GetNormalizedSafeEstimate(), IsClose(AZ::Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(AZ::Vector3(0.0f).GetNormalizedSafe(), AZ::Vector3(0.0f, 0.0f, 0.0f));
+        EXPECT_THAT(AZ::Vector3(0.0f).GetNormalizedSafeEstimate(), AZ::Vector3(0.0f, 0.0f, 0.0f));
     }
 
     TEST(MATH_Vector3, TestNormalize)
     {
-        Vector3 v1(4.0f, 3.0f, 0.0f);
+        AZ::Vector3 v1(4.0f, 3.0f, 0.0f);
         v1.Normalize();
-        EXPECT_THAT(v1, IsClose(Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
         v1.Set(4.0f, 3.0f, 0.0f);
         v1.NormalizeEstimate();
-        EXPECT_THAT(v1, IsClose(Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestNormalizeWithLength)
     {
-        Vector3 v1(4.0f, 3.0f, 0.0f);
+        AZ::Vector3 v1(4.0f, 3.0f, 0.0f);
         float length = v1.NormalizeWithLength();
         EXPECT_FLOAT_EQ(length, 5.0f);
-        EXPECT_THAT(v1, IsClose(Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
         v1.Set(4.0f, 3.0f, 0.0f);
         length = v1.NormalizeWithLengthEstimate();
         EXPECT_FLOAT_EQ(length, 5.0f);
-        EXPECT_THAT(v1, IsClose(Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestNormalizeSafe)
     {
-        Vector3 v1(0.0f, 3.0f, 4.0f);
+        AZ::Vector3 v1(0.0f, 3.0f, 4.0f);
         v1.NormalizeSafe();
-        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         v1.NormalizeSafe();
-        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(0.0f, 0.0f, 0.0f)));
         v1.Set(0.0f, 3.0f, 4.0f);
         v1.NormalizeSafeEstimate();
-        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         v1.NormalizeSafeEstimate();
-        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(0.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestNormalizeSafeWithLength)
     {
-        Vector3 v1(0.0f, 3.0f, 4.0f);
+        AZ::Vector3 v1(0.0f, 3.0f, 4.0f);
         float length = v1.NormalizeSafeWithLength();
         EXPECT_FLOAT_EQ(length, 5.0f);
-        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         length = v1.NormalizeSafeWithLength();
         EXPECT_FLOAT_EQ(length, 0.0f);
-        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(0.0f, 0.0f, 0.0f)));
         v1.Set(0.0f, 3.0f, 4.0f);
         length = v1.NormalizeSafeWithLengthEstimate();
         EXPECT_FLOAT_EQ(length, 5.0f);
-        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         length = v1.NormalizeSafeWithLengthEstimate();
         EXPECT_FLOAT_EQ(length, 0.0f);
-        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(0.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestIsNormalized)
     {
-        EXPECT_TRUE(Vector3(1.0f, 0.0f, 0.0f).IsNormalized());
-        EXPECT_TRUE(Vector3(0.7071f, 0.7071f, 0.0f).IsNormalized());
-        EXPECT_FALSE(Vector3(1.0f, 1.0f, 0.0f).IsNormalized());
+        EXPECT_TRUE(AZ::Vector3(1.0f, 0.0f, 0.0f).IsNormalized());
+        EXPECT_TRUE(AZ::Vector3(0.7071f, 0.7071f, 0.0f).IsNormalized());
+        EXPECT_FALSE(AZ::Vector3(1.0f, 1.0f, 0.0f).IsNormalized());
     }
 
     TEST(MATH_Vector3, TestSetLength)
     {
-        Vector3 v1(3.0f, 4.0f, 0.0f);
+        AZ::Vector3 v1(3.0f, 4.0f, 0.0f);
         v1.SetLength(10.0f);
-        EXPECT_THAT(v1, IsClose(Vector3(6.0f, 8.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(6.0f, 8.0f, 0.0f)));
         v1.Set(3.0f, 4.0f, 0.0f);
         v1.SetLengthEstimate(10.0f);
-        EXPECT_THAT(v1, IsCloseTolerance(Vector3(6.0f, 8.0f, 0.0f), 1e-3f));
+        EXPECT_THAT(v1, IsCloseTolerance(AZ::Vector3(6.0f, 8.0f, 0.0f), 1e-3f));
     }
 
     TEST(MATH_Vector3, TestDistance)
     {
-        Vector3 v1(1.0f, 2.0f, 3.0f);
-        EXPECT_FLOAT_EQ(v1.GetDistanceSq(Vector3(-2.0f, 6.0f, 3.0f)), 25.0f);
-        EXPECT_FLOAT_EQ(v1.GetDistance(Vector3(-2.0f, 2.0f, -1.0f)), 5.0f);
-        EXPECT_FLOAT_EQ(v1.GetDistanceEstimate(Vector3(-2.0f, 2.0f, -1.0f)), 5.0f);
+        AZ::Vector3 v1(1.0f, 2.0f, 3.0f);
+        EXPECT_FLOAT_EQ(v1.GetDistanceSq(AZ::Vector3(-2.0f, 6.0f, 3.0f)), 25.0f);
+        EXPECT_FLOAT_EQ(v1.GetDistance(AZ::Vector3(-2.0f, 2.0f, -1.0f)), 5.0f);
+        EXPECT_FLOAT_EQ(v1.GetDistanceEstimate(AZ::Vector3(-2.0f, 2.0f, -1.0f)), 5.0f);
     }
 
     TEST(MATH_Vector3, TestLerpSlerpNLerp)
     {
-        EXPECT_THAT(Vector3(4.0f, 5.0f, 6.0f).Lerp(Vector3(5.0f, 10.0f, 2.0f), 0.5f), IsClose(Vector3(4.5f, 7.5f, 4.0f)));
-        EXPECT_THAT(Vector3(1.0f, 0.0f, 0.0f).Slerp(Vector3(0.0f, 1.0f, 0.0f), 0.5f), IsClose(Vector3(0.7071f, 0.7071f, 0.0f)));
-        EXPECT_THAT(Vector3(1.0f, 0.0f, 0.0f).Nlerp(Vector3(0.0f, 1.0f, 0.0f), 0.5f), IsClose(Vector3(0.7071f, 0.7071f, 0.0f)));
+        EXPECT_THAT(AZ::Vector3(4.0f, 5.0f, 6.0f).Lerp(AZ::Vector3(5.0f, 10.0f, 2.0f), 0.5f), IsClose(AZ::Vector3(4.5f, 7.5f, 4.0f)));
+        EXPECT_THAT(AZ::Vector3(1.0f, 0.0f, 0.0f).Slerp(AZ::Vector3(0.0f, 1.0f, 0.0f), 0.5f), IsClose(AZ::Vector3(0.7071f, 0.7071f, 0.0f)));
+        EXPECT_THAT(AZ::Vector3(1.0f, 0.0f, 0.0f).Nlerp(AZ::Vector3(0.0f, 1.0f, 0.0f), 0.5f), IsClose(AZ::Vector3(0.7071f, 0.7071f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestDotProduct)
     {
-        EXPECT_FLOAT_EQ(Vector3(1.0f, 2.0f, 3.0f).Dot(Vector3(-1.0f, 5.0f, 3.0f)), 18.0f);
+        EXPECT_FLOAT_EQ(AZ::Vector3(1.0f, 2.0f, 3.0f).Dot(AZ::Vector3(-1.0f, 5.0f, 3.0f)), 18.0f);
     }
 
     TEST(MATH_Vector3, TestCrossProduct)
     {
-        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).Cross(Vector3(3.0f, 1.0f, -1.0f)), IsClose(Vector3(-5.0f, 10.0f, -5.0f)));
-        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).CrossXAxis(), IsClose(Vector3(0.0f, 3.0f, -2.0f)));
-        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).CrossYAxis(), IsClose(Vector3(-3.0f, 0.0f, 1.0f)));
-        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).CrossZAxis(), IsClose(Vector3(2.0f, -1.0f, 0.0f)));
-        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).XAxisCross(), IsClose(Vector3(0.0f, -3.0f, 2.0f)));
-        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).YAxisCross(), IsClose(Vector3(3.0f, 0.0f, -1.0f)));
-        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).ZAxisCross(), IsClose(Vector3(-2.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector3(1.0f, 2.0f, 3.0f).Cross(AZ::Vector3(3.0f, 1.0f, -1.0f)), IsClose(AZ::Vector3(-5.0f, 10.0f, -5.0f)));
+        EXPECT_THAT(AZ::Vector3(1.0f, 2.0f, 3.0f).CrossXAxis(), IsClose(AZ::Vector3(0.0f, 3.0f, -2.0f)));
+        EXPECT_THAT(AZ::Vector3(1.0f, 2.0f, 3.0f).CrossYAxis(), IsClose(AZ::Vector3(-3.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector3(1.0f, 2.0f, 3.0f).CrossZAxis(), IsClose(AZ::Vector3(2.0f, -1.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector3(1.0f, 2.0f, 3.0f).XAxisCross(), IsClose(AZ::Vector3(0.0f, -3.0f, 2.0f)));
+        EXPECT_THAT(AZ::Vector3(1.0f, 2.0f, 3.0f).YAxisCross(), IsClose(AZ::Vector3(3.0f, 0.0f, -1.0f)));
+        EXPECT_THAT(AZ::Vector3(1.0f, 2.0f, 3.0f).ZAxisCross(), IsClose(AZ::Vector3(-2.0f, 1.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestIsClose)
     {
-        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsClose(Vector3(1.0f, 2.0f, 3.0f)));
-        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsClose(Vector3(1.0f, 2.0f, 4.0f)));
-        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsClose(Vector3(1.0f, 2.0f, 3.4f), 0.5f));
+        EXPECT_TRUE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsClose(AZ::Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_FALSE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsClose(AZ::Vector3(1.0f, 2.0f, 4.0f)));
+        EXPECT_TRUE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsClose(AZ::Vector3(1.0f, 2.0f, 3.4f), 0.5f));
     }
 
     TEST(MATH_Vector3, TestEquality)
     {
-        Vector3 v3(1.0f, 2.0f, 3.0f);
-        AZ_TEST_ASSERT(v3 == Vector3(1.0f, 2.0f, 3.0f));
-        AZ_TEST_ASSERT(!(v3 == Vector3(1.0f, 2.0f, 4.0f)));
-        AZ_TEST_ASSERT(v3 != Vector3(1.0f, 2.0f, 5.0f));
-        AZ_TEST_ASSERT(!(v3 != Vector3(1.0f, 2.0f, 3.0f)));
+        AZ::Vector3 v3(1.0f, 2.0f, 3.0f);
+        AZ_TEST_ASSERT(v3 == AZ::Vector3(1.0f, 2.0f, 3.0f));
+        AZ_TEST_ASSERT(!(v3 == AZ::Vector3(1.0f, 2.0f, 4.0f)));
+        AZ_TEST_ASSERT(v3 != AZ::Vector3(1.0f, 2.0f, 5.0f));
+        AZ_TEST_ASSERT(!(v3 != AZ::Vector3(1.0f, 2.0f, 3.0f)));
     }
 
     TEST(MATH_Vector3, TestIsLessThan)
     {
-        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsLessThan(Vector3(2.0f, 3.0f, 4.0f)));
-        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsLessThan(Vector3(0.0f, 3.0f, 4.0f)));
-        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsLessThan(Vector3(2.0f, 2.0f, 4.0f)));
+        EXPECT_TRUE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsLessThan(AZ::Vector3(2.0f, 3.0f, 4.0f)));
+        EXPECT_FALSE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsLessThan(AZ::Vector3(0.0f, 3.0f, 4.0f)));
+        EXPECT_FALSE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsLessThan(AZ::Vector3(2.0f, 2.0f, 4.0f)));
     }
 
     TEST(MATH_Vector3, TestIsLessEqualThan)
     {
-        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(Vector3(1.0f, 2.0f, 3.0f)));
-        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(Vector3(2.0f, 3.0f, 4.0f)));
-        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(Vector3(0.0f, 3.0f, 4.0f)));
-        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(Vector3(2.0f, 2.0f, 4.0f)));
+        EXPECT_TRUE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(AZ::Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_TRUE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(AZ::Vector3(2.0f, 3.0f, 4.0f)));
+        EXPECT_FALSE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(AZ::Vector3(0.0f, 3.0f, 4.0f)));
+        EXPECT_TRUE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(AZ::Vector3(2.0f, 2.0f, 4.0f)));
     }
 
     TEST(MATH_Vector3, TestIsGreaterThan)
     {
-        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterThan(Vector3(0.0f, 1.0f, 2.0f)));
-        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterThan(Vector3(0.0f, 3.0f, 2.0f)));
-        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterThan(Vector3(0.0f, 2.0f, 2.0f)));
+        EXPECT_TRUE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsGreaterThan(AZ::Vector3(0.0f, 1.0f, 2.0f)));
+        EXPECT_FALSE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsGreaterThan(AZ::Vector3(0.0f, 3.0f, 2.0f)));
+        EXPECT_FALSE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsGreaterThan(AZ::Vector3(0.0f, 2.0f, 2.0f)));
     }
 
     TEST(MATH_Vector3, TestIsGreaterEqualThan)
     {
-        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(Vector3(1.0f, 2.0f, 3.0f)));
-        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(Vector3(0.0f, 1.0f, 2.0f)));
-        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(Vector3(0.0f, 3.0f, 2.0f)));
-        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(Vector3(0.0f, 2.0f, 2.0f)));
+        EXPECT_TRUE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(AZ::Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_TRUE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(AZ::Vector3(0.0f, 1.0f, 2.0f)));
+        EXPECT_FALSE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(AZ::Vector3(0.0f, 3.0f, 2.0f)));
+        EXPECT_TRUE(AZ::Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(AZ::Vector3(0.0f, 2.0f, 2.0f)));
     }
 
     TEST(MATH_Vector3, TestMinMax)
     {
-        EXPECT_THAT(Vector3(2.0f, 5.0f, 6.0f).GetMin(Vector3(1.0f, 6.0f, 5.0f)), IsClose(Vector3(1.0f, 5.0f, 5.0f)));
-        EXPECT_THAT(Vector3(2.0f, 5.0f, 6.0f).GetMax(Vector3(1.0f, 6.0f, 5.0f)), IsClose(Vector3(2.0f, 6.0f, 6.0f)));
+        EXPECT_THAT(AZ::Vector3(2.0f, 5.0f, 6.0f).GetMin(AZ::Vector3(1.0f, 6.0f, 5.0f)), IsClose(AZ::Vector3(1.0f, 5.0f, 5.0f)));
+        EXPECT_THAT(AZ::Vector3(2.0f, 5.0f, 6.0f).GetMax(AZ::Vector3(1.0f, 6.0f, 5.0f)), IsClose(AZ::Vector3(2.0f, 6.0f, 6.0f)));
     }
 
     TEST(MATH_Vector3, TestClamp)
     {
-        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).GetClamp(Vector3(0.0f, -1.0f, 4.0f), Vector3(2.0f, 1.0f, 10.0f)), IsClose(Vector3(1.0f, 1.0f, 4.0f)));
+        EXPECT_THAT(AZ::Vector3(1.0f, 2.0f, 3.0f).GetClamp(AZ::Vector3(0.0f, -1.0f, 4.0f), AZ::Vector3(2.0f, 1.0f, 10.0f)), IsClose(AZ::Vector3(1.0f, 1.0f, 4.0f)));
     }
 
     TEST(MATH_Vector3, TestTrig)
     {
-        EXPECT_THAT(Vector3(DegToRad(78.0f), DegToRad(-150.0f), DegToRad(190.0f)).GetAngleMod(), IsClose(Vector3(DegToRad(78.0f), DegToRad(-150.0f), DegToRad(-170.0f))));
-        EXPECT_THAT(Vector3(DegToRad(390.0f), DegToRad(-190.0f), DegToRad(-400.0f)).GetAngleMod(), IsClose(Vector3(DegToRad(30.0f), DegToRad(170.0f), DegToRad(-40.0f))));
-        EXPECT_THAT(Vector3(DegToRad(60.0f), DegToRad(105.0f), DegToRad(-174.0f)).GetSin(), IsCloseTolerance(Vector3(0.866f, 0.966f, -0.105f), 0.005f));
-        EXPECT_THAT(Vector3(DegToRad(60.0f), DegToRad(105.0f), DegToRad(-174.0f)).GetCos(), IsCloseTolerance(Vector3(0.5f, -0.259f, -0.995f), 0.005f));
-        Vector3 sin, cos;
-        Vector3 v1(DegToRad(60.0f), DegToRad(105.0f), DegToRad(-174.0f));
+        EXPECT_THAT(AZ::Vector3(AZ::DegToRad(78.0f), AZ::DegToRad(-150.0f), AZ::DegToRad(190.0f)).GetAngleMod(), IsClose(AZ::Vector3(AZ::DegToRad(78.0f), AZ::DegToRad(-150.0f), AZ::DegToRad(-170.0f))));
+        EXPECT_THAT(AZ::Vector3(AZ::DegToRad(390.0f), AZ::DegToRad(-190.0f), AZ::DegToRad(-400.0f)).GetAngleMod(), IsClose(AZ::Vector3(AZ::DegToRad(30.0f), AZ::DegToRad(170.0f), AZ::DegToRad(-40.0f))));
+        EXPECT_THAT(AZ::Vector3(AZ::DegToRad(60.0f), AZ::DegToRad(105.0f), AZ::DegToRad(-174.0f)).GetSin(), IsCloseTolerance(AZ::Vector3(0.866f, 0.966f, -0.105f), 0.005f));
+        EXPECT_THAT(AZ::Vector3(AZ::DegToRad(60.0f), AZ::DegToRad(105.0f), AZ::DegToRad(-174.0f)).GetCos(), IsCloseTolerance(AZ::Vector3(0.5f, -0.259f, -0.995f), 0.005f));
+        AZ::Vector3 sin, cos;
+        AZ::Vector3 v1(AZ::DegToRad(60.0f), AZ::DegToRad(105.0f), AZ::DegToRad(-174.0f));
         v1.GetSinCos(sin, cos);
-        EXPECT_THAT(sin, IsCloseTolerance(Vector3(0.866f, 0.966f, -0.105f), 0.005f));
-        EXPECT_THAT(cos, IsCloseTolerance(Vector3(0.5f, -0.259f, -0.995f), 0.005f));
+        EXPECT_THAT(sin, IsCloseTolerance(AZ::Vector3(0.866f, 0.966f, -0.105f), 0.005f));
+        EXPECT_THAT(cos, IsCloseTolerance(AZ::Vector3(0.5f, -0.259f, -0.995f), 0.005f));
     }
 
     TEST(MATH_Vector3, TestAbs)
     {
-        EXPECT_THAT(Vector3(-1.0f, 2.0f, -5.0f).GetAbs(), Vector3(1.0f, 2.0f, 5.0f));
+        EXPECT_THAT(AZ::Vector3(-1.0f, 2.0f, -5.0f).GetAbs(), AZ::Vector3(1.0f, 2.0f, 5.0f));
     }
 
     TEST(MATH_Vector3, TestReciprocal)
     {
-        EXPECT_THAT(Vector3(2.0f, 4.0f, 5.0f).GetReciprocal(), IsClose(Vector3(0.5f, 0.25f, 0.2f)));
-        EXPECT_THAT(Vector3(2.0f, 4.0f, 5.0f).GetReciprocalEstimate(), IsCloseTolerance(Vector3(0.5f, 0.25f, 0.2f), 1e-3f));
+        EXPECT_THAT(AZ::Vector3(2.0f, 4.0f, 5.0f).GetReciprocal(), IsClose(AZ::Vector3(0.5f, 0.25f, 0.2f)));
+        EXPECT_THAT(AZ::Vector3(2.0f, 4.0f, 5.0f).GetReciprocalEstimate(), IsCloseTolerance(AZ::Vector3(0.5f, 0.25f, 0.2f), 1e-3f));
     }
 
     TEST(MATH_Vector3, TestNegate)
     {
-        EXPECT_THAT((-Vector3(1.0f, 2.0f, -3.0f)), IsClose(Vector3(-1.0f, -2.0f, 3.0f)));
+        EXPECT_THAT((-AZ::Vector3(1.0f, 2.0f, -3.0f)), IsClose(AZ::Vector3(-1.0f, -2.0f, 3.0f)));
     }
 
     TEST(MATH_Vector3, TestAdd)
     {
-        EXPECT_THAT((Vector3(1.0f, 2.0f, 3.0f) + Vector3(-1.0f, 4.0f, 5.0f)) , IsClose(Vector3(0.0f, 6.0f, 8.0f)));
-        Vector3 v1(1.0f, 2.0f, 3.0f);
-        v1 += Vector3(5.0f, 3.0f, -1.0f);
-        EXPECT_THAT(v1, IsClose(Vector3(6.0f, 5.0f, 2.0f)));
+        EXPECT_THAT((AZ::Vector3(1.0f, 2.0f, 3.0f) + AZ::Vector3(-1.0f, 4.0f, 5.0f)) , IsClose(AZ::Vector3(0.0f, 6.0f, 8.0f)));
+        AZ::Vector3 v1(1.0f, 2.0f, 3.0f);
+        v1 += AZ::Vector3(5.0f, 3.0f, -1.0f);
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(6.0f, 5.0f, 2.0f)));
     }
 
     TEST(MATH_Vector3, TestSub)
     {
-        EXPECT_THAT((Vector3(1.0f, 2.0f, 3.0f) - Vector3(-1.0f, 4.0f, 5.0f)), IsClose(Vector3(2.0f, -2.0f, -2.0f)));
-        Vector3 v1(1.0f, 2.0f, 3.0f);
-        v1 += Vector3(5.0f, 3.0f, -1.0f);
-        v1 -= Vector3(2.0f, -1.0f, 3.0f);
-        EXPECT_THAT(v1, IsClose(Vector3(4.0f, 6.0f, -1.0f)));
+        EXPECT_THAT((AZ::Vector3(1.0f, 2.0f, 3.0f) - AZ::Vector3(-1.0f, 4.0f, 5.0f)), IsClose(AZ::Vector3(2.0f, -2.0f, -2.0f)));
+        AZ::Vector3 v1(1.0f, 2.0f, 3.0f);
+        v1 += AZ::Vector3(5.0f, 3.0f, -1.0f);
+        v1 -= AZ::Vector3(2.0f, -1.0f, 3.0f);
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(4.0f, 6.0f, -1.0f)));
     }
 
     TEST(MATH_Vector3, TestMul)
     {
-        EXPECT_THAT((Vector3(1.0f, 2.0f, 3.0f) * Vector3(-1.0f, 4.0f, 5.0f)), IsClose(Vector3(-1.0f, 8.0f, 15.0f)));
-        EXPECT_THAT((Vector3(1.0f, 2.0f, 3.0f) * 2.0f), IsClose(Vector3(2.0f, 4.0f, 6.0f)));
-        EXPECT_THAT((2.0f * Vector3(1.0f, 2.0f, 3.0f)), IsClose(Vector3(2.0f, 4.0f, 6.0f)));
-        Vector3 v1(1.0f, 2.0f, 3.0f);
-        v1 += Vector3(5.0f, 3.0f, -1.0f);
-        v1 -= Vector3(2.0f, -1.0f, 3.0f);
+        EXPECT_THAT((AZ::Vector3(1.0f, 2.0f, 3.0f) * AZ::Vector3(-1.0f, 4.0f, 5.0f)), IsClose(AZ::Vector3(-1.0f, 8.0f, 15.0f)));
+        EXPECT_THAT((AZ::Vector3(1.0f, 2.0f, 3.0f) * 2.0f), IsClose(AZ::Vector3(2.0f, 4.0f, 6.0f)));
+        EXPECT_THAT((2.0f * AZ::Vector3(1.0f, 2.0f, 3.0f)), IsClose(AZ::Vector3(2.0f, 4.0f, 6.0f)));
+        AZ::Vector3 v1(1.0f, 2.0f, 3.0f);
+        v1 += AZ::Vector3(5.0f, 3.0f, -1.0f);
+        v1 -= AZ::Vector3(2.0f, -1.0f, 3.0f);
         v1 *= 3.0f;
-        EXPECT_THAT(v1, IsClose(Vector3(12.0f, 18.0f, -3.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(12.0f, 18.0f, -3.0f)));
     }
 
     TEST(MATH_Vector3, TestDiv)
     {
-        EXPECT_THAT((Vector3(1.0f, 2.0f, 3.0f) / Vector3(-1.0f, 4.0f, 5.0f)), IsClose(Vector3(-1.0f, 0.5f, 3.0f / 5.0f)));
-        EXPECT_THAT((Vector3(1.0f, 2.0f, 3.0f) / 2.0f), IsClose(Vector3(0.5f, 1.0f, 1.5f)));
-        Vector3 v1(1.0f, 2.0f, 3.0f);
-        v1 += Vector3(5.0f, 3.0f, -1.0f);
-        v1 -= Vector3(2.0f, -1.0f, 3.0f);
+        EXPECT_THAT((AZ::Vector3(1.0f, 2.0f, 3.0f) / AZ::Vector3(-1.0f, 4.0f, 5.0f)), IsClose(AZ::Vector3(-1.0f, 0.5f, 3.0f / 5.0f)));
+        EXPECT_THAT((AZ::Vector3(1.0f, 2.0f, 3.0f) / 2.0f), IsClose(AZ::Vector3(0.5f, 1.0f, 1.5f)));
+        AZ::Vector3 v1(1.0f, 2.0f, 3.0f);
+        v1 += AZ::Vector3(5.0f, 3.0f, -1.0f);
+        v1 -= AZ::Vector3(2.0f, -1.0f, 3.0f);
         v1 *= 3.0f;
         v1 /= 2.0f;
-        EXPECT_THAT(v1, IsClose(Vector3(6.0f, 9.0f, -1.5f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(6.0f, 9.0f, -1.5f)));
     }
 
     TEST(MATH_Vector3, TestBuildTangentBasis)
     {
-        Vector3 v1 = Vector3(1.0f, 1.0f, 2.0f).GetNormalized();
-        Vector3 v2, v3;
+        AZ::Vector3 v1 = AZ::Vector3(1.0f, 1.0f, 2.0f).GetNormalized();
+        AZ::Vector3 v2, v3;
 
         v1.BuildTangentBasis(v2, v3);
         EXPECT_TRUE(v2.IsNormalized());
@@ -419,47 +417,47 @@ namespace UnitTest
 
     TEST(MATH_Vector3, TestMadd)
     {
-        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).GetMadd(Vector3(2.0f, 1.0f, 4.0f), Vector3(1.0f, 2.0f, 4.0f)), IsClose(Vector3(3.0f, 4.0f, 16.0f)));
-        Vector3 v1(1.0f, 2.0f, 3.0f);
-        v1.Madd(Vector3(2.0f, 1.0f, 4.0f), Vector3(1.0f, 2.0f, 4.0f));
-        EXPECT_THAT(v1, IsClose(Vector3(3.0f, 4.0f, 16.0f)));
+        EXPECT_THAT(AZ::Vector3(1.0f, 2.0f, 3.0f).GetMadd(AZ::Vector3(2.0f, 1.0f, 4.0f), AZ::Vector3(1.0f, 2.0f, 4.0f)), IsClose(AZ::Vector3(3.0f, 4.0f, 16.0f)));
+        AZ::Vector3 v1(1.0f, 2.0f, 3.0f);
+        v1.Madd(AZ::Vector3(2.0f, 1.0f, 4.0f), AZ::Vector3(1.0f, 2.0f, 4.0f));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(3.0f, 4.0f, 16.0f)));
     }
 
     TEST(MATH_Vector3, TestIsPerpendicular)
     {
-        EXPECT_TRUE(Vector3(1.0f, 2.0f, 0.0f).IsPerpendicular(Vector3(0.0f, 0.0f, 1.0f)));
-        EXPECT_FALSE(Vector3(1.0f, 2.0f, 0.0f).IsPerpendicular(Vector3(0.0f, 1.0f, 1.0f)));
+        EXPECT_TRUE(AZ::Vector3(1.0f, 2.0f, 0.0f).IsPerpendicular(AZ::Vector3(0.0f, 0.0f, 1.0f)));
+        EXPECT_FALSE(AZ::Vector3(1.0f, 2.0f, 0.0f).IsPerpendicular(AZ::Vector3(0.0f, 1.0f, 1.0f)));
     }
 
     TEST(MATH_Vector3, TestGetOrthogonalVector)
     {
-        Vector3 v1(1.0f, 2.0f, 3.0f);
-        Vector3 v2 = v1.GetOrthogonalVector();
+        AZ::Vector3 v1(1.0f, 2.0f, 3.0f);
+        AZ::Vector3 v2 = v1.GetOrthogonalVector();
         EXPECT_TRUE(v1.IsPerpendicular(v2));
-        v1 = Vector3::CreateAxisX();
+        v1 = AZ::Vector3::CreateAxisX();
         v2 = v1.GetOrthogonalVector();
         EXPECT_TRUE(v1.IsPerpendicular(v2));
     }
 
     TEST(MATH_Vector3, TestProject)
     {
-        Vector3 v1(0.5f, 0.5f, 0.5f);
-        v1.Project(Vector3(0.0f, 2.0f, 1.0f));
-        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 0.6f, 0.3f)));
+        AZ::Vector3 v1(0.5f, 0.5f, 0.5f);
+        v1.Project(AZ::Vector3(0.0f, 2.0f, 1.0f));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(0.0f, 0.6f, 0.3f)));
         v1.Set(0.5f, 0.5f, 0.5f);
-        v1.ProjectOnNormal(Vector3(0.0f, 1.0f, 0.0f));
-        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 0.5f, 0.0f)));
+        v1.ProjectOnNormal(AZ::Vector3(0.0f, 1.0f, 0.0f));
+        EXPECT_THAT(v1, IsClose(AZ::Vector3(0.0f, 0.5f, 0.0f)));
         v1.Set(1.0f, 2.0f, 3.0f);
-        EXPECT_THAT(v1.GetProjected(Vector3(1.0f, 1.0f, 1.0f)), IsClose(Vector3(2.0f, 2.0f, 2.0f)));
-        EXPECT_THAT(v1.GetProjectedOnNormal(Vector3(1.0f, 0.0f, 0.0f)), IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(v1.GetProjected(AZ::Vector3(1.0f, 1.0f, 1.0f)), IsClose(AZ::Vector3(2.0f, 2.0f, 2.0f)));
+        EXPECT_THAT(v1.GetProjectedOnNormal(AZ::Vector3(1.0f, 0.0f, 0.0f)), IsClose(AZ::Vector3(1.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestIsFinite)
     {
         //IsFinite
-        EXPECT_TRUE(Vector3(1.0f, 1.0f, 1.0f).IsFinite());
+        EXPECT_TRUE(AZ::Vector3(1.0f, 1.0f, 1.0f).IsFinite());
         const float infinity = std::numeric_limits<float>::infinity();
-        EXPECT_FALSE(Vector3(infinity, infinity, infinity).IsFinite());
+        EXPECT_FALSE(AZ::Vector3(infinity, infinity, infinity).IsFinite());
     }
 
     struct AngleTestArgs
@@ -487,12 +485,12 @@ namespace UnitTest
         MATH_Vector3,
         AngleTestFixture,
         ::testing::Values(
-            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 1.0f, 0.0f }, AZ::Constants::HalfPi },
-            AngleTestArgs{ Vector3{ 42.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 23.0f, 0.0f }, AZ::Constants::HalfPi },
-            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ -1.0f, 0.0f, 0.0f }, AZ::Constants::Pi },
-            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 1.0f, 1.0f, 0.0f }, AZ::Constants::QuarterPi },
-            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 1.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector3{ 1.0f, 1.0f, 0.0f }, Vector3{ -1.0f, -1.0f, 0.0f }, AZ::Constants::Pi }));
+            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 1.0f, 0.0f }, AZ::Constants::HalfPi },
+            AngleTestArgs{ AZ::Vector3{ 42.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 23.0f, 0.0f }, AZ::Constants::HalfPi },
+            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ -1.0f, 0.0f, 0.0f }, AZ::Constants::Pi },
+            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 1.0f, 1.0f, 0.0f }, AZ::Constants::QuarterPi },
+            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 1.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector3{ 1.0f, 1.0f, 0.0f }, AZ::Vector3{ -1.0f, -1.0f, 0.0f }, AZ::Constants::Pi }));
 
     using AngleDegTestFixture = ::testing::TestWithParam<AngleTestArgs>;
 
@@ -512,12 +510,12 @@ namespace UnitTest
         MATH_Vector3,
         AngleDegTestFixture,
         ::testing::Values(
-            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 1.0f, 0.0f }, 90.f },
-            AngleTestArgs{ Vector3{ 42.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 23.0f, 0.0f }, 90.f },
-            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ -1.0f, 0.0f, 0.0f }, 180.f },
-            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 1.0f, 1.0f, 0.0f }, 45.f },
-            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 1.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector3{ 1.0f, 1.0f, 0.0f }, Vector3{ -1.0f, -1.0f, 0.0f }, 180.f }));
+            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 1.0f, 0.0f }, 90.f },
+            AngleTestArgs{ AZ::Vector3{ 42.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 23.0f, 0.0f }, 90.f },
+            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ -1.0f, 0.0f, 0.0f }, 180.f },
+            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 1.0f, 1.0f, 0.0f }, 45.f },
+            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 1.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector3{ 1.0f, 1.0f, 0.0f }, AZ::Vector3{ -1.0f, -1.0f, 0.0f }, 180.f }));
 
     using AngleSafeInvalidAngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
 
@@ -537,27 +535,27 @@ namespace UnitTest
         MATH_Vector3,
         AngleSafeInvalidAngleTestFixture,
         ::testing::Values(
-            AngleTestArgs{ Vector3{ 0.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 1.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector3{ 0.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector3{ 0.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 323432.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector3{ 323432.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 0.0f, 0.0f }, 0.f }));
+            AngleTestArgs{ AZ::Vector3{ 0.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 1.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector3{ 0.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector3{ 0.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 323432.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector3{ 323432.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 0.0f, 0.0f }, 0.f }));
 
     TEST(MATH_Vector3, CompareTest)
     {
-        Vector3 vA(-100.0f, 10.0f, 10.0f);
-        Vector3 vB(35.0f, -11.0f, 10.0f);
+        AZ::Vector3 vA(-100.0f, 10.0f, 10.0f);
+        AZ::Vector3 vB(35.0f, -11.0f, 10.0f);
 
         // compare equal
-        Vector3 rEq = Vector3::CreateSelectCmpEqual(vA, vB, Vector3(1.0f), Vector3(0.0f));
-        EXPECT_TRUE(rEq.IsClose(Vector3(0.0f, 0.0f, 1.0f)));
+        AZ::Vector3 rEq = AZ::Vector3::CreateSelectCmpEqual(vA, vB, AZ::Vector3(1.0f), AZ::Vector3(0.0f));
+        EXPECT_TRUE(rEq.IsClose(AZ::Vector3(0.0f, 0.0f, 1.0f)));
 
         // compare greater equal
-        Vector3 rGr = Vector3::CreateSelectCmpGreaterEqual(vA, vB, Vector3(1.0f), Vector3(0.0f));
-        EXPECT_TRUE(rGr.IsClose(Vector3(0.0f, 1.0f, 1.0f)));
+        AZ::Vector3 rGr = AZ::Vector3::CreateSelectCmpGreaterEqual(vA, vB, AZ::Vector3(1.0f), AZ::Vector3(0.0f));
+        EXPECT_TRUE(rGr.IsClose(AZ::Vector3(0.0f, 1.0f, 1.0f)));
 
         // compare greater
-        Vector3 rGrEq = Vector3::CreateSelectCmpGreater(vA, vB, Vector3(1.0f), Vector3(0.0f));
-        EXPECT_TRUE(rGrEq.IsClose(Vector3(0.0f, 1.0f, 0.0f)));
+        AZ::Vector3 rGrEq = AZ::Vector3::CreateSelectCmpGreater(vA, vB, AZ::Vector3(1.0f), AZ::Vector3(0.0f));
+        EXPECT_TRUE(rGrEq.IsClose(AZ::Vector3(0.0f, 1.0f, 0.0f)));
     }
 }

--- a/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
@@ -43,13 +43,13 @@ namespace UnitTest
 
     TEST(MATH_Vector3, TestCreateFunctions)
     {
-        AZ_TEST_ASSERT(Vector3::CreateOne() == Vector3(1.0f, 1.0f, 1.0f));
-        AZ_TEST_ASSERT(Vector3::CreateZero() == Vector3(0.0f));
+        EXPECT_THAT(Vector3::CreateOne(), IsClose(Vector3(1.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(Vector3::CreateZero(), IsClose(Vector3(0.0f)));
         float values[3] = { 10.0f, 20.0f, 30.0f };
-        AZ_TEST_ASSERT(Vector3::CreateFromFloat3(values) == Vector3(10.0f, 20.0f, 30.0f));
-        AZ_TEST_ASSERT(Vector3::CreateAxisX() == Vector3(1.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(Vector3::CreateAxisY() == Vector3(0.0f, 1.0f, 0.0f));
-        AZ_TEST_ASSERT(Vector3::CreateAxisZ() == Vector3(0.0f, 0.0f, 1.0f));
+        EXPECT_THAT(Vector3::CreateFromFloat3(values), IsClose(Vector3(10.0f, 20.0f, 30.0f)));
+        EXPECT_THAT(Vector3::CreateAxisX(), IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(Vector3::CreateAxisY(), IsClose(Vector3(0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(Vector3::CreateAxisZ(), IsClose(Vector3(0.0f, 0.0f, 1.0f)));
     }
 
     TEST(MATH_Vector3, TestCompareEqual)
@@ -60,9 +60,9 @@ namespace UnitTest
 
         // operation r.x = (cmp1.x == cmp2.x) ? vA.x : vB.x per component
         Vector3 compareEqualAB = Vector3::CreateSelectCmpEqual(vA, vB, Vector3(1.0f), Vector3(0.0f));
-        AZ_TEST_ASSERT(compareEqualAB.IsClose(Vector3(0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(compareEqualAB, IsClose(Vector3(0.0f, 1.0f, 0.0f)));
         Vector3 compareEqualBC = Vector3::CreateSelectCmpEqual(vB, vC, Vector3(1.0f), Vector3(0.0f));
-        AZ_TEST_ASSERT(compareEqualBC.IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(compareEqualBC, IsClose(Vector3(1.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestCompareGreaterEqual)
@@ -73,9 +73,9 @@ namespace UnitTest
 
         // operation ( r.x = (cmp1.x >= cmp2.x) ? vA.x : vB.x ) per component
         Vector3 compareGreaterEqualAB = Vector3::CreateSelectCmpGreaterEqual(vA, vB, Vector3(1.0f), Vector3(0.0f));
-        AZ_TEST_ASSERT(compareGreaterEqualAB.IsClose(Vector3(0.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(compareGreaterEqualAB, IsClose(Vector3(0.0f, 1.0f, 1.0f)));
         Vector3 compareGreaterEqualBD = Vector3::CreateSelectCmpGreaterEqual(vB, vD, Vector3(1.0f), Vector3(0.0f));
-        AZ_TEST_ASSERT(compareGreaterEqualBD.IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(compareGreaterEqualBD, IsClose(Vector3(1.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestCompareGreater)
@@ -86,9 +86,9 @@ namespace UnitTest
 
         // operation ( r.x = (cmp1.x > cmp2.x) ? vA.x : vB.x ) per component
         Vector3 compareGreaterAB = Vector3::CreateSelectCmpGreater(vA, vB, Vector3(1.0f), Vector3(0.0f));
-        AZ_TEST_ASSERT(compareGreaterAB.IsClose(Vector3(0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(compareGreaterAB, IsClose(Vector3(0.0f, 0.0f, 1.0f)));
         Vector3 compareGreaterCA = Vector3::CreateSelectCmpGreater(vC, vA, Vector3(1.0f), Vector3(0.0f));
-        AZ_TEST_ASSERT(compareGreaterCA.IsClose(Vector3(1.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(compareGreaterCA, IsClose(Vector3(1.0f, 1.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestStoreFloat)
@@ -97,186 +97,191 @@ namespace UnitTest
         float values[3];
 
         v1.StoreToFloat3(values);
-        AZ_TEST_ASSERT(values[0] == 1.0f && values[1] == 2.0f && values[2] == 3.0f);
+        EXPECT_FLOAT_EQ(values[0], 1.0f);
+        EXPECT_FLOAT_EQ(values[1], 2.0f);
+        EXPECT_FLOAT_EQ(values[2], 3.0f);
 
         float values4[4];
         v1.StoreToFloat4(values4);
-        AZ_TEST_ASSERT(values4[0] == 1.0f && values4[1] == 2.0f && values4[2] == 3.0f);
+        EXPECT_FLOAT_EQ(values4[0], 1.0f);
+        EXPECT_FLOAT_EQ(values4[1], 2.0f);
+        EXPECT_FLOAT_EQ(values4[2], 3.0f);
+        EXPECT_FLOAT_EQ(values4[3], 0.0f);
     }
 
     TEST(MATH_Vector3, TestGetSet)
     {
         Vector3 v1(2.0f, 3.0f, 4.0f);
-        float values[3] = { 1.0f, 2.0f, 3.0f };
+        const float values[3] = { 1.0f, 2.0f, 3.0f };
 
-        AZ_TEST_ASSERT(v1 == Vector3(2.0f, 3.0f, 4.0f));
+        EXPECT_THAT(v1, IsClose(Vector3(2.0f, 3.0f, 4.0f)));
         v1.SetX(10.0f);
-        AZ_TEST_ASSERT(v1 == Vector3(10.0f, 3.0f, 4.0f));
+        EXPECT_THAT(v1, IsClose(Vector3(10.0f, 3.0f, 4.0f)));
         v1.SetY(11.0f);
-        AZ_TEST_ASSERT(v1 == Vector3(10.0f, 11.0f, 4.0f));
+        EXPECT_THAT(v1, IsClose(Vector3(10.0f, 11.0f, 4.0f)));
         v1.SetZ(12.0f);
-        AZ_TEST_ASSERT(v1 == Vector3(10.0f, 11.0f, 12.0f));
+        EXPECT_THAT(v1, IsClose(Vector3(10.0f, 11.0f, 12.0f)));
         v1.Set(15.0f);
-        AZ_TEST_ASSERT(v1 == Vector3(15.0f));
+        EXPECT_THAT(v1, IsClose(Vector3(15.0f)));
         v1.Set(values);
-        AZ_TEST_ASSERT((v1.GetX() == 1.0f) && (v1.GetY() == 2.0f) && (v1.GetZ() == 3.0f));
+        EXPECT_THAT(v1, IsClose(Vector3(1.0f, 2.0f, 3.0f)));
     }
 
     TEST(MATH_Vector3, TestIndexElement)
     {
         Vector3 v1(1.0f, 2.0f, 3.0f);
-        AZ_TEST_ASSERT(v1(0) == 1.0f);
-        AZ_TEST_ASSERT(v1(1) == 2.0f);
-        AZ_TEST_ASSERT(v1(2) == 3.0f);
-        AZ_TEST_ASSERT(v1.GetElement(0) == 1.0f);
-        AZ_TEST_ASSERT(v1.GetElement(1) == 2.0f);
-        AZ_TEST_ASSERT(v1.GetElement(2) == 3.0f);
+        EXPECT_FLOAT_EQ(v1(0), 1.0f);
+        EXPECT_FLOAT_EQ(v1(1), 2.0f);
+        EXPECT_FLOAT_EQ(v1(2), 3.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(0), 1.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(1), 2.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(2), 3.0f);
         v1.SetElement(0, 5.0f);
         v1.SetElement(1, 6.0f);
         v1.SetElement(2, 7.0f);
-        AZ_TEST_ASSERT(v1.GetElement(0) == 5.0f);
-        AZ_TEST_ASSERT(v1.GetElement(1) == 6.0f);
-        AZ_TEST_ASSERT(v1.GetElement(2) == 7.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(0), 5.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(1), 6.0f);
+        EXPECT_FLOAT_EQ(v1.GetElement(2), 7.0f);
     }
 
     TEST(MATH_Vector3, TestGetLength)
     {
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector3(3.0f, 4.0f, 0.0f).GetLengthSq(), 25.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector3(0.0f, 4.0f, -3.0f).GetLength(), 5.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector3(0.0f, 4.0f, -3.0f).GetLengthEstimate(), 5.0f);
+        EXPECT_NEAR(Vector3(3.0f, 4.0f, 0.0f).GetLengthSq(), 25.0f, .01f);
+        EXPECT_NEAR(Vector3(0.0f, 4.0f, -3.0f).GetLength(), 5.0f, .01f);
+        EXPECT_NEAR(Vector3(0.0f, 4.0f, -3.0f).GetLengthEstimate(), 5.0f, .01f);
     }
 
     TEST(MATH_Vector3, TestGetLengthReciprocal)
     {
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector3(0.0f, 4.0f, -3.0f).GetLengthReciprocal(), 0.2f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector3(0.0f, 4.0f, -3.0f).GetLengthReciprocalEstimate(), 0.2f);
+        EXPECT_NEAR(Vector3(0.0f, 4.0f, -3.0f).GetLengthReciprocal(), 0.2f, .01f);
+        EXPECT_NEAR(Vector3(0.0f, 4.0f, -3.0f).GetLengthReciprocalEstimate(), 0.2f, .01f);
     }
 
     TEST(MATH_Vector3, TestGetNormalized)
     {
-        AZ_TEST_ASSERT(Vector3(3.0f, 0.0f, 4.0f).GetNormalized().IsClose(Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
-        AZ_TEST_ASSERT(Vector3(3.0f, 0.0f, 4.0f).GetNormalizedEstimate().IsClose(Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(Vector3(3.0f, 0.0f, 4.0f).GetNormalized(), IsClose(Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(Vector3(3.0f, 0.0f, 4.0f).GetNormalizedEstimate(), IsClose(Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
     }
 
     TEST(MATH_Vector3, TestGetNormalizedSafe)
     {
-        AZ_TEST_ASSERT(Vector3(3.0f, 0.0f, 4.0f).GetNormalizedSafe().IsClose(Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
-        AZ_TEST_ASSERT(Vector3(3.0f, 0.0f, 4.0f).GetNormalizedSafeEstimate().IsClose(Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
-        AZ_TEST_ASSERT(Vector3(0.0f).GetNormalizedSafe() == Vector3(0.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(Vector3(0.0f).GetNormalizedSafeEstimate() == Vector3(0.0f, 0.0f, 0.0f));
+        EXPECT_THAT(Vector3(3.0f, 0.0f, 4.0f).GetNormalizedSafe(), IsClose(Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(Vector3(3.0f, 0.0f, 4.0f).GetNormalizedSafeEstimate(), IsClose(Vector3(3.0f / 5.0f, 0.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(Vector3(0.0f).GetNormalizedSafe(), Vector3(0.0f, 0.0f, 0.0f));
+        EXPECT_THAT(Vector3(0.0f).GetNormalizedSafeEstimate(), Vector3(0.0f, 0.0f, 0.0f));
     }
 
     TEST(MATH_Vector3, TestNormalize)
     {
         Vector3 v1(4.0f, 3.0f, 0.0f);
         v1.Normalize();
-        AZ_TEST_ASSERT(v1.IsClose(Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
         v1.Set(4.0f, 3.0f, 0.0f);
         v1.NormalizeEstimate();
-        AZ_TEST_ASSERT(v1.IsClose(Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestNormalizeWithLength)
     {
         Vector3 v1(4.0f, 3.0f, 0.0f);
         float length = v1.NormalizeWithLength();
-        AZ_TEST_ASSERT_FLOAT_CLOSE(length, 5.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
+        EXPECT_FLOAT_EQ(length, 5.0f);
+        EXPECT_THAT(v1, IsClose(Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
         v1.Set(4.0f, 3.0f, 0.0f);
         length = v1.NormalizeWithLengthEstimate();
-        AZ_TEST_ASSERT_FLOAT_CLOSE(length, 5.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
+        EXPECT_FLOAT_EQ(length, 5.0f);
+        EXPECT_THAT(v1, IsClose(Vector3(4.0f / 5.0f, 3.0f / 5.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestNormalizeSafe)
     {
         Vector3 v1(0.0f, 3.0f, 4.0f);
         v1.NormalizeSafe();
-        AZ_TEST_ASSERT(v1.IsClose(Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         v1.NormalizeSafe();
-        AZ_TEST_ASSERT(v1 == Vector3(0.0f, 0.0f, 0.0f));
+        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
         v1.Set(0.0f, 3.0f, 4.0f);
         v1.NormalizeSafeEstimate();
-        AZ_TEST_ASSERT(v1.IsClose(Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         v1.NormalizeSafeEstimate();
-        AZ_TEST_ASSERT(v1 == Vector3(0.0f, 0.0f, 0.0f));
+        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestNormalizeSafeWithLength)
     {
         Vector3 v1(0.0f, 3.0f, 4.0f);
         float length = v1.NormalizeSafeWithLength();
-        AZ_TEST_ASSERT_FLOAT_CLOSE(length, 5.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_FLOAT_EQ(length, 5.0f);
+        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         length = v1.NormalizeSafeWithLength();
-        AZ_TEST_ASSERT(length == 0.0f);
-        AZ_TEST_ASSERT(v1 == Vector3(0.0f, 0.0f, 0.0f));
+        EXPECT_FLOAT_EQ(length, 0.0f);
+        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
         v1.Set(0.0f, 3.0f, 4.0f);
         length = v1.NormalizeSafeWithLengthEstimate();
-        AZ_TEST_ASSERT_FLOAT_CLOSE(length, 5.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_FLOAT_EQ(length, 5.0f);
+        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         length = v1.NormalizeSafeWithLengthEstimate();
-        AZ_TEST_ASSERT(length == 0.0f);
-        AZ_TEST_ASSERT(v1 == Vector3(0.0f, 0.0f, 0.0f));
+        EXPECT_FLOAT_EQ(length, 0.0f);
+        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestIsNormalized)
     {
-        AZ_TEST_ASSERT(Vector3(1.0f, 0.0f, 0.0f).IsNormalized());
-        AZ_TEST_ASSERT(Vector3(0.7071f, 0.7071f, 0.0f).IsNormalized());
-        AZ_TEST_ASSERT(!Vector3(1.0f, 1.0f, 0.0f).IsNormalized());
+        EXPECT_TRUE(Vector3(1.0f, 0.0f, 0.0f).IsNormalized());
+        EXPECT_TRUE(Vector3(0.7071f, 0.7071f, 0.0f).IsNormalized());
+        EXPECT_FALSE(Vector3(1.0f, 1.0f, 0.0f).IsNormalized());
     }
 
     TEST(MATH_Vector3, TestSetLength)
     {
         Vector3 v1(3.0f, 4.0f, 0.0f);
         v1.SetLength(10.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector3(6.0f, 8.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(Vector3(6.0f, 8.0f, 0.0f)));
         v1.Set(3.0f, 4.0f, 0.0f);
         v1.SetLengthEstimate(10.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector3(6.0f, 8.0f, 0.0f), 1e-3f));
+        EXPECT_THAT(v1, IsCloseTolerance(Vector3(6.0f, 8.0f, 0.0f), 1e-3f));
     }
 
     TEST(MATH_Vector3, TestDistance)
     {
         Vector3 v1(1.0f, 2.0f, 3.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(v1.GetDistanceSq(Vector3(-2.0f, 6.0f, 3.0f)), 25.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(v1.GetDistance(Vector3(-2.0f, 2.0f, -1.0f)), 5.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(v1.GetDistanceEstimate(Vector3(-2.0f, 2.0f, -1.0f)), 5.0f);
+        EXPECT_FLOAT_EQ(v1.GetDistanceSq(Vector3(-2.0f, 6.0f, 3.0f)), 25.0f);
+        EXPECT_FLOAT_EQ(v1.GetDistance(Vector3(-2.0f, 2.0f, -1.0f)), 5.0f);
+        EXPECT_FLOAT_EQ(v1.GetDistanceEstimate(Vector3(-2.0f, 2.0f, -1.0f)), 5.0f);
     }
 
     TEST(MATH_Vector3, TestLerpSlerpNLerp)
     {
-        AZ_TEST_ASSERT(Vector3(4.0f, 5.0f, 6.0f).Lerp(Vector3(5.0f, 10.0f, 2.0f), 0.5f).IsClose(Vector3(4.5f, 7.5f, 4.0f)));
-        AZ_TEST_ASSERT(Vector3(1.0f, 0.0f, 0.0f).Slerp(Vector3(0.0f, 1.0f, 0.0f), 0.5f).IsClose(Vector3(0.7071f, 0.7071f, 0.0f)));
-        AZ_TEST_ASSERT(Vector3(1.0f, 0.0f, 0.0f).Nlerp(Vector3(0.0f, 1.0f, 0.0f), 0.5f).IsClose(Vector3(0.7071f, 0.7071f, 0.0f)));
+        EXPECT_THAT(Vector3(4.0f, 5.0f, 6.0f).Lerp(Vector3(5.0f, 10.0f, 2.0f), 0.5f), IsClose(Vector3(4.5f, 7.5f, 4.0f)));
+        EXPECT_THAT(Vector3(1.0f, 0.0f, 0.0f).Slerp(Vector3(0.0f, 1.0f, 0.0f), 0.5f), IsClose(Vector3(0.7071f, 0.7071f, 0.0f)));
+        EXPECT_THAT(Vector3(1.0f, 0.0f, 0.0f).Nlerp(Vector3(0.0f, 1.0f, 0.0f), 0.5f), IsClose(Vector3(0.7071f, 0.7071f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestDotProduct)
     {
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector3(1.0f, 2.0f, 3.0f).Dot(Vector3(-1.0f, 5.0f, 3.0f)), 18.0f);
+        EXPECT_FLOAT_EQ(Vector3(1.0f, 2.0f, 3.0f).Dot(Vector3(-1.0f, 5.0f, 3.0f)), 18.0f);
     }
 
     TEST(MATH_Vector3, TestCrossProduct)
     {
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).Cross(Vector3(3.0f, 1.0f, -1.0f)) == Vector3(-5.0f, 10.0f, -5.0f));
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).CrossXAxis() == Vector3(0.0f, 3.0f, -2.0f));
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).CrossYAxis() == Vector3(-3.0f, 0.0f, 1.0f));
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).CrossZAxis() == Vector3(2.0f, -1.0f, 0.0f));
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).XAxisCross() == Vector3(0.0f, -3.0f, 2.0f));
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).YAxisCross() == Vector3(3.0f, 0.0f, -1.0f));
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).ZAxisCross() == Vector3(-2.0f, 1.0f, 0.0f));
+        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).Cross(Vector3(3.0f, 1.0f, -1.0f)), IsClose(Vector3(-5.0f, 10.0f, -5.0f)));
+        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).CrossXAxis(), IsClose(Vector3(0.0f, 3.0f, -2.0f)));
+        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).CrossYAxis(), IsClose(Vector3(-3.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).CrossZAxis(), IsClose(Vector3(2.0f, -1.0f, 0.0f)));
+        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).XAxisCross(), IsClose(Vector3(0.0f, -3.0f, 2.0f)));
+        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).YAxisCross(), IsClose(Vector3(3.0f, 0.0f, -1.0f)));
+        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).ZAxisCross(), IsClose(Vector3(-2.0f, 1.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestIsClose)
     {
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).IsClose(Vector3(1.0f, 2.0f, 3.0f)));
-        AZ_TEST_ASSERT(!Vector3(1.0f, 2.0f, 3.0f).IsClose(Vector3(1.0f, 2.0f, 4.0f)));
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).IsClose(Vector3(1.0f, 2.0f, 3.4f), 0.5f));
+        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsClose(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsClose(Vector3(1.0f, 2.0f, 4.0f)));
+        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsClose(Vector3(1.0f, 2.0f, 3.4f), 0.5f));
     }
 
     TEST(MATH_Vector3, TestEquality)
@@ -290,113 +295,113 @@ namespace UnitTest
 
     TEST(MATH_Vector3, TestIsLessThan)
     {
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).IsLessThan(Vector3(2.0f, 3.0f, 4.0f)));
-        AZ_TEST_ASSERT(!Vector3(1.0f, 2.0f, 3.0f).IsLessThan(Vector3(0.0f, 3.0f, 4.0f)));
-        AZ_TEST_ASSERT(!Vector3(1.0f, 2.0f, 3.0f).IsLessThan(Vector3(2.0f, 2.0f, 4.0f)));
+        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsLessThan(Vector3(2.0f, 3.0f, 4.0f)));
+        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsLessThan(Vector3(0.0f, 3.0f, 4.0f)));
+        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsLessThan(Vector3(2.0f, 2.0f, 4.0f)));
     }
 
     TEST(MATH_Vector3, TestIsLessEqualThan)
     {
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(Vector3(1.0f, 2.0f, 3.0f)));
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(Vector3(2.0f, 3.0f, 4.0f)));
-        AZ_TEST_ASSERT(!Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(Vector3(0.0f, 3.0f, 4.0f)));
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(Vector3(2.0f, 2.0f, 4.0f)));
+        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(Vector3(2.0f, 3.0f, 4.0f)));
+        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(Vector3(0.0f, 3.0f, 4.0f)));
+        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsLessEqualThan(Vector3(2.0f, 2.0f, 4.0f)));
     }
 
     TEST(MATH_Vector3, TestIsGreaterThan)
     {
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).IsGreaterThan(Vector3(0.0f, 1.0f, 2.0f)));
-        AZ_TEST_ASSERT(!Vector3(1.0f, 2.0f, 3.0f).IsGreaterThan(Vector3(0.0f, 3.0f, 2.0f)));
-        AZ_TEST_ASSERT(!Vector3(1.0f, 2.0f, 3.0f).IsGreaterThan(Vector3(0.0f, 2.0f, 2.0f)));
+        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterThan(Vector3(0.0f, 1.0f, 2.0f)));
+        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterThan(Vector3(0.0f, 3.0f, 2.0f)));
+        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterThan(Vector3(0.0f, 2.0f, 2.0f)));
     }
 
     TEST(MATH_Vector3, TestIsGreaterEqualThan)
     {
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(Vector3(1.0f, 2.0f, 3.0f)));
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(Vector3(0.0f, 1.0f, 2.0f)));
-        AZ_TEST_ASSERT(!Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(Vector3(0.0f, 3.0f, 2.0f)));
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(Vector3(0.0f, 2.0f, 2.0f)));
+        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(Vector3(0.0f, 1.0f, 2.0f)));
+        EXPECT_FALSE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(Vector3(0.0f, 3.0f, 2.0f)));
+        EXPECT_TRUE(Vector3(1.0f, 2.0f, 3.0f).IsGreaterEqualThan(Vector3(0.0f, 2.0f, 2.0f)));
     }
 
     TEST(MATH_Vector3, TestMinMax)
     {
-        AZ_TEST_ASSERT(Vector3(2.0f, 5.0f, 6.0f).GetMin(Vector3(1.0f, 6.0f, 5.0f)) == Vector3(1.0f, 5.0f, 5.0f));
-        AZ_TEST_ASSERT(Vector3(2.0f, 5.0f, 6.0f).GetMax(Vector3(1.0f, 6.0f, 5.0f)) == Vector3(2.0f, 6.0f, 6.0f));
+        EXPECT_THAT(Vector3(2.0f, 5.0f, 6.0f).GetMin(Vector3(1.0f, 6.0f, 5.0f)), IsClose(Vector3(1.0f, 5.0f, 5.0f)));
+        EXPECT_THAT(Vector3(2.0f, 5.0f, 6.0f).GetMax(Vector3(1.0f, 6.0f, 5.0f)), IsClose(Vector3(2.0f, 6.0f, 6.0f)));
     }
 
     TEST(MATH_Vector3, TestClamp)
     {
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).GetClamp(Vector3(0.0f, -1.0f, 4.0f), Vector3(2.0f, 1.0f, 10.0f)) == Vector3(1.0f, 1.0f, 4.0f));
+        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).GetClamp(Vector3(0.0f, -1.0f, 4.0f), Vector3(2.0f, 1.0f, 10.0f)), IsClose(Vector3(1.0f, 1.0f, 4.0f)));
     }
 
     TEST(MATH_Vector3, TestTrig)
     {
-        AZ_TEST_ASSERT(Vector3(DegToRad(78.0f), DegToRad(-150.0f), DegToRad(190.0f)).GetAngleMod().IsClose(Vector3(DegToRad(78.0f), DegToRad(-150.0f), DegToRad(-170.0f))));
-        AZ_TEST_ASSERT(Vector3(DegToRad(390.0f), DegToRad(-190.0f), DegToRad(-400.0f)).GetAngleMod().IsClose(Vector3(DegToRad(30.0f), DegToRad(170.0f), DegToRad(-40.0f))));
-        AZ_TEST_ASSERT(Vector3(DegToRad(60.0f), DegToRad(105.0f), DegToRad(-174.0f)).GetSin().IsClose(Vector3(0.866f, 0.966f, -0.105f), 0.005f));
-        AZ_TEST_ASSERT(Vector3(DegToRad(60.0f), DegToRad(105.0f), DegToRad(-174.0f)).GetCos().IsClose(Vector3(0.5f, -0.259f, -0.995f), 0.005f));
+        EXPECT_THAT(Vector3(DegToRad(78.0f), DegToRad(-150.0f), DegToRad(190.0f)).GetAngleMod(), IsClose(Vector3(DegToRad(78.0f), DegToRad(-150.0f), DegToRad(-170.0f))));
+        EXPECT_THAT(Vector3(DegToRad(390.0f), DegToRad(-190.0f), DegToRad(-400.0f)).GetAngleMod(), IsClose(Vector3(DegToRad(30.0f), DegToRad(170.0f), DegToRad(-40.0f))));
+        EXPECT_THAT(Vector3(DegToRad(60.0f), DegToRad(105.0f), DegToRad(-174.0f)).GetSin(), IsCloseTolerance(Vector3(0.866f, 0.966f, -0.105f), 0.005f));
+        EXPECT_THAT(Vector3(DegToRad(60.0f), DegToRad(105.0f), DegToRad(-174.0f)).GetCos(), IsCloseTolerance(Vector3(0.5f, -0.259f, -0.995f), 0.005f));
         Vector3 sin, cos;
         Vector3 v1(DegToRad(60.0f), DegToRad(105.0f), DegToRad(-174.0f));
         v1.GetSinCos(sin, cos);
-        AZ_TEST_ASSERT(sin.IsClose(Vector3(0.866f, 0.966f, -0.105f), 0.005f));
-        AZ_TEST_ASSERT(cos.IsClose(Vector3(0.5f, -0.259f, -0.995f), 0.005f));
+        EXPECT_THAT(sin, IsCloseTolerance(Vector3(0.866f, 0.966f, -0.105f), 0.005f));
+        EXPECT_THAT(cos, IsCloseTolerance(Vector3(0.5f, -0.259f, -0.995f), 0.005f));
     }
 
     TEST(MATH_Vector3, TestAbs)
     {
-        AZ_TEST_ASSERT(Vector3(-1.0f, 2.0f, -5.0f).GetAbs() == Vector3(1.0f, 2.0f, 5.0f));
+        EXPECT_THAT(Vector3(-1.0f, 2.0f, -5.0f).GetAbs(), Vector3(1.0f, 2.0f, 5.0f));
     }
 
     TEST(MATH_Vector3, TestReciprocal)
     {
-        AZ_TEST_ASSERT(Vector3(2.0f, 4.0f, 5.0f).GetReciprocal().IsClose(Vector3(0.5f, 0.25f, 0.2f)));
-        AZ_TEST_ASSERT(Vector3(2.0f, 4.0f, 5.0f).GetReciprocalEstimate().IsClose(Vector3(0.5f, 0.25f, 0.2f), 1e-3f));
+        EXPECT_THAT(Vector3(2.0f, 4.0f, 5.0f).GetReciprocal(), IsClose(Vector3(0.5f, 0.25f, 0.2f)));
+        EXPECT_THAT(Vector3(2.0f, 4.0f, 5.0f).GetReciprocalEstimate(), IsCloseTolerance(Vector3(0.5f, 0.25f, 0.2f), 1e-3f));
     }
 
     TEST(MATH_Vector3, TestNegate)
     {
-        AZ_TEST_ASSERT((-Vector3(1.0f, 2.0f, -3.0f)) == Vector3(-1.0f, -2.0f, 3.0f));
+        EXPECT_THAT((-Vector3(1.0f, 2.0f, -3.0f)), IsClose(Vector3(-1.0f, -2.0f, 3.0f)));
     }
 
     TEST(MATH_Vector3, TestAdd)
     {
-        AZ_TEST_ASSERT((Vector3(1.0f, 2.0f, 3.0f) + Vector3(-1.0f, 4.0f, 5.0f)) == Vector3(0.0f, 6.0f, 8.0f));
+        EXPECT_THAT((Vector3(1.0f, 2.0f, 3.0f) + Vector3(-1.0f, 4.0f, 5.0f)) , IsClose(Vector3(0.0f, 6.0f, 8.0f)));
         Vector3 v1(1.0f, 2.0f, 3.0f);
         v1 += Vector3(5.0f, 3.0f, -1.0f);
-        AZ_TEST_ASSERT(v1 == Vector3(6.0f, 5.0f, 2.0f));
+        EXPECT_THAT(v1, IsClose(Vector3(6.0f, 5.0f, 2.0f)));
     }
 
     TEST(MATH_Vector3, TestSub)
     {
-        AZ_TEST_ASSERT((Vector3(1.0f, 2.0f, 3.0f) - Vector3(-1.0f, 4.0f, 5.0f)) == Vector3(2.0f, -2.0f, -2.0f));
+        EXPECT_THAT((Vector3(1.0f, 2.0f, 3.0f) - Vector3(-1.0f, 4.0f, 5.0f)), IsClose(Vector3(2.0f, -2.0f, -2.0f)));
         Vector3 v1(1.0f, 2.0f, 3.0f);
         v1 += Vector3(5.0f, 3.0f, -1.0f);
         v1 -= Vector3(2.0f, -1.0f, 3.0f);
-        AZ_TEST_ASSERT(v1 == Vector3(4.0f, 6.0f, -1.0f));
+        EXPECT_THAT(v1, IsClose(Vector3(4.0f, 6.0f, -1.0f)));
     }
 
     TEST(MATH_Vector3, TestMul)
     {
-        AZ_TEST_ASSERT((Vector3(1.0f, 2.0f, 3.0f) * Vector3(-1.0f, 4.0f, 5.0f)) == Vector3(-1.0f, 8.0f, 15.0f));
-        AZ_TEST_ASSERT((Vector3(1.0f, 2.0f, 3.0f) * 2.0f) == Vector3(2.0f, 4.0f, 6.0f));
-        AZ_TEST_ASSERT((2.0f * Vector3(1.0f, 2.0f, 3.0f)) == Vector3(2.0f, 4.0f, 6.0f));
+        EXPECT_THAT((Vector3(1.0f, 2.0f, 3.0f) * Vector3(-1.0f, 4.0f, 5.0f)), IsClose(Vector3(-1.0f, 8.0f, 15.0f)));
+        EXPECT_THAT((Vector3(1.0f, 2.0f, 3.0f) * 2.0f), IsClose(Vector3(2.0f, 4.0f, 6.0f)));
+        EXPECT_THAT((2.0f * Vector3(1.0f, 2.0f, 3.0f)), IsClose(Vector3(2.0f, 4.0f, 6.0f)));
         Vector3 v1(1.0f, 2.0f, 3.0f);
         v1 += Vector3(5.0f, 3.0f, -1.0f);
         v1 -= Vector3(2.0f, -1.0f, 3.0f);
         v1 *= 3.0f;
-        AZ_TEST_ASSERT(v1 == Vector3(12.0f, 18.0f, -3.0f));
+        EXPECT_THAT(v1, IsClose(Vector3(12.0f, 18.0f, -3.0f)));
     }
 
     TEST(MATH_Vector3, TestDiv)
     {
-        AZ_TEST_ASSERT((Vector3(1.0f, 2.0f, 3.0f) / Vector3(-1.0f, 4.0f, 5.0f)).IsClose(Vector3(-1.0f, 0.5f, 3.0f / 5.0f)));
-        AZ_TEST_ASSERT((Vector3(1.0f, 2.0f, 3.0f) / 2.0f).IsClose(Vector3(0.5f, 1.0f, 1.5f)));
+        EXPECT_THAT((Vector3(1.0f, 2.0f, 3.0f) / Vector3(-1.0f, 4.0f, 5.0f)), IsClose(Vector3(-1.0f, 0.5f, 3.0f / 5.0f)));
+        EXPECT_THAT((Vector3(1.0f, 2.0f, 3.0f) / 2.0f), IsClose(Vector3(0.5f, 1.0f, 1.5f)));
         Vector3 v1(1.0f, 2.0f, 3.0f);
         v1 += Vector3(5.0f, 3.0f, -1.0f);
         v1 -= Vector3(2.0f, -1.0f, 3.0f);
         v1 *= 3.0f;
         v1 /= 2.0f;
-        AZ_TEST_ASSERT(v1.IsClose(Vector3(6.0f, 9.0f, -1.5f)));
+        EXPECT_THAT(v1, IsClose(Vector3(6.0f, 9.0f, -1.5f)));
     }
 
     TEST(MATH_Vector3, TestBuildTangentBasis)
@@ -405,100 +410,138 @@ namespace UnitTest
         Vector3 v2, v3;
 
         v1.BuildTangentBasis(v2, v3);
-        AZ_TEST_ASSERT(v2.IsNormalized());
-        AZ_TEST_ASSERT(v3.IsNormalized());
-        AZ_TEST_ASSERT(fabsf(v2.Dot(v1)) < 0.001f);
-        AZ_TEST_ASSERT(fabsf(v3.Dot(v1)) < 0.001f);
-        AZ_TEST_ASSERT(fabsf(v2.Dot(v3)) < 0.001f);
+        EXPECT_TRUE(v2.IsNormalized());
+        EXPECT_TRUE(v3.IsNormalized());
+        EXPECT_TRUE(fabsf(v2.Dot(v1)) < 0.001f);
+        EXPECT_TRUE(fabsf(v3.Dot(v1)) < 0.001f);
+        EXPECT_TRUE(fabsf(v2.Dot(v3)) < 0.001f);
     }
 
     TEST(MATH_Vector3, TestMadd)
     {
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 3.0f).GetMadd(Vector3(2.0f, 1.0f, 4.0f), Vector3(1.0f, 2.0f, 4.0f)) == Vector3(3.0f, 4.0f, 16.0f));
+        EXPECT_THAT(Vector3(1.0f, 2.0f, 3.0f).GetMadd(Vector3(2.0f, 1.0f, 4.0f), Vector3(1.0f, 2.0f, 4.0f)), IsClose(Vector3(3.0f, 4.0f, 16.0f)));
         Vector3 v1(1.0f, 2.0f, 3.0f);
         v1.Madd(Vector3(2.0f, 1.0f, 4.0f), Vector3(1.0f, 2.0f, 4.0f));
-        AZ_TEST_ASSERT(v1 == Vector3(3.0f, 4.0f, 16.0f));
+        EXPECT_THAT(v1, IsClose(Vector3(3.0f, 4.0f, 16.0f)));
     }
 
     TEST(MATH_Vector3, TestIsPerpendicular)
     {
-        AZ_TEST_ASSERT(Vector3(1.0f, 2.0f, 0.0f).IsPerpendicular(Vector3(0.0f, 0.0f, 1.0f)));
-        AZ_TEST_ASSERT(!Vector3(1.0f, 2.0f, 0.0f).IsPerpendicular(Vector3(0.0f, 1.0f, 1.0f)));
+        EXPECT_TRUE(Vector3(1.0f, 2.0f, 0.0f).IsPerpendicular(Vector3(0.0f, 0.0f, 1.0f)));
+        EXPECT_FALSE(Vector3(1.0f, 2.0f, 0.0f).IsPerpendicular(Vector3(0.0f, 1.0f, 1.0f)));
     }
 
     TEST(MATH_Vector3, TestGetOrthogonalVector)
     {
         Vector3 v1(1.0f, 2.0f, 3.0f);
         Vector3 v2 = v1.GetOrthogonalVector();
-        AZ_TEST_ASSERT(v1.IsPerpendicular(v2));
+        EXPECT_TRUE(v1.IsPerpendicular(v2));
         v1 = Vector3::CreateAxisX();
         v2 = v1.GetOrthogonalVector();
-        AZ_TEST_ASSERT(v1.IsPerpendicular(v2));
+        EXPECT_TRUE(v1.IsPerpendicular(v2));
     }
 
     TEST(MATH_Vector3, TestProject)
     {
         Vector3 v1(0.5f, 0.5f, 0.5f);
         v1.Project(Vector3(0.0f, 2.0f, 1.0f));
-        AZ_TEST_ASSERT(v1 == Vector3(0.0f, 0.6f, 0.3f));
+        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 0.6f, 0.3f)));
         v1.Set(0.5f, 0.5f, 0.5f);
         v1.ProjectOnNormal(Vector3(0.0f, 1.0f, 0.0f));
-        AZ_TEST_ASSERT(v1 == Vector3(0.0f, 0.5f, 0.0f));
+        EXPECT_THAT(v1, IsClose(Vector3(0.0f, 0.5f, 0.0f)));
         v1.Set(1.0f, 2.0f, 3.0f);
-        AZ_TEST_ASSERT(v1.GetProjected(Vector3(1.0f, 1.0f, 1.0f)) == Vector3(2.0f, 2.0f, 2.0f));
-        AZ_TEST_ASSERT(v1.GetProjectedOnNormal(Vector3(1.0f, 0.0f, 0.0f)) == Vector3(1.0f, 0.0f, 0.0f));
+        EXPECT_THAT(v1.GetProjected(Vector3(1.0f, 1.0f, 1.0f)), IsClose(Vector3(2.0f, 2.0f, 2.0f)));
+        EXPECT_THAT(v1.GetProjectedOnNormal(Vector3(1.0f, 0.0f, 0.0f)), IsClose(Vector3(1.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector3, TestIsFinite)
     {
         //IsFinite
-        AZ_TEST_ASSERT(Vector3(1.0f, 1.0f, 1.0f).IsFinite());
+        EXPECT_TRUE(Vector3(1.0f, 1.0f, 1.0f).IsFinite());
         const float infinity = std::numeric_limits<float>::infinity();
-        AZ_TEST_ASSERT(!Vector3(infinity, infinity, infinity).IsFinite());
+        EXPECT_FALSE(Vector3(infinity, infinity, infinity).IsFinite());
     }
 
-    TEST(MATH_Vector3, TestAngles)
+    struct AngleTestArgs
     {
-        using Vec3CalcFunc = float(Vector3::*)(const Vector3&) const;
-        auto angleTest = [](Vec3CalcFunc func, const Vector3& self, const Vector3& other, float target)
-        {
-            const float epsilon = 0.01f;
-            float value = (self.*func)(other);
-            AZ_TEST_ASSERT(AZ::IsClose(value, target, epsilon));
-        };
+        AZ::Vector3 current;
+        AZ::Vector3 target;
+        float angle;
+    };
 
-        const Vec3CalcFunc angleFuncs[2] = { &Vector3::Angle, &Vector3::AngleSafe };
-        for (Vec3CalcFunc angleFunc : angleFuncs)
-        {
-            angleTest(angleFunc, Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 1.0f, 0.0f }, AZ::Constants::HalfPi);
-            angleTest(angleFunc, Vector3{ 42.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 23.0f, 0.0f }, AZ::Constants::HalfPi);
-            angleTest(angleFunc, Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ -1.0f, 0.0f, 0.0f }, AZ::Constants::Pi);
-            angleTest(angleFunc, Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 1.0f, 1.0f, 0.0f }, AZ::Constants::QuarterPi);
-            angleTest(angleFunc, Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 1.0f, 0.0f, 0.0f }, 0.f);
-            angleTest(angleFunc, Vector3{ 1.0f, 1.0f, 0.0f }, Vector3{ -1.0f, -1.0f, 0.0f }, AZ::Constants::Pi);
-        }
+    using AngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
 
-        const Vec3CalcFunc angleDegFuncs[2] = { &Vector3::AngleDeg, &Vector3::AngleSafeDeg };
-        for (Vec3CalcFunc angleDegFunc : angleDegFuncs)
-        {
-            angleTest(angleDegFunc, Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 1.0f, 0.0f }, 90.f);
-            angleTest(angleDegFunc, Vector3{ 42.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 23.0f, 0.0f }, 90.f);
-            angleTest(angleDegFunc, Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ -1.0f, 0.0f, 0.0f }, 180.f);
-            angleTest(angleDegFunc, Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 1.0f, 1.0f, 0.0f }, 45.f);
-            angleTest(angleDegFunc, Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 1.0f, 0.0f, 0.0f }, 0.f);
-            angleTest(angleDegFunc, Vector3{ 1.0f, 1.0f, 0.0f }, Vector3{ -1.0f, -1.0f, 0.0f }, 180.f);
-        }
-
-        const Vec3CalcFunc angleSafeFuncs[2] = { &Vector3::AngleSafe, &Vector3::AngleSafeDeg };
-        for (Vec3CalcFunc angleSafeFunc : angleSafeFuncs)
-        {
-            angleTest(angleSafeFunc, Vector3{ 0.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 1.0f, 0.0f }, 0.f);
-            angleTest(angleSafeFunc, Vector3{ 0.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 0.0f, 0.0f }, 0.f);
-            angleTest(angleSafeFunc, Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 0.0f, 0.0f }, 0.f);
-            angleTest(angleSafeFunc, Vector3{ 0.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 323432.0f, 0.0f }, 0.f);
-            angleTest(angleSafeFunc, Vector3{ 323432.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 0.0f, 0.0f }, 0.f);
-        }
+    TEST_P(AngleTestFixture, TestAngle)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.Angle(param.target), param.angle);
     }
+
+    TEST_P(AngleTestFixture, TestAngleSafe)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleSafe(param.target), param.angle);
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        MATH_Vector3,
+        AngleTestFixture,
+        ::testing::Values(
+            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 1.0f, 0.0f }, AZ::Constants::HalfPi },
+            AngleTestArgs{ Vector3{ 42.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 23.0f, 0.0f }, AZ::Constants::HalfPi },
+            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ -1.0f, 0.0f, 0.0f }, AZ::Constants::Pi },
+            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 1.0f, 1.0f, 0.0f }, AZ::Constants::QuarterPi },
+            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 1.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector3{ 1.0f, 1.0f, 0.0f }, Vector3{ -1.0f, -1.0f, 0.0f }, AZ::Constants::Pi }));
+
+    using AngleDegTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+
+    TEST_P(AngleDegTestFixture, TestAngleDeg)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleDeg(param.target), param.angle);
+    }
+
+    TEST_P(AngleDegTestFixture, TestAngleDegSafe)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        MATH_Vector3,
+        AngleDegTestFixture,
+        ::testing::Values(
+            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 1.0f, 0.0f }, 90.f },
+            AngleTestArgs{ Vector3{ 42.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 23.0f, 0.0f }, 90.f },
+            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ -1.0f, 0.0f, 0.0f }, 180.f },
+            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 1.0f, 1.0f, 0.0f }, 45.f },
+            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 1.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector3{ 1.0f, 1.0f, 0.0f }, Vector3{ -1.0f, -1.0f, 0.0f }, 180.f }));
+
+    using AngleSafeInvalidAngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+
+    TEST_P(AngleSafeInvalidAngleTestFixture, TestInvalidAngle)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleSafe(param.target), param.angle);
+    }
+
+    TEST_P(AngleSafeInvalidAngleTestFixture, TestInvalidAngleDeg)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        MATH_Vector3,
+        AngleSafeInvalidAngleTestFixture,
+        ::testing::Values(
+            AngleTestArgs{ Vector3{ 0.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 1.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector3{ 0.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector3{ 1.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector3{ 0.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 323432.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector3{ 323432.0f, 0.0f, 0.0f }, Vector3{ 0.0f, 0.0f, 0.0f }, 0.f }));
 
     TEST(MATH_Vector3, CompareTest)
     {
@@ -507,14 +550,14 @@ namespace UnitTest
 
         // compare equal
         Vector3 rEq = Vector3::CreateSelectCmpEqual(vA, vB, Vector3(1.0f), Vector3(0.0f));
-        AZ_TEST_ASSERT(rEq.IsClose(Vector3(0.0f, 0.0f, 1.0f)));
+        EXPECT_TRUE(rEq.IsClose(Vector3(0.0f, 0.0f, 1.0f)));
 
         // compare greater equal
         Vector3 rGr = Vector3::CreateSelectCmpGreaterEqual(vA, vB, Vector3(1.0f), Vector3(0.0f));
-        AZ_TEST_ASSERT(rGr.IsClose(Vector3(0.0f, 1.0f, 1.0f)));
+        EXPECT_TRUE(rGr.IsClose(Vector3(0.0f, 1.0f, 1.0f)));
 
         // compare greater
         Vector3 rGrEq = Vector3::CreateSelectCmpGreater(vA, vB, Vector3(1.0f), Vector3(0.0f));
-        AZ_TEST_ASSERT(rGrEq.IsClose(Vector3(0.0f, 1.0f, 0.0f)));
+        EXPECT_TRUE(rGrEq.IsClose(Vector3(0.0f, 1.0f, 0.0f)));
     }
 }

--- a/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
@@ -35,7 +35,7 @@ namespace UnitTest
         EXPECT_THAT(AZ::Vector3(AZ::Vector2(1.0f, 3.0f)), IsClose(AZ::Vector3(1.0f, 3.0f,0.0f)));
         EXPECT_THAT(AZ::Vector3(AZ::Vector2(1.0f, 3.0f), 6.0f), IsClose(AZ::Vector3(1.0f, 3.0f,6.0f)));
         EXPECT_THAT(AZ::Vector3(AZ::Vector4(1.0f, 3.0f, 5.0f, 2.0f)), IsClose(AZ::Vector3(1.0f, 3.0f, 5.0f)));
-        EXPECT_THAT(AZ::Vector3(Simd::Vec3::LoadImmediate(1.0f, 2.0f, 4.0f)), IsClose(AZ::Vector3(1.0f, 2.0f, 4.0f)));
+        EXPECT_THAT(AZ::Vector3(AZ::Simd::Vec3::LoadImmediate(1.0f, 2.0f, 4.0f)), IsClose(AZ::Vector3(1.0f, 2.0f, 4.0f)));
 
     }
 


### PR DESCRIPTION
## What does this PR do?

this just cleans up the existing test cases for Vector3Tests. 

- replace usage of == used with Vector4 with EXPECT_THAT
- replace TestAngles with separate parameterized tests, avoids a lot of the custom logic with parametrized test cases. 

## How was this PR tested?

run
```
./AzTestRunner ./libAzCore.Tests.so AzRunUnitTests --gtest_filter="*MATH_Vector4*"
```
