### PR TITLE
Add build failure RCA patterns

### DIFF
--- a/scripts/build/build_failure_rca/preprocess/rules.json
+++ b/scripts/build/build_failure_rca/preprocess/rules.json
@@ -1,0 +1,6 @@
+{
+    "ignore_patterns": [
+        ".*Building CXX.*",
+        ".*Linking CXX.*"
+    ]
+}

--- a/scripts/build/build_failure_rca/rca_patterns/Asset-Processing.json
+++ b/scripts/build/build_failure_rca/rca_patterns/Asset-Processing.json
@@ -1,0 +1,19 @@
+{
+    "indications": [
+      {
+        "name": "Asset Processing",
+        "description": "Asset Processing error",
+        "comment": "Asset Processing error, see log for more details",
+        "single_line": true,
+        "find_all": true,
+        "log_patterns": [
+          "^.*AssetProcessor: Failed.*$"
+        ],
+        "log_testcases": [
+          "AssetProcessor: Failed Shaders/Terrain/TerrainDetailClipmapGenerationPass.shader"
+        ],
+        "owners": []
+      }
+    ]
+  }
+  

--- a/scripts/build/build_failure_rca/rca_patterns/Build-Environment.json
+++ b/scripts/build/build_failure_rca/rca_patterns/Build-Environment.json
@@ -1,0 +1,88 @@
+{
+    "indications": [
+        {
+            "name": "Insufficient disk space",
+            "description": "Build node or EBS volume is out of disk space, rerun build with CLEAN_WORKSPACE parameter",
+            "comment": "Build node or EBS volume is out of disk space, clean build node or the EBS volume",
+            "single_line": true,
+            "find_all": false,
+            "log_patterns": [
+                "^.*No space left on device.*$"
+            ],
+            "log_testcases": [
+                "error: unable to open output file '...': 'No space left on device'"
+            ],
+            "owners": []
+        },
+        {
+            "name": "Build node disconnected",
+            "description": "Build node disconnected during the build",
+            "comment": "Build node disconnected during the build, rerun the job",
+            "single_line": true,
+            "find_all": false,
+            "log_patterns": [
+                "^.*Agent went offline during the build.*$"
+            ],
+            "log_testcases": [
+                "Agent went offline during the build"
+            ],
+            "owners": []
+        },
+        {
+            "name": "Incremental build script error",
+            "description": "Incremental build script error, merge latest from upstream",
+            "comment": "Incremental build script error, merge latest from upstream",
+            "single_line": true,
+            "find_all": true,
+            "log_patterns": [
+                "^.*File.*incremental_build_util\\.py\", line \\d+.*$"
+            ],
+            "log_testcases": [
+                "File \"scripts\\build\\bootstrap\\incremental_build_util.py\", line 87"
+            ],
+            "owners": []
+        },
+        {
+            "name": "Corrupt PDB file",
+            "description": "Corrupt PDB file, try build again with build parameter CLEAN_OUTPUT_DIRECTORY enabled",
+            "comment": "Corrupt PDB file, try build again with build parameter CLEAN_OUTPUT_DIRECTORY enabled",
+            "single_line": true,
+            "find_all": true,
+            "log_patterns": [
+                "^.*fatal error LNK1285: corrupt PDB file.*$"
+            ],
+            "log_testcases": [
+                "LINK : fatal error LNK1285: corrupt PDB file 'D:\\workspace\\o3de\\build\\windows_vs2019\\bin\\profile\\o3de.pdb'"
+            ],
+            "owners": []
+        },
+        {
+            "name": "Case sensitive/insensitive issue",
+            "description": "Once case changed in file name, run a clean build to fix the build failure.",
+            "comment": "Once case changed in file name, run a clean build to fix the build failure",
+            "single_line": true,
+            "find_all": true,
+            "log_patterns": [
+                "^.*ModuleNotFoundError: No module named 'Prefab.*$"
+            ],
+            "log_testcases": [
+                "ModuleNotFoundError: No module named 'Prefab"
+            ],
+            "owners": []
+        },
+        {
+            "name": "Jenkins build node connectivity issue",
+            "description": "Jenkins cannot reconnect to build nodes after Jenkins server restart.",
+            "comment": "Jenkins cannot reconnect to build nodes after Jenkins server restart.",
+            "single_line": true,
+            "find_all": false,
+            "log_patterns": [
+                "^Killed part of.*after waiting for.*because we assume unknown agent.*is never going to appear$"
+            ],
+            "log_testcases": [
+                "Killed part of O3DE » PR-9504 #2 after waiting for 5 min 0 sec because we assume unknown agent EC2 (us-west-2) - WIN2019_INC_3 (i-05a91a7e645fc20d1) is never going to appear"
+            ],
+            "owners": []
+        }
+    ]
+}

