### PR TITLE
Avoid reporting an error when the file open dialog is canceled

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -4510,14 +4510,17 @@ namespace ScriptCanvasEditor
         }
         else
         {
-            QMessageBox mb
-                ( QMessageBox::Warning
-                , tr("Failed to open ScriptEvent file into ScriptCanvas Editor.")
-                , result.second.c_str()
-                , QMessageBox::Close
-                , nullptr);
+            if (!result.second.empty())
+            {
+                QMessageBox mb
+                    ( QMessageBox::Warning
+                    , tr("Failed to open ScriptEvent file into ScriptCanvas Editor.")
+                    , result.second.c_str()
+                    , QMessageBox::Close
+                    , nullptr);
 
-            mb.exec();
+                mb.exec();
+            }
         }
     }
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/ScriptEventMenu.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/ScriptEventMenu.cpp
@@ -83,12 +83,8 @@ namespace ScriptEvents
                     errorMessage = "Failed to load selected file.";
                 }
             }
-            else
-            {
-                errorMessage = "Failed to select file.";
-            }
 
-            // failure
+            // failure or canceled
             return { SourceHandle(), errorMessage };
         }
 


### PR DESCRIPTION
Signed-off-by: Luis Sempé <58790905+lsemp3d@users.noreply.github.com>

## What does this PR do?

When using the Save As ScriptEvent menu option, if users canceled, they would be presented with an error dialog. Canceling is not an error, so this change does not show an error dialog if no error message is returned.

## How was this PR tested?

In ScriptCanvas editor using the Save As ScriptEvent option and canceling the Save As operation
