### PR TITLE
Added GradientBakerRequestBus so we can expose the gradient baker to script

### DIFF
--- a/Gems/GradientSignal/Code/Include/GradientSignal/Editor/EditorGradientBakerComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Editor/EditorGradientBakerComponent.h
@@ -22,6 +22,7 @@
 #include <GradientSignal/Ebuses/GradientPreviewContextRequestBus.h>
 #include <GradientSignal/Ebuses/GradientRequestBus.h>
 #include <GradientSignal/Ebuses/SectorDataRequestBus.h>
+#include <GradientSignal/Editor/EditorGradientBakerRequestBus.h>
 #include <GradientSignal/Editor/EditorGradientTypeIds.h>
 #include <GradientSignal/GradientSampler.h>
 
@@ -30,13 +31,6 @@
 
 namespace GradientSignal
 {
-    enum class OutputFormat : AZ::u8
-    {
-        R8,
-        R16,
-        R32
-    };
-
     class GradientBakerConfig : public AZ::ComponentConfig
     {
     public:
@@ -86,6 +80,7 @@ namespace GradientSignal
         : public AzToolsFramework::Components::EditorComponentBase
         , private AzToolsFramework::EntitySelectionEvents::Bus::Handler
         , private GradientRequestBus::Handler
+        , private GradientBakerRequestBus::Handler
         , private GradientPreviewContextRequestBus::Handler
         , private LmbrCentral::DependencyNotificationBus::Handler
         , private SectorDataNotificationBus::Handler
@@ -108,6 +103,17 @@ namespace GradientSignal
         float GetValue(const GradientSampleParams& sampleParams) const override;
         void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
         bool IsEntityInHierarchy(const AZ::EntityId& entityId) const override;
+
+        //! GradientBakerRequestBus overrides ...
+        AZ::EntityId GetInputBounds() const override;
+        void SetInputBounds(const AZ::EntityId& inputBounds) override;
+        AZ::Vector2 GetOutputResolution() const override;
+        void SetOutputResolution(const AZ::Vector2& resolution) override;
+        OutputFormat GetOutputFormat() const override;
+        void SetOutputFormat(OutputFormat outputFormat) override;
+        AZ::IO::Path GetOutputImagePath() const override;
+        void SetOutputImagePath(const AZ::IO::Path& outputImagePath) override;
+        void BakeImage() override;
 
         //! LmbrCentral::DependencyNotificationBus overrides ...
         void OnCompositionChanged() override;
@@ -144,7 +150,6 @@ namespace GradientSignal
 
         void SetupDependencyMonitor();
 
-        void BakeImage();
         void StartBakeImageJob();
         bool IsBakeDisabled() const;
 

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Editor/EditorGradientBakerRequestBus.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Editor/EditorGradientBakerRequestBus.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+
+#include <GradientSignal/Util.h>
+
+namespace GradientSignal
+{
+    enum class OutputFormat : AZ::u8
+    {
+        R8,
+        R16,
+        R32
+    };
+
+    class GradientBakerRequests
+        : public AZ::ComponentBus
+    {
+    public:
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+
+        virtual void BakeImage() = 0;
+
+        virtual AZ::EntityId GetInputBounds() const = 0;
+        virtual void SetInputBounds(const AZ::EntityId& inputBounds) = 0;
+
+        virtual AZ::Vector2 GetOutputResolution() const = 0;
+        virtual void SetOutputResolution(const AZ::Vector2& resolution) = 0;
+
+        virtual OutputFormat GetOutputFormat() const = 0;
+        virtual void SetOutputFormat(OutputFormat outputFormat) = 0;
+
+        virtual AZ::IO::Path GetOutputImagePath() const = 0;
+        virtual void SetOutputImagePath(const AZ::IO::Path& outputImagePath) = 0;
+    };
+
+    using GradientBakerRequestBus = AZ::EBus<GradientBakerRequests>;
+}

--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientBakerComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientBakerComponent.cpp
@@ -380,6 +380,30 @@ namespace GradientSignal
                     ;
             }
         }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<EditorGradientBakerComponent>()->RequestBus("GradientBakerRequestBus");
+
+            behaviorContext->EBus<GradientBakerRequestBus>("GradientBakerRequestBus")
+                ->Attribute(AZ::Script::Attributes::Category, "Gradient")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Module, "gradient")
+                ->Event("BakeImage", &GradientBakerRequests::BakeImage)
+                ->Event("GetInputBounds", &GradientBakerRequests::GetInputBounds)
+                ->Event("SetInputBounds", &GradientBakerRequests::SetInputBounds)
+                ->VirtualProperty("InputBounds", "GetInputBounds", "SetInputBounds")
+                ->Event("GetOutputResolution", &GradientBakerRequests::GetOutputResolution)
+                ->Event("SetOutputResolution", &GradientBakerRequests::SetOutputResolution)
+                ->VirtualProperty("OutputResolution", "GetOutputResolution", "SetOutputResolution")
+                ->Event("GetOutputFormat", &GradientBakerRequests::GetOutputFormat)
+                ->Event("SetOutputFormat", &GradientBakerRequests::SetOutputFormat)
+                ->VirtualProperty("OutputFormat", "GetOutputFormat", "SetOutputFormat")
+                ->Event("GetOutputImagePath", &GradientBakerRequests::GetOutputImagePath)
+                ->Event("SetOutputImagePath", &GradientBakerRequests::SetOutputImagePath)
+                ->VirtualProperty("OutputImagePath", "GetOutputImagePath", "SetOutputImagePath")
+                ;
+        }
     }
 
     void EditorGradientBakerComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& services)
