### PR TITLE
Fix for cycle detection logic in the o3de manifest.py

### DIFF
--- a/scripts/o3de/o3de/manifest.py
+++ b/scripts/o3de/o3de/manifest.py
@@ -340,28 +340,37 @@ def get_project_templates(project_path: pathlib.Path) -> list:
 
 # gem.json queries
 def get_gem_gems(gem_path: pathlib.Path) -> list:
-    return get_gems_from_external_subdirectories(get_gem_external_subdirectories(gem_path, set()))
+    return get_gems_from_external_subdirectories(get_gem_external_subdirectories(gem_path, list()))
 
 
-def get_gem_external_subdirectories(gem_path: pathlib.Path, visited_gem_paths: set) -> list:
+def get_gem_external_subdirectories(gem_path: pathlib.Path, visited_gem_paths: list) -> list:
+    '''
+    recursively visit each gems "external_subdirectories" entries and return them in a list
+    :param: gem_path path to the gem whose gem.json will be queried for the "external_subdirectories" field
+    :param: visited_gem_paths stores the list of gem paths visited so far up until this get_path
+    The visited_gem_paths is a list instead of a set to maintain insertion order
+    '''
     if gem_path in visited_gem_paths:
-        logger.error(f'A cycle has been detected when visiting external subdirectories at gem path "{gem_path}". The visited paths are: {visited_gem_paths}')
+        logger.warning(f'A cycle has been detected when visiting external subdirectories at gem path "{gem_path}". The visited paths are: {visited_gem_paths}')
         return []
-    visited_gem_paths.add(gem_path)
+    visited_gem_paths.append(gem_path)
 
     gem_object = get_gem_json_data(gem_path=gem_path)
+    external_subdirectories = []
     if gem_object:
         external_subdirectories = list(map(lambda rel_path: (pathlib.Path(gem_path) / rel_path).as_posix(),
             gem_object['external_subdirectories'])) if 'external_subdirectories' in gem_object else []
 
-        # recurse into gem subdirectories 
+        # recurse into gem subdirectories
         for external_subdirectory in external_subdirectories:
             gem_json_path = pathlib.Path(external_subdirectory).resolve() / 'gem.json'
             if gem_json_path.is_file():
                 external_subdirectories.extend(get_gem_external_subdirectories(external_subdirectory, visited_gem_paths))
 
-        return external_subdirectories
-    return []
+    # The gem_path has completely visited, remove it from the visit set
+    visited_gem_paths.remove(gem_path)
+
+    return list(dict.fromkeys(external_subdirectories))
 
 
 def get_gem_templates(gem_path: pathlib.Path) -> list:
@@ -392,7 +401,7 @@ def get_all_external_subdirectories(project_path: pathlib.Path = None) -> list:
 
     gem_paths = get_gems_from_external_subdirectories(external_subdirectories_data)
     for gem_path in gem_paths:
-        external_subdirectories_data.extend(get_gem_external_subdirectories(gem_path, set()))
+        external_subdirectories_data.extend(get_gem_external_subdirectories(gem_path, list()))
 
     # Remove duplicates from the list
     return list(dict.fromkeys(external_subdirectories_data))

