### PR TITLE
fix save-as window

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -1706,8 +1706,7 @@ namespace ScriptCanvasEditor
         
         while (!isValidFileName)
         {
-            selectedFile = QFileDialog::getSaveFileName
-                (nullptr, QObject::tr("Save As..."), suggestedDirectoryPath.data(), QObject::tr("All ScriptCanvas Files (*.scriptcanvas)"));
+            selectedFile = AzQtComponents::FileDialog::GetSaveFileName(this, QObject::tr("Save As..."), suggestedDirectoryPath.data(), QObject::tr("All ScriptCanvas Files (*.scriptcanvas)"));
 
             // If the selected file is empty that means we just cancelled.
             // So we want to break out.

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -1693,8 +1693,8 @@ namespace ScriptCanvasEditor
             }
             else
             {
-                auto sourceHandlePath = sourceHandle.RelativePath();
-                suggestedFilename = sourceHandle.RelativePath().Native();
+                auto sourceHandlePath = sourceHandle.AbsolutePath();
+                suggestedFilename = sourceHandle.AbsolutePath().Native();
                 sourceHandlePath.RemoveFilename();
                 suggestedDirectoryPath = sourceHandlePath.Native();
             }
@@ -1706,7 +1706,8 @@ namespace ScriptCanvasEditor
         
         while (!isValidFileName)
         {
-            selectedFile = AzQtComponents::FileDialog::GetSaveFileName(this, tr("Save As..."), suggestedDirectoryPath.data(), filter);
+            selectedFile = QFileDialog::getSaveFileName
+                (nullptr, QObject::tr("Save As..."), suggestedDirectoryPath.data(), QObject::tr("All ScriptCanvas Files (*.scriptcanvas)"));
 
             // If the selected file is empty that means we just cancelled.
             // So we want to break out.


### PR DESCRIPTION
Signed-off-by: carlitosan <82187351+carlitosan@users.noreply.github.com>

## What does this PR do?

The save-as dialog started in the wrong location and did not reveal previous .scriptcanvas files.

Closes #10789 
Closes #10698 
Closes #10398
Closes #9692
_Please describe any testing performed._

Save as  use revealed the bug, and the fix.

