### PR TITLE
P1 null render tests for PostFX Radius Weight Modifier

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
@@ -1098,13 +1098,15 @@ class AtomComponentProperties:
         """
         PostFX Radius Weight Modifier component properties. Requires PostFX Layer component.
           - 'requires' a list of component names as strings required by this component.
-            Use editor_entity_utils EditorEntity.add_components(list) to add this list of requirements.\n
+            Use editor_entity_utils EditorEntity.add_components(list) to add this list of requirements.
+          - 'Radius' Radius of the PostFX modification (float deafult 0.0 to inf)
         :param property: From the last element of the property tree path. Default 'name' for component name string.
         :return: Full property path OR component name if no property specified.
         """
         properties = {
             'name': 'PostFX Radius Weight Modifier',
             'requires': [AtomComponentProperties.postfx_layer()],
+            'Radius': 'Controller|Configuration|Radius',
         }
         return properties[property]
 

--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
@@ -1099,7 +1099,7 @@ class AtomComponentProperties:
         PostFX Radius Weight Modifier component properties. Requires PostFX Layer component.
           - 'requires' a list of component names as strings required by this component.
             Use editor_entity_utils EditorEntity.add_components(list) to add this list of requirements.
-          - 'Radius' Radius of the PostFX modification (float deafult 0.0 to inf)
+          - 'Radius' Radius of the PostFX modification (float deafult 0.0 to infinity)
         :param property: From the last element of the property tree path. Default 'name' for component name string.
         :return: Full property path OR component name if no property specified.
         """

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFXRadiusWeightModifierAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFXRadiusWeightModifierAdded.py
@@ -72,7 +72,7 @@ def AtomEditorComponents_PostFXRadiusWeightModifier_AddedToEntity():
     Test Steps:
     1) Create a Post FX Radius Weight Modifier entity with no components.
     2) Add Post FX Radius Weight Modifier component to Post FX Radius Weight Modifier entity.
-    3) Remove PostFX Radisu Weight Modifier component.
+    3) Remove PostFX Radius Weight Modifier component.
     4) UNDO the component removal.
     5) Verify PostFX Radius Weight Modifier component not enabled.
     6) Add PostFX Layer component since it is required by the PostFX Radius Weight Modifier component.
@@ -112,7 +112,7 @@ def AtomEditorComponents_PostFXRadiusWeightModifier_AddedToEntity():
             Tests.postfx_radius_weight_component,
             postfx_radius_weight_entity.has_component(AtomComponentProperties.postfx_radius()))
 
-        # 3. Remove PostFX Radisu Weight Modifier component
+        # 3. Remove PostFX Radius Weight Modifier component
         postfx_radius_component.remove()
         general.idle_wait_frames(1)
         Report.result(

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFXRadiusWeightModifierAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFXRadiusWeightModifierAdded.py
@@ -8,46 +8,52 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 class Tests:
     creation_undo = (
         "UNDO Entity creation success",
-        "UNDO Entity creation failed")
+        "P0: UNDO Entity creation failed")
     creation_redo = (
         "REDO Entity creation success",
-        "REDO Entity creation failed")
+        "P0: REDO Entity creation failed")
     postfx_radius_weight_creation = (
         "PostFX Radius Weight Modifier Entity successfully created",
-        "PostFX Radius Weight Modifier Entity failed to be created")
+        "P0: PostFX Radius Weight Modifier Entity failed to be created")
     postfx_radius_weight_component = (
         "Entity has a PostFX Radius Weight Modifier component",
-        "Entity failed to find PostFX Radius Weight Modifier component")
+        "P0: Entity failed to find PostFX Radius Weight Modifier component")
     postfx_radius_weight_disabled = (
         "PostFX Radius Weight Modifier component disabled",
-        "PostFX Radius Weight Modifier component was not disabled.")
+        "P0: PostFX Radius Weight Modifier component was not disabled.")
     postfx_layer_component = (
         "Entity has a PostFX Layer component",
-        "Entity did not have an PostFX Layer component")
+        "P0: Entity did not have an PostFX Layer component")
     postfx_radius_weight_enabled = (
         "PostFX Radius Weight Modifier component enabled",
-        "PostFX Radius Weight Modifier component was not enabled.")
+        "P0: PostFX Radius Weight Modifier component was not enabled.")
+    postfx_layer_component_removed = (
+        "PostFX Radius Weight Modifier component was removed successfully",
+        "P0: PostFX Radius Weigth Modifier component failed to be removed")
+    radius = (
+        "Radius property set successfully",
+        "P1: Radius property failed to set")
     enter_game_mode = (
         "Entered game mode",
-        "Failed to enter game mode")
+        "P0: Failed to enter game mode")
     exit_game_mode = (
         "Exited game mode",
-        "Couldn't exit game mode")
+        "P0: Couldn't exit game mode")
     is_visible = (
         "Entity is visible",
-        "Entity was not visible")
+        "P0: Entity was not visible")
     is_hidden = (
         "Entity is hidden",
-        "Entity was not hidden")
+        "P0: Entity was not hidden")
     entity_deleted = (
         "Entity deleted",
-        "Entity was not deleted")
+        "P0: Entity was not deleted")
     deletion_undo = (
         "UNDO deletion success",
-        "UNDO deletion failed")
+        "P0: UNDO deletion failed")
     deletion_redo = (
         "REDO deletion success",
-        "REDO deletion failed")
+        "P0: REDO deletion failed")
 
 
 def AtomEditorComponents_PostFXRadiusWeightModifier_AddedToEntity():
@@ -66,18 +72,19 @@ def AtomEditorComponents_PostFXRadiusWeightModifier_AddedToEntity():
     Test Steps:
     1) Create a Post FX Radius Weight Modifier entity with no components.
     2) Add Post FX Radius Weight Modifier component to Post FX Radius Weight Modifier entity.
-    3) UNDO the entity creation and component addition.
-    4) REDO the entity creation and component addition.
+    3) Remove PostFX Radisu Weight Modifier component.
+    4) UNDO the component removal.
     5) Verify PostFX Radius Weight Modifier component not enabled.
     6) Add PostFX Layer component since it is required by the PostFX Radius Weight Modifier component.
     7) Verify PostFX Radius Weight Modifier component is enabled.
-    8) Enter/Exit game mode.
-    9) Test IsHidden.
-    10) Test IsVisible.
-    11) Delete PostFX Radius Weight Modifier entity.
-    12) UNDO deletion.
-    13) REDO deletion.
-    14) Look for errors.
+    8) Set Radius property
+    9) Enter/Exit game mode.
+    10) Test IsHidden.
+    11) Test IsVisible.
+    12) Delete PostFX Radius Weight Modifier entity.
+    13) UNDO deletion.
+    14) REDO deletion.
+    15) Look for errors.
 
     :return: None
     """
