### PR TITLE
DPE: Fix combobox handler starting values and reassignment

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -255,8 +255,9 @@ namespace AzToolsFramework
             {
                 m_proxyValue = AZ::Dom::Utils::ValueToType<WrappedType>(value.value()).value_or(m_proxyValue);
             }
-            m_rpeHandler.ReadValuesIntoGUI_Internal(GetWidget(), &m_proxyNode);
+
             m_rpeHandler.ConsumeAttributes_Internal(GetWidget(), &m_proxyNode);
+            m_rpeHandler.ReadValuesIntoGUI_Internal(GetWidget(), &m_proxyNode);
 
             m_domNode = node;
         }


### PR DESCRIPTION
**Description**
Prior to this PR, combo box handlers in the DPE were being populated while their list of values from the adapter had not yet been consumed. This resulted in the combo box controls defaulting to the 0th item in their list of values and rendering their selected value unchangeable in the GUI.

This PR swaps the order of consumption and combo box population so that the values are available when the GUI is created. The change could affect any widgets loaded in a DPE that's standing in place of the RPE, so it's worth extra scrutiny.

DPE before and after change:
![dpe_fixComboBox_fieldComparison](https://user-images.githubusercontent.com/104796591/182501563-b5c830fe-cbcc-4b7a-83fe-fbdf5f06fd91.jpg)

RPE values:
![dpe_combineLabels_rpeView](https://user-images.githubusercontent.com/104796591/182501595-d8e1a40a-1aaf-40b9-b9f4-7d2affcc154f.jpg)

**Testing**
- Visual inspection of the code to verify nothing would break if executed in a different order (still could use an expert's opinion on this one)
- Verified the DOM can still be modified using other handlers and their values still initialize correctly in the GUI
- Ran a diff of the DOM before and after the change (only IDs differed):

![dpe_fixComboBox_diff](https://user-images.githubusercontent.com/104796591/182501530-108d8eb5-5136-4480-bd4c-285bd07469a5.jpg)

