### PR TITLE
[Terrain] Fix for macro materials when terrain render distance > 8km

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/FeatureProcessorFactory.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/FeatureProcessorFactory.cpp
@@ -89,25 +89,13 @@ namespace AZ
         AZ::TypeId FeatureProcessorFactory::GetFeatureProcessorTypeId(FeatureProcessorId featureProcessorId)
         {
             auto foundIt = GetEntry(featureProcessorId);
-            if (foundIt == AZStd::end(m_registry))
-            {
-                AZ_Warning("FeatureProcessorFactory", false, "FeatureProcessor '%s' could not be found in registry.", featureProcessorId.GetCStr());
-                return nullptr;
-            }
-
-            return foundIt->m_typeId;
+            return foundIt == AZStd::end(m_registry) ? nullptr : foundIt->m_typeId;
         }
 
         AZ::TypeId FeatureProcessorFactory::GetFeatureProcessorInterfaceTypeId(FeatureProcessorId featureProcessorId)
         {
             auto foundIt = GetEntry(featureProcessorId);
-            if (foundIt == AZStd::end(m_registry))
-            {
-                AZ_Warning("FeatureProcessorFactory", false, "FeatureProcessor '%s' could not be found in registry.", featureProcessorId.GetCStr());
-                return nullptr;
-            }
-
-            return foundIt->m_interfaceTypeId;
+            return foundIt == AZStd::end(m_registry) ? nullptr : foundIt->m_interfaceTypeId;
         }
 
         FeatureProcessorFactory::FeatureProcessorRegistry::const_iterator FeatureProcessorFactory::GetEntry(FeatureProcessorId featureProcessorId)

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.h
@@ -48,7 +48,7 @@ namespace Terrain
         static constexpr uint16_t MacroMaterialsPerTile = 4;
 
         using MaterialHandle = AZ::RHI::Handle<uint16_t, class Material>;
-        using TileHandle = AZ::RHI::Handle<uint16_t, class Tile>;
+        using TileHandle = AZ::RHI::Handle<uint32_t, class Tile>;
         using TileMaterials = AZStd::array<MaterialHandle, MacroMaterialsPerTile>;
 
         static constexpr TileMaterials DefaultTileMaterials

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -19,7 +19,6 @@
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RHI/RHISystemInterface.h>
 
-#include <Atom/RPI.Public/MeshDrawPacket.h>
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/View.h>
 #include <Atom/RPI.Public/AuxGeom/AuxGeomDraw.h>


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue with macro materials on large terrains, when the draw distance is greater than 8km causing the uint16 tile index to overflow. This change also removes noisy warnings from feature processor factory (sometimes these functions are called with the expectation that they may fail) and an unneeded include.

## How was this PR tested?

Tested several levels with draw distance > 8km before and after to ensure it was fixed.