### PR TITLE
DPE: Enable ReflectionAdapter to signal that a property has changed

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.cpp
@@ -21,13 +21,13 @@ namespace AZ::DocumentPropertyEditor
         CurrentNode()[attribute] = AZStd::move(value);
     }
 
-    void AdapterBuilder::OnEditorChanged(AZStd::function<void(const Dom::Path&, const Dom::Value&, Nodes::PropertyEditor::ValueChangeType)> onChangedCallback)
+    void AdapterBuilder::OnEditorChanged(AZStd::function<void(const Dom::Path&, const Dom::Value&, Nodes::ValueChangeType)> onChangedCallback)
     {
         // The value path is the first child of the PropertyEditor node
         Dom::Path changedPath = GetCurrentPath() / Nodes::Label::Value.GetName();
         CallbackAttribute(
             Nodes::PropertyEditor::OnChanged,
-            [changedPath, onChangedCallback](const Dom::Value& value, Nodes::PropertyEditor::ValueChangeType changeType)
+            [changedPath, onChangedCallback](const Dom::Value& value, Nodes::ValueChangeType changeType)
             {
                 onChangedCallback(changedPath, value, changeType);
             });

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.h
@@ -63,7 +63,7 @@ namespace AZ::DocumentPropertyEditor
         //! the path of the property value and its new value. This path can be used to generate a
         //! correct Replace patch for submitting NotifyContentsChanged.
         void OnEditorChanged(
-            AZStd::function<void(const Dom::Path&, const Dom::Value&, Nodes::PropertyEditor::ValueChangeType)> onChangedCallback);
+            AZStd::function<void(const Dom::Path&, const Dom::Value&, Nodes::ValueChangeType)> onChangedCallback);
         //! Adds a message handler bound to the given adapter for a given message name or callback attribute.
         //! \param adapter The adapter to bind this message to.
         //! \param messageName The name of the message.

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/CvarAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/CvarAdapter.cpp
@@ -30,7 +30,7 @@ namespace AZ::DocumentPropertyEditor
                 functor->GetValue(buffer);
                 builder.BeginPropertyEditor<Nodes::SpinBox<T>>(Dom::Value(buffer));
                 builder.OnEditorChanged(
-                    [this, functor](const Dom::Path& path, const Dom::Value& value, Nodes::PropertyEditor::ValueChangeType)
+                    [this, functor](const Dom::Path& path, const Dom::Value& value, Nodes::ValueChangeType)
                     {
                         T buffer;
                         if constexpr (AZStd::is_integral_v<T> && AZStd::is_signed_v<T>)
@@ -77,7 +77,7 @@ namespace AZ::DocumentPropertyEditor
                 builder.BeginPropertyEditor<Nodes::LineEdit>(Dom::Value(buffer, true));
                 builder.Attribute(Nodes::PropertyEditor::ValueType, AZ::Dom::Utils::TypeIdToDomValue(azrtti_typeid<AZStd::string>()));
                 builder.OnEditorChanged(
-                    [this, functor](const Dom::Path& path, const Dom::Value& value, Nodes::PropertyEditor::ValueChangeType)
+                    [this, functor](const Dom::Path& path, const Dom::Value& value, Nodes::ValueChangeType)
                     {
                         (*functor)({ value.GetString() });
                         m_adapter->OnContentsChanged(path, value);
@@ -98,7 +98,7 @@ namespace AZ::DocumentPropertyEditor
                 Dom::Value contents = Dom::Utils::ValueFromType(container);
                 builder.BeginPropertyEditor<NodeType>(AZStd::move(contents));
                 builder.OnEditorChanged(
-                    [this, functor](const Dom::Path& path, const Dom::Value& value, Nodes::PropertyEditor::ValueChangeType)
+                    [this, functor](const Dom::Path& path, const Dom::Value& value, Nodes::ValueChangeType)
                     {
                         VectorType newContainer = Dom::Utils::ValueToType<VectorType>(value).value_or(VectorType());
                         // ConsoleCommandContainer holds string_views, so ensure we allocate our parameters here
@@ -124,7 +124,7 @@ namespace AZ::DocumentPropertyEditor
                 functor->GetValue(value);
                 builder.BeginPropertyEditor<Nodes::CheckBox>(Dom::Value(value));
                 builder.OnEditorChanged(
-                    [this, functor](const Dom::Path& path, const Dom::Value& value, Nodes::PropertyEditor::ValueChangeType)
+                    [this, functor](const Dom::Path& path, const Dom::Value& value, Nodes::ValueChangeType)
                     {
                         (*functor)({ ConsoleTypeHelpers::ToString(value.GetBool()) });
                         m_adapter->OnContentsChanged(path, value);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
@@ -19,7 +19,7 @@ AZ_CVAR(
     false,
     nullptr,
     AZ::ConsoleFunctorFlags::DontReplicate,
-    "If set, enables debugging change change notifications on DocumentPropertyEditor adapters by validating their contents match their "
+    "If set, enables debugging change notifications on DocumentPropertyEditor adapters by validating their contents match their "
     "emitted patches");
 
 namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -77,21 +77,22 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto Value = AttributeDefinition<AZStd::string_view>("Value");
     };
 
+    //! Specifies types describing a value change's state.
+    //! Used to determine whether a value update is suitable for expensive operations like updating the undo stack or to
+    //! otherwise notify interested parties that a property's value has been changed, or is being changed, by a property editor.
+    enum class ValueChangeType
+    {
+        //! This is a "live", in-progress edit, and additional updates may follow at an arbitrarily fast rate.
+        InProgressEdit,
+        //! This is a "final" edit provided by the user doing something to signal a decision
+        //! e.g. releasing the mouse or pressing enter.
+        FinishedEdit,
+    };
+
     //! PropertyEditor: A property editor, of a type dictated by its "type" field,
     //! that can edit an associated value.
     struct PropertyEditor : NodeWithVisiblityControl
     {
-        //! Specifies the type of value change specifeid in OnChanged.
-        //! Used to determine whether a value update is suitable for expensive operations like updating the undo stack.
-        enum class ValueChangeType
-        {
-            //! This is a "live", in-progress edit, and additional updates may follow at an arbitrarily fast rate.
-            InProgressEdit,
-            //! This is a "final" edit provided by the user doing something to signal a decision
-            //! e.g. releasing the mouse or pressing enter.
-            FinishedEdit,
-        };
-
         static constexpr AZStd::string_view Name = "PropertyEditor";
         static constexpr auto Description = AttributeDefinition<AZStd::string_view>("Description");
         static constexpr auto Type = AttributeDefinition<AZStd::string_view>("Type");

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/CvarAdapterTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/CvarAdapterTests.cpp
@@ -77,7 +77,7 @@ namespace AZ::DocumentPropertyEditor::Tests
         {
             Dom::Value row = GetEntryRow(cvarName);
             ASSERT_FALSE(row.IsNull());
-            auto result = Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(row[1], value, Nodes::PropertyEditor::ValueChangeType::FinishedEdit);
+            auto result = Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(row[1], value, Nodes::ValueChangeType::FinishedEdit);
             EXPECT_TRUE(result.IsSuccess());
             AZ_Error("CvarAdapterDpeTests", result.IsSuccess(), "%s", result.GetError().c_str());
         }

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/ExampleAdapter.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/ExampleAdapter.cpp
@@ -32,7 +32,7 @@ namespace AZ::DocumentPropertyEditor
         builder.Label("Row Count");
         builder.BeginPropertyEditor<IntSpinBox>(m_rowCount);
         builder.OnEditorChanged(
-            [=](const Dom::Path&, const Dom::Value& value, Nodes::PropertyEditor::ValueChangeType)
+            [=](const Dom::Path&, const Dom::Value& value, Nodes::ValueChangeType)
             {
                 m_rowCount = aznumeric_caster(value.GetInt64());
                 ResizeMatrix();
@@ -41,7 +41,7 @@ namespace AZ::DocumentPropertyEditor
         builder.Label("Column Count");
         builder.BeginPropertyEditor<IntSpinBox>(m_columnCount);
         builder.OnEditorChanged(
-            [=](const Dom::Path&, const Dom::Value& value, Nodes::PropertyEditor::ValueChangeType)
+            [=](const Dom::Path&, const Dom::Value& value, Nodes::ValueChangeType)
             {
                 m_columnCount = aznumeric_caster(value.GetInt64());
                 ResizeMatrix();
@@ -67,7 +67,7 @@ namespace AZ::DocumentPropertyEditor
             {
                 builder.BeginPropertyEditor<IntSpinBox>(GetMatrixValue(i, c));
                 builder.OnEditorChanged(
-                    [=](const Dom::Path& path, const Dom::Value& value, Nodes::PropertyEditor::ValueChangeType)
+                    [=](const Dom::Path& path, const Dom::Value& value, Nodes::ValueChangeType)
                     {
                         SetMatrixValue(i, c, aznumeric_caster(value.GetInt64()));
                         NotifyContentsChanged({ Dom::PatchOperation::ReplaceOperation(path, value) });
@@ -97,7 +97,7 @@ namespace AZ::DocumentPropertyEditor
             builder.Label(entry.m_label);
             builder.BeginPropertyEditor(Nodes::Color::Name, AZ::Dom::Utils::ValueFromType(entry.m_node->m_color));
             builder.OnEditorChanged(
-                [=](const Dom::Path& path, const Dom::Value& value, Nodes::PropertyEditor::ValueChangeType)
+                [=](const Dom::Path& path, const Dom::Value& value, Nodes::ValueChangeType)
                 {
                     entry.m_node->m_color = AZ::Dom::Utils::ValueToType<AZ::Color>(value).value();
                     NotifyContentsChanged({ Dom::PatchOperation::ReplaceOperation(path, value) });

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
@@ -212,6 +212,12 @@ namespace AzToolsFramework
                 m_adapter = AZStd::make_shared<AZ::DocumentPropertyEditor::ReflectionAdapter>();
                 m_dpe = new DocumentPropertyEditor(this);
                 propertyEditor = m_dpe;
+                m_propertyChangeHandler = AZ::DocumentPropertyEditor::ReflectionAdapter::PropertyChangeEvent::Handler(
+                    [this](const AZ::DocumentPropertyEditor::ReflectionAdapter::PropertyChangeInfo& changeInfo)
+                    {
+                        this->OnDocumentPropertyChanged(changeInfo);
+                    });
+                m_adapter->ConnectPropertyChangeHandler(m_propertyChangeHandler);
             }
 
             propertyEditor->setObjectName("AssetEditorWidgetPropertyEditor");
@@ -957,6 +963,14 @@ namespace AzToolsFramework
         void AssetEditorWidget::AfterPropertyModified(InstanceDataNode* /*node*/)
         {
             DirtyAsset();
+        }
+
+        void AssetEditorWidget::OnDocumentPropertyChanged(const AZ::DocumentPropertyEditor::ReflectionAdapter::PropertyChangeInfo& changeInfo)
+        {
+            if (changeInfo.changeType == AZ::DocumentPropertyEditor::Nodes::ValueChangeType::FinishedEdit)
+            {
+                DirtyAsset();
+            }
         }
 
         void AssetEditorWidget::RequestPropertyContextMenu(InstanceDataNode* node, const QPoint& point)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
@@ -103,6 +103,9 @@ namespace AzToolsFramework
 
             void OnNewAsset();
 
+            // For subscribing to document property editor adapter property specific changes
+            void OnDocumentPropertyChanged(const AZ::DocumentPropertyEditor::ReflectionAdapter::PropertyChangeInfo& changeInfo);
+
         Q_SIGNALS:
             void OnAssetSavedSignal();
             void OnAssetSaveFailedSignal(const AZStd::string& error);
@@ -174,6 +177,8 @@ namespace AzToolsFramework
 
             AZStd::intrusive_ptr<AssetEditorWidgetUserSettings> m_userSettings;
             AZStd::unique_ptr< Ui::AssetEditorStatusBar > m_statusBar;
+
+            AZ::DocumentPropertyEditor::ReflectionAdapter::PropertyChangeEvent::Handler m_propertyChangeHandler;
 
             void PopulateGenericAssetTypes();
             void CreateAssetImpl(AZ::Data::AssetType assetType);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DPEDebugViewer/DPEDebugModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DPEDebugViewer/DPEDebugModel.cpp
@@ -77,7 +77,10 @@ namespace AzToolsFramework
             auto writeOutcome = AZ::Dom::Utils::SerializedStringToValue(jsonBackend, stringBuffer, AZ::Dom::Lifetime::Temporary);
 
             // invoke the actual change on the Dom, it will come back to us as an update
-            AZ::DocumentPropertyEditor::Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(GetValueFromDom(), writeOutcome.GetValue(), AZ::DocumentPropertyEditor::Nodes::PropertyEditor::ValueChangeType::FinishedEdit);
+            AZ::DocumentPropertyEditor::Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(
+                GetValueFromDom(),
+                writeOutcome.GetValue(),
+                AZ::DocumentPropertyEditor::Nodes::ValueChangeType::FinishedEdit);
         }
         return succeeded;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -85,7 +85,7 @@ namespace AzToolsFramework
         using BusIdType = QWidget*;
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
 
-        virtual void OnValueChanged(AZ::DocumentPropertyEditor::Nodes::PropertyEditor::ValueChangeType changeType) = 0;
+        virtual void OnValueChanged(AZ::DocumentPropertyEditor::Nodes::ValueChangeType changeType) = 0;
         virtual void OnRequestPropertyNotify() = 0;
     };
 
@@ -302,7 +302,7 @@ namespace AzToolsFramework
             return propertyEditorSystem->LookupNameFromId(rpeHandler.GetHandlerName()).GetStringView();
         }
 
-        void OnValueChanged(AZ::DocumentPropertyEditor::Nodes::PropertyEditor::ValueChangeType changeType) override
+        void OnValueChanged(AZ::DocumentPropertyEditor::Nodes::ValueChangeType changeType) override
         {
             using AZ::DocumentPropertyEditor::Nodes::PropertyEditor;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
@@ -178,14 +178,14 @@ namespace AzToolsFramework
         {
             IndividualPropertyHandlerEditNotifications::Bus::Event(
                 editorGUI, &IndividualPropertyHandlerEditNotifications::Bus::Events::OnValueChanged,
-                AZ::DocumentPropertyEditor::Nodes::PropertyEditor::ValueChangeType::InProgressEdit);
+                AZ::DocumentPropertyEditor::Nodes::ValueChangeType::InProgressEdit);
         }
 
         void PropertyManagerComponent::OnEditingFinished(QWidget* editorGUI)
         {
             IndividualPropertyHandlerEditNotifications::Bus::Event(
                 editorGUI, &IndividualPropertyHandlerEditNotifications::Bus::Events::OnValueChanged,
-                AZ::DocumentPropertyEditor::Nodes::PropertyEditor::ValueChangeType::FinishedEdit);
+                AZ::DocumentPropertyEditor::Nodes::ValueChangeType::FinishedEdit);
         }
 
         void PropertyManagerComponent::RequestPropertyNotify(QWidget* editorGUI)


### PR DESCRIPTION
**Description**
Prior to this PR, the DPE didn't have a way of notifying editors that its internal document had changed (user changes a property, for example). This meant that editors such as the Asset Editor wouldn't know when they could save the file.

This PR makes generally the following changes to enable saving and other property change signalling from the ReflectionAdapter to interested parties (the AssetEditorWidget in this case):
- The ReflectionAdapter now has a PropertyChangeEvent which can signal to functions taking a PropertyChangeInfo struct as described above
- The ReflectionAdapter is already listening for property change events in it's message handler, so we call its NotifyPropertyChanged function from there with the relevant data
- The AzToolsFramework::AssetEditorWidget now subscribes to the ReflectionAdapter's PropertyChangeEvent, calling into the same execution paths that it did for the RPE from there

![dpe_enableDpeDirtyDomNotifications](https://user-images.githubusercontent.com/104796591/182969897-ace512a6-2cf3-47e3-accf-8bfac1a72ace.gif)

**Testing**
- Verified properties changed in the Asset Editor were retained after saving assets and reopening both the Asset Editor and the saved file
- Verified git tracked changed asset files during the above test (to make sure they were still saving to disk)