### PR TITLE
chore: cleanup Vector2Tests

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/SimdMath.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMath.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Math/Internal/MathTypes.h>
 #include <AzCore/Math/MathUtils.h>
 #include <AzCore/std/algorithm.h>
 

--- a/Code/Framework/AzCore/AzCore/Math/SimdMathVec1.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMathVec1.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Math/Internal/MathTypes.h>
 namespace AZ
 {
     namespace Simd

--- a/Code/Framework/AzCore/AzCore/Math/SimdMathVec2.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMathVec2.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <AzCore/Math/Internal/MathTypes.h>
+
 namespace AZ
 {
     namespace Simd

--- a/Code/Framework/AzCore/AzCore/Math/SimdMathVec4.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMathVec4.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <AzCore/Math/Internal/MathTypes.h>
+
 namespace AZ
 {
     namespace Simd

--- a/Code/Framework/AzCore/Tests/Math/Vector2Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector2Tests.cpp
@@ -6,13 +6,12 @@
  *
  */
 
-#include <AzCore/Math/MathUtils.h>
-#include <AzCore/Math/Vector3.h>
-#include <AzCore/Math/Vector4.h>
-#include <AzCore/Math/Vector2.h>
-#include <AzCore/UnitTest/TestTypes.h>
 #include <AZTestShared/Math/MathTestHelpers.h>
+#include <AzCore/Math/MathUtils.h>
 #include <AzCore/Math/SimdMath.h>
+#include <AzCore/Math/Vector2.h>
+#include <AzCore/Math/Vector4.h>
+#include <AzCore/UnitTest/TestTypes.h>
 
 using namespace AZ;
 
@@ -29,28 +28,28 @@ namespace UnitTest
         Vector2 vC(1.0f, 2.0f);
         EXPECT_FLOAT_EQ(vC.GetX(), 1.0f);
         EXPECT_FLOAT_EQ(vC.GetY(), 2.0f);
-        EXPECT_THAT(Vector2(Vector4(1.0f, 3.0f,2.0f,4.0f)), IsClose(Vector2(1.0f, 3.0f)));
-        EXPECT_THAT(Vector2(Vector3(1.0f, 3.0f,2.0f)), IsClose(Vector2(1.0f, 3.0f)));
+        EXPECT_THAT(Vector2(Vector4(1.0f, 3.0f, 2.0f, 4.0f)), IsClose(Vector2(1.0f, 3.0f)));
+        EXPECT_THAT(Vector2(Vector3(1.0f, 3.0f, 2.0f)), IsClose(Vector2(1.0f, 3.0f)));
     }
 
     TEST(MATH_Vector2, TestCreate)
     {
         float values[2] = { 10.0f, 20.0f };
 
-        AZ_TEST_ASSERT(Vector2::CreateOne() == Vector2(1.0f, 1.0f));
-        AZ_TEST_ASSERT(Vector2::CreateZero() == Vector2(0.0f, 0.0f));
+        EXPECT_THAT(Vector2::CreateOne(), IsClose(Vector2(1.0f, 1.0f)));
+        EXPECT_THAT(Vector2::CreateZero(), IsClose(Vector2(0.0f, 0.0f)));
 
-        AZ_TEST_ASSERT(Vector2::CreateFromFloat2(values) == Vector2(10.0f, 20.0f));
-        AZ_TEST_ASSERT(Vector2::CreateAxisX() == Vector2(1.0f, 0.0f));
-        AZ_TEST_ASSERT(Vector2::CreateAxisY() == Vector2(0.0f, 1.0f));
+        EXPECT_THAT(Vector2::CreateFromFloat2(values), IsClose(Vector2(10.0f, 20.0f)));
+        EXPECT_THAT(Vector2::CreateAxisX(), IsClose(Vector2(1.0f, 0.0f)));
+        EXPECT_THAT(Vector2::CreateAxisY(), IsClose(Vector2(0.0f, 1.0f)));
     }
 
     TEST(MATH_Vector2, TestCreateFromAngle)
     {
-        AZ_TEST_ASSERT(Vector2::CreateFromAngle() == Vector2(0.0f, 1.0f));
-        AZ_TEST_ASSERT(Vector2::CreateFromAngle(0.78539816339f).IsClose(Vector2(0.7071067811f, 0.7071067811f)));
-        AZ_TEST_ASSERT(Vector2::CreateFromAngle(4.0f).IsClose(Vector2(-0.7568024953f, -0.6536436208f)));
-        AZ_TEST_ASSERT(Vector2::CreateFromAngle(-1.0f).IsClose(Vector2(-0.8414709848f, 0.5403023058f)));
+        EXPECT_THAT(Vector2::CreateFromAngle(), IsClose(Vector2(0.0f, 1.0f)));
+        EXPECT_THAT(Vector2::CreateFromAngle(0.78539816339f), IsClose(Vector2(0.7071067811f, 0.7071067811f)));
+        EXPECT_THAT(Vector2::CreateFromAngle(4.0f), IsClose(Vector2(-0.7568024953f, -0.6536436208f)));
+        EXPECT_THAT(Vector2::CreateFromAngle(-1.0f), IsClose(Vector2(-0.8414709848f, 0.5403023058f)));
     }
 
     TEST(MATH_Vector2, TestCompareEqual)
@@ -61,9 +60,9 @@ namespace UnitTest
 
         // operation r.x = (cmp1.x == cmp2.x) ? vA.x : vB.x per component
         Vector2 compareEqualAB = Vector2::CreateSelectCmpEqual(vA, vB, Vector2(1.0f), Vector2(0.0f));
-        AZ_TEST_ASSERT(compareEqualAB.IsClose(Vector2(0.0f, 1.0f)));
+        EXPECT_THAT(compareEqualAB, IsClose(Vector2(0.0f, 1.0f)));
         Vector2 compareEqualBC = Vector2::CreateSelectCmpEqual(vB, vC, Vector2(1.0f), Vector2(0.0f));
-        AZ_TEST_ASSERT(compareEqualBC.IsClose(Vector2(1.0f, 0.0f)));
+        EXPECT_THAT(compareEqualBC, IsClose(Vector2(1.0f, 0.0f)));
     }
 
     TEST(MATH_Vector2, TestCompareGreaterEqual)
@@ -74,9 +73,9 @@ namespace UnitTest
 
         // operation ( r.x = (cmp1.x >= cmp2.x) ? vA.x : vB.x ) per component
         Vector2 compareGreaterEqualAB = Vector2::CreateSelectCmpGreaterEqual(vA, vB, Vector2(1.0f), Vector2(0.0f));
-        AZ_TEST_ASSERT(compareGreaterEqualAB.IsClose(Vector2(0.0f, 1.0f)));
+        EXPECT_THAT(compareGreaterEqualAB, IsClose(Vector2(0.0f, 1.0f)));
         Vector2 compareGreaterEqualBD = Vector2::CreateSelectCmpGreaterEqual(vB, vD, Vector2(1.0f), Vector2(0.0f));
-        AZ_TEST_ASSERT(compareGreaterEqualBD.IsClose(Vector2(1.0f, 0.0f)));
+        EXPECT_THAT(compareGreaterEqualBD, IsClose(Vector2(1.0f, 0.0f)));
     }
 
     TEST(MATH_Vector2, TestCompareGreater)
@@ -87,9 +86,9 @@ namespace UnitTest
 
         // operation ( r.x = (cmp1.x > cmp2.x) ? vA.x : vB.x ) per component
         Vector2 compareGreaterAB = Vector2::CreateSelectCmpGreater(vA, vB, Vector2(1.0f), Vector2(0.0f));
-        AZ_TEST_ASSERT(compareGreaterAB.IsClose(Vector2(0.0f, 0.0f)));
+        EXPECT_THAT(compareGreaterAB, IsClose(Vector2(0.0f, 0.0f)));
         Vector2 compareGreaterCA = Vector2::CreateSelectCmpGreater(vC, vA, Vector2(1.0f), Vector2(0.0f));
-        AZ_TEST_ASSERT(compareGreaterCA.IsClose(Vector2(1.0f, 1.0f)));
+        EXPECT_THAT(compareGreaterCA, IsClose(Vector2(1.0f, 1.0f)));
     }
 
     TEST(MATH_Vector2, TestStoreFloat)
@@ -98,376 +97,426 @@ namespace UnitTest
 
         Vector2 vA(1.0f, 2.0f);
         vA.StoreToFloat2(values);
-        AZ_TEST_ASSERT(values[0] == 1.0f && values[1] == 2.0f);
+        EXPECT_EQ(values[0], 1.0f);
+        EXPECT_EQ(values[1], 2.0f);
     }
 
     TEST(MATH_Vector2, TestGetSet)
     {
         Vector2 vA(2.0f, 3.0f);
-        AZ_TEST_ASSERT(vA == Vector2(2.0f, 3.0f));
-        AZ_TEST_ASSERT(vA.GetX() == 2.0f && vA.GetY() == 3.0f);
-        vA.SetX(10.0f);
-        AZ_TEST_ASSERT(vA == Vector2(10.0f, 3.0f));
-        vA.SetY(11.0f);
-        AZ_TEST_ASSERT(vA == Vector2(10.0f, 11.0f));
-        vA.Set(15.0f);
-        AZ_TEST_ASSERT(vA == Vector2(15.0f));
-        vA.SetElement(0, 20.0f);
-        AZ_TEST_ASSERT(vA.GetX() == 20.0f && vA.GetY() == 15.0f);
-        AZ_TEST_ASSERT(vA.GetElement(0) == 20.0f && vA.GetElement(1) == 15.0f);
-        AZ_TEST_ASSERT(vA(0) == 20.0f && vA(1) == 15.0f);
-        vA.SetElement(1, 21.0f);
-        AZ_TEST_ASSERT(vA.GetX() == 20.0f && vA.GetY() == 21.0f);
-        AZ_TEST_ASSERT(vA.GetElement(0) == 20.0f && vA.GetElement(1) == 21.0f);
-        AZ_TEST_ASSERT(vA(0) == 20.0f && vA(1) == 21.0f);
-    }
 
