### PR TITLE
chore: remove mouse wrap for manipulator viewport

### DIFF
--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -23,7 +23,6 @@ namespace SandboxEditor
     constexpr AZStd::string_view AngleSizeSetting = "/Amazon/Preferences/Editor/AngleSize";
     constexpr AZStd::string_view ShowGridSetting = "/Amazon/Preferences/Editor/ShowGrid";
     constexpr AZStd::string_view StickySelectSetting = "/Amazon/Preferences/Editor/StickySelect";
-    constexpr AZStd::string_view ManipulatorMouseWrapSetting = "/Amazon/Preferences/Editor/Manipulator/ManipulatorMouseWrapSetting";
     constexpr AZStd::string_view ManipulatorLineBoundWidthSetting = "/Amazon/Preferences/Editor/Manipulator/LineBoundWidth";
     constexpr AZStd::string_view ManipulatorCircleBoundWidthSetting = "/Amazon/Preferences/Editor/Manipulator/CircleBoundWidth";
     constexpr AZStd::string_view CameraTranslateSpeedSetting = "/Amazon/Preferences/Editor/Camera/TranslateSpeed";
@@ -244,16 +243,6 @@ namespace SandboxEditor
     void SetStickySelectEnabled(const bool enabled)
     {
         AzToolsFramework::SetRegistry(StickySelectSetting, enabled);
-    }
-
-    bool ManipulatorMouseWrap()
-    {
-        return AzToolsFramework::GetRegistry(ManipulatorMouseWrapSetting, false);
-    }
-
-    void SetManipulatorMouseWrap(bool enabled)
-    {
-        AzToolsFramework::SetRegistry(ManipulatorMouseWrapSetting, enabled);
     }
 
     float ManipulatorLineBoundWidth()

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -57,9 +57,6 @@ namespace SandboxEditor
     SANDBOX_API bool ShowingGrid();
     SANDBOX_API void SetShowingGrid(bool showing);
 
-    SANDBOX_API bool ManipulatorMouseWrap();
-    SANDBOX_API void SetManipulatorMouseWrap(bool enabled);
-
     SANDBOX_API bool StickySelectEnabled();
     SANDBOX_API void SetStickySelectEnabled(bool enabled);
 

--- a/Code/Editor/ViewportManipulatorController.cpp
+++ b/Code/Editor/ViewportManipulatorController.cpp
@@ -78,22 +78,9 @@ namespace SandboxEditor
                 AzFramework::WindowRequestBus::EventResult(
                     windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
 
-                if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
-                {
-                    if (m_virtualNormalizedPosition)
-                    {
-                        (*m_virtualNormalizedPosition) += position->m_normalizedPositionDelta;
-                    }
-                    else
-                    {
-                        m_virtualNormalizedPosition = { position->m_normalizedPosition };
-                    }
-                }
-
-                const auto normalizedPosition = m_virtualNormalizedPosition.value_or(position->m_normalizedPosition);
-                const auto screenPoint = AzFramework::ScreenPointFromVector2(AZ::Vector2(
-                    normalizedPosition.GetX() * aznumeric_cast<float>(windowSize.m_width),
-                    normalizedPosition.GetY() * aznumeric_cast<float>(windowSize.m_height)));
+                const auto screenPoint = AzFramework::ScreenPoint(
+                    aznumeric_cast<int>(position->m_normalizedPosition.GetX() * windowSize.m_width),
+                    aznumeric_cast<int>(position->m_normalizedPosition.GetY() * windowSize.m_height));
 
                 ProjectedViewportRay ray{};
                 ViewportInteractionRequestBus::EventResult(
@@ -131,12 +118,6 @@ namespace SandboxEditor
                     }
                     eventType = MouseEvent::Down;
                 }
-                if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
-                {
-                    AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Event(
-                        GetViewportId(), &AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Events::SetCursorMode,
-                        AzToolsFramework::CursorInputMode::CursorModeWrapped);
-                }
             }
             else if (state == InputChannel::State::Ended)
             {
@@ -151,13 +132,6 @@ namespace SandboxEditor
                         m_mouseInteraction.m_mouseButtons.m_mouseButtons &= ~mouseButtonValue;
                     }
                     eventType = MouseEvent::Up;
-                }
-                if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
-                {
-                    AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Event(
-                        GetViewportId(), &AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Events::SetCursorMode,
-                        AzToolsFramework::CursorInputMode::CursorModeNone);
-                    m_virtualNormalizedPosition = AZStd::nullopt;
                 }
             }
         }

--- a/Code/Editor/ViewportManipulatorController.h
+++ b/Code/Editor/ViewportManipulatorController.h
@@ -49,6 +49,5 @@ namespace SandboxEditor
 
         AZ::ScriptTimePoint m_currentTime;
         
-        AZStd::optional<AZ::Vector2> m_virtualNormalizedPosition = AZStd::nullopt;
     };
 } // namespace SandboxEditor


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

remove mouse wrap logic in the viewport. I need to revisit this with quite a few other changes before this could work. 

The manipulator has to work in screen space because at the moment its possible to drag far enough where the position for the object is reset to (0, 0, 0).  

ref: https://github.com/o3de/o3de/pull/6497/files

## How was this PR tested?

should pass with existing test cases, verify that dragging in the viewport has not changed. 
