### PR TITLE
feat(AZCore): add CreateFromEuler/Radians/Degrees(XYZ,YXZ,ZYX)

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
@@ -414,6 +414,75 @@ namespace AZ
         Set(x, y, z, w);
     }
 
+    Quaternion Quaternion::CreateFromEulerRadiansXYZ(const Vector3& eulerRadians)
+    {
+         const Simd::Vec3::FloatType half = Simd::Vec3::Splat(0.5f);
+        const Simd::Vec3::FloatType angles = Simd::Vec3::Mul(half, eulerRadians.GetSimdValue());
+        Simd::Vec3::FloatType sin, cos;
+        Simd::Vec3::SinCos(angles, sin, cos);
+
+        const float sx = Simd::Vec3::SelectFirst(sin);
+        const float cx = Simd::Vec3::SelectFirst(cos);
+        const float sy = Simd::Vec3::SelectSecond(sin);
+        const float cy = Simd::Vec3::SelectSecond(cos);    
+        const float sz = Simd::Vec3::SelectThird(sin);
+        const float cz = Simd::Vec3::SelectThird(cos);
+
+        // rot = rotx * roty * rotz
+        return AZ::Quaternion(
+            cx * sy * sz + sx * cy * cz,
+            cx * sy * cz - sx * cy * sz,
+            cx * cy * sz + sx * sy * cz,
+            cx * cy * cz - sx * sy * sz
+        );
+    }
+
+    Quaternion Quaternion::CreateFromEulerRadiansYXZ(const Vector3& eulerRadians)
+    {
+        const Simd::Vec3::FloatType half = Simd::Vec3::Splat(0.5f);
+        const Simd::Vec3::FloatType angles = Simd::Vec3::Mul(half, eulerRadians.GetSimdValue());
+        Simd::Vec3::FloatType sin, cos;
+        Simd::Vec3::SinCos(angles, sin, cos);
+
+        const float sy = Simd::Vec3::SelectFirst(sin);
+        const float cy = Simd::Vec3::SelectFirst(cos);
+        const float sx = Simd::Vec3::SelectSecond(sin);
+        const float cx = Simd::Vec3::SelectSecond(cos);
+        const float sz = Simd::Vec3::SelectThird(sin);
+        const float cz = Simd::Vec3::SelectThird(cos);
+
+        // rot = roty * rotx * rotz
+        return AZ::Quaternion(
+            cy * sx * cz + sy * cx * sz,
+            sy * cx * cz - cy * sx * sz,
+            cy * cx * sz - sy * sx * cz,
+            cy * cx * cz + sy * sx * sz
+        );
+    }
+    Quaternion Quaternion::CreateFromEulerRadiansZYX(const Vector3& eulerRadians)
+    {
+        const Simd::Vec3::FloatType half = Simd::Vec3::Splat(0.5f);
+        const Simd::Vec3::FloatType angles = Simd::Vec3::Mul(half, eulerRadians.GetSimdValue());
+        Simd::Vec3::FloatType sin, cos;
+        Simd::Vec3::SinCos(angles, sin, cos);
+
+        const float sx = Simd::Vec3::SelectThird(sin);
+        const float cx = Simd::Vec3::SelectThird(cos);
+
+        const float sy = Simd::Vec3::SelectSecond(sin);
+        const float cy = Simd::Vec3::SelectSecond(cos);
+        
+        const float sz = Simd::Vec3::SelectFirst(sin);
+        const float cz = Simd::Vec3::SelectFirst(cos);
+ 
+        // rot = rotz * roty * rotx
+        return AZ::Quaternion(
+            sx * cy * cz - cx * sy * sz,
+            cx * sy * cz + sx * cy * sz,
+            cx * cy * sz - sx * sy * cz,
+            cx * cy * cz + sx * sy * sz
+        );
+    }
 
     void Quaternion::ConvertToAxisAngle(Vector3& outAxis, float& outAngle) const
     {

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
@@ -416,7 +416,7 @@ namespace AZ
 
     Quaternion Quaternion::CreateFromEulerRadiansXYZ(const Vector3& eulerRadians)
     {
-         const Simd::Vec3::FloatType half = Simd::Vec3::Splat(0.5f);
+        const Simd::Vec3::FloatType half = Simd::Vec3::Splat(0.5f);
         const Simd::Vec3::FloatType angles = Simd::Vec3::Mul(half, eulerRadians.GetSimdValue());
         Simd::Vec3::FloatType sin, cos;
         Simd::Vec3::SinCos(angles, sin, cos);
@@ -444,10 +444,10 @@ namespace AZ
         Simd::Vec3::FloatType sin, cos;
         Simd::Vec3::SinCos(angles, sin, cos);
 
-        const float sy = Simd::Vec3::SelectFirst(sin);
-        const float cy = Simd::Vec3::SelectFirst(cos);
-        const float sx = Simd::Vec3::SelectSecond(sin);
-        const float cx = Simd::Vec3::SelectSecond(cos);
+        const float sx = Simd::Vec3::SelectFirst(sin);
+        const float cx = Simd::Vec3::SelectFirst(cos);
+        const float sy = Simd::Vec3::SelectSecond(sin);
+        const float cy = Simd::Vec3::SelectSecond(cos);
         const float sz = Simd::Vec3::SelectThird(sin);
         const float cz = Simd::Vec3::SelectThird(cos);
 
@@ -466,15 +466,13 @@ namespace AZ
         Simd::Vec3::FloatType sin, cos;
         Simd::Vec3::SinCos(angles, sin, cos);
 
-        const float sx = Simd::Vec3::SelectThird(sin);
-        const float cx = Simd::Vec3::SelectThird(cos);
-
+        const float sx = Simd::Vec3::SelectFirst(sin);
+        const float cx = Simd::Vec3::SelectFirst(cos);
         const float sy = Simd::Vec3::SelectSecond(sin);
         const float cy = Simd::Vec3::SelectSecond(cos);
+        const float sz = Simd::Vec3::SelectThird(sin);
+        const float cz = Simd::Vec3::SelectThird(cos);
         
-        const float sz = Simd::Vec3::SelectFirst(sin);
-        const float cz = Simd::Vec3::SelectFirst(cos);
- 
         // rot = rotz * roty * rotx
         return AZ::Quaternion(
             sx * cy * cz - cx * sy * sz,

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.h
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.h
@@ -61,6 +61,14 @@ namespace AZ
         static Quaternion CreateRotationZ(float angleInRadians);
         //! @}
 
+        static Quaternion CreateFromEulerRadiansXYZ(const Vector3& eulerRadians);
+        static Quaternion CreateFromEulerRadiansYXZ(const Vector3& eulerRadians);
+        static Quaternion CreateFromEulerRadiansZYX(const Vector3& eulerRadians);
+
+        static Quaternion CreateFromEulerDegreesXYZ(const Vector3& eulerRadians);
+        static Quaternion CreateFromEulerDegreesYXZ(const Vector3& eulerRadians);
+        static Quaternion CreateFromEulerDegreesZYX(const Vector3& eulerRadians);
+
         //! Creates a quaternion from a Matrix3x3
         static Quaternion CreateFromMatrix3x3(const class Matrix3x3& m);
 
@@ -232,9 +240,11 @@ namespace AZ
         Vector3 GetEulerRadians() const;
 
         //! @param eulerRadians A vector containing component-wise rotation angles in radians.
+        //! @deprecated
         void SetFromEulerRadians(const Vector3& eulerRadians);
-
+        
         //! @param eulerDegrees A vector containing component-wise rotation angles in degrees.
+        //! @deprecated
         void SetFromEulerDegrees(const Vector3& eulerDegrees);
 
         //! Populate axis and angle of rotation from Quaternion

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.h
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.h
@@ -65,9 +65,9 @@ namespace AZ
         static Quaternion CreateFromEulerRadiansYXZ(const Vector3& eulerRadians);
         static Quaternion CreateFromEulerRadiansZYX(const Vector3& eulerRadians);
 
-        static Quaternion CreateFromEulerDegreesXYZ(const Vector3& eulerRadians);
-        static Quaternion CreateFromEulerDegreesYXZ(const Vector3& eulerRadians);
-        static Quaternion CreateFromEulerDegreesZYX(const Vector3& eulerRadians);
+        static Quaternion CreateFromEulerDegreesXYZ(const Vector3& eulerDegrees);
+        static Quaternion CreateFromEulerDegreesYXZ(const Vector3& eulerDegrees);
+        static Quaternion CreateFromEulerDegreesZYX(const Vector3& eulerDegrees);
 
         //! Creates a quaternion from a Matrix3x3
         static Quaternion CreateFromMatrix3x3(const class Matrix3x3& m);
@@ -240,11 +240,13 @@ namespace AZ
         Vector3 GetEulerRadians() const;
 
         //! @param eulerRadians A vector containing component-wise rotation angles in radians.
-        //! @deprecated
+        //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+        //! @deprecated use CreateFromEulerRadiansXYZ
         void SetFromEulerRadians(const Vector3& eulerRadians);
-        
+
         //! @param eulerDegrees A vector containing component-wise rotation angles in degrees.
-        //! @deprecated
+        //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+        //! @deprecated use CreateFromEulerDegreesXYZ
         void SetFromEulerDegrees(const Vector3& eulerDegrees);
 
         //! Populate axis and angle of rotation from Quaternion

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
@@ -66,26 +66,25 @@ namespace AZ
         return Quaternion(Simd::Vec4::FromVec3(v.GetSimdValue()));
     }
 
-    AZ_MATH_INLINE Quaternion Quaternion::CreateFromEulerDegreesXYZ(const Vector3& eulerRadians)
+    AZ_MATH_INLINE Quaternion Quaternion::CreateFromEulerDegreesXYZ(const Vector3& eulerDegrees)
     {
-        return CreateFromEulerRadiansXYZ(Vector3DegToRad(eulerRadians));
+        return CreateFromEulerRadiansXYZ(Vector3DegToRad(eulerDegrees));
     }
 
-    AZ_MATH_INLINE Quaternion Quaternion::CreateFromEulerDegreesYXZ(const Vector3& eulerRadians)
+    AZ_MATH_INLINE Quaternion Quaternion::CreateFromEulerDegreesYXZ(const Vector3& eulerDegrees)
     {
-        return CreateFromEulerRadiansYXZ(Vector3DegToRad(eulerRadians));
+        return CreateFromEulerRadiansYXZ(Vector3DegToRad(eulerDegrees));
     }
 
-    AZ_MATH_INLINE Quaternion Quaternion::CreateFromEulerDegreesZYX(const Vector3& eulerRadians)
+    AZ_MATH_INLINE Quaternion Quaternion::CreateFromEulerDegreesZYX(const Vector3& eulerDegrees)
     {
-        return CreateFromEulerRadiansZYX(Vector3DegToRad(eulerRadians));
+        return CreateFromEulerRadiansZYX(Vector3DegToRad(eulerDegrees));
     }
 
     AZ_MATH_INLINE Quaternion Quaternion::CreateFromVector3AndValue(const Vector3& v, float w)
     {
         return Quaternion(v, w);
     }
-
 
     AZ_MATH_INLINE Quaternion Quaternion::CreateRotationX(float angleInRadians)
     {

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
@@ -66,6 +66,20 @@ namespace AZ
         return Quaternion(Simd::Vec4::FromVec3(v.GetSimdValue()));
     }
 
+    AZ_MATH_INLINE Quaternion Quaternion::CreateFromEulerDegreesXYZ(const Vector3& eulerRadians)
+    {
+        return CreateFromEulerRadiansXYZ(Vector3DegToRad(eulerRadians));
+    }
+
+    AZ_MATH_INLINE Quaternion Quaternion::CreateFromEulerDegreesYXZ(const Vector3& eulerRadians)
+    {
+        return CreateFromEulerRadiansYXZ(Vector3DegToRad(eulerRadians));
+    }
+
+    AZ_MATH_INLINE Quaternion Quaternion::CreateFromEulerDegreesZYX(const Vector3& eulerRadians)
+    {
+        return CreateFromEulerRadiansZYX(Vector3DegToRad(eulerRadians));
+    }
 
     AZ_MATH_INLINE Quaternion Quaternion::CreateFromVector3AndValue(const Vector3& v, float w)
     {

--- a/Code/Framework/AzCore/Tests/Math/QuaternionPerformanceTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/QuaternionPerformanceTests.cpp
@@ -6,6 +6,8 @@
  *
  */
 
+#include "AzCore/Math/MathUtils.h"
+#include "AzCore/Math/Vector3.h"
 #if defined(HAVE_BENCHMARK)
 
 #include <AzCore/Math/Quaternion.h>
@@ -758,6 +760,134 @@ namespace Benchmark
             benchmark::DoNotOptimize(position);
         }
     }
-}
+
+
+    class BM_MathEulerRadians
+        : public benchmark::Fixture
+    {
+        void internalSetUp()
+        {
+            m_eulerDataArray.resize(1000);
+
+            const unsigned int seed = 1;
+            std::mt19937_64 rng(seed);
+            std::uniform_real_distribution<float> unif(-AZ::Constants::Pi, AZ::Constants::Pi);
+
+            std::generate(m_eulerDataArray.begin(), m_eulerDataArray.end(), [&unif, &rng]()
+            {
+                EulerData eulerData;
+                eulerData.radiansX = unif(rng);
+                eulerData.radiansY = unif(rng);
+                eulerData.radiansZ = unif(rng);
+
+                eulerData.degreesX = unif(rng) * (180.0f / AZ::Constants::Pi);
+                eulerData.degreesY = unif(rng) * (180.0f / AZ::Constants::Pi);
+                eulerData.degreesZ = unif(rng) * (180.0f / AZ::Constants::Pi);
+                return eulerData;
+            });
+        }
+    public:
+        void SetUp(const benchmark::State&) override
+        {
+            internalSetUp();
+        }
+        void SetUp(benchmark::State&) override
+        {
+            internalSetUp();
+        }
+
+        struct EulerData
+        {
+            float radiansX;
+            float radiansY;
+            float radiansZ;
+
+            float degreesX;
+            float degreesY;
+            float degreesZ;
+        };
+
+        std::vector<EulerData> m_eulerDataArray;
+    };
+
+    BENCHMARK_F(BM_MathEulerRadians, CreateFromEulerRadiansXYZ)(benchmark::State& state)
+    {
+        for ([[maybe_unused]] auto _ : state)
+        {
+            for (auto& eulerData : m_eulerDataArray)
+            {
+                AZ::Quaternion result =
+                    AZ::Quaternion::CreateFromEulerRadiansXYZ(AZ::Vector3(eulerData.radiansX, eulerData.radiansY, eulerData.radiansZ));
+                benchmark::DoNotOptimize(result);
+            }
+        }
+    }
+
+    BENCHMARK_F(BM_MathEulerRadians, CreateFromEulerRadiansYXZ)(benchmark::State& state)
+    {
+        for ([[maybe_unused]] auto _ : state)
+        {
+            for (auto& eulerData : m_eulerDataArray)
+            {
+                AZ::Quaternion result =
+                    AZ::Quaternion::CreateFromEulerRadiansYXZ(AZ::Vector3(eulerData.radiansX, eulerData.radiansY, eulerData.radiansZ));
+                benchmark::DoNotOptimize(result);
+            }
+        }
+    }
+
+    BENCHMARK_F(BM_MathEulerRadians, CreateFromEulerRadiansZYX)(benchmark::State& state)
+    {
+        for ([[maybe_unused]] auto _ : state)
+        {
+            for (auto& eulerData : m_eulerDataArray)
+            {
+                AZ::Quaternion result =
+                    AZ::Quaternion::CreateFromEulerRadiansZYX(AZ::Vector3(eulerData.radiansX, eulerData.radiansY, eulerData.radiansZ));
+                benchmark::DoNotOptimize(result);
+            }
+        }
+    }
+
+    BENCHMARK_F(BM_MathEulerRadians, CreateFromEulerDegreesXYZ)(benchmark::State& state)
+    {
+        for ([[maybe_unused]] auto _ : state)
+        {
+            for (auto& eulerData : m_eulerDataArray)
+            {
+                AZ::Quaternion result =
+                    AZ::Quaternion::CreateFromEulerDegreesXYZ(AZ::Vector3(eulerData.degreesX, eulerData.degreesY, eulerData.degreesZ));
+                benchmark::DoNotOptimize(result);
+            }
+        }
+    }
+
+    BENCHMARK_F(BM_MathEulerRadians, CreateFromEulerDegreesYXZ)(benchmark::State& state)
+    {
+        for ([[maybe_unused]] auto _ : state)
+        {
+            for (auto& eulerData : m_eulerDataArray)
+            {
+                AZ::Quaternion result =
+                    AZ::Quaternion::CreateFromEulerDegreesYXZ(AZ::Vector3(eulerData.degreesX, eulerData.degreesY, eulerData.degreesZ));
+                benchmark::DoNotOptimize(result);
+            }
+        }
+    }
+
+    BENCHMARK_F(BM_MathEulerRadians, CreateFromEulerDegreesZYX)(benchmark::State& state)
+    {
+        for ([[maybe_unused]] auto _ : state)
+        {
+            for (auto& eulerData : m_eulerDataArray)
+            {
+                AZ::Quaternion result =
+                    AZ::Quaternion::CreateFromEulerDegreesZYX(AZ::Vector3(eulerData.degreesX, eulerData.degreesY, eulerData.degreesZ));
+                benchmark::DoNotOptimize(result);
+            }
+        }
+    }
+
+} // namespace Benchmark
 
 #endif

