### PR TITLE
fix PhysX specific rigid body configuration not getting reflected in …

### DIFF
--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
@@ -326,7 +326,6 @@ namespace PhysX
     void EditorRigidBodyComponent::Reflect(AZ::ReflectContext* context)
     {
         EditorRigidBodyConfiguration::Reflect(context);
-        RigidBodyConfiguration::Reflect(context);
 
         auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
         if (serializeContext)

--- a/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
@@ -25,6 +25,7 @@ namespace PhysX
 {
     void RigidBodyComponent::Reflect(AZ::ReflectContext* context)
     {
+        RigidBodyConfiguration::Reflect(context);
         RigidBody::Reflect(context);
 
         AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);


### PR DESCRIPTION
…launcher

Signed-off-by: greerdv <greerdv@amazon.com>

## What does this PR do?
Fixes a bug introduced in #10992 where the newly introduced PhysX specific rigid body configuration was being reflected in an editor component, and so did not get reflected in the launcher.

## How was this PR tested?
Verified by @moraaar that the launcher works correctly.