### PR TITLE
Added Landscape Canvas support or Axis Aligned Box Shape

### DIFF
--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -98,6 +98,7 @@
 #include <Editor/Nodes/GradientModifiers/PosterizeGradientModifierNode.h>
 #include <Editor/Nodes/GradientModifiers/SmoothStepGradientModifierNode.h>
 #include <Editor/Nodes/GradientModifiers/ThresholdGradientModifierNode.h>
+#include <Editor/Nodes/Shapes/AxisAlignedBoxShapeNode.h>
 #include <Editor/Nodes/Shapes/BoxShapeNode.h>
 #include <Editor/Nodes/Shapes/CapsuleShapeNode.h>
 #include <Editor/Nodes/Shapes/CompoundShapeNode.h>
@@ -373,6 +374,7 @@ namespace LandscapeCanvasEditor
         // Shapes
         GraphCanvas::IconDecoratedNodePaletteTreeItem* shapeCategory = rootItem->CreateChildNode<GraphCanvas::IconDecoratedNodePaletteTreeItem>("Shapes", editorId);
         shapeCategory->SetTitlePalette("ShapeNodeTitlePalette");
+        REGISTER_NODE_PALETTE_ITEM(shapeCategory, AxisAlignedBoxShapeNode, editorId);
         REGISTER_NODE_PALETTE_ITEM(shapeCategory, BoxShapeNode, editorId);
         REGISTER_NODE_PALETTE_ITEM(shapeCategory, CapsuleShapeNode, editorId);
         REGISTER_NODE_PALETTE_ITEM(shapeCategory, CompoundShapeNode, editorId);

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/AxisAlignedBoxShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/AxisAlignedBoxShapeNode.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// Qt
+#include <QObject>
+
+// AZ
+#include <AzCore/Serialization/SerializeContext.h>
+
+// Landscape Canvas
+#include "AxisAlignedBoxShapeNode.h"
+
+namespace LandscapeCanvas
+{
+    void AxisAlignedBoxShapeNode::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<AxisAlignedBoxShapeNode, BaseShapeNode>()
+                ->Version(0)
+                ;
+        }
+    }
+
+    const QString AxisAlignedBoxShapeNode::TITLE = QObject::tr("Axis Aligned Box Shape");
+
+    AxisAlignedBoxShapeNode::AxisAlignedBoxShapeNode(GraphModel::GraphPtr graph)
+        : BaseShapeNode(graph)
+    {
+    }
+} // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/AxisAlignedBoxShapeNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/AxisAlignedBoxShapeNode.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+// Landscape Canvas
+#include <Editor/Nodes/Shapes/BaseShapeNode.h>
+
+namespace LandscapeCanvas
+{
+    class AxisAlignedBoxShapeNode : public BaseShapeNode
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(AxisAlignedBoxShapeNode, AZ::SystemAllocator, 0);
+        AZ_RTTI(AxisAlignedBoxShapeNode, "{C33B49D1-F3AF-432D-9DD5-239C053A5A55}", BaseShapeNode);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        AxisAlignedBoxShapeNode() = default;
+        explicit AxisAlignedBoxShapeNode(GraphModel::GraphPtr graph);
+
+        static const QString TITLE;
+        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+
+    };
+}

--- a/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.cpp
@@ -70,6 +70,7 @@
 #include <Editor/Nodes/GradientModifiers/PosterizeGradientModifierNode.h>
 #include <Editor/Nodes/GradientModifiers/SmoothStepGradientModifierNode.h>
 #include <Editor/Nodes/GradientModifiers/ThresholdGradientModifierNode.h>
+#include <Editor/Nodes/Shapes/AxisAlignedBoxShapeNode.h>
 #include <Editor/Nodes/Shapes/BoxShapeNode.h>
 #include <Editor/Nodes/Shapes/CapsuleShapeNode.h>
 #include <Editor/Nodes/Shapes/CompoundShapeNode.h>
@@ -105,6 +106,7 @@ namespace LandscapeCanvas
     /* Area selector nodes */    \
     VISITOR_FUNCTION<AssetWeightSelectorNode>(Vegetation::EditorDescriptorWeightSelectorComponentTypeId, ##__VA_ARGS__);     \
     /* Shape nodes */    \
+    VISITOR_FUNCTION<AxisAlignedBoxShapeNode>(LmbrCentral::EditorAxisAlignedBoxShapeComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<BoxShapeNode>(LmbrCentral::EditorBoxShapeComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<CapsuleShapeNode>(LmbrCentral::EditorCapsuleShapeComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<CompoundShapeNode>(LmbrCentral::EditorCompoundShapeComponentTypeId, ##__VA_ARGS__);     \

--- a/Gems/LandscapeCanvas/Code/landscapecanvas_editor_static_files.cmake
+++ b/Gems/LandscapeCanvas/Code/landscapecanvas_editor_static_files.cmake
@@ -100,6 +100,8 @@ set(FILES
     Source/Editor/Nodes/GradientModifiers/SmoothStepGradientModifierNode.h
     Source/Editor/Nodes/GradientModifiers/ThresholdGradientModifierNode.cpp
     Source/Editor/Nodes/GradientModifiers/ThresholdGradientModifierNode.h
+    Source/Editor/Nodes/Shapes/AxisAlignedBoxShapeNode.cpp
+    Source/Editor/Nodes/Shapes/AxisAlignedBoxShapeNode.h
     Source/Editor/Nodes/Shapes/BaseShapeNode.cpp
     Source/Editor/Nodes/Shapes/BaseShapeNode.h
     Source/Editor/Nodes/Shapes/BoxShapeNode.cpp


### PR DESCRIPTION
## What does this PR do?

Added support to Landscape Canvas for the `Axis Aligned Box Shape`.

![AxisAlignedBoxShape](https://user-images.githubusercontent.com/7519264/182942538-4c8631e2-955e-47a1-9465-8d7d5e6a5ad5.png)

## How was this PR tested?

Tested and verified the `Axis Aligned Box Shape` can be parsed from an existing entity, and can also be created in the graph.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>