### PR TITLE
Prefab/Add template propagation when entering and exiting prefab focus mode

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.cpp
@@ -29,12 +29,6 @@ namespace AzToolsFramework
             // Get EditorEntityContextId
             EditorEntityContextRequestBus::BroadcastResult(s_editorEntityContextId, &EditorEntityContextRequests::GetEditorEntityContextId);
 
-            m_prefabFocusInterface = AZ::Interface<PrefabFocusInterface>::Get();
-            AZ_Assert(m_prefabFocusInterface != nullptr,
-                "Prefab - InstanceDomGenerator::Initialize - "
-                "Prefab Focus Interface could not be found. "
-                "Check that it is being correctly initialized.");
-
             m_prefabSystemComponentInterface = AZ::Interface<PrefabSystemComponentInterface>::Get();
             AZ_Assert(m_prefabSystemComponentInterface != nullptr,
                 "Prefab - InstanceDomGenerator::Initialize - "
@@ -45,15 +39,18 @@ namespace AzToolsFramework
         void InstanceDomGenerator::UnregisterInstanceDomGeneratorInterface()
         {
             m_prefabSystemComponentInterface = nullptr;
-            m_prefabFocusInterface = nullptr;
 
             AZ::Interface<InstanceDomGeneratorInterface>::Unregister(this);
         }
 
         bool InstanceDomGenerator::GenerateInstanceDom(const Instance* instance, PrefabDom& instanceDom)
         {
-            // Retrieve focused instance
-            auto focusedInstance = m_prefabFocusInterface->GetFocusedPrefabInstance(s_editorEntityContextId);
+            // Retrieve focused instance.
+            auto prefabFocusInterface = AZ::Interface<PrefabFocusInterface>::Get();
+            AZ_Assert(prefabFocusInterface, "Prefab - InstanceDomGenerator::GenerateInstanceDom - "
+                "Prefab Focus Interface couldn not be found.");
+
+            auto focusedInstance = prefabFocusInterface->GetFocusedPrefabInstance(s_editorEntityContextId);
             Instance* targetInstance = nullptr;
             if (focusedInstance.has_value())
             {
@@ -156,5 +153,5 @@ namespace AzToolsFramework
                 containerPath.Set(focusedInstanceDom, containerDom, focusedInstanceDom.GetAllocator());
             }
         }
-    }
-}
+    } // namespace Prefab
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.cpp
@@ -50,8 +50,8 @@ namespace AzToolsFramework
             AZ_Assert(prefabFocusInterface, "Prefab - InstanceDomGenerator::GenerateInstanceDom - "
                 "Prefab Focus Interface couldn not be found.");
 
-            auto focusedInstance = prefabFocusInterface->GetFocusedPrefabInstance(s_editorEntityContextId);
-            Instance* targetInstance = nullptr;
+            InstanceOptionalConstReference focusedInstance = prefabFocusInterface->GetFocusedPrefabInstance(s_editorEntityContextId);
+            const Instance* targetInstance = nullptr;
             if (focusedInstance.has_value())
             {
                 targetInstance = &(focusedInstance->get());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.h
@@ -18,7 +18,6 @@ namespace AzToolsFramework
     namespace Prefab
     {
         class Instance;
-        class PrefabFocusInterface;
         class PrefabSystemComponentInterface;
 
         class InstanceDomGenerator
@@ -43,8 +42,7 @@ namespace AzToolsFramework
 
             static AzFramework::EntityContextId s_editorEntityContextId;
 
-            PrefabFocusInterface* m_prefabFocusInterface = nullptr;
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
         };
-    }
-}
+    } // namespace Prefab
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -83,7 +83,7 @@ namespace AzToolsFramework
                 return;
             }
 
-            m_instancesUpdateQueue.emplace_back(&instance->get());
+            m_instancesUpdateQueue.emplace_back(&(instance->get()));
         }
 
         void InstanceUpdateExecutor::AddTemplateInstancesToQueue(TemplateId instanceTemplateId, InstanceOptionalConstReference instanceToExclude)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -72,6 +72,20 @@ namespace AzToolsFramework
             AZ::Interface<InstanceUpdateExecutorInterface>::Unregister(this);
         }
 
