### PR TITLE
Added friendly types for Multiplayer auto-components

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Spawnable.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Spawnable.h
@@ -209,4 +209,7 @@ namespace AzFramework
 
         mutable AZStd::atomic<int32_t> m_shareState{ ShareState::NotShared };
     };
+
+    using SpawnableAsset = AZ::Data::Asset<AzFramework::Spawnable>;
+    using SpawnableAssetVector = AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>>;
 } // namespace AzFramework


### PR DESCRIPTION
Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>

## What does this PR do?

Add helpful types for Multiplayer auto-components.
Without this change, network components often have to escape in the following way:
```
    <ArchetypeProperty Type="AZ::Data::Asset&lt;AzFramework::Spawnable&gt;" Name="CoinSpawnable"
                       ExposeToEditor="true" Description="Prefab to use for coins" />
```
With this change, one can do it as:
```
    <ArchetypeProperty Type="AzFramework::SpawnableAsset" Name="CoinSpawnable"
                       ExposeToEditor="true" Description="Prefab to use for coins" />
```

## How was this PR tested?

Compiled o3de-multiplayersample.
