### PR TITLE
Add settings to set editor camera near and far plane distances

### DIFF
--- a/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
@@ -23,6 +23,8 @@ void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& seria
         ->Version(1)
         ->Field("Sync2DViews", &General::m_sync2DViews)
         ->Field("DefaultFOV", &General::m_defaultFOV)
+        ->Field("DefaultNearPlane", &General::m_defaultNearPlane)
+        ->Field("DefaultFarPlane", &General::m_defaultFarPlane)
         ->Field("DefaultAspectRatio", &General::m_defaultAspectRatio)
         ->Field("EnableContextMenu", &General::m_contextMenuEnabled)
         ->Field("StickySelect", &General::m_stickySelectEnabled);
@@ -85,6 +87,8 @@ void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& seria
             ->Attribute("Multiplier", RAD2DEG(1))
             ->Attribute(AZ::Edit::Attributes::Min, 1.0f)
             ->Attribute(AZ::Edit::Attributes::Max, 120.0f)
+            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &General::m_defaultNearPlane, "Perspective Near Plane", "Perspective Near Plane")
+            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &General::m_defaultFarPlane, "Perspective Far Plane", "Perspective Far Plane")
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox, &General::m_defaultAspectRatio, "Perspective View Aspect Ratio",
                 "Perspective View Aspect Ratio")
@@ -219,6 +223,9 @@ void CEditorPreferencesPage_ViewportGeneral::OnApply()
     gSettings.viewports.bSync2DViews = m_general.m_sync2DViews;
     SandboxEditor::SetStickySelectEnabled(m_general.m_stickySelectEnabled);
 
+    SandboxEditor::SetCameraDefaultNearPlaneDistance(m_general.m_defaultNearPlane);
+    SandboxEditor::SetCameraDefaultFarPlaneDistance(m_general.m_defaultFarPlane);
+
     gSettings.viewports.bShowSafeFrame = m_display.m_showSafeFrame;
     gSettings.viewports.bHighlightSelectedGeometry = m_display.m_highlightSelGeom;
     gSettings.viewports.bHighlightSelectedVegetation = m_display.m_highlightSelVegetation;
@@ -276,6 +283,8 @@ void CEditorPreferencesPage_ViewportGeneral::InitializeSettings()
 
     m_general.m_defaultAspectRatio = gSettings.viewports.fDefaultAspectRatio;
     m_general.m_defaultFOV = gSettings.viewports.fDefaultFov;
+    m_general.m_defaultNearPlane = SandboxEditor::CameraDefaultNearPlaneDistance();
+    m_general.m_defaultFarPlane = SandboxEditor::CameraDefaultFarPlaneDistance();
     m_general.m_contextMenuEnabled = gSettings.viewports.bEnableContextMenu;
     m_general.m_sync2DViews = gSettings.viewports.bSync2DViews;
     m_general.m_stickySelectEnabled = SandboxEditor::StickySelectEnabled();

--- a/Code/Editor/EditorPreferencesPageViewportGeneral.h
+++ b/Code/Editor/EditorPreferencesPageViewportGeneral.h
@@ -41,6 +41,8 @@ private:
 
         bool m_sync2DViews;
         float m_defaultFOV;
+        float m_defaultFarPlane;
+        float m_defaultNearPlane;
         float m_defaultAspectRatio;
         bool m_contextMenuEnabled;
         bool m_stickySelectEnabled;

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -20,6 +20,7 @@ namespace SandboxEditor
 {
     using AngleSnappingChangedEvent = AZ::Event<bool>;
     using GridSnappingChangedEvent = AZ::Event<bool>;
+    using NearFarPlaneChangedEvent = AZ::Event<float>;
 
     //! Set callbacks to listen for editor settings change events.
     class EditorViewportSettingsCallbacks
@@ -27,8 +28,10 @@ namespace SandboxEditor
     public:
         virtual ~EditorViewportSettingsCallbacks() = default;
 
-        virtual void SetAngleSnappingChangedEvent(GridSnappingChangedEvent::Handler& handler) = 0;
+        virtual void SetAngleSnappingChangedEvent(AngleSnappingChangedEvent::Handler& handler) = 0;
         virtual void SetGridSnappingChangedEvent(GridSnappingChangedEvent::Handler& handler) = 0;
+        virtual void SetFarPlaneDistanceChangedEvent(NearFarPlaneChangedEvent::Handler& handler) = 0;
+        virtual void SetNearPlaneDistanceChangedEvent(NearFarPlaneChangedEvent::Handler& handler) = 0;
     };
 
     //! Create an instance of EditorViewportSettingsCallbacks