--- a/Code/Framework/AzCore/Tests/Math/QuaternionPerformanceTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/QuaternionPerformanceTests.cpp
@@ -762,7 +762,7 @@ namespace Benchmark
     }
 
 
-    class BM_MathEulerRadians
+    class BM_MathQuaternionEulerRadians
         : public benchmark::Fixture
     {
         void internalSetUp()
@@ -810,7 +810,7 @@ namespace Benchmark
         std::vector<EulerData> m_eulerDataArray;
     };
 
-    BENCHMARK_F(BM_MathEulerRadians, CreateFromEulerRadiansXYZ)(benchmark::State& state)
+    BENCHMARK_F(BM_MathQuaternionEulerRadians, CreateFromEulerRadiansXYZ)(benchmark::State& state)
     {
         for ([[maybe_unused]] auto _ : state)
         {
@@ -823,7 +823,7 @@ namespace Benchmark
         }
     }
 
-    BENCHMARK_F(BM_MathEulerRadians, CreateFromEulerRadiansYXZ)(benchmark::State& state)
+    BENCHMARK_F(BM_MathQuaternionEulerRadians, CreateFromEulerRadiansYXZ)(benchmark::State& state)
     {
         for ([[maybe_unused]] auto _ : state)
         {
@@ -836,7 +836,7 @@ namespace Benchmark
         }
     }
 