+        void InstanceUpdateExecutor::AddInstanceToQueue(InstanceOptionalReference instance)
+        {
+            if (!instance.has_value())
+            {
+                AZ_Warning(
+                    "Prefab", false, "InstanceUpdateExecutor::AddInstanceToQueue - "
+                    "Caller tried to insert null instance into the queue.");
+
+                return;
+            }
+
+            m_instancesUpdateQueue.emplace_back(&instance->get());
+        }
+
         void InstanceUpdateExecutor::AddTemplateInstancesToQueue(TemplateId instanceTemplateId, InstanceOptionalConstReference instanceToExclude)
         {
             auto findInstancesResult =

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -35,6 +35,7 @@ namespace AzToolsFramework
 
             explicit InstanceUpdateExecutor(int instanceCountToUpdateInBatch = 0);
 
+            void AddInstanceToQueue(InstanceOptionalReference instance) override;
             void AddTemplateInstancesToQueue(TemplateId instanceTemplateId, InstanceOptionalConstReference instanceToExclude = AZStd::nullopt) override;
             bool UpdateTemplateInstancesInQueue() override;
             void RemoveTemplateInstanceFromQueue(const Instance* instance) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -41,7 +41,7 @@ namespace AzToolsFramework
             void RemoveTemplateInstanceFromQueue(const Instance* instance) override;
             void QueueRootPrefabLoadedNotificationForNextPropagation() override;
 
-            void SetShouldPauseInstancePropagation(bool shouldPausePropagation);
+            void SetShouldPauseInstancePropagation(bool shouldPausePropagation) override;
 
             void RegisterInstanceUpdateExecutorInterface();
             void UnregisterInstanceUpdateExecutorInterface();
@@ -49,7 +49,7 @@ namespace AzToolsFramework
         private:
             //! Connect the game mode event handler in a lazy fashion rather than at construction of this class.
             //! This is required because the event won't be ready for connection during construction as EditorEntityContextComponent
-            //! gets initialized after the PrefabSystemComponent
+            //! gets initialized after the PrefabSystemComponent.
             void LazyConnectGameModeEventHandler();
 
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
@@ -22,13 +22,16 @@ namespace AzToolsFramework
             AZ_RTTI(InstanceUpdateExecutorInterface, "{26BB4ACF-6EA5-4668-84E7-AB75B90BA449}");
             virtual ~InstanceUpdateExecutorInterface() = default;
 
-            // Add all Instances of Template with given Id into a queue for updating them later.
+            // Add an instance into queue for updating later on next system tick.
+            virtual void AddInstanceToQueue(InstanceOptionalReference instance) = 0;
+
+            // Add all instances of template with given id into queue for updating later on next system tick.
             virtual void AddTemplateInstancesToQueue(TemplateId instanceTemplateId, InstanceOptionalConstReference instanceToExclude = AZStd::nullopt) = 0;
 
-            // Update Instances in the waiting queue.
+            // Update instances in the waiting queue.
             virtual bool UpdateTemplateInstancesInQueue() = 0;
 
-            // Remove an Instance from the waiting queue.
+            // Remove an instance from the waiting queue.
             virtual void RemoveTemplateInstanceFromQueue(const Instance* instance) = 0;
 
             // A notification OnRootPrefabInstanceLoaded will fire during the propagation if root

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
@@ -22,10 +22,10 @@ namespace AzToolsFramework
             AZ_RTTI(InstanceUpdateExecutorInterface, "{26BB4ACF-6EA5-4668-84E7-AB75B90BA449}");
             virtual ~InstanceUpdateExecutorInterface() = default;
 
-            // Add an instance into queue for updating later on next system tick.
+            // Add an instance into queue for updating it later.
             virtual void AddInstanceToQueue(InstanceOptionalReference instance) = 0;
 
-            // Add all instances of template with given id into queue for updating later on next system tick.
+            // Add all instances of template with given id into queue for updating them later.
             virtual void AddTemplateInstancesToQueue(TemplateId instanceTemplateId, InstanceOptionalConstReference instanceToExclude = AZStd::nullopt) = 0;
 
             // Update instances in the waiting queue.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
@@ -16,32 +16,40 @@ namespace AzToolsFramework
 {
     namespace Prefab
     {
+        //! Interface to handle instance update in template propagation.
         class InstanceUpdateExecutorInterface
         {
         public:
             AZ_RTTI(InstanceUpdateExecutorInterface, "{26BB4ACF-6EA5-4668-84E7-AB75B90BA449}");
             virtual ~InstanceUpdateExecutorInterface() = default;
 
-            // Add an instance into queue for updating it later.
+            //! Adds an instance into queue for updating it later.
+            //! @param instance The instance to be added to queue.
             virtual void AddInstanceToQueue(InstanceOptionalReference instance) = 0;
 
-            // Add all instances of template with given id into queue for updating them later.
+            //! Adds all instances of template with given id into queue for updating them later.
+            //! @param instanceTemplateId The template id used to retrieve all instances.
+            //! @param instanceToExclude The instance to be excluded. It is nullopt by default.
             virtual void AddTemplateInstancesToQueue(TemplateId instanceTemplateId, InstanceOptionalConstReference instanceToExclude = AZStd::nullopt) = 0;
 
-            // Update instances in the waiting queue.
+            //! Updates instances in the waiting queue.
+            //! @return bool on wheter the operation succeeds.
             virtual bool UpdateTemplateInstancesInQueue() = 0;
 
-            // Remove an instance from the waiting queue.
+            //! Removes an instance from the waiting queue.
+            //! @param instance The instance to be removed from queue.
             virtual void RemoveTemplateInstanceFromQueue(const Instance* instance) = 0;
 
-            // A notification OnRootPrefabInstanceLoaded will fire during the propagation if root
-            // prefab instance is loaded for the first time after this function is called.
+            //! Sets the flag that tells whether root prefab instance is loaded to false.
+            //! A notification OnRootPrefabInstanceLoaded will fire during the propagation if root
+            //! prefab instance is loaded for the first time after this function is called.
             virtual void QueueRootPrefabLoadedNotificationForNextPropagation() = 0;
 
             //! Sets whether to pause instance propagation or not.
             //! When making property changes in the entity editor, pausing propagation during
             //! editing will prevent the user from losing control of the properties they are editing.
+            //! @param shouldPausePropagation Flag that decides whether to pause propagation.
             virtual void SetShouldPauseInstancePropagation(bool shouldPausePropagation) = 0;
         };
-    }
-}
+    } // namespace Prefab
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -293,7 +293,6 @@ namespace AzToolsFramework::Prefab
         PrefabFocusNotificationBus::Broadcast(&PrefabFocusNotifications::OnPrefabFocusChanged);
 
         // Force propagation on both the previous and the new focused instances to ensure they are represented correctly.
