### PR TITLE
Updated the `FileIOBase::FindFiles` to not convert to alias

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/FileIO.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/FileIO.cpp
@@ -286,7 +286,7 @@ namespace AZ::IO
         return "";
     }
 
-    bool NameMatchesFilter(const char* name, const char* filter)
+    bool NameMatchesFilter(AZStd::string_view name, AZStd::string_view filter)
     {
         return AZStd::wildcard_match(filter, name);
     }

--- a/Code/Framework/AzCore/AzCore/IO/FileIO.h
+++ b/Code/Framework/AzCore/AzCore/IO/FileIO.h
@@ -31,7 +31,7 @@ namespace AZ
         /// return true if name of file matches glob filter.
         /// glob filters are MS-DOS (or windows) findNextFile style filters
         /// like "*.bat" or "blah??.pak" or "test*.exe" and such.
-        bool NameMatchesFilter(const char* name, const char* filter);
+        bool NameMatchesFilter(AZStd::string_view name, AZStd::string_view filter);
 
         using HandleType = AZ::u32;
         static const HandleType InvalidHandle = 0;


### PR DESCRIPTION
The `AZ::IO::FileIOBase::FindFiles` function would attempt to convert
the located file back into an alias path, which makes it cumbersome to
use when a real path is needed.

Updated the FileIO platform specific CreatePath and FindFiles functions
to use AZ::IO::FixedMaxPath

fixes #10436

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Validated that FileIOTest and Archive test passes
