### PR TITLE
Fixed compile errors in Vector2/3/4 unit tests

### DIFF
--- a/Code/Framework/AzCore/Tests/Math/Vector2Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector2Tests.cpp
@@ -437,22 +437,22 @@ namespace UnitTest
         const float infinity = std::numeric_limits<float>::infinity();
         EXPECT_FALSE(AZ::Vector2(infinity, infinity).IsFinite());
     }
-    struct AngleTestArgs
+    struct Vector2AngleTestArgs
     {
         AZ::Vector2 current;
         AZ::Vector2 target;
         float angle;
     };
 
-    using AngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+    using Vector2AngleTestFixture = ::testing::TestWithParam<Vector2AngleTestArgs>;
 
-    TEST_P(AngleTestFixture, TestAngle)
+    TEST_P(Vector2AngleTestFixture, TestAngle)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.Angle(param.target), param.angle);
     }
 
-    TEST_P(AngleTestFixture, TestAngleSafe)
+    TEST_P(Vector2AngleTestFixture, TestAngleSafe)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleSafe(param.target), param.angle);
@@ -460,24 +460,24 @@ namespace UnitTest
 
     INSTANTIATE_TEST_CASE_P(
         MATH_Vector2,
-        AngleTestFixture,
+        Vector2AngleTestFixture,
         ::testing::Values(
-            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 0.0f, 1.0f }, AZ::Constants::HalfPi },
-            AngleTestArgs{ AZ::Vector2{ 42.0f, 0.0f }, AZ::Vector2{ 0.0f, 23.0f }, AZ::Constants::HalfPi },
-            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ -1.0f, 0.0f }, AZ::Constants::Pi },
-            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 1.0f, 1.0f }, AZ::Constants::QuarterPi },
-            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 1.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector2{ 1.0f, 1.0f }, AZ::Vector2{ -1.0f, -1.0f }, AZ::Constants::Pi }));
+            Vector2AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 0.0f, 1.0f }, AZ::Constants::HalfPi },
+            Vector2AngleTestArgs{ AZ::Vector2{ 42.0f, 0.0f }, AZ::Vector2{ 0.0f, 23.0f }, AZ::Constants::HalfPi },
+            Vector2AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ -1.0f, 0.0f }, AZ::Constants::Pi },
+            Vector2AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 1.0f, 1.0f }, AZ::Constants::QuarterPi },
+            Vector2AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 1.0f, 0.0f }, 0.f },
+            Vector2AngleTestArgs{ AZ::Vector2{ 1.0f, 1.0f }, AZ::Vector2{ -1.0f, -1.0f }, AZ::Constants::Pi }));
 
-    using AngleDegTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+    using Vector2AngleDegTestFixture = ::testing::TestWithParam<Vector2AngleTestArgs>;
 
-    TEST_P(AngleDegTestFixture, TestAngleDeg)
+    TEST_P(Vector2AngleDegTestFixture, TestAngleDeg)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleDeg(param.target), param.angle);
     }
 
-    TEST_P(AngleDegTestFixture, TestAngleDegSafe)
+    TEST_P(Vector2AngleDegTestFixture, TestAngleDegSafe)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
@@ -485,24 +485,24 @@ namespace UnitTest
 
     INSTANTIATE_TEST_CASE_P(
         MATH_Vector2,
-        AngleDegTestFixture,
+        Vector2AngleDegTestFixture,
         ::testing::Values(
-            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 0.0f, 1.0f }, 90.f },
-            AngleTestArgs{ AZ::Vector2{ 42.0f, 0.0f }, AZ::Vector2{ 0.0f, 23.0f }, 90.f },
-            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ -1.0f, 0.0f }, 180.f },
-            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 1.0f, 1.0f }, 45.f },
-            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 1.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector2{ 1.0f, 1.0f }, AZ::Vector2{ -1.0f, -1.0f }, 180.f }));
+            Vector2AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 0.0f, 1.0f }, 90.f },
+            Vector2AngleTestArgs{ AZ::Vector2{ 42.0f, 0.0f }, AZ::Vector2{ 0.0f, 23.0f }, 90.f },
+            Vector2AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ -1.0f, 0.0f }, 180.f },
+            Vector2AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 1.0f, 1.0f }, 45.f },
+            Vector2AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 1.0f, 0.0f }, 0.f },
+            Vector2AngleTestArgs{ AZ::Vector2{ 1.0f, 1.0f }, AZ::Vector2{ -1.0f, -1.0f }, 180.f }));
 
-    using AngleSafeInvalidAngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+    using AngleSafeInvalidVector2AngleTestFixture = ::testing::TestWithParam<Vector2AngleTestArgs>;
 
-    TEST_P(AngleSafeInvalidAngleTestFixture, TestInvalidAngle)
+    TEST_P(AngleSafeInvalidVector2AngleTestFixture, TestInvalidAngle)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleSafe(param.target), param.angle);
     }
 
