### PR TITLE
Removing the need to register a feature processor before enabling it

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/AuxGeom/AuxGeomFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/AuxGeom/AuxGeomFeatureProcessor.h
@@ -26,7 +26,7 @@ namespace AZ
         {
         public: // functions
 
-            AZ_RTTI(AuxGeomFeatureProcessor, "{75E17417-C8E3-4B64-8469-7662D1E0904A}", RPI::AuxGeomFeatureProcessorInterface);
+            AZ_RTTI(AZ::Render::AuxGeomFeatureProcessor, "{75E17417-C8E3-4B64-8469-7662D1E0904A}", AZ::RPI::AuxGeomFeatureProcessorInterface);
             AZ_FEATURE_PROCESSOR(AuxGeomFeatureProcessor);
 
             static void Reflect(AZ::ReflectContext* context);

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DiskLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DiskLightFeatureProcessorInterface.h
@@ -52,7 +52,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::DiskLightFeatureProcessorInterface, "{A78A8FBD-1494-4EF9-9C05-AF153FDB1F17}"); 
+            AZ_RTTI(AZ::Render::DiskLightFeatureProcessorInterface, "{A78A8FBD-1494-4EF9-9C05-AF153FDB1F17}", AZ::RPI::FeatureProcessor);
 
             using LightHandle = RHI::Handle<uint16_t, class DiskLight>;
             static constexpr PhotometricUnit PhotometricUnitType = PhotometricUnit::Candela;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/QuadLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/QuadLightFeatureProcessorInterface.h
@@ -64,7 +64,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::QuadLightFeatureProcessorInterface, "{D86216E4-92A8-43BE-A5E4-883489C6AF06}");
+            AZ_RTTI(AZ::Render::QuadLightFeatureProcessorInterface, "{D86216E4-92A8-43BE-A5E4-883489C6AF06}", AZ::RPI::FeatureProcessor);
 
             using LightHandle = RHI::Handle<uint16_t, class QuadLight>;
             static constexpr PhotometricUnit PhotometricUnitType = PhotometricUnit::Nit;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CubeMapCapture/CubeMapCaptureFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CubeMapCapture/CubeMapCaptureFeatureProcessorInterface.h
@@ -29,7 +29,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::CubeMapCaptureFeatureProcessorInterface, "{77C6838D-6693-4CF4-9FFC-8110C4551761}");
+            AZ_RTTI(AZ::Render::CubeMapCaptureFeatureProcessorInterface, "{77C6838D-6693-4CF4-9FFC-8110C4551761}", AZ::RPI::FeatureProcessor);
 
             virtual CubeMapCaptureHandle AddCubeMapCapture(const AZ::Transform& transform) = 0;
             virtual void RemoveCubeMapCapture(CubeMapCaptureHandle& cubeMapCapture) = 0;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RenderDebugFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RenderDebugFeatureProcessorInterface.h
@@ -19,7 +19,7 @@ namespace AZ::Render
         : public RPI::FeatureProcessor
     {
     public:
-        AZ_RTTI(AZ::Render::RenderDebugFeatureProcessorInterface, "{9774C763-178C-4CE2-99CD-3ABDE12445A4}", RPI::FeatureProcessor);
+        AZ_RTTI(AZ::Render::RenderDebugFeatureProcessorInterface, "{9774C763-178C-4CE2-99CD-3ABDE12445A4}", AZ::RPI::FeatureProcessor);
 
         //! Retrieves existing settings. If none found, returns nullptr.
         virtual RenderDebugSettingsInterface* GetSettingsInterface() = 0;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Decals/DecalFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Decals/DecalFeatureProcessorInterface.h
@@ -50,7 +50,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::DecalFeatureProcessorInterface, "{4A64E427-7F9F-4AF7-B414-69EA91323827}", RPI::FeatureProcessor);
+            AZ_RTTI(AZ::Render::DecalFeatureProcessorInterface, "{4A64E427-7F9F-4AF7-B414-69EA91323827}", AZ::RPI::FeatureProcessor);
 
             using DecalHandle = RHI::Handle<uint16_t, class Decal>;
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessorInterface.h
@@ -30,7 +30,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::DiffuseProbeGridFeatureProcessorInterface, "{BD8CA35A-47C3-4FD8-932B-18495EF07527}");
+            AZ_RTTI(AZ::Render::DiffuseProbeGridFeatureProcessorInterface, "{BD8CA35A-47C3-4FD8-932B-18495EF07527}", AZ::RPI::FeatureProcessor);
 
             virtual void SetQualityLevel(DiffuseGlobalIlluminationQualityLevel qualityLevel) = 0;
         };

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DiffuseGlobalIllumination/DiffuseProbeGridFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DiffuseGlobalIllumination/DiffuseProbeGridFeatureProcessorInterface.h
@@ -106,7 +106,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::DiffuseProbeGridFeatureProcessorInterface, "{6EF4F226-D473-4D50-8884-D407E4D145F4}");
+            AZ_RTTI(AZ::Render::DiffuseProbeGridFeatureProcessorInterface, "{6EF4F226-D473-4D50-8884-D407E4D145F4}", AZ::RPI::FeatureProcessor);
 
             virtual DiffuseProbeGridHandle AddProbeGrid(const AZ::Transform& transform, const AZ::Vector3& extents, const AZ::Vector3& probeSpacing) = 0;
             virtual void RemoveProbeGrid(DiffuseProbeGridHandle& handle) = 0;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperFeatureProcessorInterface.h