-    BENCHMARK_F(BM_MathEulerRadians, CreateFromEulerRadiansZYX)(benchmark::State& state)
+    BENCHMARK_F(BM_MathQuaternionEulerRadians, CreateFromEulerRadiansZYX)(benchmark::State& state)
     {
         for ([[maybe_unused]] auto _ : state)
         {
@@ -849,7 +849,7 @@ namespace Benchmark
         }
     }
 
-    BENCHMARK_F(BM_MathEulerRadians, CreateFromEulerDegreesXYZ)(benchmark::State& state)
+    BENCHMARK_F(BM_MathQuaternionEulerRadians, CreateFromEulerDegreesXYZ)(benchmark::State& state)
     {
         for ([[maybe_unused]] auto _ : state)
         {
@@ -862,7 +862,7 @@ namespace Benchmark
         }
     }
 
-    BENCHMARK_F(BM_MathEulerRadians, CreateFromEulerDegreesYXZ)(benchmark::State& state)
+    BENCHMARK_F(BM_MathQuaternionEulerRadians, CreateFromEulerDegreesYXZ)(benchmark::State& state)
     {
         for ([[maybe_unused]] auto _ : state)
         {
@@ -875,7 +875,7 @@ namespace Benchmark
         }
     }
 
-    BENCHMARK_F(BM_MathEulerRadians, CreateFromEulerDegreesZYX)(benchmark::State& state)
+    BENCHMARK_F(BM_MathQuaternionEulerRadians, CreateFromEulerDegreesZYX)(benchmark::State& state)
     {
         for ([[maybe_unused]] auto _ : state)
         {

--- a/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
@@ -542,7 +542,6 @@ namespace UnitTest
         EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesXYZ(Vector3RadToDeg(param.eular)), IsClose(param.result));
     }
 
