### PR TITLE
Fix the root motion extraction rotation problem

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
@@ -179,6 +179,11 @@ namespace AZ::Render
             RenderTrajectoryPath(debugDisplay, instance, renderActorSettings.m_trajectoryHeadColor, renderActorSettings.m_trajectoryPathColor);
         }
 
+        if (CheckBitsAny(renderFlags, EMotionFX::ActorRenderFlags::RootMotion))
+        {
+            RenderRootMotion(debugDisplay, instance, AZ::Colors::Red);
+        }
+
         // Render vertex normal, face normal, tagent and wireframe.
         const bool renderVertexNormals = CheckBitsAny(renderFlags, EMotionFX::ActorRenderFlags::VertexNormals);
         const bool renderFaceNormals = CheckBitsAny(renderFlags, EMotionFX::ActorRenderFlags::FaceNormals);
@@ -1208,5 +1213,21 @@ namespace AZ::Render
             oldLeft = vertices[2];
             oldRight = vertices[3];
         }
+    }
+
+    void AtomActorDebugDraw::RenderRootMotion(AzFramework::DebugDisplayRequests* debugDisplay,
+        const EMotionFX::ActorInstance* actorInstance,
+        const AZ::Color& rootColor)
+    {
+        const AZ::Transform actorTransform = actorInstance->GetWorldSpaceTransform().ToAZTransform();
+
+        // Render two circle around the character position.
+        debugDisplay->SetColor(rootColor);
+        debugDisplay->DrawCircle(actorTransform.GetTranslation(), 1.0f);
+        debugDisplay->DrawCircle(actorTransform.GetTranslation(), 0.05f);
+
+        // Render the character facing direction.
+        const AZ::Vector3 forward = actorTransform.GetBasisY();
+        debugDisplay->DrawArrow(actorTransform.GetTranslation(), actorTransform.GetTranslation() + forward);
     }
 } // namespace AZ::Render

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.h
@@ -107,6 +107,10 @@ namespace AZ::Render
             const EMotionFX::ActorInstance* actorInstance,
             const AZ::Color& headColor,
             const AZ::Color& pathColor);
+        void RenderRootMotion(
+            AzFramework::DebugDisplayRequests* debugDisplay,
+            const EMotionFX::ActorInstance* actorInstance,
+            const AZ::Color& rootColor);
         // Return a non-owning trajectory path pointer.
         TrajectoryTracePath* FindTrajectoryPath(const EMotionFX::ActorInstance* actorInstance);
         EMotionFX::Mesh* m_currentMesh = nullptr; //!< A pointer to the mesh whose world space positions are in the pre-calculated positions buffer.

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportToolBar.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportToolBar.cpp
@@ -93,6 +93,7 @@ namespace EMStudio
 
             contextMenu->addSeparator();
             CreateViewOptionEntry(contextMenu, "Motion Extraction", EMotionFX::ActorRenderFlagIndex::MOTIONEXTRACTION);
+            CreateViewOptionEntry(contextMenu, "Root Motion", EMotionFX::ActorRenderFlagIndex::ROOTMOTION);
             CreateViewOptionEntry(contextMenu, "Debug Rendering", EMotionFX::ActorRenderFlagIndex::EMFX_DEBUG);
         }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/NonUniformMotionData.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/NonUniformMotionData.cpp
@@ -1238,12 +1238,21 @@ namespace EMotionFX
                 const float x = transitionZeroXAxis ? m_jointData[sampleJointDataIndex].m_positionTrack.m_values[i].GetX() : 0;
                 const float y = transitionZeroYAxis ? m_jointData[sampleJointDataIndex].m_positionTrack.m_values[i].GetY() : 0;
                 const float z = m_jointData[sampleJointDataIndex].m_positionTrack.m_values[i].GetZ();
