### PR TITLE
Increasing timeout in automated tests that verify level save

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/BasicEditorWorkflows_LevelEntityComponentCRUD.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/BasicEditorWorkflows_LevelEntityComponentCRUD.py
@@ -143,7 +143,6 @@ def BasicEditorWorkflows_LevelEntityComponentCRUD():
                                                                   "Box Shape|Box Configuration|Dimensions")
         Report.result(Tests.component_updated, box_shape_dimensions == dimensions_to_set)
 
-
         # Remove the component
         child_entity.remove_component("Box Shape")
         component_rem_success = await pyside_utils.wait_for_condition(lambda: not hydra.has_components(child_entity.id,
@@ -156,7 +155,7 @@ def BasicEditorWorkflows_LevelEntityComponentCRUD():
 
         # 5) Verify the save/export of the level
         level_prefab_path = os.path.join(paths.products, "levels", lvl_name, f"{lvl_name}.spawnable")
-        success = await pyside_utils.wait_for_condition(lambda: os.path.exists(level_prefab_path), 5.0)
+        success = await pyside_utils.wait_for_condition(lambda: os.path.exists(level_prefab_path), 10.0)
         Report.result(Tests.saved_and_exported, success)
 
     run_test()

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/LayerBlender_E2E_Editor.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/LayerBlender_E2E_Editor.py
@@ -151,7 +151,7 @@ def LayerBlender_E2E_Editor():
     # 6) Save the created level
     general.save_level()
     level_prefab_path = os.path.join(paths.products, "levels", lvl_name, f"{lvl_name}.spawnable")
-    success = helper.wait_for_condition(lambda: os.path.exists(level_prefab_path), 5.0)
+    success = helper.wait_for_condition(lambda: os.path.exists(level_prefab_path), 10.0)
     Report.result(Tests.saved_and_exported, success)
 
 

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PrefabInstanceSpawner_Embedded_E2E.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PrefabInstanceSpawner_Embedded_E2E.py
@@ -110,7 +110,7 @@ def PrefabInstanceSpawner_Embedded_E2E():
     # 6) Save the created level
     general.save_level()
     level_prefab_path = os.path.join(paths.products, "levels", lvl_name, f"{lvl_name}.spawnable")
-    success = helper.wait_for_condition(lambda: os.path.exists(level_prefab_path), 5.0)
+    success = helper.wait_for_condition(lambda: os.path.exists(level_prefab_path), 10.0)
     Report.result(Tests.saved_and_exported, success)
 
 

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PrefabInstanceSpawner_External_E2E.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PrefabInstanceSpawner_External_E2E.py
@@ -131,7 +131,7 @@ def PrefabInstanceSpawner_External_E2E():
     # 6) Save the created level
     general.save_level()
     level_prefab_path = os.path.join(paths.products, "levels", lvl_name, f"{lvl_name}.spawnable")
-    success = helper.wait_for_condition(lambda: os.path.exists(level_prefab_path), 5.0)
+    success = helper.wait_for_condition(lambda: os.path.exists(level_prefab_path), 10.0)
     Report.result(Tests.saved_and_exported, success)
 
 


### PR DESCRIPTION
Signed-off-by: jckand-amzn <82226555+jckand-amzn@users.noreply.github.com>

Increases the timeout to 10s for tests that verify a spawnable is properly processed on level save. These tests have intermittently failed to find the spawnable after the previously set 5s.

## How was this PR tested?

Ran all updated tests locally without issue.
