### PR TITLE
chore: update LmbrCentral remove usage of VectorConversions

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Ai/EditorNavigationAreaComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Ai/EditorNavigationAreaComponent.cpp
@@ -10,7 +10,6 @@
 
 #include "EditorNavigationUtil.h"
 #include <AzCore/Component/TransformBus.h>
-#include <AzCore/Math/VectorConversions.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <LmbrCentral/Shape/PolygonPrismShapeComponentBus.h>
@@ -197,7 +196,7 @@ namespace LmbrCentral
 
                 for (size_t i = 0; i < vertexCount; ++i)
                 {
-                    verticesWorld.push_back(transform.TransformPoint(AZ::Vector2ToVector3(verticesLocal[i])));
+                    verticesWorld.push_back(transform.TransformPoint(AZ::Vector3(verticesLocal[i])));
                 }
 
                 // The volume could be set but if the binary data didn't exist the volume was not correctly recreated

--- a/Gems/LmbrCentral/Code/Source/Shape/PolygonPrismShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/PolygonPrismShape.cpp
@@ -11,7 +11,6 @@
 #include <AzCore/Math/Aabb.h>
 #include <AzCore/Math/IntersectSegment.h>
 #include <AzCore/Math/Transform.h>
-#include <AzCore/Math/VectorConversions.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
@@ -86,8 +85,8 @@ namespace LmbrCentral
         for (size_t i = 0; i < vertexCount; ++i)
         {
             // local vertex positions
-            const AZ::Vector3 currentPoint = nonUniformScale * AZ::Vector2ToVector3(vertices[i]);
-            const AZ::Vector3 nextPoint = nonUniformScale * AZ::Vector2ToVector3(vertices[(i + 1) % vertexCount]);
+            const AZ::Vector3 currentPoint = nonUniformScale * AZ::Vector3(vertices[i]);
+            const AZ::Vector3 nextPoint = nonUniformScale * AZ::Vector3(vertices[(i + 1) % vertexCount]);
             const AZ::Vector3 p1 = currentPoint + bottomVector;
             const AZ::Vector3 p2 = nextPoint + bottomVector;
             const AZ::Vector3 p3 = currentPoint + topVector;
@@ -125,22 +124,22 @@ namespace LmbrCentral
         for (size_t i = 0; i < verticalLineCount; ++i)
         {
             // vertical line
-            lines[lineVertIndex++] = nonUniformScale * AZ::Vector2ToVector3(vertices[i]);
-            lines[lineVertIndex++] = nonUniformScale * AZ::Vector2ToVector3(vertices[i], height);
+            lines[lineVertIndex++] = nonUniformScale * AZ::Vector3(vertices[i]);
+            lines[lineVertIndex++] = nonUniformScale * AZ::Vector3(vertices[i], height);
         }
 
         for (size_t i = 0; i < horizontalLineCount; ++i)
         {
             // bottom line
-            lines[lineVertIndex++] = nonUniformScale * AZ::Vector2ToVector3(vertices[i]);
-            lines[lineVertIndex++] = nonUniformScale * AZ::Vector2ToVector3(vertices[(i + 1) % vertexCount]);
+            lines[lineVertIndex++] = nonUniformScale * AZ::Vector3(vertices[i]);
+            lines[lineVertIndex++] = nonUniformScale * AZ::Vector3(vertices[(i + 1) % vertexCount]);
         }
 
         for (size_t i = 0; i < horizontalLineCount; ++i)
         {
             // top line
-            lines[lineVertIndex++] = nonUniformScale * AZ::Vector2ToVector3(vertices[i], height);
-            lines[lineVertIndex++] = nonUniformScale * AZ::Vector2ToVector3(vertices[(i + 1) % vertexCount], height);
+            lines[lineVertIndex++] = nonUniformScale * AZ::Vector3(vertices[i], height);
+            lines[lineVertIndex++] = nonUniformScale * AZ::Vector3(vertices[(i + 1) % vertexCount], height);
         }
     }
 
