### PR TITLE
bugfix(Whitebox): fix crash when switching modes while dragging manipulator

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorManager.cpp
@@ -67,6 +67,11 @@ namespace AzToolsFramework
             return;
         }
 
+        if (m_activeManipulator && m_activeManipulator->GetManipulatorId() == manipulator->GetManipulatorId())
+        {
+            m_activeManipulator = nullptr;
+        }
+
         m_manipulatorIdToPtrMap.erase(manipulator->GetManipulatorId());
         manipulator->Invalidate();
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorManager.cpp
@@ -69,7 +69,7 @@ namespace AzToolsFramework
 
         if (m_activeManipulator && m_activeManipulator->GetManipulatorId() == manipulator->GetManipulatorId())
         {
-            m_activeManipulator = nullptr;
+            m_activeManipulator.reset();
         }
 
         m_manipulatorIdToPtrMap.erase(manipulator->GetManipulatorId());
@@ -223,14 +223,14 @@ namespace AzToolsFramework
             if (interaction.m_mouseButtons.Left())
             {
                 m_activeManipulator->OnLeftMouseUp(interaction);
-                m_activeManipulator = nullptr;
+                m_activeManipulator.reset();
                 return true;
             }
 
             if (interaction.m_mouseButtons.Right())
             {
                 m_activeManipulator->OnRightMouseUp(interaction);
-                m_activeManipulator = nullptr;
+                m_activeManipulator.reset();
                 return true;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/MultiLinearManipulator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/MultiLinearManipulator.cpp
@@ -51,6 +51,11 @@ namespace AzToolsFramework
         m_onMouseMoveCallback = onMouseMoveCallback;
     }
 
+    void MultiLinearManipulator::InstallInvalidateCallback(const InvalidateActionCallback& onInvalidateCallback)
+    {
+        m_onInvalidateCallback = onInvalidateCallback;
+    }
+
     static MultiLinearManipulator::Action BuildMultiLinearManipulatorAction(
         const AZ::Transform& worldFromLocal,
         const AZ::Vector3& nonUniformScale,
@@ -173,6 +178,11 @@ namespace AzToolsFramework
         for (auto& view : m_manipulatorViews)
         {
             view->Invalidate(GetManipulatorManagerId());
+        }
+
+        if (m_onInvalidateCallback)
+        {
+            m_onInvalidateCallback();
         }
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/MultiLinearManipulator.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/MultiLinearManipulator.h
@@ -49,10 +49,12 @@ namespace AzToolsFramework
         //! This is the function signature of callbacks that will be invoked whenever a MultiLinearManipulator
         //! is clicked on or dragged.
         using MouseActionCallback = AZStd::function<void(const Action&)>;
+        using InvalidateActionCallback = AZStd::function<void()>;
 
         void InstallLeftMouseDownCallback(const MouseActionCallback& onMouseDownCallback);
         void InstallMouseMoveCallback(const MouseActionCallback& onMouseMoveCallback);
         void InstallLeftMouseUpCallback(const MouseActionCallback& onMouseUpCallback);
+        void InstallInvalidateCallback(const InvalidateActionCallback& onInvalidateCallback);
 
         // BaseManipulator ...
         void Draw(
@@ -89,6 +91,7 @@ namespace AzToolsFramework
         MouseActionCallback m_onLeftMouseDownCallback = nullptr;
         MouseActionCallback m_onLeftMouseUpCallback = nullptr;
         MouseActionCallback m_onMouseMoveCallback = nullptr;
+        InvalidateActionCallback m_onInvalidateCallback = nullptr;
 
         ManipulatorViews m_manipulatorViews; //!< Look of manipulator.
     };

--- a/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxVertexTranslationModifier.cpp
+++ b/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxVertexTranslationModifier.cpp
@@ -9,8 +9,10 @@
 #include "SubComponentModes/EditorWhiteBoxDefaultModeBus.h"
 #include "Util/WhiteBoxMathUtil.h"
 #include "Viewport/WhiteBoxModifierUtil.h"
+#include "WhiteBox/WhiteBoxToolApi.h"
 #include "WhiteBoxVertexTranslationModifier.h"
 
+#include <AzCore/Debug/Trace.h>
 #include <AzFramework/Viewport/ViewportScreen.h>
 #include <AzToolsFramework/Manipulators/ManipulatorManager.h>
 #include <AzToolsFramework/Manipulators/ManipulatorView.h>
@@ -127,6 +129,9 @@ namespace WhiteBox
             AZStd::vector<AZStd::pair<AZ::Vector3, AZ::Vector3>> m_edgeBeginEnds;
             // has the modifier moved during the action
             bool m_moved = false;
+            
+            // copy of the whitebox mesh before modifying
+            Api::WhiteBoxMeshPtr m_originalMesh = nullptr; 
         };
 
         auto sharedState = AZStd::make_shared<SharedState>();
@@ -143,6 +148,7 @@ namespace WhiteBox
 
                 sharedState->m_appendStage = AppendStage::None;
                 sharedState->m_moved = false;
