### PR TITLE
Removed legacy unused GUI settings

### DIFF
--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -217,15 +217,7 @@ SEditorSettings::SEditorSettings()
     //////////////////////////////////////////////////////////////////////////
     // Initialize GUI settings.
     //////////////////////////////////////////////////////////////////////////
-    gui.bWindowsVista = QOperatingSystemVersion::current() >= QOperatingSystemVersion(QOperatingSystemVersion::Windows7);
-
     gui.nToolbarIconSize = static_cast<int>(AzQtComponents::ToolBar::ToolBarIconSize::Default);
-
-    int lfHeight = 8;// -MulDiv(8, GetDeviceCaps(GetDC(nullptr), LOGPIXELSY), 72);
-    gui.nDefaultFontHieght = lfHeight;
-    gui.hSystemFont = QFont("Ms Shell Dlg 2", lfHeight, QFont::Normal);
-    gui.hSystemFontBold = QFont("Ms Shell Dlg 2", lfHeight, QFont::Bold);
-    gui.hSystemFontItalic = QFont("Ms Shell Dlg 2", lfHeight, QFont::Normal, true);
 
     backgroundUpdatePeriod = 0;
     g_TemporaryLevelName = nullptr;

--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -182,12 +182,6 @@ struct SSelectObjectDialogSettings
 //////////////////////////////////////////////////////////////////////////
 struct SGUI_Settings
 {
-    bool bWindowsVista;        // true when running on windows Vista
-    QFont hSystemFont;         // Default system GUI font.
-    QFont hSystemFontBold;     // Default system GUI bold font.
-    QFont hSystemFontItalic;   // Default system GUI italic font.
-    int nDefaultFontHieght;    // Default font height for 8 logical units.
-
     int nToolbarIconSize;      // Override size of the toolbar icons
 };
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/PhonemeSelectionWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/PhonemeSelectionWindow.cpp
@@ -128,7 +128,6 @@ namespace EMStudio
             painter.setPen(QColor(0, 0, 0));
         }
 
-        //painter.setFont( QFont("MS Shell Dlg 2", 8) );
         painter.drawText(70, (height() / 2) + 4, m_fileNameWithoutExt.c_str());
     }
 


### PR DESCRIPTION
## What does this PR do?

Removed unused legacy GUI settings from `SGUI_Settings`. The only setting in it still used is `nToolbarIconSize`, so we should look at moving that when working on the new toolbar management. Also removed commented out unused font family.

## How was this PR tested?

Built/ran unit tests. No compile errors after removing the unused settings.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>