### PR TITLE
Fixed missing punctuation in PhysX Configuration label

### DIFF
--- a/Gems/PhysX/Code/Editor/SettingsWidget.cpp
+++ b/Gems/PhysX/Code/Editor/SettingsWidget.cpp
@@ -18,7 +18,7 @@ namespace PhysX
 {
     namespace Editor
     {
-        static const char* const s_settingsDocumentationLink = "Learn more about <a href=%0>configuring PhysX</a>";
+        static const char* const s_settingsDocumentationLink = "Learn more about <a href=%0>configuring PhysX.</a>";
         static const char* const s_settingsDocumentationAddress = "configuring/configuration-global";
 
         SettingsWidget::SettingsWidget(QWidget* parent)


### PR DESCRIPTION
## What does this PR do?

Fixes #10712 

Added missing punctuation mark from label in PhysX Configuration tool.

## How was this PR tested?

Launched PhysX Configuration tool and verified the punctuation mark is now there, which makes it consistent with the other tabs inside the PhysX Configuration tool.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>