### PR TITLE
[LYN-14013] Asset Manager - Fix old asset references destroying containers for current loads

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -1372,7 +1372,9 @@ namespace AZ::Data
 
             // Make sure the asset instance we're releasing is the same as the one for the container
             // Sometimes old references (from before a reload) are released which should not cancel newer loads
-            if (itr->second->GetRootAsset()->GetCreationToken() == asset->GetCreationToken())
+            const Asset<AssetData>& rootAsset = itr->second->GetRootAsset();
+
+            if (!rootAsset || (rootAsset && rootAsset->GetCreationToken() == asset->GetCreationToken()))
             {
                 itr->second->ClearRootAsset();
 

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -1369,21 +1369,26 @@ namespace AZ::Data
         {
             AZ_Assert(itr->second->GetContainerAssetId() == assetId,
                 "Asset container is incorrectly associated with the asset being destroyed.");
-            itr->second->ClearRootAsset();
 
-            // Only remove owned asset containers if they aren't currently loading.
-            // If they *are* currently loading, removing them could cause dependent asset loads that were triggered to
-            // remain in a perpetual loading state.  Instead, leave the containers for now, they will get removed during
-            // the OnAssetContainerReady callback.
-            if (!itr->second->IsLoading())
+            // Make sure the asset instance we're releasing is the same as the one for the container
+            // Sometimes old references (from before a reload) are released which should not cancel newer loads
+            if (itr->second->GetRootAsset()->GetCreationToken() == asset->GetCreationToken())
             {
-                m_ownedAssetContainers.erase(itr->second);
-                itr = m_ownedAssetContainerLookup.erase(itr);
+                itr->second->ClearRootAsset();
+
+                // Only remove owned asset containers if they aren't currently loading.
+                // If they *are* currently loading, removing them could cause dependent asset loads that were triggered to
+                // remain in a perpetual loading state.  Instead, leave the containers for now, they will get removed during
+                // the OnAssetContainerReady callback.
+                if (!itr->second->IsLoading())
+                {
+                    m_ownedAssetContainers.erase(itr->second);
+                    itr = m_ownedAssetContainerLookup.erase(itr);
+                    continue;
+                }
             }
-            else
-            {
-                ++itr;
-            }
+
+            ++itr;
         }
     }
 
@@ -1536,7 +1541,7 @@ namespace AZ::Data
 #endif
 
         container = GetAssetContainer(newAsset, {}, true);
-        
+
         if (container)
         {
             [[maybe_unused]] auto result = m_ownedAssetContainers.insert({ container.get(), container });
@@ -2310,7 +2315,7 @@ namespace AZ::Data
 
         AZStd::scoped_lock<AZStd::recursive_mutex> containerLock(m_assetContainerMutex);
         AssetContainerKey containerKey{ asset.GetId(), loadParams };
-        
+
         auto curIter = m_assetContainers.find(containerKey);
         if (curIter != m_assetContainers.end())
         {


### PR DESCRIPTION
## What does this PR do?

Fixes another bug with asset loading/reloading and asset containers caused by the following situation:

1. Asset is loaded and referenced
2. Reload occurs and completes
3. GetAsset is called for the same asset and starts the load process
4. Before the load can complete, the original reference is released
5. Asset containers for the AssetId are unloaded
6. Load cannot complete since there is no container remaining

This fix prevents this by verifying the creation token of the unloading asset matches the token for the container asset, which is the same check done in ReleaseAsset to prevent incorrectly removing old assets from m_asset

## How was this PR tested?

Created and ran unit test