### PR TITLE
Settings registry editor/origin tracking

### DIFF
--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -70,9 +70,9 @@ namespace SandboxEditor
                 using AZ::SettingsRegistryMergeUtils::IsPathAncestorDescendantOrEqual;
 
                 m_angleSnappingNotifyEventHandler = registry->RegisterNotifier(
-                    [this](const AZStd::string_view path, [[maybe_unused]] const AZ::SettingsRegistryInterface::Type type)
+                    [this](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
                     {
-                        if (IsPathAncestorDescendantOrEqual(AngleSnappingSetting, path))
+                        if (IsPathAncestorDescendantOrEqual(AngleSnappingSetting, notifyEventArgs.m_jsonKeyPath))
                         {
                             m_angleSnappingChanged.Signal(AngleSnappingEnabled());
                         }
@@ -80,9 +80,9 @@ namespace SandboxEditor
                 );
 
                 m_gridSnappingNotifyEventHandler = registry->RegisterNotifier(
-                    [this](const AZStd::string_view path, [[maybe_unused]] const AZ::SettingsRegistryInterface::Type type)
+                    [this](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
                     {
-                        if (IsPathAncestorDescendantOrEqual(GridSnappingSetting, path))
+                        if (IsPathAncestorDescendantOrEqual(GridSnappingSetting, notifyEventArgs.m_jsonKeyPath))
                         {
                             m_gridSnappingChanged.Signal(GridSnappingEnabled());
                         }

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -41,6 +41,7 @@
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/Settings/SettingsRegistryScriptUtils.h>
 #include <AzCore/Settings/SettingsRegistryVisitorUtils.h>
+#include <AzCore/Settings/SettingsRegistryOriginTracker.h>
 #include <AzCore/StringFunc/StringFunc.h>
 
 #include <AzCore/Module/Module.h>
@@ -469,6 +470,8 @@ namespace AZ
         {
             SettingsRegistry::Register(m_settingsRegistry.get());
         }
+
+        m_settingsRegistryOriginTracker = AZStd::make_unique<SettingsRegistryOriginTracker>(*m_settingsRegistry);
 
         // Add the Command Line arguments into the SettingsRegistry
         SettingsRegistryMergeUtils::StoreCommandLineToRegistry(*m_settingsRegistry, m_commandLine);

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -562,6 +562,13 @@ namespace AZ
         m_console.reset();
 
         m_moduleManager.reset();
+
+        // Unregister the global settings registry origin tracker if this application owns is
+        if (AZ::Interface<AZ::SettingsRegistryOriginTracker>::Get() == m_settingsRegistryOriginTracker.get())
+        {
+            AZ::Interface<AZ::SettingsRegistryOriginTracker>::Unregister(m_settingsRegistryOriginTracker.get());
+        }
+        m_settingsRegistryOriginTracker.reset();
         // Unregister the global Settings Registry if it is owned by this application instance
         if (AZ::SettingsRegistry::Get() == m_settingsRegistry.get())
         {
@@ -569,7 +576,6 @@ namespace AZ
             ComponentApplicationLifecycle::SignalEvent(*m_settingsRegistry, "SettingsRegistryUnavailable", R"({})");
             ComponentApplicationLifecycle::SignalEvent(*m_settingsRegistry, "SystemAllocatorPendingDestruction", R"({})");
         }
-        m_settingsRegistryOriginTracker.reset();
         m_settingsRegistry.reset();
 
         // Unregister the Name Dictionary with the AZ Interface system and reset it

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -519,6 +519,7 @@ namespace AZ
             AZ::Interface<AZ::IConsole>::Register(m_console.get());
             m_console->LinkDeferredFunctors(AZ::ConsoleFunctorBase::GetDeferredHead());
             m_settingsRegistryConsoleFunctors = AZ::SettingsRegistryConsoleUtils::RegisterAzConsoleCommands(*m_settingsRegistry, *m_console);
+            m_settingsRegistryOriginTrackerConsoleFunctors = AZ::SettingsRegistryConsoleUtils::RegisterAzConsoleCommands(*m_settingsRegistryOriginTracker, *m_console);
             ComponentApplicationLifecycle::SignalEvent(*m_settingsRegistry, "ConsoleAvailable", R"({})");
         }
     }
@@ -562,6 +563,7 @@ namespace AZ
             ComponentApplicationLifecycle::SignalEvent(*m_settingsRegistry, "SettingsRegistryUnavailable", R"({})");
             ComponentApplicationLifecycle::SignalEvent(*m_settingsRegistry, "SystemAllocatorPendingDestruction", R"({})");
         }
+        m_settingsRegistryOriginTracker.reset();
         m_settingsRegistry.reset();
 
         // Unregister the Name Dictionary with the AZ Interface system and reset it

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -199,14 +199,14 @@ namespace AZ
         {
         }
 
-        void operator()(AZStd::string_view path, AZ::SettingsRegistryInterface::Type)
+        void operator()(const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
         {
             // Update the project settings when the project path is set
             using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
             const auto projectPathKey = FixedValueString(AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) + "/project_path";
 
             AZ::IO::FixedMaxPath newProjectPath;
-            if (SettingsRegistryMergeUtils::IsPathAncestorDescendantOrEqual(projectPathKey, path)
+            if (SettingsRegistryMergeUtils::IsPathAncestorDescendantOrEqual(projectPathKey, notifyEventArgs.m_jsonKeyPath)
                 && m_registry.Get(newProjectPath.Native(), projectPathKey) && newProjectPath != m_oldProjectPath)
             {
                 // Update old Project path before attempting to merge in new Settings Registry values in order to prevent recursive calls
@@ -232,14 +232,14 @@ namespace AZ
         {
         }
 
-        void operator()(AZStd::string_view path, AZ::SettingsRegistryInterface::Type)
+        void operator()(const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
         {
             // Update the project specialization when the project name is set
             using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
             const auto projectNameKey = FixedValueString(AZ::SettingsRegistryMergeUtils::ProjectSettingsRootKey) + "/project_name";
 
             FixedValueString newProjectName;
-            if (SettingsRegistryMergeUtils::IsPathAncestorDescendantOrEqual(projectNameKey, path)
+            if (SettingsRegistryMergeUtils::IsPathAncestorDescendantOrEqual(projectNameKey, notifyEventArgs.m_jsonKeyPath)
                 && m_registry.Get(newProjectName, projectNameKey) && newProjectName != m_oldProjectName)
             {
                 // Add the project_name as a specialization for loading the build system dependency .setreg files
@@ -268,10 +268,10 @@ namespace AZ
         {
         }
 
-        void operator()(AZStd::string_view path, AZ::SettingsRegistryInterface::Type)
+        void operator()(const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
         {
             // Update the ComponentApplication CommandLine instance when the command line settings are merged into the Settings Registry
-            if (path == AZ::SettingsRegistryMergeUtils::CommandLineValueChangedKey)
+            if (notifyEventArgs.m_jsonKeyPath == AZ::SettingsRegistryMergeUtils::CommandLineValueChangedKey)
             {
                 AZ::SettingsRegistryMergeUtils::GetCommandLineFromRegistry(m_registry, m_commandLine);
             }

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -473,6 +473,12 @@ namespace AZ
 
         m_settingsRegistryOriginTracker = AZStd::make_unique<SettingsRegistryOriginTracker>(*m_settingsRegistry);
 
+        // Register the Settings Registry Origin Tracker with the AZ Interface system
+        if (AZ::Interface<AZ::SettingsRegistryOriginTracker>::Get() == nullptr)
+        {
+            AZ::Interface<AZ::SettingsRegistryOriginTracker>::Register(m_settingsRegistryOriginTracker.get());
+        }
+
         // Add the Command Line arguments into the SettingsRegistry
         SettingsRegistryMergeUtils::StoreCommandLineToRegistry(*m_settingsRegistry, m_commandLine);
 

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.h
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.h
@@ -382,6 +382,7 @@ namespace AZ
         // ConsoleFunctorHandle is responsible for unregistering the Settings Registry Console
         // from the m_console member when it goes out of scope
         AZ::SettingsRegistryConsoleUtils::ConsoleFunctorHandle m_settingsRegistryConsoleFunctors;
+        AZ::SettingsRegistryConsoleUtils::ConsoleFunctorHandle m_settingsRegistryOriginTrackerConsoleFunctors;
 
 #if !defined(_RELEASE)
         Debug::BudgetTracker m_budgetTracker;

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.h
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.h
@@ -25,6 +25,7 @@
 #include <AzCore/Settings/CommandLine.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Settings/SettingsRegistryConsoleUtils.h>
+#include <AzCore/Settings/SettingsRegistryOriginTracker.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/std/string/conversions.h>
@@ -358,6 +359,7 @@ namespace AZ
         AZStd::unique_ptr<ModuleManager>            m_moduleManager;
         AZStd::unique_ptr<NameDictionary>           m_nameDictionary;
         AZStd::unique_ptr<SettingsRegistryInterface> m_settingsRegistry;
+        AZStd::unique_ptr<SettingsRegistryOriginTracker> m_settingsRegistryOriginTracker;
         AZStd::unique_ptr<AZ::IConsole>             m_console;
         EntityAddedEvent                            m_entityAddedEvent;
         EntityRemovedEvent                          m_entityRemovedEvent;

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplicationLifecycle.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplicationLifecycle.cpp
@@ -59,7 +59,6 @@ namespace AZ::ComponentApplicationLifecycle
         AZ::SettingsRegistryInterface::NotifyCallback callback, AZStd::string_view eventName, bool autoRegisterEvent)
     {
         using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
-        using Type = AZ::SettingsRegistryInterface::Type;
         using NotifyEventHandler = AZ::SettingsRegistryInterface::NotifyEventHandler;
 
         // Some systems may attempt to register a handler before the settings registry has been loaded

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplicationLifecycle.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplicationLifecycle.cpp
@@ -77,11 +77,12 @@ namespace AZ::ComponentApplicationLifecycle
         }
         auto eventNameRegistrationKey = FixedValueString::format("%.*s/%.*s", AZ_STRING_ARG(ApplicationLifecycleEventRegistrationKey),
             AZ_STRING_ARG(eventName));
-        auto lifecycleCallback = [callback = AZStd::move(callback), eventNameRegistrationKey](AZStd::string_view path, Type type)
+        auto lifecycleCallback = [callback = AZStd::move(callback), eventNameRegistrationKey](
+            const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
         {
-            if (path == eventNameRegistrationKey)
+            if (notifyEventArgs.m_jsonKeyPath == eventNameRegistrationKey)
             {
-                callback(path, type);
+                callback(notifyEventArgs);
             }
         };
 

--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -495,46 +495,20 @@ namespace AZ
         {
         }
 
-        // Responsible for using the Json Serialization Issue Callback system
-        // to determine when a JSON Patch or JSON Merge Patch modifies a value
-        // at a path underneath the IConsole::ConsoleRuntimeCommandKey JSON pointer
-        JsonSerializationResult::ResultCode operator()(AZStd::string_view message,
-            JsonSerializationResult::ResultCode result, AZStd::string_view path)
-        {
-            constexpr AZ::IO::PathView consoleRootCommandKey{ IConsole::ConsoleRuntimeCommandKey, AZ::IO::PosixPathSeparator };
-            constexpr AZ::IO::PathView consoleAutoexecCommandKey{ IConsole::ConsoleAutoexecCommandKey, AZ::IO::PosixPathSeparator };
-            AZ::IO::PathView inputKey{ path, AZ::IO::PosixPathSeparator };
-            if (result.GetTask() == JsonSerializationResult::Tasks::Merge
-                && result.GetProcessing() == JsonSerializationResult::Processing::Completed
-                && (inputKey.IsRelativeTo(consoleRootCommandKey) || inputKey.IsRelativeTo(consoleAutoexecCommandKey)))
-            {
-                if (auto type = m_settingsRegistry.GetType(path); type != SettingsRegistryInterface::Type::NoType)
-                {
-                    operator()(path, type);
-                }
-            }
-
-            // This is the default issue reporting, that logs using the warning category
-            if (result.GetProcessing() != JsonSerializationResult::Processing::Completed)
-            {
-                scratchBuffer.append(message.begin(), message.end());
-                scratchBuffer.append("\n    Reason: ");
-                result.AppendToString(scratchBuffer, path);
-                scratchBuffer.append(".");
-                AZ_Warning("JSON Serialization", false, "%s", scratchBuffer.c_str());
-
-                scratchBuffer.clear();
-            }
-            return result;
-        }
-
-        void operator()(AZStd::string_view path, SettingsRegistryInterface::Type type)
+        // NotifyEventHandler function for handling when settings underneath the
+        // ConsoleAutoexecCommandKey or ConsoleRuntimeCommandKey key paths are modified
+        void operator()(const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
         {
             using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
 
+            if (notifyEventArgs.m_type == AZ::SettingsRegistryInterface::Type::NoType)
+            {
+                return;
+            }
+
             constexpr AZ::IO::PathView consoleRuntimeCommandKey{ IConsole::ConsoleRuntimeCommandKey, AZ::IO::PosixPathSeparator };
             constexpr AZ::IO::PathView consoleAutoexecCommandKey{ IConsole::ConsoleAutoexecCommandKey, AZ::IO::PosixPathSeparator };
-            AZ::IO::PathView inputKey{ path, AZ::IO::PosixPathSeparator };
+            AZ::IO::PathView inputKey{ notifyEventArgs.m_jsonKeyPath, AZ::IO::PosixPathSeparator };
 
             // Abuses the IsRelativeToFuncton function of the path class to extract the console
             // command from the settings registry objects
@@ -556,9 +530,9 @@ namespace AZ
                 // and therefore doesn't own the memory.
                 FixedValueString commandArgString;
 
-                if (type == SettingsRegistryInterface::Type::String)
+                if (notifyEventArgs.m_type == SettingsRegistryInterface::Type::String)
                 {
-                    if (m_settingsRegistry.Get(commandArgString, path))
+                    if (m_settingsRegistry.Get(commandArgString, notifyEventArgs.m_jsonKeyPath))
                     {
                         auto ConvertCommandArgumentToArray = [&commandArgs](AZStd::string_view token)
                         {
@@ -568,35 +542,35 @@ namespace AZ
                         StringFunc::TokenizeVisitor(commandArgString, ConvertCommandArgumentToArray, commandSeparators);
                     }
                 }
-                else if (type == SettingsRegistryInterface::Type::Boolean)
+                else if (notifyEventArgs.m_type == SettingsRegistryInterface::Type::Boolean)
                 {
                     bool commandArgBool{};
-                    if (m_settingsRegistry.Get(commandArgBool, path))
+                    if (m_settingsRegistry.Get(commandArgBool, notifyEventArgs.m_jsonKeyPath))
                     {
                         commandArgString = commandArgBool ? "true" : "false";
                         commandArgs.emplace_back(commandArgString);
                     }
                 }
-                else if (type == SettingsRegistryInterface::Type::Integer)
+                else if (notifyEventArgs.m_type == SettingsRegistryInterface::Type::Integer)
                 {
                     // Try converting to a signed 64-bit number first and then an unsigned 64-bit number
                     AZ::s64 commandArgInt{};
                     AZ::u64 commandArgUInt{};
-                    if (m_settingsRegistry.Get(commandArgInt, path))
+                    if (m_settingsRegistry.Get(commandArgInt, notifyEventArgs.m_jsonKeyPath))
                     {
                         AZStd::to_string(commandArgString, commandArgInt);
                         commandArgs.emplace_back(commandArgString);
                     }
-                    else if (m_settingsRegistry.Get(commandArgUInt, path))
+                    else if (m_settingsRegistry.Get(commandArgUInt, notifyEventArgs.m_jsonKeyPath))
                     {
                         AZStd::to_string(commandArgString, commandArgUInt);
                         commandArgs.emplace_back(commandArgString);
                     }
                 }
-                else if (type == SettingsRegistryInterface::Type::FloatingPoint)
+                else if (notifyEventArgs.m_type == SettingsRegistryInterface::Type::FloatingPoint)
                 {
                     double commandArgFloat{};
-                    if (m_settingsRegistry.Get(commandArgFloat, path))
+                    if (m_settingsRegistry.Get(commandArgFloat, notifyEventArgs.m_jsonKeyPath))
                     {
                         AZStd::to_string(commandArgString, commandArgFloat);
                         commandArgs.emplace_back(commandArgString);

--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -645,8 +645,6 @@ namespace AZ
             IConsole::ConsoleAutoexecCommandKey);
         m_consoleCommandKeyHandler = settingsRegistry.RegisterNotifier(ConsoleCommandKeyNotificationHandler{ settingsRegistry, *this });
 
-        JsonApplyPatchSettings applyPatchSettings;
-        applyPatchSettings.m_reporting = ConsoleCommandKeyNotificationHandler{ settingsRegistry, *this };
-        settingsRegistry.SetApplyPatchSettings(applyPatchSettings);
+        settingsRegistry.SetNotifyForMergeOperations(true);
     }
 }

--- a/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.inl
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.inl
@@ -190,7 +190,7 @@ namespace AZ::Dom
             path,
             [&visitor](const Path& path, T& value)
             {
-                visitor(path, value);
+                return visitor(path, value);
             },
             flags);
     }

--- a/Code/Framework/AzCore/AzCore/Math/Uuid.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Uuid.cpp
@@ -18,19 +18,6 @@
 
 namespace AZ
 {
-    //=========================================================================
-    // CreateNull
-    // [4/10/2012]
-    //=========================================================================
-    Uuid Uuid::CreateNull()
-    {
-        Uuid id;
-        u64* value64 = reinterpret_cast<u64*>(id.data);
-        value64[0] = 0;
-        value64[1] = 0;
-        return id;
-    }
-
     static const char* const s_uuid_digits = "0123456789ABCDEFabcdef";
     static const unsigned char s_uuid_values[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 10, 11, 12, 13, 14, 15, static_cast<unsigned char>(-1) };
 

--- a/Code/Framework/AzCore/AzCore/Math/Uuid.h
+++ b/Code/Framework/AzCore/AzCore/Math/Uuid.h
@@ -46,10 +46,10 @@ namespace AZ
         static constexpr int ValidUuidStringLength = 32; /// Number of characters (data only, no extra formatting) in a valid UUID string
         static constexpr size_t MaxStringBuffer = 39; /// 32 Uuid + 4 dashes + 2 brackets + 1 terminate
         using FixedString = AZStd::fixed_string<MaxStringBuffer>;
-        Uuid() = default;
+        constexpr Uuid() = default;
         Uuid(const char* string, size_t stringLength = 0) { *this = CreateString(string, stringLength); }
 
-        static Uuid CreateNull();
+        static constexpr Uuid CreateNull() { return Uuid{}; };
         /// Create a Uuid (VAR_RFC_4122,VER_RANDOM)
         static Uuid Create()        { return CreateRandom(); }
         /**
@@ -178,7 +178,7 @@ namespace AZ
         }
 
         // or _m128i and VMX ???
-        alignas(16) unsigned char data[16];
+        alignas(16) unsigned char data[16]{};
     };
 } // namespace AZ
 

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
@@ -119,39 +119,27 @@ namespace AZ
             JsonMergePatch  //!< Using the json merge patch format to merge JSON data into the Settings Registry.
         };
 
-        using NotifyCallback = AZStd::function<void(AZStd::string_view path, Type type)>;
-        using NotifyEvent = AZ::Event<AZStd::string_view, Type>;
+        struct NotifyEventArgs
+        {
+            AZStd::string_view m_jsonKeyPath;
+            Type m_type = Type::NoType;
+            AZStd::string_view m_mergeFilePath;
+        };
+        using NotifyCallback = AZStd::function<void(const NotifyEventArgs& notifierArgs)>;
+        using NotifyEvent = AZ::Event<const NotifyEventArgs&>;
         using NotifyEventHandler = typename NotifyEvent::Handler;
 
-        using PreMergeEventCallback = AZStd::function<void(AZStd::string_view path, AZStd::string_view rootKey)>;
-        using PostMergeEventCallback = AZStd::function<void(AZStd::string_view path, AZStd::string_view rootKey)>;
-        using PreMergeEvent = AZ::Event<AZStd::string_view, AZStd::string_view>;
-        using PostMergeEvent = AZ::Event<AZStd::string_view, AZStd::string_view>;
+        struct MergeEventArgs
+        {
+            AZStd::string_view m_mergeFilePath;
+            AZStd::string_view m_jsonKeyPath;
+        };
+        using PreMergeEventCallback = AZStd::function<void(const MergeEventArgs&)>;
+        using PostMergeEventCallback = AZStd::function<void(const MergeEventArgs&)>;
+        using PreMergeEvent = AZ::Event<const MergeEventArgs&>;
+        using PostMergeEvent = AZ::Event<const MergeEventArgs&>;
         using PreMergeEventHandler = typename PreMergeEvent::Handler;
         using PostMergeEventHandler = typename PostMergeEvent::Handler;
-
-        struct ScopedMergeEvent
-        {
-            ScopedMergeEvent(
-                PreMergeEvent& preMergeEvent, PostMergeEvent& postMergeEvent, AZStd::string_view filePath, AZStd::string_view rootKey)
-                : m_preMergeEvent{ preMergeEvent }
-                , m_postMergeEvent{ postMergeEvent }
-                , m_filePath{ filePath }
-                , m_rootKey{ rootKey }
-            {
-                preMergeEvent.Signal(m_filePath, m_rootKey);
-            }
-
-            ~ScopedMergeEvent()
-            {
-                m_postMergeEvent.Signal(m_filePath, m_rootKey);
-            }
-
-            PreMergeEvent& m_preMergeEvent;
-            PostMergeEvent& m_postMergeEvent;
-            AZStd::string_view m_filePath;
-            AZStd::string_view m_rootKey;
-        };
 
         using VisitorCallback =
             AZStd::function<VisitResponse(AZStd::string_view path, AZStd::string_view valueName, VisitAction action, Type type)>;

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
@@ -374,13 +374,12 @@ namespace AZ
         virtual bool MergeSettingsFolder(AZStd::string_view path, const Specializations& specializations,
             AZStd::string_view platform = {}, AZStd::string_view anchorKey = "", AZStd::vector<char>* scratchBuffer = nullptr) = 0;
 
-        //! Stores the settings structure which is used when merging settings to the Settings Registry
-        //! using JSON Merge Patch or JSON Merge Patch.
-        //! The settings contain an issue reporting callback which can be used to track patching process.
-        //! Potential application of the reporting callback could be to update a UI whenever a key receives an updated value
-        //! @param applyPatchSettings The ApplyPatchSettings which are using during JSON Merging
-        virtual void SetApplyPatchSettings(const AZ::JsonApplyPatchSettings& applyPatchSettings) = 0;
-        virtual void GetApplyPatchSettings(AZ::JsonApplyPatchSettings& applyPatchSettings) = 0;
+        //! Indicates whether the Merge functions should send notification events for individual operations
+        //! using JSON Patch or JSON Merge Patch.
+        //! @param notify If true, the patching operations are forwarded through the NotifyEvent
+        virtual void SetNotifyForMergeOperations(bool notify) = 0;
+        //! @return returns true if merge operations signals the notification events
+        virtual bool GetNotifyForMergeOperations() const = 0;
 
         //! Stores option to indicate whether the FileIOBase instance should be used for file operations
         //! @param useFileIo If true the FileIOBase instance will attempted to be used for FileIOBase

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/Settings/SettingsRegistryConsoleUtils.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/Settings/SettingsRegistryOriginTracker.h>
 #include <AzCore/StringFunc/StringFunc.h>
 
 namespace AZ::SettingsRegistryConsoleUtils
@@ -120,6 +121,38 @@ namespace AZ::SettingsRegistryConsoleUtils
                 AZ_STRING_ARG(filePath), jsonAnchorPath.c_str());
             AZ::Debug::Trace::Output("SettingsRegistry", mergeFileOutput.c_str());
         }
+    }
+
+    static void ConsoleDumpSettingsFileOriginValue(SettingsRegistryOriginTracker& settingsRegistryOriginTracker, const ConsoleCommandContainer& commandArgs)
+    {
+        AZStd::string outputString;
+        for (AZStd::string_view settingsKeyToDump : (commandArgs.empty() ? AZStd::vector<AZStd::string_view>{""} : commandArgs))
+        {
+            settingsRegistryOriginTracker.VisitOrigins(settingsKeyToDump, [&outputString](const AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin& settingsRegistryOrigin)
+            {
+                outputString += AZStd::string::format("Key: %s Origin: %s Value when Merged: %s\n", settingsRegistryOrigin.m_settingsKey.c_str(),
+                        settingsRegistryOrigin.m_originFilePath.c_str(),
+                        settingsRegistryOrigin.m_settingsValue.has_value() ? settingsRegistryOrigin.m_settingsValue.value().c_str()
+                                                                           : "<removed>");
+                    return true;
+            });
+        }
+    
+        AZ::Debug::Trace::Output("SettingsRegistry", outputString.c_str());
+    }
+
+    [[nodiscard]] ConsoleFunctorHandle RegisterAzConsoleCommands(SettingsRegistryOriginTracker& originTracker, AZ::IConsole& azConsole)
+    {
+        ConsoleFunctorHandle resultHandle{};
+        resultHandle.m_originTrackerConsoleFunctors.emplace_back(
+            azConsole,
+            SettingsRegistryDumpOrigin,
+        R"(Dump the file origin of one or more settings from the global settings registry at the input JSON pointer paths.)" "\n"
+        R"(If no pointer-path argument is supplied, then all file origins for the global settings registry are dumped)" "\n"
+        R"(@param pointer-path - space separate list of JSON key paths whose file origin should be dumped )",
+        ConsoleFunctorFlags::Null, AZ::TypeId::CreateNull(), originTracker, &ConsoleDumpSettingsFileOriginValue);
+
+        return resultHandle;
     }
 
 

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.cpp
@@ -130,7 +130,7 @@ namespace AZ::SettingsRegistryConsoleUtils
         {
             settingsRegistryOriginTracker.VisitOrigins(settingsKeyToDump, [&outputString](const AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin& settingsRegistryOrigin)
             {
-                outputString += AZStd::string::format("Key: %s Origin: %s Value when Merged: %s\n", settingsRegistryOrigin.m_settingsKey.c_str(),
+                outputString += AZStd::string::format("Key: \"%s\" Origin: \"%s\" Value when Merged: %s\n", settingsRegistryOrigin.m_settingsKey.c_str(),
                         settingsRegistryOrigin.m_originFilePath.c_str(),
                         settingsRegistryOrigin.m_settingsValue.has_value() ? settingsRegistryOrigin.m_settingsValue.value().c_str()
                                                                            : "<removed>");

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.h
@@ -68,7 +68,7 @@ namespace AZ::SettingsRegistryConsoleUtils
     //! "sr_dump_origin" accepts 0 or more arguments <settings-key path>*
     //!  Outputs the file origin starting at the supplied settings key path to stdout.
     //!  The settings keys are recursed to find children settings. Each of those have their file origins output as well
-    //!  If no arguments settings key aarguments are supplied, all settigns file origins are output
+    //!  If no arguments settings key arguments are supplied, all settings file origins are output
     //!  NOTE: this might result in a large amount of output to the console
     [[nodiscard]] ConsoleFunctorHandle RegisterAzConsoleCommands(AZ::SettingsRegistryOriginTracker& settingsRegistryOriginTracker, AZ::IConsole& azConsole);
     

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.h
@@ -11,6 +11,7 @@
 #include <AzCore/std/containers/fixed_vector.h>
 #include <AzCore/Console/ConsoleFunctor.h>
 #include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryOriginTracker.h>
 
 namespace AZ::SettingsRegistryConsoleUtils
 {
@@ -18,12 +19,14 @@ namespace AZ::SettingsRegistryConsoleUtils
     //! "regset", "regremove", "regdump", "regdumpall", "regset-file"
     //! The value should be increased if more commands are needed
     inline constexpr size_t MaxSettingsRegistryConsoleFunctors = 5;
+    inline constexpr size_t MaxSettingsRegistryOriginTrackerConsoleFunctors = 1;
 
     inline constexpr const char* SettingsRegistrySet = "sr_regset";
     inline constexpr const char* SettingsRegistryRemove = "sr_regremove";
     inline constexpr const char* SettingsRegistryDump = "sr_regdump";
     inline constexpr const char* SettingsRegistryDumpAll = "sr_regdumpall";
     inline constexpr const char* SettingsRegistryMergeFile = "sr_regset_file";
+    inline constexpr const char* SettingsRegistryDumpOrigin = "sr_dump_origin";
 
     // RAII structure which owns the instances of the Settings Registry Console commands
     // registered with an AZ Console
@@ -33,8 +36,11 @@ namespace AZ::SettingsRegistryConsoleUtils
         ConsoleFunctorHandle() = default;
         using SettingsRegistryConsoleFunctor = AZ::ConsoleFunctor<SettingsRegistryInterface, false>;
         using SettingsRegistryFunctorsArray = AZStd::fixed_vector<SettingsRegistryConsoleFunctor, MaxSettingsRegistryConsoleFunctors>;
+        using SettingsRegistryOriginTrackerConsoleFunctor = AZ::ConsoleFunctor<SettingsRegistryOriginTracker, false>;
+        using SettingsRegistryOriginTrackerFunctorsArray = AZStd::fixed_vector<SettingsRegistryOriginTrackerConsoleFunctor, MaxSettingsRegistryOriginTrackerConsoleFunctors>;
 
         SettingsRegistryFunctorsArray m_consoleFunctors;
+        SettingsRegistryOriginTrackerFunctorsArray m_originTrackerConsoleFunctors;
     };
 
     //! Registers the following console commands
@@ -57,5 +63,13 @@ namespace AZ::SettingsRegistryConsoleUtils
     //!  Merges the json formatted file <file path> into the settings registry underneath the root anchor ""
     //!  or <anchor json path> if supplied
     [[nodiscard]] ConsoleFunctorHandle RegisterAzConsoleCommands(SettingsRegistryInterface& registry, AZ::IConsole& azConsole);
+
+    //! Registers the following console commands for the SettingsRegistryOriginTracker
+    //! "sr_dump_origin" accepts 0 or more arguments <settings-key path>*
+    //!  Outputs the file origin starting at the supplied settings key path to stdout.
+    //!  The settings keys are recursed to find children settings. Each of those have their file origins output as well
+    //!  If no arguments settings key aarguments are supplied, all settigns file origins are output
+    //!  NOTE: this might result in a large amount of output to the console
+    [[nodiscard]] ConsoleFunctorHandle RegisterAzConsoleCommands(AZ::SettingsRegistryOriginTracker& settingsRegistryOriginTracker, AZ::IConsole& azConsole);
     
 }

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.h
@@ -10,7 +10,7 @@
 
 #include <AzCore/JSON/document.h>
 #include <AzCore/JSON/pointer.h>
-#include <AzCore/IO/Path/Path_fwd.h>
+#include <AzCore/IO/Path/Path.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/Settings/SettingsRegistry.h>
@@ -40,7 +40,7 @@ namespace AZ
         //! otherwise always use SystemFile
         explicit SettingsRegistryImpl(bool useFileIo);
         AZ_DISABLE_COPY_MOVE(SettingsRegistryImpl);
-        ~SettingsRegistryImpl() override = default;
+        ~SettingsRegistryImpl() override;
 
         void SetContext(SerializeContext* context);
         void SetContext(JsonRegistrationContext* context);
@@ -114,6 +114,7 @@ namespace AZ
         bool MergeSettingsFileInternal(const char* path, Format format, AZStd::string_view rootKey, AZStd::vector<char>& scratchBuffer);
 
         void SignalNotifier(AZStd::string_view jsonPath, Type type);
+
         
         mutable AZStd::recursive_mutex m_settingMutex;
         mutable AZStd::recursive_mutex m_notifierMutex;
@@ -122,14 +123,15 @@ namespace AZ
         PostMergeEvent m_postMergeEvent;
 
         //! NOTE: During SignalNotifier, the registered notify event handlers are moved to a local NotifyEvent
-        //! Therefore setting a value within the registry during signaling will queue future SignalNotifer calls
-        //! These calls will then be invoked after the current signaling has completex
+        //! Therefore setting a value within the registry during signaling will queue future SignalNotifeir calls
+        //! These calls will then be invoked after the current signaling has completed
         //! This is done to avoid deadlock if another thread attempts to access register a notifier or signal one
         mutable AZStd::mutex m_signalMutex;
         struct SignalNotifierArgs
         {
             FixedValueString m_jsonPath;
             Type m_type;
+            AZ::IO::FixedMaxPath m_mergeFilePath;
         };
         AZStd::deque<SignalNotifierArgs> m_signalNotifierQueue;
         AZStd::atomic_int m_signalCount{};
@@ -137,8 +139,23 @@ namespace AZ
         rapidjson::Document m_settings;
         JsonSerializerSettings m_serializationSettings;
         JsonDeserializerSettings m_deserializationSettings;
+        //! If set to true, then the JSON Patch/JSON Merge Patch operations
+        //! also result in the signaling of a notification event
         bool m_mergeOperationNotify{};
-
+        //! When true use the Registered FileIOBase for file open operations
         bool m_useFileIo{};
+
+
+        struct ScopedMergeEvent
+        {
+            ScopedMergeEvent(SettingsRegistryImpl& settingsRegistry, MergeEventArgs mergeEventArgs);
+            ~ScopedMergeEvent();
+
+            SettingsRegistryImpl& m_settingsRegistry;
+            MergeEventArgs m_mergeEventArgs;
+        };
+        //! Stack tracking the files currently being merged
+        //! This is protected by m_settingsMutex
+        AZStd::stack<AZ::IO::FixedMaxPath> m_mergeFilePathStack;
     };
 } // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.h
@@ -123,7 +123,7 @@ namespace AZ
         PostMergeEvent m_postMergeEvent;
 
         //! NOTE: During SignalNotifier, the registered notify event handlers are moved to a local NotifyEvent
-        //! Therefore setting a value within the registry during signaling will queue future SignalNotifeir calls
+        //! Therefore setting a value within the registry during signaling will queue future SignalNotifier calls
         //! These calls will then be invoked after the current signaling has completed
         //! This is done to avoid deadlock if another thread attempts to access register a notifier or signal one
         mutable AZStd::mutex m_signalMutex;

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.h
@@ -84,8 +84,8 @@ namespace AZ
         bool MergeSettingsFolder(AZStd::string_view path, const Specializations& specializations,
             AZStd::string_view platform, AZStd::string_view anchorKey = "", AZStd::vector<char>* scratchBuffer = nullptr) override;
 
-        void SetApplyPatchSettings(const AZ::JsonApplyPatchSettings& applyPatchSettings) override;
-        void GetApplyPatchSettings(AZ::JsonApplyPatchSettings& applyPatchSettings) override;
+        void SetNotifyForMergeOperations(bool notify) override;
+        bool GetNotifyForMergeOperations() const override;
 
         void SetUseFileIO(bool useFileIo) override;
 
@@ -137,7 +137,7 @@ namespace AZ
         rapidjson::Document m_settings;
         JsonSerializerSettings m_serializationSettings;
         JsonDeserializerSettings m_deserializationSettings;
-        JsonApplyPatchSettings m_applyPatchSettings;
+        bool m_mergeOperationNotify{};
 
         bool m_useFileIo{};
     };

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.cpp
@@ -6,8 +6,6 @@
  *
  */
 
-#pragma once
-
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Settings/SettingsRegistryOriginTracker.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.cpp
@@ -41,6 +41,11 @@ namespace AZ
         return m_settingsRegistry;
     }
 
+    const AZ::SettingsRegistryInterface& SettingsRegistryOriginTracker::GetSettingsRegistry() const
+    {
+        return m_settingsRegistry;
+    }
+
     SettingsRegistryOriginTracker::SettingsNotificationHandler::~SettingsNotificationHandler() = default;
 
     bool SettingsRegistryOriginTracker::SettingsRegistryOrigin::operator==(const SettingsRegistryOrigin& origin) const
@@ -74,9 +79,9 @@ namespace AZ
         m_originTracker.AddOrigin(notifyEventArgs.m_jsonKeyPath, notifyEventArgs.m_mergeFilePath);
     }
 
-    bool SettingsRegistryOriginTracker::FindLastOrigin(AZ::IO::Path& originPath, AZStd::string_view key)
+    bool SettingsRegistryOriginTracker::FindLastOrigin(AZ::IO::Path& originPath, AZStd::string_view key) const
     {
-        auto populateOriginPath = [&](const AZ::Dom::Path&, const SettingsRegistryOriginStack& stack)
+        auto populateOriginPath = [&originPath](const AZ::Dom::Path&, const SettingsRegistryOriginStack& stack)
         {
             if (!stack.empty())
             {
@@ -86,7 +91,7 @@ namespace AZ
             return true;
         };
         AZ::Dom::Path jsonPath = AZ::Dom::Path(key);
-        AZ::Dom::PrefixTreeTraversalFlags traversalFlags = AZ::Dom::PrefixTreeTraversalFlags::ExcludeChildPaths | AZ::Dom::PrefixTreeTraversalFlags::TraverseMostToLeastSpecific;
+        constexpr AZ::Dom::PrefixTreeTraversalFlags traversalFlags = AZ::Dom::PrefixTreeTraversalFlags::ExcludeChildPaths | AZ::Dom::PrefixTreeTraversalFlags::TraverseMostToLeastSpecific;
         m_settingsOriginPrefixTree.VisitPath(jsonPath, populateOriginPath, traversalFlags);
         return !originPath.empty();
     }
@@ -209,9 +214,9 @@ namespace AZ
         m_settingsOriginPrefixTree.VisitPath(jsonPath, removeOriginAtKey, traversalFlags);
     }
 
-    void SettingsRegistryOriginTracker::VisitOrigins(AZStd::string_view key, const OriginVisitorCallback& visitCallback)
+    void SettingsRegistryOriginTracker::VisitOrigins(AZStd::string_view key, const OriginVisitorCallback& visitCallback) const
     {
-        auto visitOriginStackCallback = [&](const AZ::Dom::Path&, SettingsRegistryOriginStack& stack)
+        auto visitOriginStackCallback = [&](const AZ::Dom::Path&, const SettingsRegistryOriginStack& stack)
         {
             for (const auto& origin : stack)
             {
@@ -223,7 +228,7 @@ namespace AZ
             return true;
         };
         AZ::Dom::Path jsonPath = AZ::Dom::Path(key);
-        AZ::Dom::PrefixTreeTraversalFlags traversalFlags =
+        constexpr AZ::Dom::PrefixTreeTraversalFlags traversalFlags =
             AZ::Dom::PrefixTreeTraversalFlags::TraverseLeastToMostSpecific | AZ::Dom::PrefixTreeTraversalFlags::ExcludeParentPaths;
         m_settingsOriginPrefixTree.VisitPath(jsonPath, visitOriginStackCallback, traversalFlags);
     }

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AZCore/Settings/SettingsRegistryOriginTracker.h>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/IO/ByteContainerStream.h>
+
+namespace AZ
+{
+    SettingsRegistryOriginTracker::SettingsRegistryOriginTracker(AZ::SettingsRegistryInterface& registry)
+        : m_settingsRegistry(registry)
+    {
+        registry.SetNotifyForMergeOperations(true);
+        auto preMergeCallback =
+            [this](AZStd::string_view filePath, [[maybe_unused]] AZStd::string_view rootKey)
+        {
+            m_currentOriginStack.emplace(filePath);
+        };
+        auto postMergeCallback =
+            [this]([[maybe_unused]] AZStd::string_view path, [[maybe_unused]] AZStd::string_view rootKey)
+        {
+            m_currentOriginStack.pop();
+        };
+        m_preMergeEventHandler = m_settingsRegistry.RegisterPreMergeEvent(preMergeCallback);
+        m_postMergeEventHandler = m_settingsRegistry.RegisterPostMergeEvent(postMergeCallback);
+        m_notifyHandler = m_settingsRegistry.RegisterNotifier(SettingsNotificationHandler(*this));
+    };
+
+    SettingsRegistryOriginTracker::~SettingsRegistryOriginTracker()
+    {
+        AZ_Assert(
+            m_currentOriginStack.empty(),
+            "The Settings Registry Origin Tracker origin stack should be empty on destruction."
+            " This implies that it is being destroyed during the middle of merging a file");
+    };
+
+    SettingsRegistryOriginTracker::SettingsNotificationHandler::SettingsNotificationHandler(AZ::SettingsRegistryOriginTracker &originTracker) : m_originTracker(originTracker){
+    };
+
+    SettingsRegistryOriginTracker::SettingsNotificationHandler::~SettingsNotificationHandler() = default;
+
+    bool SettingsRegistryOriginTracker::SettingsRegistryOrigin::operator==(const SettingsRegistryOrigin& origin) const
+    {
+        return (
+            m_originFilePath == origin.m_originFilePath && m_settingsKey == origin.m_settingsKey &&
+            m_settingsValue == origin.m_settingsValue);
+    }
+
+
+    void AZ::SettingsRegistryOriginTracker::SettingsNotificationHandler::operator()(AZStd::string_view path, AZ::SettingsRegistryInterface::Type){
+        AZ::IO::Path originPath =
+            !m_originTracker.m_currentOriginStack.empty() ? m_originTracker.m_currentOriginStack.top() : "<in-memory>";
+        m_originTracker.AddOrigin(path, originPath);
+    };
+
+    bool SettingsRegistryOriginTracker::FindLastOrigin(AZ::IO::Path &originPath, AZStd::string_view key) {
+        auto populateOriginPath = [&](const AZ::Dom::Path&, const SettingsRegistryOriginStack& stack)
+        {
+            if (originPath.empty() && !stack.empty())
+            {
+                originPath = stack.back().m_originFilePath;
+                return false;
+            };
+            return true;
+        };
+        AZ::Dom::Path jsonPath = AZ::Dom::Path(key);
+        m_settingsOriginPrefixTree.VisitPath(
+            jsonPath, populateOriginPath, AZ::Dom::PrefixTreeTraversalFlags::TraverseLeastToMostSpecific);
+        return !originPath.empty();
+    }
+
+    void SettingsRegistryOriginTracker::AddOrigin(AZStd::string_view key, AZ::IO::PathView originPath)
+    {
+        AZ::Dom::Path jsonPath = AZ::Dom::Path(key);
+        m_settingsOriginPrefixTree.ValueAtPathOrDefault(
+            jsonPath, SettingsRegistryOriginStack(), AZ::Dom::PrefixTreeMatch::PathAndParents);
+        auto removeExistingOrigin = [&](const AZ::Dom::Path&, SettingsRegistryOriginStack& stack)
+        {
+            for (auto it = stack.begin(); it != stack.end(); ++it)
+            {
+                if (it->m_originFilePath == originPath)
+                {
+                    stack.erase(it);
+                    break;
+                };
+            };
+            return true;
+        };
+        m_settingsOriginPrefixTree.VisitPath(jsonPath, removeExistingOrigin, AZ::Dom::PrefixTreeTraversalFlags::TraverseLeastToMostSpecific);
+        auto addOriginToStack = [&](const AZ::Dom::Path& path, SettingsRegistryOriginStack& stack) {
+            if (stack.empty() || path == jsonPath)
+            {
+                AZStd::string_view pathStr = AZStd::string_view(path.ToString());
+                AZStd::string settingJsonStr;
+                AZ::IO::ByteContainerStream stringWriter(&settingJsonStr);
+                AZ::SettingsRegistryMergeUtils::DumperSettings dumperSettings;
+                AZ::SettingsRegistryMergeUtils::DumpSettingsRegistryToStream(this->m_settingsRegistry, key, stringWriter, dumperSettings);
+                SettingsRegistryOriginTracker::SettingsRegistryOrigin origin{ originPath, pathStr, settingJsonStr };
+                stack.emplace_back(origin);
+            };
+            return true;
+        };
+        m_settingsOriginPrefixTree.VisitPath(jsonPath, addOriginToStack, AZ::Dom::PrefixTreeTraversalFlags::TraverseLeastToMostSpecific);
+    };
+
+    void RemoveOrigin(AZStd::string_view key, AZ::IO::PathView originPath, bool recurseChildren)
+    {
+        (void)key;
+        (void)originPath;
+        (void)recurseChildren;
+    };
+
+    void SettingsRegistryOriginTracker::VisitOrigins(AZStd::string_view key, const OriginVisitorCallback& visitCallback)
+    {
+        auto visitOriginStackCallback = [&](const AZ::Dom::Path&, SettingsRegistryOriginStack& stack)
+        {
+            for (auto& origin : stack)
+            {
+                if (visitCallback(origin))
+                {
+                    break;
+                }
+            }
+            AZ::Dom::Path jsonPath = AZ::Dom::Path(key);
+            return true;
+        };
+        AZ::Dom::Path jsonPath = AZ::Dom::Path(key);
+        m_settingsOriginPrefixTree.VisitPath(jsonPath, visitOriginStackCallback, AZ::Dom::PrefixTreeTraversalFlags::TraverseLeastToMostSpecific);
+    };
+
+
+};

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.cpp
@@ -119,14 +119,27 @@ namespace AZ
             if (auto type = m_settingsRegistry.GetType(key);
                 type != AZ::SettingsRegistryInterface::Type::NoType)
             {
-                // Retrieve the JSON value as a string using the SettingsRegistryMergeUtils::DumpSettingsRegistryToStream function
+                // If the Type is an array or object just add a marker value instead of dumping the entire object
                 AZStd::string settingsValue;
-                AZ::IO::ByteContainerStream stringWriter(&settingsValue);
-                AZ::SettingsRegistryMergeUtils::DumperSettings dumperSettings;
-                dumperSettings.m_prettifyOutput = false;
-                AZ_Verify(AZ::SettingsRegistryMergeUtils::DumpSettingsRegistryToStream(m_settingsRegistry, key, stringWriter, dumperSettings),
-                    R"(Failed to Dump SettingsRegistry at key "%.*s")", AZ_STRING_ARG(key));
-
+                if (type == AZ::SettingsRegistryInterface::Type::Object)
+                {
+                    constexpr AZStd::string_view ObjectMarkerValue = "<object>";
+                    settingsValue = ObjectMarkerValue;
+                }
+                else if (type == AZ::SettingsRegistryInterface::Type::Array)
+                {
+                    constexpr AZStd::string_view ArrayMarkerValue = "<array>";
+                    settingsValue = ArrayMarkerValue;
+                }
+                else
+                {
+                    // Retrieve the JSON value as a string using the SettingsRegistryMergeUtils::DumpSettingsRegistryToStream function
+                    AZ::IO::ByteContainerStream stringWriter(&settingsValue);
+                    AZ::SettingsRegistryMergeUtils::DumperSettings dumperSettings;
+                    dumperSettings.m_prettifyOutput = false;
+                    AZ_Verify(AZ::SettingsRegistryMergeUtils::DumpSettingsRegistryToStream(m_settingsRegistry, key, stringWriter, dumperSettings),
+                        R"(Failed to Dump SettingsRegistry at key "%.*s")", AZ_STRING_ARG(key));
+                }
                 // The settings at the json pointer path has been written to the string writer as JSON
                 // So emplace it into the settings value of SettingsRegistryOrigin
                 settingsRegistryOrigin.m_settingsValue.emplace(settingsValue);

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
@@ -39,9 +39,10 @@ namespace AZ
 
         //! Gets setting registry being tracked
         AZ::SettingsRegistryInterface& GetSettingsRegistry();
+        const AZ::SettingsRegistryInterface& GetSettingsRegistry() const;
 
         //! Returns the last origin associated with the given key
-        bool FindLastOrigin(AZ::IO::Path& originPath, AZStd::string_view key);
+        bool FindLastOrigin(AZ::IO::Path& originPath, AZStd::string_view key) const;
 
         struct SettingsRegistryOrigin
         {
@@ -69,7 +70,7 @@ namespace AZ
 
         //! Visit all settings keys that are at specified key path and any children in the DomPrefixTree
         //! and invoke the supplied callback with the visit key and the SettingsRegistryOriginStack
-        void VisitOrigins(AZStd::string_view key, const OriginVisitorCallback& visitCallback);
+        void VisitOrigins(AZStd::string_view key, const OriginVisitorCallback& visitCallback) const;
 
     private:
 

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
@@ -35,6 +35,9 @@ namespace AZ
         //! If empty, all settings within the associated registry will be tracked
         void SetTrackingFilter(TrackingFilterCallback filterCallback);
 
+        //! Gets setting registry being tracked
+        AZ::SettingsRegistryInterface& GetSettingsRegistry();
+
         //! Returns the last origin associated with the given key
         bool FindLastOrigin(AZ::IO::Path& originPath, AZStd::string_view key);
 

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/string/string_view.h>
+#include <AzCore/std/optional.h>
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/std/containers/deque.h>
+#include <AzCore/std/containers/stack.h>
+#include <AzCore/std/function/function_template.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryImpl.h>
+#include <AzCore/DOM/DomPrefixTree.h>
+#include <AzCore/Serialization/Json/JsonSerializationResult.h>
+
+namespace AZ
+{
+    class SettingsRegistryOriginTracker
+    {
+        public:
+            explicit SettingsRegistryOriginTracker(AZ::SettingsRegistryInterface& registry);
+            ~SettingsRegistryOriginTracker();
+        
+            //! TrackingFilterCallback will be invoked with the JSON settings key being updated
+            //! It should return true if the key at that JSON path should be tracked
+            using TrackingFilterCallback = AZStd::function<bool(AZStd::string_view keyPath)>;
+        
+            //! Sets functions which will be used to filter which settings should be tracked
+            //! If empty, all settings within the associated registry will be tracked
+            void SetTrackingFilter(TrackingFilterCallback filterCallback);
+        
+            //! Returns the last origin associated with the given key
+            bool FindLastOrigin(AZ::IO::Path &originPath, AZStd::string_view key);
+        
+            struct SettingsRegistryOrigin
+            {
+                //! Path to the file where the settings is sourced from or a special value in angle brackets to indicate a non-file source(<C++>, <command-line>, etc...)
+                AZ::IO::Path m_originFilePath;
+                //! The value of the settings key associated with the origin
+                AZStd::string m_settingsKey;
+                
+                //! Sutable for representing a setting as a JSON string or to be not engaged if the setting has been deleted.
+                using ValueType = AZStd::optional<AZStd::string>;
+        
+                //! The value of the setting as a JSON string at the time the origin entry was created
+                //! If the value is a nullopt, then the setting was removed
+                ValueType m_settingsValue;
+
+                bool operator==(const SettingsRegistryOrigin& origin) const;
+            };
+
+            using SettingsRegistryOriginStack = AZStd::deque<SettingsRegistryOrigin>;
+
+            //! Origin Visitor is callback is invoked for each setting key found during the VisitOrigins method
+            //! @param settingsRegistryOrigin entry being visited
+            //! @returns True should be returned if the visitation should continue.
+            using OriginVisitorCallback = AZStd::function<bool(const SettingsRegistryOrigin&)>;
+
+            //! Visit all settings keys that are at specified key path and any children in the DomPrefixTree
+            //! and invoke the supplied callback with the visit key and the SettingsRegistryOriginStack
+            void VisitOrigins(AZStd::string_view key, const OriginVisitorCallback& visitCallback);
+
+        private:
+
+            struct SettingsNotificationHandler
+            {
+                SettingsNotificationHandler(SettingsRegistryOriginTracker& originTracker);
+                ~SettingsNotificationHandler();
+        
+                void operator()(AZStd::string_view path, AZ::SettingsRegistryInterface::Type type);
+        
+            private:
+                SettingsRegistryOriginTracker& m_originTracker;
+                AZ::JsonSerializationResult::JsonIssueCallback m_prevReportingCallback;
+            };
+        
+            using SettingsRegistryOriginPrefixTree = AZ::Dom::DomPrefixTree<SettingsRegistryOriginStack>;
+            
+            //! Origin Visitor is callback is invoked for each setting key found during the VisitOrigins method
+            //! @param settingsRegistryOrigin entry being visited
+            //! @returns True should be returned if the visitation should continue.
+            using OriginVisitorCallback = AZStd::function<bool(const SettingsRegistryOrigin&)>;
+        
+            //! Afterwards push a new entry into the Origin Stack PrefixTree for the origin path
+            void AddOrigin(AZStd::string_view key, AZ::IO::PathView originPath);
+            //! Looks up the settings key in the Origin Stack Prefix Tree dict and removes an entry with the origin path
+            //! If after this opration the Origin Stack is empty, then prefix tree entry is removed
+            //! @param recurseChildren, If true children entries from the key in the Prefix Tree will also be visited.
+            void RemoveOrigin(AZStd::string_view key, AZ::IO::PathView originPath, bool recurseChildren = false);
+        
+        
+        private: // member variables
+            AZ::SettingsRegistryInterface& m_settingsRegistry;
+            AZ::SettingsRegistryInterface::PreMergeEventHandler m_preMergeEventHandler;
+            AZ::SettingsRegistryInterface::PostMergeEventHandler m_postMergeEventHandler;
+            AZ::SettingsRegistryInterface::NotifyEventHandler m_notifyHandler;
+        
+            //! Maps a DOM path for the setting to a stack of entries which contain the source file where the setting originates from and a patch that recreate the value within that file
+            SettingsRegistryOriginPrefixTree m_settingsOriginPrefixTree;
+            //! Stack tracking the current settings file origin
+            //! If empty the settings is set within the runtime and not from a file
+            AZStd::stack<AZ::IO::Path> m_currentOriginStack;
+            //! Callback that is invoked when a setting field is added/updated/removed
+            TrackingFilterCallback m_trackingFilter;
+    };
+};

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
@@ -93,7 +93,7 @@ namespace AZ
             //! If after this opration the Origin Stack is empty, then prefix tree entry is removed
             //! @param recurseChildren, If true children entries from the key in the Prefix Tree will also be visited.
             void RemoveOrigin(AZStd::string_view key, AZ::IO::PathView originPath, bool recurseChildren = false);
-        
+
         
         private: // member variables
             AZ::SettingsRegistryInterface& m_settingsRegistry;
@@ -106,7 +106,7 @@ namespace AZ
             //! Stack tracking the current settings file origin
             //! If empty the settings is set within the runtime and not from a file
             AZStd::stack<AZ::IO::Path> m_currentOriginStack;
-            //! Callback that is invoked when a setting field is added/updated/removed
+            //! Stack containing vectors of keys being added or modified while a file is being merged
             TrackingFilterCallback m_trackingFilter;
     };
 };

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
@@ -23,90 +23,85 @@ namespace AZ
 {
     class SettingsRegistryOriginTracker
     {
-        public:
-            explicit SettingsRegistryOriginTracker(AZ::SettingsRegistryInterface& registry);
-            ~SettingsRegistryOriginTracker();
-        
-            //! TrackingFilterCallback will be invoked with the JSON settings key being updated
-            //! It should return true if the key at that JSON path should be tracked
-            using TrackingFilterCallback = AZStd::function<bool(AZStd::string_view keyPath)>;
-        
-            //! Sets functions which will be used to filter which settings should be tracked
-            //! If empty, all settings within the associated registry will be tracked
-            void SetTrackingFilter(TrackingFilterCallback filterCallback);
-        
-            //! Returns the last origin associated with the given key
-            bool FindLastOrigin(AZ::IO::Path &originPath, AZStd::string_view key);
-        
-            struct SettingsRegistryOrigin
-            {
-                //! Path to the file where the settings is sourced from or a special value in angle brackets to indicate a non-file source(<C++>, <command-line>, etc...)
-                AZ::IO::Path m_originFilePath;
-                //! The value of the settings key associated with the origin
-                AZStd::string m_settingsKey;
-                
-                //! Sutable for representing a setting as a JSON string or to be not engaged if the setting has been deleted.
-                using ValueType = AZStd::optional<AZStd::string>;
-        
-                //! The value of the setting as a JSON string at the time the origin entry was created
-                //! If the value is a nullopt, then the setting was removed
-                ValueType m_settingsValue;
+    public:
+        explicit SettingsRegistryOriginTracker(AZ::SettingsRegistryInterface& registry);
+        ~SettingsRegistryOriginTracker();
 
-                bool operator==(const SettingsRegistryOrigin& origin) const;
-            };
+        //! TrackingFilterCallback will be invoked with the JSON settings key being updated
+        //! It should return true if the key at that JSON path should be tracked
+        using TrackingFilterCallback = AZStd::function<bool(AZStd::string_view keyPath)>;
 
-            using SettingsRegistryOriginStack = AZStd::deque<SettingsRegistryOrigin>;
+        //! Sets functions which will be used to filter which settings should be tracked
+        //! If empty, all settings within the associated registry will be tracked
+        void SetTrackingFilter(TrackingFilterCallback filterCallback);
 
-            //! Origin Visitor is callback is invoked for each setting key found during the VisitOrigins method
-            //! @param settingsRegistryOrigin entry being visited
-            //! @returns True should be returned if the visitation should continue.
-            using OriginVisitorCallback = AZStd::function<bool(const SettingsRegistryOrigin&)>;
+        //! Returns the last origin associated with the given key
+        bool FindLastOrigin(AZ::IO::Path& originPath, AZStd::string_view key);
 
-            //! Visit all settings keys that are at specified key path and any children in the DomPrefixTree
-            //! and invoke the supplied callback with the visit key and the SettingsRegistryOriginStack
-            void VisitOrigins(AZStd::string_view key, const OriginVisitorCallback& visitCallback);
+        struct SettingsRegistryOrigin
+        {
+            //! Path to the file where the settings is sourced from or a special value in angle brackets to indicate a non-file source(<C++>, <command-line>, etc...)
+            AZ::IO::Path m_originFilePath;
+            //! The value of the settings key associated with the origin
+            AZStd::string m_settingsKey;
+
+            //! Sutable for representing a setting as a JSON string or to be not engaged if the setting has been deleted.
+            using ValueType = AZStd::optional<AZStd::string>;
+
+            //! The value of the setting as a JSON string at the time the origin entry was created
+            //! If the value is a nullopt, then the setting was removed
+            ValueType m_settingsValue;
+
+            bool operator==(const SettingsRegistryOrigin& origin) const;
+        };
+
+        using SettingsRegistryOriginStack = AZStd::deque<SettingsRegistryOrigin>;
+
+        //! Origin Visitor is callback is invoked for each setting key found during the VisitOrigins method
+        //! @param settingsRegistryOrigin entry being visited
+        //! @returns True should be returned if the visitation should continue.
+        using OriginVisitorCallback = AZStd::function<bool(const SettingsRegistryOrigin&)>;
+
+        //! Visit all settings keys that are at specified key path and any children in the DomPrefixTree
+        //! and invoke the supplied callback with the visit key and the SettingsRegistryOriginStack
+        void VisitOrigins(AZStd::string_view key, const OriginVisitorCallback& visitCallback);
+
+    private:
+
+        struct SettingsNotificationHandler
+        {
+            SettingsNotificationHandler(SettingsRegistryOriginTracker& originTracker);
+            ~SettingsNotificationHandler();
+
+            void operator()(const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs);
 
         private:
+            SettingsRegistryOriginTracker& m_originTracker;
+            AZ::JsonSerializationResult::JsonIssueCallback m_prevReportingCallback;
+        };
 
-            struct SettingsNotificationHandler
-            {
-                SettingsNotificationHandler(SettingsRegistryOriginTracker& originTracker);
-                ~SettingsNotificationHandler();
-        
-                void operator()(AZStd::string_view path, AZ::SettingsRegistryInterface::Type type);
-        
-            private:
-                SettingsRegistryOriginTracker& m_originTracker;
-                AZ::JsonSerializationResult::JsonIssueCallback m_prevReportingCallback;
-            };
-        
-            using SettingsRegistryOriginPrefixTree = AZ::Dom::DomPrefixTree<SettingsRegistryOriginStack>;
-            
-            //! Origin Visitor is callback is invoked for each setting key found during the VisitOrigins method
-            //! @param settingsRegistryOrigin entry being visited
-            //! @returns True should be returned if the visitation should continue.
-            using OriginVisitorCallback = AZStd::function<bool(const SettingsRegistryOrigin&)>;
-        
-            //! Afterwards push a new entry into the Origin Stack PrefixTree for the origin path
-            void AddOrigin(AZStd::string_view key, AZ::IO::PathView originPath);
-            //! Looks up the settings key in the Origin Stack Prefix Tree dict and removes an entry with the origin path
-            //! If after this opration the Origin Stack is empty, then prefix tree entry is removed
-            //! @param recurseChildren, If true children entries from the key in the Prefix Tree will also be visited.
-            void RemoveOrigin(AZStd::string_view key, AZ::IO::PathView originPath, bool recurseChildren = false);
+        using SettingsRegistryOriginPrefixTree = AZ::Dom::DomPrefixTree<SettingsRegistryOriginStack>;
 
-        
-        private: // member variables
-            AZ::SettingsRegistryInterface& m_settingsRegistry;
-            AZ::SettingsRegistryInterface::PreMergeEventHandler m_preMergeEventHandler;
-            AZ::SettingsRegistryInterface::PostMergeEventHandler m_postMergeEventHandler;
-            AZ::SettingsRegistryInterface::NotifyEventHandler m_notifyHandler;
-        
-            //! Maps a DOM path for the setting to a stack of entries which contain the source file where the setting originates from and a patch that recreate the value within that file
-            SettingsRegistryOriginPrefixTree m_settingsOriginPrefixTree;
-            //! Stack tracking the current settings file origin
-            //! If empty the settings is set within the runtime and not from a file
-            AZStd::stack<AZ::IO::Path> m_currentOriginStack;
-            //! Stack containing vectors of keys being added or modified while a file is being merged
-            TrackingFilterCallback m_trackingFilter;
+        //! Origin Visitor is callback is invoked for each setting key found during the VisitOrigins method
+        //! @param settingsRegistryOrigin entry being visited
+        //! @returns True should be returned if the visitation should continue.
+        using OriginVisitorCallback = AZStd::function<bool(const SettingsRegistryOrigin&)>;
+
+        //! Afterwards push a new entry into the Origin Stack PrefixTree for the origin path
+        void AddOrigin(AZStd::string_view key, AZ::IO::PathView originPath);
+        //! Looks up the settings key in the Origin Stack Prefix Tree dict and removes an entry with the origin path
+        //! If after this opration the Origin Stack is empty, then prefix tree entry is removed
+        //! @param recurseChildren, If true children entries from the key in the Prefix Tree will also be visited.
+        void RemoveOrigin(AZStd::string_view key, AZ::IO::PathView originPath, bool recurseChildren = false);
+
+
+    private: // member variables
+        AZ::SettingsRegistryInterface& m_settingsRegistry;
+        AZ::SettingsRegistryInterface::NotifyEventHandler m_notifyHandler;
+
+        //! Maps a DOM path for the setting to a stack of entries which contain the source file where the setting originates from and a patch that recreate the value within that file
+        SettingsRegistryOriginPrefixTree m_settingsOriginPrefixTree;
+        //! Stack containing vectors of keys being added or modified while a file is being merged
+        TrackingFilterCallback m_trackingFilter;
     };
 };

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
@@ -24,6 +24,8 @@ namespace AZ
     class SettingsRegistryOriginTracker
     {
     public:
+        AZ_TYPE_INFO(SettingsRegistryOriginTracker, "{F6E3B4E5-F8CF-43D8-8609-BC322D9D08C5}");
+
         explicit SettingsRegistryOriginTracker(AZ::SettingsRegistryInterface& registry);
         ~SettingsRegistryOriginTracker();
 
@@ -107,4 +109,4 @@ namespace AZ
         //! Stack containing vectors of keys being added or modified while a file is being merged
         TrackingFilterCallback m_trackingFilter;
     };
-};
+}

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryOriginTracker.h
@@ -88,11 +88,6 @@ namespace AZ
 
         using SettingsRegistryOriginPrefixTree = AZ::Dom::DomPrefixTree<SettingsRegistryOriginStack>;
 
-        //! Origin Visitor is callback is invoked for each setting key found during the VisitOrigins method
-        //! @param settingsRegistryOrigin entry being visited
-        //! @returns True should be returned if the visitation should continue.
-        using OriginVisitorCallback = AZStd::function<bool(const SettingsRegistryOrigin&)>;
-
         //! Afterwards push a new entry into the Origin Stack PrefixTree for the origin path
         void AddOrigin(AZStd::string_view key, AZ::IO::PathView originPath);
         //! Looks up the settings key in the Origin Stack Prefix Tree dict and removes an entry with the origin path

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryScriptUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryScriptUtils.cpp
@@ -20,11 +20,12 @@ namespace AZ::SettingsRegistryScriptUtils::Internal
     {
         if (settingsRegistry != nullptr)
         {
-            auto ForwardSettingsUpdateToProxyEvent = [notifyEventProxy](AZStd::string_view path, AZ::SettingsRegistryInterface::Type)
+            auto ForwardSettingsUpdateToProxyEvent = [notifyEventProxy](
+                const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
             {
                 if (notifyEventProxy)
                 {
-                    notifyEventProxy->m_scriptNotifyEvent.Signal(path);
+                    notifyEventProxy->m_scriptNotifyEvent.Signal(notifyEventArgs.m_jsonKeyPath);
                 }
             };
             // Register the forwarding function with the BehaviorContext

--- a/Code/Framework/AzCore/AzCore/UnitTest/Mocks/MockSettingsRegistry.h
+++ b/Code/Framework/AzCore/AzCore/UnitTest/Mocks/MockSettingsRegistry.h
@@ -55,8 +55,8 @@ namespace AZ
             MergeSettingsFolder,
             bool(AZStd::string_view, const Specializations&, AZStd::string_view, AZStd::string_view, AZStd::vector<char>*));
 
-        MOCK_METHOD1(SetApplyPatchSettings, void(const JsonApplyPatchSettings&));
-        MOCK_METHOD1(GetApplyPatchSettings, void(JsonApplyPatchSettings&));
+        MOCK_METHOD1(SetNotifyForMergeOperations, void(bool));
+        MOCK_CONST_METHOD0(GetNotifyForMergeOperations, bool());
         MOCK_METHOD1(SetUseFileIO, void(bool));
     };
 } // namespace AZ

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -583,6 +583,8 @@ set(FILES
     Settings/SettingsRegistryImpl.h
     Settings/SettingsRegistryMergeUtils.cpp
     Settings/SettingsRegistryMergeUtils.h
+    Settings/SettingsRegistryOriginTracker.cpp
+    Settings/SettingsRegistryOriginTracker.h
     Settings/SettingsRegistryScriptUtils.cpp
     Settings/SettingsRegistryScriptUtils.h
     Settings/SettingsRegistryVisitorUtils.cpp

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryConsoleUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryConsoleUtilsTests.cpp
@@ -6,11 +6,14 @@
  *
  */
 
+#include <AzCore/Name/NameDictionary.h>
 #include <AzCore/Console/Console.h>
 #include <AzCore/Debug/TraceMessageBus.h>
 #include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzCore/Settings/SettingsRegistryConsoleUtils.h>
+#include <AzCore/Settings/SettingsRegistryOriginTracker.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/std/string/string.h>
 
 namespace SettingsRegistryConsoleUtilsTests
 {
@@ -19,9 +22,21 @@ namespace SettingsRegistryConsoleUtilsTests
     {
     public:
 
+        SettingsRegistryConsoleUtilsFixture()
+            : ScopedAllocatorSetupFixture()
+        {
+            AZ::NameDictionary::Create();
+        }
+
+        ~SettingsRegistryConsoleUtilsFixture()
+        {
+            AZ::NameDictionary::Destroy();
+        }
+
         void SetUp() override
         {
             m_registry = AZStd::make_unique<AZ::SettingsRegistryImpl>();
+            m_originTracker = AZStd::make_unique<AZ::SettingsRegistryOriginTracker>(*m_registry);
             // Store off the old global settings registry to restore after each test
             m_oldSettingsRegistry = AZ::SettingsRegistry::Get();
             if (m_oldSettingsRegistry != nullptr)
@@ -40,10 +55,12 @@ namespace SettingsRegistryConsoleUtilsTests
                 AZ::SettingsRegistry::Register(m_oldSettingsRegistry);
                 m_oldSettingsRegistry = {};
             }
+            m_originTracker.reset();
             m_registry.reset();
         }
 
         AZStd::unique_ptr<AZ::SettingsRegistryImpl> m_registry;
+        AZStd::unique_ptr<AZ::SettingsRegistryOriginTracker> m_originTracker;
         AZ::SettingsRegistryInterface* m_oldSettingsRegistry{};
     };
 
@@ -248,6 +265,60 @@ namespace SettingsRegistryConsoleUtilsTests
         SettingsRegistryDumpAllCommandHandler traceHandler{ SettingsKey, SettingsKey2, ExpectedValue, ExpectedValue2 };
         traceHandler.BusConnect();
         EXPECT_TRUE(testConsole.PerformCommand(AZ::SettingsRegistryConsoleUtils::SettingsRegistryDumpAll));
+        traceHandler.BusDisconnect();
+    }
+
+    TEST_F(SettingsRegistryConsoleUtilsFixture, SettingsRegistryCommand_DumpOrigin_Succeeds)
+    {
+        constexpr const char* SettingsKey = "TestKey";
+        constexpr const char* SettingsKey2 = "TestKey2";
+        constexpr const char* ExpectedValue = R"(TestValue)";
+        constexpr const char* ExpectedValue2 = R"(Hello World)";
+        AZ::Console testConsole(*m_registry);
+
+        AZ::SettingsRegistryConsoleUtils::ConsoleFunctorHandle handle{ AZ::SettingsRegistryConsoleUtils::RegisterAzConsoleCommands(
+            *m_originTracker, testConsole) };
+
+        // Add settings to settings registry
+        auto jsonPointerPath = AZ::SettingsRegistryInterface::FixedValueString::format("/%s", SettingsKey);
+        EXPECT_TRUE(m_registry->Set(jsonPointerPath, ExpectedValue));
+
+        // Second Setting to set
+        jsonPointerPath = AZ::SettingsRegistryInterface::FixedValueString::format("/%s", SettingsKey2);
+        EXPECT_TRUE(m_registry->Set(jsonPointerPath, ExpectedValue2));
+
+        // Create a TraceMessageBus Handler for capturing the dumping of the settings
+        struct SettingsRegistryDumpOriginCommandHandler : public AZ::Debug::TraceMessageBus::Handler
+        {
+            SettingsRegistryDumpOriginCommandHandler(
+                const char* settingsKey, const char* settingsKey2, const char* expectedValue, const char* expectedValue2)
+                : m_settingsKey{ settingsKey }
+                , m_settingsKey2{ settingsKey2 }
+                , m_expectedValue{ expectedValue }
+                , m_expectedValue2{ expectedValue2 }
+            {
+            }
+            bool OnOutput(const char* window, const char* message) override
+            {
+                if (window == AZStd::string_view("SettingsRegistry"))
+                {
+                    // Test for in memory origin
+                    AZStd::string messageStr;
+                    messageStr = message;
+                    EXPECT_TRUE(messageStr.contains("<in-memory>"));
+                }
+                return false;
+            }
+
+            const char* m_settingsKey{};
+            const char* m_settingsKey2{};
+            const char* m_expectedValue{};
+            const char* m_expectedValue2{};
+        };
+
+        SettingsRegistryDumpOriginCommandHandler traceHandler{ SettingsKey, SettingsKey2, ExpectedValue, ExpectedValue2 };
+        traceHandler.BusConnect();
+        EXPECT_TRUE(testConsole.PerformCommand(AZ::SettingsRegistryConsoleUtils::SettingsRegistryDumpOrigin));
         traceHandler.BusDisconnect();
     }
 } 

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryConsoleUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryConsoleUtilsTests.cpp
@@ -303,9 +303,8 @@ namespace SettingsRegistryConsoleUtilsTests
                 if (window == AZStd::string_view("SettingsRegistry"))
                 {
                     // Test for in memory origin
-                    AZStd::string messageStr;
-                    messageStr = message;
-                    EXPECT_TRUE(messageStr.contains("<in-memory>"));
+                    AZStd::string_view messageView = message;
+                    EXPECT_TRUE(messageView.contains("<in-memory>"));
                 }
                 return false;
             }

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryOriginTrackerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryOriginTrackerTests.cpp
@@ -37,6 +37,9 @@ namespace AZ
 
 namespace SettingsRegistryOriginTrackerTests
 {
+    const AZStd::string OBJECT_VALUE = "<object>";
+    const AZStd::string ARRAY_VALUE = "<array>";
+
     class SettingsRegistryOriginTrackerFixture
         : public UnitTest::ScopedAllocatorSetupFixture
     {
@@ -109,7 +112,6 @@ namespace SettingsRegistryOriginTrackerTests
             for (const auto& settingsRegistryOrigin : expected)
             {
                 EXPECT_THAT(originArray, ::testing::Contains(settingsRegistryOrigin));
-                std::cout << "hi";
             }
             EXPECT_EQ(expected.size(), originArray.size());
         }
@@ -118,7 +120,7 @@ namespace SettingsRegistryOriginTrackerTests
         AZStd::unique_ptr<AZ::SettingsRegistryImpl> m_registry;
         AZStd::unique_ptr<AZ::SettingsRegistryOriginTracker> m_originTracker;
         AZ::Test::ScopedAutoTempDirectory m_testFolder;
-        bool m_createdNameDictionary;
+        bool m_createdNameDictionary = false;
     };
 
    TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFile_TracksOrigin_Successful)
@@ -168,20 +170,8 @@ namespace SettingsRegistryOriginTrackerTests
            "",
            nullptr);
        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
-           { filePath1.String(), "/O3DE/Settings/ObjectValue", R"(
-               {
-                   "StringKey1": "Hello",
-                   "BoolKey1": true
-               }
-               )"
-           },
-           { filePath2.String(), "/O3DE/Settings/ObjectValue", R"(
-               {
-                   "StringKey1": "Hello",
-                   "BoolKey1": true,
-                   "IntKey2": 9001
-               }
-               )" },
+           { filePath1.String(), "/O3DE/Settings/ObjectValue", OBJECT_VALUE },
+           { filePath2.String(), "/O3DE/Settings/ObjectValue", OBJECT_VALUE},
            { filePath2.String(), "/O3DE/Settings/ObjectValue/IntKey2", "9001" },
            { filePath1.String(), "/O3DE/Settings/ObjectValue/BoolKey1", "true" },
            { filePath1.String(), "/O3DE/Settings/ObjectValue/StringKey1", "\"Hello\"" },
@@ -214,10 +204,7 @@ namespace SettingsRegistryOriginTrackerTests
        m_registry->MergeSettingsFile(filePath1.Native(), AZ::SettingsRegistryInterface::Format::JsonPatch);
        m_registry->MergeSettingsFile(filePath2.Native(), AZ::SettingsRegistryInterface::Format::JsonPatch);
        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedArrayValueOriginStack = {
-           {
-               filePath1.String(),
-               "/O3DE/ArrayValue", "[5,7,40000000,-89396]"
-           },
+           {filePath1.String(), "/O3DE/ArrayValue", ARRAY_VALUE },
            { filePath1.String(), "/O3DE/ArrayValue/3", "-89396" },
            { filePath1.String(), "/O3DE/ArrayValue/2", "40000000" },
            { filePath2.String(), "/O3DE/ArrayValue/2", "42" },
@@ -261,25 +248,8 @@ namespace SettingsRegistryOriginTrackerTests
        m_registry->MergeSettingsFile(filePath2.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
        m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
-           { filePath1.String(),
-             "/O3DE/Settings/ObjectValue",
-                 R"(
-               {
-                   "StringKey1": "Hello",
-                   "BoolKey1": true,
-                   "IntKey2": 9001
-               }
-               )"
-           },
-           { filePath2.String(),
-             "/O3DE/Settings/ObjectValue",
-             R"(
-               {
-                   "StringKey1": "Hello",
-                   "BoolKey1": true,
-                   "IntKey2": 9001
-               }
-               )" },
+           { filePath1.String(), "/O3DE/Settings/ObjectValue", OBJECT_VALUE },
+           { filePath2.String(), "/O3DE/Settings/ObjectValue", OBJECT_VALUE },
            { filePath1.String(), "/O3DE/Settings/ObjectValue/BoolKey1", "true" },
            { filePath1.String(), "/O3DE/Settings/ObjectValue/StringKey1", "\"Hello\"" },
            { filePath2.String(), "/O3DE/Settings/ObjectValue/IntKey2", "9001" }
@@ -319,24 +289,8 @@ namespace SettingsRegistryOriginTrackerTests
        ASSERT_TRUE(m_registry->Set(stringKey1Path, stringKey1NewValue));
        m_registry->MergeSettingsFile(filePath2.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
-           { filePath1.String(),
-             "/O3DE/ObjectValue",
-                 R"(
-              {
-                   "StringKey1": "Hello",
-                   "BoolKey1": true
-              }
-              )"
-           },
-           { filePath2.String(),
-             "/O3DE/ObjectValue",
-             R"(
-              {
-                   "StringKey1": "Hi",
-                   "BoolKey1": true,
-                   "IntKey2": 9001
-              }
-              )" },
+           { filePath1.String(), "/O3DE/ObjectValue", OBJECT_VALUE },
+           { filePath2.String(), "/O3DE/ObjectValue", OBJECT_VALUE },
            { filePath2.String(), "/O3DE/ObjectValue/IntKey2", "9001" },
            { filePath1.String(), "/O3DE/ObjectValue/BoolKey1", "true" },
            { filePath1.String(), "/O3DE/ObjectValue/StringKey1", "\"Hello\"" },
@@ -382,16 +336,7 @@ namespace SettingsRegistryOriginTrackerTests
         m_registry->MergeSettingsFile(filePath1.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
         AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedO3DEOriginStack =
         {
-            { filePath1.String(),
-              "/O3DE",
-                  R"(
-                        {
-                            "foo": 1,
-                            "bar": true,
-                            "baz": "yes"
-                        }
-                    )"
-            },
+            { filePath1.String(), "/O3DE", OBJECT_VALUE },
             { filePath2.String(), "/O3DE/foo", "3" },
             { filePath1.String(), "/O3DE/foo", "1" },
             { filePath1.String(), "/O3DE/bar", "true" },
@@ -415,7 +360,7 @@ namespace SettingsRegistryOriginTrackerTests
     TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFiles_LargeInput_Successful)
     {
         auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
-        int numIterations = 3;
+        int numIterations = 10;
         for (int i = 0; i < numIterations; i++)
         {
             AZ::IO::FixedMaxPath filePath = tempRootFolder / AZStd::string::format("file%d.setreg", i);
@@ -429,30 +374,17 @@ namespace SettingsRegistryOriginTrackerTests
             )",i, i)));
             m_registry->MergeSettingsFile(filePath.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
         }
-        rapidjson::Document expectedO3DEOriginValue;
-        expectedO3DEOriginValue.SetObject();
-        expectedO3DEOriginValue.AddMember("persistentKey", 0, expectedO3DEOriginValue.GetAllocator());
         AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedO3DEOriginStack;
         for (int i = 0; i < numIterations; i++)
         {
             AZ::IO::FixedMaxPath filePath = tempRootFolder / AZStd::string::format("file%d.setreg", i);
-            rapidjson::Value& persistentKeyValue = expectedO3DEOriginValue["persistentKey"];
-            persistentKeyValue.SetInt(i);
-            AZStd::string changingKeyString = AZStd::string::format("changingKey%d", i);
-            rapidjson::Value changingKey(changingKeyString.c_str(), expectedO3DEOriginValue.GetAllocator());
-            expectedO3DEOriginValue.AddMember(changingKey, true, expectedO3DEOriginValue.GetAllocator());
-            rapidjson::StringBuffer expectedO3DEOriginValueBuffer;
-            rapidjson::Writer<rapidjson::StringBuffer> writer(expectedO3DEOriginValueBuffer);
-            expectedO3DEOriginValue.Accept(writer);
-            AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin o3deOrigin{ filePath.String(),
-                                                                                           "/O3DE",
-                                                                                  expectedO3DEOriginValueBuffer.GetString() };
+            AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin o3deOrigin{ filePath.String(), "/O3DE", OBJECT_VALUE };
             AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin persistentKeyOrigin{ filePath.String(),
-                                                                              "/O3DE/persistentKey",
-                                                                              AZStd::string::format("%d", i) };
+                                                                                           "/O3DE/persistentKey",
+                                                                                           AZStd::string::format("%d", i) };
             AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin changingKeyOrigin{ filePath.String(),
-                                                                                AZStd::string::format("/O3DE/changingKey%d", i),
-                                                                                "true" };
+                                                                                         AZStd::string::format("/O3DE/changingKey%d", i),
+                                                                                         "true" };
             expectedO3DEOriginStack.emplace_back(o3deOrigin);
             expectedO3DEOriginStack.emplace_back(changingKeyOrigin);
             expectedO3DEOriginStack.emplace_back(persistentKeyOrigin);
@@ -496,23 +428,8 @@ namespace SettingsRegistryOriginTrackerTests
         m_registry->MergeSettingsFile(filePath1.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
         m_registry->MergeSettingsFile(filePath2.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
         AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
-            { filePath1.String(),
-              "/O3DE/ObjectValue",
-              R"(
-              {
-                   "StringKey1": "Hello",
-                   "BoolKey1": true
-              }
-              )" },
-            { filePath2.String(),
-              "/O3DE/ObjectValue",
-              R"(
-              {
-                   "StringKey1": "Hello",
-                   "BoolKey1": true,
-                   "IntKey2": 9001
-              }
-              )" },
+            { filePath1.String(), "/O3DE/ObjectValue", OBJECT_VALUE },
+            { filePath2.String(), "/O3DE/ObjectValue", OBJECT_VALUE },
             { filePath1.String(), "/O3DE/ObjectValue/BoolKey1", "true" },
             { filePath1.String(), "/O3DE/ObjectValue/StringKey1", "\"Hello\"" }
         };

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryOriginTrackerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryOriginTrackerTests.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/IO/SystemFile.h>
 
+#include <AzCore/Name/NameDictionary.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
@@ -19,27 +20,37 @@
 #include <AzCore/std/string/string_view.h>
 #include <AzCore/std/containers/deque.h>
 
-#include <AzCore/Name/NameDictionary.h>
-#include <AzCore/std/string/regex.h>
 
 #include <AZTestShared/Utils/Utils.h>
 
-namespace SettingsRegistryOriginTrackerTests {
-
-    class SettingsRegistryOriginTrackerFixture : public UnitTest::ScopedAllocatorSetupFixture
+namespace AZ
+{
+    // Pretty printers for the SettingsRegistryOrigin struct
+    void PrintTo(const AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin& origin, ::std::ostream* os)
     {
+        *os << "file path: " << AZ::IO::Path(origin.m_originFilePath.Native(), AZ::IO::PosixPathSeparator).MakePreferred().c_str() << '\n';
+        *os << "key path: " << origin.m_settingsKey.c_str() << '\n';
+        *os << "value when origin set: " << (origin.m_settingsValue.has_value() ? origin.m_settingsValue->c_str() : "<removed>") << '\n';
+    }
+}
+
+namespace SettingsRegistryOriginTrackerTests
+{
+    class SettingsRegistryOriginTrackerFixture
+        : public UnitTest::ScopedAllocatorSetupFixture
+    {
+        static AZ::SystemAllocator::Descriptor CreateAllocatorDescriptorForFixture()
+        {
+            AZ::SystemAllocator::Descriptor desc;
+            desc.m_stackRecordLevels = 30;
+            return desc;
+        }
     public:
         SettingsRegistryOriginTrackerFixture()
-            : ScopedAllocatorSetupFixture(
-                  []()
-                  {
-                      AZ::SystemAllocator::Descriptor desc;
-                      desc.m_stackRecordLevels = 30;
-                      return desc;
-                  }())
+            : ScopedAllocatorSetupFixture(CreateAllocatorDescriptorForFixture())
         {
             AZ::NameDictionary::Create();
-        };
+        }
 
         ~SettingsRegistryOriginTrackerFixture()
         {
@@ -89,7 +100,7 @@ namespace SettingsRegistryOriginTrackerTests {
             };
             m_originTracker->VisitOrigins(path, callback);
             EXPECT_EQ(counter, expected.size());
-        };
+        }
 
     protected:
         AZStd::unique_ptr<AZ::SettingsRegistryImpl> m_registry;
@@ -97,216 +108,207 @@ namespace SettingsRegistryOriginTrackerTests {
         AZ::Test::ScopedAutoTempDirectory m_testFolder;
     };
 
-     /* TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFile_TracksOrigin_Successful)
-    {
-        AZStd::regex r("\\s+");
-        auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
-        AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.json";
-        AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.json";
-        ASSERT_TRUE(CreateTestFile(filePath1, R"(
-            {
-                "O3DE": {
-                    "Settings": {
-                        "ArrayValue": [
-                            5,
-                            7,
-                            40000000,
-                            -89396
-                        ],
-                        "ObjectValue": {
-                            "StringKey1": "Hello",
-                            "BoolKey1": true
-                        }
-                    }
-                }
-            }
-        )"));
-        ASSERT_TRUE(CreateTestFile(filePath2, R"(
-            {
-                "O3DE": {
-                    "Settings": {
-                        "ArrayValue": [
-                            27,
-                            39,
-                            42
-                        ],
-                        "ObjectValue": {
-                            "IntKey2": 9001,
-                         },
-                        "DoubleValue": 4.0
-                    }
-                }
-            }
-        )"));
-        m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "",
-            nullptr);
-        m_registry->MergeSettingsFile(filePath2.FixedMaxPathString(),
-            AZ::SettingsRegistryInterface::Format::JsonMergePatch,
-            "",
-            nullptr);
-        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
-            { filePath1.String(), "/O3DE/Settings/ObjectValue", AZStd::regex_replace(R"(
-                {
-                    "StringKey1": "Hello",
-                    "BoolKey1": true
-                }
-            )", r,"")
-            },
-            { filePath2.String(), "/O3DE/Settings/ObjectValue/IntKey2", "9001" },
-            { filePath1.String(), "/O3DE/Settings/ObjectValue/BoolKey1", "true" },
-            { filePath1.String(), "/O3DE/Settings/ObjectValue/StringKey1", "\"Hello\"" },
-        };
-        CheckOriginsAtPath(expectedObjectValueOriginStack, "/O3DE/Settings/ObjectValue");
-    }
+   TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFile_TracksOrigin_Successful)
+   {
+       auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
+       AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.json";
+       AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.json";
+       ASSERT_TRUE(CreateTestFile(filePath1, R"(
+           {
+               "O3DE": {
+                   "Settings": {
+                       "ArrayValue": [
+                           5,
+                           7,
+                           40000000,
+                           -89396
+                       ],
+                       "ObjectValue": {
+                           "StringKey1": "Hello",
+                           "BoolKey1": true
+                       }
+                   }
+               }
+           }
+       )"));
+       ASSERT_TRUE(CreateTestFile(filePath2, R"(
+           {
+               "O3DE": {
+                   "Settings": {
+                       "ArrayValue": [
+                           27,
+                           39,
+                           42
+                       ],
+                       "ObjectValue": {
+                           "IntKey2": 9001,
+                        },
+                       "DoubleValue": 4.0
+                   }
+               }
+           }
+       )"));
+       m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "",
+           nullptr);
+       m_registry->MergeSettingsFile(filePath2.FixedMaxPathString(),
+           AZ::SettingsRegistryInterface::Format::JsonMergePatch,
+           "",
+           nullptr);
+       AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
+           { filePath1.String(), "/O3DE/Settings/ObjectValue", R"(
+               {
+                   "StringKey1": "Hello",
+                   "BoolKey1": true
+               }
+               )"
+           },
+           { filePath2.String(), "/O3DE/Settings/ObjectValue/IntKey2", "9001" },
+           { filePath1.String(), "/O3DE/Settings/ObjectValue/BoolKey1", "true" },
+           { filePath1.String(), "/O3DE/Settings/ObjectValue/StringKey1", "\"Hello\"" },
+       };
+       CheckOriginsAtPath(expectedObjectValueOriginStack, "/O3DE/Settings/ObjectValue");
+   }
 
-    TEST_F(SettingsRegistryOriginTrackerFixture, MergeArraySettings_TracksArrayOriginWithPatch_Successful)
-    {
-        AZStd::regex r("\\s+");
-        auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
-        AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.setregpatch";
-        AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.setregpatch";
-        ASSERT_TRUE(CreateTestFile(filePath1, R"(
-            [
-                {"op": "add", "path": "/O3DE", "value": {}},
-                {"op": "add", "path" : "/O3DE/ArrayValue", "value": []},
-                {"op": "add", "path" : "/O3DE/ArrayValue/0", "value": 5},
-                {"op": "add", "path" : "/O3DE/ArrayValue/1", "value": 7},
-                {"op": "add", "path" : "/O3DE/ArrayValue/2", "value": 40000000},
-                {"op": "add", "path" : "/O3DE/ArrayValue/3", "value": -89396}
-            ]
-        )"));
-        ASSERT_TRUE(CreateTestFile(filePath2, R"(
-            [
-                {"op": "replace", "path" : "/O3DE/ArrayValue/0", "value" : 27},
-                {"op": "replace", "path" : "/O3DE/ArrayValue/1", "value" : 39},
-                {"op": "replace", "path" : "/O3DE/ArrayValue/2", "value" : 42}
-            ]
-        )"));
-        m_registry->MergeSettingsFile(filePath1.Native(), AZ::SettingsRegistryInterface::Format::JsonPatch);
-        m_registry->MergeSettingsFile(filePath2.Native(), AZ::SettingsRegistryInterface::Format::JsonPatch);
-        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedArrayValueOriginStack = {
-            {
-                filePath1.String(),
-                "/O3DE/ArrayValue", "[5,7,40000000,-89396]"
-            },
-            { filePath1.String(), "/O3DE/ArrayValue/3", "-89396" },
-            { filePath1.String(), "/O3DE/ArrayValue/2", "40000000" },
-            { filePath2.String(), "/O3DE/ArrayValue/2", "42" },
-            { filePath1.String(), "/O3DE/ArrayValue/1", "7" },
-            { filePath2.String(), "/O3DE/ArrayValue/1", "39" },
-            { filePath1.String(), "/O3DE/ArrayValue/0", "5" },
-            { filePath2.String(), "/O3DE/ArrayValue/0", "27" },
-        };
-        CheckOriginsAtPath(expectedArrayValueOriginStack, "/O3DE/ArrayValue");
-    }
+   TEST_F(SettingsRegistryOriginTrackerFixture, MergeArraySettings_TracksArrayOriginWithPatch_Successful)
+   {
+       auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
+       AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.setregpatch";
+       AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.setregpatch";
+       ASSERT_TRUE(CreateTestFile(filePath1, R"(
+           [
+               {"op": "add", "path": "/O3DE", "value": {}},
+               {"op": "add", "path" : "/O3DE/ArrayValue", "value": []},
+               {"op": "add", "path" : "/O3DE/ArrayValue/0", "value": 5},
+               {"op": "add", "path" : "/O3DE/ArrayValue/1", "value": 7},
+               {"op": "add", "path" : "/O3DE/ArrayValue/2", "value": 40000000},
+               {"op": "add", "path" : "/O3DE/ArrayValue/3", "value": -89396}
+           ]
+       )"));
+       ASSERT_TRUE(CreateTestFile(filePath2, R"(
+           [
+               {"op": "replace", "path" : "/O3DE/ArrayValue/0", "value" : 27},
+               {"op": "replace", "path" : "/O3DE/ArrayValue/1", "value" : 39},
+               {"op": "replace", "path" : "/O3DE/ArrayValue/2", "value" : 42}
+           ]
+       )"));
+       m_registry->MergeSettingsFile(filePath1.Native(), AZ::SettingsRegistryInterface::Format::JsonPatch);
+       m_registry->MergeSettingsFile(filePath2.Native(), AZ::SettingsRegistryInterface::Format::JsonPatch);
+       AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedArrayValueOriginStack = {
+           {
+               filePath1.String(),
+               "/O3DE/ArrayValue", "[5,7,40000000,-89396]"
+           },
+           { filePath1.String(), "/O3DE/ArrayValue/3", "-89396" },
+           { filePath1.String(), "/O3DE/ArrayValue/2", "40000000" },
+           { filePath2.String(), "/O3DE/ArrayValue/2", "42" },
+           { filePath1.String(), "/O3DE/ArrayValue/1", "7" },
+           { filePath2.String(), "/O3DE/ArrayValue/1", "39" },
+           { filePath1.String(), "/O3DE/ArrayValue/0", "5" },
+           { filePath2.String(), "/O3DE/ArrayValue/0", "27" },
+       };
+       CheckOriginsAtPath(expectedArrayValueOriginStack, "/O3DE/ArrayValue");
+   }
 
-    TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFile_RemoveDuplicateOrigin_Successful)
-    {
-        AZStd::regex r("\\s+");
-        auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
-        AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.json";
-        AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.json";
-        ASSERT_TRUE(CreateTestFile(filePath1, R"(
-            {
-                "O3DE": {
-                    "Settings": {
-                        "ObjectValue": {
-                            "StringKey1": "Hello",
-                            "BoolKey1": true
-                        }
-                    }
-                }
-            }
-        )"));
-        ASSERT_TRUE(CreateTestFile(filePath2, R"(
-            {
-                "O3DE": {
-                    "Settings": {
-                        "ObjectValue": {
-                            "IntKey2": 9001
-                         },
-                    }
-                }
-            }
-        )"));
-        m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
-        m_registry->MergeSettingsFile(filePath2.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
-        m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
-        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
-            { filePath1.String(),
-              "/O3DE/Settings/ObjectValue",
-              AZStd::regex_replace(
-                  R"(
-                {
-                    "StringKey1": "Hello",
-                    "BoolKey1": true
-                }
-            )",
-                  r,
-                  "") },
-            { filePath1.String(), "/O3DE/Settings/ObjectValue/BoolKey1", "true" },
-            { filePath1.String(), "/O3DE/Settings/ObjectValue/StringKey1", "\"Hello\"" },
-            { filePath2.String(), "/O3DE/Settings/ObjectValue/IntKey2", "9001" }
-        };
-        CheckOriginsAtPath(expectedObjectValueOriginStack, "/O3DE/Settings/ObjectValue");
-    }
+   TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFile_RemoveDuplicateOrigin_Successful)
+   {
+       auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
+       AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.json";
+       AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.json";
+       ASSERT_TRUE(CreateTestFile(filePath1, R"(
+           {
+               "O3DE": {
+                   "Settings": {
+                       "ObjectValue": {
+                           "StringKey1": "Hello",
+                           "BoolKey1": true
+                       }
+                   }
+               }
+           }
+       )"));
+       ASSERT_TRUE(CreateTestFile(filePath2, R"(
+           {
+               "O3DE": {
+                   "Settings": {
+                       "ObjectValue": {
+                           "IntKey2": 9001
+                        },
+                   }
+               }
+           }
+       )"));
+       m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
+       m_registry->MergeSettingsFile(filePath2.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
+       m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
+       AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
+           { filePath1.String(),
+             "/O3DE/Settings/ObjectValue",
+                 R"(
+               {
+                   "StringKey1": "Hello",
+                   "BoolKey1": true
+               }
+               )"
+           },
+           { filePath1.String(), "/O3DE/Settings/ObjectValue/BoolKey1", "true" },
+           { filePath1.String(), "/O3DE/Settings/ObjectValue/StringKey1", "\"Hello\"" },
+           { filePath2.String(), "/O3DE/Settings/ObjectValue/IntKey2", "9001" }
+       };
+       CheckOriginsAtPath(expectedObjectValueOriginStack, "/O3DE/Settings/ObjectValue");
+   }
 
-    TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFileAndCode_TracksOrigin_Successful)
-    {
-        AZStd::regex r("\\s+");
-        auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
-        AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.setreg";
-        AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.setreg";
-        ASSERT_TRUE(CreateTestFile(filePath1, R"(
-            {
-                "O3DE": {
-                    "ObjectValue": {
-                        "StringKey1": "Hello",
-                        "BoolKey1": true
-                    }
-                    
-                }
-            }
-        )"));
-        ASSERT_TRUE(CreateTestFile(filePath2, R"(
-            {
-                "O3DE": {
-                    "ObjectValue": {
-                        "StringKey1": "Hi",
-                        "IntKey2": 9001
-                    }
-                }
-            }
-        )"));
-        m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
-        AZStd::string_view stringKey1Path = "/O3DE/ObjectValue/StringKey1";
-        AZStd::string_view stringKey1NewValue = R"(Greetings)";
-        ASSERT_TRUE(m_registry->Set(stringKey1Path, stringKey1NewValue));
-        m_registry->MergeSettingsFile(filePath2.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
-        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
-            { filePath1.String(),
-              "/O3DE/ObjectValue",
-              AZStd::regex_replace(
-                  R"(
-                {
-                    "StringKey1": "Hello",
-                    "BoolKey1": true
-                }
-            )",
-                  r,
-                  "") },
-            { filePath2.String(), "/O3DE/ObjectValue/IntKey2", "9001" },
-            { filePath1.String(), "/O3DE/ObjectValue/BoolKey1", "true" },
-            { filePath1.String(), "/O3DE/ObjectValue/StringKey1", "\"Hello\"" },
-            { "<in-memory>", "/O3DE/ObjectValue/StringKey1", "\"Greetings\"" },
-            { filePath2.String(), "/O3DE/ObjectValue/StringKey1", "\"Hi\"" }
-        };
-        CheckOriginsAtPath(expectedObjectValueOriginStack, "/O3DE/ObjectValue");
-    }*/
+   TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFileAndCode_TracksOrigin_Successful)
+   {
+       auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
+       AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.setreg";
+       AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.setreg";
+       ASSERT_TRUE(CreateTestFile(filePath1, R"(
+           {
+               "O3DE": {
+                   "ObjectValue": {
+                       "StringKey1": "Hello",
+                       "BoolKey1": true
+                   }
+
+               }
+           }
+       )"));
+       ASSERT_TRUE(CreateTestFile(filePath2, R"(
+           {
+               "O3DE": {
+                   "ObjectValue": {
+                       "StringKey1": "Hi",
+                       "IntKey2": 9001
+                   }
+               }
+           }
+       )"));
+       m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
+       AZStd::string_view stringKey1Path = "/O3DE/ObjectValue/StringKey1";
+       AZStd::string_view stringKey1NewValue = R"(Greetings)";
+       ASSERT_TRUE(m_registry->Set(stringKey1Path, stringKey1NewValue));
+       m_registry->MergeSettingsFile(filePath2.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
+       AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
+           { filePath1.String(),
+             "/O3DE/ObjectValue",
+                 R"(
+              {
+                   "StringKey1": "Hello",
+                   "BoolKey1": true
+              }
+              )"
+           },
+           { filePath2.String(), "/O3DE/ObjectValue/IntKey2", "9001" },
+           { filePath1.String(), "/O3DE/ObjectValue/BoolKey1", "true" },
+           { filePath1.String(), "/O3DE/ObjectValue/StringKey1", "\"Hello\"" },
+           { "<in-memory>", "/O3DE/ObjectValue/StringKey1", "\"Greetings\"" },
+           { filePath2.String(), "/O3DE/ObjectValue/StringKey1", "\"Hi\"" }
+       };
+       CheckOriginsAtPath(expectedObjectValueOriginStack, "/O3DE/ObjectValue");
+   }
 
     TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFiles_NestedMerge_Successful)
     {
-        AZStd::regex r("\\s+");
         auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
         AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.setreg";
         AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.setreg";
@@ -329,38 +331,47 @@ namespace SettingsRegistryOriginTrackerTests {
             }
         )"));
         bool mergeFile = true;
-        auto callback = [this, &mergeFile, &filePath2](AZStd::string_view path, AZ::SettingsRegistryInterface::Type)
+        auto callback = [this, &mergeFile, &filePath2](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
         {
-            if (path == "/O3DE/foo" && mergeFile)
+            if (notifyEventArgs.m_jsonKeyPath == "/O3DE" && mergeFile)
             {
                 mergeFile = false;
                 m_registry->MergeSettingsFile(filePath2.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
-                
             }
         };
 
         auto testNotifier = m_registry->RegisterNotifier(callback);
         m_registry->MergeSettingsFile(filePath1.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
-        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedO3DEOriginStack = {
+        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedO3DEOriginStack =
+        {
             { filePath1.String(),
               "/O3DE",
-              AZStd::regex_replace(
                   R"(
                         {
                             "foo": 1,
                             "bar": true,
                             "baz": "yes"
                         }
-                    )", r,
-                  "") },
+                    )"
+            },
             { filePath2.String(), "/O3DE/foo", "3" },
             { filePath1.String(), "/O3DE/foo", "1" },
             { filePath1.String(), "/O3DE/bar", "true" },
-            { filePath1.String(), "/O3DE/bar", "false" },
-            { filePath1.String(), "/O3DE/baz", "\"yes\"" },
-            { filePath1.String(), "/O3DE/baz", "\"no\"" },
+            { filePath2.String(), "/O3DE/bar", "false" },
+            { filePath1.String(), "/O3DE/baz", R"("yes")" },
+            { filePath2.String(), "/O3DE/baz", R"("no")"},
         };
-        CheckOriginsAtPath(expectedO3DEOriginStack, "/O3DE");
+
+        AZStd::vector<AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin> originArray;
+        auto GetOrigins  = [&originArray](AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin origin)
+        {
+            originArray.push_back(origin);
+            return true;
+        };
+        m_originTracker->VisitOrigins("/O3DE", GetOrigins);
+        for (const auto& settingsRegistryOrigin : expectedO3DEOriginStack)
+        {
+            EXPECT_THAT(originArray, ::testing::Contains(settingsRegistryOrigin));
+        }
     }
-   
 }

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryOriginTrackerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryOriginTrackerTests.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/IO/SystemFile.h>
+
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryImpl.h>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/Settings/SettingsRegistryOriginTracker.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/containers/deque.h>
+
+#include <AZTestShared/Utils/Utils.h>
+
+namespace SettingsRegistryOriginTrackerTests {
+
+    class SettingsRegistryOriginTrackerFixture : public UnitTest::AllocatorsFixture
+    {
+    public:
+
+        void SetUp() override
+        {
+            SetupAllocator();
+
+            m_registry = AZStd::make_unique<AZ::SettingsRegistryImpl>();
+            m_originTracker = AZStd::make_unique<AZ::SettingsRegistryOriginTracker>(*m_registry);
+        }
+
+        void TearDown() override
+        {
+
+            m_originTracker.reset();
+            m_registry.reset();
+            
+
+            TeardownAllocator();
+        }
+
+        static bool CreateTestFile(const AZ::IO::FixedMaxPath& testPath, AZStd::string_view content)
+        {
+            AZ::IO::SystemFile file;
+            if (!file.Open(testPath.c_str(), AZ::IO::SystemFile::OpenMode::SF_OPEN_CREATE
+                | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY))
+            {
+                AZ_Assert(false, "Unable to open test file for writing: %s", testPath.c_str());
+                return false;
+            }
+
+            if (file.Write(content.data(), content.size()) != content.size())
+            {
+                AZ_Assert(false, "Unable to write content to test file: %s", testPath.c_str());
+                return false;
+            }
+
+            return true;
+        }
+
+        void CheckOriginsAtPath(const AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack& expected, AZStd::string_view path = "")
+        {
+            int counter = 0;
+            auto callback = [&](AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin origin)
+            {
+                auto expectedOrigin = expected.at(counter);
+                EXPECT_EQ(expectedOrigin, origin);
+                counter += 1;
+                return true;
+            };
+            m_originTracker->VisitOrigins(path, callback);
+            EXPECT_EQ(counter, expected.size());
+        };
+
+    protected:
+        AZStd::unique_ptr<AZ::SettingsRegistryImpl> m_registry;
+        AZStd::unique_ptr<AZ::SettingsRegistryOriginTracker> m_originTracker;
+        AZ::Test::ScopedAutoTempDirectory m_testFolder;
+    };
+
+    TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFile_TracksOrigin_Successful)
+    {
+        auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
+        AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.json";
+        AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.json";
+        AZ::IO::FixedMaxPath filePath3 = tempRootFolder / "folder3" / "file3.json";
+        ASSERT_TRUE(CreateTestFile(filePath1, R"(
+            {
+                "O3DE": {
+                    "Settings": {
+                        "ArrayValue": [
+                        5,
+                        7,
+                        40000000,
+                        -89396
+                    ],
+                    "ObjectValue": {
+                        "StringKey1": "Hello",
+                        "BoolKey1": true
+                    }
+                    }
+                }
+            }
+        )"));
+        ASSERT_TRUE(CreateTestFile(filePath2, R"(
+            {
+                "O3DE": {
+                    "Settings": {
+                        "ArrayValue": [
+                        27,
+                        39,
+                        42
+                        ],
+                        "ObjectValue": {
+                        "IntKey2": 9001,
+                        },
+                        "DoubleValue": 4.0
+                    }
+                }
+            }
+        )"));
+        ASSERT_TRUE(CreateTestFile(filePath3, R"(
+            {
+                "O3DE": {
+                    "Settings": {
+                        "ArrayValue": [
+                        -5,
+                        39,
+                        42
+                        ],
+                        "ObjectValue": {
+                        "StringKey1": "Hi",
+                        "BoolKey1": true,
+                        "IntKey2": 9001
+                        },
+                        "DoubleValue": 4.0
+                    }
+                }
+            }
+        )"));
+        m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(),
+            AZ::SettingsRegistryInterface::Format::JsonMergePatch, {},
+            nullptr);
+        m_registry->MergeSettingsFile(filePath2.FixedMaxPathString(),
+            AZ::SettingsRegistryInterface::Format::JsonMergePatch,
+            "",
+            nullptr);
+        m_registry->MergeSettingsFile(filePath3.FixedMaxPathString(),
+            AZ::SettingsRegistryInterface::Format::JsonMergePatch,
+            "",
+            nullptr);
+        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedStringKey1OriginStack = {
+            { filePath1.Filename(), "/O3DE/Settings/ObjectValue/StringKey1", "Hi" }
+        };
+        CheckOriginsAtPath(expectedStringKey1OriginStack, "/O3DE/Settings/ObjectValue/StringKey1");
+    }
+   
+}

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryOriginTrackerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryOriginTrackerTests.cpp
@@ -124,25 +124,6 @@ namespace SettingsRegistryOriginTrackerTests {
                 }
             }
         )"));
-        ASSERT_TRUE(CreateTestFile(filePath3, R"(
-            {
-                "O3DE": {
-                    "Settings": {
-                        "ArrayValue": [
-                        -5,
-                        39,
-                        42
-                        ],
-                        "ObjectValue": {
-                        "StringKey1": "Hi",
-                        "BoolKey1": true,
-                        "IntKey2": 9001
-                        },
-                        "DoubleValue": 4.0
-                    }
-                }
-            }
-        )"));
         m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(),
             AZ::SettingsRegistryInterface::Format::JsonMergePatch, {},
             nullptr);
@@ -150,14 +131,11 @@ namespace SettingsRegistryOriginTrackerTests {
             AZ::SettingsRegistryInterface::Format::JsonMergePatch,
             "",
             nullptr);
-        m_registry->MergeSettingsFile(filePath3.FixedMaxPathString(),
-            AZ::SettingsRegistryInterface::Format::JsonMergePatch,
-            "",
-            nullptr);
         AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedStringKey1OriginStack = {
-            { filePath1.Filename(), "/O3DE/Settings/ObjectValue/StringKey1", "Hi" }
+            { filePath1.String(), "/O3DE/Settings/ObjectValue/StringKey1", "Hello" }
         };
         CheckOriginsAtPath(expectedStringKey1OriginStack, "/O3DE/Settings/ObjectValue/StringKey1");
+        ASSERT_FALSE(false);
     }
    
 }

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -85,6 +85,7 @@ set(FILES
     Settings/SettingsRegistryTests.cpp
     Settings/SettingsRegistryConsoleUtilsTests.cpp
     Settings/SettingsRegistryMergeUtilsTests.cpp
+    Settings/SettingsRegistryOriginTrackerTests.cpp
     Settings/SettingsRegistryScriptUtilsTests.cpp
     Settings/SettingsRegistryVisitorUtilsTests.cpp
     Streamer/BlockCacheTests.cpp

--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
@@ -370,7 +370,7 @@ namespace AZ::IO
             // this system is initialized before the settings registry has loaded the event list.
             AZ::ComponentApplicationLifecycle::RegisterHandler(
                 *settingsRegistry, m_componentApplicationLifecycleHandler,
-                [this](AZStd::string_view /*path*/, AZ::SettingsRegistryInterface::Type /*type*/)
+                [this](const AZ::SettingsRegistryInterface::NotifyEventArgs&)
                 {
                     OnSystemEntityActivated();
                 },

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableSystemComponent.cpp
@@ -165,7 +165,7 @@ namespace AzFramework
         auto settingsRegistry = AZ::SettingsRegistry::Get();
         AZ_Assert(settingsRegistry, "Unable to change root spawnable callback because Settings Registry is not available.");
 
-        auto LifecycleCallback = [this](AZStd::string_view, AZ::SettingsRegistryInterface::Type)
+        auto LifecycleCallback = [this](const AZ::SettingsRegistryInterface::NotifyEventArgs&)
         {
             LoadRootSpawnableFromSettingsRegistry();
         };
@@ -176,9 +176,9 @@ namespace AzFramework
         RootSpawnableNotificationBus::Handler::BusConnect();
         AZ::TickBus::Handler::BusConnect();
 
-        m_registryChangeHandler = settingsRegistry->RegisterNotifier([this](AZStd::string_view path, AZ::SettingsRegistryInterface::Type /*type*/)
+        m_registryChangeHandler = settingsRegistry->RegisterNotifier([this](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
             {
-                if (path.starts_with(RootSpawnableRegistryKey))
+                if (notifyEventArgs.m_jsonKeyPath.starts_with(RootSpawnableRegistryKey))
                 {
                     LoadRootSpawnableFromSettingsRegistry();
                 }

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -151,7 +151,7 @@ namespace AZ
                     // this system is initialized before the settings registry has loaded the event list.
                     AZ::ComponentApplicationLifecycle::RegisterHandler(
                         *settingsRegistry, m_componentApplicationLifecycleHandler,
-                        [this](AZStd::string_view /*path*/, AZ::SettingsRegistryInterface::Type /*type*/)
+                        [this](const AZ::SettingsRegistryInterface::NotifyEventArgs&)
                         {
                             Initialize();
                         },

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/EditorCommonFeaturesSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/EditorCommonFeaturesSystemComponent.cpp
@@ -91,7 +91,7 @@ namespace AZ
             AzToolsFramework::AssetBrowser::PreviewerRequestBus::Handler::BusConnect();
             if (auto settingsRegistry{ AZ::SettingsRegistry::Get() }; settingsRegistry != nullptr)
             {
-                auto LifecycleCallback = [this](AZStd::string_view, AZ::SettingsRegistryInterface::Type)
+                auto LifecycleCallback = [this](const AZ::SettingsRegistryInterface::NotifyEventArgs&)
                 {
                     SetupThumbnails();
                 };

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
@@ -55,7 +55,7 @@ namespace Multiplayer
             {
                 AZ::ComponentApplicationLifecycle::RegisterHandler(
                     *settingsRegistry, m_componentApplicationLifecycleHandler,
-                    [this](AZStd::string_view /*path*/, AZ::SettingsRegistryInterface::Type /*type*/)
+                    [this](const AZ::SettingsRegistryInterface::NotifyEventArgs&)
                     {
                         ActivateDedicatedEditorServer();
                     },

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkSpawnableLibrary.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkSpawnableLibrary.cpp
@@ -20,7 +20,7 @@ namespace Multiplayer
         AZ::Interface<INetworkSpawnableLibrary>::Register(this);
         if (auto settingsRegistry{ AZ::SettingsRegistry::Get() }; settingsRegistry != nullptr)
         {
-            auto LifecycleCallback = [this](AZStd::string_view, AZ::SettingsRegistryInterface::Type)
+            auto LifecycleCallback = [this](const AZ::SettingsRegistryInterface::NotifyEventArgs&)
             {
                 BuildSpawnablesList();
             };


### PR DESCRIPTION
## What does this PR do?

Added implementation of a Settings Registry File Origin Tracker

The Settings Registry File Origin Tracker is responsible storing which files resulted in a particular value of a setting being read.
It does so by using the SettingsRegistry NotifyEvent mechanism to retrieve files being merged and add origin structs to the origin tracker's Prefix Dom Tree when setting values are added, modified, or removed. The origin tracker will also track if a settings value was changed in-memory.

Modified the Settings Registry implementation to send NotifyEvent signals for each key during a merge operation rather than only at the end of merging a json object.

Added a settings registry console command (`sr_dump_origin`) to dump all in-memory settings registry origins to the console.

Registered the origin tracker as a singleton using `AZ::Interface`. 

## How was this PR tested?

Unit tests for the origin tracker are contained in `SettingsRegistryOriginTrackerTests.cpp`. Ensure that AzCore.Tests passes.