+                sharedState->m_originalMesh = Api::CloneMesh(*whiteBox);
                 sharedState->m_edgeBeginEnds.clear();
                 m_actionIndex = InvalidAxisIndex;
 
@@ -214,8 +220,17 @@ namespace WhiteBox
                 WhiteBoxMesh* whiteBox = nullptr;
                 EditorWhiteBoxComponentRequestBus::EventResult(
                     whiteBox, m_entityComponentIdPair, &EditorWhiteBoxComponentRequests::GetWhiteBoxMesh);
-                EditorWhiteBoxComponentRequestBus::Event(m_entityComponentIdPair, &EditorWhiteBoxComponentRequests::DeserializeWhiteBox);
-                
+
+                Api::WhiteBoxMeshStream clondData;
+                if (sharedState->m_originalMesh && Api::ReadMesh(*sharedState->m_originalMesh.get(), clondData) == Api::ReadResult::Full)
+                {
+                    if (!Api::WriteMesh(*whiteBox, clondData))
+                    {
+                        AZ_Error("WhiteBox", false, "failed to restore WhiteBox mesh");
+                    }
+                }
+
+                sharedState->m_originalMesh = nullptr;
                 m_pressTime = 0.0f;
                 m_actionIndex = InvalidAxisIndex;
                 this->AZ::TickBus::Handler::BusDisconnect();
@@ -246,6 +261,7 @@ namespace WhiteBox
                         manipulator->AddAxes(Api::VertexUserEdgeAxes(*whiteBox, m_vertexHandle));
                     }
 
+                    sharedState->m_originalMesh = nullptr;
                     EditorWhiteBoxComponentRequestBus::Event(
                         m_entityComponentIdPair, &EditorWhiteBoxComponentRequests::SerializeWhiteBox);
                 }

--- a/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxVertexTranslationModifier.cpp
+++ b/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxVertexTranslationModifier.cpp
@@ -216,6 +216,8 @@ namespace WhiteBox
                     whiteBox, m_entityComponentIdPair, &EditorWhiteBoxComponentRequests::GetWhiteBoxMesh);
                 EditorWhiteBoxComponentRequestBus::Event(m_entityComponentIdPair, &EditorWhiteBoxComponentRequests::DeserializeWhiteBox);
                 
+                m_pressTime = 0.0f;
+                m_actionIndex = InvalidAxisIndex;
                 this->AZ::TickBus::Handler::BusDisconnect();
             });
 

--- a/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxVertexTranslationModifier.cpp
+++ b/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxVertexTranslationModifier.cpp
@@ -208,6 +208,17 @@ namespace WhiteBox
                 Api::CalculatePlanarUVs(*whiteBox);
             });
 
