### PR TITLE
Fix crash with view bookmarks

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/LocalViewBookmarkLoader.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/LocalViewBookmarkLoader.cpp
@@ -507,6 +507,11 @@ namespace AzToolsFramework
     LocalViewBookmarkComponent* LocalViewBookmarkLoader::FindOrCreateLocalViewBookmarkComponent()
     {
         auto prefabEditorEntityOwnershipInterface = AZ::Interface<PrefabEditorEntityOwnershipInterface>::Get();
+        if (!prefabEditorEntityOwnershipInterface)
+        {
+            return nullptr;
+        }
+
         const AZ::EntityId containerEntityId = prefabEditorEntityOwnershipInterface->GetRootPrefabInstance()->get().GetContainerEntityId();
         if (!containerEntityId.IsValid())
         {


### PR DESCRIPTION
Signed-off-by: Tom Hulton-Harrop <82228511+hultonha@users.noreply.github.com>

## What does this PR do?

Fixes a crash bug when slices are enabled when using view bookmarks

Fixes https://github.com/o3de/o3de/issues/10305
Fixes https://github.com/o3de/o3de/issues/10305

## How was this PR tested?

Tested starting the Atom Sample Viewer project and verified the Editor did not crash