-        m_instanceUpdateExecutorInterface = AZ::Interface<InstanceUpdateExecutorInterface>::Get();
         if (previousFocusedInstance.has_value())
         {
             m_instanceUpdateExecutorInterface->AddInstanceToQueue(previousFocusedInstance);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -14,6 +14,7 @@
 #include <AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityInterface.h>
 #include <AzToolsFramework/Prefab/Instance/Instance.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceEntityMapperInterface.h>
+#include <AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h>
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
 #include <AzToolsFramework/Prefab/PrefabFocusNotificationBus.h>
 #include <AzToolsFramework/Prefab/PrefabFocusUndo.h>
@@ -21,8 +22,16 @@
 
 namespace AzToolsFramework::Prefab
 {
-    PrefabFocusHandler::PrefabFocusHandler()
+    void PrefabFocusHandler::RegisterPrefabFocusInterface()
     {
+        AZ::Interface<PrefabFocusInterface>::Register(this);
+        AZ::Interface<PrefabFocusPublicInterface>::Register(this);
+
+        EditorEntityInfoNotificationBus::Handler::BusConnect();
+        EditorEntityContextNotificationBus::Handler::BusConnect();
+        PrefabPublicNotificationBus::Handler::BusConnect();
+        PrefabFocusPublicRequestBus::Handler::BusConnect();
+
         m_instanceEntityMapperInterface = AZ::Interface<InstanceEntityMapperInterface>::Get();
         AZ_Assert(
             m_instanceEntityMapperInterface,
@@ -30,22 +39,26 @@ namespace AzToolsFramework::Prefab
             "Instance Entity Mapper Interface could not be found. "
             "Check that it is being correctly initialized.");
 
-        EditorEntityInfoNotificationBus::Handler::BusConnect();
-        EditorEntityContextNotificationBus::Handler::BusConnect();
-        PrefabPublicNotificationBus::Handler::BusConnect();
-        AZ::Interface<PrefabFocusInterface>::Register(this);
-        AZ::Interface<PrefabFocusPublicInterface>::Register(this);
-        PrefabFocusPublicRequestBus::Handler::BusConnect();
+        m_instanceUpdateExecutorInterface = AZ::Interface<InstanceUpdateExecutorInterface>::Get();
+        AZ_Assert(
+            m_instanceUpdateExecutorInterface,
+            "Prefab - PrefabFocusHandler - "
+            "Instance Update Executor Interface could not be found. "
+            "Check that it is being correctly initialized.");
     }
 
-    PrefabFocusHandler::~PrefabFocusHandler()
+    void PrefabFocusHandler::UnregisterPrefabFocusInterface()
     {
+        m_instanceUpdateExecutorInterface = nullptr;
+        m_instanceEntityMapperInterface = nullptr;
+
         PrefabFocusPublicRequestBus::Handler::BusDisconnect();
-        AZ::Interface<PrefabFocusPublicInterface>::Unregister(this);
-        AZ::Interface<PrefabFocusInterface>::Unregister(this);
         PrefabPublicNotificationBus::Handler::BusDisconnect();
         EditorEntityContextNotificationBus::Handler::BusDisconnect();
         EditorEntityInfoNotificationBus::Handler::BusDisconnect();
+
+        AZ::Interface<PrefabFocusPublicInterface>::Unregister(this);
+        AZ::Interface<PrefabFocusInterface>::Unregister(this);
     }
 
     void PrefabFocusHandler::Reflect(AZ::ReflectContext* context)
@@ -278,6 +291,14 @@ namespace AzToolsFramework::Prefab
         SetInstanceContainersOpenState(m_rootAliasFocusPath, true);
 
         PrefabFocusNotificationBus::Broadcast(&PrefabFocusNotifications::OnPrefabFocusChanged);
+
+        // Force propagation on both the previous and the new focused instances to ensure they are represented correctly.
+        m_instanceUpdateExecutorInterface = AZ::Interface<InstanceUpdateExecutorInterface>::Get();
+        if (previousFocusedInstance.has_value())
+        {
+            m_instanceUpdateExecutorInterface->AddInstanceToQueue(previousFocusedInstance);
+        }
+        m_instanceUpdateExecutorInterface->AddInstanceToQueue(focusedInstance);
 
         return AZ::Success();
     }
@@ -585,5 +606,4 @@ namespace AzToolsFramework::Prefab
 
         return AZStd::nullopt;
     }
