### PR TITLE
feat: add DrawPolyLine that accepts a span instead of a pointer and a size

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Entity/EntityDebugDisplayBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Entity/EntityDebugDisplayBus.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/base.h>
+#include <AzCore/std/containers/span.h>
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Math/Aabb.h>
 #include <AzCore/Math/Vector2.h>
@@ -62,6 +63,7 @@ namespace AzFramework
         virtual void DrawLine(const AZ::Vector3& p1, const AZ::Vector3& p2, const AZ::Vector4& col1, const AZ::Vector4& col2) { (void)p1; (void)p2; (void)col1; (void)col2; }
         virtual void DrawLines(const AZStd::vector<AZ::Vector3>& lines, const AZ::Color& color) { (void)lines; (void)color; }
         virtual void DrawPolyLine(const AZ::Vector3* pnts, int numPoints, bool cycled = true) { (void)pnts; (void)numPoints; (void)cycled; }
+        virtual void DrawPolyLine(AZStd::span<const AZ::Vector3> points, bool cycled = true) { (void)points; (void)cycled; }
         virtual void DrawWireQuad2d(const AZ::Vector2& p1, const AZ::Vector2& p2, float z) { (void)p1; (void)p2; (void)z; }
         virtual void DrawLine2d(const AZ::Vector2& p1, const AZ::Vector2& p2, float z) { (void)p1; (void)p2; (void)z; }
         virtual void DrawLine2dGradient(const AZ::Vector2& p1, const AZ::Vector2& p2, float z, const AZ::Vector4& firstColor, const AZ::Vector4& secondColor) { (void)p1; (void)p2; (void)z; (void)firstColor; (void)secondColor; }

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
@@ -705,26 +705,7 @@ namespace AZ::AtomBridge
 
     void AtomDebugDisplayViewportInterface::DrawPolyLine(const AZ::Vector3* pnts, int numPoints, bool cycled)
     {
-        if (m_auxGeomPtr)
-        {
-            AZStd::vector<AZ::Vector3> wsPoints(static_cast<size_t>(numPoints));
-            for (int index = 0; index < numPoints; ++index)
-            {
-                wsPoints[index] = ToWorldSpacePosition(pnts[index]);
-            }
-            AZ::RPI::AuxGeomDraw::PolylineEnd polylineEnd = cycled ? AZ::RPI::AuxGeomDraw::PolylineEnd::Closed : AZ::RPI::AuxGeomDraw::PolylineEnd::Open;
-            AZ::RPI::AuxGeomDraw::AuxGeomDynamicDrawArguments drawArgs;
-            drawArgs.m_verts = wsPoints.data();
-            drawArgs.m_vertCount = aznumeric_cast<uint32_t>(numPoints);
-            drawArgs.m_colors = &m_rendState.m_color;
-            drawArgs.m_colorCount = 1;
-            drawArgs.m_size = m_rendState.m_lineWidth;
-            drawArgs.m_opacityType = m_rendState.m_opacityType;
-            drawArgs.m_depthTest = m_rendState.m_depthTest;
-            drawArgs.m_depthWrite = m_rendState.m_depthWrite;
-            drawArgs.m_viewProjectionOverrideIndex = m_rendState.m_viewProjOverrideIndex;
-            m_auxGeomPtr->DrawPolylines(drawArgs, polylineEnd);
-        }
+        DrawPolyLine(AZStd::span<const AZ::Vector3>(pnts, numPoints), cycled);
     }
 
     void AtomDebugDisplayViewportInterface::DrawWireQuad2d(const AZ::Vector2& p1, const AZ::Vector2& p2, float z)

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
@@ -691,7 +691,7 @@ namespace AZ::AtomBridge
             AZ::RPI::AuxGeomDraw::PolylineEnd polylineEnd = cycled ? AZ::RPI::AuxGeomDraw::PolylineEnd::Closed : AZ::RPI::AuxGeomDraw::PolylineEnd::Open;
             AZ::RPI::AuxGeomDraw::AuxGeomDynamicDrawArguments drawArgs;
             drawArgs.m_verts = wsPoints.data();
-            drawArgs.m_vertCount = wsPoints.size();
+            drawArgs.m_vertCount = aznumeric_cast <uint32_t>(wsPoints.size());
             drawArgs.m_colors = &m_rendState.m_color;
             drawArgs.m_colorCount = 1;
             drawArgs.m_size = m_rendState.m_lineWidth;

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.h
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.h
@@ -154,6 +154,7 @@ namespace AZ::AtomBridge
         void DrawLine(const AZ::Vector3& p1, const AZ::Vector3& p2, const AZ::Vector4& col1, const AZ::Vector4& col2) override;
         void DrawLines(const AZStd::vector<AZ::Vector3>& lines, const AZ::Color& color) override;
         void DrawPolyLine(const AZ::Vector3* pnts, int numPoints, bool cycled = true) override;
+        void DrawPolyLine(AZStd::span<const AZ::Vector3>, bool cycled = true) override;
         void DrawWireQuad2d(const AZ::Vector2& p1, const AZ::Vector2& p2, float z) override;
         void DrawLine2d(const AZ::Vector2& p1, const AZ::Vector2& p2, float z) override;
         void DrawLine2dGradient(const AZ::Vector2& p1, const AZ::Vector2& p2, float z, const AZ::Vector4& firstColor, const AZ::Vector4& secondColor) override;


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

when I was working on this change: https://github.com/o3de/o3de/pull/9925. I would rather of passed a vector then the beginning and a size into this method. This is just a minor tweak to the API to avoid passing in a raw pointer.
