### PR TITLE
Fix function node slot reset crash

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.cpp
@@ -1291,15 +1291,19 @@ namespace ScriptCanvas
         const_cast<bool&>(m_isOverloadedStorage) = isOverloadedStorage;
     }
 
-    void Datum::DeepCopyDatum(const Datum& source)
+    void Datum::CopyDatumTypeAndValue(const Datum& source)
     {
         if (this != &source)
         {
-            m_originality = eOriginality::Original;
-            InitializeOverloadedStorage(source.m_type, m_originality);
-            m_class = source.m_class;
-            m_type = source.m_type;
+            SetType(source.m_type);
+            CopyDatumStorage(source);
+        }
+    }
 
+    void Datum::CopyDatumStorage(const Datum& source)
+    {
+        if (this != &source)
+        {
             if (!Data::IsValueType(m_type))
             {
                 AZ::BehaviorContext* behaviorContext = nullptr;
@@ -1320,6 +1324,19 @@ namespace ScriptCanvas
                 m_storage.value = source.m_storage.value;
                 m_conversionStorage = source.m_conversionStorage;
             }
+        }
+    }
+
+    void Datum::DeepCopyDatum(const Datum& source)
+    {
+        if (this != &source)
+        {
+            m_originality = eOriginality::Original;
+            InitializeOverloadedStorage(source.m_type, m_originality);
+            m_class = source.m_class;
+            m_type = source.m_type;
+
+            CopyDatumStorage(source);
 
             m_notificationId = source.m_notificationId;
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.h
@@ -69,6 +69,7 @@ namespace ScriptCanvas
         void ReconfigureDatumTo(Datum&& object);
         void ReconfigureDatumTo(const Datum& object);
 
+        void CopyDatumTypeAndValue(const Datum& object);
         void DeepCopyDatum(const Datum& object);
 
         const AZStd::any& ToAny() const;
@@ -187,6 +188,7 @@ namespace ScriptCanvas
 
     private:
 
+        void CopyDatumStorage(const Datum& object);
         AZ::Crc32 GetDatumVisibility() const;
 
         template<typename t_Value, bool isReference>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurations.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurations.cpp
@@ -89,6 +89,11 @@ namespace ScriptCanvas
         SetConnectionType(connectionType);
     }
 
+    void DataSlotConfiguration::CopyTypeAndValueFrom(const Datum& source)
+    {
+        m_datum.CopyDatumTypeAndValue(source);
+    }
+
     void DataSlotConfiguration::DeepCopyFrom(const Datum& source)
     {
         m_datum.DeepCopyDatum(source);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurations.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurations.h
@@ -300,6 +300,8 @@ namespace ScriptCanvas
             m_datum.ReconfigureDatumTo(AZStd::move(datum));
         }
 
+        void CopyTypeAndValueFrom(const Datum& source);
+
         void DeepCopyFrom(const Datum& source);
 
         const Datum& GetDatum() const

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.cpp
@@ -195,7 +195,7 @@ namespace ScriptCanvas
                     config.m_displayGroup = displayGroup;
                     config.m_addUniqueSlotByNameAndType = false;
                     config.SetConnectionType(ScriptCanvas::ConnectionType::Input);
-                    config.DeepCopyFrom(input.datum);
+                    config.CopyTypeAndValueFrom(input.datum);
                     auto previousSlotId = previousMap.FindInputSlotIdBySource(input.sourceID, inSourceId);
                     if (previousSlotId.IsValid())
                     {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.cpp
@@ -195,6 +195,9 @@ namespace ScriptCanvas
                     config.m_displayGroup = displayGroup;
                     config.m_addUniqueSlotByNameAndType = false;
                     config.SetConnectionType(ScriptCanvas::ConnectionType::Input);
+                    // For current use case, we don't need to deep copy datum from subgraphinterface
+                    // Later if we need to make deep copy, we must verify the subgraphinterface is accurate.
+                    // For example, when subgraphinterface shows datum as dynamic, we should create slot by using DynamicDataSlotConfiguration
                     config.CopyTypeAndValueFrom(input.datum);
                     auto previousSlotId = previousMap.FindInputSlotIdBySource(input.sourceID, inSourceId);
                     if (previousSlotId.IsValid())

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Serialization/DatumSerializer.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Serialization/DatumSerializer.cpp
@@ -107,7 +107,8 @@ namespace AZ
             }
 
             result.Combine(ContinueLoadingFromJsonObjectField(AZStd::any_cast<void>(&storage), typeId, inputValue, "value", context));
-            *outputDatum = Datum(scType, Datum::eOriginality::Original, AZStd::any_cast<void>(&storage), scType.GetAZType());
+            outputDatum->ReconfigureDatumTo(
+                Datum(scType, Datum::eOriginality::Original, AZStd::any_cast<void>(&storage), scType.GetAZType()));
         } // datum storage end
 
         AZStd::string label;


### PR DESCRIPTION
## What does this PR do?
Fixes https://github.com/o3de/o3de/issues/8384

Problem is function node slot not constructed correctly. The metadata gets used to construct function node slot is from subgraphinterface. The metadata marks slot m_isOverloadedStorage = True which means slot is potentially a dynamic slot. When user reset slot, the slot datum type gets cleared.

The fix is to only copy type and value from subgraphinterface metadata for function node slot.

PS. Fix datum serializer error which could drop serialized data after reopening an existing graph. See following clip as an example.

https://user-images.githubusercontent.com/5900509/183148500-c0d262a4-6caa-4dc9-800a-578be56e95ec.mp4


## How was this PR tested?
Manually tested following GHI reproduce step, can't reproduce crash

Signed-off-by: onecent1101 <liug@amazon.com>