-    TEST_P(AngleSafeInvalidAngleTestFixture, TestInvalidAngleDeg)
+    TEST_P(AngleSafeInvalidVector2AngleTestFixture, TestInvalidAngleDeg)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
@@ -510,11 +510,11 @@ namespace UnitTest
 
     INSTANTIATE_TEST_CASE_P(
         MATH_Vector2,
-        AngleSafeInvalidAngleTestFixture,
+        AngleSafeInvalidVector2AngleTestFixture,
         ::testing::Values(
-            AngleTestArgs{ AZ::Vector2{ 0.0f, 0.0f }, AZ::Vector2{ 0.0f, 1.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector2{ 0.0f, 0.0f }, AZ::Vector2{ 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector2{ 0.0f, 0.0f }, AZ::Vector2{ 0.0f, 323432.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector2{ 323432.0f, 0.0f }, AZ::Vector2{ 0.0f, 0.0f }, 0.f }));
+            Vector2AngleTestArgs{ AZ::Vector2{ 0.0f, 0.0f }, AZ::Vector2{ 0.0f, 1.0f }, 0.f },
+            Vector2AngleTestArgs{ AZ::Vector2{ 0.0f, 0.0f }, AZ::Vector2{ 0.0f, 0.0f }, 0.f },
+            Vector2AngleTestArgs{ AZ::Vector2{ 1.0f, 0.0f }, AZ::Vector2{ 0.0f, 0.0f }, 0.f },
+            Vector2AngleTestArgs{ AZ::Vector2{ 0.0f, 0.0f }, AZ::Vector2{ 0.0f, 323432.0f }, 0.f },
+            Vector2AngleTestArgs{ AZ::Vector2{ 323432.0f, 0.0f }, AZ::Vector2{ 0.0f, 0.0f }, 0.f }));
 } // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
@@ -460,22 +460,22 @@ namespace UnitTest
         EXPECT_FALSE(AZ::Vector3(infinity, infinity, infinity).IsFinite());
     }
 
-    struct AngleTestArgs
+    struct Vector3AngleTestArgs
     {
         AZ::Vector3 current;
         AZ::Vector3 target;
         float angle;
     };
 
-    using AngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+    using Vector3AngleTestFixture = ::testing::TestWithParam<Vector3AngleTestArgs>;
 
-    TEST_P(AngleTestFixture, TestAngle)
+    TEST_P(Vector3AngleTestFixture, TestAngle)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.Angle(param.target), param.angle);
     }
 
-    TEST_P(AngleTestFixture, TestAngleSafe)
+    TEST_P(Vector3AngleTestFixture, TestAngleSafe)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleSafe(param.target), param.angle);
@@ -483,24 +483,24 @@ namespace UnitTest
 
     INSTANTIATE_TEST_CASE_P(
         MATH_Vector3,
-        AngleTestFixture,
+        Vector3AngleTestFixture,
         ::testing::Values(
-            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 1.0f, 0.0f }, AZ::Constants::HalfPi },
-            AngleTestArgs{ AZ::Vector3{ 42.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 23.0f, 0.0f }, AZ::Constants::HalfPi },
-            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ -1.0f, 0.0f, 0.0f }, AZ::Constants::Pi },
-            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 1.0f, 1.0f, 0.0f }, AZ::Constants::QuarterPi },
-            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 1.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector3{ 1.0f, 1.0f, 0.0f }, AZ::Vector3{ -1.0f, -1.0f, 0.0f }, AZ::Constants::Pi }));
+            Vector3AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 1.0f, 0.0f }, AZ::Constants::HalfPi },
+            Vector3AngleTestArgs{ AZ::Vector3{ 42.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 23.0f, 0.0f }, AZ::Constants::HalfPi },
+            Vector3AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ -1.0f, 0.0f, 0.0f }, AZ::Constants::Pi },
+            Vector3AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 1.0f, 1.0f, 0.0f }, AZ::Constants::QuarterPi },
+            Vector3AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 1.0f, 0.0f, 0.0f }, 0.f },
+            Vector3AngleTestArgs{ AZ::Vector3{ 1.0f, 1.0f, 0.0f }, AZ::Vector3{ -1.0f, -1.0f, 0.0f }, AZ::Constants::Pi }));
 
-    using AngleDegTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+    using Vector3AngleDegTestFixture = ::testing::TestWithParam<Vector3AngleTestArgs>;
 
-    TEST_P(AngleDegTestFixture, TestAngleDeg)
+    TEST_P(Vector3AngleDegTestFixture, TestAngleDeg)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleDeg(param.target), param.angle);
     }
 
