### PR TITLE
Avoid layout clean up warning

### DIFF
--- a/Gems/GraphCanvas/Code/Source/Widgets/NodePropertyDisplayWidget.cpp
+++ b/Gems/GraphCanvas/Code/Source/Widgets/NodePropertyDisplayWidget.cpp
@@ -180,6 +180,7 @@ namespace GraphCanvas
 
         if (m_nodePropertyDisplay == nullptr)
         {
+            ClearLayout();
             return;
         }
 


### PR DESCRIPTION
## What does this PR do?
See warning when hovering mouse over node with combobox, it complains some ebus is still connected with other id before trying to connect to it.

Previously, moving layout cleanup call into the QTimer (for removing layout item from scene) somehow breaks the logic in this use case. As UpdateLayout does get triggered multiple times. When m_nodePropertyDisplay is null QTimer won't be trigger, we still need to ClearLayout to clear stale layout item.

The fix is straightforward, when QTimer should be triggered, we do ClearLayout inside QTimer. When QTimer won't be triggered, we keep old behavior. 

## How was this PR tested?
Tested manually, no more warnings.

Signed-off-by: onecent1101 <liug@amazon.com>