@@ -160,4 +163,10 @@ namespace SandboxEditor
 
     SANDBOX_API AzFramework::InputChannelId CameraFocusChannelId();
     SANDBOX_API void SetCameraFocusChannelId(AZStd::string_view cameraFocusId);
+
+    SANDBOX_API float CameraDefaultNearPlaneDistance();
+    SANDBOX_API void SetCameraDefaultNearPlaneDistance(float distance);
+
+    SANDBOX_API float CameraDefaultFarPlaneDistance();
+    SANDBOX_API void SetCameraDefaultFarPlaneDistance(float distance);
 } // namespace SandboxEditor

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -124,6 +124,9 @@ public:
     void SetFOV(float fov) override;
     float GetFOV() const override;
 
+    // Callback for cvar modification
+    void OnDefaultCameraNearFarChange();
+
     // AzFramework::ViewportBorderRequestBus overrides ...
     AZStd::optional<AzFramework::ViewportBorderPadding> GetViewportBorderPadding() const override;
 
@@ -245,6 +248,7 @@ private:
     ////////////////////////////////////////////////////////////////////////
     // Private helpers...
     void SetViewTM(const Matrix34& tm, bool bMoveOnly);
+    void SetDefaultCameraNearFar();
     void RenderSnapMarker();
     void RenderAll();
 

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -124,9 +124,6 @@ public:
     void SetFOV(float fov) override;
     float GetFOV() const override;
 
-    // Callback for cvar modification
-    void OnDefaultCameraNearFarChange();
-
     // AzFramework::ViewportBorderRequestBus overrides ...
     AZStd::optional<AzFramework::ViewportBorderPadding> GetViewportBorderPadding() const override;
 
@@ -212,6 +209,9 @@ private:
 
     // IEditorEventListener overrides ...
     void OnEditorNotifyEvent(EEditorNotifyEvent event) override;
+
+    // Callback for setting modification
+    void OnDefaultCameraNearFarChanged();
 
     // AzToolsFramework::EditorEntityContextNotificationBus overrides ...
     // note: handler moved to cpp to resolve link issues in unity builds
@@ -404,6 +404,7 @@ private:
     // Handlers for snapping/editor event callbacks
     SandboxEditor::AngleSnappingChangedEvent::Handler m_angleSnappingHandler;
     SandboxEditor::GridSnappingChangedEvent::Handler m_gridSnappingHandler;
+    SandboxEditor::NearFarPlaneChangedEvent::Handler m_nearFarPlaneDistanceHandler;
     AZStd::unique_ptr<SandboxEditor::EditorViewportSettingsCallbacks> m_editorViewportSettingsCallbacks;
 
     // Used for some legacy logic which lets the widget release a grabbed keyboard at the right times