-
 } // namespace AzToolsFramework::Prefab

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
@@ -29,6 +29,7 @@ namespace AzToolsFramework
 namespace AzToolsFramework::Prefab
 {
     class InstanceEntityMapperInterface;
+    class InstanceUpdateExecutorInterface;
     class PrefabSystemComponentInterface;
 
     //! Handles Prefab Focus mode, determining which prefab file entity changes will target.
@@ -42,8 +43,8 @@ namespace AzToolsFramework::Prefab
     public:
         AZ_CLASS_ALLOCATOR(PrefabFocusHandler, AZ::SystemAllocator, 0);
 
-        PrefabFocusHandler();
-        ~PrefabFocusHandler();
+        void RegisterPrefabFocusInterface();
+        void UnregisterPrefabFocusInterface();
 
         static void Reflect(AZ::ReflectContext* context);
 
@@ -95,9 +96,11 @@ namespace AzToolsFramework::Prefab
         //! The current focus mode.
         PrefabEditScope m_prefabEditScope = PrefabEditScope::HIDE_NESTED_INSTANCES_CONTENT;
 
+        InstanceEntityMapperInterface* m_instanceEntityMapperInterface = nullptr;
+        InstanceUpdateExecutorInterface* m_instanceUpdateExecutorInterface = nullptr;
+
         ContainerEntityInterface* m_containerEntityInterface = nullptr;
         FocusModeInterface* m_focusModeInterface = nullptr;
-        InstanceEntityMapperInterface* m_instanceEntityMapperInterface = nullptr;
         ReadOnlyEntityQueryInterface* m_readOnlyEntityQueryInterface = nullptr;
     };
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -26,6 +26,7 @@
 #include <AzToolsFramework/Prefab/Instance/InstanceEntityMapperInterface.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h>
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
+#include <AzToolsFramework/Prefab/PrefabFocusHandler.h>
 #include <AzToolsFramework/Prefab/PrefabLoaderInterface.h>
 #include <AzToolsFramework/Prefab/PrefabPublicHandler.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
