### PR TITLE
Remove AR artifact upload spam

### DIFF
--- a/Tools/LyTestTools/tests/unit/test_abstract_resource_locator.py
+++ b/Tools/LyTestTools/tests/unit/test_abstract_resource_locator.py
@@ -36,7 +36,6 @@ class TestFindEngineRoot(object):
 
         assert engine_root == mock_engine_root
         mock_path_exists.assert_called_once()
-        assert False
 
     @mock.patch('ly_test_tools._internal.managers.abstract_resource_locator.os.path.abspath')
     @mock.patch('ly_test_tools._internal.managers.abstract_resource_locator.os.path.exists')

--- a/Tools/LyTestTools/tests/unit/test_abstract_resource_locator.py
+++ b/Tools/LyTestTools/tests/unit/test_abstract_resource_locator.py
@@ -36,6 +36,7 @@ class TestFindEngineRoot(object):
 
         assert engine_root == mock_engine_root
         mock_path_exists.assert_called_once()
+        assert False
 
     @mock.patch('ly_test_tools._internal.managers.abstract_resource_locator.os.path.abspath')
     @mock.patch('ly_test_tools._internal.managers.abstract_resource_locator.os.path.exists')

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -470,7 +470,7 @@ def ArchiveArtifactsOnS3(String artifactsSource, String s3Prefix="", boolean rec
     palSh("echo ${env.BUILD_URL} > ${s3Prefix}/build_url.txt")
     // archiveArtifacts is very slow, so we only archive one file and upload the rest artifacts to the same bucket using S3 CLI.
     archiveArtifacts artifacts: "${s3Prefix}/build_url.txt"
-    def command = "aws s3 cp ${artifactsSource} s3://${env.JENKINS_ARTIFACTS_S3_BUCKET}/${env.JENKINS_JOB_NAME}/${env.BUILD_NUMBER}/artifacts/${s3Prefix} "
+    def command = "aws s3 cp ${artifactsSource} s3://${env.JENKINS_ARTIFACTS_S3_BUCKET}/${env.JENKINS_JOB_NAME}/${env.BUILD_NUMBER}/artifacts/${s3Prefix} --only-show-errors "
     excludes.each{ exclude ->
         command += "--exclude \"${exclude}\" "
     }

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -470,7 +470,7 @@ def ArchiveArtifactsOnS3(String artifactsSource, String s3Prefix="", boolean rec
     palSh("echo ${env.BUILD_URL} > ${s3Prefix}/build_url.txt")
     // archiveArtifacts is very slow, so we only archive one file and upload the rest artifacts to the same bucket using S3 CLI.
     archiveArtifacts artifacts: "${s3Prefix}/build_url.txt"
-    def command = "aws s3 cp ${artifactsSource} s3://${env.JENKINS_ARTIFACTS_S3_BUCKET}/${env.JENKINS_JOB_NAME}/${env.BUILD_NUMBER}/artifacts/${s3Prefix} --only-show-errors "
+    def command = "aws s3 cp ${artifactsSource} s3://${env.JENKINS_ARTIFACTS_S3_BUCKET}/${env.JENKINS_JOB_NAME}/${env.BUILD_NUMBER}/artifacts/${s3Prefix} "
     excludes.each{ exclude ->
         command += "--exclude \"${exclude}\" "
     }


### PR DESCRIPTION
Signed-off-by: evanchia-ly-sdets <evanchia@amazon.com>

## What does this PR do?
Reduces log spam when test artifacts are uploaded. Had the options between --no-progress and --only-show-errors for the aws cp command. Decided on the --only-show-errors to minimize log size and the Jenkins log still shows the aws command.


## How was this PR tested?
Tested by intentionally failing AR and uploading artifacts. Jenkins logs reduced from 15 MB to 4 MB during testing.