### PR TITLE
Update ASV material versions so warnings should be gone

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Assets/Objects/Hermanubis/Hermanubis_stone.material
+++ b/Gems/AtomLyIntegration/CommonFeatures/Assets/Objects/Hermanubis/Hermanubis_stone.material
@@ -23,7 +23,7 @@
             "applySpecularAA": true
         },
         "irradiance": {
-            "color": [
+            "manualColor": [
                 0.7304646372795105,
                 0.6938735246658325,
                 0.6866865158081055,


### PR DESCRIPTION
Signed-off-by: jiaweig <51759646+jiaweig-amzn@users.noreply.github.com>

## What does this PR do?

This material has a version 5 but uses a property name in version 4. The value will be ignored.
Other updates in https://github.com/o3de/o3de-atom-sampleviewer/pull/484

## How was this PR tested?

Tested on ASV SSR which uses this material.
