### PR TITLE
Material Canvas: fixed more shortcuts by adding shortcut context to asset browser actions

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -429,34 +429,38 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
             if (calledFromAssetBrowser)
             {
                 // Add Rename option
-                menu->addAction(
-                        QObject::tr("Rename asset"),
-                        [treeView]()
-                        {
-                            treeView->RenameEntry();
-                        })
-                    ->setShortcut(Qt::Key_F2);
+                QAction* action = menu->addAction(
+                    QObject::tr("Rename asset"),
+                    [treeView]()
+                    {
+                        treeView->RenameEntry();
+                    });
+                action->setShortcut(Qt::Key_F2);
+                action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
             }
         }
 
         if (calledFromAssetBrowser)
         {
             // Add Delete option
-            menu->addAction(
-                    QObject::tr("Delete asset%1").arg(numOfEntries > 1 ? "s" : ""),
-                    [treeView]()
-                    {
-                        treeView->DeleteEntries();
-                    })
-                ->setShortcut(QKeySequence::Delete);
+            QAction* action = menu->addAction(
+                QObject::tr("Delete asset%1").arg(numOfEntries > 1 ? "s" : ""),
+                [treeView]()
+                {
+                    treeView->DeleteEntries();
+                });
+            action->setShortcut(QKeySequence::Delete);
+            action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+
             // Add Duplicate option
-            menu->addAction(
-                    QObject::tr("Duplicate asset"),
-                    [treeView]()
-                    {
-                        treeView->DuplicateEntries();
-                    })
-                ->setShortcut(QKeySequence("Ctrl+D"));
+            action = menu->addAction(
+                QObject::tr("Duplicate asset"),
+                [treeView]()
+                {
+                    treeView->DuplicateEntries();
+                });
+            action->setShortcut(QKeySequence("Ctrl+D"));
+            action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
         }
     }
     break;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -67,6 +67,7 @@ namespace AzToolsFramework
 
             QAction* deleteAction = new QAction("Delete Action", this);
             deleteAction->setShortcut(QKeySequence::Delete);
+            deleteAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
             connect(
                 deleteAction, &QAction::triggered, this, [this]()
                 {
@@ -76,6 +77,7 @@ namespace AzToolsFramework
 
             QAction* renameAction = new QAction("Rename Action", this);
             renameAction->setShortcut(Qt::Key_F2);
+            renameAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
             connect(
                 renameAction, &QAction::triggered, this, [this]()
                 {
@@ -85,6 +87,7 @@ namespace AzToolsFramework
 
             QAction* duplicateAction = new QAction("Duplicate Action", this);
             duplicateAction->setShortcut(QKeySequence("Ctrl+D"));
+            duplicateAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
             connect(
                 duplicateAction, &QAction::triggered, this, [this]()
                 {


### PR DESCRIPTION
## What does this PR do?

Adds files missed from previous PR https://github.com/o3de/o3de/pull/11044 addressing https://github.com/o3de/o3de/issues/10909

Signed-off-by: Guthrie Adams <guthadam@amazon.com>

## How was this PR tested?

Retested key bindings with latest development branch