### PR TITLE
Add VS debug visualization for AZStd::span

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
+++ b/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
@@ -44,6 +44,17 @@
     </Expand>
   </Type>
 
+  <Type Name="AZStd::span&lt;*&gt;">
+    <DisplayString>span[{m_size}]</DisplayString>
+    <Expand>
+      <Item Name="[size]">m_size</Item>
+      <ArrayItems>
+        <Size>m_size</Size>
+        <ValuePointer>m_data</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
   <Type Name="AZStd::Internal::fixed_zero_size_storage&lt;*&gt;">
     <AlternativeType Name="AZStd::fixed_vector&lt;*,0&gt;" />
     <DisplayString>fixed_vector[0] capacity 0</DisplayString>


### PR DESCRIPTION
## What does this PR do?
This adds Visual Studio debugger visualizations for the AZStd::span type.

## How was this PR tested?
Ran Visual Studio and examined a few span<> variables in the debugger.

Before:
![image](https://user-images.githubusercontent.com/82224783/182179322-11b92e61-e2b2-457b-aa12-2e1a4b3e1b1f.png)

After:
![image](https://user-images.githubusercontent.com/82224783/182178907-eda392aa-c2c5-4ac9-bf12-8140cefa60d3.png)

