### PR TITLE
AssetBrowser: Fix ScriptCanvas file openers

### DIFF
--- a/Gems/ScriptCanvas/Code/Asset/EditorAssetSystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Asset/EditorAssetSystemComponent.cpp
@@ -65,32 +65,18 @@ namespace ScriptCanvasEditor
     {
         m_editorAssetRegistry.Register<ScriptCanvas::SubgraphInterfaceAsset, ScriptCanvas::SubgraphInterfaceAssetHandler, ScriptCanvas::SubgraphInterfaceAssetDescription>();
 
-        AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler::BusConnect();
         EditorAssetConversionBus::Handler::BusConnect();
     }
 
     void EditorAssetSystemComponent::Deactivate()
     {
         EditorAssetConversionBus::Handler::BusDisconnect();
-        AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler::BusDisconnect();
         m_editorAssetRegistry.Unregister();
     }
 
     ScriptCanvas::AssetRegistry& EditorAssetSystemComponent::GetAssetRegistry()
     {
         return m_editorAssetRegistry;
-    }
-
-    static bool HandlesSource(const AzToolsFramework::AssetBrowser::SourceAssetBrowserEntry* entry)
-    {
-        AZStd::string_view targetExtension = entry->GetExtension();
-        AZStd::string_view scriptCanvasFileFilter = SourceDescription::GetFileFilter();
-        if (AZStd::wildcard_match(scriptCanvasFileFilter.data(), targetExtension.data()))
-        {
-            return true;
-        }
-
-        return false;
     }
 
     AZ::Outcome<AZ::Data::Asset<ScriptCanvas::RuntimeAsset>, AZStd::string> EditorAssetSystemComponent::CreateRuntimeAsset(const SourceHandle& editAsset)
@@ -101,53 +87,5 @@ namespace ScriptCanvasEditor
     AZ::Outcome<ScriptCanvas::Translation::LuaAssetResult, AZStd::string> EditorAssetSystemComponent::CreateLuaAsset(const SourceHandle& editAsset, AZStd::string_view graphPathForRawLuaFile)
     {
         return ScriptCanvasBuilder::CreateLuaAsset(editAsset, graphPathForRawLuaFile);
-    }
-
-    void EditorAssetSystemComponent::AddSourceFileOpeners
-        ( [[maybe_unused]] const char* fullSourceFileName
-        , const AZ::Uuid& sourceUuid
-        , AzToolsFramework::AssetBrowser::SourceFileOpenerList& openers)
-    {
-        using namespace AzToolsFramework;
-        using namespace AzToolsFramework::AssetBrowser;
-        // get the full details of the source file based on its UUID.
-        if (const SourceAssetBrowserEntry* source = SourceAssetBrowserEntry::GetSourceByUuid(sourceUuid))  
-        {
-            if (!HandlesSource(source))
-            {
-                return;
-            }
-        }
-        else
-        {
-            // has no UUID / Not a source file.
-            return;
-        }
-
-        // You can push back any number of "Openers" - choose a unique identifier, and icon,
-        // and then a lambda which will be activated if the user chooses to open it with your opener:
-
-        openers.push_back({ "ScriptCanvas_Editor_Asset_Edit", "Script Canvas Editor..."
-            , QIcon(ScriptCanvasEditor::SourceDescription::GetIconPath()),
-            [](const char*, const AZ::Uuid& scSourceUuid)
-            {
-                AzToolsFramework::OpenViewPane(LyViewPane::ScriptCanvas);
-
-                if (auto sourceHandle = CompleteDescription(SourceHandle(nullptr, scSourceUuid)))
-                {
-                    AZ::Outcome<int, AZStd::string> openOutcome = AZ::Failure(AZStd::string());
-                    GeneralRequestBus::BroadcastResult(openOutcome, &GeneralRequests::OpenScriptCanvasAsset
-                        , *sourceHandle, Tracker::ScriptCanvasFileState::UNMODIFIED, -1);
-                    if (!openOutcome)
-                    {
-                        AZ_Warning("ScriptCanvas", openOutcome, "%s", openOutcome.GetError().data());
-                    }
-                }
-                else
-                {
-                    AZ_Warning("ScriptCanvas", false
-                        , "Unabled to find full path for Source UUid %s", scSourceUuid.ToString<AZStd::string>().c_str());
-                }            
-            }});
     }
 }

--- a/Gems/ScriptCanvas/Code/Asset/EditorAssetSystemComponent.h
+++ b/Gems/ScriptCanvas/Code/Asset/EditorAssetSystemComponent.h
@@ -20,7 +20,6 @@ namespace ScriptCanvasEditor
     class EditorAssetSystemComponent
         : public AZ::Component
         , public EditorAssetConversionBus::Handler
