### PR TITLE
Fixed the AZ::IO::Path RootPath function

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.h
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.h
@@ -355,7 +355,7 @@ namespace AZ::IO
         constexpr int ComparePathView(const PathView& other) const;
         constexpr AZStd::string_view root_name_view() const;
         constexpr AZStd::string_view root_directory_view() const;
-        constexpr AZStd::string_view root_path_raw_view() const;
+        constexpr AZStd::string_view root_path_view() const;
         constexpr AZStd::string_view relative_path_view() const;
         constexpr AZStd::string_view parent_path_view() const;
         constexpr AZStd::string_view filename_view() const;
@@ -372,7 +372,7 @@ namespace AZ::IO
     //! then their hash values are also equal
     //! For example : path "a//b" equals  "a/b", the
     //! hash value of "a//b" would also equal the hash value of "a/b"
-    size_t hash_value(const PathView& pathToHash) noexcept;
+    constexpr size_t hash_value(const PathView& pathToHash) noexcept;
 
     // path.comparison
     constexpr bool operator==(const PathView& lhs, const PathView& rhs) noexcept;
@@ -726,7 +726,7 @@ namespace AZ::IO
     //! For example : path "a//b" equals  "a/b", the
     //! hash value of "a//b" would also equal the hash value of "a/b"
     template <typename StringType>
-    size_t hash_value(const BasicPath<StringType>& pathToHash);
+    constexpr size_t hash_value(const BasicPath<StringType>& pathToHash);
 
     // path.append
     template <typename StringType>


### PR DESCRIPTION
The RootPath function was not returning the root directory part of the
path if that part didn't match the preferred path separator.

Also fixed the PathDecomposition functions to correctly propagate the
preferred separator of the path being decomposed to the returned
PathView.

Updated the ComparePathSegments and HashSegments functions of the
PathParser to be constexpr again by using std::is_constant_evaluated
intrinsic to branch the logic on compile time vs run time.

Added test to validate the Path Decompositions functions when using a
path instance with the windows path separator set as the preferred
separator, but the RootPath itself containied a Posix path separator

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>


## How was this PR tested?

Added UnitTest to validate that the RootPath function on the Path classes returned the correct root path when stored path contains Posix path separators and the preferred separator is set to the Windows path separator