### PR TITLE
bugfix(AP): AssetProcessor exits due to an assert in BuilderInfoMetricsModel.cpp Linux

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/BuilderInfoMetricsModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/BuilderInfoMetricsModel.cpp
@@ -213,15 +213,19 @@ namespace AssetProcessor
             return QModelIndex();
         }
 
-        auto sharedParentitem = parentItem.lock();
-        if (sharedParentitem == rootItem || sharedParentitem == nullptr)
+        auto sharedParentItem = parentItem.lock();
+        if (sharedParentItem == rootItem || sharedParentItem == nullptr || rootItem == nullptr)
         {
             return QModelIndex();
         }
 
-        QModelIndex parentIndex = createIndex(sharedParentitem->GetRow(), 0, sharedParentitem.get());
-        Q_ASSERT(checkIndex(parentIndex));
-        return parentIndex;
+        QModelIndex parentIndex = createIndex(sharedParentItem->GetRow(), 0, sharedParentItem.get());
+        if (checkIndex(parentIndex))
+        {
+            return parentIndex;
+        }
+        AZ_Warning("BuilderInfoMetricsModel", false, "invalid parent in BuilderInfoMetricsModel for %s", sharedParentItem->GetName());
+        return QModelIndex();
     }
 
     void BuilderInfoMetricsModel::OnDurationChanged(BuilderDataItem* item)


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/10991
ref: https://github.com/o3de/o3de/pull/10863/files

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

The AssetProcessor will abort early when it tries to query for the parent in BuilderInfoMetricsModel.cpp. I changed the assert to a warning. I verified that the metric info is correct for the cases where the index is invalid. I rather not have the editor in this state if it can't be helped. 

![image](https://user-images.githubusercontent.com/854359/182044088-518ca601-b258-4530-9952-88a20ec1fbd4.png)
 

## How was this PR tested?

run editor on linux and verify that the AP is still running.
