### PR TITLE
Add the Host IP Address to the Multiplayer Viewport Connection Status

### DIFF
--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.cpp
@@ -113,7 +113,7 @@ namespace Multiplayer
         {        
             // Display the connection status in the bottom-right viewport
             m_drawParams.m_hAlign = AzFramework::TextHorizontalAlignment::Right;
-            m_drawParams.m_position = AZ::Vector3(static_cast<float>(viewportSize.m_width), static_cast<float>(viewportSize.m_height), 1.0f) + AZ::Vector3(viewportConnectionBottomRightBorderPadding) * viewport->GetDpiScalingFactor();
+            m_drawParams.m_position = AZ::Vector3(aznumeric_cast<float>(viewportSize.m_width), aznumeric_cast<float>(viewportSize.m_height), 1.0f) + AZ::Vector3(viewportConnectionBottomRightBorderPadding) * viewport->GetDpiScalingFactor();
 
             if (AzNetworking::INetworkInterface* networkInterface = AZ::Interface<AzNetworking::INetworking>::Get()->RetrieveNetworkInterface(AZ::Name(MpNetworkInterfaceName)))
             {
@@ -148,7 +148,7 @@ namespace Multiplayer
             connectionStateColor = AZ::Colors::Green;
             break;
         case AzNetworking::ConnectionState::Disconnecting:
-            connectionStateColor = AZ::Colors::Orange;
+            connectionStateColor = AZ::Colors::Yellow;
             break;
         case AzNetworking::ConnectionState::Disconnected:
             connectionStateColor = AZ::Colors::Red;
@@ -162,7 +162,8 @@ namespace Multiplayer
         MultiplayerAgentType agentType = multiplayerSystemComponent->GetAgentType();
         if (agentType == MultiplayerAgentType::Client)
         {
-            DrawConnectionStatusLine(hostIpAddress.GetString().c_str(), connectionStateColor);
+            auto hostAddressText = AZStd::fixed_string<32>::format("Server IP %s", hostIpAddress.GetString().c_str());
+            DrawConnectionStatusLine(hostAddressText.c_str(), connectionStateColor);
         }
 
         // Draw the connect state (example: Connected or Disconnected)

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.h
@@ -72,5 +72,6 @@ namespace Multiplayer
         AzFramework::TextDrawParameters m_drawParams;
         float m_lineSpacing = 0.0f;
         AzNetworking::IpAddress m_hostIpAddress;
+        int m_currentConnectionsDrawCount = 0;
     };
 }

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.h
@@ -64,11 +64,13 @@ namespace Multiplayer
         void OnPlayModeEnd() override;
         //! @}
 
-        void DrawConnectionStatus(AzNetworking::ConnectionState connectionState);
+        void DrawConnectionStatus(AzNetworking::ConnectionState connectionState, const AzNetworking::IpAddress& hostAddress);
+        void DrawConnectionStatusLine(const char* line, const AZ::Color& color);
 
         AZStd::fixed_string<MaxMessageLength> m_centerViewportDebugText;
         AzFramework::FontDrawInterface* m_fontDrawInterface = nullptr;
         AzFramework::TextDrawParameters m_drawParams;
         float m_lineSpacing = 0.0f;
+        AzNetworking::IpAddress m_hostIpAddress;
     };
 }


### PR DESCRIPTION
## What does this PR do?
Adding the host ip address to the multiplayer viewport connection status. It's a common mistake for users to accidently connect to the wrong ip address. This is a feature so that devs can quickly see on screen which server ip they are using.

![image](https://user-images.githubusercontent.com/32776221/180916950-691fe969-bad8-462f-a108-9d9ddfeaa099.png)

Partial fix for #9514

## How was this PR tested?
1. Ran the editor with editor server enabled; noticed that the connection status contained the server IP. Closed the server and made sure the server ip was still present on the client even after disconnected.
2. Launched ServerLauncher and GameLauncher and attempted to connect to an incorrect port. See the connecting attempt status and then disconnect status with the wrong ip address in the viewport status; thus making it easier for users to see that they used the wrong ip address