-    TEST_P(AngleDegTestFixture, TestAngleDegSafe)
+    TEST_P(Vector3AngleDegTestFixture, TestAngleDegSafe)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
@@ -508,24 +508,24 @@ namespace UnitTest
 
     INSTANTIATE_TEST_CASE_P(
         MATH_Vector3,
-        AngleDegTestFixture,
+        Vector3AngleDegTestFixture,
         ::testing::Values(
-            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 1.0f, 0.0f }, 90.f },
-            AngleTestArgs{ AZ::Vector3{ 42.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 23.0f, 0.0f }, 90.f },
-            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ -1.0f, 0.0f, 0.0f }, 180.f },
-            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 1.0f, 1.0f, 0.0f }, 45.f },
-            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 1.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector3{ 1.0f, 1.0f, 0.0f }, AZ::Vector3{ -1.0f, -1.0f, 0.0f }, 180.f }));
+            Vector3AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 1.0f, 0.0f }, 90.f },
+            Vector3AngleTestArgs{ AZ::Vector3{ 42.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 23.0f, 0.0f }, 90.f },
+            Vector3AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ -1.0f, 0.0f, 0.0f }, 180.f },
+            Vector3AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 1.0f, 1.0f, 0.0f }, 45.f },
+            Vector3AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 1.0f, 0.0f, 0.0f }, 0.f },
+            Vector3AngleTestArgs{ AZ::Vector3{ 1.0f, 1.0f, 0.0f }, AZ::Vector3{ -1.0f, -1.0f, 0.0f }, 180.f }));
 
-    using AngleSafeInvalidAngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+    using AngleSafeInvalidVector3AngleTestFixture = ::testing::TestWithParam<Vector3AngleTestArgs>;
 
-    TEST_P(AngleSafeInvalidAngleTestFixture, TestInvalidAngle)
+    TEST_P(AngleSafeInvalidVector3AngleTestFixture, TestInvalidAngle)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleSafe(param.target), param.angle);
     }
 
-    TEST_P(AngleSafeInvalidAngleTestFixture, TestInvalidAngleDeg)
+    TEST_P(AngleSafeInvalidVector3AngleTestFixture, TestInvalidAngleDeg)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
@@ -533,13 +533,13 @@ namespace UnitTest
 
     INSTANTIATE_TEST_CASE_P(
         MATH_Vector3,
-        AngleSafeInvalidAngleTestFixture,
+        AngleSafeInvalidVector3AngleTestFixture,
         ::testing::Values(
-            AngleTestArgs{ AZ::Vector3{ 0.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 1.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector3{ 0.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector3{ 0.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 323432.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector3{ 323432.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 0.0f, 0.0f }, 0.f }));
+            Vector3AngleTestArgs{ AZ::Vector3{ 0.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 1.0f, 0.0f }, 0.f },
+            Vector3AngleTestArgs{ AZ::Vector3{ 0.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 0.0f, 0.0f }, 0.f },
+            Vector3AngleTestArgs{ AZ::Vector3{ 1.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 0.0f, 0.0f }, 0.f },
+            Vector3AngleTestArgs{ AZ::Vector3{ 0.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 323432.0f, 0.0f }, 0.f },
+            Vector3AngleTestArgs{ AZ::Vector3{ 323432.0f, 0.0f, 0.0f }, AZ::Vector3{ 0.0f, 0.0f, 0.0f }, 0.f }));
 
     TEST(MATH_Vector3, CompareTest)
     {

--- a/Code/Framework/AzCore/Tests/Math/Vector4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector4Tests.cpp
@@ -415,22 +415,22 @@ namespace UnitTest
         EXPECT_THAT(v1, IsClose(AZ::Vector4(6.0f, 9.0f, -1.5f, 7.5f)));
     }
 
-    struct AngleTestArgs
+    struct Vector4AngleTestArgs
     {
         AZ::Vector4 current;
         AZ::Vector4 target;
         float angle;
     };
 
-    using AngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+    using Vector4AngleTestFixture = ::testing::TestWithParam<Vector4AngleTestArgs>;
 
-    TEST_P(AngleTestFixture, TestAngle)
+    TEST_P(Vector4AngleTestFixture, TestAngle)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.Angle(param.target), param.angle);
     }
 