+        EXPECT_TRUE(vA == Vector2(2.0f, 3.0f));
+        EXPECT_FLOAT_EQ(vA.GetX(), 2.0f);
+        EXPECT_FLOAT_EQ(vA.GetY(), 3.0f);
+
+        vA.SetX(10.0f);
+        EXPECT_TRUE(vA == Vector2(10.0f, 3.0f));
+
+        vA.SetY(11.0f);
+        EXPECT_TRUE(vA == Vector2(10.0f, 11.0f));
+
+        vA.Set(15.0f);
+        EXPECT_TRUE(vA == Vector2(15.0f));
+
+        vA.SetElement(0, 20.0f);
+        EXPECT_FLOAT_EQ(vA.GetX(), 20.0f);
+        EXPECT_FLOAT_EQ(vA.GetY(), 15.0f);
+        EXPECT_FLOAT_EQ(vA.GetElement(0), 20.0f);
+        EXPECT_FLOAT_EQ(vA.GetElement(1), 15.0f);
+        EXPECT_FLOAT_EQ(vA(0), 20.0f);
+        EXPECT_FLOAT_EQ(vA(1), 15.0f);
+
+        vA.SetElement(1, 21.0f);
+        EXPECT_FLOAT_EQ(vA.GetX(), 20.0f);
+        EXPECT_FLOAT_EQ(vA.GetY(), 21.0f);
+        EXPECT_FLOAT_EQ(vA.GetElement(0), 20.0f);
+        EXPECT_FLOAT_EQ(vA.GetElement(1), 21.0f);
+        EXPECT_FLOAT_EQ(vA(0), 20.0f);
+        EXPECT_FLOAT_EQ(vA(1), 21.0f);
+    }
 
     TEST(MATH_Vector2, TestGetLength)
     {
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector2(3.0f, 4.0f).GetLengthSq(), 25.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector2(4.0f, -3.0f).GetLength(), 5.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector2(4.0f, -3.0f).GetLengthEstimate(), 5.0f);
+        EXPECT_FLOAT_EQ(Vector2(3.0f, 4.0f).GetLengthSq(), 25.0f);
+        EXPECT_FLOAT_EQ(Vector2(4.0f, -3.0f).GetLength(), 5.0f);
+        EXPECT_FLOAT_EQ(Vector2(4.0f, -3.0f).GetLengthEstimate(), 5.0f);
     }
 
     TEST(MATH_Vector2, TestGetLengthReciprocal)
     {
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector2(4.0f, -3.0f).GetLengthReciprocal(), 0.2f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector2(4.0f, -3.0f).GetLengthReciprocalEstimate(), 0.2f);
+        EXPECT_NEAR(Vector2(4.0f, -3.0f).GetLengthReciprocal(), 0.2f, 0.01f);
+        EXPECT_NEAR(Vector2(4.0f, -3.0f).GetLengthReciprocalEstimate(), 0.2f, 0.01f);
     }
 
     TEST(MATH_Vector2, TestGetNormalized)
     {
-        AZ_TEST_ASSERT(Vector2(3.0f, 4.0f).GetNormalized().IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
-        AZ_TEST_ASSERT(Vector2(3.0f, 4.0f).GetNormalizedEstimate().IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(Vector2(3.0f, 4.0f).GetNormalized(), IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(Vector2(3.0f, 4.0f).GetNormalizedEstimate(), IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
     }
 
     TEST(MATH_Vector2, TestGetNormalizedSafe)
     {
-        AZ_TEST_ASSERT(Vector2(3.0f, 4.0f).GetNormalizedSafe().IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
-        AZ_TEST_ASSERT(Vector2(3.0f, 4.0f).GetNormalizedSafeEstimate().IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
-        AZ_TEST_ASSERT(Vector2(0.0f).GetNormalizedSafe() == Vector2(0.0f, 0.0f));
-        AZ_TEST_ASSERT(Vector2(0.0f).GetNormalizedSafeEstimate() == Vector2(0.0f, 0.0f));
+        EXPECT_THAT(Vector2(3.0f, 4.0f).GetNormalizedSafe(), IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(Vector2(3.0f, 4.0f).GetNormalizedSafeEstimate(), IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(Vector2(0.0f).GetNormalizedSafe(), IsClose(Vector2(0.0f, 0.0f)));
+        EXPECT_THAT(Vector2(0.0f).GetNormalizedSafeEstimate(), IsClose(Vector2(0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector2, TestNormalize)
     {
         Vector2 v1(4.0f, 3.0f);
         v1.Normalize();
-        AZ_TEST_ASSERT(v1.IsClose(Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
         v1.Set(4.0f, 3.0f);
         v1.NormalizeEstimate();
-        AZ_TEST_ASSERT(v1.IsClose(Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
     }
 
     TEST(MATH_Vector2, TestNormalizeWithLength)
     {
         Vector2 v1(4.0f, 3.0f);
         float length = v1.NormalizeWithLength();
-        AZ_TEST_ASSERT_FLOAT_CLOSE(length, 5.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
+        EXPECT_FLOAT_EQ(length, 5.0f);
+        EXPECT_THAT(v1, IsClose(Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
         v1.Set(4.0f, 3.0f);
         length = v1.NormalizeWithLengthEstimate();
-        AZ_TEST_ASSERT_FLOAT_CLOSE(length, 5.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
+        EXPECT_FLOAT_EQ(length, 5.0f);
+        EXPECT_THAT(v1, IsClose(Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
     }
 
     TEST(MATH_Vector2, TestNormalizeSafe)
     {
         Vector2 v1(3.0f, 4.0f);
         v1.NormalizeSafe();
-        AZ_TEST_ASSERT(v1.IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         v1.NormalizeSafe();
-        AZ_TEST_ASSERT(v1 == Vector2(0.0f, 0.0f));
+        EXPECT_THAT(v1, IsClose(Vector2(0.0f, 0.0f)));
         v1.Set(3.0f, 4.0f);
         v1.NormalizeSafeEstimate();
-        AZ_TEST_ASSERT(v1.IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         v1.NormalizeSafeEstimate();
-        AZ_TEST_ASSERT(v1 == Vector2(0.0f, 0.0f));
+        EXPECT_THAT(v1, IsClose(Vector2(0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector2, TestNormalizeSafeWithLength)
     {
         Vector2 v1(3.0f, 4.0f);
         float length = v1.NormalizeSafeWithLength();
-        AZ_TEST_ASSERT_FLOAT_CLOSE(length, 5.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_FLOAT_EQ(length, 5.0f);
+        EXPECT_THAT(v1, IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         length = v1.NormalizeSafeWithLength();
-        AZ_TEST_ASSERT(length == 0.0f);
-        AZ_TEST_ASSERT(v1 == Vector2(0.0f, 0.0f));
+        EXPECT_FLOAT_EQ(length, 0.0f);
+        EXPECT_THAT(v1, IsClose(Vector2(0.0f, 0.0f)));
         v1.Set(3.0f, 4.0f);
         length = v1.NormalizeSafeWithLengthEstimate();
-        AZ_TEST_ASSERT_FLOAT_CLOSE(length, 5.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_FLOAT_EQ(length, 5.0f);
+        EXPECT_THAT(v1, IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         length = v1.NormalizeSafeWithLengthEstimate();
-        AZ_TEST_ASSERT(length == 0.0f);
-        AZ_TEST_ASSERT(v1 == Vector2(0.0f, 0.0f));
+        EXPECT_FLOAT_EQ(length, 0.0f);
+        EXPECT_THAT(v1, IsClose(Vector2(0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector2, TestIsNormalized)
     {
-        AZ_TEST_ASSERT(Vector2(1.0f, 0.0f).IsNormalized());
-        AZ_TEST_ASSERT(Vector2(0.7071f, 0.7071f).IsNormalized());
-        AZ_TEST_ASSERT(!Vector2(1.0f, 1.0f).IsNormalized());
+        EXPECT_TRUE(Vector2(1.0f, 0.0f).IsNormalized());
+        EXPECT_TRUE(Vector2(0.7071f, 0.7071f).IsNormalized());
+        EXPECT_FALSE(Vector2(1.0f, 1.0f).IsNormalized());
     }
 
     TEST(MATH_Vector2, TestSetLength)
     {
         Vector2 v1(3.0f, 4.0f);
         v1.SetLength(10.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector2(6.0f, 8.0f)));
+        EXPECT_THAT(v1, IsClose(Vector2(6.0f, 8.0f)));
         v1.Set(3.0f, 4.0f);
         v1.SetLengthEstimate(10.0f);
-        AZ_TEST_ASSERT(v1.IsClose(Vector2(6.0f, 8.0f), 1e-3f));
+        EXPECT_THAT(v1, IsCloseTolerance(Vector2(6.0f, 8.0f), 1e-3f));
     }
 
     TEST(MATH_Vector2, TestDistance)
     {
         Vector2 vA(1.0f, 2.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(vA.GetDistanceSq(Vector2(-2.0f, 6.0f)), 25.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(vA.GetDistance(Vector2(5.0f, -1.0f)), 5.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(vA.GetDistanceEstimate(Vector2(5.0f, -1.0f)), 5.0f);
+        EXPECT_FLOAT_EQ(vA.GetDistanceSq(Vector2(-2.0f, 6.0f)), 25.0f);
+        EXPECT_FLOAT_EQ(vA.GetDistance(Vector2(5.0f, -1.0f)), 5.0f);
+        EXPECT_FLOAT_EQ(vA.GetDistanceEstimate(Vector2(5.0f, -1.0f)), 5.0f);
     }
 
     TEST(MATH_Vector2, TestLerpSlerpNLerp)
     {
-        AZ_TEST_ASSERT(Vector2(4.0f, 5.0f).Lerp(Vector2(5.0f, 10.0f), 0.5f).IsClose(Vector2(4.5f, 7.5f)));
-        AZ_TEST_ASSERT(Vector2(1.0f, 0.0f).Slerp(Vector2(0.0f, 1.0f), 0.5f).IsClose(Vector2(0.7071f, 0.7071f)));
-        AZ_TEST_ASSERT(Vector2(1.0f, 0.0f).Nlerp(Vector2(0.0f, 1.0f), 0.5f).IsClose(Vector2(0.7071f, 0.7071f)));
+        EXPECT_THAT(Vector2(4.0f, 5.0f).Lerp(Vector2(5.0f, 10.0f), 0.5f), IsClose(Vector2(4.5f, 7.5f)));
+        EXPECT_THAT(Vector2(1.0f, 0.0f).Slerp(Vector2(0.0f, 1.0f), 0.5f), IsClose(Vector2(0.7071f, 0.7071f)));
+        EXPECT_THAT(Vector2(1.0f, 0.0f).Nlerp(Vector2(0.0f, 1.0f), 0.5f), IsClose(Vector2(0.7071f, 0.7071f)));
     }
 
     TEST(MATH_Vector2, TestGetPerpendicular)
     {
-        AZ_TEST_ASSERT(Vector2(1.0f, 2.0f).GetPerpendicular() == Vector2(-2.0f, 1.0f));
+        EXPECT_THAT(Vector2(1.0f, 2.0f).GetPerpendicular(), IsClose(Vector2(-2.0f, 1.0f)));
     }
 
     TEST(MATH_Vector2, TestIsClose)
     {
-        AZ_TEST_ASSERT(Vector2(1.0f, 2.0f).IsClose(Vector2(1.0f, 2.0f)));
-        AZ_TEST_ASSERT(!Vector2(1.0f, 2.0f).IsClose(Vector2(1.0f, 3.0f)));
+        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsClose(Vector2(1.0f, 2.0f)));
+        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsClose(Vector2(1.0f, 3.0f)));
 
         // Verify tolerance works
-        AZ_TEST_ASSERT(Vector2(1.0f, 2.0f).IsClose(Vector2(1.0f, 2.4f), 0.5f));
+        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsClose(Vector2(1.0f, 2.4f), 0.5f));
     }
 
     TEST(MATH_Vector2, TestIsZero)
     {
-        AZ_TEST_ASSERT(Vector2(0.0f).IsZero());
-        AZ_TEST_ASSERT(!Vector2(1.0f).IsZero());
+        EXPECT_TRUE(Vector2(0.0f).IsZero());
+        EXPECT_FALSE(Vector2(1.0f).IsZero());
 
         // Verify tolerance works
-        AZ_TEST_ASSERT(Vector2(0.05f).IsZero(0.1f));
+        EXPECT_TRUE(Vector2(0.05f).IsZero(0.1f));
     }
 
     TEST(MATH_Vector2, TestEqualityInequality)
     {
         Vector2 vA(1.0f, 2.0f);
-        AZ_TEST_ASSERT(vA == Vector2(1.0f, 2.0f));
-        AZ_TEST_ASSERT(!(vA == Vector2(5.0f, 6.0f)));
-        AZ_TEST_ASSERT(vA != Vector2(7.0f, 8.0f));
-        AZ_TEST_ASSERT(!(vA != Vector2(1.0f, 2.0f)));
+        EXPECT_TRUE(vA == Vector2(1.0f, 2.0f));
+        EXPECT_FALSE((vA == Vector2(5.0f, 6.0f)));
+        EXPECT_TRUE(vA != Vector2(7.0f, 8.0f));
+        EXPECT_FALSE((vA != Vector2(1.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestIsLessThan)
     {
-        AZ_TEST_ASSERT(Vector2(1.0f, 2.0f).IsLessThan(Vector2(2.0f, 3.0f)));
-        AZ_TEST_ASSERT(!Vector2(1.0f, 2.0f).IsLessThan(Vector2(0.0f, 3.0f)));
-        AZ_TEST_ASSERT(!Vector2(1.0f, 2.0f).IsLessThan(Vector2(2.0f, 2.0f)));
+        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsLessThan(Vector2(2.0f, 3.0f)));
+        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsLessThan(Vector2(0.0f, 3.0f)));
+        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsLessThan(Vector2(2.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestIsLessEqualThan)
     {
-        AZ_TEST_ASSERT(Vector2(1.0f, 2.0f).IsLessEqualThan(Vector2(2.0f, 3.0f)));
-        AZ_TEST_ASSERT(!Vector2(1.0f, 2.0f).IsLessEqualThan(Vector2(0.0f, 3.0f)));
-        AZ_TEST_ASSERT(Vector2(1.0f, 2.0f).IsLessEqualThan(Vector2(2.0f, 2.0f)));
+        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsLessEqualThan(Vector2(2.0f, 3.0f)));
+        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsLessEqualThan(Vector2(0.0f, 3.0f)));
+        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsLessEqualThan(Vector2(2.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestIsGreaterThan)
     {
-        AZ_TEST_ASSERT(Vector2(1.0f, 2.0f).IsGreaterThan(Vector2(0.0f, 1.0f)));
-        AZ_TEST_ASSERT(!Vector2(1.0f, 2.0f).IsGreaterThan(Vector2(0.0f, 3.0f)));
-        AZ_TEST_ASSERT(!Vector2(1.0f, 2.0f).IsGreaterThan(Vector2(0.0f, 2.0f)));
+        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsGreaterThan(Vector2(0.0f, 1.0f)));
+        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsGreaterThan(Vector2(0.0f, 3.0f)));
+        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsGreaterThan(Vector2(0.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestIsGreaterEqualThan)
     {
-        AZ_TEST_ASSERT(Vector2(1.0f, 2.0f).IsGreaterEqualThan(Vector2(0.0f, 1.0f)));
-        AZ_TEST_ASSERT(!Vector2(1.0f, 2.0f).IsGreaterEqualThan(Vector2(0.0f, 3.0f)));
-        AZ_TEST_ASSERT(Vector2(1.0f, 2.0f).IsGreaterEqualThan(Vector2(0.0f, 2.0f)));
+        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsGreaterEqualThan(Vector2(0.0f, 1.0f)));
+        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsGreaterEqualThan(Vector2(0.0f, 3.0f)));
+        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsGreaterEqualThan(Vector2(0.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestMinMax)
     {
-        AZ_TEST_ASSERT(Vector2(2.0f, 3.0f).GetMin(Vector2(1.0f, 4.0f)) == Vector2(1.0f, 3.0f));
-        AZ_TEST_ASSERT(Vector2(2.0f, 3.0f).GetMax(Vector2(1.0f, 4.0f)) == Vector2(2.0f, 4.0f));
+        EXPECT_THAT(Vector2(2.0f, 3.0f).GetMin(Vector2(1.0f, 4.0f)), IsClose(Vector2(1.0f, 3.0f)));
+        EXPECT_THAT(Vector2(2.0f, 3.0f).GetMax(Vector2(1.0f, 4.0f)), IsClose(Vector2(2.0f, 4.0f)));
     }
 
     TEST(MATH_Vector2, TestClamp)
     {
-        AZ_TEST_ASSERT(Vector2(1.0f, 2.0f).GetClamp(Vector2(5.0f, -10.0f), Vector2(10.0f, -5.0f)) == Vector2(5.0f, -5.0f));
-        AZ_TEST_ASSERT(Vector2(1.0f, 2.0f).GetClamp(Vector2(0.0f, 0.0f), Vector2(10.0f, 10.0f)) == Vector2(1.0f, 2.0f));
+        EXPECT_THAT(Vector2(1.0f, 2.0f).GetClamp(Vector2(5.0f, -10.0f), Vector2(10.0f, -5.0f)), IsClose(Vector2(5.0f, -5.0f)));
+        EXPECT_THAT(Vector2(1.0f, 2.0f).GetClamp(Vector2(0.0f, 0.0f), Vector2(10.0f, 10.0f)), IsClose(Vector2(1.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestSelect)
     {
         Vector2 vA(1.0f);
         Vector2 vB(2.0f);
-        AZ_TEST_ASSERT(vA.GetSelect(Vector2(0.0f, 1.0f), vB) == Vector2(1.0f, 2.0f));
+        EXPECT_THAT(vA.GetSelect(Vector2(0.0f, 1.0f), vB), IsClose(Vector2(1.0f, 2.0f)));
         vA.Select(Vector2(1.0f, 0.0f), vB);
-        AZ_TEST_ASSERT(vA == Vector2(2.0f, 1.0f));
+        EXPECT_THAT(vA, IsClose(Vector2(2.0f, 1.0f)));
     }
 
     TEST(MATH_Vector2, TestAbs)
     {
-        AZ_TEST_ASSERT(Vector2(-1.0f, 2.0f).GetAbs() == Vector2(1.0f, 2.0f));
-        AZ_TEST_ASSERT(Vector2(3.0f, -4.0f).GetAbs() == Vector2(3.0f, 4.0f));
+        EXPECT_THAT(Vector2(-1.0f, 2.0f).GetAbs(), IsClose(Vector2(1.0f, 2.0f)));
+        EXPECT_THAT(Vector2(3.0f, -4.0f).GetAbs(), IsClose(Vector2(3.0f, 4.0f)));
     }
 
     TEST(MATH_Vector2, TestReciprocal)
     {
-        AZ_TEST_ASSERT(Vector2(2.0f, 4.0f).GetReciprocal().IsClose(Vector2(0.5f, 0.25f)));
-        AZ_TEST_ASSERT(Vector2(2.0f, 4.0f).GetReciprocalEstimate().IsClose(Vector2(0.5f, 0.25f)));
+        EXPECT_THAT(Vector2(2.0f, 4.0f).GetReciprocal(), IsClose(Vector2(0.5f, 0.25f)));
+        EXPECT_THAT(Vector2(2.0f, 4.0f).GetReciprocalEstimate(), IsClose(Vector2(0.5f, 0.25f)));
     }
 
     TEST(MATH_Vector2, TestAdd)
     {
         Vector2 vA(1.0f, 2.0f);
         vA += Vector2(3.0f, 4.0f);
-        AZ_TEST_ASSERT(vA == Vector2(4.0f, 6.0f));
-        AZ_TEST_ASSERT((Vector2(1.0f, 2.0f) + Vector2(2.0f, -1.0f)) == Vector2(3.0f, 1.0f));
+        EXPECT_THAT(vA, IsClose(Vector2(4.0f, 6.0f)));
+        EXPECT_THAT((Vector2(1.0f, 2.0f) + Vector2(2.0f, -1.0f)), IsClose(Vector2(3.0f, 1.0f)));
     }
 
     TEST(MATH_Vector2, TestSub)
     {
         Vector2 vA(10.0f, 11.0f);
         vA -= Vector2(2.0f, 4.0f);
-        AZ_TEST_ASSERT(vA == Vector2(8.0f, 7.0f));
-        AZ_TEST_ASSERT((Vector2(1.0f, 2.0f) - Vector2(2.0f, -1.0f)) == Vector2(-1.0f, 3.0f));
+        EXPECT_THAT(vA, IsClose(Vector2(8.0f, 7.0f)));
+        EXPECT_THAT((Vector2(1.0f, 2.0f) - Vector2(2.0f, -1.0f)), IsClose(Vector2(-1.0f, 3.0f)));
     }
 
     TEST(MATH_Vector2, TestMul)
     {
         Vector2 vA(2.0f, 4.0f);
         vA *= Vector2(3.0f, 6.0f);
-        AZ_TEST_ASSERT(vA == Vector2(6.0f, 24.0f));
+        EXPECT_THAT(vA, IsClose(Vector2(6.0f, 24.0f)));
 
         vA.Set(2.0f, 3.0f);
         vA *= 5.0f;
-        AZ_TEST_ASSERT(vA == Vector2(10.0f, 15.0f));
+        EXPECT_THAT(vA, IsClose(Vector2(10.0f, 15.0f)));
 
-        AZ_TEST_ASSERT((Vector2(3.0f, 2.0f) * Vector2(2.0f, -4.0f)) == Vector2(6.0f, -8.0f));
-        AZ_TEST_ASSERT((Vector2(3.0f, 2.0f) * 2.0f) == Vector2(6.0f, 4.0f));
+        EXPECT_THAT((Vector2(3.0f, 2.0f) * Vector2(2.0f, -4.0f)), IsClose(Vector2(6.0f, -8.0f)));
+        EXPECT_THAT((Vector2(3.0f, 2.0f) * 2.0f), IsClose(Vector2(6.0f, 4.0f)));
     }
 
     TEST(MATH_Vector2, TestDiv)
     {
         Vector2 vA(15.0f, 20.0f);
         vA /= Vector2(3.0f, 2.0f);
-        AZ_TEST_ASSERT(vA == Vector2(5.0f, 10.0f));
+        EXPECT_THAT(vA, IsClose(Vector2(5.0f, 10.0f)));
 
         vA.Set(20.0f, 30.0f);
         vA /= 10.0f;
-        AZ_TEST_ASSERT(vA == Vector2(2.0f, 3.0f));
+        EXPECT_THAT(vA, IsClose(Vector2(2.0f, 3.0f)));
 
-        AZ_TEST_ASSERT((Vector2(30.0f, 20.0f) / Vector2(10.0f, -4.0f)) == Vector2(3.0f, -5.0f));
-        AZ_TEST_ASSERT((Vector2(30.0f, 20.0f) / 10.0f) == Vector2(3.0f, 2.0f));
+        EXPECT_THAT((Vector2(30.0f, 20.0f) / Vector2(10.0f, -4.0f)), IsClose(Vector2(3.0f, -5.0f)));
+        EXPECT_THAT((Vector2(30.0f, 20.0f) / 10.0f), IsClose(Vector2(3.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestNegate)
     {
-        AZ_TEST_ASSERT((-Vector2(1.0f, -2.0f)) == Vector2(-1.0f, 2.0f));
+        EXPECT_THAT((-Vector2(1.0f, -2.0f)), IsClose(Vector2(-1.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestDot)
     {
-        AZ_TEST_ASSERT_FLOAT_CLOSE(Vector2(1.0f, 2.0f).Dot(Vector2(-1.0f, 5.0f)), 9.0f);
+        EXPECT_FLOAT_EQ(Vector2(1.0f, 2.0f).Dot(Vector2(-1.0f, 5.0f)), 9.0f);
     }
 
     TEST(MATH_Vector2, TestMadd)
     {
-        AZ_TEST_ASSERT(Vector2(1.0f, 2.0f).GetMadd(Vector2(2.0f, 6.0f), Vector2(3.0f, 4.0f)) == Vector2(5.0f, 16.0f));
+        EXPECT_THAT(Vector2(1.0f, 2.0f).GetMadd(Vector2(2.0f, 6.0f), Vector2(3.0f, 4.0f)), IsClose(Vector2(5.0f, 16.0f)));
         Vector2 vA(1.0f, 2.0f);
         vA.Madd(Vector2(2.0f, 6.0f), Vector2(3.0f, 4.0f));
-        AZ_TEST_ASSERT(vA == Vector2(5.0f, 16.0f));
+        EXPECT_THAT(vA, IsClose(Vector2(5.0f, 16.0f)));
     }
 
     TEST(MATH_Vector2, TestProject)
     {
         Vector2 vA(0.5f);
         vA.Project(Vector2(0.0f, 2.0f));
-        AZ_TEST_ASSERT(vA == Vector2(0.0f, 0.5f));
+        EXPECT_THAT(vA, IsClose(Vector2(0.0f, 0.5f)));
         vA.Set(0.5f);
         vA.ProjectOnNormal(Vector2(0.0f, 1.0f));
-        AZ_TEST_ASSERT(vA == Vector2(0.0f, 0.5f));
+        EXPECT_THAT(vA, IsClose(Vector2(0.0f, 0.5f)));
         vA.Set(2.0f, 4.0f);
-        AZ_TEST_ASSERT(vA.GetProjected(Vector2(1.0f, 1.0f)) == Vector2(3.0f, 3.0f));
-        AZ_TEST_ASSERT(vA.GetProjectedOnNormal(Vector2(1.0f, 0.0f)) == Vector2(2.0f, 0.0f));
+        EXPECT_THAT(vA.GetProjected(Vector2(1.0f, 1.0f)), IsClose(Vector2(3.0f, 3.0f)));
+        EXPECT_THAT(vA.GetProjectedOnNormal(Vector2(1.0f, 0.0f)), IsClose(Vector2(2.0f, 0.0f)));
     }
 
     TEST(MATH_Vector2, TestTrig)
     {
-        AZ_TEST_ASSERT(Vector2(DegToRad(78.0f), DegToRad(-150.0f)).GetAngleMod().IsClose(Vector2(DegToRad(78.0f), DegToRad(-150.0f))));
-        AZ_TEST_ASSERT(Vector2(DegToRad(390.0f), DegToRad(-190.0f)).GetAngleMod().IsClose(Vector2(DegToRad(30.0f), DegToRad(170.0f))));
-        AZ_TEST_ASSERT(Vector2(DegToRad(60.0f), DegToRad(105.0f)).GetSin().IsClose(Vector2(0.866f, 0.966f), 0.005f));
-        AZ_TEST_ASSERT(Vector2(DegToRad(60.0f), DegToRad(105.0f)).GetCos().IsClose(Vector2(0.5f, -0.259f), 0.005f));
+        EXPECT_THAT(Vector2(DegToRad(78.0f), DegToRad(-150.0f)).GetAngleMod(), IsClose(Vector2(DegToRad(78.0f), DegToRad(-150.0f))));
+        EXPECT_THAT(Vector2(DegToRad(390.0f), DegToRad(-190.0f)).GetAngleMod(), IsClose(Vector2(DegToRad(30.0f), DegToRad(170.0f))));
+        EXPECT_THAT(Vector2(DegToRad(60.0f), DegToRad(105.0f)).GetSin(), IsCloseTolerance(Vector2(0.866f, 0.966f), 0.005f));
+        EXPECT_THAT(Vector2(DegToRad(60.0f), DegToRad(105.0f)).GetCos(), IsCloseTolerance(Vector2(0.5f, -0.259f), 0.005f));
         Vector2 sin, cos;
         Vector2 v1(DegToRad(60.0f), DegToRad(105.0f));
         v1.GetSinCos(sin, cos);
-        AZ_TEST_ASSERT(sin.IsClose(Vector2(0.866f, 0.966f), 0.005f));
-        AZ_TEST_ASSERT(cos.IsClose(Vector2(0.5f, -0.259f), 0.005f));
+        EXPECT_THAT(sin, IsCloseTolerance(Vector2(0.866f, 0.966f), 0.005f));
+        EXPECT_THAT(cos, IsCloseTolerance(Vector2(0.5f, -0.259f), 0.005f));
     }
 
     TEST(MATH_Vector2, TestIsFinite)
     {
-        AZ_TEST_ASSERT(Vector2(1.0f, 1.0f).IsFinite());
+        EXPECT_TRUE(Vector2(1.0f, 1.0f).IsFinite());
         const float infinity = std::numeric_limits<float>::infinity();
-        AZ_TEST_ASSERT(!Vector2(infinity, infinity).IsFinite());
+        EXPECT_FALSE(Vector2(infinity, infinity).IsFinite());
     }
-
-    TEST(MATH_Vector2, TestAngles)
+    struct AngleTestArgs
     {
-        using Vec2CalcFunc = float(Vector2::*)(const Vector2&) const;
-        auto angleTest = [](Vec2CalcFunc func, const Vector2& self, const Vector2& other, const float target)
-        {
-            const float epsilon = 0.01f;
-            float value = (self.*func)(other);
-            AZ_TEST_ASSERT(AZ::IsClose(value, target, epsilon));
-        };
+        AZ::Vector2 current;
+        AZ::Vector2 target;
+        float angle;
+    };
 
-        const Vec2CalcFunc angleFuncs[2] = { &Vector2::Angle, &Vector2::AngleSafe };
-        for (Vec2CalcFunc angleFunc : angleFuncs)
-        {
-            angleTest(angleFunc, Vector2{ 1.0f, 0.0f }, Vector2{ 0.0f, 1.0f }, AZ::Constants::HalfPi);
-            angleTest(angleFunc, Vector2{ 42.0f, 0.0f }, Vector2{ 0.0f, 23.0f }, AZ::Constants::HalfPi);
-            angleTest(angleFunc, Vector2{ 1.0f, 0.0f }, Vector2{ -1.0f, 0.0f }, AZ::Constants::Pi);
-            angleTest(angleFunc, Vector2{ 1.0f, 0.0f }, Vector2{ 1.0f, 1.0f }, AZ::Constants::QuarterPi);
-            angleTest(angleFunc, Vector2{ 1.0f, 0.0f }, Vector2{ 1.0f, 0.0f }, 0.f);
-            angleTest(angleFunc, Vector2{ 1.0f, 1.0f }, Vector2{ -1.0f, -1.0f }, AZ::Constants::Pi);
-        }
+    using AngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
 
-        const Vec2CalcFunc angleDegFuncs[2] = { &Vector2::AngleDeg, &Vector2::AngleSafeDeg };
-        for (Vec2CalcFunc angleDegFunc : angleDegFuncs)
-        {
-            angleTest(angleDegFunc, Vector2{ 1.0f, 0.0f }, Vector2{ 0.0f, 1.0f }, 90.f);
-            angleTest(angleDegFunc, Vector2{ 42.0f, 0.0f }, Vector2{ 0.0f, 23.0f }, 90.f);
-            angleTest(angleDegFunc, Vector2{ 1.0f, 0.0f }, Vector2{ -1.0f, 0.0f }, 180.f);
-            angleTest(angleDegFunc, Vector2{ 1.0f, 0.0f }, Vector2{ 1.0f, 1.0f }, 45.f);
-            angleTest(angleDegFunc, Vector2{ 1.0f, 0.0f }, Vector2{ 1.0f, 0.0f }, 0.f);
-            angleTest(angleDegFunc, Vector2{ 1.0f, 1.0f }, Vector2{ -1.0f, -1.0f }, 180.f);
-        }
-
-        const Vec2CalcFunc angleSafeFuncs[2] = { &Vector2::AngleSafe, &Vector2::AngleSafeDeg };
-        for (Vec2CalcFunc angleSafeFunc : angleSafeFuncs)
-        {
-            angleTest(angleSafeFunc, Vector2{ 0.0f, 0.0f }, Vector2{ 0.0f, 1.0f }, 0.f);
-            angleTest(angleSafeFunc, Vector2{ 0.0f, 0.0f }, Vector2{ 0.0f, 0.0f }, 0.f);
-            angleTest(angleSafeFunc, Vector2{ 1.0f, 0.0f }, Vector2{ 0.0f, 0.0f }, 0.f);
-            angleTest(angleSafeFunc, Vector2{ 0.0f, 0.0f }, Vector2{ 0.0f, 323432.0f }, 0.f);
-            angleTest(angleSafeFunc, Vector2{ 323432.0f, 0.0f }, Vector2{ 0.0f, 0.0f }, 0.f);
-        }
+    TEST_P(AngleTestFixture, TestAngle)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.Angle(param.target), param.angle);
     }
-}
+
+    TEST_P(AngleTestFixture, TestAngleSafe)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleSafe(param.target), param.angle);
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        MATH_Vector2,
+        AngleTestFixture,
+        ::testing::Values(
+            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 0.0f, 1.0f }, AZ::Constants::HalfPi },
+            AngleTestArgs{ Vector2{ 42.0f, 0.0f }, Vector2{ 0.0f, 23.0f }, AZ::Constants::HalfPi },
+            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ -1.0f, 0.0f }, AZ::Constants::Pi },
+            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 1.0f, 1.0f }, AZ::Constants::QuarterPi },
+            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 1.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector2{ 1.0f, 1.0f }, Vector2{ -1.0f, -1.0f }, AZ::Constants::Pi }));
+
+    using AngleDegTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+
+    TEST_P(AngleDegTestFixture, TestAngleDeg)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleDeg(param.target), param.angle);
+    }
+
+    TEST_P(AngleDegTestFixture, TestAngleDegSafe)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        MATH_Vector2,
+        AngleDegTestFixture,
+        ::testing::Values(
+            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 0.0f, 1.0f }, 90.f },
+            AngleTestArgs{ Vector2{ 42.0f, 0.0f }, Vector2{ 0.0f, 23.0f }, 90.f },
+            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ -1.0f, 0.0f }, 180.f },
+            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 1.0f, 1.0f }, 45.f },
+            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 1.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector2{ 1.0f, 1.0f }, Vector2{ -1.0f, -1.0f }, 180.f }));
+
+    using AngleSafeInvalidAngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+
+    TEST_P(AngleSafeInvalidAngleTestFixture, TestInvalidAngle)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleSafe(param.target), param.angle);
+    }
+
+    TEST_P(AngleSafeInvalidAngleTestFixture, TestInvalidAngleDeg)
+    {
+        auto& param = GetParam();
+        EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        MATH_Vector2,
+        AngleSafeInvalidAngleTestFixture,
+        ::testing::Values(
+            AngleTestArgs{ Vector2{ 0.0f, 0.0f }, Vector2{ 0.0f, 1.0f }, 0.f },
+            AngleTestArgs{ Vector2{ 0.0f, 0.0f }, Vector2{ 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ Vector2{ 0.0f, 0.0f }, Vector2{ 0.0f, 323432.0f }, 0.f },
+            AngleTestArgs{ Vector2{ 323432.0f, 0.0f }, Vector2{ 0.0f, 0.0f }, 0.f }));
+} // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Math/Vector2Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector2Tests.cpp
@@ -6,12 +6,12 @@
  *
  */
 
-#include <AZTestShared/Math/MathTestHelpers.h>
 #include <AzCore/Math/MathUtils.h>
-#include <AzCore/Math/SimdMath.h>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector4.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
+#include <AzCore/Math/SimdMath.h>
 
 using namespace AZ;
 

--- a/Code/Framework/AzCore/Tests/Math/Vector2Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector2Tests.cpp
@@ -6,96 +6,94 @@
  *
  */
 
+#include <AZTestShared/Math/MathTestHelpers.h>
 #include <AzCore/Math/MathUtils.h>
+#include <AzCore/Math/SimdMath.h>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector4.h>
 #include <AzCore/UnitTest/TestTypes.h>
-#include <AZTestShared/Math/MathTestHelpers.h>
-#include <AzCore/Math/SimdMath.h>
-
-using namespace AZ;
 
 namespace UnitTest
 {
     TEST(MATH_Vector2, TestConstructors)
     {
-        Vector2 vA(0.0f);
+        AZ::Vector2 vA(0.0f);
         EXPECT_FLOAT_EQ(vA.GetX(), 0.0f);
         EXPECT_FLOAT_EQ(vA.GetY(), 0.0f);
-        Vector2 vB(5.0f);
+        AZ::Vector2 vB(5.0f);
         EXPECT_FLOAT_EQ(vB.GetX(), 5.0f);
         EXPECT_FLOAT_EQ(vB.GetY(), 5.0f);
-        Vector2 vC(1.0f, 2.0f);
+        AZ::Vector2 vC(1.0f, 2.0f);
         EXPECT_FLOAT_EQ(vC.GetX(), 1.0f);
         EXPECT_FLOAT_EQ(vC.GetY(), 2.0f);
-        EXPECT_THAT(Vector2(Vector4(1.0f, 3.0f, 2.0f, 4.0f)), IsClose(Vector2(1.0f, 3.0f)));
-        EXPECT_THAT(Vector2(Vector3(1.0f, 3.0f, 2.0f)), IsClose(Vector2(1.0f, 3.0f)));
+        EXPECT_THAT(AZ::Vector2(AZ::Vector4(1.0f, 3.0f, 2.0f, 4.0f)), IsClose(AZ::Vector2(1.0f, 3.0f)));
+        EXPECT_THAT(AZ::Vector2(AZ::Vector3(1.0f, 3.0f, 2.0f)), IsClose(AZ::Vector2(1.0f, 3.0f)));
     }
 
     TEST(MATH_Vector2, TestCreate)
     {
         float values[2] = { 10.0f, 20.0f };
 
-        EXPECT_THAT(Vector2::CreateOne(), IsClose(Vector2(1.0f, 1.0f)));
-        EXPECT_THAT(Vector2::CreateZero(), IsClose(Vector2(0.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector2::CreateOne(), IsClose(AZ::Vector2(1.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector2::CreateZero(), IsClose(AZ::Vector2(0.0f, 0.0f)));
 
-        EXPECT_THAT(Vector2::CreateFromFloat2(values), IsClose(Vector2(10.0f, 20.0f)));
-        EXPECT_THAT(Vector2::CreateAxisX(), IsClose(Vector2(1.0f, 0.0f)));
-        EXPECT_THAT(Vector2::CreateAxisY(), IsClose(Vector2(0.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector2::CreateFromFloat2(values), IsClose(AZ::Vector2(10.0f, 20.0f)));
+        EXPECT_THAT(AZ::Vector2::CreateAxisX(), IsClose(AZ::Vector2(1.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector2::CreateAxisY(), IsClose(AZ::Vector2(0.0f, 1.0f)));
     }
 
     TEST(MATH_Vector2, TestCreateFromAngle)
     {
-        EXPECT_THAT(Vector2::CreateFromAngle(), IsClose(Vector2(0.0f, 1.0f)));
-        EXPECT_THAT(Vector2::CreateFromAngle(0.78539816339f), IsClose(Vector2(0.7071067811f, 0.7071067811f)));
-        EXPECT_THAT(Vector2::CreateFromAngle(4.0f), IsClose(Vector2(-0.7568024953f, -0.6536436208f)));
-        EXPECT_THAT(Vector2::CreateFromAngle(-1.0f), IsClose(Vector2(-0.8414709848f, 0.5403023058f)));
+        EXPECT_THAT(AZ::Vector2::CreateFromAngle(), IsClose(AZ::Vector2(0.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector2::CreateFromAngle(0.78539816339f), IsClose(AZ::Vector2(0.7071067811f, 0.7071067811f)));
+        EXPECT_THAT(AZ::Vector2::CreateFromAngle(4.0f), IsClose(AZ::Vector2(-0.7568024953f, -0.6536436208f)));
+        EXPECT_THAT(AZ::Vector2::CreateFromAngle(-1.0f), IsClose(AZ::Vector2(-0.8414709848f, 0.5403023058f)));
     }
 
     TEST(MATH_Vector2, TestCompareEqual)
     {
-        Vector2 vA(-100.0f, 10.0f);
-        Vector2 vB(35.0f, 10.0f);
-        Vector2 vC(35.0f, 20.0f);
+        AZ::Vector2 vA(-100.0f, 10.0f);
+        AZ::Vector2 vB(35.0f, 10.0f);
+        AZ::Vector2 vC(35.0f, 20.0f);
 
         // operation r.x = (cmp1.x == cmp2.x) ? vA.x : vB.x per component
-        Vector2 compareEqualAB = Vector2::CreateSelectCmpEqual(vA, vB, Vector2(1.0f), Vector2(0.0f));
-        EXPECT_THAT(compareEqualAB, IsClose(Vector2(0.0f, 1.0f)));
-        Vector2 compareEqualBC = Vector2::CreateSelectCmpEqual(vB, vC, Vector2(1.0f), Vector2(0.0f));
-        EXPECT_THAT(compareEqualBC, IsClose(Vector2(1.0f, 0.0f)));
+        AZ::Vector2 compareEqualAB = AZ::Vector2::CreateSelectCmpEqual(vA, vB, AZ::Vector2(1.0f), AZ::Vector2(0.0f));
+        EXPECT_THAT(compareEqualAB, IsClose(AZ::Vector2(0.0f, 1.0f)));
+        AZ::Vector2 compareEqualBC = AZ::Vector2::CreateSelectCmpEqual(vB, vC, AZ::Vector2(1.0f), AZ::Vector2(0.0f));
+        EXPECT_THAT(compareEqualBC, IsClose(AZ::Vector2(1.0f, 0.0f)));
     }
 
     TEST(MATH_Vector2, TestCompareGreaterEqual)
     {
-        Vector2 vA(-100.0f, 10.0f);
-        Vector2 vB(35.0f, 10.0f);
-        Vector2 vD(15.0f, 30.0f);
+        AZ::Vector2 vA(-100.0f, 10.0f);
+        AZ::Vector2 vB(35.0f, 10.0f);
+        AZ::Vector2 vD(15.0f, 30.0f);
 
         // operation ( r.x = (cmp1.x >= cmp2.x) ? vA.x : vB.x ) per component
-        Vector2 compareGreaterEqualAB = Vector2::CreateSelectCmpGreaterEqual(vA, vB, Vector2(1.0f), Vector2(0.0f));
-        EXPECT_THAT(compareGreaterEqualAB, IsClose(Vector2(0.0f, 1.0f)));
-        Vector2 compareGreaterEqualBD = Vector2::CreateSelectCmpGreaterEqual(vB, vD, Vector2(1.0f), Vector2(0.0f));
-        EXPECT_THAT(compareGreaterEqualBD, IsClose(Vector2(1.0f, 0.0f)));
+        AZ::Vector2 compareGreaterEqualAB = AZ::Vector2::CreateSelectCmpGreaterEqual(vA, vB, AZ::Vector2(1.0f), AZ::Vector2(0.0f));
+        EXPECT_THAT(compareGreaterEqualAB, IsClose(AZ::Vector2(0.0f, 1.0f)));
+        AZ::Vector2 compareGreaterEqualBD = AZ::Vector2::CreateSelectCmpGreaterEqual(vB, vD, AZ::Vector2(1.0f), AZ::Vector2(0.0f));
+        EXPECT_THAT(compareGreaterEqualBD, IsClose(AZ::Vector2(1.0f, 0.0f)));
     }
 
     TEST(MATH_Vector2, TestCompareGreater)
     {
-        Vector2 vA(-100.0f, 10.0f);
-        Vector2 vB(35.0f, 10.0f);
-        Vector2 vC(35.0f, 20.0f);
+        AZ::Vector2 vA(-100.0f, 10.0f);
+        AZ::Vector2 vB(35.0f, 10.0f);
+        AZ::Vector2 vC(35.0f, 20.0f);
 
         // operation ( r.x = (cmp1.x > cmp2.x) ? vA.x : vB.x ) per component
-        Vector2 compareGreaterAB = Vector2::CreateSelectCmpGreater(vA, vB, Vector2(1.0f), Vector2(0.0f));
-        EXPECT_THAT(compareGreaterAB, IsClose(Vector2(0.0f, 0.0f)));
-        Vector2 compareGreaterCA = Vector2::CreateSelectCmpGreater(vC, vA, Vector2(1.0f), Vector2(0.0f));
-        EXPECT_THAT(compareGreaterCA, IsClose(Vector2(1.0f, 1.0f)));
+        AZ::Vector2 compareGreaterAB = AZ::Vector2::CreateSelectCmpGreater(vA, vB, AZ::Vector2(1.0f), AZ::Vector2(0.0f));
+        EXPECT_THAT(compareGreaterAB, IsClose(AZ::Vector2(0.0f, 0.0f)));
+        AZ::Vector2 compareGreaterCA = AZ::Vector2::CreateSelectCmpGreater(vC, vA, AZ::Vector2(1.0f), AZ::Vector2(0.0f));
+        EXPECT_THAT(compareGreaterCA, IsClose(AZ::Vector2(1.0f, 1.0f)));
     }
 
     TEST(MATH_Vector2, TestStoreFloat)
     {
         float values[2] = { 0.0f, 0.0f };
 
-        Vector2 vA(1.0f, 2.0f);
+        AZ::Vector2 vA(1.0f, 2.0f);
         vA.StoreToFloat2(values);
         EXPECT_EQ(values[0], 1.0f);
         EXPECT_EQ(values[1], 2.0f);
@@ -103,20 +101,20 @@ namespace UnitTest
 
     TEST(MATH_Vector2, TestGetSet)
     {
-        Vector2 vA(2.0f, 3.0f);
+        AZ::Vector2 vA(2.0f, 3.0f);
 
-        EXPECT_TRUE(vA == Vector2(2.0f, 3.0f));
+        EXPECT_TRUE(vA == AZ::Vector2(2.0f, 3.0f));
         EXPECT_FLOAT_EQ(vA.GetX(), 2.0f);
         EXPECT_FLOAT_EQ(vA.GetY(), 3.0f);
 
         vA.SetX(10.0f);
-        EXPECT_TRUE(vA == Vector2(10.0f, 3.0f));
+        EXPECT_TRUE(vA == AZ::Vector2(10.0f, 3.0f));
 
         vA.SetY(11.0f);
-        EXPECT_TRUE(vA == Vector2(10.0f, 11.0f));
+        EXPECT_TRUE(vA == AZ::Vector2(10.0f, 11.0f));
 
         vA.Set(15.0f);
-        EXPECT_TRUE(vA == Vector2(15.0f));
+        EXPECT_TRUE(vA == AZ::Vector2(15.0f));
 
         vA.SetElement(0, 20.0f);
         EXPECT_FLOAT_EQ(vA.GetX(), 20.0f);
@@ -137,307 +135,307 @@ namespace UnitTest
 
     TEST(MATH_Vector2, TestGetLength)
     {
-        EXPECT_FLOAT_EQ(Vector2(3.0f, 4.0f).GetLengthSq(), 25.0f);
-        EXPECT_FLOAT_EQ(Vector2(4.0f, -3.0f).GetLength(), 5.0f);
-        EXPECT_FLOAT_EQ(Vector2(4.0f, -3.0f).GetLengthEstimate(), 5.0f);
+        EXPECT_FLOAT_EQ(AZ::Vector2(3.0f, 4.0f).GetLengthSq(), 25.0f);
+        EXPECT_FLOAT_EQ(AZ::Vector2(4.0f, -3.0f).GetLength(), 5.0f);
+        EXPECT_FLOAT_EQ(AZ::Vector2(4.0f, -3.0f).GetLengthEstimate(), 5.0f);
     }
 
     TEST(MATH_Vector2, TestGetLengthReciprocal)
     {
-        EXPECT_NEAR(Vector2(4.0f, -3.0f).GetLengthReciprocal(), 0.2f, 0.01f);
-        EXPECT_NEAR(Vector2(4.0f, -3.0f).GetLengthReciprocalEstimate(), 0.2f, 0.01f);
+        EXPECT_NEAR(AZ::Vector2(4.0f, -3.0f).GetLengthReciprocal(), 0.2f, 0.01f);
+        EXPECT_NEAR(AZ::Vector2(4.0f, -3.0f).GetLengthReciprocalEstimate(), 0.2f, 0.01f);
     }
 
     TEST(MATH_Vector2, TestGetNormalized)
     {
-        EXPECT_THAT(Vector2(3.0f, 4.0f).GetNormalized(), IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
-        EXPECT_THAT(Vector2(3.0f, 4.0f).GetNormalizedEstimate(), IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(AZ::Vector2(3.0f, 4.0f).GetNormalized(), IsClose(AZ::Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(AZ::Vector2(3.0f, 4.0f).GetNormalizedEstimate(), IsClose(AZ::Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
     }
 
     TEST(MATH_Vector2, TestGetNormalizedSafe)
     {
-        EXPECT_THAT(Vector2(3.0f, 4.0f).GetNormalizedSafe(), IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
-        EXPECT_THAT(Vector2(3.0f, 4.0f).GetNormalizedSafeEstimate(), IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
-        EXPECT_THAT(Vector2(0.0f).GetNormalizedSafe(), IsClose(Vector2(0.0f, 0.0f)));
-        EXPECT_THAT(Vector2(0.0f).GetNormalizedSafeEstimate(), IsClose(Vector2(0.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector2(3.0f, 4.0f).GetNormalizedSafe(), IsClose(AZ::Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(AZ::Vector2(3.0f, 4.0f).GetNormalizedSafeEstimate(), IsClose(AZ::Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(AZ::Vector2(0.0f).GetNormalizedSafe(), IsClose(AZ::Vector2(0.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector2(0.0f).GetNormalizedSafeEstimate(), IsClose(AZ::Vector2(0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector2, TestNormalize)
     {
-        Vector2 v1(4.0f, 3.0f);
+        AZ::Vector2 v1(4.0f, 3.0f);
         v1.Normalize();
-        EXPECT_THAT(v1, IsClose(Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
         v1.Set(4.0f, 3.0f);
         v1.NormalizeEstimate();
-        EXPECT_THAT(v1, IsClose(Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
     }
 
     TEST(MATH_Vector2, TestNormalizeWithLength)
     {
-        Vector2 v1(4.0f, 3.0f);
+        AZ::Vector2 v1(4.0f, 3.0f);
         float length = v1.NormalizeWithLength();
         EXPECT_FLOAT_EQ(length, 5.0f);
-        EXPECT_THAT(v1, IsClose(Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
         v1.Set(4.0f, 3.0f);
         length = v1.NormalizeWithLengthEstimate();
         EXPECT_FLOAT_EQ(length, 5.0f);
-        EXPECT_THAT(v1, IsClose(Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector2(4.0f / 5.0f, 3.0f / 5.0f)));
     }
 
     TEST(MATH_Vector2, TestNormalizeSafe)
     {
-        Vector2 v1(3.0f, 4.0f);
+        AZ::Vector2 v1(3.0f, 4.0f);
         v1.NormalizeSafe();
-        EXPECT_THAT(v1, IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         v1.NormalizeSafe();
-        EXPECT_THAT(v1, IsClose(Vector2(0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector2(0.0f, 0.0f)));
         v1.Set(3.0f, 4.0f);
         v1.NormalizeSafeEstimate();
-        EXPECT_THAT(v1, IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         v1.NormalizeSafeEstimate();
-        EXPECT_THAT(v1, IsClose(Vector2(0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector2(0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector2, TestNormalizeSafeWithLength)
     {
-        Vector2 v1(3.0f, 4.0f);
+        AZ::Vector2 v1(3.0f, 4.0f);
         float length = v1.NormalizeSafeWithLength();
         EXPECT_FLOAT_EQ(length, 5.0f);
-        EXPECT_THAT(v1, IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         length = v1.NormalizeSafeWithLength();
         EXPECT_FLOAT_EQ(length, 0.0f);
-        EXPECT_THAT(v1, IsClose(Vector2(0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector2(0.0f, 0.0f)));
         v1.Set(3.0f, 4.0f);
         length = v1.NormalizeSafeWithLengthEstimate();
         EXPECT_FLOAT_EQ(length, 5.0f);
-        EXPECT_THAT(v1, IsClose(Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector2(3.0f / 5.0f, 4.0f / 5.0f)));
         v1.Set(0.0f);
         length = v1.NormalizeSafeWithLengthEstimate();
         EXPECT_FLOAT_EQ(length, 0.0f);
-        EXPECT_THAT(v1, IsClose(Vector2(0.0f, 0.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector2(0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector2, TestIsNormalized)
     {
-        EXPECT_TRUE(Vector2(1.0f, 0.0f).IsNormalized());
-        EXPECT_TRUE(Vector2(0.7071f, 0.7071f).IsNormalized());
-        EXPECT_FALSE(Vector2(1.0f, 1.0f).IsNormalized());
+        EXPECT_TRUE(AZ::Vector2(1.0f, 0.0f).IsNormalized());
+        EXPECT_TRUE(AZ::Vector2(0.7071f, 0.7071f).IsNormalized());
+        EXPECT_FALSE(AZ::Vector2(1.0f, 1.0f).IsNormalized());
     }
 
     TEST(MATH_Vector2, TestSetLength)
     {
-        Vector2 v1(3.0f, 4.0f);
+        AZ::Vector2 v1(3.0f, 4.0f);
         v1.SetLength(10.0f);
-        EXPECT_THAT(v1, IsClose(Vector2(6.0f, 8.0f)));
+        EXPECT_THAT(v1, IsClose(AZ::Vector2(6.0f, 8.0f)));
         v1.Set(3.0f, 4.0f);
         v1.SetLengthEstimate(10.0f);
-        EXPECT_THAT(v1, IsCloseTolerance(Vector2(6.0f, 8.0f), 1e-3f));
+        EXPECT_THAT(v1, IsCloseTolerance(AZ::Vector2(6.0f, 8.0f), 1e-3f));
     }
 
     TEST(MATH_Vector2, TestDistance)
     {
-        Vector2 vA(1.0f, 2.0f);
-        EXPECT_FLOAT_EQ(vA.GetDistanceSq(Vector2(-2.0f, 6.0f)), 25.0f);
-        EXPECT_FLOAT_EQ(vA.GetDistance(Vector2(5.0f, -1.0f)), 5.0f);
-        EXPECT_FLOAT_EQ(vA.GetDistanceEstimate(Vector2(5.0f, -1.0f)), 5.0f);
+        AZ::Vector2 vA(1.0f, 2.0f);
+        EXPECT_FLOAT_EQ(vA.GetDistanceSq(AZ::Vector2(-2.0f, 6.0f)), 25.0f);
+        EXPECT_FLOAT_EQ(vA.GetDistance(AZ::Vector2(5.0f, -1.0f)), 5.0f);
+        EXPECT_FLOAT_EQ(vA.GetDistanceEstimate(AZ::Vector2(5.0f, -1.0f)), 5.0f);
     }
 
     TEST(MATH_Vector2, TestLerpSlerpNLerp)
     {
-        EXPECT_THAT(Vector2(4.0f, 5.0f).Lerp(Vector2(5.0f, 10.0f), 0.5f), IsClose(Vector2(4.5f, 7.5f)));
-        EXPECT_THAT(Vector2(1.0f, 0.0f).Slerp(Vector2(0.0f, 1.0f), 0.5f), IsClose(Vector2(0.7071f, 0.7071f)));
-        EXPECT_THAT(Vector2(1.0f, 0.0f).Nlerp(Vector2(0.0f, 1.0f), 0.5f), IsClose(Vector2(0.7071f, 0.7071f)));
+        EXPECT_THAT(AZ::Vector2(4.0f, 5.0f).Lerp(AZ::Vector2(5.0f, 10.0f), 0.5f), IsClose(AZ::Vector2(4.5f, 7.5f)));
+        EXPECT_THAT(AZ::Vector2(1.0f, 0.0f).Slerp(AZ::Vector2(0.0f, 1.0f), 0.5f), IsClose(AZ::Vector2(0.7071f, 0.7071f)));
+        EXPECT_THAT(AZ::Vector2(1.0f, 0.0f).Nlerp(AZ::Vector2(0.0f, 1.0f), 0.5f), IsClose(AZ::Vector2(0.7071f, 0.7071f)));
     }
 
     TEST(MATH_Vector2, TestGetPerpendicular)
     {
-        EXPECT_THAT(Vector2(1.0f, 2.0f).GetPerpendicular(), IsClose(Vector2(-2.0f, 1.0f)));
+        EXPECT_THAT(AZ::Vector2(1.0f, 2.0f).GetPerpendicular(), IsClose(AZ::Vector2(-2.0f, 1.0f)));
     }
 
     TEST(MATH_Vector2, TestIsClose)
     {
-        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsClose(Vector2(1.0f, 2.0f)));
-        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsClose(Vector2(1.0f, 3.0f)));
+        EXPECT_TRUE(AZ::Vector2(1.0f, 2.0f).IsClose(AZ::Vector2(1.0f, 2.0f)));
+        EXPECT_FALSE(AZ::Vector2(1.0f, 2.0f).IsClose(AZ::Vector2(1.0f, 3.0f)));
 
         // Verify tolerance works
-        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsClose(Vector2(1.0f, 2.4f), 0.5f));
+        EXPECT_TRUE(AZ::Vector2(1.0f, 2.0f).IsClose(AZ::Vector2(1.0f, 2.4f), 0.5f));
     }
 
     TEST(MATH_Vector2, TestIsZero)
     {
-        EXPECT_TRUE(Vector2(0.0f).IsZero());
-        EXPECT_FALSE(Vector2(1.0f).IsZero());
+        EXPECT_TRUE(AZ::Vector2(0.0f).IsZero());
+        EXPECT_FALSE(AZ::Vector2(1.0f).IsZero());
 
         // Verify tolerance works
-        EXPECT_TRUE(Vector2(0.05f).IsZero(0.1f));
+        EXPECT_TRUE(AZ::Vector2(0.05f).IsZero(0.1f));
     }
 
     TEST(MATH_Vector2, TestEqualityInequality)
     {
-        Vector2 vA(1.0f, 2.0f);
-        EXPECT_TRUE(vA == Vector2(1.0f, 2.0f));
-        EXPECT_FALSE((vA == Vector2(5.0f, 6.0f)));
-        EXPECT_TRUE(vA != Vector2(7.0f, 8.0f));
-        EXPECT_FALSE((vA != Vector2(1.0f, 2.0f)));
+        AZ::Vector2 vA(1.0f, 2.0f);
+        EXPECT_TRUE(vA == AZ::Vector2(1.0f, 2.0f));
+        EXPECT_FALSE((vA == AZ::Vector2(5.0f, 6.0f)));
+        EXPECT_TRUE(vA != AZ::Vector2(7.0f, 8.0f));
+        EXPECT_FALSE((vA != AZ::Vector2(1.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestIsLessThan)
     {
-        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsLessThan(Vector2(2.0f, 3.0f)));
-        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsLessThan(Vector2(0.0f, 3.0f)));
-        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsLessThan(Vector2(2.0f, 2.0f)));
+        EXPECT_TRUE(AZ::Vector2(1.0f, 2.0f).IsLessThan(AZ::Vector2(2.0f, 3.0f)));
+        EXPECT_FALSE(AZ::Vector2(1.0f, 2.0f).IsLessThan(AZ::Vector2(0.0f, 3.0f)));
+        EXPECT_FALSE(AZ::Vector2(1.0f, 2.0f).IsLessThan(AZ::Vector2(2.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestIsLessEqualThan)
     {
-        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsLessEqualThan(Vector2(2.0f, 3.0f)));
-        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsLessEqualThan(Vector2(0.0f, 3.0f)));
-        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsLessEqualThan(Vector2(2.0f, 2.0f)));
+        EXPECT_TRUE(AZ::Vector2(1.0f, 2.0f).IsLessEqualThan(AZ::Vector2(2.0f, 3.0f)));
+        EXPECT_FALSE(AZ::Vector2(1.0f, 2.0f).IsLessEqualThan(AZ::Vector2(0.0f, 3.0f)));
+        EXPECT_TRUE(AZ::Vector2(1.0f, 2.0f).IsLessEqualThan(AZ::Vector2(2.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestIsGreaterThan)
     {
-        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsGreaterThan(Vector2(0.0f, 1.0f)));
-        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsGreaterThan(Vector2(0.0f, 3.0f)));
-        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsGreaterThan(Vector2(0.0f, 2.0f)));
+        EXPECT_TRUE(AZ::Vector2(1.0f, 2.0f).IsGreaterThan(AZ::Vector2(0.0f, 1.0f)));
+        EXPECT_FALSE(AZ::Vector2(1.0f, 2.0f).IsGreaterThan(AZ::Vector2(0.0f, 3.0f)));
+        EXPECT_FALSE(AZ::Vector2(1.0f, 2.0f).IsGreaterThan(AZ::Vector2(0.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestIsGreaterEqualThan)
     {
-        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsGreaterEqualThan(Vector2(0.0f, 1.0f)));
-        EXPECT_FALSE(Vector2(1.0f, 2.0f).IsGreaterEqualThan(Vector2(0.0f, 3.0f)));
-        EXPECT_TRUE(Vector2(1.0f, 2.0f).IsGreaterEqualThan(Vector2(0.0f, 2.0f)));
+        EXPECT_TRUE(AZ::Vector2(1.0f, 2.0f).IsGreaterEqualThan(AZ::Vector2(0.0f, 1.0f)));
+        EXPECT_FALSE(AZ::Vector2(1.0f, 2.0f).IsGreaterEqualThan(AZ::Vector2(0.0f, 3.0f)));
+        EXPECT_TRUE(AZ::Vector2(1.0f, 2.0f).IsGreaterEqualThan(AZ::Vector2(0.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestMinMax)
     {
-        EXPECT_THAT(Vector2(2.0f, 3.0f).GetMin(Vector2(1.0f, 4.0f)), IsClose(Vector2(1.0f, 3.0f)));
-        EXPECT_THAT(Vector2(2.0f, 3.0f).GetMax(Vector2(1.0f, 4.0f)), IsClose(Vector2(2.0f, 4.0f)));
+        EXPECT_THAT(AZ::Vector2(2.0f, 3.0f).GetMin(AZ::Vector2(1.0f, 4.0f)), IsClose(AZ::Vector2(1.0f, 3.0f)));
+        EXPECT_THAT(AZ::Vector2(2.0f, 3.0f).GetMax(AZ::Vector2(1.0f, 4.0f)), IsClose(AZ::Vector2(2.0f, 4.0f)));
     }
 
     TEST(MATH_Vector2, TestClamp)
     {
-        EXPECT_THAT(Vector2(1.0f, 2.0f).GetClamp(Vector2(5.0f, -10.0f), Vector2(10.0f, -5.0f)), IsClose(Vector2(5.0f, -5.0f)));
-        EXPECT_THAT(Vector2(1.0f, 2.0f).GetClamp(Vector2(0.0f, 0.0f), Vector2(10.0f, 10.0f)), IsClose(Vector2(1.0f, 2.0f)));
+        EXPECT_THAT(AZ::Vector2(1.0f, 2.0f).GetClamp(AZ::Vector2(5.0f, -10.0f), AZ::Vector2(10.0f, -5.0f)), IsClose(AZ::Vector2(5.0f, -5.0f)));
+        EXPECT_THAT(AZ::Vector2(1.0f, 2.0f).GetClamp(AZ::Vector2(0.0f, 0.0f), AZ::Vector2(10.0f, 10.0f)), IsClose(AZ::Vector2(1.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestSelect)
     {
-        Vector2 vA(1.0f);
-        Vector2 vB(2.0f);
-        EXPECT_THAT(vA.GetSelect(Vector2(0.0f, 1.0f), vB), IsClose(Vector2(1.0f, 2.0f)));
-        vA.Select(Vector2(1.0f, 0.0f), vB);
-        EXPECT_THAT(vA, IsClose(Vector2(2.0f, 1.0f)));
+        AZ::Vector2 vA(1.0f);
+        AZ::Vector2 vB(2.0f);
+        EXPECT_THAT(vA.GetSelect(AZ::Vector2(0.0f, 1.0f), vB), IsClose(AZ::Vector2(1.0f, 2.0f)));
+        vA.Select(AZ::Vector2(1.0f, 0.0f), vB);
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(2.0f, 1.0f)));
     }
 
     TEST(MATH_Vector2, TestAbs)
     {
-        EXPECT_THAT(Vector2(-1.0f, 2.0f).GetAbs(), IsClose(Vector2(1.0f, 2.0f)));
-        EXPECT_THAT(Vector2(3.0f, -4.0f).GetAbs(), IsClose(Vector2(3.0f, 4.0f)));
+        EXPECT_THAT(AZ::Vector2(-1.0f, 2.0f).GetAbs(), IsClose(AZ::Vector2(1.0f, 2.0f)));
+        EXPECT_THAT(AZ::Vector2(3.0f, -4.0f).GetAbs(), IsClose(AZ::Vector2(3.0f, 4.0f)));
     }
 
     TEST(MATH_Vector2, TestReciprocal)
     {
-        EXPECT_THAT(Vector2(2.0f, 4.0f).GetReciprocal(), IsClose(Vector2(0.5f, 0.25f)));
-        EXPECT_THAT(Vector2(2.0f, 4.0f).GetReciprocalEstimate(), IsClose(Vector2(0.5f, 0.25f)));
+        EXPECT_THAT(AZ::Vector2(2.0f, 4.0f).GetReciprocal(), IsClose(AZ::Vector2(0.5f, 0.25f)));
+        EXPECT_THAT(AZ::Vector2(2.0f, 4.0f).GetReciprocalEstimate(), IsClose(AZ::Vector2(0.5f, 0.25f)));
     }
 
     TEST(MATH_Vector2, TestAdd)
     {
-        Vector2 vA(1.0f, 2.0f);
-        vA += Vector2(3.0f, 4.0f);
-        EXPECT_THAT(vA, IsClose(Vector2(4.0f, 6.0f)));
-        EXPECT_THAT((Vector2(1.0f, 2.0f) + Vector2(2.0f, -1.0f)), IsClose(Vector2(3.0f, 1.0f)));
+        AZ::Vector2 vA(1.0f, 2.0f);
+        vA += AZ::Vector2(3.0f, 4.0f);
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(4.0f, 6.0f)));
+        EXPECT_THAT((AZ::Vector2(1.0f, 2.0f) + AZ::Vector2(2.0f, -1.0f)), IsClose(AZ::Vector2(3.0f, 1.0f)));
     }
 
     TEST(MATH_Vector2, TestSub)
     {
-        Vector2 vA(10.0f, 11.0f);
-        vA -= Vector2(2.0f, 4.0f);
-        EXPECT_THAT(vA, IsClose(Vector2(8.0f, 7.0f)));
-        EXPECT_THAT((Vector2(1.0f, 2.0f) - Vector2(2.0f, -1.0f)), IsClose(Vector2(-1.0f, 3.0f)));
+        AZ::Vector2 vA(10.0f, 11.0f);
+        vA -= AZ::Vector2(2.0f, 4.0f);
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(8.0f, 7.0f)));
+        EXPECT_THAT((AZ::Vector2(1.0f, 2.0f) - AZ::Vector2(2.0f, -1.0f)), IsClose(AZ::Vector2(-1.0f, 3.0f)));
     }
 
     TEST(MATH_Vector2, TestMul)
     {
-        Vector2 vA(2.0f, 4.0f);
-        vA *= Vector2(3.0f, 6.0f);
-        EXPECT_THAT(vA, IsClose(Vector2(6.0f, 24.0f)));
+        AZ::Vector2 vA(2.0f, 4.0f);
+        vA *= AZ::Vector2(3.0f, 6.0f);
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(6.0f, 24.0f)));
 
         vA.Set(2.0f, 3.0f);
         vA *= 5.0f;
-        EXPECT_THAT(vA, IsClose(Vector2(10.0f, 15.0f)));
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(10.0f, 15.0f)));
 
-        EXPECT_THAT((Vector2(3.0f, 2.0f) * Vector2(2.0f, -4.0f)), IsClose(Vector2(6.0f, -8.0f)));
-        EXPECT_THAT((Vector2(3.0f, 2.0f) * 2.0f), IsClose(Vector2(6.0f, 4.0f)));
+        EXPECT_THAT((AZ::Vector2(3.0f, 2.0f) * AZ::Vector2(2.0f, -4.0f)), IsClose(AZ::Vector2(6.0f, -8.0f)));
+        EXPECT_THAT((AZ::Vector2(3.0f, 2.0f) * 2.0f), IsClose(AZ::Vector2(6.0f, 4.0f)));
     }
 
     TEST(MATH_Vector2, TestDiv)
     {
-        Vector2 vA(15.0f, 20.0f);
-        vA /= Vector2(3.0f, 2.0f);
-        EXPECT_THAT(vA, IsClose(Vector2(5.0f, 10.0f)));
+        AZ::Vector2 vA(15.0f, 20.0f);
+        vA /= AZ::Vector2(3.0f, 2.0f);
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(5.0f, 10.0f)));
 
         vA.Set(20.0f, 30.0f);
         vA /= 10.0f;
-        EXPECT_THAT(vA, IsClose(Vector2(2.0f, 3.0f)));
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(2.0f, 3.0f)));
 
-        EXPECT_THAT((Vector2(30.0f, 20.0f) / Vector2(10.0f, -4.0f)), IsClose(Vector2(3.0f, -5.0f)));
-        EXPECT_THAT((Vector2(30.0f, 20.0f) / 10.0f), IsClose(Vector2(3.0f, 2.0f)));
+        EXPECT_THAT((AZ::Vector2(30.0f, 20.0f) / AZ::Vector2(10.0f, -4.0f)), IsClose(AZ::Vector2(3.0f, -5.0f)));
+        EXPECT_THAT((AZ::Vector2(30.0f, 20.0f) / 10.0f), IsClose(AZ::Vector2(3.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestNegate)
     {
-        EXPECT_THAT((-Vector2(1.0f, -2.0f)), IsClose(Vector2(-1.0f, 2.0f)));
+        EXPECT_THAT((-AZ::Vector2(1.0f, -2.0f)), IsClose(AZ::Vector2(-1.0f, 2.0f)));
     }
 
     TEST(MATH_Vector2, TestDot)
     {
-        EXPECT_FLOAT_EQ(Vector2(1.0f, 2.0f).Dot(Vector2(-1.0f, 5.0f)), 9.0f);
+        EXPECT_FLOAT_EQ(AZ::Vector2(1.0f, 2.0f).Dot(AZ::Vector2(-1.0f, 5.0f)), 9.0f);
     }
 
     TEST(MATH_Vector2, TestMadd)
     {
-        EXPECT_THAT(Vector2(1.0f, 2.0f).GetMadd(Vector2(2.0f, 6.0f), Vector2(3.0f, 4.0f)), IsClose(Vector2(5.0f, 16.0f)));
-        Vector2 vA(1.0f, 2.0f);
-        vA.Madd(Vector2(2.0f, 6.0f), Vector2(3.0f, 4.0f));
-        EXPECT_THAT(vA, IsClose(Vector2(5.0f, 16.0f)));
+        EXPECT_THAT(AZ::Vector2(1.0f, 2.0f).GetMadd(AZ::Vector2(2.0f, 6.0f), AZ::Vector2(3.0f, 4.0f)), IsClose(AZ::Vector2(5.0f, 16.0f)));
+        AZ::Vector2 vA(1.0f, 2.0f);
+        vA.Madd(AZ::Vector2(2.0f, 6.0f), AZ::Vector2(3.0f, 4.0f));
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(5.0f, 16.0f)));
     }
 
     TEST(MATH_Vector2, TestProject)
     {
-        Vector2 vA(0.5f);
-        vA.Project(Vector2(0.0f, 2.0f));
-        EXPECT_THAT(vA, IsClose(Vector2(0.0f, 0.5f)));
+        AZ::Vector2 vA(0.5f);
+        vA.Project(AZ::Vector2(0.0f, 2.0f));
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(0.0f, 0.5f)));
         vA.Set(0.5f);
-        vA.ProjectOnNormal(Vector2(0.0f, 1.0f));
-        EXPECT_THAT(vA, IsClose(Vector2(0.0f, 0.5f)));
+        vA.ProjectOnNormal(AZ::Vector2(0.0f, 1.0f));
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(0.0f, 0.5f)));
         vA.Set(2.0f, 4.0f);
-        EXPECT_THAT(vA.GetProjected(Vector2(1.0f, 1.0f)), IsClose(Vector2(3.0f, 3.0f)));
-        EXPECT_THAT(vA.GetProjectedOnNormal(Vector2(1.0f, 0.0f)), IsClose(Vector2(2.0f, 0.0f)));
+        EXPECT_THAT(vA.GetProjected(AZ::Vector2(1.0f, 1.0f)), IsClose(AZ::Vector2(3.0f, 3.0f)));
+        EXPECT_THAT(vA.GetProjectedOnNormal(AZ::Vector2(1.0f, 0.0f)), IsClose(AZ::Vector2(2.0f, 0.0f)));
     }
 
     TEST(MATH_Vector2, TestTrig)
     {
-        EXPECT_THAT(Vector2(DegToRad(78.0f), DegToRad(-150.0f)).GetAngleMod(), IsClose(Vector2(DegToRad(78.0f), DegToRad(-150.0f))));
-        EXPECT_THAT(Vector2(DegToRad(390.0f), DegToRad(-190.0f)).GetAngleMod(), IsClose(Vector2(DegToRad(30.0f), DegToRad(170.0f))));
-        EXPECT_THAT(Vector2(DegToRad(60.0f), DegToRad(105.0f)).GetSin(), IsCloseTolerance(Vector2(0.866f, 0.966f), 0.005f));
-        EXPECT_THAT(Vector2(DegToRad(60.0f), DegToRad(105.0f)).GetCos(), IsCloseTolerance(Vector2(0.5f, -0.259f), 0.005f));
-        Vector2 sin, cos;
-        Vector2 v1(DegToRad(60.0f), DegToRad(105.0f));
+        EXPECT_THAT(AZ::Vector2(AZ::DegToRad(78.0f), AZ::DegToRad(-150.0f)).GetAngleMod(), IsClose(AZ::Vector2(AZ::DegToRad(78.0f), AZ::DegToRad(-150.0f))));
+        EXPECT_THAT(AZ::Vector2(AZ::DegToRad(390.0f), AZ::DegToRad(-190.0f)).GetAngleMod(), IsClose(AZ::Vector2(AZ::DegToRad(30.0f), AZ::DegToRad(170.0f))));
+        EXPECT_THAT(AZ::Vector2(AZ::DegToRad(60.0f), AZ::DegToRad(105.0f)).GetSin(), IsCloseTolerance(AZ::Vector2(0.866f, 0.966f), 0.005f));
+        EXPECT_THAT(AZ::Vector2(AZ::DegToRad(60.0f), AZ::DegToRad(105.0f)).GetCos(), IsCloseTolerance(AZ::Vector2(0.5f, -0.259f), 0.005f));
+        AZ::Vector2 sin, cos;
+        AZ::Vector2 v1(AZ::DegToRad(60.0f), AZ::DegToRad(105.0f));
         v1.GetSinCos(sin, cos);
-        EXPECT_THAT(sin, IsCloseTolerance(Vector2(0.866f, 0.966f), 0.005f));
-        EXPECT_THAT(cos, IsCloseTolerance(Vector2(0.5f, -0.259f), 0.005f));
+        EXPECT_THAT(sin, IsCloseTolerance(AZ::Vector2(0.866f, 0.966f), 0.005f));
+        EXPECT_THAT(cos, IsCloseTolerance(AZ::Vector2(0.5f, -0.259f), 0.005f));
     }
 
     TEST(MATH_Vector2, TestIsFinite)
     {
-        EXPECT_TRUE(Vector2(1.0f, 1.0f).IsFinite());
+        EXPECT_TRUE(AZ::Vector2(1.0f, 1.0f).IsFinite());
         const float infinity = std::numeric_limits<float>::infinity();
-        EXPECT_FALSE(Vector2(infinity, infinity).IsFinite());
+        EXPECT_FALSE(AZ::Vector2(infinity, infinity).IsFinite());
     }
     struct AngleTestArgs
     {
@@ -464,12 +462,12 @@ namespace UnitTest
         MATH_Vector2,
         AngleTestFixture,
         ::testing::Values(
-            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 0.0f, 1.0f }, AZ::Constants::HalfPi },
-            AngleTestArgs{ Vector2{ 42.0f, 0.0f }, Vector2{ 0.0f, 23.0f }, AZ::Constants::HalfPi },
-            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ -1.0f, 0.0f }, AZ::Constants::Pi },
-            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 1.0f, 1.0f }, AZ::Constants::QuarterPi },
-            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 1.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector2{ 1.0f, 1.0f }, Vector2{ -1.0f, -1.0f }, AZ::Constants::Pi }));
+            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 0.0f, 1.0f }, AZ::Constants::HalfPi },
+            AngleTestArgs{ AZ::Vector2{ 42.0f, 0.0f }, AZ::Vector2{ 0.0f, 23.0f }, AZ::Constants::HalfPi },
+            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ -1.0f, 0.0f }, AZ::Constants::Pi },
+            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 1.0f, 1.0f }, AZ::Constants::QuarterPi },
+            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 1.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector2{ 1.0f, 1.0f }, AZ::Vector2{ -1.0f, -1.0f }, AZ::Constants::Pi }));
 
     using AngleDegTestFixture = ::testing::TestWithParam<AngleTestArgs>;
 
@@ -489,12 +487,12 @@ namespace UnitTest
         MATH_Vector2,
         AngleDegTestFixture,
         ::testing::Values(
-            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 0.0f, 1.0f }, 90.f },
-            AngleTestArgs{ Vector2{ 42.0f, 0.0f }, Vector2{ 0.0f, 23.0f }, 90.f },
-            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ -1.0f, 0.0f }, 180.f },
-            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 1.0f, 1.0f }, 45.f },
-            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 1.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector2{ 1.0f, 1.0f }, Vector2{ -1.0f, -1.0f }, 180.f }));
+            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 0.0f, 1.0f }, 90.f },
+            AngleTestArgs{ AZ::Vector2{ 42.0f, 0.0f }, AZ::Vector2{ 0.0f, 23.0f }, 90.f },
+            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ -1.0f, 0.0f }, 180.f },
+            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 1.0f, 1.0f }, 45.f },
+            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 1.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector2{ 1.0f, 1.0f }, AZ::Vector2{ -1.0f, -1.0f }, 180.f }));
 
     using AngleSafeInvalidAngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
 
@@ -514,9 +512,9 @@ namespace UnitTest
         MATH_Vector2,
         AngleSafeInvalidAngleTestFixture,
         ::testing::Values(
-            AngleTestArgs{ Vector2{ 0.0f, 0.0f }, Vector2{ 0.0f, 1.0f }, 0.f },
-            AngleTestArgs{ Vector2{ 0.0f, 0.0f }, Vector2{ 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector2{ 1.0f, 0.0f }, Vector2{ 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ Vector2{ 0.0f, 0.0f }, Vector2{ 0.0f, 323432.0f }, 0.f },
-            AngleTestArgs{ Vector2{ 323432.0f, 0.0f }, Vector2{ 0.0f, 0.0f }, 0.f }));
+            AngleTestArgs{ AZ::Vector2{ 0.0f, 0.0f }, AZ::Vector2{ 0.0f, 1.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector2{ 0.0f, 0.0f }, AZ::Vector2{ 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 0.0f, 0.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector2{ 0.0f, 0.0f }, AZ::Vector2{ 0.0f, 323432.0f }, 0.f },
+            AngleTestArgs{ AZ::Vector2{ 323432.0f, 0.0f }, AZ::Vector2{ 0.0f, 0.0f }, 0.f }));
 } // namespace UnitTest


### PR DESCRIPTION
## What does this PR do?

this just cleans up the existing test cases for Vector4Tests. 

- replace usage of == used with Vector4 with EXPECT_THAT
- replace TestAngles with separate parameterized tests, avoids a lot of the custom logic with parametrized test cases. 

## How was this PR tested?

run
```
./AzTestRunner ./libAzCore.Tests.so AzRunUnitTests --gtest_filter="*MATH_Vector2*"
```