@@ -105,29 +112,19 @@ def AtomEditorComponents_PostFXRadiusWeightModifier_AddedToEntity():
             Tests.postfx_radius_weight_component,
             postfx_radius_weight_entity.has_component(AtomComponentProperties.postfx_radius()))
 
-        # 3. UNDO the entity creation and component addition.
-        # -> UNDO component addition.
-        general.undo()
-        # -> UNDO naming entity.
-        general.undo()
-        # -> UNDO selecting entity.
-        general.undo()
-        # -> UNDO entity creation.
-        general.undo()
+        # 3. Remove PostFX Radisu Weight Modifier component
+        postfx_radius_component.remove()
         general.idle_wait_frames(1)
-        Report.result(Tests.creation_undo, not postfx_radius_weight_entity.exists())
+        Report.result(
+            Tests.postfx_layer_component_removed,
+            not postfx_radius_weight_entity.has_component(AtomComponentProperties.postfx_radius()))
 
-        # 4. REDO the entity creation and component addition.
-        # -> REDO entity creation.
-        general.redo()
-        # -> REDO selecting entity.
-        general.redo()
-        # -> REDO naming entity.
-        general.redo()
-        # -> REDO component addition.
-        general.redo()
+        # 4. UNDO the component removal.
+        general.undo()
         general.idle_wait_frames(1)
-        Report.result(Tests.creation_redo, postfx_radius_weight_entity.exists())
+        Report.critical_result(
+            Tests.postfx_radius_weight_component,
+            postfx_radius_weight_entity.has_component(AtomComponentProperties.postfx_radius()))
 
         # 5. Verify PostFX Radius Weight Modifier component not enabled.
         Report.result(Tests.postfx_radius_weight_disabled, not postfx_radius_component.is_enabled())