@@ -48,14 +49,14 @@ namespace AzToolsFramework
             m_instanceToTemplateInterface = AZ::Interface<InstanceToTemplateInterface>::Get();
             AZ_Assert(m_instanceToTemplateInterface, "PrefabPublicHandler - Could not retrieve instance of InstanceToTemplateInterface");
 
+            m_prefabLoaderInterface = AZ::Interface<PrefabLoaderInterface>::Get();
+            AZ_Assert(m_prefabLoaderInterface, "Could not get PrefabLoaderInterface on PrefabPublicHandler construction.");
+
             m_prefabFocusInterface = AZ::Interface<PrefabFocusInterface>::Get();
             AZ_Assert(m_prefabFocusInterface, "Could not get PrefabFocusInterface on PrefabPublicHandler construction.");
 
             m_prefabFocusPublicInterface = AZ::Interface<PrefabFocusPublicInterface>::Get();
             AZ_Assert(m_prefabFocusPublicInterface, "Could not get PrefabFocusPublicInterface on PrefabPublicHandler construction.");
-
-            m_prefabLoaderInterface = AZ::Interface<PrefabLoaderInterface>::Get();
-            AZ_Assert(m_prefabLoaderInterface, "Could not get PrefabLoaderInterface on PrefabPublicHandler construction.");
 
             m_prefabSystemComponentInterface = AZ::Interface<PrefabSystemComponentInterface>::Get();
             AZ_Assert(m_prefabSystemComponentInterface, "Could not get PrefabSystemComponentInterface on PrefabPublicHandler construction.");

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -26,7 +26,6 @@
 #include <AzToolsFramework/Prefab/Instance/InstanceEntityMapperInterface.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h>
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
-#include <AzToolsFramework/Prefab/PrefabFocusHandler.h>
 #include <AzToolsFramework/Prefab/PrefabLoaderInterface.h>
 #include <AzToolsFramework/Prefab/PrefabPublicHandler.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
