### PR TITLE
Fix Multiplayer Component Archetype Property Init

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Header.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Header.jinja
@@ -211,11 +211,11 @@ AZStd::array<{{ Property.attrib['Type'] }}, {{ Property.attrib['Count'] }}> m_{{
 {% elif Property.attrib['Container'] == 'Vector' %}
 AZStd::fixed_vector<{{ Property.attrib['Type'] }}, {{ Property.attrib['Count'] }}> m_{{ LowerFirst(Property.attrib['Name']) }};
 {% else %}
-  {% if Property.attrib['Init'] | length %}
+{%    if Property.attrib['Init'] | length %}
 {{ Property.attrib['Type'] }} m_{{ LowerFirst(Property.attrib['Name']) }} = {{Property.attrib['Init']}};
-  {% else %}
+{%    else %}
 {{ Property.attrib['Type'] }} m_{{ LowerFirst(Property.attrib['Name']) }};
-  {% endif %}
+{%    endif %}
 {% endif %}
 {% endcall %}
 {% endmacro %}

--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Header.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Header.jinja
@@ -211,7 +211,11 @@ AZStd::array<{{ Property.attrib['Type'] }}, {{ Property.attrib['Count'] }}> m_{{
 {% elif Property.attrib['Container'] == 'Vector' %}
 AZStd::fixed_vector<{{ Property.attrib['Type'] }}, {{ Property.attrib['Count'] }}> m_{{ LowerFirst(Property.attrib['Name']) }};
 {% else %}
+  {% if Property.attrib['Init'] | length %}
+{{ Property.attrib['Type'] }} m_{{ LowerFirst(Property.attrib['Name']) }} = {{Property.attrib['Init']}};
+  {% else %}
 {{ Property.attrib['Type'] }} m_{{ LowerFirst(Property.attrib['Name']) }};
+  {% endif %}
 {% endif %}
 {% endcall %}
 {% endmacro %}


### PR DESCRIPTION
Fix Multiplayer auto-component archetype property so that they use their Init value. If the init value is empty, then don't init and leave it empty

Signed-off-by: Gene Walters <genewalt@amazon.com>

## What does this PR do?
Fixes auto-component archetype property so that jinja uses the Init value. Before this change the value of properties were undefined, for example, an int could be initialized to some random number, often leading to confusing outcomes which needed debugging.

Resolves #4099 

## How was this PR tested?
1) Made sure existing Multiplayer Sample are compiled
2) Added a Multiplayer component in editor and see that the archetype proper was now initialized