### PR TITLE
Fix ScriptCanvas Editor node flickering issue

### DIFF
--- a/Gems/GraphCanvas/Code/Source/Widgets/NodePropertyDisplayWidget.cpp
+++ b/Gems/GraphCanvas/Code/Source/Widgets/NodePropertyDisplayWidget.cpp
@@ -48,8 +48,6 @@ namespace GraphCanvas
     {
         ClearLayout();
         delete m_nodePropertyDisplay;
-
-        AZ::SystemTickBus::Handler::BusDisconnect();
     }
 
     void NodePropertyDisplayWidget::RefreshStyle()
@@ -57,14 +55,6 @@ namespace GraphCanvas
         if (m_nodePropertyDisplay)
         {
             m_nodePropertyDisplay->RefreshStyle();
-        }
-    }
-
-    void NodePropertyDisplayWidget::OnSystemTick()
-    {
-        if (m_nodePropertyDisplay)
-        {
-            NodeUIRequestBus::Event(m_nodePropertyDisplay->GetNodeId(), &NodeUIRequests::AdjustSize);
         }
     }
 
@@ -188,8 +178,6 @@ namespace GraphCanvas
             return;
         }
 
-        ClearLayout();
-        
         if (m_nodePropertyDisplay == nullptr)
         {
             return;
@@ -201,6 +189,9 @@ namespace GraphCanvas
         // remove an item from the scene while that is in progress, it can crash since it is
         // still internally using a cached list of the scene items.
         QTimer::singleShot(0, this, [this, isForcedEdit]() {
+            // There is only one m_layoutItem in m_layout, so we are ok to clear layout in this timer event
+            ClearLayout();
+
             // Element here needs to be removed from the scene since removing it from the layout
             // doesn't actually remove it from the scene. The end result of this is you get an elements
             // which is still being rendered, and acts like it's apart of the layout despite not being
@@ -272,7 +263,5 @@ namespace GraphCanvas
             m_layoutItem->updateGeometry();
             m_layout->invalidate();
         }
-
-        AZ::SystemTickBus::Handler::BusConnect();
     }
 }

--- a/Gems/GraphCanvas/Code/Source/Widgets/NodePropertyDisplayWidget.h
+++ b/Gems/GraphCanvas/Code/Source/Widgets/NodePropertyDisplayWidget.h
@@ -12,7 +12,6 @@
 #include <QTimer>
 
 #include <AzCore/Component/EntityId.h>
-#include <AzCore/Component/TickBus.h>
 
 #include <GraphCanvas/Components/Nodes/NodeUIBus.h>
 #include <GraphCanvas/Components/Slots/SlotBus.h>
@@ -30,7 +29,6 @@ namespace GraphCanvas
         , public RootGraphicsItemNotificationBus::Handler
         , public NodePropertiesRequestBus::Handler
         , public NodePropertyRequestBus::Handler
-        , public AZ::SystemTickBus::Handler
     {
     public:
         AZ_CLASS_ALLOCATOR(NodePropertyDisplayWidget, AZ::SystemAllocator, 0);
@@ -39,10 +37,6 @@ namespace GraphCanvas
         ~NodePropertyDisplayWidget() override;
 
         void RefreshStyle();
-
-        // AZ::SystemTickBus
-        void OnSystemTick() override;
-        ////
 
         // RootGraphicsItemNotificationBus
         void OnDisplayStateChanged(RootGraphicsItemDisplayState oldState, RootGraphicsItemDisplayState newState) override;


### PR DESCRIPTION
## What does this PR do?

Thanks to @cgalvan with his shared information. As ScriptCanvas node has edit and read-only widget, when hovering mouse over the node, node needs to switch between above two modes. And with extra resizeEvent getting triggered, we are able to see the weird flickering behavior.

## How was this PR tested?
Before fix

https://user-images.githubusercontent.com/5900509/181655632-b0c092b8-82f2-415c-a02a-f6b2efc8965a.mp4

With this PR change

https://user-images.githubusercontent.com/5900509/181655656-e50afdc5-aa99-40cd-b6ec-851a658c3409.mp4



Signed-off-by: onecent1101 <liug@amazon.com>
