### PR TITLE
Add missing FPs for anim editor

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
@@ -32,6 +32,7 @@ namespace AZ::Render
         : m_entityId(entityId)
     {
         m_auxGeomFeatureProcessor = RPI::Scene::GetFeatureProcessorForEntity<RPI::AuxGeomFeatureProcessorInterface>(entityId);
+        AZ_Assert(m_auxGeomFeatureProcessor, "AuxGeomFeatureProcessor doesn't exist. Check if it is missing from AnimViewport.setreg file.");
     }
 
     // Function for providing data required for debug drawing colliders

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Registry/AnimViewport.setreg
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Registry/AnimViewport.setreg
@@ -13,6 +13,7 @@
                             "AZ::Render::SkinnedMeshFeatureProcessor",
                             "AZ::Render::SkyBoxFeatureProcessor",
                             "AZ::Render::TransformServiceFeatureProcessor",
+                            "AZ::Render::AuxGeomFeatureProcessor",
 
                             // These FPs can be removed once the LightCullingPass issue [ATOM-17812] is addressed 
                             "AZ::Render::SimplePointLightFeatureProcessor",


### PR DESCRIPTION
Signed-off-by: rhhong <rhhong@amazon.com>

## What does this PR do?

Add the missing auxGeom FPs to anim editor. Without it the debug render stop working.

## How was this PR tested?

Run the editor, open anim editor, see the debug render function back up again.
