### PR TITLE
Added missing expansion of home directory in the global_project test

### DIFF
--- a/scripts/o3de/tests/test_global_project.py
+++ b/scripts/o3de/tests/test_global_project.py
@@ -25,8 +25,8 @@ PROJECT_PATH_KEY = ('Amazon', 'AzCore', 'Bootstrap', 'project_path')
 class TestSetGlobalProject:
     @pytest.mark.parametrize(
         "output_path, project_path, force, expected_result", [
-            pytest.param(pathlib.Path('~/.o3de/Registry/bootstrap.setreg'), pathlib.Path('A:/'), False, False),
-            pytest.param(pathlib.Path('~/.o3de/Registry/bootstrap.setreg'), pathlib.Path('A:/'), True, True)
+            pytest.param(pathlib.Path('~/.o3de/Registry/bootstrap.setreg').expanduser(), pathlib.Path('A:/'), False, False),
+            pytest.param(pathlib.Path('~/.o3de/Registry/bootstrap.setreg').expanduser(), pathlib.Path('A:/'), True, True)
         ]
     )
     def test_set_global_project_non_existent_project_path(self, output_path, project_path, force, expected_result):


### PR DESCRIPTION
This was causing a directory structure of "~/.o3de" to be added to
current directory.

![image](https://user-images.githubusercontent.com/56135373/182743418-079498b7-58f9-4629-8b2b-6f6cb99c9db5.png)


Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>


## How was this PR tested?

Validated, that the "~" directory was no longer created when running the o3de CLI test.