-
                 m_jointData[sampleJointDataIndex].m_positionTrack.m_values[i].Set(x, y, z);
 
                 if (extractRotation)
                 {
-                    m_jointData[sampleJointDataIndex].m_rotationTrack.m_values[i].FromQuaternion(AZ::Quaternion::CreateIdentity());
+                    const AZ::Quaternion sampleJointRot = m_jointData[sampleJointDataIndex].m_rotationTrack.m_values[i].ToQuaternion();
+
+                    // Final root rotation only keeps the rotation around Z-axis
+                    const AZ::Vector3 rootRotEular = AZ::ConvertQuaternionToEulerRadians(sampleJointRot);
+                    const AZ::Quaternion finalRootRot = AZ::ConvertEulerRadiansToQuaternion(AZ::Vector3(0, 0, rootRotEular.GetZ()));
+
+                    // Calculate the final sample rotation
+                    AZ::Quaternion finalSampleRot = finalRootRot.GetInverseFull() * sampleJointRot;
+
+                    m_jointData[rootJointDataIndex].m_rotationTrack.m_values[i].FromQuaternion(finalRootRot);
+                    m_jointData[sampleJointDataIndex].m_rotationTrack.m_values[i].FromQuaternion(finalSampleRot);
                 }
             }
         }

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/NonUniformMotionData.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/NonUniformMotionData.cpp
@@ -1242,17 +1242,17 @@ namespace EMotionFX
 
                 if (extractRotation)
                 {
-                    const AZ::Quaternion sampleJointRot = m_jointData[sampleJointDataIndex].m_rotationTrack.m_values[i].ToQuaternion();
+                    const AZ::Quaternion sampleJointRotation = m_jointData[sampleJointDataIndex].m_rotationTrack.m_values[i].ToQuaternion();
 
                     // Final root rotation only keeps the rotation around Z-axis
-                    const AZ::Vector3 rootRotEular = AZ::ConvertQuaternionToEulerRadians(sampleJointRot);
-                    const AZ::Quaternion finalRootRot = AZ::ConvertEulerRadiansToQuaternion(AZ::Vector3(0, 0, rootRotEular.GetZ()));
+                    const AZ::Vector3 rootRotEuler = AZ::ConvertQuaternionToEulerRadians(sampleJointRotation);
+                    const AZ::Quaternion finalRootRotation = AZ::ConvertEulerRadiansToQuaternion(AZ::Vector3(0, 0, rootRotEuler.GetZ()));
 
                     // Calculate the final sample rotation
-                    AZ::Quaternion finalSampleRot = finalRootRot.GetInverseFull() * sampleJointRot;
+                    const AZ::Quaternion finalSampleRotation = finalRootRotation.GetInverseFull() * sampleJointRotation;
 
-                    m_jointData[rootJointDataIndex].m_rotationTrack.m_values[i].FromQuaternion(finalRootRot);
-                    m_jointData[sampleJointDataIndex].m_rotationTrack.m_values[i].FromQuaternion(finalSampleRot);
+                    m_jointData[rootJointDataIndex].m_rotationTrack.m_values[i].FromQuaternion(finalRootRotation);
+                    m_jointData[sampleJointDataIndex].m_rotationTrack.m_values[i].FromQuaternion(finalSampleRotation);
                 }
             }
         }

--- a/Gems/EMotionFX/Code/Source/Integration/Rendering/RenderFlag.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Rendering/RenderFlag.h
@@ -40,7 +40,8 @@ namespace EMotionFX
         SIMULATEDOBJECT_COLLIDERS = 21,
         SIMULATEJOINTS = 22,
         EMFX_DEBUG = 23,
-        NUM_RENDERFLAGINDEXES = 24
+        ROOTMOTION = 24,
+        NUM_RENDERFLAGINDEXES = 25
     };
 
     //! A set of combinable flags which indicate which render option in turned on for the actor.
@@ -70,7 +71,8 @@ namespace EMotionFX
         (ClothColliders, AZ_BIT(ActorRenderFlagIndex::CLOTH_COLLIDERS)),
         (SimulatedObjectColliders, AZ_BIT(ActorRenderFlagIndex::SIMULATEDOBJECT_COLLIDERS)),
         (SimulatedJoints, AZ_BIT(ActorRenderFlagIndex::SIMULATEJOINTS)),
-        (EmfxDebug, AZ_BIT(ActorRenderFlagIndex::EMFX_DEBUG))
+        (EmfxDebug, AZ_BIT(ActorRenderFlagIndex::EMFX_DEBUG)),
+        (RootMotion, AZ_BIT(ActorRenderFlagIndex::ROOTMOTION))
     );
 
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(ActorRenderFlags);


### PR DESCRIPTION
Fixed the problem that when rotation is enabled the character feet sink under the ground.
Before:
![image](https://user-images.githubusercontent.com/69218254/181704890-c0d73bc8-8b7d-464d-848b-b37639f17111.png)
After:
![image](https://user-images.githubusercontent.com/69218254/181704934-1b35f072-082e-466f-a97e-d17e27d19d69.png)
https://user-images.githubusercontent.com/69218254/181704634-c0de6960-8b5d-4277-af24-827b01350f36.mp4

Also added some debug rendering for root motion
