### PR TITLE
Adding implementation of the Decompression Factory to the Compression Gem

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@
 /Code/Framework/AzGameFramework/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Code/LauncherUnified/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /engine.json @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/Gems/Compression/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Gems/CrashReporting/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Gems/ImGui/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Gems/LmbrCentral/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers

--- a/Gems/Compression/Code/Include/Compression/CompressionInterfaceAPI.h
+++ b/Gems/Compression/Code/Include/Compression/CompressionInterfaceAPI.h
@@ -62,9 +62,13 @@ namespace Compression
         AZ_RTTI(CompressionFactoryInterface, "{92251FE8-9D19-4A23-9A2B-F91D99D9491B}");
         virtual ~CompressionFactoryInterface() = default;
 
-        //! Returns a span containing all registered Compression Interfaces
-        //! @return view of registered Compression Interfaces.
-        virtual AZStd::span<ICompressionInterface* const> GetCompressionInterfaces() const = 0;
+
+        //! Callback function that is invoked for every registered compression interface
+        //! return true to indicate that visitation of compression interfaces should continue
+        //! returning false halts iteration
+        using VisitCompressionInterfaceCallback = AZStd::function<bool(ICompressionInterface&)>;
+        //! Invokes the supplied visitor for each register compression interface that is non-nullptr
+        virtual void VisitCompressionInterfaces(const VisitCompressionInterfaceCallback&) const = 0;
 
         //! Registers a compression interface with the compression factory.
         //! If a compression interface with a CompressionAlgorithmId is registered that

--- a/Gems/Compression/Code/Include/Compression/CompressionInterfaceStructs.h
+++ b/Gems/Compression/Code/Include/Compression/CompressionInterfaceStructs.h
@@ -18,4 +18,7 @@ namespace Compression
     constexpr CompressionAlgorithmId Uncompressed{};
     constexpr CompressionAlgorithmId Invalid{ AZStd::numeric_limits<AZ::u32>::max() };
 
+    // Implements the Relational Operators for the CompressionAlgorithmId class
+    // only for use in the CompressionFactoryImpl/DecompressionFactoryImpl class to allow it to be added to a set
+    AZ_DEFINE_ENUM_RELATIONAL_OPERATORS(CompressionAlgorithmId);
 } // namespace Compression

--- a/Gems/Compression/Code/Include/Compression/DecompressionInterfaceAPI.h
+++ b/Gems/Compression/Code/Include/Compression/DecompressionInterfaceAPI.h
@@ -63,9 +63,12 @@ namespace Compression
         AZ_RTTI(DecompressionFactoryInterface, "{DB1ACA55-B36F-469B-9704-EC486D9FC810}");
         virtual ~DecompressionFactoryInterface() = default;
 
-        //! Returns a span containing all registered Decompression Interfaces
-        //! @return view of registered Decompression Interfaces.
-        virtual AZStd::span<IDecompressionInterface* const> GetDecompressionInterfaces() const= 0;
+        //! Callback function that is invoked for every registered decompression interface
+        //! return true to indicate that visitation of decompression interfaces should continue
+        //! returning false halts iteration
+        using VisitDecompressionInterfaceCallback = AZStd::function<bool(IDecompressionInterface&)>;
+        //! Invokes the supplied visitor for each register decompression interface that is non-nullptr
+        virtual void VisitDecompressionInterfaces(const VisitDecompressionInterfaceCallback&) const = 0;
 
         //! Registers a decompression interface with the decompression factory.
         //! If a decompression interface with a CompressionAlgorithmId is registered that
@@ -80,7 +83,7 @@ namespace Compression
         //!
         //! @param compressionAlgorithmId unique Id that identifies the Decompression Interface
         //! @return true if the IDecompressionInterface was unregistered, otherwise false
-        virtual bool UnregisterCompressionInterface(CompressionAlgorithmId) = 0;
+        virtual bool UnregisterDecompressionInterface(CompressionAlgorithmId) = 0;
 
         //! Queries the Decompression Interface with the compression algorithmd Id
         //! @param compressionAlgorithmId unique Id of Decompression Interface to query

--- a/Gems/Compression/Code/Source/Clients/CompressionModule.cpp
+++ b/Gems/Compression/Code/Source/Clients/CompressionModule.cpp
@@ -10,6 +10,7 @@
 #include <CompressionModuleInterface.h>
 #include "CompressionSystemComponent.h"
 #include <Compression/DecompressionInterfaceAPI.h>
