### PR TITLE
Development build fix

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Script/ScriptRemoteDebuggingConstants.h
+++ b/Code/Framework/AzFramework/AzFramework/Script/ScriptRemoteDebuggingConstants.h
@@ -8,10 +8,11 @@
 #pragma once
 
 #include <AzCore/Name/Name.h>
+#include <AzCore/Name/NameDictionary.h>
 
 namespace AzFramework
 {
-    static const AZ::Name LuaToolsName = AZ::Name::FromStringLiteral("LuaRemoteTools");
+    static const AZ::Name LuaToolsName = AZ::Name::FromStringLiteral("LuaRemoteTools", nullptr);
     static constexpr AZ::Crc32 LuaToolsKey("LuaRemoteTools");
     static constexpr uint16_t LuaToolsPort = 6777;
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Utils/ScriptCanvasConstants.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Utils/ScriptCanvasConstants.h
@@ -8,10 +8,11 @@
 #pragma once
 
 #include <AzCore/Name/Name.h>
+#include <AzCore/Name/NameDictionary.h>
 
 namespace ScriptCanvas
 {
-    static const AZ::Name RemoteToolsName = AZ::Name::FromStringLiteral("ScriptCanvasRemoteTools");
+    static const AZ::Name RemoteToolsName = AZ::Name::FromStringLiteral("ScriptCanvasRemoteTools", nullptr);
     static constexpr AZ::Crc32 RemoteToolsKey("ScriptCanvasRemoteTools");
     static constexpr uint16_t RemoteToolsPort = 6787;
 }


### PR DESCRIPTION
The AZ::Name::FromStringLiteral API was updated and the newly added
ScriptRemoteDebuggingConstants.h and ScriptCanvasConstants.h needs to be
updated to use that API.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Built AzFramework and the ScriptCanvas Gems successfully
