### PR TITLE
bugfix(Vulkan): set access bit on image barrier

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.h
@@ -83,5 +83,6 @@ namespace AZ
         VkImageUsageFlags ImageUsageFlagsOfFormatFeatureFlags(VkFormatFeatureFlags formatFeatureFlags);
         VkAccessFlags GetSupportedAccessFlags(VkPipelineStageFlags pipelineStageFlags);
         bool ShouldApplyDeviceAddressBit(RHI::BufferBindFlags bindFlags);
+        bool HasExplicitClear(const RHI::ScopeAttachment& scopeAttachment, const RHI::ScopeAttachmentDescriptor& descriptor);
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
@@ -321,17 +321,8 @@ namespace AZ
             for (const auto* scopeAttachment : attachments)
             {
                 const auto& bindingDescriptor = scopeAttachment->GetDescriptor();
-                const bool isClearAction = bindingDescriptor.m_loadStoreAction.m_loadAction == RHI::AttachmentLoadAction::Clear;
-                const bool isClearActionStencil = bindingDescriptor.m_loadStoreAction.m_loadActionStencil == RHI::AttachmentLoadAction::Clear;
-                bool isClear = isClearAction || isClearActionStencil;
-
-                for (const RHI::ScopeAttachmentUsageAndAccess& usageAndAccess : scopeAttachment->GetUsageAndAccess())
-                {
-                    if (usageAndAccess.m_usage == RHI::ScopeAttachmentUsage::Shader && isClear)
-                    {
-                        clearRequests.push_back({ bindingDescriptor.m_loadStoreAction.m_clearValue, scopeAttachment->GetResourceView() });
-                        break;
-                    }
+                if (HasExplicitClear(*scopeAttachment, bindingDescriptor)) {
+                    clearRequests.push_back({ bindingDescriptor.m_loadStoreAction.m_clearValue, scopeAttachment->GetResourceView() });
                 }
             }
         }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
@@ -321,7 +321,8 @@ namespace AZ
             for (const auto* scopeAttachment : attachments)
             {
                 const auto& bindingDescriptor = scopeAttachment->GetDescriptor();
-                if (HasExplicitClear(*scopeAttachment, bindingDescriptor)) {
+                if (HasExplicitClear(*scopeAttachment, bindingDescriptor))
+                {
                     clearRequests.push_back({ bindingDescriptor.m_loadStoreAction.m_clearValue, scopeAttachment->GetResourceView() });
                 }
             }


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

documentation: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAccessFlagBits.html
```
VK_ACCESS_TRANSFER_WRITE_BIT specifies write 
access to an image or buffer in a [clear](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#clears) or [copy](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#copies) operation. Such access occurs in the VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT pipeline stage.
```

VK_ACCESS_TRANSFER_WRITE_BIT specifies a write access on an image this is placed on the barrier proceeding the  vkcmdclearimage. This appears to be reletaed to AMD where the clear and read seem to be happening at the same time. this produces the square artifacts on the image. (https://github.com/o3de/o3de/issues/4379)

## How was this PR tested?

ref: https://gitlab.freedesktop.org/mesa/mesa/-/issues/6702#note_1481580
ref: https://github.com/o3de/o3de/issues/4379
ref: https://github.com/o3de/o3de/pull/5034

![A](https://user-images.githubusercontent.com/51759646/184939582-c6358641-5616-43c2-b6f9-3494dde7cc7c.JPG)
![B](https://user-images.githubusercontent.com/51759646/184939601-33ccf0b9-6a13-4ad4-8d43-b084bbc327a5.JPG)
![C](https://user-images.githubusercontent.com/51759646/184939465-a3559d85-e556-43fb-baea-bace29b39076.JPG)
![D](https://user-images.githubusercontent.com/51759646/184939471-7e3369ad-4d32-4e99-b6ef-37487f80b4d0.JPG)
![E](https://user-images.githubusercontent.com/51759646/184939480-60c5642f-78ba-4cc4-9ace-4b99191a09bd.JPG)
Verified with AtomSampleViewer full test suit. Some tests are broken at the moment due to unrelated code changes. Verified with both with and without the changes.