@@ -141,35 +138,42 @@ def AtomEditorComponents_PostFXRadiusWeightModifier_AddedToEntity():
         # 7. Verify PostFX Radius Weight Modifier component is enabled.
         Report.result(Tests.postfx_radius_weight_enabled, postfx_radius_component.is_enabled())
 
-        # 8. Enter/Exit game mode.
+        # 8. Set Radius property
+        postfx_radius_component.set_component_property_value(AtomComponentProperties.postfx_radius('Radius'), 100.0)
+        Report.result(
+            Tests.radius,
+            postfx_radius_component.get_component_property_value(
+                AtomComponentProperties.postfx_radius('Radius')) == 100.0)
+
+        # 9. Enter/Exit game mode.
         TestHelper.enter_game_mode(Tests.enter_game_mode)
         general.idle_wait_frames(1)
         TestHelper.exit_game_mode(Tests.exit_game_mode)
 
-        # 9. Test IsHidden.
+        # 10. Test IsHidden.
         postfx_radius_weight_entity.set_visibility_state(False)
         Report.result(Tests.is_hidden, postfx_radius_weight_entity.is_hidden() is True)
 
-        # 10. Test IsVisible.
+        # 11. Test IsVisible.
         postfx_radius_weight_entity.set_visibility_state(True)
         general.idle_wait_frames(1)
         Report.result(Tests.is_visible, postfx_radius_weight_entity.is_visible() is True)
 
-        # 11. Delete PostFX Radius Weight Modifier entity.
+        # 12. Delete PostFX Radius Weight Modifier entity.
         postfx_radius_weight_entity.delete()
         Report.result(Tests.entity_deleted, not postfx_radius_weight_entity.exists())
 
-        # 12. UNDO deletion.
+        # 13. UNDO deletion.
         general.undo()
         general.idle_wait_frames(1)
         Report.result(Tests.deletion_undo, postfx_radius_weight_entity.exists())
 
-        # 13. REDO deletion.
+        # 14. REDO deletion.
         general.redo()
         general.idle_wait_frames(1)
         Report.result(Tests.deletion_redo, not postfx_radius_weight_entity.exists())
 
-        # 14. Look for errors and asserts.
+        # 15. Look for errors and asserts.
         TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
         for error_info in error_tracer.errors:
             Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")


### PR DESCRIPTION
Signed-off-by: Scott Murray <scottmur@amazon.com>

## What does this PR do?
Adds P1 null render tests for PostFX Radius Weight Component namely the radius property is exercised.

## How was this PR tested?
```
Report:
[SUCCESS] Success: PostFX Radius Weight Modifier Entity successfully created
[SUCCESS] Success: Entity has a PostFX Radius Weight Modifier component
[SUCCESS] Success: PostFX Radius Weight Modifier component was removed successfully
[SUCCESS] Success: Entity has a PostFX Radius Weight Modifier component
[SUCCESS] Success: PostFX Radius Weight Modifier component disabled
[SUCCESS] Success: Entity has a PostFX Layer component
[SUCCESS] Success: PostFX Radius Weight Modifier component enabled
[SUCCESS] Success: Radius property set successfully
[SUCCESS] Success: Entered game mode
[SUCCESS] Success: Exited game mode
[SUCCESS] Success: Entity is hidden
[SUCCESS] Success: Entity is visible
[SUCCESS] Success: Entity deleted
[SUCCESS] Success: UNDO deletion success
[SUCCESS] Success: REDO deletion success
Test result:  SUCCESS
```
```
    Start 167: AutomatedTesting::Atom_Main_Null_Render_03.main::TEST_RUN
1/4 Test #167: AutomatedTesting::Atom_Main_Null_Render_03.main::TEST_RUN ...   Passed   45.60 sec
    Start 166: AutomatedTesting::Atom_Main_Null_Render_02.main::TEST_RUN
2/4 Test #166: AutomatedTesting::Atom_Main_Null_Render_02.main::TEST_RUN ...   Passed   51.52 sec
    Start 165: AutomatedTesting::Atom_Main_Null_Render_01.main::TEST_RUN
3/4 Test #165: AutomatedTesting::Atom_Main_Null_Render_01.main::TEST_RUN ...   Passed   41.45 sec
    Start 164: AutomatedTesting::Atom_Main_Null_Render_00.main::TEST_RUN
4/4 Test #164: AutomatedTesting::Atom_Main_Null_Render_00.main::TEST_RUN ...   Passed   35.32 sec
```