--- a/scripts/build/build_failure_rca/rca_patterns/Cmake.json
+++ b/scripts/build/build_failure_rca/rca_patterns/Cmake.json
@@ -1,0 +1,18 @@
+{
+    "indications": [
+      {
+        "name": "CMake Error",
+        "description": "CMake error",
+        "comment": "CMake error, see log for more details",
+        "single_line": true,
+        "find_all": true,
+        "log_patterns": [
+          "^.*CMake Error at .*CMakeLists.txt.*$"
+        ],
+        "log_testcases": [
+          "CMake Error at CMakeLists.txt"
+        ],
+        "owners": []
+      }
+    ]
+  }

--- a/scripts/build/build_failure_rca/rca_patterns/Compilation.json
+++ b/scripts/build/build_failure_rca/rca_patterns/Compilation.json
@@ -1,0 +1,60 @@
+{
+    "indications": [
+      {
+        "name": "Compilation error",
+        "description": "Compilation error, see log for more details",
+        "comment": "Compilation error, see log for more details",
+        "single_line": false,
+        "find_all": false,
+        "log_patterns": [
+          "The following build commands failed:.*\\(\\d+ failure\\)"
+        ],
+        "log_testcases": [
+          "The following build commands failed:\\nLd /Users/lybuilder/workspace/o3de/build/ios/bin/debug/AutomatedTesting.GameLauncher.app/AutomatedTesting.GameLauncher normal\\n(1 failure)"
+        ],
+        "owners": []
+      },
+      {
+        "name": "Ninja Build Compilation Failure",
+        "description": "Build failed to compile, check above error message to see compilation error(s).",
+        "comment": "Build failed to compile",
+        "single_line": true,
+        "find_all": true,
+        "log_patterns": [
+          "^.*ninja: build stopped: subcommand failed.*$"
+        ],
+        "log_testcases": [
+          "ninja: build stopped: subcommand failed."
+        ],
+        "owners": []
+      },
+      {
+        "name": "Warning is treated as an error",
+        "description": "Warning is treated as an error, see log for more details",
+        "comment": "Warning is treated as an error, see log for more details",
+        "single_line": true,
+        "find_all": true,
+        "log_patterns": [
+          "^.*error C2220: the following warning is treated as an error.*$"
+        ],
+        "log_testcases": [
+          "D:/workspace/o3de/Code/Framework/AzCore/AzCore/Task/TaskExecutor.cpp(47,17): error C2220: the following warning is treated as an error [D:\\workspace\\o3de\\build\\windows_vs2019\\Code\\Framework\\AzCore\\AzCore.vcxproj]"
+        ],
+        "owners": []
+      },
+      {
+        "name": "Local variable is initialized but not referenced",
+        "description": "Warning C4189: local variable is initialized but not referenced. This warning is a result of an unused variable or parameter, see https://github.com/aws-lumberyard/build-failure-rca/blob/main/build-failure-rca/docs/warning_c4189.md for details",
+        "comment": "",
+        "single_line": true,
+        "find_all": true,
+        "log_patterns": [
+          "^.*warning C4189: '[\\w]*': local variable is initialized but not referenced.*$"
+        ],
+        "log_testcases": [
+          "D:/workspace/o3de/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp(301,30): warning C4189: 'success': local variable is initialized but not referenced"
+        ],
+        "owners": []
+      }
+    ]
+  }

--- a/scripts/build/build_failure_rca/rca_patterns/Test.json
+++ b/scripts/build/build_failure_rca/rca_patterns/Test.json
@@ -1,0 +1,19 @@
+{
+    "indications": [
+      {
+        "name": "CTest failure(s)/error(s)",
+        "description": "Errors while running CTest",
+        "comment": "Errors while running CTest",
+        "single_line": false,
+        "find_all": false,
+        "log_patterns": [
+          "The following tests FAILED:.*Errors while running CTest"
+        ],
+        "log_testcases": [
+          "The following tests FAILED:"
+        ],
+        "owners": []
+      }
+    ]
+  }
+  


### PR DESCRIPTION
Add build failure RCA patterns in O3DE repo. Build failure RCA lambda functions will read these patterns using Github API.

RFC: https://github.com/o3de/sig-build/blob/main/rfcs/rfc-bld-20220623-1-build-failure-rca.md