### PR TITLE
[LYN-14130] Asset Processor - Removed job grace period and fingerprint-changing wait

### DIFF
--- a/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.h
+++ b/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.h
@@ -729,7 +729,7 @@ namespace AssetBuilderSDK
         JobDescriptor m_jobDescription; ///! job descriptor for this job.  Note that this still contains the job parameters from when you emitted it during CreateJobs
         PlatformInfo m_platformInfo; ///! the information about the platform that this job was emitted for.
         AZStd::string m_tempDirPath; // temp directory that the builder should use to create job outputs for this job request
-        AZ::u64 m_jobId; ///! job id for this job, this is also the address for the JobCancelListener
+        AZ::u64 m_jobId{}; ///! job id for this job, this is also the address for the JobCancelListener
         AZ::Uuid m_sourceFileUUID; ///! the UUID of the source file.  Will be used as the uuid of the AssetID of the product when combined with the subID.
         AZStd::vector<SourceFileDependency> m_sourceFileDependencyList;
 

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
@@ -371,7 +371,10 @@ namespace AssetProcessor
             // We will only continue once we get exclusive lock on the source file
             while (!AssetUtilities::CheckCanLock(inputFile))
             {
+                // Wait for a while before checking again, we need to let some time pass for the other process to finish whatever work it is doing
                 QThread::msleep(g_sleepDurationForLockingAndFingerprintChecking);
+
+                // If AP shutdown is requested, the job is canceled or we exceeded the max wait time, abort the loop and mark the job as canceled
                 if (listener.WasQuitRequested() || cancelListener.IsCancelled() || (ticker.elapsed() > g_jobMaximumWaitTime))
                 {
                     result.m_resultCode = AssetBuilderSDK::ProcessJobResult_Cancelled;

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
@@ -5,9 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #include "rcjob.h"
-
-
 
 #include <AzToolsFramework/UI/Logging/LogLine.h>
 
@@ -20,7 +19,6 @@
 #include "native/utilities/JobDiagnosticTracker.h"
 
 #include <qstorageinfo.h>
-
 
 namespace
 {
@@ -277,12 +275,12 @@ namespace AssetProcessor
     {
         // the following trace can be uncommented if there is a need to deeply inspect job running.
         //AZ_TracePrintf(AssetProcessor::DebugChannel, "JobTrace Start(%i %s,%s,%s)\n", this, GetInputFileAbsolutePath().toUtf8().data(), GetPlatform().toUtf8().data(), GetJobKey().toUtf8().data());
-        
+
         AssetUtilities::QuitListener listener;
         listener.BusConnect();
         RCParams rc(this);
         BuilderParams builderParams(this);
-        
+
         //Create the process job request
         AssetBuilderSDK::ProcessJobRequest processJobRequest;
         PopulateProcessJobRequest(processJobRequest);
@@ -342,7 +340,7 @@ namespace AssetProcessor
 
         // Signal start and end of the job
         ScopedJobSignaler signaler;
-        
+
         // listen for the user quitting (CTRL-C or otherwise)
         AssetUtilities::QuitListener listener;
         listener.BusConnect();
@@ -382,7 +380,7 @@ namespace AssetProcessor
                 }
             }
         }
-            
+
         Q_EMIT builderParams.m_rcJob->BeginWork();
         // We will actually start working on the job after this point and even if RcController gets the same job again, we will put it in the queue for processing
         builderParams.m_rcJob->DoWork(result, builderParams, listener);


### PR DESCRIPTION
## What does this PR do?

Fixes an issue with AP jobs piling up as a result of many rapid changes to a file.

This block of code was really not serving any purpose.  If the fingerprint of a file changed, AP would pick up the file change and trigger another job anyway.  rccontroller would attempt to cancel the already-running job but this would fail since there was no listener set up at this point.
By removing this block, AP is much more responsive to rapidly changing files with no apparent downsides.

Note that testing also showed that a file which was opened for write with no shared access (exclusive write) would fail at the CreateJobs stage since the file can't be opened to even create the job, further making this code useless since it wasn't even possible to get to this code while the file was still locked.

## How was this PR tested?

Manual testing with material editor auto save feature set to an interval of 1ms as well as a custom program which opened a file for write, wrote + flushed contents every 25ms in a 5 second loop.