@@ -43,6 +42,8 @@ namespace AzToolsFramework
     {
         void PrefabPublicHandler::RegisterPrefabPublicHandlerInterface()
         {
+            m_prefabFocusHandler.RegisterPrefabFocusInterface();
+
             m_instanceEntityMapperInterface = AZ::Interface<InstanceEntityMapperInterface>::Get();
             AZ_Assert(m_instanceEntityMapperInterface, "PrefabPublicHandler - Could not retrieve instance of InstanceEntityMapperInterface");
 
@@ -71,6 +72,15 @@ namespace AzToolsFramework
             AZ::Interface<PrefabPublicInterface>::Unregister(this);
 
             m_prefabUndoCache.Destroy();
+
+            m_prefabSystemComponentInterface = nullptr;
+            m_prefabFocusPublicInterface = nullptr;
+            m_prefabFocusInterface = nullptr;
+            m_prefabLoaderInterface = nullptr;
+            m_instanceToTemplateInterface = nullptr;
+            m_instanceEntityMapperInterface = nullptr;
+
+            m_prefabFocusHandler.UnregisterPrefabFocusInterface();
         }
 
         CreatePrefabResult PrefabPublicHandler::CreatePrefabInMemory(const EntityIdList& entityIds, AZ::IO::PathView filePath)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -14,7 +14,6 @@
 
 #include <AzToolsFramework/Entity/EntityTypes.h>
 #include <AzToolsFramework/Prefab/Instance/Instance.h>
-#include <AzToolsFramework/Prefab/PrefabFocusHandler.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 #include <AzToolsFramework/Prefab/PrefabUndoCache.h>
@@ -198,9 +197,6 @@ namespace AzToolsFramework
             PrefabFocusPublicInterface* m_prefabFocusPublicInterface = nullptr;
             PrefabLoaderInterface* m_prefabLoaderInterface = nullptr;
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
-
-            // Handles the Prefab Focus API that determines what prefab is being edited.
-            PrefabFocusHandler m_prefabFocusHandler;
 
             // Caches entity states for undo/redo purposes
             PrefabUndoCache m_prefabUndoCache;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -14,6 +14,7 @@
 
 #include <AzToolsFramework/Entity/EntityTypes.h>
 #include <AzToolsFramework/Prefab/Instance/Instance.h>
+#include <AzToolsFramework/Prefab/PrefabFocusHandler.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 #include <AzToolsFramework/Prefab/PrefabUndoCache.h>
@@ -198,8 +199,11 @@ namespace AzToolsFramework
             PrefabLoaderInterface* m_prefabLoaderInterface = nullptr;
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
 
-            // Caches entity states for undo/redo purposes
+            //! Caches entity states for undo/redo purposes.
             PrefabUndoCache m_prefabUndoCache;
+
+            //! Handles the Prefab Focus API that determines what prefab is being edited.
+            PrefabFocusHandler m_prefabFocusHandler;
 
             uint64_t m_newEntityCounter = 1;
         };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -33,10 +33,13 @@ namespace AzToolsFramework
         void PrefabSystemComponent::Activate()
         {
             AZ::Interface<PrefabSystemComponentInterface>::Register(this);
+
             m_prefabLoader.RegisterPrefabLoaderInterface();
             m_instanceToTemplatePropagator.RegisterInstanceToTemplateInterface();
             m_instanceUpdateExecutor.RegisterInstanceUpdateExecutorInterface();
+            m_prefabFocusHandler.RegisterPrefabFocusInterface();
             m_prefabPublicHandler.RegisterPrefabPublicHandlerInterface();
+
             m_prefabPublicRequestHandler.Connect();
             m_prefabSystemScriptingHandler.Connect(this);
             AZ::SystemTickBus::Handler::BusConnect();
@@ -47,10 +50,13 @@ namespace AzToolsFramework
             AZ::SystemTickBus::Handler::BusDisconnect();
             m_prefabSystemScriptingHandler.Disconnect();
             m_prefabPublicRequestHandler.Disconnect();
+
             m_prefabPublicHandler.UnregisterPrefabPublicHandlerInterface();
+            m_prefabFocusHandler.UnregisterPrefabFocusInterface();
             m_instanceUpdateExecutor.UnregisterInstanceUpdateExecutorInterface();
             m_instanceToTemplatePropagator.UnregisterInstanceToTemplateInterface();
             m_prefabLoader.UnregisterPrefabLoaderInterface();
+
             AZ::Interface<PrefabSystemComponentInterface>::Unregister(this);
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -37,7 +37,6 @@ namespace AzToolsFramework
             m_prefabLoader.RegisterPrefabLoaderInterface();
             m_instanceToTemplatePropagator.RegisterInstanceToTemplateInterface();
             m_instanceUpdateExecutor.RegisterInstanceUpdateExecutorInterface();
-            m_prefabFocusHandler.RegisterPrefabFocusInterface();
             m_prefabPublicHandler.RegisterPrefabPublicHandlerInterface();
 
             m_prefabPublicRequestHandler.Connect();
@@ -52,7 +51,6 @@ namespace AzToolsFramework
             m_prefabPublicRequestHandler.Disconnect();
 
             m_prefabPublicHandler.UnregisterPrefabPublicHandlerInterface();
-            m_prefabFocusHandler.UnregisterPrefabFocusInterface();
             m_instanceUpdateExecutor.UnregisterInstanceUpdateExecutorInterface();
             m_instanceToTemplatePropagator.UnregisterInstanceToTemplateInterface();
             m_prefabLoader.UnregisterPrefabLoaderInterface();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
@@ -22,6 +22,7 @@
 #include <AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.h>
 #include <AzToolsFramework/Prefab/Instance/TemplateInstanceMapper.h>
 #include <AzToolsFramework/Prefab/Link/Link.h>
+#include <AzToolsFramework/Prefab/PrefabFocusHandler.h>
 #include <AzToolsFramework/Prefab/PrefabIdTypes.h>
 #include <AzToolsFramework/Prefab/PrefabLoader.h>
 #include <AzToolsFramework/Prefab/PrefabPublicHandler.h>
@@ -421,6 +422,9 @@ namespace AzToolsFramework
 
             // Handler of the public Prefab requests.
             PrefabPublicRequestHandler m_prefabPublicRequestHandler;
+
+            // Handles the Prefab Focus API that determines what prefab is being edited.
+            PrefabFocusHandler m_prefabFocusHandler;
 
             PrefabSystemScriptingHandler m_prefabSystemScriptingHandler;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
@@ -22,7 +22,6 @@
 #include <AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.h>
 #include <AzToolsFramework/Prefab/Instance/TemplateInstanceMapper.h>
 #include <AzToolsFramework/Prefab/Link/Link.h>
-#include <AzToolsFramework/Prefab/PrefabFocusHandler.h>
 #include <AzToolsFramework/Prefab/PrefabIdTypes.h>
 #include <AzToolsFramework/Prefab/PrefabLoader.h>
 #include <AzToolsFramework/Prefab/PrefabPublicHandler.h>
@@ -422,9 +421,6 @@ namespace AzToolsFramework
 
             // Handler of the public Prefab requests.
             PrefabPublicRequestHandler m_prefabPublicRequestHandler;
-
-            // Handles the Prefab Focus API that determines what prefab is being edited.
-            PrefabFocusHandler m_prefabFocusHandler;
 
             PrefabSystemScriptingHandler m_prefabSystemScriptingHandler;
 


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

Try to fix: #10942

This PR adds template propagation when entering and exiting prefab focus mode. Specifically, whenever focused instance is changed, the previously and currently focused instances will be put into propagation queue. This makes sure that instance DOM includes a valid link id if needed.

Example: 

```
Level          (prefab)
|-- Car        (prefab)
    |-- Wheel  (prefab)
```

- Exiting focus mode on Car and entering focus on Level will put Car and Level into propagation queue.
- Exiting focus mode on Car and entering focus on Wheel will put Car and Wheel into propagation queue.
  - Note: When InstanceDomGenerator tries to generate DOM for Car, the focused instance is Wheel. The generator will climb up to root instance (Level) to get the Car instance DOM, which contains the link id.

## How was this PR tested?

- [x] Performed manual validation in editor - No crash
- [x] Passed AzToolsFramework unit tests
- [x] Passed prefab auto tests
- [ ] AR