-
     INSTANTIATE_TEST_CASE_P(
         MATH_Quaternion,
         AngleRadianTestFixtureXYZ,
@@ -560,7 +559,20 @@ namespace UnitTest
             EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, Constants::QuarterPi), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
             EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) *
-                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)}));
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
+                
+            EularTestArgs{ AZ::Vector3(Constants::HalfPi, 0, Constants::QuarterPi), 
+                AZ::Quaternion::CreateRotationX(Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
+            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, -Constants::HalfPi, Constants::QuarterPi), 
+                AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationY(-Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
+            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, Constants::HalfPi, Constants::TwoOverPi), 
+                AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationY(Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationZ(Constants::TwoOverPi)}
+                ));
 
     using AngleRadianTestFixtureYXZ = ::testing::TestWithParam<EularTestArgs>;
 
@@ -591,7 +603,20 @@ namespace UnitTest
             EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, Constants::QuarterPi), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
             EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
-                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)}
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
+
+            EularTestArgs{ AZ::Vector3(Constants::HalfPi, 0, Constants::QuarterPi), 
+                AZ::Quaternion::CreateRotationY(Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
+            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, -Constants::HalfPi, Constants::QuarterPi), 
+                AZ::Quaternion::CreateRotationY(-Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationX(-Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
+            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, Constants::HalfPi, Constants::TwoOverPi), 
+                AZ::Quaternion::CreateRotationY(-Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationX(Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationZ(Constants::TwoOverPi)}
+                
         ));
 
     using AngleRadianTestFixtureZYX = ::testing::TestWithParam<EularTestArgs>;
@@ -623,7 +648,19 @@ namespace UnitTest
             EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, Constants::QuarterPi), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
             EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) *
