### PR TITLE
Added setreg for UI viewport and animation viewport to limit feature …

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
@@ -56,16 +56,18 @@ namespace EMStudio
         m_frameworkScene = createSceneOutcome.TakeValue();
         m_frameworkScene->SetSubsystem<AzFramework::EntityContext::SceneStorageType>(m_entityContext.get());
 
-        // Create and register a scene with all available feature processors
+        // Create and register a scene with feature processors defined in the viewport settings
         AZ::RPI::SceneDescriptor sceneDesc;
         sceneDesc.m_nameId = AZ::Name("AnimViewport");
+        auto settingsRegistry = AZ::SettingsRegistry::Get();
+        const char* viewportSettingPath = "/O3DE/Editor/Viewport/Animation/Scene";
+        bool sceneDescLoaded = settingsRegistry->GetObject(sceneDesc, viewportSettingPath);
         m_scene = AZ::RPI::Scene::CreateScene(sceneDesc);
-        m_scene->EnableAllFeatureProcessors();
-        // Disable the terrain feature processor as we don't need terrian in anim editor.
-        const AZ::Name terrainFeatureProcessor("TerrainFeatureProcessor");
-        if (m_scene->GetFeatureProcessor(terrainFeatureProcessor))
+
+        if (!sceneDescLoaded)
         {
-            m_scene->DisableFeatureProcessor(terrainFeatureProcessor);
+            AZ_Warning("AnimViewportRenderer", false, "Unable to load setting registery for the viewport's scene settings. Enable all feature processors.");
+            m_scene->EnableAllFeatureProcessors();
         }
 
         // Link our RPI::Scene to the AzFramework::Scene

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
@@ -66,7 +66,8 @@ namespace EMStudio
 
         if (!sceneDescLoaded)
         {
-            AZ_Warning("AnimViewportRenderer", false, "Unable to load setting registery for the viewport's scene settings. Enable all feature processors.");
+            AZ_Warning("AnimViewportRenderer", false, "Settings registry is missing the scene settings for this viewport, so all feature processors will be enabled. "
+                        "To enable only a minimal set, add the specific list of feature processors with a registry path of '%s'.", viewportSettingPath);
             m_scene->EnableAllFeatureProcessors();
         }
 

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Registry/AnimViewport.setreg
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Registry/AnimViewport.setreg
@@ -3,27 +3,27 @@
         "Editor": {
             "Viewport": {
                 "Animation": {
-					"Scene": {
-						"FeatureProcessors": [						
-							"AZ::Render::AcesDisplayMapperFeatureProcessor",
-							"AZ::Render::DirectionalLightFeatureProcessor",
-							"AZ::Render::MeshFeatureProcessor",
-							"AZ::Render::ImageBasedLightFeatureProcessor",
-							"AZ::Render::PostProcessFeatureProcessor",
-							"AZ::Render::SkinnedMeshFeatureProcessor",
-							"AZ::Render::SkyBoxFeatureProcessor",
-							"AZ::Render::TransformServiceFeatureProcessor",
-							
-							// These FPs can be removed once the LightCullingPass issue [ATOM-17812] is addressed 
-							"AZ::Render::SimplePointLightFeatureProcessor",
-							"AZ::Render::SimpleSpotLightFeatureProcessor",
-							"AZ::Render::PointLightFeatureProcessor",
-							"AZ::Render::DiskLightFeatureProcessor",
-							"AZ::Render::CapsuleLightFeatureProcessor",
-							"AZ::Render::QuadLightFeatureProcessor",
-							"AZ::Render::DecalTextureArrayFeatureProcessor"
-						]
-					}
+                    "Scene": {
+                        "FeatureProcessors": [
+                            "AZ::Render::AcesDisplayMapperFeatureProcessor",
+                            "AZ::Render::DirectionalLightFeatureProcessor",
+                            "AZ::Render::MeshFeatureProcessor",
+                            "AZ::Render::ImageBasedLightFeatureProcessor",
+                            "AZ::Render::PostProcessFeatureProcessor",
+                            "AZ::Render::SkinnedMeshFeatureProcessor",
+                            "AZ::Render::SkyBoxFeatureProcessor",
+                            "AZ::Render::TransformServiceFeatureProcessor",
+
+                            // These FPs can be removed once the LightCullingPass issue [ATOM-17812] is addressed 
+                            "AZ::Render::SimplePointLightFeatureProcessor",
+                            "AZ::Render::SimpleSpotLightFeatureProcessor",
+                            "AZ::Render::PointLightFeatureProcessor",
+                            "AZ::Render::DiskLightFeatureProcessor",
+                            "AZ::Render::CapsuleLightFeatureProcessor",
+                            "AZ::Render::QuadLightFeatureProcessor",
+                            "AZ::Render::DecalTextureArrayFeatureProcessor"
+                        ]
+                    }
                 }
             }
         }

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Registry/AnimViewport.setreg
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Registry/AnimViewport.setreg
@@ -1,0 +1,31 @@
+{
+    "O3DE": {
+        "Editor": {
+            "Viewport": {
+                "Animation": {
+					"Scene": {
+						"FeatureProcessors": [						
+							"AZ::Render::AcesDisplayMapperFeatureProcessor",
+							"AZ::Render::DirectionalLightFeatureProcessor",
+							"AZ::Render::MeshFeatureProcessor",
+							"AZ::Render::ImageBasedLightFeatureProcessor",
+							"AZ::Render::PostProcessFeatureProcessor",
+							"AZ::Render::SkinnedMeshFeatureProcessor",
+							"AZ::Render::SkyBoxFeatureProcessor",
+							"AZ::Render::TransformServiceFeatureProcessor",
+							
+							// These FPs can be removed once the LightCullingPass issue [ATOM-17812] is addressed 
+							"AZ::Render::SimplePointLightFeatureProcessor",
+							"AZ::Render::SimpleSpotLightFeatureProcessor",
+							"AZ::Render::PointLightFeatureProcessor",
+							"AZ::Render::DiskLightFeatureProcessor",
+							"AZ::Render::CapsuleLightFeatureProcessor",
+							"AZ::Render::QuadLightFeatureProcessor",
+							"AZ::Render::DecalTextureArrayFeatureProcessor"
+						]
+					}
+                }
+            }
+        }
+    }
+}