--- a/Code/Framework/AzCore/AzCore/Math/MatrixUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixUtils.cpp
@@ -62,8 +62,8 @@ namespace AZ
 
     void SetPerspectiveMatrixNearFar(Matrix4x4& out, float nearDist, float farDist, bool reverseDepth)
     {
-        AZ_Assert(nearDist > FloatEpsilon, "Near distance should be greater than zero (float epsilon)");
-        AZ_Assert(farDist > nearDist, "Far should be greater than near");
+        AZ_Assert(nearDist > FloatEpsilon, "Near distance should be greater than zero (float epsilon) in a perspective matrix");
+        AZ_Assert(farDist > nearDist, "Far should be greater than near in a perspective matrix");
 
         if (reverseDepth)
         {

--- a/Code/Framework/AzCore/AzCore/Math/MatrixUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixUtils.cpp
@@ -62,8 +62,8 @@ namespace AZ
 
     void SetPerspectiveMatrixNearFar(Matrix4x4& out, float nearDist, float farDist, bool reverseDepth)
     {
-        AZ_Assert(nearDist > FloatEpsilon, "near distance should be greater than 0.f");
-        AZ_Assert(farDist > nearDist, "far should be greater than near");
+        AZ_Assert(nearDist > FloatEpsilon, "Near distance should be greater than zero (float epsilon)");
+        AZ_Assert(farDist > nearDist, "Far should be greater than near");
 
         if (reverseDepth)
         {

--- a/Code/Framework/AzCore/AzCore/Math/MatrixUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixUtils.cpp
@@ -60,6 +60,20 @@ namespace AZ
         return 2.0f * AZStd::atan(1.0f / m.GetElement(1, 1));
     }
 
+    void SetPerspectiveMatrixNearFar(Matrix4x4& out, float nearDist, float farDist, bool reverseDepth)
+    {
+        AZ_Assert(nearDist > FloatEpsilon, "near distance should be greater than 0.f");
+        AZ_Assert(farDist > nearDist, "far should be greater than near");
+
+        if (reverseDepth)
+        {
+            AZStd::swap(nearDist, farDist);
+        }
+
+        out.SetElement(2, 2, farDist / (nearDist - farDist));
+        out.SetElement(2, 3, nearDist * farDist / (nearDist - farDist));
+    }
+
     Matrix4x4* MakeFrustumMatrixRH(Matrix4x4& out, float left, float right, float bottom, float top, float nearDist, float farDist, bool reverseDepth)
     {
         AZ_Assert(right > left, "right should be greater than left");

--- a/Code/Framework/AzCore/AzCore/Math/MatrixUtils.h
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixUtils.h
@@ -68,10 +68,10 @@ namespace AZ
     void SetPerspectiveMatrixFOV(Matrix4x4& out, float fovY, float aspectRatio);
     float GetPerspectiveMatrixFOV(const Matrix4x4& m);
 
-    //! Adjust the near/far planes of an existing right-handed perspective projection matrix
-    //! @param out Matrix which stores output result
+    //! Adjust the near/far planes of an existing right-handed perspective projection matrix.
+    //! @param out Matrix which stores output result.
     //! @param near Distance to the near view-plane. Must be no less than zero.
     //! @param far Distance to the far view-plane. Must be greater than zero.
     //! @param reverseDepth Set to true to reverse depth which means near distance maps to 1 and far distance maps to 0.
-    void SetPerspectiveMatrixNearFar(Matrix4x4& out, float nearDist, float farDist, bool reverseDepth = false);
+    void SetPerspectiveMatrixNearFar(Matrix4x4& out, float nearDist, float farDist, bool reverseDepth = true);
 } // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Math/MatrixUtils.h
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixUtils.h
@@ -68,4 +68,10 @@ namespace AZ
     void SetPerspectiveMatrixFOV(Matrix4x4& out, float fovY, float aspectRatio);
     float GetPerspectiveMatrixFOV(const Matrix4x4& m);
 
+    //! Adjust the near/far planes of an existing right-handed perspective projection matrix
+    //! @param out Matrix which stores output result
+    //! @param near Distance to the near view-plane. Must be no less than zero.
+    //! @param far Distance to the far view-plane. Must be greater than zero.
+    //! @param reverseDepth Set to true to reverse depth which means near distance maps to 1 and far distance maps to 0.
+    void SetPerspectiveMatrixNearFar(Matrix4x4& out, float nearDist, float farDist, bool reverseDepth = false);
 } // namespace AZ


### PR DESCRIPTION
## What does this PR do?

This PR adds cvars to control the editor camera near and far planes.

We sometimes need to watch some details from a very near point of view, which is too close to the object and found no way to set the near and far planes.

## How was this PR tested?

We successfully used both cvar in our project.