-                AZ::Quaternion::CreateRotationX(Constants::QuarterPi)}
+                AZ::Quaternion::CreateRotationX(Constants::QuarterPi)},
+                
+            EularTestArgs{ AZ::Vector3(Constants::HalfPi, 0, Constants::QuarterPi), 
+                AZ::Quaternion::CreateRotationZ(Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationX(Constants::QuarterPi)},
+            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, -Constants::HalfPi, Constants::QuarterPi), 
+                AZ::Quaternion::CreateRotationZ(-Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationY(-Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationX(Constants::QuarterPi)},
+            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, Constants::HalfPi, Constants::TwoOverPi), 
+                AZ::Quaternion::CreateRotationZ(-Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationY(Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationX(Constants::TwoOverPi)}
         ));
 
 }

--- a/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
@@ -525,142 +525,142 @@ namespace UnitTest
         EXPECT_THAT(angle, testing::FloatEq(-AZ::Constants::HalfPi));
     }
 
-    struct EularTestArgs {
-        AZ::Vector3 eular;
+    struct EulerTestArgs {
+        AZ::Vector3 euler;
         AZ::Quaternion result;
     };
 
-    using AngleRadianTestFixtureXYZ = ::testing::TestWithParam<EularTestArgs>;
+    using AngleRadianTestFixtureXYZ = ::testing::TestWithParam<EulerTestArgs>;
 
-    TEST_P(AngleRadianTestFixtureXYZ, EularRadiansXYZ) {
+    TEST_P(AngleRadianTestFixtureXYZ, EulerRadiansXYZ) {
         auto& param = GetParam();
-        EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansXYZ(param.eular), IsClose(param.result));
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansXYZ(param.euler), IsClose(param.result));
     }
 
