### PR TITLE
[Terrain] Macro material order determinism

### DIFF
--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.h
@@ -78,9 +78,15 @@ namespace Terrain
         };
         static_assert(sizeof(MacroMaterialShaderData) % 16 == 0, "MacroMaterialShaderData must be 16 byte aligned.");
 
-        struct MacroMaterialMetaData
+        struct MacroMaterialPriority
         {
             int32_t m_priority{ 0 };
+            uint32_t m_hash{ 0 };
+
+            bool operator>(MacroMaterialPriority& other)
+            {
+                return m_priority > other.m_priority || (m_priority == other.m_priority && m_hash > other.m_hash);
+            }
         };
 
         struct MacroMaterialGridShaderData
@@ -114,7 +120,7 @@ namespace Terrain
 
         // Macro materials stored in a grid of (MacroMaterialGridCount * MacroMaterialGridCount) where each tile in the grid covers
         // an area of (MacroMaterialGridSize * MacroMaterialGridSize) and each tile can hold MacroMaterialsPerTile macro materials
-        AZ::Render::MultiSparseVector<MacroMaterialShaderData, MacroMaterialMetaData> m_materialData; // Info about the macro material itself.
+        AZ::Render::MultiSparseVector<MacroMaterialShaderData, MacroMaterialPriority> m_materialData; // Info about the macro material itself.
         AZStd::vector<TileMaterials> m_materialRefGridShaderData; // A grid of macro material references that covers the world.
 
         AZStd::map<AZ::EntityId, MaterialHandle> m_entityToMaterialHandle; // Used for looking up macro materials by entity id when the data isn't provided by a bus.

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.h
@@ -83,7 +83,7 @@ namespace Terrain
             int32_t m_priority{ 0 };
             uint32_t m_hash{ 0 };
 
-            bool operator>(MacroMaterialPriority& other)
+            bool operator>(MacroMaterialPriority& other) const
             {
                 return m_priority > other.m_priority || (m_priority == other.m_priority && m_hash > other.m_hash);
             }


### PR DESCRIPTION
## What does this PR do?

This PR makes macro materials fall back to the entity ID for order if their priorities are the same. This isn't meant to offer true stability across runs, but keeps the macro material from looking broken in a session. Currently it's possible for different terrain tiles to have different macro material orders for the same materials if the priorities are the same. With this change, all the tiles will have the same order.

## How was this PR tested?

Tested a level with many macro materials of different / same priorities.
