### PR TITLE
fix quaternion to Euler angle conversion when pitch is close to +-pi

### DIFF
--- a/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
@@ -317,7 +317,11 @@ namespace UnitTest
         AZ::Quaternion(0.70f, -0.34f, -0.38f, 0.50f),
         AZ::Quaternion(0.00f, 0.00f, -0.28f, 0.96f),
         AZ::Quaternion(0.24f, -0.64f, 0.72f, 0.12f),
-        AZ::Quaternion(-0.66f, 0.62f, 0.42f, 0.06f)
+        AZ::Quaternion(-0.66f, 0.62f, 0.42f, 0.06f),
+        AZ::Quaternion(0.5f, 0.5f, 0.5f, 0.5f),
+        AZ::Quaternion(0.5f, -0.5f, 0.5f, -0.5f),
+        AZ::Quaternion(0.34f, 0.62f, -0.34f, -0.62f),
+        AZ::Quaternion(-0.1f, -0.7f, 0.1f, 0.7f)
     };
 
     TEST_P(QuaternionEulerFixture, EulerOrderCorrect)


### PR DESCRIPTION
Signed-off-by: greerdv <greerdv@amazon.com>

## What does this PR do?
Fixes #11000 
The issue occurred because the terms which are used in the atan2 calls both go to zero when the pitch is exactly +-pi, which destroys any information they contain about the roll and yaw.
Also fixes another issue where accuracy would be severely affected when the pitch is close to +- pi, because asin has extremely high sensitivity near +-1.

## How was this PR tested?
Added further test cases in the quaternion unit tests which target pitch angles of +-pi. Verified that all branches in the revised function were being called during the tests. Ran a quaternion -> Euler -> quaternion cycle on 1000000 random quaternions.
