### PR TITLE
Update reflection of optional<T>::value_or to copy its return value

### DIFF
--- a/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflection.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflection.inl
@@ -1098,7 +1098,7 @@ namespace AZ
                     AZ_Assert(false, "Optional does not have a value, a default constructed value will be returned instead");
                     return typename OptionalType::value_type{};
                 };
-                auto valueOrFunc = [](OptionalType* optionalInst, const typename OptionalType::value_type& defaultValue) -> const typename OptionalType::value_type&
+                auto valueOrFunc = [](OptionalType* optionalInst, const typename OptionalType::value_type& defaultValue) -> typename OptionalType::value_type
                 {
                     return optionalInst->has_value() ? optionalInst->value() : defaultValue;
                 };


### PR DESCRIPTION
The LuaScriptCaller does not copy const ref return values when executing
methods. In the case of `optional<T>::value_or`, it is possible for one
of its parameters to be its return value. In this case, the LuaScriptCaller
will allocate a new variable for the parameter, then clean up the value
used for the parameter and the value used for the return. If the return
value is the same as one of the parameters, it results in a double free.

This fixes the issue for `optional<T>::value_or` by forcing a copy of the
return value to take place.

Signed-off-by: Chris Burel <burelc@amazon.com>

```cpp
#include <AzCore/IO/ByteContainerStream.h>
#include <AzCore/Memory/Memory.h>
#include <AzCore/Memory/SystemAllocator.h>
#include <AzCore/RTTI/BehaviorContext.h>
#include <AzCore/Script/ScriptContext.h>

class MyClass final
{
public:
    AZ_RTTI(MyClass, "{78A22A17-B8CD-415C-BCC8-5F30EA41BE3A}");
    const AZStd::string& value(const AZStd::string& value) const { return value; }
    static void Reflect(AZ::BehaviorContext* bc)
    {
        bc->Class<MyClass>("MyClass")->Method("value", &MyClass::value);
    }
};

int main()
{
    AZ::AllocatorInstance<AZ::SystemAllocator>::Create();
    {
        AZ::BehaviorContext bc;
        MyClass::Reflect(&bc);

        AZ::ScriptContext script;
        script.BindTo(&bc);
        AZStd::string scrip{R"(MyClass():value("mystr"))"};
        AZ::IO::ByteContainerStream<AZStd::string> stream(&scrip);
        script.LoadFromStream(&stream, "accessingOptionalValueOrCausesDoubleFree", "t");
        script.Execute();
    }
    AZ::AllocatorInstance<AZ::SystemAllocator>::Destroy();

    return 0;
}

```

```
==56152==ERROR: AddressSanitizer: heap-use-after-free on address 0x11b6d22a28b0 at pc 0x7ff6340e0dc6 bp 0x00869c5bc050 sp 0x00869c5bc058
READ of size 4 at 0x11b6d22a28b0 thread T0
    #0 0x7ff6340e0dc5 in AZ::MallocSchema::DeAllocate(void *, unsigned __int64, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\Memory\MallocSchema.cpp:96
    #1 0x7ff6341291a8 in AZ::SystemAllocator::DeAllocate(void *, unsigned __int64, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\Memory\SystemAllocator.cpp:255
    #2 0x7ff633bf80a9 in AZStd::allocator::deallocate(void *, unsigned __int64, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\std\allocator.cpp:30
    #3 0x7ff633a3101a in AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>::deallocate_memory(char *, unsigned __int64, struct std::integral_constant<bool, 0> const &) E:\ws\main\Code\Framework\AzCore\AzCore\std\string\string.h:1672
    #4 0x7ff633a0433f in AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>::~basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>(void) E:\ws\main\Code\Framework\AzCore\AzCore\std\string\string.h:166
    #5 0x7ff633eb26a6 in AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>::`scalar deleting dtor'(unsigned int) (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x1404f26a6)
    #6 0x7ff63432e849 in AZ::BehaviorContext::DefaultDestruct<class AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>>(void *, void *) E:\ws\main\Code\Framework\AzCore\AzCore\RTTI\BehaviorContext.h:1564
    #7 0x7ff634575acc in AZ::LuaScriptCaller::Call(struct lua_State *) E:\ws\main\Code\Framework\AzCore\AzCore\Script\ScriptContext.cpp:3605
    #8 0x7ff636431aa6 in lua_yieldk (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a71aa6)
    #9 0x7ff63641f423 in fprintf (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a5f423)
    #10 0x7ff63642aeb2 in luaL_where (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a6aeb2)
    #11 0x7ff63641eea7 in fprintf (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a5eea7)
    #12 0x7ff63641f952 in fprintf (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a5f952)
    #13 0x7ff63642e4ad in lua_pcallk (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a6e4ad)
    #14 0x7ff6342b4756 in AZ::Internal::LuaSafeCall(struct lua_State *, int, int) E:\ws\main\Code\Framework\AzCore\AzCore\Script\ScriptContext.cpp:616
    #15 0x7ff634589780 in AZ::ScriptContextImpl::Execute(char const *, char const *, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\Script\ScriptContext.cpp:5656
    #16 0x7ff6342b6ce3 in AZ::ScriptContext::Execute(char const *, char const *, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\Script\ScriptContext.cpp:5888
    #17 0x7ff6339ccb6c in main E:\ws\main\accessingOptionalValueOrCausesDoubleFree.cpp:38
    #18 0x7ff63648bd58 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #19 0x7ff63648bcad in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #20 0x7ff63648bb6d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #21 0x7ff63648bdcd in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16
    #22 0x7ffee41354df  (C:\WINDOWS\System32\KERNEL32.DLL+0x1800154df)
    #23 0x7ffee444485a  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18000485a)