+        m_translationManipulator->InstallInvalidateCallback(
+            [this, sharedState]()
+            {
+                WhiteBoxMesh* whiteBox = nullptr;
+                EditorWhiteBoxComponentRequestBus::EventResult(
+                    whiteBox, m_entityComponentIdPair, &EditorWhiteBoxComponentRequests::GetWhiteBoxMesh);
+                EditorWhiteBoxComponentRequestBus::Event(m_entityComponentIdPair, &EditorWhiteBoxComponentRequests::DeserializeWhiteBox);
+                
+                this->AZ::TickBus::Handler::BusDisconnect();
+            });
+
         m_translationManipulator->InstallLeftMouseUpCallback(
             [this, sharedState,
              translationManipulator = AZStd::weak_ptr<MultiLinearManipulator>(m_translationManipulator)](

--- a/Gems/WhiteBox/Code/Tests/WhiteBoxComponentTest.cpp
+++ b/Gems/WhiteBox/Code/Tests/WhiteBoxComponentTest.cpp
@@ -253,7 +253,7 @@ namespace UnitTest
         EXPECT_THAT(polygonModifierDetector.m_nextPolygonHandle, Ne(polygonModifierDetector.m_previousPolygonHandle));
     }
 
-    TEST_F(EditorWhiteBoxModifierTestFixture, SwitchToRestoreModeDestroysModiferWhileInteracting)
+    TEST_F(EditorWhiteBoxModifierTestFixture, SwitchToRestoreModeDestroysModifierWhileInteractingWithFace)
     {
         namespace Api = WhiteBox::Api;
         using AzToolsFramework::ViewportInteraction::KeyboardModifier;
@@ -346,6 +346,96 @@ namespace UnitTest
             ->ExpectEq(subMode(), WhiteBox::SubMode::Default);
     }
 
+    TEST_F(EditorWhiteBoxModifierTestFixture, SwitchToRestoreModeDestroysModifierWhileInteractingWithVertex)
+    {
+        namespace Api = WhiteBox::Api;
+        using AzToolsFramework::ViewportInteraction::KeyboardModifier;
+
+        const auto entityComponentIdPair = AZ::EntityComponentIdPair(m_whiteBoxEntityId, m_whiteBoxComponent->GetId());
+
+        const auto displayEntityViewport = [whiteBoxEntityId = m_whiteBoxEntityId]()
+        {
+            AzFramework::EntityDebugDisplayEventBus::Event(
+                whiteBoxEntityId, &AzFramework::EntityDebugDisplayEvents::DisplayEntityViewport,
+                AzFramework::ViewportInfo{0}, NullDebugDisplayRequests{});
+        };
+
+        // helper to check which submode we're in
+        const auto subMode = [entityComponentIdPair]()
+        {
+            WhiteBox::SubMode subMode;
+            WhiteBox::EditorWhiteBoxComponentModeRequestBus::EventResult(
+                subMode, entityComponentIdPair,
+                &WhiteBox::EditorWhiteBoxComponentModeRequestBus::Events::GetCurrentSubMode);
+            return subMode;
+        };
+
+        // the initial starting position of the entity (in front of and just below the camera)
+        const AZ::Transform initialEntityTransformWorld =
+            AZ::Transform::CreateTranslation(AZ::Vector3(0.0f, 7.0f, 23.0f));
+
+        // grab the White Box Mesh (for use with the White Box Tool Api)
+        WhiteBox::WhiteBoxMesh* whiteBox = nullptr;
+        WhiteBox::EditorWhiteBoxComponentRequestBus::EventResult(
+            whiteBox, entityComponentIdPair, &WhiteBox::EditorWhiteBoxComponentRequestBus::Events::GetWhiteBoxMesh);
+
+        // move the entity to its starting position
+        AzToolsFramework::SetWorldTransform(m_whiteBoxEntityId, initialEntityTransformWorld);
+        // select the entity with the White Box Component
+        AzToolsFramework::SelectEntity(m_whiteBoxEntityId);
+        // mimic pressing the 'Edit' button on the Component Card
+        EnterComponentMode<WhiteBox::EditorWhiteBoxComponent>();
+
+        // override the default modifier key behavior for the white box component mode
+        WhiteBox::EditorWhiteBoxComponentModeRequestBus::Event(
+            entityComponentIdPair,
+            &WhiteBox::EditorWhiteBoxComponentModeRequestBus::Events::OverrideKeyboardModifierQuery,
+            [this]()
+            {
+                return m_actionDispatcher->QueryKeyboardModifiers();
+            });
+
+        AzFramework::SetCameraTransform(
+            m_cameraState,
+            AZ::Transform::CreateFromMatrix3x3AndTranslation(
+                AZ::Matrix3x3::CreateRotationX(AZ::DegToRad(-45.0f)), AZ::Vector3(0.0f, 4.0f, 26.0f)));
+
+        const AZ::Vector3 vertexLocalPosition = Api::VertexPosition(*whiteBox, Api::VertexHandle(1)); 
+        const AZ::Vector3 topPolygonNextPositionLocal = vertexLocalPosition + AZ::Vector3::CreateAxisZ(0.5f);
+
+        // the middle of the top
+        MultiSpacePoint topPolygonMidpoint(vertexLocalPosition, initialEntityTransformWorld, m_cameraState);
+        MultiSpacePoint topPolygonNext(topPolygonNextPositionLocal, initialEntityTransformWorld, m_cameraState);
+
+        // begin interacting with a polygon and then use the modifier keys to
+        // mimic transitioning to restore mode
+        m_actionDispatcher->CameraState(m_cameraState)
+            ->MousePosition(topPolygonMidpoint.GetScreenSpace())
+            ->MouseLButtonDown()
+            ->MousePosition(topPolygonNext.GetScreenSpace())
+            ->KeyboardModifierDown(KeyboardModifier::Ctrl)
+            ->KeyboardModifierDown(KeyboardModifier::Shift)
+            // trigger moving to RestoreMode (handled in Display of EditorWhiteBoxComponentMode)
+            ->ExecuteBlock(
+                [displayEntityViewport]()
+                {
+                    displayEntityViewport();
+                })
+            ->ExpectEq(subMode(), WhiteBox::SubMode::EdgeRestore)
+            // continue trying to move in RestoreMode
+            ->MousePosition(topPolygonMidpoint.GetScreenSpace())
+            ->MouseLButtonUp()
+            ->KeyboardModifierUp(KeyboardModifier::Ctrl)
+            ->KeyboardModifierUp(KeyboardModifier::Shift)
+            // run update/draw logic again to change modes
+            ->ExecuteBlock(
+                [displayEntityViewport]()
+                {
+                    displayEntityViewport();
+                })
+            // verify we are back in DefaultMode
+            ->ExpectEq(subMode(), WhiteBox::SubMode::Default);
+    }
     TEST_F(EditorWhiteBoxModifierTestFixture, SelectedVertexModifierIsCleanedUpAfterDefaultShapeChange)
     {
         namespace Api = WhiteBox::Api;


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/10543

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

the active manipulator is getting called while the defaultMode is freed when switching mode. The active manipulator has just been freed causing a crash when the user releases the mouse button which causes MouseUpCallback to be called into freed memory.  This change will clear the active manipulator and adds logic to restore the mesh to the last serialized state so this should just clear the action that the user was just starting.  

## How was this PR tested?

follow the steps with the referenced ticket. 