-     TEST_P(AngleRadianTestFixtureXYZ, EularDegreesXYZ) {
+     TEST_P(AngleRadianTestFixtureXYZ, EulerDegreesXYZ) {
         auto& param = GetParam();
-        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesXYZ(Vector3RadToDeg(param.eular)), IsClose(param.result));
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesXYZ(Vector3RadToDeg(param.euler)), IsClose(param.result));
     }
 
     INSTANTIATE_TEST_CASE_P(
         MATH_Quaternion,
         AngleRadianTestFixtureXYZ,
         ::testing::Values(
-            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
 
-            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, -Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(-Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, 0, -Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(-Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(-Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, -Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(-Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, 0, -Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(-Constants::QuarterPi) },
 
-            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) *
+            EulerTestArgs{ AZ::Vector3(Constants::QuarterPi, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, Constants::QuarterPi), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
+            EulerTestArgs{ AZ::Vector3(0, Constants::QuarterPi, Constants::QuarterPi), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) *
+            EulerTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
                 
-            EularTestArgs{ AZ::Vector3(Constants::HalfPi, 0, Constants::QuarterPi), 
+            EulerTestArgs{ AZ::Vector3(Constants::HalfPi, 0, Constants::QuarterPi), 
                 AZ::Quaternion::CreateRotationX(Constants::HalfPi) *
                 AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
-            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, -Constants::HalfPi, Constants::QuarterPi), 
+            EulerTestArgs{ AZ::Vector3(-Constants::QuarterPi, -Constants::HalfPi, Constants::QuarterPi), 
                 AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationY(-Constants::HalfPi) *
                 AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
-            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, Constants::HalfPi, Constants::TwoOverPi), 
+            EulerTestArgs{ AZ::Vector3(-Constants::QuarterPi, Constants::HalfPi, Constants::TwoOverPi), 
                 AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationY(Constants::HalfPi) *
                 AZ::Quaternion::CreateRotationZ(Constants::TwoOverPi)}
                 ));
 
-    using AngleRadianTestFixtureYXZ = ::testing::TestWithParam<EularTestArgs>;
+    using AngleRadianTestFixtureYXZ = ::testing::TestWithParam<EulerTestArgs>;
 
-    TEST_P(AngleRadianTestFixtureYXZ, EularRadiansYXZ) {
+    TEST_P(AngleRadianTestFixtureYXZ, EulerRadiansYXZ) {
         auto& param = GetParam();
-        EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansYXZ(param.eular), IsClose(param.result));
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansYXZ(param.euler), IsClose(param.result));
     }
 
-    TEST_P(AngleRadianTestFixtureYXZ, EularDegreesYXZ) {
+    TEST_P(AngleRadianTestFixtureYXZ, EulerDegreesYXZ) {
         auto& param = GetParam();
-        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesYXZ(Vector3RadToDeg(param.eular)), IsClose(param.result));
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesYXZ(Vector3RadToDeg(param.euler)), IsClose(param.result));
     }
 
     INSTANTIATE_TEST_CASE_P(
         MATH_Quaternion,
         AngleRadianTestFixtureYXZ,
         ::testing::Values(
-            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
 
-            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationY(-Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, -Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, 0, -Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(-Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(-Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, -Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(-Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, 0, -Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(-Constants::QuarterPi) },
 
-            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
+            EulerTestArgs{ AZ::Vector3(Constants::QuarterPi, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, Constants::QuarterPi), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) *
+            EulerTestArgs{ AZ::Vector3(0, Constants::QuarterPi, Constants::QuarterPi), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
+            EulerTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
 
-            EularTestArgs{ AZ::Vector3(Constants::HalfPi, 0, Constants::QuarterPi), 
-                AZ::Quaternion::CreateRotationY(Constants::HalfPi) *
-                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
-            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, -Constants::HalfPi, Constants::QuarterPi), 
-                AZ::Quaternion::CreateRotationY(-Constants::QuarterPi) *
-                AZ::Quaternion::CreateRotationX(-Constants::HalfPi) *
-                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
-            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, Constants::HalfPi, Constants::TwoOverPi), 
-                AZ::Quaternion::CreateRotationY(-Constants::QuarterPi) *
+            EulerTestArgs{ AZ::Vector3(Constants::HalfPi, 0, Constants::QuarterPi), 
                 AZ::Quaternion::CreateRotationX(Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
+            EulerTestArgs{ AZ::Vector3(-Constants::QuarterPi, -Constants::HalfPi, Constants::QuarterPi), 
+                AZ::Quaternion::CreateRotationY(-Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)},
+            EulerTestArgs{ AZ::Vector3(-Constants::QuarterPi, Constants::HalfPi, Constants::TwoOverPi), 
+                AZ::Quaternion::CreateRotationY(Constants::HalfPi) *
+                AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationZ(Constants::TwoOverPi)}
                 
         ));
 
-    using AngleRadianTestFixtureZYX = ::testing::TestWithParam<EularTestArgs>;
+    using AngleRadianTestFixtureZYX = ::testing::TestWithParam<EulerTestArgs>;
 
-    TEST_P(AngleRadianTestFixtureZYX, EularRadiansYXZ) {
+    TEST_P(AngleRadianTestFixtureZYX, EulerRadiansYXZ) {
         auto& param = GetParam();
-        EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansZYX(param.eular), IsClose(param.result));
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansZYX(param.euler), IsClose(param.result));
     }
 
-    TEST_P(AngleRadianTestFixtureZYX, EularDegreesYXZ) {
+    TEST_P(AngleRadianTestFixtureZYX, EulerDegreesYXZ) {
         auto& param = GetParam();
-        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesZYX(Vector3RadToDeg(param.eular)), IsClose(param.result));
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesZYX(Vector3RadToDeg(param.euler)), IsClose(param.result));
     }
 
     INSTANTIATE_TEST_CASE_P(
         MATH_Quaternion,
         AngleRadianTestFixtureZYX,
         ::testing::Values(
-            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
 
-            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationZ(-Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, -Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(-Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, 0, -Constants::QuarterPi), AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(-Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, -Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(-Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(0, 0, -Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(-Constants::QuarterPi) },
 
-            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) *
-                AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, Constants::QuarterPi), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
+            EulerTestArgs{ AZ::Vector3(Constants::QuarterPi, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
-            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) *
+            EulerTestArgs{ AZ::Vector3(0, Constants::QuarterPi, Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationX(Constants::QuarterPi)},
                 
-            EularTestArgs{ AZ::Vector3(Constants::HalfPi, 0, Constants::QuarterPi), 
-                AZ::Quaternion::CreateRotationZ(Constants::HalfPi) *
-                AZ::Quaternion::CreateRotationX(Constants::QuarterPi)},
-            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, -Constants::HalfPi, Constants::QuarterPi), 
-                AZ::Quaternion::CreateRotationZ(-Constants::QuarterPi) *
+            EulerTestArgs{ AZ::Vector3(Constants::HalfPi, 0, Constants::QuarterPi), 
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationX(Constants::HalfPi)},
+            EulerTestArgs{ AZ::Vector3(-Constants::QuarterPi, -Constants::HalfPi, Constants::QuarterPi), 
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationY(-Constants::HalfPi) *
-                AZ::Quaternion::CreateRotationX(Constants::QuarterPi)},
-            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, Constants::HalfPi, Constants::TwoOverPi), 
-                AZ::Quaternion::CreateRotationZ(-Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationX(-Constants::QuarterPi)},
+            EulerTestArgs{ AZ::Vector3(-Constants::QuarterPi, Constants::HalfPi, Constants::TwoOverPi), 
+                AZ::Quaternion::CreateRotationZ(Constants::TwoOverPi) *
                 AZ::Quaternion::CreateRotationY(Constants::HalfPi) *
-                AZ::Quaternion::CreateRotationX(Constants::TwoOverPi)}
+                AZ::Quaternion::CreateRotationX(-Constants::QuarterPi)}
         ));
 
 }

--- a/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
@@ -525,19 +525,22 @@ namespace UnitTest
         EXPECT_THAT(angle, testing::FloatEq(-AZ::Constants::HalfPi));
     }
 
-    struct EulerTestArgs {
+    struct EulerTestArgs
+    {
         AZ::Vector3 euler;
         AZ::Quaternion result;
     };
 
     using AngleRadianTestFixtureXYZ = ::testing::TestWithParam<EulerTestArgs>;
 
-    TEST_P(AngleRadianTestFixtureXYZ, EulerRadiansXYZ) {
+    TEST_P(AngleRadianTestFixtureXYZ, EulerRadiansXYZ)
+    {
         auto& param = GetParam();
         EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansXYZ(param.euler), IsClose(param.result));
     }
 
-     TEST_P(AngleRadianTestFixtureXYZ, EulerDegreesXYZ) {
+    TEST_P(AngleRadianTestFixtureXYZ, EulerDegreesXYZ)
+    {
         auto& param = GetParam();
         EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesXYZ(Vector3RadToDeg(param.euler)), IsClose(param.result));
     }
@@ -576,12 +579,14 @@ namespace UnitTest
 
     using AngleRadianTestFixtureYXZ = ::testing::TestWithParam<EulerTestArgs>;
 
-    TEST_P(AngleRadianTestFixtureYXZ, EulerRadiansYXZ) {
+    TEST_P(AngleRadianTestFixtureYXZ, EulerRadiansYXZ)
+    {
         auto& param = GetParam();
         EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansYXZ(param.euler), IsClose(param.result));
     }
 
-    TEST_P(AngleRadianTestFixtureYXZ, EulerDegreesYXZ) {
+    TEST_P(AngleRadianTestFixtureYXZ, EulerDegreesYXZ)
+    {
         auto& param = GetParam();
         EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesYXZ(Vector3RadToDeg(param.euler)), IsClose(param.result));
     }
@@ -621,12 +626,14 @@ namespace UnitTest
 
     using AngleRadianTestFixtureZYX = ::testing::TestWithParam<EulerTestArgs>;
 
-    TEST_P(AngleRadianTestFixtureZYX, EulerRadiansYXZ) {
+    TEST_P(AngleRadianTestFixtureZYX, EulerRadiansYXZ)
+    {
         auto& param = GetParam();
         EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansZYX(param.euler), IsClose(param.result));
     }
 
-    TEST_P(AngleRadianTestFixtureZYX, EulerDegreesYXZ) {
+    TEST_P(AngleRadianTestFixtureZYX, EulerDegreesYXZ)
+    {
         auto& param = GetParam();
         EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesZYX(Vector3RadToDeg(param.euler)), IsClose(param.result));
     }
@@ -663,4 +670,4 @@ namespace UnitTest
                 AZ::Quaternion::CreateRotationX(-Constants::QuarterPi)}
         ));
 
-}
+} // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AZTestShared/Math/MathTestHelpers.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Matrix3x3.h>
@@ -523,4 +524,106 @@ namespace UnitTest
         const float angle = absQuat.GetEulerRadians().GetX();
         EXPECT_THAT(angle, testing::FloatEq(-AZ::Constants::HalfPi));
     }