--- a/Gems/LyShine/Code/Source/UiRenderer.cpp
+++ b/Gems/LyShine/Code/Source/UiRenderer.cpp
@@ -18,8 +18,9 @@
 #include <Atom/RPI.Public/RenderPipeline.h>
 #include <Atom/RPI.Public/Pass/RasterPass.h>
 
-#include <AzCore/Math/MatrixUtils.h>
 #include <AzCore/Debug/Trace.h>
+#include <AzCore/Math/MatrixUtils.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 
 #include <LyShine/IDraw2d.h>
 
@@ -93,11 +94,19 @@ void UiRenderer::OnBootstrapSceneReady(AZ::RPI::Scene* bootstrapScene)
 
 AZ::RPI::ScenePtr UiRenderer::CreateScene(AZStd::shared_ptr<AZ::RPI::ViewportContext> viewportContext)
 {
-    // Create a scene with the necessary feature processors
+    // Create and register a scene with feature processors defined in the viewport settings
     AZ::RPI::SceneDescriptor sceneDesc;
     sceneDesc.m_nameId = AZ::Name("UiRenderer");
+    auto settingsRegistry = AZ::SettingsRegistry::Get();
+    const char* viewportSettingPath = "/O3DE/Editor/Viewport/UI/Scene";
+    bool sceneDescLoaded = settingsRegistry->GetObject(sceneDesc, viewportSettingPath);
     AZ::RPI::ScenePtr atomScene = AZ::RPI::Scene::CreateScene(sceneDesc);
-    atomScene->EnableAllFeatureProcessors(); // [LYSHINE_ATOM_TODO][GHI #6272] Enable minimal feature processors
+
+    if (!sceneDescLoaded)
+    {
+        //AZ_Warning("UiRenderer", false, "Unable to load setting registery for the viewport's scene settings. Enable all feature processors.");
+        atomScene->EnableAllFeatureProcessors();
+    }
 
     // Assign the new scene to the specified viewport context
     viewportContext->SetRenderScene(atomScene);

--- a/Gems/LyShine/Code/Source/UiRenderer.cpp
+++ b/Gems/LyShine/Code/Source/UiRenderer.cpp
@@ -104,7 +104,8 @@ AZ::RPI::ScenePtr UiRenderer::CreateScene(AZStd::shared_ptr<AZ::RPI::ViewportCon
 
     if (!sceneDescLoaded)
     {
-        //AZ_Warning("UiRenderer", false, "Unable to load setting registery for the viewport's scene settings. Enable all feature processors.");
+        AZ_Warning("UiRenderer", false, "Settings registry is missing the scene settings for this viewport, so all feature processors will be enabled. "
+                    "To enable only a minimal set, add the specific list of feature processors with a registry path of '%s'.", viewportSettingPath);
         atomScene->EnableAllFeatureProcessors();
     }
 

--- a/Gems/LyShine/Registry/UiViewport.setreg
+++ b/Gems/LyShine/Registry/UiViewport.setreg
@@ -1,0 +1,23 @@
+{
+    "O3DE": {
+        "Editor": {
+            "Viewport": {
+                "UI": {
+					"Scene": {
+						"FeatureProcessors": [												
+							"LyShineFeatureProcessor",
+							// These FPs can be removed once the LightCullingPass issue [ATOM-17812] is addressed 
+							"AZ::Render::SimplePointLightFeatureProcessor",
+							"AZ::Render::SimpleSpotLightFeatureProcessor",
+							"AZ::Render::PointLightFeatureProcessor",
+							"AZ::Render::DiskLightFeatureProcessor",
+							"AZ::Render::CapsuleLightFeatureProcessor",
+							"AZ::Render::QuadLightFeatureProcessor",
+							"AZ::Render::DecalTextureArrayFeatureProcessor"
+						]
+					}
+                }
+            }
+        }
+    }
+}

--- a/Gems/LyShine/Registry/UiViewport.setreg
+++ b/Gems/LyShine/Registry/UiViewport.setreg
@@ -3,19 +3,19 @@
         "Editor": {
             "Viewport": {
                 "UI": {
-					"Scene": {
-						"FeatureProcessors": [												
-							"LyShineFeatureProcessor",
-							// These FPs can be removed once the LightCullingPass issue [ATOM-17812] is addressed 
-							"AZ::Render::SimplePointLightFeatureProcessor",
-							"AZ::Render::SimpleSpotLightFeatureProcessor",
-							"AZ::Render::PointLightFeatureProcessor",
-							"AZ::Render::DiskLightFeatureProcessor",
-							"AZ::Render::CapsuleLightFeatureProcessor",
-							"AZ::Render::QuadLightFeatureProcessor",
-							"AZ::Render::DecalTextureArrayFeatureProcessor"
-						]
-					}
+                    "Scene": {
+                        "FeatureProcessors": [
+                            "LyShineFeatureProcessor",
+                            // These FPs can be removed once the LightCullingPass issue [ATOM-17812] is addressed 
+                            "AZ::Render::SimplePointLightFeatureProcessor",
+                            "AZ::Render::SimpleSpotLightFeatureProcessor",
+                            "AZ::Render::PointLightFeatureProcessor",
+                            "AZ::Render::DiskLightFeatureProcessor",
+                            "AZ::Render::CapsuleLightFeatureProcessor",
+                            "AZ::Render::QuadLightFeatureProcessor",
+                            "AZ::Render::DecalTextureArrayFeatureProcessor"
+                        ]
+                    }
                 }
             }
         }


### PR DESCRIPTION
…processors enabled for their scenes.

https://github.com/o3de/o3de/issues/10931

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>

## What does this PR do?

The PR added setreg files for UI viewport and Animation viewport to limit feature processors enabled when create their scene. This will reduce memory overhead and also avoid crash issue reported in https://github.com/o3de/o3de/issues/10931.
This also address part of the issue mentioned in https://github.com/o3de/o3de/issues/6272

## How was this PR tested?

Open the TerrainPhysicsCollider_MaterialMapping_Works.prefab level in o3de Editor. 
Open UI editor then open the lyshine sample uicanvas file. 
Open Animation editor then open a actor file. 