0x11b6d22a28b0 is located 0 bytes inside of 42-byte region [0x11b6d22a28b0,0x11b6d22a28da)
freed by thread T0 here:
    #0 0x7ffe83b6ee12  (E:\ws\main\ninja-cl-debug-2019\bin\debug\clang_rt.asan_dbg_dynamic-x86_64.dll+0x18004ee12)
    #1 0x7ff6340e0e4c in AZ::MallocSchema::DeAllocate(void *, unsigned __int64, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\Memory\MallocSchema.cpp:99
    #2 0x7ff6341291a8 in AZ::SystemAllocator::DeAllocate(void *, unsigned __int64, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\Memory\SystemAllocator.cpp:255
    #3 0x7ff633bf80a9 in AZStd::allocator::deallocate(void *, unsigned __int64, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\std\allocator.cpp:30
    #4 0x7ff633a3101a in AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>::deallocate_memory(char *, unsigned __int64, struct std::integral_constant<bool, 0> const &) E:\ws\main\Code\Framework\AzCore\AzCore\std\string\string.h:1672
    #5 0x7ff633a0433f in AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>::~basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>(void) E:\ws\main\Code\Framework\AzCore\AzCore\std\string\string.h:166
    #6 0x7ff633eb26a6 in AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>::`scalar deleting dtor'(unsigned int) (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x1404f26a6)
    #7 0x7ff63432e849 in AZ::BehaviorContext::DefaultDestruct<class AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>>(void *, void *) E:\ws\main\Code\Framework\AzCore\AzCore\RTTI\BehaviorContext.h:1564
    #8 0x7ff6345758ae in AZ::LuaScriptCaller::Call(struct lua_State *) E:\ws\main\Code\Framework\AzCore\AzCore\Script\ScriptContext.cpp:3581
    #9 0x7ff636431aa6 in lua_yieldk (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a71aa6)
    #10 0x7ff63641f423 in fprintf (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a5f423)
    #11 0x7ff63642aeb2 in luaL_where (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a6aeb2)
    #12 0x7ff63641eea7 in fprintf (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a5eea7)
    #13 0x7ff63641f952 in fprintf (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a5f952)
    #14 0x7ff63642e4ad in lua_pcallk (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a6e4ad)
    #15 0x7ff6342b4756 in AZ::Internal::LuaSafeCall(struct lua_State *, int, int) E:\ws\main\Code\Framework\AzCore\AzCore\Script\ScriptContext.cpp:616
    #16 0x7ff634589780 in AZ::ScriptContextImpl::Execute(char const *, char const *, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\Script\ScriptContext.cpp:5656
    #17 0x7ff6342b6ce3 in AZ::ScriptContext::Execute(char const *, char const *, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\Script\ScriptContext.cpp:5888
    #18 0x7ff6339ccb6c in main E:\ws\main\accessingOptionalValueOrCausesDoubleFree.cpp:38
    #19 0x7ff63648bd58 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #20 0x7ff63648bcad in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #21 0x7ff63648bb6d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #22 0x7ff63648bdcd in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16
    #23 0x7ffee41354df  (C:\WINDOWS\System32\KERNEL32.DLL+0x1800154df)
    #24 0x7ffee444485a  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18000485a)