+
+    struct EularTestArgs {
+        AZ::Vector3 eular;
+        AZ::Quaternion result;
+    };
+
+    using AngleRadianTestFixtureXYZ = ::testing::TestWithParam<EularTestArgs>;
+
+    TEST_P(AngleRadianTestFixtureXYZ, EularRadiansXYZ) {
+        auto& param = GetParam();
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansXYZ(param.eular), IsClose(param.result));
+    }
+
+     TEST_P(AngleRadianTestFixtureXYZ, EularDegreesXYZ) {
+        auto& param = GetParam();
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesXYZ(Vector3RadToDeg(param.eular)), IsClose(param.result));
+    }
+
+
+    INSTANTIATE_TEST_CASE_P(
+        MATH_Quaternion,
+        AngleRadianTestFixtureXYZ,
+        ::testing::Values(
+            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
+
+            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, -Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(-Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, 0, -Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(-Constants::QuarterPi) },
+
+            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, Constants::QuarterPi), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)}));
+
+    using AngleRadianTestFixtureYXZ = ::testing::TestWithParam<EularTestArgs>;
+
+    TEST_P(AngleRadianTestFixtureYXZ, EularRadiansYXZ) {
+        auto& param = GetParam();
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansYXZ(param.eular), IsClose(param.result));
+    }
+
+    TEST_P(AngleRadianTestFixtureYXZ, EularDegreesYXZ) {
+        auto& param = GetParam();
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesYXZ(Vector3RadToDeg(param.eular)), IsClose(param.result));
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        MATH_Quaternion,
+        AngleRadianTestFixtureYXZ,
+        ::testing::Values(
+            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
+
+            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationY(-Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, -Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, 0, -Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(-Constants::QuarterPi) },
+
+            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, Constants::QuarterPi), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)}
+        ));
+
+    using AngleRadianTestFixtureZYX = ::testing::TestWithParam<EularTestArgs>;
+
+    TEST_P(AngleRadianTestFixtureZYX, EularRadiansYXZ) {
+        auto& param = GetParam();
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansZYX(param.eular), IsClose(param.result));
+    }
+
+    TEST_P(AngleRadianTestFixtureZYX, EularDegreesYXZ) {
+        auto& param = GetParam();
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesZYX(Vector3RadToDeg(param.eular)), IsClose(param.result));
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        MATH_Quaternion,
+        AngleRadianTestFixtureZYX,
+        ::testing::Values(
+            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
+
+            EularTestArgs{ AZ::Vector3(-Constants::QuarterPi, 0, 0), AZ::Quaternion::CreateRotationZ(-Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, -Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationY(-Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, 0, -Constants::QuarterPi), AZ::Quaternion::CreateRotationX(-Constants::QuarterPi) },
+
+            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, Constants::QuarterPi, 0), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationY(Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(0, Constants::QuarterPi, Constants::QuarterPi), AZ::Quaternion::CreateRotationY(Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationX(Constants::QuarterPi) },
+            EularTestArgs{ AZ::Vector3(Constants::QuarterPi, 0, Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(Constants::QuarterPi) *
+                AZ::Quaternion::CreateRotationX(Constants::QuarterPi)}
+        ));
+
 }


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

this change was in response to the PR referenced here. this adds tait-bryan angles for XYZ, YXZ, and ZYX. 

ref: https://github.com/o3de/o3de/pull/10508

## How was this PR tested?

this can be verified with the unit tests added. 