@@ -38,7 +38,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::DisplayMapperFeatureProcessorInterface, "{FA57793A-1C7B-4B44-88C4-02AA431C468F}", FeatureProcessor);
+            AZ_RTTI(AZ::Render::DisplayMapperFeatureProcessorInterface, "{FA57793A-1C7B-4B44-88C4-02AA431C468F}", AZ::RPI::FeatureProcessor);
 
             virtual void GetOwnedLut(DisplayMapperLut& displayMapperLut, const AZ::Name& lutName) = 0;
             virtual void GetDisplayMapperLut(DisplayMapperLut& displayMapperLut) = 0;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ImageBasedLights/ImageBasedLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ImageBasedLights/ImageBasedLightFeatureProcessorInterface.h
@@ -21,7 +21,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::ImageBasedLightFeatureProcessorInterface, "{EE7441A3-B406-4717-8F35-E3DAC60E3BDB}", RPI::FeatureProcessor);
+            AZ_RTTI(AZ::Render::ImageBasedLightFeatureProcessorInterface, "{EE7441A3-B406-4717-8F35-E3DAC60E3BDB}", AZ::RPI::FeatureProcessor);
 
             //! Sets the global specular IBL image for this scene
             virtual void SetSpecularImage(const Data::Asset<RPI::StreamingImageAsset>& imageAsset) = 0;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -125,7 +125,7 @@ namespace AZ
         {
         public:
 
-            AZ_RTTI(AZ::Render::MeshFeatureProcessor, "{6E3DFA1D-22C7-4738-A3AE-1E10AB88B29B}", MeshFeatureProcessorInterface);
+            AZ_RTTI(AZ::Render::MeshFeatureProcessor, "{6E3DFA1D-22C7-4738-A3AE-1E10AB88B29B}", AZ::Render::MeshFeatureProcessorInterface);
 
             static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -43,7 +43,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::MeshFeatureProcessorInterface, "{975D7F0C-2E7E-4819-94D0-D3C4E2024721}", FeatureProcessor);
+            AZ_RTTI(AZ::Render::MeshFeatureProcessorInterface, "{975D7F0C-2E7E-4819-94D0-D3C4E2024721}", AZ::RPI::FeatureProcessor);
 
             using MeshHandle = StableDynamicArrayHandle<ModelDataInstance>;
             using ModelChangedEvent = Event<const Data::Instance<RPI::Model>>;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/OcclusionCullingPlane/OcclusionCullingPlaneFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/OcclusionCullingPlane/OcclusionCullingPlaneFeatureProcessorInterface.h
@@ -25,7 +25,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::OcclusionCullingPlaneFeatureProcessorInterface, "{50F6B45E-A622-44EC-B962-DE25FBD44095}");
+            AZ_RTTI(AZ::Render::OcclusionCullingPlaneFeatureProcessorInterface, "{50F6B45E-A622-44EC-B962-DE25FBD44095}", AZ::RPI::FeatureProcessor);
 
             virtual OcclusionCullingPlaneHandle AddOcclusionCullingPlane(const AZ::Transform& transform) = 0;
             virtual void RemoveOcclusionCullingPlane(OcclusionCullingPlaneHandle& handle) = 0;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/PostProcessing/SMAAFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/PostProcessing/SMAAFeatureProcessorInterface.h
@@ -84,7 +84,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::SMAAFeatureProcessorInterface, "{7E6A9FB5-E42C-41C3-8F84-40A1D4433A94}");
+            AZ_RTTI(AZ::Render::SMAAFeatureProcessorInterface, "{7E6A9FB5-E42C-41C3-8F84-40A1D4433A94}", AZ::RPI::FeatureProcessor);
 
             //! Enable/disable SMAA feature.
             //! @param enable Flag for SMAA feature.

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ReflectionProbe/ReflectionProbeFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ReflectionProbe/ReflectionProbeFeatureProcessorInterface.h
@@ -38,7 +38,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::ReflectionProbeFeatureProcessorInterface, "{805FA0F8-765A-4072-A8B1-41C4708B6E36}");
+            AZ_RTTI(AZ::Render::ReflectionProbeFeatureProcessorInterface, "{805FA0F8-765A-4072-A8B1-41C4708B6E36}", AZ::RPI::FeatureProcessor);
 
             //! Add a new reflection probe, returns the handle of the new probe
             virtual ReflectionProbeHandle AddReflectionProbe(const AZ::Transform& transform, bool useParallaxCorrection) = 0;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshFeatureProcessorInterface.h
@@ -25,7 +25,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::SkinnedMeshFeatureProcessorInterface, "{6BE6D9D7-FFD7-4C35-9A84-4EFDE730F06B}");
+            AZ_RTTI(AZ::Render::SkinnedMeshFeatureProcessorInterface, "{6BE6D9D7-FFD7-4C35-9A84-4EFDE730F06B}", AZ::RPI::FeatureProcessor);
 
             using SkinnedMeshHandle = StableDynamicArrayHandle<SkinnedMeshRenderProxy>;
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkyBox/SkyBoxFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkyBox/SkyBoxFeatureProcessorInterface.h
@@ -43,7 +43,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
             public:
