### PR TITLE
Fixed rigid body reflection that was causing asserts in game mode

### DIFF
--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
@@ -326,7 +326,6 @@ namespace PhysX
     void EditorRigidBodyComponent::Reflect(AZ::ReflectContext* context)
     {
         EditorRigidBodyConfiguration::Reflect(context);
-        RigidBodyConfiguration::Reflect(context);
 
         auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
         if (serializeContext)

--- a/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
@@ -26,6 +26,7 @@ namespace PhysX
     void RigidBodyComponent::Reflect(AZ::ReflectContext* context)
     {
         RigidBody::Reflect(context);
+        RigidBodyConfiguration::Reflect(context);
 
         AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
         if (serializeContext)


### PR DESCRIPTION
Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>

## What does this PR do?

Fixes a bug where RigidBodyConfiguration wasn't reflected in game mode thus causing assert on every RigidBody entity throwing an assert at runtime

## How was this PR tested?

Tested manually in a project that was reproing the issue.