@@ -514,8 +513,8 @@ namespace LmbrCentral
             // (odd number of intersections - inside, even number of intersections - outside)
             for (size_t i = 0; i < vertexCount; ++i)
             {
-                const AZ::Vector3 segmentStart = AZ::Vector2ToVector3(vertices[i]);
-                const AZ::Vector3 segmentEnd = AZ::Vector2ToVector3(vertices[(i + 1) % vertexCount]);
+                const AZ::Vector3 segmentStart = AZ::Vector3(vertices[i]);
+                const AZ::Vector3 segmentEnd = AZ::Vector3(vertices[(i + 1) % vertexCount]);
 
                 AZ::Vector3 closestPosRay, closestPosSegment;
                 float rayProportion, segmentProportion;
@@ -599,8 +598,8 @@ namespace LmbrCentral
             float minDistanceSq = std::numeric_limits<float>::max();
             for (size_t i = 0; i < vertexCount; ++i)
             {
-                const AZ::Vector3 segmentStart = combinedScale * AZ::Vector2ToVector3(vertices[i]);
-                const AZ::Vector3 segmentEnd = combinedScale * AZ::Vector2ToVector3(vertices[(i + 1) % vertexCount]);
+                const AZ::Vector3 segmentStart = combinedScale * AZ::Vector3(vertices[i]);
+                const AZ::Vector3 segmentEnd = combinedScale * AZ::Vector3(vertices[(i + 1) % vertexCount]);
 
                 AZ::Vector3 position;
                 float proportion;

--- a/Gems/LmbrCentral/Code/Source/Shape/ShapeGeometryUtil.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/ShapeGeometryUtil.cpp
@@ -10,7 +10,6 @@
 
 #include <AzCore/Math/IntersectPoint.h>
 #include <AzCore/Math/IntersectSegment.h>
-#include <AzCore/Math/VectorConversions.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <Shape/ShapeDisplay.h>
@@ -77,10 +76,10 @@ namespace LmbrCentral
                 float aa, bb;
                 AZ::Vector3 a, b;
                 AZ::Intersect::ClosestSegmentSegment(
-                    AZ::Vector2ToVector3(vertices[i]),
-                    AZ::Vector2ToVector3(vertices[(i + 1) % vertexCount]),
-                    AZ::Vector2ToVector3(vertices[j]),
-                    AZ::Vector2ToVector3(vertices[(j + 1) % vertexCount]),
+                    AZ::Vector3(vertices[i]),
+                    AZ::Vector3(vertices[(i + 1) % vertexCount]),
+                    AZ::Vector3(vertices[j]),
+                    AZ::Vector3(vertices[(j + 1) % vertexCount]),
                     aa, bb, a, b);
 
                 if ((a - b).GetLength() < 0.001f)
@@ -169,10 +168,10 @@ namespace LmbrCentral
                     for (size_t j = (nextIndex + 1) % vertices.size(); j != prevIndex; j = (j + 1) % vertices.size())
                     {
                         if (AZ::Intersect::TestPointTriangle(
-                            AZ::Vector2ToVector3(vertices[j]),
-                            AZ::Vector2ToVector3(prev),
-                            AZ::Vector2ToVector3(curr),
-                            AZ::Vector2ToVector3(next)))
+                            AZ::Vector3(vertices[j]),
+                            AZ::Vector3(prev),
+                            AZ::Vector3(curr),
+                            AZ::Vector3(next)))
                         {
                             pointInside = true;
                             break;
@@ -186,9 +185,9 @@ namespace LmbrCentral
                 }
 
                 // form new triangle from 'ear'
-                triangles.push_back(AZ::Vector2ToVector3(prev));
-                triangles.push_back(AZ::Vector2ToVector3(curr));
-                triangles.push_back(AZ::Vector2ToVector3(next));
+                triangles.push_back(AZ::Vector3(prev));
+                triangles.push_back(AZ::Vector3(curr));
+                triangles.push_back(AZ::Vector3(next));
 
                 // if work is still do be done, remove vertex from list and iterate again
                 if (vertices.size() > 3)


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

remove usage of VectorConversions from LmbrCentral