-            AZ_RTTI(AZ::Render::SkyBoxFeatureProcessorInterface, "{71061869-1190-4451-A337-E9CFF16441B4}"); 
+            AZ_RTTI(AZ::Render::SkyBoxFeatureProcessorInterface, "{71061869-1190-4451-A337-E9CFF16441B4}", AZ::RPI::FeatureProcessor); 
 
             virtual void Enable(bool enable) = 0;
             virtual bool IsEnabled() = 0;

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomFeatureProcessor.cpp
@@ -28,7 +28,7 @@ namespace AZ
             {
                 serializeContext
                     ->Class<AuxGeomFeatureProcessor, FeatureProcessor>()
-                    ->Version(0);
+                    ->Version(1);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.cpp
@@ -31,7 +31,7 @@ namespace AZ
             {
                 serializeContext
                     ->Class<DiskLightFeatureProcessor, FeatureProcessor>()
-                    ->Version(0);
+                    ->Version(1);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/QuadLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/QuadLightFeatureProcessor.cpp
@@ -33,7 +33,7 @@ namespace AZ
             {
                 serializeContext
                     ->Class<QuadLightFeatureProcessor, FeatureProcessor>()
-                    ->Version(0);
+                    ->Version(1);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapCaptureFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapCaptureFeatureProcessor.cpp
@@ -20,7 +20,7 @@ namespace AZ
             {
                 serializeContext
                     ->Class<CubeMapCaptureFeatureProcessor, FeatureProcessor>()
-                    ->Version(0);
+                    ->Version(1);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapCaptureFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapCaptureFeatureProcessor.h
@@ -19,7 +19,7 @@ namespace AZ
             : public CubeMapCaptureFeatureProcessorInterface
         {
         public:
-            AZ_RTTI(CubeMapCaptureFeatureProcessor, "{821039A3-AF40-4E69-A7EF-D44D81EAF1FA}", CubeMapCaptureFeatureProcessorInterface);
+            AZ_RTTI(AZ::Render::CubeMapCaptureFeatureProcessor, "{821039A3-AF40-4E69-A7EF-D44D81EAF1FA}", AZ::Render::CubeMapCaptureFeatureProcessorInterface);
 
             static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessor.cpp
@@ -24,7 +24,7 @@ namespace AZ
             {
                 serializeContext
                     ->Class<DiffuseGlobalIlluminationFeatureProcessor, FeatureProcessor>()
-                    ->Version(0);
+                    ->Version(1);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessor.h
@@ -20,7 +20,7 @@ namespace AZ
             : public DiffuseGlobalIlluminationFeatureProcessorInterface
         {
         public:
-            AZ_RTTI(AZ::Render::DiffuseGlobalIlluminationFeatureProcessor, "{14F7DF46-AA2C-49EF-8A2C-0A7CB7390BB7}", DiffuseGlobalIlluminationFeatureProcessorInterface);
+            AZ_RTTI(AZ::Render::DiffuseGlobalIlluminationFeatureProcessor, "{14F7DF46-AA2C-49EF-8A2C-0A7CB7390BB7}", AZ::Render::DiffuseGlobalIlluminationFeatureProcessorInterface);
 
             static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridFeatureProcessor.cpp
@@ -34,7 +34,7 @@ namespace AZ
             {
                 serializeContext
                     ->Class<DiffuseProbeGridFeatureProcessor, FeatureProcessor>()
-                    ->Version(0);
+                    ->Version(1);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridFeatureProcessor.h
@@ -24,7 +24,7 @@ namespace AZ
             , private Data::AssetBus::MultiHandler
         {
         public:
-            AZ_RTTI(AZ::Render::DiffuseProbeGridFeatureProcessor, "{BCD232F9-1EBF-4D0D-A5F4-84AEC933A93C}", DiffuseProbeGridFeatureProcessorInterface);
+            AZ_RTTI(AZ::Render::DiffuseProbeGridFeatureProcessor, "{BCD232F9-1EBF-4D0D-A5F4-84AEC933A93C}", AZ::Render::DiffuseProbeGridFeatureProcessorInterface);
 
             static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -44,7 +44,7 @@ namespace AZ
             {
                 serializeContext
                     ->Class<MeshFeatureProcessor, FeatureProcessor>()
-                    ->Version(0);
+                    ->Version(1);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/OcclusionCullingPlane/OcclusionCullingPlaneFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/OcclusionCullingPlane/OcclusionCullingPlaneFeatureProcessor.cpp
@@ -22,7 +22,7 @@ namespace AZ
             {
                 serializeContext
                     ->Class<OcclusionCullingPlaneFeatureProcessor, FeatureProcessor>()
-                    ->Version(0);
+                    ->Version(1);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/OcclusionCullingPlane/OcclusionCullingPlaneFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/OcclusionCullingPlane/OcclusionCullingPlaneFeatureProcessor.h
@@ -20,7 +20,7 @@ namespace AZ
             : public OcclusionCullingPlaneFeatureProcessorInterface
         {
         public:
-            AZ_RTTI(AZ::Render::OcclusionCullingPlaneFeatureProcessor, "{C3DE91D7-EF7A-4A82-A55F-E22BC52074EA}", OcclusionCullingPlaneFeatureProcessorInterface);
+            AZ_RTTI(AZ::Render::OcclusionCullingPlaneFeatureProcessor, "{C3DE91D7-EF7A-4A82-A55F-E22BC52074EA}", AZ::Render::OcclusionCullingPlaneFeatureProcessorInterface);
 
             static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -32,7 +32,7 @@ namespace AZ
             {
                 serializeContext
                     ->Class<RayTracingFeatureProcessor, FeatureProcessor>()
-                    ->Version(0);
+                    ->Version(1);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -54,7 +54,7 @@ namespace AZ
         {
         public:
 
-            AZ_RTTI(AZ::Render::RayTracingFeatureProcessor, "{5017EFD3-A996-44B0-9ED2-C47609A2EE8D}", RPI::FeatureProcessor);
+            AZ_RTTI(AZ::Render::RayTracingFeatureProcessor, "{5017EFD3-A996-44B0-9ED2-C47609A2EE8D}", AZ::RPI::FeatureProcessor);
 
             static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
@@ -30,7 +30,7 @@ namespace AZ
             {
                 serializeContext
                     ->Class<ReflectionProbeFeatureProcessor, FeatureProcessor>()
-                    ->Version(0);
+                    ->Version(1);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.h
@@ -20,7 +20,7 @@ namespace AZ
               private Data::AssetBus::MultiHandler
         {
         public:
-            AZ_RTTI(ReflectionProbeFeatureProcessor, "{A08C591F-D2AB-4550-852A-4436533DB137}", ReflectionProbeFeatureProcessorInterface);
+            AZ_RTTI(AZ::Render::ReflectionProbeFeatureProcessor, "{A08C591F-D2AB-4550-852A-4436533DB137}", AZ::Render::ReflectionProbeFeatureProcessorInterface);
 
             static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h
@@ -26,7 +26,7 @@ namespace AZ
             : public FeatureProcessor
         {
         public:
-            AZ_RTTI(AuxGeomFeatureProcessorInterface, "{2750EE44-5AE6-4379-BA3B-EDCD1507C997}", FeatureProcessor);
+            AZ_RTTI(AZ::RPI::AuxGeomFeatureProcessorInterface, "{2750EE44-5AE6-4379-BA3B-EDCD1507C997}", AZ::RPI::FeatureProcessor);
 
             AuxGeomFeatureProcessorInterface() = default;
             virtual ~AuxGeomFeatureProcessorInterface() = default;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessorFactory.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessorFactory.h
@@ -17,14 +17,7 @@ namespace AZ
     namespace RPI
     {
         class FeatureProcessor;
-
-        class FeatureProcessorDeleter
-        {
-        public:
-            void operator()(FeatureProcessor* featureProcessor) const;
-        };
-
-        using FeatureProcessorPtr = AZStd::unique_ptr<FeatureProcessor, FeatureProcessorDeleter>;
+        using FeatureProcessorPtr = AZStd::unique_ptr<FeatureProcessor>;
 
         //! The feature processor factory is where gems should register their
         //! feature processors. Once registered, these feature processors can

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -228,6 +228,9 @@ namespace AZ
             void FinalizeDrawListsTaskGraph();
             void FinalizeDrawListsJobs();
 
+            template<typename Predicate>
+            FeatureProcessor* GetFeatureProcessor(const Predicate& predicate) const;
+
             // List of feature processors that are active for this scene
             AZStd::vector<FeatureProcessorPtr> m_featureProcessors;
 
@@ -281,6 +284,14 @@ namespace AZ
         };
 
         // --- Template functions ---
+
+        template<typename Predicate>
+        FeatureProcessor* Scene::GetFeatureProcessor(const Predicate& predicate) const
+        {
+            auto foundFP = AZStd::find_if(AZStd::begin(m_featureProcessors), AZStd::end(m_featureProcessors), predicate);
+            return foundFP == AZStd::end(m_featureProcessors) ? nullptr : (*foundFP).get();
+        }
+
         template<typename FeatureProcessorType>
         FeatureProcessorType* Scene::EnableFeatureProcessor()
         {

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -102,6 +102,11 @@ namespace AZ
 
             void DisableAllFeatureProcessors();
 
+            //! Callback function that will be invoked with each non-pointer FeatureProcessor
+            //! return true to continue visiting or false to halt
+            using FeatureProcessorVisitCallback = AZStd::function<bool(FeatureProcessor&)>;
+            void VisitFeatureProcessor(FeatureProcessorVisitCallback callback) const;
+
             //! Linear search to retrieve specific class of a feature processor.
             //! Returns nullptr if a feature processor with the specified id is
             //! not found.
@@ -228,9 +233,6 @@ namespace AZ
             void FinalizeDrawListsTaskGraph();
             void FinalizeDrawListsJobs();
 
-            template<typename Predicate>
-            FeatureProcessor* GetFeatureProcessor(const Predicate& predicate) const;
-
             // List of feature processors that are active for this scene
             AZStd::vector<FeatureProcessorPtr> m_featureProcessors;
 
@@ -284,13 +286,6 @@ namespace AZ
         };
 
         // --- Template functions ---
-
-        template<typename Predicate>
-        FeatureProcessor* Scene::GetFeatureProcessor(const Predicate& predicate) const
-        {
-            auto foundFP = AZStd::find_if(AZStd::begin(m_featureProcessors), AZStd::end(m_featureProcessors), predicate);
-            return foundFP == AZStd::end(m_featureProcessors) ? nullptr : (*foundFP).get();
-        }
 
         template<typename FeatureProcessorType>
         FeatureProcessorType* Scene::EnableFeatureProcessor()

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/FeatureProcessorFactory.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/FeatureProcessorFactory.cpp
@@ -18,36 +18,6 @@ namespace AZ
 {
     namespace RPI
     {
-        void FeatureProcessorDeleter::operator()(FeatureProcessor* featureProcessor) const
-        {
-            auto featureProcessorLib = FeatureProcessorFactory::Get();
-
-            AZ::SerializeContext* serializeContext = nullptr;
-            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
-            FeatureProcessorId featureProcessorId{ featureProcessor->RTTI_GetTypeName() };
-
-            if (!serializeContext)
-            {
-                AZ_Warning("FeatureProcessorFactory", false, "FeatureProcessor '%s' could not be destroyed since could not retrieve serialize context.", featureProcessorId.GetCStr());
-                return;
-            }
-
-            auto foundIt = featureProcessorLib->GetEntry(featureProcessorId);
-            if (foundIt == AZStd::end(featureProcessorLib->m_registry))
-            {
-                AZ_Warning("FeatureProcessorFactory", false, "FeatureProcessor '%s' could not be destroyed since failed to find it in registry.", featureProcessorId.GetCStr());
-                return;
-            }
-
-            auto* classData = serializeContext->FindClassData(foundIt->m_typeId);
-            if (!classData)
-            {
-                AZ_Warning("FeatureProcessorFactory", false, "FeatureProcessor '%s' could not be destroyed since failed to get class data.", featureProcessorId.GetCStr());
-                return;
-            }
-            
-            classData->m_factory->Destroy(featureProcessor);
-        }
 
         FeatureProcessorFactory* FeatureProcessorFactory::Get()
         {
@@ -75,7 +45,7 @@ namespace AZ
 
             if (!serializeContext)
             {
-                AZ_Warning("FeatureProcessorFactory", false, "FeatureProcessor '%s' could not be created since the serialize context could not be retrieved.", featureProcessorId.GetCStr());
+                AZ_Warning("FeatureProcessorFactory", false, "Provided type '%s' could not be created since the serialize context could not be retrieved.", featureProcessorId.GetCStr());
                 return nullptr;
             }
 
@@ -93,15 +63,11 @@ namespace AZ
 
                 if (foundUuids.empty())
                 {
-                    AZ_Error("FeatureProcessorFactory", false, "Provided type %s is either an invalid TypeId or does not match any class names", featureProcessorId.GetCStr());
-                    return nullptr;
+                    AZ_Warning("FeatureProcessorFactory", false, "Provided type %s is either an invalid TypeId or does not match any class names", featureProcessorId.GetCStr());
                 }
-                typeId = foundUuids[0];
-
-                if (!serializeContext->CanDowncast(typeId, FeatureProcessor::RTTI_Type()))
+                else
                 {
-                    AZ_Error("FeatureProcessorFactory", false, "Provided type %s is not a Feature Processor", featureProcessorId.GetCStr());
-                    return nullptr;
+                    typeId = foundUuids[0];
                 }
             }
 
@@ -109,7 +75,12 @@ namespace AZ
             auto* classData = serializeContext->FindClassData(typeId);
             if (!classData)
             {
-                AZ_Warning("FeatureProcessorFactory", false, "FeatureProcessor '%s' could not be created since failed to get class data.", featureProcessorId.GetCStr());
+                AZ_Warning("FeatureProcessorFactory", false, "Provided type '%s' could not be created since failed to get class data. Make sure it was reflected to the serialize context.", featureProcessorId.GetCStr());
+                return nullptr;
+            }
+            else if (!(classData->m_azRtti && classData->m_azRtti->IsTypeOf(FeatureProcessor::RTTI_Type())))
+            {
+                AZ_Warning("FeatureProcessorFactory", false, "Provided type %s is not a Feature Processor, or could not find RTTI information.", featureProcessorId.GetCStr());
                 return nullptr;
             }
             return FeatureProcessorPtr(reinterpret_cast<FeatureProcessor*>(classData->m_factory->Create("FeatureProcessor")));
@@ -141,9 +112,9 @@ namespace AZ
 
         FeatureProcessorFactory::FeatureProcessorRegistry::const_iterator FeatureProcessorFactory::GetEntry(FeatureProcessorId featureProcessorId)
         {
-            auto findFn = [featureProcessorId](const FeatureProcessorEntry& entry) 
-            { 
-                return entry.m_featureProcessorId == featureProcessorId; 
+            auto findFn = [featureProcessorId](const FeatureProcessorEntry& entry)
+            {
+                return entry.m_featureProcessorId == featureProcessorId;
             };
 
             return AZStd::find_if(AZStd::begin(m_registry), AZStd::end(m_registry), findFn);
@@ -169,7 +140,7 @@ namespace AZ
                     continue;
                 }
 
-                FeatureProcessorPtr fp = FeatureProcessorPtr(reinterpret_cast<FeatureProcessor*>(classData->m_factory->Create("FeatureProcessor")));              
+                FeatureProcessorPtr fp = FeatureProcessorPtr(reinterpret_cast<FeatureProcessor*>(classData->m_factory->Create("FeatureProcessor")));
                 scene->AddFeatureProcessor(AZStd::move(fp));
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -279,19 +279,22 @@ namespace AZ
         
         FeatureProcessor* Scene::GetFeatureProcessor(const FeatureProcessorId& featureProcessorId) const
         {
-            AZ::TypeId featureProcessorTypeId = FeatureProcessorFactory::Get()->GetFeatureProcessorTypeId(featureProcessorId);
-
-            return GetFeatureProcessor(featureProcessorTypeId);
+            return GetFeatureProcessor(
+                [featureProcessorId](const FeatureProcessorPtr& fp)
+                {
+                    return FeatureProcessorId(fp->RTTI_TypeName()) == featureProcessorId;
+                }
+            );
         }
         
         FeatureProcessor* Scene::GetFeatureProcessor(const TypeId& featureProcessorTypeId) const
         {
-            auto foundFP = AZStd::find_if(
-                AZStd::begin(m_featureProcessors),
-                AZStd::end(m_featureProcessors),
-                [featureProcessorTypeId](const FeatureProcessorPtr& fp) { return fp->RTTI_IsTypeOf(featureProcessorTypeId); });
-
-            return foundFP == AZStd::end(m_featureProcessors) ? nullptr : (*foundFP).get();
+            return GetFeatureProcessor(
+                [featureProcessorTypeId](const FeatureProcessorPtr& fp)
+                {
+                    return fp->RTTI_IsTypeOf(featureProcessorTypeId);
+                }
+            );
         }
 
         void Scene::TryApplyRenderPipelineChanges(RenderPipeline* pipeline)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -282,7 +282,7 @@ namespace AZ
             return GetFeatureProcessor(
                 [featureProcessorId](const FeatureProcessorPtr& fp)
                 {
-                    return FeatureProcessorId(fp->RTTI_TypeName()) == featureProcessorId;
+                    return FeatureProcessorId(fp->RTTI_GetTypeName()) == featureProcessorId;
                 }
             );
         }

--- a/Gems/Atom/RPI/Code/Tests/System/FeatureProcessorFactoryTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/System/FeatureProcessorFactoryTests.cpp
@@ -98,24 +98,12 @@ namespace UnitTest
     {
         FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<TestFeatureProcessorImplementation>();
 
-        // TestFeatureProcessorImplementation can no longer be created because it has been unregistered
-        FeatureProcessorPtr implementation1 = FeatureProcessorFactory::Get()->CreateFeatureProcessor(FeatureProcessorId{ TestFeatureProcessorImplementation::RTTI_TypeName() });
-        FeatureProcessorPtr implementation2 = FeatureProcessorFactory::Get()->CreateFeatureProcessor(FeatureProcessorId{ TestFeatureProcessorImplementation2::RTTI_TypeName() });
-
-        EXPECT_TRUE(implementation1 == nullptr);
-        EXPECT_TRUE(implementation2 != nullptr);
-    }
-
-    TEST_F(FeatureProcessorFactoryTests, UnregisterFeatureProcessor_MultipleImplmentationsOfTheSameInterface_OnlyTestFeatureProcessorImplementation2IsUnregistered)
-    {
-        FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<TestFeatureProcessorImplementation2>();
-
-        // TestFeatureProcessorImplementation can no longer be created because it has been unregistered
+        // Should still be able to create both feature processors even with one unregistered.
         FeatureProcessorPtr implementation1 = FeatureProcessorFactory::Get()->CreateFeatureProcessor(FeatureProcessorId{ TestFeatureProcessorImplementation::RTTI_TypeName() });
         FeatureProcessorPtr implementation2 = FeatureProcessorFactory::Get()->CreateFeatureProcessor(FeatureProcessorId{ TestFeatureProcessorImplementation2::RTTI_TypeName() });
 
         EXPECT_TRUE(implementation1 != nullptr);
-        EXPECT_TRUE(implementation2 == nullptr);
+        EXPECT_TRUE(implementation2 != nullptr);
     }
 
     //
@@ -123,7 +111,9 @@ namespace UnitTest
     //
     TEST_F(FeatureProcessorFactoryTests, CreateFeatureProcessor_ByInterfaceName_FailsToCreate)
     {
+        AZ_TEST_START_TRACE_SUPPRESSION; // FeatureProcessorFactory may throw an error for this
         EXPECT_TRUE(AZ::RPI::FeatureProcessorFactory::Get()->CreateFeatureProcessor(FeatureProcessorId{ TestFeatureProcessorInterface::RTTI_TypeName() }) == nullptr);
+        AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
     }
 
     // Get typeid from interface

--- a/Gems/Atom/RPI/Code/Tests/System/FeatureProcessorFactoryTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/System/FeatureProcessorFactoryTests.cpp
@@ -89,8 +89,8 @@ namespace UnitTest
     {
         FeatureProcessorPtr implementation1 = FeatureProcessorFactory::Get()->CreateFeatureProcessor(FeatureProcessorId{ TestFeatureProcessorImplementation::RTTI_TypeName() });
         FeatureProcessorPtr implementation2 = FeatureProcessorFactory::Get()->CreateFeatureProcessor(FeatureProcessorId{ TestFeatureProcessorImplementation2::RTTI_TypeName() });
-        EXPECT_TRUE(implementation1 != nullptr);
-        EXPECT_TRUE(implementation2 != nullptr);
+        EXPECT_NE(implementation1, nullptr);
+        EXPECT_NE(implementation2, nullptr);
         EXPECT_NE(implementation1, implementation2);
     }
 
@@ -102,8 +102,8 @@ namespace UnitTest
         FeatureProcessorPtr implementation1 = FeatureProcessorFactory::Get()->CreateFeatureProcessor(FeatureProcessorId{ TestFeatureProcessorImplementation::RTTI_TypeName() });
         FeatureProcessorPtr implementation2 = FeatureProcessorFactory::Get()->CreateFeatureProcessor(FeatureProcessorId{ TestFeatureProcessorImplementation2::RTTI_TypeName() });
 
-        EXPECT_TRUE(implementation1 != nullptr);
-        EXPECT_TRUE(implementation2 != nullptr);
+        EXPECT_NE(implementation1, nullptr);
+        EXPECT_NE(implementation2, nullptr);
     }
 
     //
@@ -112,7 +112,7 @@ namespace UnitTest
     TEST_F(FeatureProcessorFactoryTests, CreateFeatureProcessor_ByInterfaceName_FailsToCreate)
     {
         AZ_TEST_START_TRACE_SUPPRESSION; // FeatureProcessorFactory may throw an error for this
-        EXPECT_TRUE(AZ::RPI::FeatureProcessorFactory::Get()->CreateFeatureProcessor(FeatureProcessorId{ TestFeatureProcessorInterface::RTTI_TypeName() }) == nullptr);
+        EXPECT_EQ(AZ::RPI::FeatureProcessorFactory::Get()->CreateFeatureProcessor(FeatureProcessorId{ TestFeatureProcessorInterface::RTTI_TypeName() }), nullptr);
         AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
     }
 

--- a/Gems/Atom/RPI/Code/Tests/System/SceneTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/System/SceneTests.cpp
@@ -389,11 +389,6 @@ namespace UnitTest
         ScenePtr testScene = Scene::CreateScene(sceneDesc);
         testScene->Activate();
 
-        AZ_TEST_START_ASSERTTEST;
-        FeatureProcessor* featureProcessor = testScene->EnableFeatureProcessor(FeatureProcessorId{ TestFeatureProcessorInterface::RTTI_TypeName() });
-        AZ_TEST_STOP_ASSERTTEST(1);
-
-        EXPECT_TRUE(featureProcessor == nullptr);
         EXPECT_TRUE(testScene->GetFeatureProcessor<TestFeatureProcessorImplementation>() == nullptr);
         EXPECT_TRUE(testScene->GetFeatureProcessor<TestFeatureProcessorInterface>() == nullptr);
 

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.cpp
@@ -24,7 +24,9 @@ namespace AZ
         {
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
             {
-                serializeContext->Class<EditorModeFeatureProcessor, RPI::FeatureProcessor>()->Version(0);
+                serializeContext
+                    ->Class<EditorModeFeatureProcessor, RPI::FeatureProcessor>()
+                    ->Version(1);
             }
         }
 

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.h
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.h
@@ -20,7 +20,7 @@ namespace AZ
             : public RPI::FeatureProcessor
         {
         public:
-            AZ_RTTI(AZ::Render::EditorModeFeatureProcessor, "{78D40D57-F564-4ECD-B9F5-D8C9784B15D0}", RPI::FeatureProcessor);
+            AZ_RTTI(AZ::Render::EditorModeFeatureProcessor, "{78D40D57-F564-4ECD-B9F5-D8C9784B15D0}", AZ::RPI::FeatureProcessor);
 
             static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -85,7 +85,7 @@ namespace AZ
                 {
                     serializeContext
                         ->Class<HairFeatureProcessor, RPI::FeatureProcessor>()
-                        ->Version(0);
+                        ->Version(1);
                 }
             }
 

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
@@ -97,7 +97,7 @@ namespace AZ
                 Name HairShortCutResolveColorPassName;
 
             public:
-                AZ_RTTI(AZ::Render::Hair::HairFeatureProcessor, "{5F9DDA81-B43F-4E30-9E56-C7C3DC517A4C}", RPI::FeatureProcessor);
+                AZ_RTTI(AZ::Render::Hair::HairFeatureProcessor, "{5F9DDA81-B43F-4E30-9E56-C7C3DC517A4C}", AZ::RPI::FeatureProcessor);
 
                 static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/Stars/Code/Include/Stars/StarsFeatureProcessorInterface.h
+++ b/Gems/Stars/Code/Include/Stars/StarsFeatureProcessorInterface.h
@@ -20,7 +20,7 @@ namespace AZ::Render
         : public RPI::FeatureProcessor
     {
     public:
-        AZ_RTTI(AZ::Render::StarsFeatureProcessorInterface, "{7ECE8A5E-366B-4942-B6F9-370DC6017927}"); 
+        AZ_RTTI(AZ::Render::StarsFeatureProcessorInterface, "{7ECE8A5E-366B-4942-B6F9-370DC6017927}", AZ::RPI::FeatureProcessor);
 
         struct StarVertex 
         {

--- a/Gems/Stars/Code/Source/EditorStarsComponent.cpp
+++ b/Gems/Stars/Code/Source/EditorStarsComponent.cpp
@@ -104,11 +104,11 @@ namespace AZ::Render
     {
         if (visibility)
         {
-            m_controller.RegisterFeatureProcessor(GetEntityId());
+            m_controller.EnableFeatureProcessor(GetEntityId());
         }
         else
         {
-            m_controller.UnregisterFeatureProcessor();
+            m_controller.DisableFeatureProcessor();
         }
     }
 }

--- a/Gems/Stars/Code/Source/StarsComponentController.cpp
+++ b/Gems/Stars/Code/Source/StarsComponentController.cpp
@@ -68,7 +68,6 @@ namespace AZ::Render
 
     void StarsComponentController::RegisterFeatureProcessor(EntityId entityId)
     {
-        RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<StarsFeatureProcessor, StarsFeatureProcessorInterface>();
         m_scene = RPI::Scene::GetSceneForEntityId(entityId);
         if (m_scene)
         {
@@ -102,8 +101,6 @@ namespace AZ::Render
             m_scene->DisableFeatureProcessor<StarsFeatureProcessor>();
 
             m_starsFeatureProcessor = nullptr;
-
-            RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<StarsFeatureProcessor>();
         }
     }
 

--- a/Gems/Stars/Code/Source/StarsComponentController.cpp
+++ b/Gems/Stars/Code/Source/StarsComponentController.cpp
@@ -61,12 +61,12 @@ namespace AZ::Render
 
     void StarsComponentController::Activate(EntityId entityId)
     {
-        RegisterFeatureProcessor(entityId);
+        EnableFeatureProcessor(entityId);
 
         TransformNotificationBus::Handler::BusConnect(entityId);
     }
 
-    void StarsComponentController::RegisterFeatureProcessor(EntityId entityId)
+    void StarsComponentController::EnableFeatureProcessor(EntityId entityId)
     {
         m_scene = RPI::Scene::GetSceneForEntityId(entityId);
         if (m_scene)
@@ -94,7 +94,7 @@ namespace AZ::Render
         OnConfigChanged();
     }
 
-    void StarsComponentController::UnregisterFeatureProcessor()
+    void StarsComponentController::DisableFeatureProcessor()
     {
         if (m_scene && m_starsFeatureProcessor)
         {
@@ -175,7 +175,7 @@ namespace AZ::Render
         TransformNotificationBus::Handler::BusDisconnect();
         Data::AssetBus::MultiHandler::BusDisconnect();
 
-        UnregisterFeatureProcessor();
+        DisableFeatureProcessor();
     }
 
     void StarsComponentController::SetConfiguration(const StarsComponentConfig& config)

--- a/Gems/Stars/Code/Source/StarsComponentController.h
+++ b/Gems/Stars/Code/Source/StarsComponentController.h
@@ -56,8 +56,8 @@ namespace AZ::Render
         void OnConfigChanged();
         void OnStarsAssetChanged();
         void UpdateStarsFromAsset(Data::Asset<Data::AssetData> asset);
-        void RegisterFeatureProcessor(EntityId entityId);
-        void UnregisterFeatureProcessor();
+        void EnableFeatureProcessor(EntityId entityId);
+        void DisableFeatureProcessor();
 
         StarsComponentConfig m_configuration;
 

--- a/Gems/Terrain/Code/Source/Components/TerrainWorldRendererComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainWorldRendererComponent.cpp
@@ -227,8 +227,6 @@ namespace Terrain
     {
         // On component activation, register the terrain feature processor with Atom and the scene related to this entity context.
 
-        AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessor<Terrain::TerrainFeatureProcessor>();
-
         if (AZ::RPI::Scene* scene = GetScene(); scene)
         {
             m_terrainFeatureProcessor = scene->EnableFeatureProcessor<Terrain::TerrainFeatureProcessor>();
@@ -257,8 +255,6 @@ namespace Terrain
             }
         }
         m_terrainFeatureProcessor = nullptr;
-
-        AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<Terrain::TerrainFeatureProcessor>();
     }
 
     bool TerrainWorldRendererComponent::ReadInConfig(const AZ::ComponentConfig* baseConfig)


### PR DESCRIPTION
## What does this PR do?

Currently feature processors need to be registered with the feature processor factory before they can be enabled, since the process of enabling them involves searching the registry. However, once feature processors are in the registry, they may be created by a call to `EnableAllFeatureProcessors()`. This is commonly used when setting up a new scene for a separate viewport in the editor. However, if a component registers a feature processor in order to add it to its own scene, it's possible this feature processor could end up inadvertently added to another scene if `EnableAllFeatureProcessors()` is called during creation. At best this leads to unnecessary feature processors being added to a scene that doesn't require them, at worst this could lead to crashing (like in the case of the Terrain or Stars feature processors).

This PR includes two changes to fix the problem, neither of which require updates to code which uses the scene or feature processor factory. 
1. Make `CreateFeatureProcessor()` fall back on the serialize context when a feature processor can't be found in the registry. This means feature processors can be added by components without concern that they might show up in another scene.
2. Update Scene's `GetFeatureProcessor()` to no longer rely on the registry, instead just checking its feature processors directly for matching feature processor Ids. This allows `GetFeatureProcessor()` to work for all feature processors on a scene regardless of how they were added to the scene.

fixes https://github.com/o3de/o3de/issues/10931
fixes https://github.com/o3de/o3de/issues/9315

## How was this PR tested?

Opened several levels, checked Animation and UI editors to make sure they worked correctly even when terrain or stars were loaded. Checked ASV to make sure samples still ran normally.