-        , private AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler
     {
     public:
         AZ_COMPONENT(EditorAssetSystemComponent, "{2FB1C848-B863-4562-9C4B-01E18BD61583}");
@@ -38,11 +37,6 @@ namespace ScriptCanvasEditor
         void Init() override;
         void Activate() override;
         void Deactivate() override;
-        ////////////////////////////////////////////////////////////////////////
-        
-        ////////////////////////////////////////////////////////////////////////
-        // AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler...
-        void AddSourceFileOpeners(const char* fullSourceFileName, const AZ::Uuid& sourceUuid, AzToolsFramework::AssetBrowser::SourceFileOpenerList& openers) override;
         ////////////////////////////////////////////////////////////////////////
 
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -205,31 +205,40 @@ namespace ScriptCanvasEditor
         using namespace AzToolsFramework;
         using namespace AzToolsFramework::AssetBrowser;
 
-        bool isScriptCanvasAsset = false;
-
-        if (AZStd::wildcard_match(ScriptCanvasEditor::SourceDescription::GetFileExtension(), fullSourceFileName))
+        if (AZ::IO::Path(fullSourceFileName).Extension() == ScriptCanvasEditor::SourceDescription::GetFileExtension())
         {
-            isScriptCanvasAsset = true;
-        }
-
-        if (isScriptCanvasAsset)
-        {
-            auto scriptCanvasEditorCallback = []([[maybe_unused]] const char* fullSourceFileNameInCall, const AZ::Uuid& sourceUUIDInCall)
+            auto scriptCanvasOpenInEditorCallback = []([[maybe_unused]] const char* fullSourceFileNameInCall, const AZ::Uuid& sourceUUIDInCall)
             {
                 AZ::Outcome<int, AZStd::string> openOutcome = AZ::Failure(AZStd::string());
-                const SourceAssetBrowserEntry* fullDetails = SourceAssetBrowserEntry::GetSourceByUuid(sourceUUIDInCall);
-                if (fullDetails)
-                {
-                    AzToolsFramework::OpenViewPane(LyViewPane::ScriptCanvas);
 
+                auto sourceHandle = CompleteDescription(SourceHandle(nullptr, sourceUUIDInCall));
+
+                if (sourceHandle)
+                {
                     AzToolsFramework::EditorRequests::Bus::Broadcast(&AzToolsFramework::EditorRequests::OpenViewPane, "Script Canvas");
+
                     GeneralRequestBus::BroadcastResult(openOutcome
                         , &GeneralRequests::OpenScriptCanvasAsset
-                        , SourceHandle(nullptr, sourceUUIDInCall), Tracker::ScriptCanvasFileState::UNMODIFIED, -1);
+                        , *sourceHandle
+                        , Tracker::ScriptCanvasFileState::UNMODIFIED
+                        , -1);
+
+                    if (!openOutcome.IsSuccess())
+                    {
+                        AZ_Error("ScriptCanvas", false, openOutcome.GetError().data());
+                    }
+                }
+                else
+                {
+                    AZ_Warning("ScriptCanvas", false
+                        , "Unabled to find full path for Source UUid %s", sourceUUIDInCall.ToString<AZStd::string>().c_str());
                 }
             };
 
-            openers.push_back({ "O3DE_ScriptCanvasEditor", "Open In Script Canvas Editor...", QIcon(ScriptCanvasEditor::SourceDescription::GetIconPath()), scriptCanvasEditorCallback });
+            openers.push_back({ "O3DE_ScriptCanvasEditor"
+                , "Open In Script Canvas Editor..."
+                , QIcon(ScriptCanvasEditor::SourceDescription::GetIconPath())
+                , scriptCanvasOpenInEditorCallback });
         }
     }
 


### PR DESCRIPTION
**Description**
Prior to this PR, double clicking on ScriptCanvas assets in the AssetBrowser would not open them in the ScriptCanvas editor. This is also exhibited in their opener not showing up in the context menu.

This PR removes one of two `.scriptcanvas` file openers and fixes the other so that ScriptCanvas assets can be opened via the AssetBrowser.

Before fix:
![assetBrowser_scAssetOpenerFails](https://user-images.githubusercontent.com/104796591/182012236-7839b07b-ba05-4be7-b1b6-74b4e6ff72e8.gif)

After fix:
![assetBrowser_scAssetOpenerWorking](https://user-images.githubusercontent.com/104796591/182012343-d156752d-6e7e-4d45-9b8e-358264a1ede6.gif)

**Testing**
- Verified that ScriptCanvas files can be opened in the ScriptCanvas editor using double-click as well as the context menu option