-    TEST_P(AngleTestFixture, TestAngleSafe)
+    TEST_P(Vector4AngleTestFixture, TestAngleSafe)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleSafe(param.target), param.angle);
@@ -438,47 +438,47 @@ namespace UnitTest
 
     INSTANTIATE_TEST_CASE_P(
         MATH_Vector4,
-        AngleTestFixture,
+        Vector4AngleTestFixture,
         ::testing::Values(
-            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, AZ::Constants::HalfPi },
-            AngleTestArgs{ AZ::Vector4{ 42.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 23.0f, 0.0f, 0.0f }, AZ::Constants::HalfPi },
-            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ -1.0f, 0.0f, 0.0f, 0.0f }, AZ::Constants::Pi },
-            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, AZ::Constants::QuarterPi },
-            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, AZ::Vector4{ -1.0f, -1.0f, 0.0f, 0.0f }, AZ::Constants::Pi }));
+            Vector4AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, AZ::Constants::HalfPi },
+            Vector4AngleTestArgs{ AZ::Vector4{ 42.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 23.0f, 0.0f, 0.0f }, AZ::Constants::HalfPi },
+            Vector4AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ -1.0f, 0.0f, 0.0f, 0.0f }, AZ::Constants::Pi },
+            Vector4AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, AZ::Constants::QuarterPi },
+            Vector4AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, 0.f },
+            Vector4AngleTestArgs{ AZ::Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, AZ::Vector4{ -1.0f, -1.0f, 0.0f, 0.0f }, AZ::Constants::Pi }));
 
-    using AngleDegTestFixture = ::testing::TestWithParam<AngleTestArgs>;
+    using Vector4AngleDegTestFixture = ::testing::TestWithParam<Vector4AngleTestArgs>;
 
-    TEST_P(AngleDegTestFixture, TestAngleDeg)
+    TEST_P(Vector4AngleDegTestFixture, TestAngleDeg)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleDeg(param.target), param.angle);
     }
 
-    TEST_P(AngleDegTestFixture, TestAngleDegSafe)
+    TEST_P(Vector4AngleDegTestFixture, TestAngleDegSafe)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
     }
     INSTANTIATE_TEST_CASE_P(
         MATH_Vector4,
-        AngleDegTestFixture,
+        Vector4AngleDegTestFixture,
         ::testing::Values(
-            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, 90.f },
-            AngleTestArgs{ AZ::Vector4{ 42.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 23.0f, 0.0f, 0.0f }, 90.f },
-            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ -1.0f, 0.0f, 0.0f, 0.0f }, 180.f },
-            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, 45.f },
-            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, AZ::Vector4{ -1.0f, -1.0f, 0.0f, 0.0f }, 180.f }));
+            Vector4AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, 90.f },
+            Vector4AngleTestArgs{ AZ::Vector4{ 42.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 23.0f, 0.0f, 0.0f }, 90.f },
+            Vector4AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ -1.0f, 0.0f, 0.0f, 0.0f }, 180.f },
+            Vector4AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, 45.f },
+            Vector4AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, 0.f },
+            Vector4AngleTestArgs{ AZ::Vector4{ 1.0f, 1.0f, 0.0f, 0.0f }, AZ::Vector4{ -1.0f, -1.0f, 0.0f, 0.0f }, 180.f }));
 
-    using AngleSafeInvalidAngleTestFixture = ::testing::TestWithParam<AngleTestArgs>;
-    TEST_P(AngleSafeInvalidAngleTestFixture, TestInvalidAngle)
+    using AngleSafeInvalidVector4AngleTestFixture = ::testing::TestWithParam<Vector4AngleTestArgs>;
+    TEST_P(AngleSafeInvalidVector4AngleTestFixture, TestInvalidAngle)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleSafe(param.target), param.angle);
     }
 
-    TEST_P(AngleSafeInvalidAngleTestFixture, TestInvalidAngleDeg)
+    TEST_P(AngleSafeInvalidVector4AngleTestFixture, TestInvalidAngleDeg)
     {
         auto& param = GetParam();
         EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
@@ -486,11 +486,11 @@ namespace UnitTest
 
     INSTANTIATE_TEST_CASE_P(
         MATH_Vector4,
-        AngleSafeInvalidAngleTestFixture,
+        AngleSafeInvalidVector4AngleTestFixture,
         ::testing::Values(
-            AngleTestArgs{ AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 323432.0f, 0.0f, 0.0f }, 0.f },
-            AngleTestArgs{ AZ::Vector4{ 323432.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f }));
+            Vector4AngleTestArgs{ AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 1.0f, 0.0f, 0.0f }, 0.f },
+            Vector4AngleTestArgs{ AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f },
+            Vector4AngleTestArgs{ AZ::Vector4{ 1.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f },
+            Vector4AngleTestArgs{ AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 323432.0f, 0.0f, 0.0f }, 0.f },
+            Vector4AngleTestArgs{ AZ::Vector4{ 323432.0f, 0.0f, 0.0f, 0.0f }, AZ::Vector4{ 0.0f, 0.0f, 0.0f, 0.0f }, 0.f }));
 } // namespace UnitTest


### PR DESCRIPTION
## What does this PR do?

Fixes #11026 

Fixed redefinition of struct/fixture names in `Vector2/3/4` unit tests, causing compile errors.

## How was this PR tested?

Verified local unity build now compiles and ran `AzCore` unit tests.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>
