### PR TITLE
chore: remove Vector3ToVector2 for Gems/Camera

### DIFF
--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -9,13 +9,13 @@
 #include "CameraComponentController.h"
 #include "CameraViewRegistrationBus.h"
 
-#include <AzCore/Math/MatrixUtils.h>
-#include <AzCore/Math/VectorConversions.h>
 #include <Atom/RPI.Public/View.h>
 #include <Atom/RPI.Public/ViewportContextManager.h>
 #include <Atom/RPI.Public/ViewportContext.h>
 
 #include <AzCore/Component/EntityBus.h>
+#include <AzCore/Math/MatrixUtils.h>
+#include <AzCore/Math/Vector2.h>
 
 #include <AzFramework/Viewport/ViewportScreen.h>
 
@@ -450,7 +450,7 @@ namespace Camera
     {
         const AzFramework::CameraState& cameraState = GetCameraState();
         const AZ::Vector3 screenPosition = AzFramework::WorldToScreenNdc(worldPosition, AzFramework::CameraView(cameraState), AzFramework::CameraProjection(cameraState));
-        return AZ::Vector3ToVector2(screenPosition); 
+        return AZ::Vector2(screenPosition); 
     }
 
     AZ::Vector2 CameraComponentController::WorldToScreen(const AZ::Vector3& worldPosition)


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

remove dependency from VectorConversions for CameraComponentController.cpp


