### PR TITLE
chore: update Framework and remove usage of VectorConversions

### DIFF
--- a/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
@@ -10,7 +10,6 @@
 #include <AzCore/Math/Matrix3x4.h>
 #include <AzCore/Math/Matrix3x3.h>
 #include <AzCore/Math/Quaternion.h>
-#include <AzCore/Math/VectorConversions.h>
 #include <AZTestShared/Math/MathTestHelpers.h>
 #include <AzCore/Math/Vector4.h>
 #include "MathTestData.h"

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.cpp
@@ -12,7 +12,6 @@
 #include <AzCore/Math/Matrix4x4.h>
 #include <AzCore/Math/MatrixUtils.h>
 #include <AzCore/Math/Vector4.h>
-#include <AzCore/Math/VectorConversions.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzFramework/Viewport/CameraState.h>
 #include <AzFramework/Viewport/ScreenGeometry.h>
@@ -97,11 +96,11 @@ namespace AzFramework
     AZ::Vector3 WorldToScreenNdc(const AZ::Vector3& worldPosition, const AZ::Matrix3x4& cameraView, const AZ::Matrix4x4& cameraProjection)
     {
         // transform the world space position to clip space
-        const auto clipSpacePosition = cameraProjection * AZ::Vector3ToVector4(cameraView.TransformPoint(worldPosition), 1.0f);
+        const auto clipSpacePosition = cameraProjection * AZ::Vector4(cameraView.TransformPoint(worldPosition), 1.0f);
         // transform the clip space position to ndc space (perspective divide)
         const auto ndcPosition = clipSpacePosition / clipSpacePosition.GetW();
         // transform ndc space from <-1,1> to <0, 1> range
-        return (AZ::Vector4ToVector3(ndcPosition) + AZ::Vector3::CreateOne()) * 0.5f;
+        return (AZ::Vector3(ndcPosition) + AZ::Vector3::CreateOne()) * 0.5f;
     }
 
     ScreenPoint WorldToScreen(
@@ -111,7 +110,7 @@ namespace AzFramework
         const ScreenSize& viewportSize)
     {
         // scale ndc position by screen dimensions to return screen position
-        return ScreenPointFromNdc(AZ::Vector3ToVector2(WorldToScreenNdc(worldPosition, cameraView, cameraProjection)), viewportSize);
+        return ScreenPointFromNdc(AZ::Vector2(WorldToScreenNdc(worldPosition, cameraView, cameraProjection)), viewportSize);
     }
 
     ScreenPoint WorldToScreen(const AZ::Vector3& worldPosition, const CameraState& cameraState)
@@ -126,9 +125,9 @@ namespace AzFramework
         const auto ndcPosition = normalizedScreenPosition * 2.0f - AZ::Vector2::CreateOne();
 
         // transform ndc space position to clip space
-        const auto clipSpacePosition = inverseCameraProjection * Vector2ToVector4(ndcPosition, -1.0f, 1.0f);
+        const auto clipSpacePosition = inverseCameraProjection * AZ::Vector4(ndcPosition, -1.0f, 1.0f);
         // transform clip space to camera space
-        const auto cameraSpacePosition = AZ::Vector4ToVector3(clipSpacePosition) / clipSpacePosition.GetW();
+        const auto cameraSpacePosition = AZ::Vector3(clipSpacePosition) / clipSpacePosition.GetW();
         // transform camera space to world space
         const auto worldPosition = inverseCameraView * cameraSpacePosition;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorView.cpp
@@ -11,7 +11,6 @@
 #include <AzCore/Component/NonUniformScaleBus.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Console/IConsole.h>
-#include <AzCore/Math/VectorConversions.h>
 #include <AzCore/std/containers/array.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzToolsFramework/Manipulators/AngularManipulator.h>
@@ -388,7 +387,7 @@ namespace AzToolsFramework
 
         if (manipulatorState.m_mouseOver)
         {
-            debugDisplay.SetColor(Vector3ToVector4(m_mouseOverColor.GetAsVector3(), 0.5f));
+            debugDisplay.SetColor(AZ::Vector4(m_mouseOverColor.GetAsVector3(), 0.5f));
 
             debugDisplay.CullOff();
             debugDisplay.DrawQuad(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/TranslationManipulators.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/TranslationManipulators.cpp
@@ -8,7 +8,6 @@
 
 #include "TranslationManipulators.h"
 
-#include <AzCore/Math/VectorConversions.h>
 #include <AzToolsFramework/Manipulators/ManipulatorView.h>
 #include <AzToolsFramework/Viewport/ViewportSettings.h>
 
@@ -330,7 +329,7 @@ namespace AzToolsFramework
                    const AZ::Color& defaultColor) -> AZ::Color
                 {
                     const AZ::Color color[2] = {
-                        defaultColor, Vector3ToVector4(BaseManipulator::s_defaultMouseOverColor.GetAsVector3(), SurfaceManipulatorOpacity())
+                        defaultColor, AZ::Vector4(BaseManipulator::s_defaultMouseOverColor.GetAsVector3(), SurfaceManipulatorOpacity())
                     };
 
                     return color[mouseOver];

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorHelpers.cpp
@@ -9,7 +9,6 @@
 #include "EditorHelpers.h"
 
 #include <AzCore/Console/Console.h>
-#include <AzCore/Math/VectorConversions.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzFramework/Viewport/CameraState.h>
 #include <AzFramework/Viewport/ViewportScreen.h>
@@ -212,7 +211,7 @@ namespace AzToolsFramework
                     // selecting based on 2d icon - should only do it when visible and not selected
                     const AZ::Vector3 ndcPoint = AzFramework::WorldToScreenNdc(entityPosition, cameraView, cameraProjection);
                     const AzFramework::ScreenPoint screenPosition =
-                        AzFramework::ScreenPointFromNdc(AZ::Vector3ToVector2(ndcPoint), cameraState.m_viewportSize);
+                        AzFramework::ScreenPointFromNdc(AZ::Vector2(ndcPoint), cameraState.m_viewportSize);
 
                     const float distanceFromCamera = cameraState.m_position.GetDistance(entityPosition);
                     const auto iconRange = GetIconSize(distanceFromCamera) * 0.5f;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -12,7 +12,6 @@
 #include <AzCore/Math/Matrix3x3.h>
 #include <AzCore/Math/Matrix3x4.h>
 #include <AzCore/Math/Matrix4x4.h>
-#include <AzCore/Math/VectorConversions.h>
 #include <AzCore/std/algorithm.h>
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/Viewport/CameraState.h>

--- a/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportScreenTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportScreenTests.cpp
@@ -10,7 +10,6 @@
 #include <AzCore/Math/Matrix3x4.h>
 #include <AzCore/Math/Matrix4x4.h>
 #include <AzCore/Math/Transform.h>
-#include <AzCore/Math/VectorConversions.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzFramework/Viewport/CameraState.h>
 #include <AzFramework/Viewport/ViewportScreen.h>
@@ -27,7 +26,7 @@ namespace UnitTest
         const auto worldResult =
             AzFramework::ScreenNdcToWorld(ndcPoint, InverseCameraView(cameraState), InverseCameraProjection(cameraState));
         const auto ndcResult = AzFramework::WorldToScreenNdc(worldResult, CameraView(cameraState), CameraProjection(cameraState));
-        return AZ::Vector3ToVector2(ndcResult);
+        return AZ::Vector2(ndcResult);
     }
 
     // transform a point from screen space to world space, and then from world space back to screen space


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/pull/10597

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

remove the usage of VectorConversion.h from the rest of Framework.
