### PR TITLE
Updating the AZCore Utils functions

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.cpp
@@ -800,14 +800,14 @@ namespace AZ::SettingsRegistryMergeUtils
     {
         auto MergeGemPathToRegistry = [&registry](AZStd::string_view manifestKey,
             AZStd::string_view gemName,
-            AZStd::string_view gemRootPath)
+            AZ::IO::PathView gemRootPath)
         {
             using FixedValueString = SettingsRegistryInterface::FixedValueString;
             if (manifestKey == GemNameKey)
             {
                 const auto manifestGemJsonPath = FixedValueString::format("%s/%.*s/Path",
                     ManifestGemsRootKey, AZ_STRING_ARG(gemName));
-                registry.Set(manifestGemJsonPath, gemRootPath);
+                registry.Set(manifestGemJsonPath, gemRootPath.LexicallyNormal().Native());
             }
         };
 
@@ -1462,8 +1462,8 @@ namespace AZ::SettingsRegistryMergeUtils
             if (FixedValueString externalSubdirectoryPath;
                 manifestJsonRegistry.Get(externalSubdirectoryPath, externalSubdirectoryJsonPath))
             {
-                auto gemManifestPath = AZ::IO::FixedMaxPath(manifestRootDirView)
-                    / externalSubdirectoryPath / Internal::GemJsonFilename;
+                auto gemManifestPath = (AZ::IO::FixedMaxPath(manifestRootDirView)
+                    / externalSubdirectoryPath / Internal::GemJsonFilename).LexicallyNormal();
                 if (AZ::IO::SystemFile::Exists(gemManifestPath.c_str()))
                 {
                     VisitManifestJson(gemManifestCallback, gemManifestPath.Native(), GemNameKey);

--- a/Code/Framework/AzCore/AzCore/Utils/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Utils/Utils.h
@@ -71,37 +71,56 @@ namespace AZ
         //! Retrieves the full path of the directory containing the executable
         AZ::IO::FixedMaxPathString GetExecutableDirectory();
 
-        //! Retrieves the full path to the engine from settings registry
-        AZ::IO::FixedMaxPathString GetEnginePath();
+        //! Retrieves the full path to the engine from the settings registry
+        //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup
+        //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
+        AZ::IO::FixedMaxPathString GetEnginePath(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
 
-        //! Retrieves the full path to the project from settings registry
-        AZ::IO::FixedMaxPathString GetProjectPath();
+        //! Retrieves the full path to the project from the settings registry
+        //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup
+        //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
+        AZ::IO::FixedMaxPathString GetProjectPath(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
 
         //! Retrieves the project name from the settings registry
-        AZ::SettingsRegistryInterface::FixedValueString GetProjectName();
+        //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup
+        //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
+        AZ::SettingsRegistryInterface::FixedValueString GetProjectName(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
 
-        //! Retrieves the full directory to the Home directory, i.e. "<userhome> or overrideHomeDirectory"
-        AZ::IO::FixedMaxPathString GetHomeDirectory();
+        //! Lookups the full path for a gem, given it's name from the settings registry
+        //! @param gemName path of the gem whose paths will be queried from within the settings registry
+        //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup
+        //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
+        AZ::IO::FixedMaxPathString GetGemPath(AZStd::string_view gemName, AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
+
+        //! Retrieves the full directory to the Home directory, i.e. "<userhome>" or overrideHomeDirectory
+        //! @param settingsRegistry pointer to the SettingsRegistry to lookup the overrideHomeDirectory
+        //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
+        AZ::IO::FixedMaxPathString GetHomeDirectory(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
 
         //! Retrieves the full directory to the O3DE manifest directory, i.e. "<userhome>/.o3de"
-        AZ::IO::FixedMaxPathString GetO3deManifestDirectory();
+        //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup
+        //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
+        AZ::IO::FixedMaxPathString GetO3deManifestDirectory(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
 
         //! Retrieves the full path where the manifest file lives, i.e. "<userhome>/.o3de/o3de_manifest.json"
-        AZ::IO::FixedMaxPathString GetO3deManifestPath();
+        //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup
+        //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
+        AZ::IO::FixedMaxPathString GetO3deManifestPath(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
 
         //! Retrieves the full directory to the O3DE logs directory, i.e. "<userhome>/.o3de/Logs"
-        AZ::IO::FixedMaxPathString GetO3deLogsDirectory();
+        //! //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup
+        //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
+        AZ::IO::FixedMaxPathString GetO3deLogsDirectory(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
 
-        //! Retrieves the App root path to use on the current platform
-        //! If the optional is not engaged the AppRootPath should be calculated based
-        //! on the location of the bootstrap.cfg file
+        //! Retrieves the application root path for a non-host platform
+        //! On host platforms this returns a nullopt
         AZStd::optional<AZ::IO::FixedMaxPathString> GetDefaultAppRootPath();
 
         //! Retrieves the development write storage path to use on the current platform, may be considered
         //! temporary or cache storage
         AZStd::optional<AZ::IO::FixedMaxPathString> GetDevWriteStoragePath();
 
-        // Attempts the supplied path to an absolute path.
+        //! Attempts the supplied path to an absolute path.
         //! Returns nullopt if path cannot be converted to an absolute path
         AZStd::optional<AZ::IO::FixedMaxPathString> ConvertToAbsolutePath(AZStd::string_view path);
         bool ConvertToAbsolutePath(AZ::IO::FixedMaxPath& outputPath, AZStd::string_view path);
@@ -109,6 +128,7 @@ namespace AZ
 
         //! Save a string to a file. Otherwise returns a failure with error message.
         AZ::Outcome<void, AZStd::string> WriteFile(AZStd::string_view content, AZStd::string_view filePath);
+        AZ::Outcome<void, AZStd::string> WriteFile(AZStd::span<AZStd::byte const> content, AZStd::string_view filePath);
 
         //! Read a file into a string. Returns a failure with error message if the content could not be loaded or if
         //! the file size is larger than the max file size provided.

--- a/Code/Framework/AzCore/Platform/Common/Unimplemented/AzCore/Utils/Utils_Unimplemented.cpp
+++ b/Code/Framework/AzCore/Platform/Common/Unimplemented/AzCore/Utils/Utils_Unimplemented.cpp
@@ -10,7 +10,7 @@
 
 namespace AZ::Utils
 {
-    AZ::IO::FixedMaxPathString GetHomeDirectory()
+    AZ::IO::FixedMaxPathString GetHomeDirectory(AZ::SettingsRegistryInterface*)
     {
         return {};
     }

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Utils/Utils_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Utils/Utils_UnixLike.cpp
@@ -21,11 +21,16 @@ namespace AZ::Utils
 
     void NativeErrorMessageBox(const char*, const char*) {}
 
-    AZ::IO::FixedMaxPathString GetHomeDirectory()
+    AZ::IO::FixedMaxPathString GetHomeDirectory(AZ::SettingsRegistryInterface* settingsRegistry)
     {
         constexpr AZStd::string_view overrideHomeDirKey = "/Amazon/Settings/override_home_dir";
         AZ::IO::FixedMaxPathString overrideHomeDir;
-        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
+        if (settingsRegistry == nullptr)
+        {
+            settingsRegistry = AZ::SettingsRegistry::Get();
+        }
+
+        if (settingsRegistry != nullptr)
         {
             if (settingsRegistry->Get(overrideHomeDir, overrideHomeDirKey))
             {

--- a/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
+++ b/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
@@ -978,4 +978,11 @@
         </Expand>
     </Type>
 
+    <Type Name="AZ::SettingsRegistryImpl">
+        <DisplayString>{m_settings}</DisplayString>
+        <Expand>
+            <ExpandedItem>m_settings</ExpandedItem>
+        </Expand>
+    </Type>
+
 </AutoVisualizer>

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/Utils/Utils_Windows.cpp
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/Utils/Utils_Windows.cpp
@@ -23,11 +23,16 @@ namespace AZ::Utils
         ::MessageBoxW(0, wmessage.c_str(), wtitle.c_str(), MB_OK | MB_ICONERROR);
     }
 
-    AZ::IO::FixedMaxPathString GetHomeDirectory()
+    AZ::IO::FixedMaxPathString GetHomeDirectory(AZ::SettingsRegistryInterface* settingsRegistry)
     {
         constexpr AZStd::string_view overrideHomeDirKey = "/Amazon/Settings/override_home_dir";
         AZ::IO::FixedMaxPathString overrideHomeDir;
-        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
+        if (settingsRegistry == nullptr)
+        {
+            settingsRegistry = AZ::SettingsRegistry::Get();
+        }
+
+        if (settingsRegistry != nullptr)
         {
             if (settingsRegistry->Get(overrideHomeDir, overrideHomeDirKey))
             {

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryMergeUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryMergeUtilsTests.cpp
@@ -557,6 +557,37 @@ tags=tools,renderer,metal)"
             gemVisitParams.m_expectedActiveGemPaths.begin(), gemVisitParams.m_expectedActiveGemPaths.end()));
     }
 
+    TEST_P(SettingsRegistryGemVisitFixture, Validate_SettingsRegistryUtilsQueries_WorksWithLocalRegistry)
+    {
+        const AZ::IO::FixedMaxPath tempRootFolder(m_testFolder.GetDirectory());
+        AZ::IO::FixedMaxPath testPath = AZ::Utils::GetO3deManifestDirectory(m_registry.get());
+        EXPECT_EQ((tempRootFolder / "o3de"), testPath);
+
+        testPath = AZ::Utils::GetEnginePath(m_registry.get());
+        EXPECT_EQ((tempRootFolder / "engine"), testPath);
+
+        testPath = AZ::Utils::GetProjectPath(m_registry.get());
+        EXPECT_EQ((tempRootFolder / "project"), testPath);
+
+        testPath = AZ::Utils::GetGemPath("outerGem1", m_registry.get());
+        EXPECT_EQ((tempRootFolder / "o3de/outerGem1"), testPath);
+
+        testPath = AZ::Utils::GetGemPath("outerGem2", m_registry.get());
+        EXPECT_EQ((tempRootFolder / "o3de/outerGem2"), testPath);
+
+        testPath = AZ::Utils::GetGemPath("innerGem1", m_registry.get());
+        EXPECT_EQ((tempRootFolder / "o3de/outerGem2/innerGem1"), testPath);
+
+        testPath = AZ::Utils::GetGemPath("engineGem1", m_registry.get());
+        EXPECT_EQ((tempRootFolder / "engine/engineGem1"), testPath);
+
+        testPath = AZ::Utils::GetGemPath("projectGem1", m_registry.get());
+        EXPECT_EQ((tempRootFolder / "project/projectGem1"), testPath);
+
+        testPath = AZ::Utils::GetGemPath("outsideGem1", m_registry.get());
+        EXPECT_EQ((tempRootFolder / "outsideGem1"), testPath);
+    }
+
     static auto MakeGemVisitTestingValues()
     {
         return AZStd::array{
@@ -577,7 +608,8 @@ tags=tools,renderer,metal)"
                 R"({
                     "project_name": "TestProject",
                     "external_subdirectories": [
-                        "projectGem1"
+                        "projectGem1",
+                        "../outsideGem1"
                     ]
                    })",
                 {
@@ -609,6 +641,11 @@ tags=tools,renderer,metal)"
                         "gem_name": "projectGem1",
                        })"
                     ),
+                    AZStd::make_tuple("outsideGem1",
+                    R"({
+                        "gem_name": "outsideGem1",
+                       })"
+                    ),
                 },
                 R"({
                     "O3DE": {
@@ -631,7 +668,8 @@ tags=tools,renderer,metal)"
                     "o3de/outerGem2",
                     "o3de/outerGem2/innerGem1",
                     "engine/engineGem1",
-                    "project/projectGem1"
+                    "project/projectGem1",
+                    "outsideGem1"
                 }
             } };
     }


### PR DESCRIPTION
The Utils function which retrieves paths from the SettingsRegistry have
been updated to accept an optional pointer to the SettingsRegistry to
use to lookup the paths.

Added a GetGemPath function which can query the SettingsRegistry for the
absolute path to the gem root by supplying the gem name.

Updated the ReadFile utility function to support reading into an
`AZStd::vector<AZStd::byte>`

Updated the WriteFile utility function to write from an
`AZStd::span<AZStd::byte>`

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Added UnitTest to validate the supplying a SettingsRegistry instance to the GetEnginePath, GetProjectPath, GetGemPath and GetO3deDirectory functions
