### PR TITLE
Adding Native Visualization entry for the Dom PrefixTree.

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
+++ b/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
@@ -720,20 +720,6 @@
     <Expand/>
   </Type>
 
-  <Type Name="AZStd::nullopt_t">
-    <DisplayString>nullopt</DisplayString>
-  </Type>
-
-  <Type Name="AZStd::optional&lt;*&gt;">
-    <Intrinsic Name="has_value" Expression="this-&gt;m_engaged"/>
-    <Intrinsic Name="value" Expression="this-&gt;m_object"/>
-    <DisplayString Condition="!has_value()">nullopt</DisplayString>
-    <DisplayString Condition="has_value()">{value()}</DisplayString>
-    <Expand>
-      <Item Condition="has_value()" Name="value">value()</Item>
-    </Expand>
-  </Type>
-
   <Type Name="AZStd::variant_detail::alternative_impl&lt;*,*&gt;">
     <DisplayString>{m_value}</DisplayString>
   </Type>
@@ -741,38 +727,72 @@
   <Type Name="AZStd::variant&lt;*&gt;">
     <Intrinsic Name="index" Expression="(size_t)m_impl.m_index"/>
     <DisplayString Condition="index() == AZStd::variant_npos">[valueless]</DisplayString>
-    <DisplayString Condition="index() == 0" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 1" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 2" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 3" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 4" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 5" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 6" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 7" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 8" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 9" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 10" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 11" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 12" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 13" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 14" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 15" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 16" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 17" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 18" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 19" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 20" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 21" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 22" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 23" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 24" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 25" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 26" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 27" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 28" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 29" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 30" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
-    <DisplayString Condition="index() == 31" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <!-- Shows the value of the selected variant alternative without any other formatting. Available when the simple view is used !-->
+    <DisplayString IncludeView="simple" Condition="index() == 0" Optional="true">{m_impl.m_union_data.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 1" Optional="true">{m_impl.m_union_data.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 2" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 3" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 4" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 5" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 6" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 7" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 8" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 9" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 10" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 11" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 12" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 13" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 14" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 15" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 16" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 17" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 18" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 19" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 20" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 21" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 22" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 23" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 24" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 25" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 26" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 27" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 28" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 29" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 30" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <DisplayString IncludeView="simple" Condition="index() == 31" Optional="true">{m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head}</DisplayString>
+    <!-- Shows the elements of the variant with the index of the alternative. It is not used in simple views !-->
+    <DisplayString ExcludeView="simple" Condition="index() == 0" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 1" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 2" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 3" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 4" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 5" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 6" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 7" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 8" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 9" Optional="true"> {{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 10" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 11" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 12" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 13" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 14" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 15" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 16" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 17" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 18" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 19" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 20" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 21" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 22" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 23" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 24" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 25" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 26" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 27" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 28" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 29" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 30" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="index() == 31" Optional="true">{{ index={index()}, value={m_impl.m_union_data.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_tail.m_head} }}</DisplayString>
     <Expand>
       <Item Name="index">index()</Item>
       <Item Name="[value]" Condition="index() == 0" Optional="true">m_impl.m_union_data.m_head</Item>
@@ -905,6 +925,45 @@
             <ExpandedItem Condition="IsArray()">Array()</ExpandedItem>
             <ExpandedItem Condition="IsNode()">Node()</ExpandedItem>
             <ExpandedItem Condition="IsOpaque()">Opaque()</ExpandedItem>
+        </Expand>
+    </Type>
+
+    <Type Name="AZ::Dom::PathEntry">
+        <!-- Shows the DomPathEntry m_value variant using a view option of simple to only show the plain value !-->
+        <DisplayString>{m_value, view(simple)}</DisplayString>
+        <Expand>
+            <ExpandedItem>m_value</ExpandedItem>
+        </Expand>
+    </Type>
+
+    <Type Name="AZ::Dom::DomPrefixTree&lt;*&gt;::Node">
+        <DisplayString Condition="m_data.has_value()">{m_data}</DisplayString>
+        <Expand>
+            <CustomListItems>
+                <Variable Name="rootNode" InitialValue="this"/>
+                <Variable Name="prefixPathEntry" InitialValue="(AZ::Dom::PathEntry*)0"/>
+                <Variable Name="childPrefixNode" InitialValue="(AZ::Dom::DomPrefixTree&lt;$T1&gt;::Node*)0"/>
+                <Variable Name="listHead" InitialValue="(AZStd::Internal::list_node&lt;AZStd::pair&lt;AZ::Dom::PathEntry,AZ::Dom::DomPrefixTree&lt;$T1&gt;::Node&gt; &gt;*)(&amp;rootNode-&gt;m_values.m_data.m_list.m_head)"/>
+                <Variable Name="listNode" InitialValue="(AZStd::Internal::list_node&lt;AZStd::pair&lt;AZ::Dom::PathEntry,AZ::Dom::DomPrefixTree&lt;$T1&gt;::Node&gt; &gt;*)(listHead-&gt;m_next)"/>
+                <Loop>
+                    <!-- If the prefix tree child value hash table is empty(via checking the unordered_map list), then teminate iteration of the DomPrefixTree -->
+                    <Break Condition="listNode == listHead"/>
+                    <Exec>prefixPathEntry = &amp;listNode-&gt;m_value.first</Exec>
+                    <Exec>childPrefixNode = &amp;listNode-&gt;m_value.second</Exec>
+                    <Item Name="{*prefixPathEntry}">*childPrefixNode</Item>
+                    <Exec>listNode = (AZStd::Internal::list_node&lt;AZStd::pair&lt;AZ::Dom::PathEntry,AZ::Dom::DomPrefixTree&lt;$T1&gt;::Node&gt; &gt;*)(listNode-&gt;m_next)</Exec>
+                </Loop>
+            </CustomListItems>
+        </Expand>
+    </Type>
+
+    <!-- Protip - Natvis uses pre-C++11 parsing of templates as it concerns the double greater than symbol token(>>)
+    It still parses it as a the right shift operator, whether than two template closing braces. So a space is needed between
+    two consecutive &gt; tokens in that case -->
+    <Type Name="AZ::Dom::DomPrefixTree&lt;*&gt;">
+        <DisplayString Condition="m_rootNode.m_data.has_value()">{m_rootNode.m_data}</DisplayString>
+        <Expand>
+            <Item Condition="m_rootNode.m_data.has_value()" Name="&quot;&quot;">m_rootNode</Item>
         </Expand>
     </Type>
 


### PR DESCRIPTION

Added a simple view DisplayString for `AZStd::variant to remove the index
from being displayed.

The DomPathEntry uses that simple view for AZStd::variant

Removed the `AZStd::optional` and `AZStd::nullopt_t` entries as those are no
longer used. The MSVC toolset std::optional and std::nullopt_t entries
are used since we alias those classes into the AZStd namespace from std.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## What does this PR do?

Adds natvis entries for the DOM PrefixTree class for visualizing the associated prefixes.

![image](https://user-images.githubusercontent.com/56135373/181359090-3bdfb146-cfd4-46e4-8ef8-999ed4e6cebb.png)

## How was this PR tested?

By looking at a Dom::PrefixTree in the watch window