--- a/scripts/o3de/o3de/manifest.py
+++ b/scripts/o3de/o3de/manifest.py
@@ -358,7 +358,7 @@ def get_gem_external_subdirectories(gem_path: pathlib.Path, visited_gem_paths: l
     gem_object = get_gem_json_data(gem_path=gem_path)
     external_subdirectories = []
     if gem_object:
-        external_subdirectories = list(map(lambda rel_path: (pathlib.Path(gem_path) / rel_path).as_posix(),
+        external_subdirectories = list(map(lambda rel_path: (pathlib.Path(gem_path) / rel_path).resolve().as_posix(),
             gem_object['external_subdirectories'])) if 'external_subdirectories' in gem_object else []
 
         # recurse into gem subdirectories

--- a/scripts/o3de/tests/test_manifest.py
+++ b/scripts/o3de/tests/test_manifest.py
@@ -309,8 +309,8 @@ class TestGetAllGems:
                                 expected_cycle_detected""", [
             pytest.param( 
                 {
-                    'D:/Gem1':['D:/Gem2'],
-                    'D:/Gem2':['D:/Gem1']
+                    'D:/Gem1':['../Gem2'],
+                    'D:/Gem2':['../Gem1']
                 },
                 True),
             pytest.param(
@@ -341,8 +341,7 @@ class TestGetAllGems:
 
         with patch('o3de.manifest.get_gem_json_data', side_effect=get_gem_json_data) as _1, \
             patch('logging.Logger.warning', side_effect=cycle_detected) as _2, \
-            patch('pathlib.Path.is_file', return_value=True) as _3,\
-            patch('pathlib.Path.resolve', self.resolve) as _4:
+            patch('pathlib.Path.is_file', return_value=True) as _3:
 
             self.cycle_detected = False
 

--- a/scripts/o3de/tests/test_manifest.py
+++ b/scripts/o3de/tests/test_manifest.py
@@ -245,12 +245,12 @@ class TestGetAllGems:
     def resolve(self):
         return self
 
-    @pytest.mark.parametrize("""manifest_external_subdirectories, 
-                                engine_external_subdirectories, 
+    @pytest.mark.parametrize("""manifest_external_subdirectories,
+                                engine_external_subdirectories,
                                 gem_external_subdirectories,
                                 expected_gem_paths""", [
-            pytest.param(['D:/GemOutsideEngine'], 
-                ['GemInEngine'], 
+            pytest.param(['D:/GemOutsideEngine'],
+                ['GemInEngine'],
                 ['GemInGem'],
                 ['D:/GemOutsideEngine', 'D:/o3de/o3de/GemInEngine',
                 'D:/GemOutsideEngine/GemInGem', 'D:/o3de/o3de/GemInEngine/GemInGem']),
@@ -261,33 +261,37 @@ class TestGetAllGems:
                 'D:/GemOutsideEngine/GemInGem', 'D:/o3de/o3de/GemInEngine/GemInGem']),
         ]
     )
-    def test_get_all_gems_returns_unique_paths(self, manifest_external_subdirectories, 
+    def test_get_all_gems_returns_unique_paths(self, manifest_external_subdirectories,
         engine_external_subdirectories, gem_external_subdirectories,
         expected_gem_paths ):
 
         def get_engine_json_data(engine_name: str = None,
                                 engine_path: str or pathlib.Path = None) -> dict or None:
             engine_payload = json.loads(TEST_ENGINE_JSON_PAYLOAD)
-            engine_payload['external_subdirectores'] = engine_external_subdirectories
+            engine_payload['external_subdirectories'] = engine_external_subdirectories
             return engine_payload
 
         def load_o3de_manifest(manifest_path: pathlib.Path = None) -> dict:
             manifest_payload = json.loads(TEST_O3DE_MANIFEST_JSON_PAYLOAD)
-            manifest_payload['external_subdirectores'] = manifest_external_subdirectories
+            manifest_payload['external_subdirectories'] = manifest_external_subdirectories
             return manifest_payload
 
         def get_gem_json_data(gem_name: str = None, gem_path: str or pathlib.Path = None,
             project_path: pathlib.Path = None) -> dict or None:
 
-            if 'NonGem' in gem_path:
-                return None
-
             gem_payload = json.loads(TEST_GEM_JSON_PAYLOAD)
 
-            if not 'GemInGem' in gem_path:
+            if 'GemInGem' != gem_path.name:
                 gem_payload["external_subdirectories"] = gem_external_subdirectories
 
             return gem_payload
+
+        def is_file(path : pathlib.Path) -> bool:
+
+            if path.match("*/NonGem/gem.json"):
+                return False
+
+            return True
 
         with patch('o3de.manifest.get_gem_json_data', side_effect=get_gem_json_data) \
                 as get_gem_json_data_patch,\
@@ -295,9 +299,9 @@ class TestGetAllGems:
                 as get_engine_json_data_patch,\
             patch('o3de.manifest.get_this_engine_path', side_effect=self.get_this_engine_path) \
                 as get_this_engine_path_patch,\
-            patch('pathlib.Path.is_file', return_value=True) \
+            patch('pathlib.Path.is_file', new=is_file) \
                 as pathlib_is_file_mock,\
-            patch('pathlib.Path.resolve', self.resolve) \
+            patch('pathlib.Path.resolve', new=self.resolve) \
                 as pathlib_is_resolve_mock,\
             patch('o3de.manifest.load_o3de_manifest', side_effect=load_o3de_manifest) \
                 as load_o3de_manifest_patch:
@@ -307,31 +311,37 @@ class TestGetAllGems:
 
     @pytest.mark.parametrize("""gem_external_subdirectories,
                                 expected_cycle_detected""", [
-            pytest.param( 
+            pytest.param(
                 {
-                    'D:/Gem1':['../Gem2'],
-                    'D:/Gem2':['../Gem1']
+                    'Gems/Gem1':['../Gem2'],
+                    'Gems/Gem2':['../Gem1']
                 },
                 True),
             pytest.param(
                 {
-                    'D:/Gem1':['Gem2'],
-                    'D:/Gem1/Gem2':['Gem3','Gem4'],
-                    'D:/Gem1/Gem2/Gem3':[],
-                    'D:/Gem1/Gem2/Gem4':[]
+                    'Gems/Gem1':['Gem2'],
+                    'Gems/Gem1/Gem2':['Gem3','Gem4'],
+                    'Gems/Gem1/Gem2/Gem3':[],
+                    'Gems/Gem1/Gem2/Gem4':[]
                 },
                 False)
         ]
     )
-    def test_get_gem_external_subdirectories_detects_cycles(self, 
+    def test_get_gem_external_subdirectories_detects_cycles(self,
         gem_external_subdirectories,
         expected_cycle_detected ):
 
         def get_gem_json_data(gem_name: str = None, gem_path: str or pathlib.Path = None,
             project_path: pathlib.Path = None) -> dict or None:
 
+            # Try to make path relative to the current working directory
+            try:
+                gem_rel_path = pathlib.Path(gem_path).relative_to(pathlib.Path.cwd())
+            except ValueError:
+                gem_rel_path = gem_path
+
             gem_payload = json.loads(TEST_GEM_JSON_PAYLOAD)
-            gem_payload["external_subdirectories"] = gem_external_subdirectories[gem_path]
+            gem_payload["external_subdirectories"] = gem_external_subdirectories[gem_rel_path.as_posix()]
 
             return gem_payload
 
@@ -346,10 +356,10 @@ class TestGetAllGems:
             self.cycle_detected = False
 
             # start with the first path in the dictionary
-            gem_path = list(gem_external_subdirectories.keys())[0]
+            gem_path = pathlib.Path(list(gem_external_subdirectories.keys())[0])
             manifest.get_gem_external_subdirectories(gem_path, list())
 
-            assert self.cycle_detected == expected_cycle_detected 
+            assert self.cycle_detected == expected_cycle_detected
 
 class TestManifestProjects:
     @staticmethod
@@ -361,25 +371,25 @@ class TestManifestProjects:
         return self.as_posix() == otherFile.as_posix()
 
     @pytest.mark.parametrize("project_path, project_engine_name, engines, expected_engine_path", [
-            pytest.param(pathlib.Path('C:/project1'), 
-                'engine1', 
+            pytest.param(pathlib.Path('C:/project1'),
+                'engine1',
                 {'engine1': pathlib.Path('C:/engine1'), 'engine2': pathlib.Path('D:/engine2')},
                 pathlib.Path('C:/engine1')),
-            pytest.param(pathlib.Path('C:/project1'), 
-                'engine2', 
+            pytest.param(pathlib.Path('C:/project1'),
+                'engine2',
                 {'engine1': pathlib.Path('C:/engine1'), 'engine2': pathlib.Path('D:/engine2')},
                 pathlib.Path('D:/engine2')),
-            pytest.param(pathlib.Path('C:/engine1/project1'), 
-                '', 
+            pytest.param(pathlib.Path('C:/engine1/project1'),
+                '',
                 {'engine1': pathlib.Path('C:/engine1'), 'engine2': pathlib.Path('D:/engine2')},
                 pathlib.Path('C:/engine1')),
-            pytest.param(pathlib.Path('C:/project1'), 
-                '', 
+            pytest.param(pathlib.Path('C:/project1'),
+                '',
                 {'engine1': pathlib.Path('C:/engine1'), 'engine2': pathlib.Path('D:/engine2')},
                 None),
         ]
     )
-    def test_get_project_engines(self, project_path, project_engine_name, 
+    def test_get_project_engines(self, project_path, project_engine_name,
                                     engines, expected_engine_path):
         def get_project_json_data(project_name: str = None,
             project_path: str or pathlib.Path = None) -> dict or None:


### PR DESCRIPTION
The get_gem_external_subdirectories function wasn't removing the path
that completely visited from the set of visited gem paths when detecting
a cycle.

Also changed the visited gem `set` to a `list` to maintain insertion
order so that the error output show the visit order that led to the
cycle.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?
Validated that the `o3de.py enable-gem -gn <gem-name> -pp <project-name>` command no longer incorrectly reported a cycle for the Atom RHI gems when enabling a gem.

```
[ERROR] o3de.manifest: A cycle has been detected when visiting external subdirectories at gem path "/home/user/o3de/Gems/Atom/RHI/DX12". The visited paths are: {'/home/user/o3de/Gems/Atom/Asset/Shader', '/home/user/o3de/Gems/Atom/RHI/Vulkan', '/home/user/o3de/Gems/Atom/RHI/Null', '/home/user/o3de/Gems/Atom/Tools/MaterialCanvas', '/home/user/o3de/Gems/Atom/RHI/DX12', '/home/user/o3de/Gems/Atom/Tools/ShaderManagementConsole', '/home/user/o3de/Gems/Atom/Bootstrap', '/home/user/o3de/Gems/Atom/RPI', '/home/user/o3de/Gems/Atom/Tools/MaterialEditor', '/home/user/o3de/Gems/Atom/RHI', '/home/user/o3de/Gems/Atom/Component/DebugCamera', '/home/user/o3de/Gems/Atom/Feature/Common', '/home/user/o3de/Gems/Atom/Tools/AtomToolsFramework', '/home/user/o3de/Gems/Atom', '/home/user/o3de/Gems/Atom/RHI/Metal', '/home/user/o3de/Gems/Atom/Asset/ImageProcessingAtom'}
```