### PR TITLE
Fix for pasting incompatible components

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -3447,6 +3447,13 @@ namespace AzToolsFramework
             return false;
         }
 
+        SelectionEntityTypeInfo selectionTypeInfo = GetSelectionEntityTypeInfo(m_selectedEntityIds);
+        if (!CanAddComponentsToSelection(selectionTypeInfo))
+        {
+            // Can't paste components if there is a mixed selection or read only entities
+            return false;
+        }
+
         // Grab component data from clipboard, if exists
         const QMimeData* mimeData = ComponentMimeData::GetComponentMimeDataFromClipboard();
 
@@ -3493,9 +3500,9 @@ namespace AzToolsFramework
         {
             if (componentClassData)
             {
-                // A component can be pasted onto an entity if it appears in the game component menu or if it already exists on the entity
+                // A component can be pasted onto an entity if it appears in the add component menu or if it already exists on the entity
                 auto existingComponent = entity->FindComponent(componentClassData->m_typeId);
-                if (!existingComponent && !AppearsInGameComponentMenu(*componentClassData))
+                if (!existingComponent && (!m_componentFilter || !m_componentFilter(*componentClassData)))
                 {
                     canPaste = false;
                     break;


### PR DESCRIPTION
Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

When pasting components onto selected entities, it was assumed that all entities were of a certain type. This change checks entity type and uses the correct filter to determine whether the components are compatible with the selected entities.

Fixes #4236.
