### PR TITLE
Do not activate graphs on CreateJobs(), which results in not loading assets.

### DIFF
--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.cpp
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.cpp
@@ -53,7 +53,7 @@ namespace ScriptCanvasBuilder
         // By default, entity IDs are made unique, so that multiple instances of the script canvas file can be loaded at the same time.
         // However, in this case the file is not loaded multiple times at once, and the entity IDs need to be stable so that
         // the logic used to generate the fingerprint for this file remains stable.
-        auto result = LoadFromFile(fullPath, MakeInternalGraphEntitiesUnique::No);
+        auto result = LoadFromFile(fullPath, MakeInternalGraphEntitiesUnique::No, LoadReferencedAssets::No);
         if (result)
         {
             sourceHandle = result.m_handle;

--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.h
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.h
@@ -68,7 +68,7 @@ namespace ScriptCanvasBuilder
         ExecutionStateAsLightUserdata,
         UpdateDependencyHandling,
         AddExplicitDestructCallForMemberVariables,
-
+        DoNotLoadScriptEventsDuringCreateJobs,
         // add new entries above
         Current,
     };

--- a/Gems/ScriptCanvas/Code/Editor/Assets/ScriptCanvasFileHandling.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Assets/ScriptCanvasFileHandling.cpp
@@ -122,7 +122,10 @@ namespace ScriptCanvas
         return AZ::Success(result);
     }
 
-    FileLoadResult LoadFromFile(AZStd::string_view path, MakeInternalGraphEntitiesUnique makeEntityIdsUnique)
+    FileLoadResult LoadFromFile
+        ( AZStd::string_view path
+        , MakeInternalGraphEntitiesUnique makeEntityIdsUnique
+        , LoadReferencedAssets loadReferencedAssets)
     {
         namespace JSRU = AZ::JsonSerializationUtils;
 
@@ -137,7 +140,7 @@ namespace ScriptCanvas
         }
 
         const auto& asString = fileStringOutcome.GetValue();
-        result.m_deserializeResult = Deserialize(asString, makeEntityIdsUnique);
+        result.m_deserializeResult = Deserialize(asString, makeEntityIdsUnique, loadReferencedAssets);
         result.m_isSuccess = result.m_deserializeResult;
 
         result.m_handle = SourceHandle::FromRelativePath(result.m_deserializeResult.m_graphDataPtr, path);

--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Assets/ScriptCanvasFileHandling.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Assets/ScriptCanvasFileHandling.h
@@ -48,8 +48,12 @@ namespace ScriptCanvas
     * @param makeEntityIdsUnique controls if the entity IDs are re-generated for the graph to make them unique.
     *   Set to true if there's a chance the graph may be loaded multiple times, so that buses can be used safely with those IDs.
     *   Set to false when doing operations that rely on stable entity ID order between runs.
+    * @param loadReferencedAssets controls whether referenced assets in the graph are loaded or not. In practice, this controls whether or not the
+    * graph and underlying nodes are fully activated.
     * @return An FileLoadResult with either the handle to the data loaded and a string with deserialization issues, or a failure if the file did not load.
     */
-    FileLoadResult LoadFromFile(AZStd::string_view path
-        , MakeInternalGraphEntitiesUnique makeEntityIdsUnique = MakeInternalGraphEntitiesUnique::Yes);
+    FileLoadResult LoadFromFile
+        ( AZStd::string_view path
+        , MakeInternalGraphEntitiesUnique makeEntityIdsUnique = MakeInternalGraphEntitiesUnique::Yes
+        , LoadReferencedAssets loadReferencedAssets = LoadReferencedAssets::Yes);
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphSerialization.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphSerialization.cpp
@@ -121,7 +121,8 @@ namespace ScriptCanvas
 
     DeserializeResult Deserialize
         ( AZStd::string_view source
-        , MakeInternalGraphEntitiesUnique makeUniqueEntities)
+        , MakeInternalGraphEntitiesUnique makeUniqueEntities
+        , LoadReferencedAssets loadReferencedAssets)
     {
         namespace JSRU = AZ::JsonSerializationUtils;
         using namespace GraphSerializationCpp;
@@ -202,8 +203,12 @@ namespace ScriptCanvas
         }
 
         graph->MarkOwnership(*result.m_graphDataPtr);
-        entity->Init();
-        entity->Activate();
+
+        if (loadReferencedAssets == LoadReferencedAssets::Yes)
+        {
+            entity->Init();
+            entity->Activate();
+        }
         // ...can be deprecated ECS management
 
         result.m_isSuccessful = true;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphSerialization.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphSerialization.h
@@ -44,6 +44,12 @@ namespace ScriptCanvas
         Yes,
     };
 
+    enum class LoadReferencedAssets
+    {
+        No,
+        Yes
+    };
+
     struct DeserializeResult
     {
         bool m_isSuccessful = false;
@@ -64,7 +70,8 @@ namespace ScriptCanvas
 
     DeserializeResult Deserialize
         ( AZStd::string_view source
-        , MakeInternalGraphEntitiesUnique makeUniqueEntities = MakeInternalGraphEntitiesUnique::Yes);
+        , MakeInternalGraphEntitiesUnique makeUniqueEntities = MakeInternalGraphEntitiesUnique::Yes
+        , LoadReferencedAssets loadReferencedAssets = LoadReferencedAssets::Yes);
 
     struct SerializationResult
     {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ScriptEventBase.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ScriptEventBase.cpp
@@ -47,7 +47,7 @@ namespace ScriptCanvas
                 ScriptEventBase::ScriptEventBase()
                     : m_version(0)
                     , m_scriptEventAssetId(0)
-                    , m_asset(AZ::Data::AssetLoadBehavior::PreLoad)
+                    , m_asset(AZ::Data::AssetLoadBehavior::NoLoad)
                 {
                 }
 


### PR DESCRIPTION
Signed-off-by: carlitosan <82187351+carlitosan@users.noreply.github.com>

## What does this PR do?

After deserialization, the source graphs are no longer activated, which stops their script event assets from loading if they are present.

Fixes #10972 

## How was this PR tested?

All SC assets were rebuilt, editor tests were successful.
