### PR TITLE
DPE: Add item size caching and invalidation to DPELayout

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -46,6 +46,7 @@ namespace AzToolsFramework
         , m_depth(depth)
     {
     }
+
     DPELayout::~DPELayout()
     {
         if (m_expanderWidget)
@@ -91,8 +92,20 @@ namespace AzToolsFramework
         return m_expanded;
     }
 
+    void DPELayout::invalidate()
+    {
+        QHBoxLayout::invalidate();
+        m_cachedLayoutSize = QSize();
+        m_cachedMinLayoutSize = QSize();
+    }
+
     QSize DPELayout::sizeHint() const
     {
+        if (m_cachedLayoutSize.isValid())
+        {
+            return m_cachedLayoutSize;
+        }
+
         int cumulativeWidth = 0;
         int preferredHeight = 0;
 
@@ -104,11 +117,20 @@ namespace AzToolsFramework
             cumulativeWidth += widgetSizeHint.width();
             preferredHeight = AZStd::max(widgetSizeHint.height(), preferredHeight);
         }
+
+        m_cachedLayoutSize = QSize(cumulativeWidth, preferredHeight);
+
         return { cumulativeWidth, preferredHeight };
     }
 
     QSize DPELayout::minimumSize() const
     {
+        if (m_cachedMinLayoutSize.isValid())
+        {
+            return m_cachedMinLayoutSize;
+        }
+
+
         int cumulativeWidth = 0;
         int minimumHeight = 0;
 
@@ -127,6 +149,9 @@ namespace AzToolsFramework
                 minimumHeight = AZStd::max(widgetChild->sizeHint().height(), minimumHeight);
             }
         }
+
+        m_cachedMinLayoutSize = QSize(cumulativeWidth, minimumHeight);
+
         return { cumulativeWidth, minimumHeight };
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -43,6 +43,7 @@ namespace AzToolsFramework
         bool IsExpanded() const;
 
         // QLayout overrides
+        void invalidate() override;
         QSize sizeHint() const override;
         QSize minimumSize() const override;
         void setGeometry(const QRect& rect) override;
@@ -59,7 +60,13 @@ namespace AzToolsFramework
         bool m_showExpander = false;
         bool m_expanded = true;
         QCheckBox* m_expanderWidget = nullptr;
+
+    private:
+        // These cached sizes must be mutable since they are set inside of an overidden const function
+        mutable QSize m_cachedLayoutSize;
+        mutable QSize m_cachedMinLayoutSize;
     };
+
     class DPERowWidget : public QWidget
     {
         Q_OBJECT


### PR DESCRIPTION
**Description**
This PR changes `DPELayout` to cache `sizeHint` and `minimumSize` calculations and return those calculations until `QLayout::invalidate` is called.

If a cached value is present then it will be returned. If the cached value (a `QSize` member) is invalid then it will recalculate the layout size.

**Testing**

- Added logging statements to see when the functions were being called, and when cached values were returned/recalculated.
- Verified the DPE still works with some tif assets found in the AutomatedTesting project.