@@ -414,6 +438,8 @@ namespace GradientSignal
         // Setup the dependency monitor and listen for gradient requests
         SetupDependencyMonitor();
 
+        GradientBakerRequestBus::Handler::BusConnect(GetEntityId());
+
         UpdatePreviewSettings();
 
         // If we have a valid output image path set and the other criteria for baking
@@ -434,6 +460,8 @@ namespace GradientSignal
     {
         // Disconnect from GradientRequestBus first to ensure no queries are in process when deactivating.
         GradientRequestBus::Handler::BusDisconnect();
+
+        GradientBakerRequestBus::Handler::BusDisconnect();
 
         m_dependencyMonitor.Reset();
 
@@ -617,6 +645,54 @@ namespace GradientSignal
     bool EditorGradientBakerComponent::IsEntityInHierarchy(const AZ::EntityId& entityId) const
     {
         return m_configuration.m_gradientSampler.IsEntityInHierarchy(entityId);
+    }
+
+    AZ::EntityId EditorGradientBakerComponent::GetInputBounds() const
+    {
+        return m_configuration.m_inputBounds;
+    }
+
+    void EditorGradientBakerComponent::SetInputBounds(const AZ::EntityId& inputBounds)
+    {
+        m_configuration.m_inputBounds = inputBounds;
+
+        LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+    }
+
+    AZ::Vector2 EditorGradientBakerComponent::GetOutputResolution() const
+    {
+        return m_configuration.m_outputResolution;
+    }
+
+    void EditorGradientBakerComponent::SetOutputResolution(const AZ::Vector2& resolution)
+    {
+        m_configuration.m_outputResolution = resolution;
+
+        LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+    }
+
+    OutputFormat EditorGradientBakerComponent::GetOutputFormat() const
+    {
+        return m_configuration.m_outputFormat;
+    }
+
+    void EditorGradientBakerComponent::SetOutputFormat(OutputFormat outputFormat)
+    {
+        m_configuration.m_outputFormat = outputFormat;
+
+        LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+    }
+
+    AZ::IO::Path EditorGradientBakerComponent::GetOutputImagePath() const
+    {
+        return m_configuration.m_outputImagePath;
+    }
+
+    void EditorGradientBakerComponent::SetOutputImagePath(const AZ::IO::Path& outputImagePath)
+    {
+        m_configuration.m_outputImagePath = outputImagePath;
+
+        LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
     }
 
     void EditorGradientBakerComponent::OnSectorDataConfigurationUpdated() const

--- a/Gems/GradientSignal/Code/Tests/EditorGradientSignalBakerTests.cpp
+++ b/Gems/GradientSignal/Code/Tests/EditorGradientSignalBakerTests.cpp
@@ -181,6 +181,12 @@ namespace UnitTest
         TestBakeImage(".png", GradientSignal::OutputFormat::R8, AZ::Vector2(10.0f), true, inputBounds);
     }
 
+    TEST_F(EditorGradientSignalBakerTestsFixture, NonSquareOutputResolution)
+    {
+        // Verify we support output resolutions where the width isn't equal to the height
+        TestBakeImage(".png", GradientSignal::OutputFormat::R8, AZ::Vector2(13.0f, 37.0f));
+    }
+
     TEST_F(EditorGradientSignalBakerTestsFixture, BakedImage_PNG_R8)
     {
         TestBakeImage(".png", GradientSignal::OutputFormat::R8);

--- a/Gems/GradientSignal/Code/gradientsignal_editor_files.cmake
+++ b/Gems/GradientSignal/Code/gradientsignal_editor_files.cmake
@@ -8,6 +8,7 @@
 
 set(FILES
     Include/GradientSignal/Editor/EditorGradientBakerComponent.h
+    Include/GradientSignal/Editor/EditorGradientBakerRequestBus.h
     Include/GradientSignal/Editor/EditorGradientComponentBase.h
     Include/GradientSignal/Editor/EditorGradientComponentBase.inl
     Include/GradientSignal/Editor/EditorGradientPreviewRenderer.h


### PR DESCRIPTION
## What does this PR do?

Added `GradientBakerRequestBus` with APIs to get/set the appropriate fields on the gradient baker and also an event for initiating the bake action. Also added a unit test for verifying support for output resolutions of non-square resolution.

## How was this PR tested?

Tested new APIs from python script and ran unit tests.
