### PR TITLE
bugfix: fix rendering of arrow for tableview for linux

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.qss
@@ -84,16 +84,16 @@ QTreeView::indicator
     margin-left: -3px;
 }
 
-QTreeView::branch:open:has-children
-{
-    image: url(:/TreeView/open.svg);
-    padding: 10px 4px;
-}
-
-QTreeView::branch:closed:has-children
-{
+QTreeView::branch:has-children:!has-siblings:closed,
+QTreeView::branch:closed:has-children:has-siblings {
     image: url(:/TreeView/closed.svg);
     padding: 8px 6px;
+}
+
+QTreeView::branch:open:has-children:!has-siblings,
+QTreeView::branch:open:has-children:has-siblings  {
+    image: url(:/TreeView/open.svg);
+    padding: 10px 4px;
 }
 
 QTreeView::item:disabled 


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

arrows for the tableview fails to show up on linux. 

![image](https://user-images.githubusercontent.com/854359/182052494-454a3426-e127-4a25-8f32-bcc91f5b4dbc.png)



## How was this PR tested?

in the asset processor open up Builder/metrics. 

- click the green icon bottom right of the Editor
- select builder
- click metrics

![image](https://user-images.githubusercontent.com/854359/182051359-fd6d19de-284c-4b20-b353-ccac9c74f94e.png)