previously allocated by thread T0 here:
    #0 0x7ffe83b6ef9e  (E:\ws\main\ninja-cl-debug-2019\bin\debug\clang_rt.asan_dbg_dynamic-x86_64.dll+0x18004ef9e)
    #1 0x7ff6340e0b61 in AZ::MallocSchema::Allocate(unsigned __int64, unsigned __int64, int, char const *, char const *, int, unsigned int) E:\ws\main\Code\Framework\AzCore\AzCore\Memory\MallocSchema.cpp:71
    #2 0x7ff634128ab2 in AZ::SystemAllocator::Allocate(unsigned __int64, unsigned __int64, int, char const *, char const *, int, unsigned int) E:\ws\main\Code\Framework\AzCore\AzCore\Memory\SystemAllocator.cpp:220
    #3 0x7ff633bf7fab in AZStd::allocator::allocate(unsigned __int64, unsigned __int64, int) E:\ws\main\Code\Framework\AzCore\AzCore\std\allocator.cpp:21
    #4 0x7ff633a30844 in AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>::copy(unsigned __int64, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\std\string\string.h:1624
    #5 0x7ff633a3aa86 in AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>::grow(unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\std\string\string.h:1648
    #6 0x7ff633a2af29 in AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>::assign(char const *, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\std\string\string.h:373
    #7 0x7ff633a2ad99 in AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>::assign(char const *) E:\ws\main\Code\Framework\AzCore\AzCore\std\string\string.h:386
    #8 0x7ff6339f6b52 in AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>(char const *, class AZStd::allocator const &) E:\ws\main\Code\Framework\AzCore\AzCore\std\string\string.h:111
    #9 0x7ff6343fe6aa in AZ::OnDemandLuaFunctions::StringTypeFromLua<class AZStd::basic_string<char, struct AZStd::char_traits<char>, class AZStd::allocator>>(struct lua_State *, int, struct AZ::BehaviorArgument &, class AZ::BehaviorClass *, class AZStd::static_buffer_allocator<256, 16> *) E:\ws\main\Code\Framework\AzCore\AzCore\RTTI\AzStdOnDemandReflectionLuaFunctions.inl:106
    #10 0x7ff634574f6d in AZ::LuaScriptCaller::Call(struct lua_State *) E:\ws\main\Code\Framework\AzCore\AzCore\Script\ScriptContext.cpp:3520
    #11 0x7ff636431aa6 in lua_yieldk (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a71aa6)
    #12 0x7ff63641f423 in fprintf (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a5f423)
    #13 0x7ff63642aeb2 in luaL_where (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a6aeb2)
    #14 0x7ff63641eea7 in fprintf (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a5eea7)
    #15 0x7ff63641f952 in fprintf (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a5f952)
    #16 0x7ff63642e4ad in lua_pcallk (E:\ws\main\ninja-cl-debug-2019\bin\debug\accessingOptionalValueOrCausesDoubleFree.exe+0x142a6e4ad)
    #17 0x7ff6342b4756 in AZ::Internal::LuaSafeCall(struct lua_State *, int, int) E:\ws\main\Code\Framework\AzCore\AzCore\Script\ScriptContext.cpp:616
    #18 0x7ff634589780 in AZ::ScriptContextImpl::Execute(char const *, char const *, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\Script\ScriptContext.cpp:5656
    #19 0x7ff6342b6ce3 in AZ::ScriptContext::Execute(char const *, char const *, unsigned __int64) E:\ws\main\Code\Framework\AzCore\AzCore\Script\ScriptContext.cpp:5888
    #20 0x7ff6339ccb6c in main E:\ws\main\accessingOptionalValueOrCausesDoubleFree.cpp:38
    #21 0x7ff63648bd58 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #22 0x7ff63648bcad in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #23 0x7ff63648bb6d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #24 0x7ff63648bdcd in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16
    #25 0x7ffee41354df  (C:\WINDOWS\System32\KERNEL32.DLL+0x1800154df)
    #26 0x7ffee444485a  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18000485a)
```