+#include "DecompressionFactoryImpl.h"
 
 namespace Compression
 {
@@ -20,9 +21,10 @@ namespace Compression
         AZ_RTTI(CompressionModule, "{6D256D91-6F1F-4132-B78E-6C24BA9D688C}", CompressionModuleInterface);
         AZ_CLASS_ALLOCATOR(CompressionModule, AZ::SystemAllocator, 0);
 
-         CompressionModule()
+        CompressionModule()
         {
             // Create and Register the Decompression Factory
+            m_decompressionFactoryInterface = AZStd::make_unique<DecompressionFactoryImpl>();
             if (DecompressionFactory::Get() == nullptr)
             {
                 DecompressionFactory::Register(m_decompressionFactoryInterface.get());

--- a/Gems/Compression/Code/Source/Clients/DecompressionFactoryImpl.cpp
+++ b/Gems/Compression/Code/Source/Clients/DecompressionFactoryImpl.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "DecompressionFactoryImpl.h"
+#include <AzCore/std/functional.h>
+#include <AzCore/std/ranges/ranges_algorithm.h>
+
+namespace Compression
+{
+    DecompressionFactoryImpl::~DecompressionFactoryImpl() = default;
+
+    void DecompressionFactoryImpl::VisitDecompressionInterfaces(const VisitDecompressionInterfaceCallback& callback) const
+    {
+        auto VisitInterface = [&callback](const AZStd::unique_ptr<IDecompressionInterface>& decompressionInterface)
+        {
+            return decompressionInterface != nullptr ? callback(*decompressionInterface) : true;
+        };
+
+        AZStd::ranges::all_of(m_decompressionInterfaces, VisitInterface);
+    }
+
+    bool DecompressionFactoryImpl::RegisterDecompressionInterface(AZStd::unique_ptr<IDecompressionInterface>&& decompressionInterface)
+    {
+        if (decompressionInterface == nullptr)
+        {
+            return false;
+        }
+
+        CompressionAlgorithmId compressionAlgorithmId = decompressionInterface->GetCompressionAlgorithmId();
+        const size_t compressionIndex = FindDecompressionIndex(compressionAlgorithmId);
+        if (compressionIndex < m_decompressionInterfaces.size())
+        {
+            return false;
+        }
+
+        // Insert new compression interface since it is not registered
+        m_decompressionInterfaces.emplace_back(AZStd::move(decompressionInterface));
+        const size_t emplaceIndex = m_decompressionInterfaces.size() - 1;
+
+        // Use UpperBound to find the insertion slot for the new entry within the compression index set
+        auto FindIdIndexEntry = [](const DecompressionIdIndexEntry& lhs, const DecompressionIdIndexEntry& rhs)
+        {
+            return lhs.m_id < rhs.m_id;
+        };
+        DecompressionIdIndexEntry newEntry{ compressionAlgorithmId, emplaceIndex };
+        m_decompressionIdIndexSet.insert(AZStd::upper_bound(m_decompressionIdIndexSet.begin(), m_decompressionIdIndexSet.end(),
+            newEntry, AZStd::move(FindIdIndexEntry)),
+            AZStd::move(newEntry));
+        return true;
+    }
+
+    bool DecompressionFactoryImpl::UnregisterDecompressionInterface(CompressionAlgorithmId compressionAlgorithmId)
+    {
+        const size_t compressionIndex = FindDecompressionIndex(compressionAlgorithmId);
+        if (compressionIndex < m_decompressionInterfaces.size())
+        {
+            auto oldInterfaceIter = m_decompressionInterfaces.begin() + compressionIndex;
+            m_decompressionInterfaces.erase(oldInterfaceIter);
+            return true;
+        }
+
+        return false;
+    }
+
+    IDecompressionInterface* DecompressionFactoryImpl::FindDecompressionInterface(CompressionAlgorithmId compressionAlgorithmId) const
+    {
+        const size_t compressionIndex = FindDecompressionIndex(compressionAlgorithmId);
+        return compressionIndex < m_decompressionInterfaces.size()
+            ? m_decompressionInterfaces[compressionIndex].get() : nullptr;
+    }
+
+    // find decompression index entry in vector
+    // returns the index into the m_decompressionInterfaces vector that matches the compression algorithm Id
+    // otherwise returns the size of the m_decompressionInterfaces container to indicate out of bounds
+    size_t DecompressionFactoryImpl::FindDecompressionIndex(CompressionAlgorithmId compressionAlgorithmId) const
+    {
+        auto FindIdIndexEntry = [](const DecompressionIdIndexEntry& lhs, const DecompressionIdIndexEntry& rhs)
+        {
+            return lhs.m_id < rhs.m_id;
+        };
+        auto searchIter = AZStd::lower_bound(m_decompressionIdIndexSet.begin(), m_decompressionIdIndexSet.end(),
+            DecompressionIdIndexEntry{ compressionAlgorithmId }, FindIdIndexEntry);
+
+        return searchIter != m_decompressionIdIndexSet.end() && !FindIdIndexEntry(
+            DecompressionIdIndexEntry{ compressionAlgorithmId }, *searchIter) ?
+            searchIter->m_index : m_decompressionInterfaces.size();
+    }
+}// namespace Compression

--- a/Gems/Compression/Code/Source/Clients/DecompressionFactoryImpl.h
+++ b/Gems/Compression/Code/Source/Clients/DecompressionFactoryImpl.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <Compression/DecompressionInterfaceAPI.h>
+
+namespace Compression
+{
+    class DecompressionFactoryImpl final
+        : public DecompressionFactoryInterface
+    {
+    public:
+        AZ_RTTI(DecompressionFactoryImpl, "{2353362A-A059-4681-ADF0-5ABE41E85A6B}", DecompressionFactoryInterface);
+        AZ_CLASS_ALLOCATOR(DecompressionFactoryImpl, AZ::SystemAllocator, 0);
+
+        ~DecompressionFactoryImpl();
+
+        void VisitDecompressionInterfaces(const VisitDecompressionInterfaceCallback&) const override;
+        bool RegisterDecompressionInterface(AZStd::unique_ptr<IDecompressionInterface>&&) override;
+        bool UnregisterDecompressionInterface(CompressionAlgorithmId) override;
+        IDecompressionInterface* FindDecompressionInterface(CompressionAlgorithmId) const override;
+
+    private:
+        size_t FindDecompressionIndex(CompressionAlgorithmId) const;
+        struct DecompressionIdIndexEntry
+        {
+            CompressionAlgorithmId m_id;
+            size_t m_index;
+        };
+        //! Index into the Decompression Interfaces vector
+        AZStd::vector<DecompressionIdIndexEntry> m_decompressionIdIndexSet;
+        AZStd::vector<AZStd::unique_ptr<IDecompressionInterface>> m_decompressionInterfaces;
+    };
+}// namespace Compression

--- a/Gems/Compression/Code/Source/Tools/CompressionFactoryImpl.h
+++ b/Gems/Compression/Code/Source/Tools/CompressionFactoryImpl.h
@@ -21,7 +21,7 @@ namespace Compression
 
         ~CompressionFactoryImpl();
 
-        AZStd::span<ICompressionInterface* const> GetCompressionInterfaces() const override;
+        void VisitCompressionInterfaces(const VisitCompressionInterfaceCallback&) const override;
         bool RegisterCompressionInterface(AZStd::unique_ptr<ICompressionInterface>&&) override;
         bool UnregisterCompressionInterface(CompressionAlgorithmId) override;
         ICompressionInterface* FindCompressionInterface(CompressionAlgorithmId) const override;
@@ -35,6 +35,6 @@ namespace Compression
         };
         //! Index into the Compression Interfaces vector
         AZStd::vector<CompressionIdIndexEntry> m_compressionIdIndexSet;
-        AZStd::vector<ICompressionInterface*> m_compressionInterfaces;
+        AZStd::vector<AZStd::unique_ptr<ICompressionInterface>> m_compressionInterfaces;
     };
 }// namespace Compression

--- a/Gems/Compression/Code/compression_private_files.cmake
+++ b/Gems/Compression/Code/compression_private_files.cmake
@@ -8,4 +8,6 @@ set(FILES
     Source/CompressionModuleInterface.h
     Source/Clients/CompressionSystemComponent.cpp
     Source/Clients/CompressionSystemComponent.h
+    Source/Clients/DecompressionFactoryImpl.cpp
+    Source/Clients/DecompressionFactoryImpl.h
 )


### PR DESCRIPTION
Registered an instance of the DecompressionFactory with an AZ::Interface.

Added VisitCompressionInterfaces/VisitDecompressionInterfaces functions
to both Compression and Decompression Archive Factories.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
