### PR TITLE
Add entities for transform nodes not associated with a mesh

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/Motion/SceneDebug/Jack_Idle_Aim_ZUp.dbgsg
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/Motion/SceneDebug/Jack_Idle_Aim_ZUp.dbgsg
@@ -25,6 +25,15 @@ Node Type: AnimationData
 	KeyFrames: Count 195. Hash: 8622607111849624366
 	TimeStepBetweenFrames: 0.033333
 
+Node Name: transform
+Node Path: RootNode.jack_root.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.jack_root.custom_properties
 Node Type: CustomPropertyData

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/Motion/SceneDebug/jack_idle_aim_zup.dbgsg.xml
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/Motion/SceneDebug/jack_idle_aim_zup.dbgsg.xml
@@ -56,6 +56,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.jack_root.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.jack_root.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/OneMeshMultipleMaterials/SceneDebug/single_mesh_multiple_materials.dbgsg
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/OneMeshMultipleMaterials/SceneDebug/single_mesh_multiple_materials.dbgsg
@@ -26,6 +26,14 @@ Node Type: MeshData
 	FaceList: Count 1152. Hash: 3035560221708475304
 	FaceMaterialIds: Count 1152. Hash: 2033667258170256242
 
+Node Name: Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized
+Node Path: RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized
+Node Type: MeshData
+	Positions: Count 2304. Hash: 12560656679477605282
+	Normals: Count 2304. Hash: 14915939258818888021
+	FaceList: Count 1152. Hash: 3035560221708475304
+	FaceMaterialIds: Count 1152. Hash: 2033667258170256242
+
 Node Name: transform
 Node Path: RootNode.Torus.transform
 Node Type: TransformData
@@ -250,6 +258,132 @@ Node Type: MaterialData
 
 Node Name: FirstTextureMaterial
 Node Path: RootNode.Torus_single_mesh_multiple_materials_optimized.FirstTextureMaterial
+Node Type: MaterialData
+	MaterialName: FirstTextureMaterial
+	UniqueId: 2580020563915538382
+	IsNoDraw: false
+	DiffuseColor: < 0.800000,  0.800000,  0.800000>
+	SpecularColor: < 0.800000,  0.800000,  0.800000>
+	EmissiveColor: < 0.000000,  0.000000,  0.000000>
+	Opacity: 1.000000
+	Shininess: 25.000000
+	UseColorMap: Not set
+	BaseColor: Not set
+	UseMetallicMap: Not set
+	MetallicFactor: Not set
+	UseRoughnessMap: Not set
+	RoughnessFactor: Not set
+	UseEmissiveMap: Not set
+	EmissiveIntensity: Not set
+	UseAOMap: Not set
+	DiffuseTexture: OneMeshMultipleMaterials/FBXTestTexture.png
+	SpecularTexture: 
+	BumpTexture: 
+	NormalTexture: 
+	MetallicTexture: 
+	RoughnessTexture: 
+	AmbientOcclusionTexture: 
+	EmissiveTexture: 
+	BaseColorTexture: OneMeshMultipleMaterials/FBXTestTexture.png
+
+Node Name: UV0
+Node Path: RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.UV0
+Node Type: MeshVertexUVData
+	UVs: Count 2304. Hash: 6069930558565069665
+	UVCustomName: UV0
+
+Node Name: TangentSet_0
+Node Path: RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.TangentSet_0
+Node Type: MeshVertexTangentData
+	Tangents: Count 2304. Hash: 17641066831235827929
+	GenerationMethod: 1
+	SetIndex: 0
+
+Node Name: BitangentSet_0
+Node Path: RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.BitangentSet_0
+Node Type: MeshVertexBitangentData
+	Bitangents: Count 2304. Hash: 6274616552656695154
+	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 100.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000, -0.000016,  100.000000>
+		BasisZ: < 0.000000, -100.000000, -0.000016>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
+Node Name: custom_properties
+Node Path: RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.custom_properties
+Node Type: CustomPropertyData
+	UserProperties: 
+	IsNull: false
+	DefaultAttributeIndex: 0
+	InheritType: 1
+
+Node Name: OrangeMaterial
+Node Path: RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.OrangeMaterial
+Node Type: MaterialData
+	MaterialName: OrangeMaterial
+	UniqueId: 10937477720113828524
+	IsNoDraw: false
+	DiffuseColor: < 0.800000,  0.113346,  0.000000>
+	SpecularColor: < 0.800000,  0.113346,  0.000000>
+	EmissiveColor: < 0.000000,  0.000000,  0.000000>
+	Opacity: 1.000000
+	Shininess: 25.000000
+	UseColorMap: Not set
+	BaseColor: Not set
+	UseMetallicMap: Not set
+	MetallicFactor: Not set
+	UseRoughnessMap: Not set
+	RoughnessFactor: Not set
+	UseEmissiveMap: Not set
+	EmissiveIntensity: Not set
+	UseAOMap: Not set
+	DiffuseTexture: 
+	SpecularTexture: 
+	BumpTexture: 
+	NormalTexture: 
+	MetallicTexture: 
+	RoughnessTexture: 
+	AmbientOcclusionTexture: 
+	EmissiveTexture: 
+	BaseColorTexture: 
+
+Node Name: SecondTextureMaterial
+Node Path: RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.SecondTextureMaterial
+Node Type: MaterialData
+	MaterialName: SecondTextureMaterial
+	UniqueId: 16601413836225607467
+	IsNoDraw: false
+	DiffuseColor: < 0.800000,  0.800000,  0.800000>
+	SpecularColor: < 0.800000,  0.800000,  0.800000>
+	EmissiveColor: < 0.000000,  0.000000,  0.000000>
+	Opacity: 1.000000
+	Shininess: 25.000000
+	UseColorMap: Not set
+	BaseColor: Not set
+	UseMetallicMap: Not set
+	MetallicFactor: Not set
+	UseRoughnessMap: Not set
+	RoughnessFactor: Not set
+	UseEmissiveMap: Not set
+	EmissiveIntensity: Not set
+	UseAOMap: Not set
+	DiffuseTexture: OneMeshMultipleMaterials/FBXSecondTestTexture.png
+	SpecularTexture: 
+	BumpTexture: 
+	NormalTexture: 
+	MetallicTexture: 
+	RoughnessTexture: 
+	AmbientOcclusionTexture: 
+	EmissiveTexture: 
+	BaseColorTexture: OneMeshMultipleMaterials/FBXSecondTestTexture.png
+
+Node Name: FirstTextureMaterial
+Node Path: RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.FirstTextureMaterial
 Node Type: MaterialData
 	MaterialName: FirstTextureMaterial
 	UniqueId: 2580020563915538382

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/OneMeshMultipleMaterials/SceneDebug/single_mesh_multiple_materials.dbgsg.xml
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/OneMeshMultipleMaterials/SceneDebug/single_mesh_multiple_materials.dbgsg.xml
@@ -128,6 +128,61 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MeshData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Positions - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="2304" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Positions - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="12560656679477605282" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Normals - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="2304" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Normals - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="14915939258818888021" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="FaceList - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="1152" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="FaceList - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="3035560221708475304" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="FaceMaterialIds - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="1152" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="FaceMaterialIds - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="2033667258170256242" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.Torus.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -631,6 +686,284 @@
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="FirstTextureMaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.Torus_single_mesh_multiple_materials_optimized.FirstTextureMaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MaterialData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="MaterialName" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZStd::string" field="m_data" value="FirstTextureMaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="UniqueId" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="2580020563915538382" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNoDraw" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DiffuseColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.8000000 0.8000000 0.8000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="SpecularColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.8000000 0.8000000 0.8000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="EmissiveColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.0000000 0.0000000 0.0000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Opacity" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="1.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Shininess" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="25.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="UV0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.UV0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MeshVertexUVData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="UVs - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="2304" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="UVs - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="6069930558565069665" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="TangentSet_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.TangentSet_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MeshVertexTangentData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Tangents - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="2304" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Tangents - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="17641066831235827929" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="SetIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="0" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="BitangentSet_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.BitangentSet_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MeshVertexBitangentData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Bitangents - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="2304" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Bitangents - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="6274616552656695154" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="100.0000000 0.0000000 0.0000000 0.0000000 -0.0000163 100.0000000 0.0000000 -100.0000000 -0.0000163 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNull" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DefaultAttributeIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="0" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="InheritType" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="OrangeMaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.OrangeMaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MaterialData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="MaterialName" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZStd::string" field="m_data" value="OrangeMaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="UniqueId" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="10937477720113828524" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNoDraw" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DiffuseColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.8000001 0.1133456 0.0000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="SpecularColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.8000001 0.1133456 0.0000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="EmissiveColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.0000000 0.0000000 0.0000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Opacity" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="1.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Shininess" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="25.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="SecondTextureMaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.SecondTextureMaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MaterialData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="MaterialName" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZStd::string" field="m_data" value="SecondTextureMaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="UniqueId" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="16601413836225607467" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNoDraw" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DiffuseColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.8000000 0.8000000 0.8000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="SpecularColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.8000000 0.8000000 0.8000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="EmissiveColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.0000000 0.0000000 0.0000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Opacity" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="1.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Shininess" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="25.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="FirstTextureMaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Torus_default_single_mesh_multiple_materials_119330EA_25E9_5416_BD8B_4394E9E13E93__optimized.FirstTextureMaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="MaterialData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/ShaderBall/SceneDebug/shaderball.dbgsg
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/ShaderBall/SceneDebug/shaderball.dbgsg
@@ -30,40 +30,46 @@ Node Type: CustomPropertyData
 
 Node Name: InnerPortion
 Node Path: RootNode.ShaderBall_1m.InnerPortion
-Node Type: CustomPropertyData
-	IsNull: true
-	RotationActive: true
-	DefaultAttributeIndex: 0
-	UserProperties: 
-	InheritType: 1
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: MaterialBase
 Node Path: RootNode.ShaderBall_1m.MaterialBase
-Node Type: CustomPropertyData
-	IsNull: true
-	RotationActive: true
-	DefaultAttributeIndex: 0
-	currentUVSet: UVW
-	UserProperties: 
-	InheritType: 1
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: InlayRings
 Node Path: RootNode.ShaderBall_1m.InlayRings
-Node Type: CustomPropertyData
-	IsNull: true
-	RotationActive: true
-	DefaultAttributeIndex: 0
-	currentUVSet: UVW
-	UserProperties: 
-	InheritType: 1
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: MainSphere
 Node Path: RootNode.ShaderBall_1m.MainSphere
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
+Node Name: custom_properties
+Node Path: RootNode.ShaderBall_1m.InnerPortion.custom_properties
 Node Type: CustomPropertyData
 	IsNull: true
 	RotationActive: true
 	DefaultAttributeIndex: 0
-	currentUVSet: UVW
 	UserProperties: 
 	InheritType: 1
 
@@ -114,6 +120,16 @@ Node Type: MeshData
 	Normals: Count 5846. Hash: 12980164457801827192
 	FaceList: Count 9800. Hash: 2914108932212582430
 	FaceMaterialIds: Count 9800. Hash: 2219364576630417284
+
+Node Name: custom_properties
+Node Path: RootNode.ShaderBall_1m.MaterialBase.custom_properties
+Node Type: CustomPropertyData
+	IsNull: true
+	RotationActive: true
+	DefaultAttributeIndex: 0
+	currentUVSet: UVW
+	UserProperties: 
+	InheritType: 1
 
 Node Name: InnerCone
 Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCone
@@ -283,6 +299,16 @@ Node Type: MeshData
 	FaceList: Count 10024. Hash: 10907381836011223214
 	FaceMaterialIds: Count 10024. Hash: 9849297365743356453
 
+Node Name: custom_properties
+Node Path: RootNode.ShaderBall_1m.InlayRings.custom_properties
+Node Type: CustomPropertyData
+	IsNull: true
+	RotationActive: true
+	DefaultAttributeIndex: 0
+	currentUVSet: UVW
+	UserProperties: 
+	InheritType: 1
+
 Node Name: RingLeft
 Node Path: RootNode.ShaderBall_1m.InlayRings.RingLeft
 Node Type: MeshData
@@ -330,6 +356,16 @@ Node Type: MeshData
 	Normals: Count 720. Hash: 14263134585377771060
 	FaceList: Count 1280. Hash: 13824345071081010014
 	FaceMaterialIds: Count 1280. Hash: 6371267399123018661
+
+Node Name: custom_properties
+Node Path: RootNode.ShaderBall_1m.MainSphere.custom_properties
+Node Type: CustomPropertyData
+	IsNull: true
+	RotationActive: true
+	DefaultAttributeIndex: 0
+	currentUVSet: UVW
+	UserProperties: 
+	InheritType: 1
 
 Node Name: RightHub
 Node Path: RootNode.ShaderBall_1m.MainSphere.RightHub
@@ -427,6 +463,15 @@ Node Type: MeshData
 	FaceList: Count 9456. Hash: 13541126452398082145
 	FaceMaterialIds: Count 9456. Hash: 13982281543095132650
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.InnerPortion.HubCap.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.InnerPortion.HubCap.custom_properties
 Node Type: CustomPropertyData
@@ -504,6 +549,15 @@ Node Path: RootNode.ShaderBall_1m.InnerPortion.HubCap.BitangentSet_1
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 20476. Hash: 309820643999247955
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.InnerPortion.InnerSphere.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.InnerPortion.InnerSphere.custom_properties
@@ -621,6 +675,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 4724. Hash: 1080930468361041453
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.InnerPortion.HubCap_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.InnerPortion.HubCap_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -698,6 +761,15 @@ Node Path: RootNode.ShaderBall_1m.InnerPortion.HubCap_default_shaderball_E95B8EA
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 4724. Hash: 1080930468361041453
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.InnerPortion.HubCap_default_shaderball_E95B8EA6_DCA7_501D_AE59_1088AB70DF38__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.InnerPortion.HubCap_default_shaderball_E95B8EA6_DCA7_501D_AE59_1088AB70DF38__optimized.custom_properties
@@ -777,6 +849,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 5846. Hash: 6861847030641362531
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.InnerPortion.InnerSphere_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.InnerPortion.InnerSphere_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -855,6 +936,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 5846. Hash: 6861847030641362531
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.InnerPortion.InnerSphere_default_shaderball_473A4A86_CC7E_55D2_91F6_7EF87FBD5C01__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.InnerPortion.InnerSphere_default_shaderball_473A4A86_CC7E_55D2_91F6_7EF87FBD5C01__optimized.custom_properties
 Node Type: CustomPropertyData
@@ -894,6 +984,15 @@ Node Type: MaterialData
 	AmbientOcclusionTexture: 
 	EmissiveTexture: 
 	BaseColorTexture: ShaderBall/_dev_shaderball_00_basecolor.png
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCone.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCone.custom_properties
@@ -973,6 +1072,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 192. Hash: 14378088137727336097
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerPost.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerPost.custom_properties
 Node Type: CustomPropertyData
@@ -1050,6 +1158,15 @@ Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerPost.BitangentSet_1
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 4864. Hash: 12470368568863176335
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerBaseCuff.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerBaseCuff.custom_properties
@@ -1129,6 +1246,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 4096. Hash: 16465645522600859391
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.Inset.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.Inset.custom_properties
 Node Type: CustomPropertyData
@@ -1206,6 +1332,15 @@ Node Path: RootNode.ShaderBall_1m.MaterialBase.Inset.BitangentSet_1
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 1536. Hash: 17779645716491562667
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.BottomCap.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.BottomCap.custom_properties
@@ -1285,6 +1420,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 960. Hash: 15826838159231044203
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCushion.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCushion.custom_properties
 Node Type: CustomPropertyData
@@ -1362,6 +1506,15 @@ Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCushion.BitangentSet_1
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 54208. Hash: 2074363216216487237
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.OuterBaseCuff.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.OuterBaseCuff.custom_properties
@@ -1479,6 +1632,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 65. Hash: 15200278891890596008
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCone_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCone_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -1556,6 +1718,15 @@ Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCone_default_shaderball_F50B
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 65. Hash: 15200278891890596008
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCone_default_shaderball_F50B5AC3_CCD7_5683_9F22_9A229001ABFF__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCone_default_shaderball_F50B5AC3_CCD7_5683_9F22_9A229001ABFF__optimized.custom_properties
@@ -1635,6 +1806,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 1300. Hash: 14920629477034919393
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerPost_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerPost_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -1712,6 +1892,15 @@ Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerPost_default_shaderball_FEA7
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 1300. Hash: 14920629477034919393
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerPost_default_shaderball_FEA7D61B_0535_550B_86E8_B48BD812D84A__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerPost_default_shaderball_FEA7D61B_0535_550B_86E8_B48BD812D84A__optimized.custom_properties
@@ -1791,6 +1980,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 1122. Hash: 100095329364523248
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerBaseCuff_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerBaseCuff_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -1868,6 +2066,15 @@ Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerBaseCuff_default_shaderball_
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 1122. Hash: 100095329364523248
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerBaseCuff_default_shaderball_9714DB61_2272_55A8_80FD_0386DF43C72C__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerBaseCuff_default_shaderball_9714DB61_2272_55A8_80FD_0386DF43C72C__optimized.custom_properties
@@ -1947,6 +2154,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 448. Hash: 8818080862566813062
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.Inset_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.Inset_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -2024,6 +2240,15 @@ Node Path: RootNode.ShaderBall_1m.MaterialBase.Inset_default_shaderball_6D25426B
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 448. Hash: 8818080862566813062
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.Inset_default_shaderball_6D25426B_F22E_54CA_B38A_1F8D65A05243__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.Inset_default_shaderball_6D25426B_F22E_54CA_B38A_1F8D65A05243__optimized.custom_properties
@@ -2103,6 +2328,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 257. Hash: 9909736394462106525
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.BottomCap_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.BottomCap_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -2180,6 +2414,15 @@ Node Path: RootNode.ShaderBall_1m.MaterialBase.BottomCap_default_shaderball_1C4F
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 257. Hash: 9909736394462106525
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.BottomCap_default_shaderball_1C4F5C76_38DF_5289_AF68_EB96F7658B86__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.BottomCap_default_shaderball_1C4F5C76_38DF_5289_AF68_EB96F7658B86__optimized.custom_properties
@@ -2259,6 +2502,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 13860. Hash: 7251784463761381809
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCushion_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCushion_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -2336,6 +2588,15 @@ Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCushion_default_shaderball_4
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 13860. Hash: 7251784463761381809
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCushion_default_shaderball_491DD9C0_9F62_538A_8637_2F85BDEE4675__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.InnerCushion_default_shaderball_491DD9C0_9F62_538A_8637_2F85BDEE4675__optimized.custom_properties
@@ -2415,6 +2676,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 5206. Hash: 8652443944286435468
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.OuterBaseCuff_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.OuterBaseCuff_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -2493,6 +2763,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 5206. Hash: 8652443944286435468
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MaterialBase.OuterBaseCuff_default_shaderball_61FA311B_958E_5E8A_A4C1_96AA01552B5D__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MaterialBase.OuterBaseCuff_default_shaderball_61FA311B_958E_5E8A_A4C1_96AA01552B5D__optimized.custom_properties
 Node Type: CustomPropertyData
@@ -2532,6 +2811,15 @@ Node Type: MaterialData
 	AmbientOcclusionTexture: 
 	EmissiveTexture: 
 	BaseColorTexture: ShaderBall/_dev_shaderball_00_basecolor.png
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.InlayRings.RingLeft.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.InlayRings.RingLeft.custom_properties
@@ -2610,6 +2898,15 @@ Node Path: RootNode.ShaderBall_1m.InlayRings.RingLeft.BitangentSet_1
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 2560. Hash: 3318206549561696188
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.InlayRings.RingRight.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.InlayRings.RingRight.custom_properties
@@ -2727,6 +3024,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 720. Hash: 16922723248982534245
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.InlayRings.RingLeft_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.InlayRings.RingLeft_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -2804,6 +3110,15 @@ Node Path: RootNode.ShaderBall_1m.InlayRings.RingLeft_default_shaderball_92798A1
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 720. Hash: 16922723248982534245
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.InlayRings.RingLeft_default_shaderball_92798A1A_DA92_5BCB_8E70_6433043ABDB6__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.InlayRings.RingLeft_default_shaderball_92798A1A_DA92_5BCB_8E70_6433043ABDB6__optimized.custom_properties
@@ -2883,6 +3198,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 720. Hash: 12477592739739533067
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.InlayRings.RingRight_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.InlayRings.RingRight_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -2961,6 +3285,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 720. Hash: 12477592739739533067
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.InlayRings.RingRight_default_shaderball_60E3FD38_62BE_5AF8_8DF9_085F00380C7C__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.InlayRings.RingRight_default_shaderball_60E3FD38_62BE_5AF8_8DF9_085F00380C7C__optimized.custom_properties
 Node Type: CustomPropertyData
@@ -3000,6 +3333,15 @@ Node Type: MaterialData
 	AmbientOcclusionTexture: 
 	EmissiveTexture: 
 	BaseColorTexture: ShaderBall/_dev_shaderball_00_basecolor.png
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MainSphere.RightHub.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MainSphere.RightHub.custom_properties
@@ -3079,6 +3421,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 6304. Hash: 3046294637431015510
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MainSphere.LeftHub.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MainSphere.LeftHub.custom_properties
 Node Type: CustomPropertyData
@@ -3157,6 +3508,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 6304. Hash: 4969210758291089995
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MainSphere.Inside.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MainSphere.Inside.custom_properties
 Node Type: CustomPropertyData
@@ -3234,6 +3594,15 @@ Node Path: RootNode.ShaderBall_1m.MainSphere.Inside.BitangentSet_1
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 3520. Hash: 8463107387658894201
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MainSphere.MainOuterSphere.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MainSphere.MainOuterSphere.custom_properties
@@ -3351,6 +3720,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 1617. Hash: 6416015160247779547
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MainSphere.RightHub_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MainSphere.RightHub_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -3428,6 +3806,15 @@ Node Path: RootNode.ShaderBall_1m.MainSphere.RightHub_default_shaderball_51CC241
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 1617. Hash: 6416015160247779547
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MainSphere.RightHub_default_shaderball_51CC241B_C54B_50F2_AED7_113C1327FAD0__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MainSphere.RightHub_default_shaderball_51CC241B_C54B_50F2_AED7_113C1327FAD0__optimized.custom_properties
@@ -3507,6 +3894,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 1617. Hash: 14516337485055158228
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MainSphere.LeftHub_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MainSphere.LeftHub_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -3584,6 +3980,15 @@ Node Path: RootNode.ShaderBall_1m.MainSphere.LeftHub_default_shaderball_2386C2AB
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 1617. Hash: 14516337485055158228
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MainSphere.LeftHub_default_shaderball_2386C2AB_0C4B_554F_B3BC_43754B12017E__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MainSphere.LeftHub_default_shaderball_2386C2AB_0C4B_554F_B3BC_43754B12017E__optimized.custom_properties
@@ -3663,6 +4068,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 960. Hash: 6108415656799664788
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MainSphere.Inside_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MainSphere.Inside_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -3740,6 +4154,15 @@ Node Path: RootNode.ShaderBall_1m.MainSphere.Inside_default_shaderball_0E8A4436_
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 960. Hash: 6108415656799664788
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MainSphere.Inside_default_shaderball_0E8A4436_3658_5EF3_8EA9_0503A42060D6__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MainSphere.Inside_default_shaderball_0E8A4436_3658_5EF3_8EA9_0503A42060D6__optimized.custom_properties
@@ -3819,6 +4242,15 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 4891. Hash: 7889928104085840247
 	GenerationMethod: 1
 
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MainSphere.MainOuterSphere_shaderball_optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MainSphere.MainOuterSphere_shaderball_optimized.custom_properties
 Node Type: CustomPropertyData
@@ -3896,6 +4328,15 @@ Node Path: RootNode.ShaderBall_1m.MainSphere.MainOuterSphere_default_shaderball_
 Node Type: MeshVertexBitangentData
 	Bitangents: Count 4891. Hash: 7889928104085840247
 	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.ShaderBall_1m.MainSphere.MainOuterSphere_default_shaderball_1616D68E_F072_5643_BD07_565772CD0E30__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 1.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000,  1.000000,  0.000000>
+		BasisZ: < 0.000000,  0.000000,  1.000000>
+		Transl: < 0.000000,  0.000000,  0.000000>
 
 Node Name: custom_properties
 Node Path: RootNode.ShaderBall_1m.MainSphere.MainOuterSphere_default_shaderball_1616D68E_F072_5643_BD07_565772CD0E30__optimized.custom_properties

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/ShaderBall/SceneDebug/shaderball.dbgsg.xml
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/ShaderBall/SceneDebug/shaderball.dbgsg.xml
@@ -64,30 +64,12 @@
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="InnerPortion" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InnerPortion" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="IsNull" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="bool" field="m_data" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="RotationActive" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="bool" field="m_data" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="DefaultAttributeIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="AZ::s64" field="m_data" value="0" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="InheritType" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -95,30 +77,12 @@
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="MaterialBase" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="IsNull" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="bool" field="m_data" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="RotationActive" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="bool" field="m_data" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="DefaultAttributeIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="AZ::s64" field="m_data" value="0" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="InheritType" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -126,30 +90,12 @@
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="InlayRings" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InlayRings" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="IsNull" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="bool" field="m_data" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="RotationActive" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="bool" field="m_data" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="DefaultAttributeIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="AZ::s64" field="m_data" value="0" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="InheritType" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -157,6 +103,19 @@
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="MainSphere" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InnerPortion.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -511,6 +470,37 @@
 						<Class name="AZStd::string" field="value1" value="FaceMaterialIds - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::u64" field="m_data" value="2219364576630417284" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNull" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="RotationActive" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DefaultAttributeIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="0" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="InheritType" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -1671,6 +1661,37 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InlayRings.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNull" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="RotationActive" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DefaultAttributeIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="0" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="InheritType" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="RingLeft" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InlayRings.RingLeft" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="MeshData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -1996,6 +2017,37 @@
 						<Class name="AZStd::string" field="value1" value="FaceMaterialIds - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::u64" field="m_data" value="6371267399123018661" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNull" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="RotationActive" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DefaultAttributeIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="0" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="InheritType" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -2661,6 +2713,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InnerPortion.HubCap.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InnerPortion.HubCap.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -2892,6 +2957,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InnerPortion.InnerSphere.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -3283,6 +3361,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InnerPortion.HubCap_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InnerPortion.HubCap_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -3514,6 +3605,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InnerPortion.HubCap_default_shaderball_E95B8EA6_DCA7_501D_AE59_1088AB70DF38__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -3755,6 +3859,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InnerPortion.InnerSphere_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InnerPortion.InnerSphere_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -3991,6 +4108,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InnerPortion.InnerSphere_default_shaderball_473A4A86_CC7E_55D2_91F6_7EF87FBD5C01__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InnerPortion.InnerSphere_default_shaderball_473A4A86_CC7E_55D2_91F6_7EF87FBD5C01__optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -4072,6 +4202,19 @@
 						<Class name="AZStd::string" field="value1" value="Shininess" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="double" field="m_data" value="6.3117909" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerCone.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -4313,6 +4456,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerPost.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerPost.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -4544,6 +4700,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerBaseCuff.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -4785,6 +4954,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.Inset.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.Inset.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -5016,6 +5198,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.BottomCap.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -5257,6 +5452,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerCushion.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerCushion.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -5488,6 +5696,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.OuterBaseCuff.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -5879,6 +6100,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerCone_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerCone_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -6110,6 +6344,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerCone_default_shaderball_F50B5AC3_CCD7_5683_9F22_9A229001ABFF__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -6351,6 +6598,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerPost_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerPost_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -6582,6 +6842,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerPost_default_shaderball_FEA7D61B_0535_550B_86E8_B48BD812D84A__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -6823,6 +7096,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerBaseCuff_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerBaseCuff_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -7054,6 +7340,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerBaseCuff_default_shaderball_9714DB61_2272_55A8_80FD_0386DF43C72C__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -7295,6 +7594,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.Inset_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.Inset_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -7526,6 +7838,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.Inset_default_shaderball_6D25426B_F22E_54CA_B38A_1F8D65A05243__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -7767,6 +8092,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.BottomCap_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.BottomCap_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -7998,6 +8336,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.BottomCap_default_shaderball_1C4F5C76_38DF_5289_AF68_EB96F7658B86__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -8239,6 +8590,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerCushion_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerCushion_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -8470,6 +8834,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.InnerCushion_default_shaderball_491DD9C0_9F62_538A_8637_2F85BDEE4675__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -8711,6 +9088,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.OuterBaseCuff_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.OuterBaseCuff_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -8947,6 +9337,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.OuterBaseCuff_default_shaderball_61FA311B_958E_5E8A_A4C1_96AA01552B5D__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MaterialBase.OuterBaseCuff_default_shaderball_61FA311B_958E_5E8A_A4C1_96AA01552B5D__optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -9028,6 +9431,19 @@
 						<Class name="AZStd::string" field="value1" value="Shininess" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="double" field="m_data" value="6.3117909" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InlayRings.RingLeft.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -9264,6 +9680,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InlayRings.RingRight.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -9655,6 +10084,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InlayRings.RingLeft_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InlayRings.RingLeft_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -9886,6 +10328,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InlayRings.RingLeft_default_shaderball_92798A1A_DA92_5BCB_8E70_6433043ABDB6__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -10127,6 +10582,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InlayRings.RingRight_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InlayRings.RingRight_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -10363,6 +10831,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InlayRings.RingRight_default_shaderball_60E3FD38_62BE_5AF8_8DF9_085F00380C7C__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.InlayRings.RingRight_default_shaderball_60E3FD38_62BE_5AF8_8DF9_085F00380C7C__optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -10444,6 +10925,19 @@
 						<Class name="AZStd::string" field="value1" value="Shininess" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="double" field="m_data" value="6.3117909" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.RightHub.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -10685,6 +11179,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.LeftHub.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.LeftHub.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -10921,6 +11428,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.Inside.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.Inside.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -11152,6 +11672,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.MainOuterSphere.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -11543,6 +12076,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.RightHub_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.RightHub_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -11774,6 +12320,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.RightHub_default_shaderball_51CC241B_C54B_50F2_AED7_113C1327FAD0__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -12015,6 +12574,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.LeftHub_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.LeftHub_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -12246,6 +12818,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.LeftHub_default_shaderball_2386C2AB_0C4B_554F_B3BC_43754B12017E__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -12487,6 +13072,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.Inside_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.Inside_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -12718,6 +13316,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.Inside_default_shaderball_0E8A4436_3658_5EF3_8EA9_0503A42060D6__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -12959,6 +13570,19 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.MainOuterSphere_shaderball_optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.MainOuterSphere_shaderball_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
@@ -13190,6 +13814,19 @@
 						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.ShaderBall_1m.MainSphere.MainOuterSphere_default_shaderball_1616D68E_F072_5643_BD07_565772CD0E30__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
 						</Class>
 					</Class>
 				</Class>

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/TwoMeshLinkedMaterials/SceneDebug/multiple_mesh_linked_materials.dbgsg
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/TwoMeshLinkedMaterials/SceneDebug/multiple_mesh_linked_materials.dbgsg
@@ -34,8 +34,24 @@ Node Type: MeshData
 	FaceList: Count 12. Hash: 9888799799190757436
 	FaceMaterialIds: Count 12. Hash: 7113802799051126666
 
+Node Name: Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized
+Node Path: RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized
+Node Type: MeshData
+	Positions: Count 24. Hash: 8661923109306356285
+	Normals: Count 24. Hash: 5807525742165000561
+	FaceList: Count 12. Hash: 9888799799190757436
+	FaceMaterialIds: Count 12. Hash: 7113802799051126666
+
 Node Name: Cone_multiple_mesh_linked_materials_optimized
 Node Path: RootNode.Cone_multiple_mesh_linked_materials_optimized
+Node Type: MeshData
+	Positions: Count 128. Hash: 14946490408303214595
+	Normals: Count 128. Hash: 367461522682321485
+	FaceList: Count 62. Hash: 17210030509394354449
+	FaceMaterialIds: Count 62. Hash: 15454348664434923102
+
+Node Name: Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized
+Node Path: RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized
 Node Type: MeshData
 	Positions: Count 128. Hash: 14946490408303214595
 	Normals: Count 128. Hash: 367461522682321485
@@ -331,6 +347,102 @@ Node Type: MaterialData
 	BaseColorTexture: 
 
 Node Name: UV0
+Node Path: RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.UV0
+Node Type: MeshVertexUVData
+	UVs: Count 24. Hash: 1622169145591646736
+	UVCustomName: UV0
+
+Node Name: TangentSet_0
+Node Path: RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.TangentSet_0
+Node Type: MeshVertexTangentData
+	Tangents: Count 24. Hash: 13438447437797057049
+	GenerationMethod: 1
+	SetIndex: 0
+
+Node Name: BitangentSet_0
+Node Path: RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.BitangentSet_0
+Node Type: MeshVertexBitangentData
+	Bitangents: Count 24. Hash: 11372562338897179017
+	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 100.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000, -0.000016,  100.000000>
+		BasisZ: < 0.000000, -100.000000, -0.000016>
+		Transl: < 0.000000,  0.000000,  0.000000>
+
+Node Name: custom_properties
+Node Path: RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.custom_properties
+Node Type: CustomPropertyData
+	UserProperties: 
+	IsNull: false
+	DefaultAttributeIndex: 0
+	InheritType: 1
+
+Node Name: SharedBlack
+Node Path: RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.SharedBlack
+Node Type: MaterialData
+	MaterialName: SharedBlack
+	UniqueId: 5248829540156873090
+	IsNoDraw: false
+	DiffuseColor: < 0.000000,  0.000000,  0.000000>
+	SpecularColor: < 0.000000,  0.000000,  0.000000>
+	EmissiveColor: < 0.000000,  0.000000,  0.000000>
+	Opacity: 1.000000
+	Shininess: 25.000000
+	UseColorMap: Not set
+	BaseColor: Not set
+	UseMetallicMap: Not set
+	MetallicFactor: Not set
+	UseRoughnessMap: Not set
+	RoughnessFactor: Not set
+	UseEmissiveMap: Not set
+	EmissiveIntensity: Not set
+	UseAOMap: Not set
+	DiffuseTexture: 
+	SpecularTexture: 
+	BumpTexture: 
+	NormalTexture: 
+	MetallicTexture: 
+	RoughnessTexture: 
+	AmbientOcclusionTexture: 
+	EmissiveTexture: 
+	BaseColorTexture: 
+
+Node Name: SharedOrange
+Node Path: RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.SharedOrange
+Node Type: MaterialData
+	MaterialName: SharedOrange
+	UniqueId: 9470651048605569128
+	IsNoDraw: false
+	DiffuseColor: < 0.800000,  0.139382,  0.014429>
+	SpecularColor: < 0.800000,  0.139382,  0.014429>
+	EmissiveColor: < 0.000000,  0.000000,  0.000000>
+	Opacity: 1.000000
+	Shininess: 25.000000
+	UseColorMap: Not set
+	BaseColor: Not set
+	UseMetallicMap: Not set
+	MetallicFactor: Not set
+	UseRoughnessMap: Not set
+	RoughnessFactor: Not set
+	UseEmissiveMap: Not set
+	EmissiveIntensity: Not set
+	UseAOMap: Not set
+	DiffuseTexture: 
+	SpecularTexture: 
+	BumpTexture: 
+	NormalTexture: 
+	MetallicTexture: 
+	RoughnessTexture: 
+	AmbientOcclusionTexture: 
+	EmissiveTexture: 
+	BaseColorTexture: 
+
+Node Name: UV0
 Node Path: RootNode.Cone_multiple_mesh_linked_materials_optimized.UV0
 Node Type: MeshVertexUVData
 	UVs: Count 128. Hash: 7173974213247584731
@@ -398,6 +510,102 @@ Node Type: MaterialData
 
 Node Name: SharedBlack
 Node Path: RootNode.Cone_multiple_mesh_linked_materials_optimized.SharedBlack
+Node Type: MaterialData
+	MaterialName: SharedBlack
+	UniqueId: 5248829540156873090
+	IsNoDraw: false
+	DiffuseColor: < 0.000000,  0.000000,  0.000000>
+	SpecularColor: < 0.000000,  0.000000,  0.000000>
+	EmissiveColor: < 0.000000,  0.000000,  0.000000>
+	Opacity: 1.000000
+	Shininess: 25.000000
+	UseColorMap: Not set
+	BaseColor: Not set
+	UseMetallicMap: Not set
+	MetallicFactor: Not set
+	UseRoughnessMap: Not set
+	RoughnessFactor: Not set
+	UseEmissiveMap: Not set
+	EmissiveIntensity: Not set
+	UseAOMap: Not set
+	DiffuseTexture: 
+	SpecularTexture: 
+	BumpTexture: 
+	NormalTexture: 
+	MetallicTexture: 
+	RoughnessTexture: 
+	AmbientOcclusionTexture: 
+	EmissiveTexture: 
+	BaseColorTexture: 
+
+Node Name: UV0
+Node Path: RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.UV0
+Node Type: MeshVertexUVData
+	UVs: Count 128. Hash: 7173974213247584731
+	UVCustomName: UV0
+
+Node Name: TangentSet_0
+Node Path: RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.TangentSet_0
+Node Type: MeshVertexTangentData
+	Tangents: Count 128. Hash: 5198081677141836233
+	GenerationMethod: 1
+	SetIndex: 0
+
+Node Name: BitangentSet_0
+Node Path: RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.BitangentSet_0
+Node Type: MeshVertexBitangentData
+	Bitangents: Count 128. Hash: 6948605204859680167
+	GenerationMethod: 1
+
+Node Name: transform
+Node Path: RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.transform
+Node Type: TransformData
+	Matrix:
+		BasisX: < 100.000000,  0.000000,  0.000000>
+		BasisY: < 0.000000, -0.000016,  100.000000>
+		BasisZ: < 0.000000, -100.000000, -0.000016>
+		Transl: < 0.000000,  0.000000,  2.000000>
+
+Node Name: custom_properties
+Node Path: RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.custom_properties
+Node Type: CustomPropertyData
+	UserProperties: 
+	IsNull: false
+	DefaultAttributeIndex: 0
+	InheritType: 1
+
+Node Name: SharedOrange
+Node Path: RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.SharedOrange
+Node Type: MaterialData
+	MaterialName: SharedOrange
+	UniqueId: 9470651048605569128
+	IsNoDraw: false
+	DiffuseColor: < 0.800000,  0.139382,  0.014429>
+	SpecularColor: < 0.800000,  0.139382,  0.014429>
+	EmissiveColor: < 0.000000,  0.000000,  0.000000>
+	Opacity: 1.000000
+	Shininess: 25.000000
+	UseColorMap: Not set
+	BaseColor: Not set
+	UseMetallicMap: Not set
+	MetallicFactor: Not set
+	UseRoughnessMap: Not set
+	RoughnessFactor: Not set
+	UseEmissiveMap: Not set
+	EmissiveIntensity: Not set
+	UseAOMap: Not set
+	DiffuseTexture: 
+	SpecularTexture: 
+	BumpTexture: 
+	NormalTexture: 
+	MetallicTexture: 
+	RoughnessTexture: 
+	AmbientOcclusionTexture: 
+	EmissiveTexture: 
+	BaseColorTexture: 
+
+Node Name: SharedBlack
+Node Path: RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.SharedBlack
 Node Type: MaterialData
 	MaterialName: SharedBlack
 	UniqueId: 5248829540156873090

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/TwoMeshLinkedMaterials/SceneDebug/multiple_mesh_linked_materials.dbgsg.xml
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/TwoMeshLinkedMaterials/SceneDebug/multiple_mesh_linked_materials.dbgsg.xml
@@ -183,8 +183,118 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MeshData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Positions - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="24" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Positions - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="8661923109306356285" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Normals - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="24" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Normals - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="5807525742165000561" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="FaceList - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="12" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="FaceList - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="9888799799190757436" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="FaceMaterialIds - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="12" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="FaceMaterialIds - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="7113802799051126666" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="Cone_multiple_mesh_linked_materials_optimized" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.Cone_multiple_mesh_linked_materials_optimized" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MeshData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Positions - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="128" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Positions - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="14946490408303214595" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Normals - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="128" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Normals - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="367461522682321485" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="FaceList - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="62" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="FaceList - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="17210030509394354449" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="FaceMaterialIds - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="62" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="FaceMaterialIds - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="15454348664434923102" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="MeshData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -908,6 +1018,229 @@
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="UV0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.UV0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MeshVertexUVData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="UVs - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="24" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="UVs - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="1622169145591646736" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="TangentSet_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.TangentSet_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MeshVertexTangentData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Tangents - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="24" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Tangents - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="13438447437797057049" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="SetIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="0" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="BitangentSet_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.BitangentSet_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MeshVertexBitangentData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Bitangents - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="24" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Bitangents - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="11372562338897179017" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="100.0000000 0.0000000 0.0000000 0.0000000 -0.0000163 100.0000000 0.0000000 -100.0000000 -0.0000163 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNull" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DefaultAttributeIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="0" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="InheritType" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="SharedBlack" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.SharedBlack" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MaterialData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="MaterialName" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZStd::string" field="m_data" value="SharedBlack" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="UniqueId" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="5248829540156873090" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNoDraw" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DiffuseColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.0000000 0.0000000 0.0000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="SpecularColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.0000000 0.0000000 0.0000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="EmissiveColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.0000000 0.0000000 0.0000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Opacity" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="1.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Shininess" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="25.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="SharedOrange" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cube_default_multiple_mesh_linked_materials_CD5677E5_7F52_5F9A_8D80_2E8F59711E4E__optimized.SharedOrange" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MaterialData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="MaterialName" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZStd::string" field="m_data" value="SharedOrange" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="UniqueId" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="9470651048605569128" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNoDraw" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DiffuseColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.8000001 0.1393822 0.0144289" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="SpecularColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.8000001 0.1393822 0.0144289" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="EmissiveColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.0000000 0.0000000 0.0000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Opacity" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="1.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Shininess" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="25.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="UV0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.Cone_multiple_mesh_linked_materials_optimized.UV0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="MeshVertexUVData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
@@ -1077,6 +1410,229 @@
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
 				<Class name="AZStd::string" field="Name" value="SharedBlack" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Path" value="RootNode.Cone_multiple_mesh_linked_materials_optimized.SharedBlack" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MaterialData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="MaterialName" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZStd::string" field="m_data" value="SharedBlack" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="UniqueId" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="5248829540156873090" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNoDraw" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DiffuseColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.0000000 0.0000000 0.0000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="SpecularColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.0000000 0.0000000 0.0000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="EmissiveColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.0000000 0.0000000 0.0000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Opacity" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="1.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Shininess" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="25.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="UV0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.UV0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MeshVertexUVData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="UVs - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="128" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="UVs - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="7173974213247584731" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="TangentSet_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.TangentSet_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MeshVertexTangentData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Tangents - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="128" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Tangents - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="5198081677141836233" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="SetIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="0" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="BitangentSet_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.BitangentSet_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MeshVertexBitangentData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Bitangents - Count" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="128" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Bitangents - Hash" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="6948605204859680167" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="GenerationMethod" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="TransformData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Matrix3x4" field="m_data" value="100.0000000 0.0000000 0.0000000 0.0000000 -0.0000163 100.0000000 0.0000000 -100.0000000 -0.0000163 0.0000000 0.0000000 2.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNull" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DefaultAttributeIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="0" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="InheritType" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="SharedOrange" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.SharedOrange" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="MaterialData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="MaterialName" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZStd::string" field="m_data" value="SharedOrange" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="UniqueId" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::u64" field="m_data" value="9470651048605569128" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNoDraw" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DiffuseColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.8000001 0.1393822 0.0144289" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="SpecularColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.8000001 0.1393822 0.0144289" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="EmissiveColor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="Vector3" field="m_data" value="0.0000000 0.0000000 0.0000000" type="{8379EB7D-01FA-4538-B64B-A6543B4BE73D}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Opacity" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="1.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="Shininess" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="25.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="SharedBlack" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Cone_default_multiple_mesh_linked_materials_B5BE5D70_315F_5F54_807F_CC03F671024D__optimized.SharedBlack" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="MaterialData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.cpp
@@ -56,12 +56,6 @@ namespace AZ
 
                 DataTypes::MatrixType localTransform = GetLocalSpaceBindPoseTransform(scene, currentNode);
 
-                // Don't bother adding a node with the identity matrix
-                if (localTransform == DataTypes::MatrixType::Identity())
-                {
-                    return Events::ProcessingResult::Ignored;
-                }
-
                 context.m_sourceSceneSystem.SwapTransformForUpAxis(localTransform);
                 context.m_sourceSceneSystem.ConvertUnit(localTransform);
 

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.cpp
@@ -39,7 +39,7 @@ namespace AZ
                 SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context);
                 if (serializeContext)
                 {
-                    serializeContext->Class<AssImpTransformImporter, SceneCore::LoadingComponent>()->Version(1);
+                    serializeContext->Class<AssImpTransformImporter, SceneCore::LoadingComponent>()->Version(2);
                 }
             }
 

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
@@ -97,21 +97,21 @@ namespace AZ::SceneAPI::Behaviors
             return m_preExportEventContextFunction(context);
         }
 
-        // this stores the data related with MeshData nodes
-        struct MeshNodeData
+        // this stores the data related with nodes that will translate to entities in the prefab group
+        struct NodeDataForEntity
         {
             Containers::SceneGraph::NodeIndex m_meshIndex = {};
             Containers::SceneGraph::NodeIndex m_transformIndex = {};
             Containers::SceneGraph::NodeIndex m_propertyMapIndex = {};
         };
 
-        using MeshDataMapEntry = AZStd::pair<Containers::SceneGraph::NodeIndex, MeshNodeData>;
-        using MeshDataMap = AZStd::unordered_map<Containers::SceneGraph::NodeIndex, MeshNodeData>; // MeshData Index -> MeshNodeData
+        using NodeDataMapEntry = AZStd::pair<Containers::SceneGraph::NodeIndex, NodeDataForEntity>;
+        using NodeDataMap = AZStd::unordered_map<Containers::SceneGraph::NodeIndex, NodeDataForEntity>; // NodeIndex -> NodeDataForEntity
         using ManifestUpdates = AZStd::vector<AZStd::shared_ptr<DataTypes::IManifestObject>>;
-        using NodeEntityMap = AZStd::unordered_map<Containers::SceneGraph::NodeIndex, AZ::EntityId>; // MeshData Index -> EntityId
+        using NodeEntityMap = AZStd::unordered_map<Containers::SceneGraph::NodeIndex, AZ::EntityId>; // NodeIndex -> EntityId
         using EntityIdList = AZStd::vector<AZ::EntityId>;
 
-        MeshDataMap CalculateMeshTransformMap(const Containers::Scene& scene)
+        NodeDataMap CalculateNodeDataMap(const Containers::Scene& scene)
         {
             auto graph = scene.GetGraph();
             const auto view = Containers::Views::MakeSceneGraphDownwardsView<Containers::Views::BreadthFirst>(
@@ -125,11 +125,10 @@ namespace AZ::SceneAPI::Behaviors
                 return {};
             }
 
-            MeshDataMap meshDataMap;
+            NodeDataMap nodeDataMap;
             for (auto it = view.begin(); it != view.end(); ++it)
             {
                 Containers::SceneGraph::NodeIndex currentIndex = graph.ConvertToNodeIndex(it.GetHierarchyIterator());
-                AZStd::string currentNodeName = graph.GetNodeName(currentIndex).GetPath();
                 const auto currentContent = graph.GetNodeContent(currentIndex);
                 if (currentContent)
                 {
@@ -138,32 +137,44 @@ namespace AZ::SceneAPI::Behaviors
                         // get the MeshData child node index values for Transform and CustomPropertyData
                         auto childIndex = it.GetHierarchyIterator()->GetChildIndex();
 
-                        MeshNodeData meshNodeData;
-                        meshNodeData.m_meshIndex = currentIndex;
+                        NodeDataForEntity nodeDataForEntity;
+                        nodeDataForEntity.m_meshIndex = currentIndex;
 
                         while (childIndex.IsValid())
                         {
                             const auto childContent = graph.GetNodeContent(childIndex);
-                            if (currentContent.get())
+                            if (childContent)
                             {
                                 if (azrtti_istypeof<AZ::SceneAPI::DataTypes::ITransform>(childContent.get()))
                                 {
-                                    meshNodeData.m_transformIndex = childIndex;
+                                    nodeDataForEntity.m_transformIndex = childIndex;
                                 }
                                 else if (azrtti_istypeof<AZ::SceneAPI::DataTypes::ICustomPropertyData>(childContent.get()))
                                 {
-                                    meshNodeData.m_propertyMapIndex = childIndex;
+                                    nodeDataForEntity.m_propertyMapIndex = childIndex;
                                 }
                             }
                             childIndex = graph.GetNodeSibling(childIndex);
                         }
 
-                        meshDataMap.emplace(MeshDataMapEntry{ currentIndex, AZStd::move(meshNodeData) });
+                        nodeDataMap.emplace(NodeDataMapEntry{ currentIndex, AZStd::move(nodeDataForEntity) });
+                    }
+                    else if (azrtti_istypeof<AZ::SceneAPI::DataTypes::ITransform>(currentContent.get()))
+                    {
+                        // Check if this transform node is not associated with any meshes
+                        auto parentNodeIndex = graph.GetNodeParent(currentIndex);
+                        const auto parentContent = graph.GetNodeContent(parentNodeIndex);
+                        if (!azrtti_istypeof<AZ::SceneAPI::DataTypes::IMeshData>(parentContent.get()))
+                        {
+                            NodeDataForEntity nodeDataForEntity;
+                            nodeDataForEntity.m_transformIndex = currentIndex;
+                            nodeDataMap.emplace(NodeDataMapEntry{ currentIndex, AZStd::move(nodeDataForEntity) });
+                        }
                     }
                 }
             }
 
-            return meshDataMap;
+            return nodeDataMap;
         }
 
         bool AddEditorMaterialComponent(const AZ::EntityId& entityId, const DataTypes::ICustomPropertyData& propertyData)
@@ -265,93 +276,124 @@ namespace AZ::SceneAPI::Behaviors
             return result;
         }
 
-        NodeEntityMap CreateMeshGroups(
+        bool CreateMeshGroupAndComponents(
             ManifestUpdates& manifestUpdates,
-            const MeshDataMap& meshDataMap,
+            AZ::EntityId entityId,
+            const NodeDataForEntity& nodeData,
+            const NodeDataMap& nodeDataMap,
+            const Containers::Scene& scene,
+            const AZStd::string& relativeSourcePath)
+        {
+            const auto meshNodeIndex = nodeData.m_meshIndex;
+            const auto propertyDataIndex = nodeData.m_propertyMapIndex;
+
+            const auto& graph = scene.GetGraph();
+            const auto meshNodeName = graph.GetNodeName(meshNodeIndex);
+            const auto meshSubId =
+                DataTypes::Utilities::CreateStableUuid(scene, azrtti_typeid<AZ::SceneAPI::SceneData::MeshGroup>(), meshNodeName.GetPath());
+
+            AZStd::string meshGroupName = "default_";
+            meshGroupName += scene.GetName();
+            meshGroupName += meshSubId.ToFixedString().c_str();
+
+            // clean up the mesh group name
+            AZStd::replace_if(
+                meshGroupName.begin(),
+                meshGroupName.end(),
+                [](char c)
+                {
+                    return (!AZStd::is_alnum(c) && c != '_');
+                },
+                '_');
+
+            AZStd::string meshNodePath{ meshNodeName.GetPath() };
+            auto meshGroup = AZStd::make_shared<AZ::SceneAPI::SceneData::MeshGroup>();
+            meshGroup->SetName(meshGroupName);
+            meshGroup->GetSceneNodeSelectionList().AddSelectedNode(AZStd::move(meshNodePath));
+            for (const auto& meshGoupNamePair : nodeDataMap)
+            {
+                if (meshGoupNamePair.second.m_meshIndex != meshNodeIndex)
+                {
+                    const auto nodeName = graph.GetNodeName(meshGoupNamePair.second.m_meshIndex);
+                    meshGroup->GetSceneNodeSelectionList().RemoveSelectedNode(nodeName.GetPath());
+                }
+            }
+            meshGroup->OverrideId(meshSubId);
+
+            // this clears out the mesh coordinates each mesh group will be rotated and translated
+            // using the attached scene graph node
+            auto coordinateSystemRule = AZStd::make_shared<AZ::SceneAPI::SceneData::CoordinateSystemRule>();
+            coordinateSystemRule->SetUseAdvancedData(true);
+            coordinateSystemRule->SetRotation(AZ::Quaternion::CreateIdentity());
+            coordinateSystemRule->SetTranslation(AZ::Vector3::CreateZero());
+            coordinateSystemRule->SetScale(1.0f);
+            meshGroup->GetRuleContainer().AddRule(coordinateSystemRule);
+
+            // create an empty LOD rule in order to skip the LOD buffer creation
+            meshGroup->GetRuleContainer().AddRule(AZStd::make_shared<AZ::SceneAPI::SceneData::LodRule>());
+
+            manifestUpdates.emplace_back(meshGroup);
+
+            if (AddEditorMeshComponent(entityId, relativeSourcePath, meshGroupName) == false)
+            {
+                return false;
+            }
+
+            if (propertyDataIndex.IsValid())
+            {
+                const auto customPropertyData = azrtti_cast<const DataTypes::ICustomPropertyData*>(graph.GetNodeContent(propertyDataIndex));
+                if (!customPropertyData)
+                {
+                    AZ_Error("prefab", false, "Missing custom propertiy data content for node.");
+                    return false;
+                }
+
+                if (AddEditorMaterialComponent(entityId, *(customPropertyData.get())) == false)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        NodeEntityMap CreateNodeEntityMap(
+            ManifestUpdates& manifestUpdates,
+            const NodeDataMap& nodeDataMap,
             const Containers::Scene& scene,
             const AZStd::string& relativeSourcePath)
         {
             NodeEntityMap nodeEntityMap;
             const auto& graph = scene.GetGraph();
 
-            for (const auto& entry : meshDataMap)
+            for (const auto& entry : nodeDataMap)
             {
                 const auto thisNodeIndex = entry.first;
                 const auto meshNodeIndex = entry.second.m_meshIndex;
                 const auto propertyDataIndex = entry.second.m_propertyMapIndex;
-                const auto meshNodeName = graph.GetNodeName(meshNodeIndex);
-                const auto meshSubId = DataTypes::Utilities::CreateStableUuid(
-                    scene,
-                    azrtti_typeid<AZ::SceneAPI::SceneData::MeshGroup>(),
-                    meshNodeName.GetPath());
 
-                AZStd::string meshGroupName = "default_";
-                meshGroupName += scene.GetName();
-                meshGroupName += meshSubId.ToFixedString().c_str();
+                Containers::SceneGraph::NodeIndex nodeIndexForEntityName;
+                nodeIndexForEntityName = meshNodeIndex.IsValid() ? meshNodeIndex : thisNodeIndex;
+                const auto nodeNameForEntity = graph.GetNodeName(nodeIndexForEntityName);
 
-                // clean up the mesh group name
-                AZStd::replace_if(
-                    meshGroupName.begin(),
-                    meshGroupName.end(),
-                    [](char c) { return (!AZStd::is_alnum(c) && c != '_'); },
-                    '_');
-
-                AZStd::string meshNodePath{ meshNodeName.GetPath() };
-                auto meshGroup = AZStd::make_shared<AZ::SceneAPI::SceneData::MeshGroup>();
-                meshGroup->SetName(meshGroupName);
-                meshGroup->GetSceneNodeSelectionList().AddSelectedNode(AZStd::move(meshNodePath));
-                for (const auto& meshGoupNamePair : meshDataMap)
-                {
-                    if (meshGoupNamePair.second.m_meshIndex != meshNodeIndex)
-                    {
-                        const auto nodeName = graph.GetNodeName(meshGoupNamePair.second.m_meshIndex);
-                        meshGroup->GetSceneNodeSelectionList().RemoveSelectedNode(nodeName.GetPath());
-                    }
-                }
-                meshGroup->OverrideId(meshSubId);
-
-                // this clears out the mesh coordinates each mesh group will be rotated and translated
-                // using the attached scene graph node
-                auto coordinateSystemRule = AZStd::make_shared<AZ::SceneAPI::SceneData::CoordinateSystemRule>();
-                coordinateSystemRule->SetUseAdvancedData(true);
-                coordinateSystemRule->SetRotation(AZ::Quaternion::CreateIdentity());
-                coordinateSystemRule->SetTranslation(AZ::Vector3::CreateZero());
-                coordinateSystemRule->SetScale(1.0f);
-                meshGroup->GetRuleContainer().AddRule(coordinateSystemRule);
-
-                // create an empty LOD rule in order to skip the LOD buffer creation
-                meshGroup->GetRuleContainer().AddRule(AZStd::make_shared<AZ::SceneAPI::SceneData::LodRule>());
-
-                manifestUpdates.emplace_back(meshGroup);
-
-                // create an entity for each MeshGroup
+                // create an entity for each node data entry
                 AZ::EntityId entityId;
                 AzToolsFramework::EntityUtilityBus::BroadcastResult(
-                    entityId,
-                    &AzToolsFramework::EntityUtilityBus::Events::CreateEditorReadyEntity,
-                    meshNodeName.GetName());
+                    entityId, &AzToolsFramework::EntityUtilityBus::Events::CreateEditorReadyEntity, nodeNameForEntity.GetName());
 
                 if (entityId.IsValid() == false)
                 {
                     return {};
                 }
 
-
-                if (AddEditorMeshComponent(entityId, relativeSourcePath, meshGroupName) == false)
+                if (meshNodeIndex.IsValid())
                 {
-                    return {};
-                }
-
-                if (propertyDataIndex.IsValid())
-                {
-                    const auto customPropertyData = azrtti_cast<const DataTypes::ICustomPropertyData*>(graph.GetNodeContent(propertyDataIndex));
-                    if (!customPropertyData)
-                    {
-                        AZ_Error("prefab", false, "Missing custom propertiy data content for node.");
-                        return {};
-                    }
-
-                    if (AddEditorMaterialComponent(entityId, *(customPropertyData.get())) == false)
+                    if (!CreateMeshGroupAndComponents(manifestUpdates,
+                        entityId,
+                        entry.second,
+                        nodeDataMap,
+                        scene,
+                        relativeSourcePath))
                     {
                         return {};
                     }
@@ -366,7 +408,7 @@ namespace AZ::SceneAPI::Behaviors
         EntityIdList FixUpEntityParenting(
             const NodeEntityMap& nodeEntityMap,
             const Containers::SceneGraph& graph,
-            const MeshDataMap& meshDataMap)
+            const NodeDataMap& nodeDataMap)
         {
             EntityIdList entities;
             entities.reserve(nodeEntityMap.size());
@@ -381,8 +423,8 @@ namespace AZ::SceneAPI::Behaviors
                 auto parentNodeIndex = graph.GetNodeParent(thisNodeIndex);
                 while (parentNodeIndex.IsValid())
                 {
-                    auto parentNodeIterator = meshDataMap.find(parentNodeIndex);
-                    if (meshDataMap.end() != parentNodeIterator)
+                    auto parentNodeIterator = nodeDataMap.find(parentNodeIndex);
+                    if (nodeDataMap.end() != parentNodeIterator)
                     {
                         auto parentEntiyIterator = nodeEntityMap.find(parentNodeIterator->first);
                         if (nodeEntityMap.end() != parentEntiyIterator)
@@ -414,8 +456,8 @@ namespace AZ::SceneAPI::Behaviors
                     entityTransform->SetParent(parentEntityId);
                 }
 
-                auto thisNodeIterator = meshDataMap.find(thisNodeIndex);
-                AZ_Assert(thisNodeIterator != meshDataMap.end(), "This node index missing.");
+                auto thisNodeIterator = nodeDataMap.find(thisNodeIndex);
+                AZ_Assert(thisNodeIterator != nodeDataMap.end(), "This node index missing.");
                 auto thisTransformIndex = thisNodeIterator->second.m_transformIndex;
 
                 // get node matrix data to set the entity's local transform
@@ -486,7 +528,7 @@ namespace AZ::SceneAPI::Behaviors
 
             manifestUpdates.emplace_back(prefabGroup);
 
-            // update manifest if there where no errors
+            // update manifest if there were no errors
             for (auto update : manifestUpdates)
             {
                 scene.GetManifest().AddEntry(update);
@@ -526,7 +568,7 @@ namespace AZ::SceneAPI::Behaviors
         }
         else if (action == Events::AssetImportRequest::ConstructDefault && requester == RequestingApplication::Editor)
         {
-            // ignore constructing a default procedurla prefab if the Editor's "Edit Settings..." is being used
+            // ignore constructing a default procedural prefab if the Editor's "Edit Settings..." is being used
             // the user is trying to assign the source scene asset their own mesh groups
             return Events::ProcessingResult::Ignored;
         }
@@ -542,15 +584,15 @@ namespace AZ::SceneAPI::Behaviors
             }
         }
 
-        auto meshTransformMap = CalculateMeshTransformMap(scene);
-        if (meshTransformMap.empty())
+        auto nodeDataMap = CalculateNodeDataMap(scene);
+        if (nodeDataMap.empty())
         {
             return Events::ProcessingResult::Ignored;
         }
 
         // compute the filenames of the scene file
         AZStd::string relativeSourcePath = scene.GetSourceFilename();
-        // the watch folder and forward slash is used to in the asset hint path of the file
+        // the watch folder and forward slash is used in the asset hint path of the file
         AZStd::string watchFolder = scene.GetWatchFolder() + "/";
         AZ::StringFunc::Replace(relativeSourcePath, watchFolder.c_str(), "");
         AZ::StringFunc::Replace(relativeSourcePath, ".", "_");
@@ -560,13 +602,13 @@ namespace AZ::SceneAPI::Behaviors
 
         ManifestUpdates manifestUpdates;
 
-        auto nodeEntityMap = CreateMeshGroups(manifestUpdates, meshTransformMap, scene, relativeSourcePath);
+        auto nodeEntityMap = CreateNodeEntityMap(manifestUpdates, nodeDataMap, scene, relativeSourcePath);
         if(nodeEntityMap.empty())
         {
             return Events::ProcessingResult::Ignored;
         }
 
-        auto entities = FixUpEntityParenting(nodeEntityMap, scene.GetGraph(), meshTransformMap);
+        auto entities = FixUpEntityParenting(nodeEntityMap, scene.GetGraph(), nodeDataMap);
         if(entities.empty())
         {
             return Events::ProcessingResult::Ignored;

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
@@ -370,7 +370,6 @@ namespace AZ::SceneAPI::Behaviors
             {
                 const auto thisNodeIndex = entry.first;
                 const auto meshNodeIndex = entry.second.m_meshIndex;
-                const auto propertyDataIndex = entry.second.m_propertyMapIndex;
 
                 Containers::SceneGraph::NodeIndex nodeIndexForEntityName;
                 nodeIndexForEntityName = meshNodeIndex.IsValid() ? meshNodeIndex : thisNodeIndex;

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
@@ -312,7 +312,8 @@ namespace AZ::SceneAPI::Behaviors
             meshGroup->GetSceneNodeSelectionList().AddSelectedNode(AZStd::move(meshNodePath));
             for (const auto& meshGoupNamePair : nodeDataMap)
             {
-                if (meshGoupNamePair.second.m_meshIndex != meshNodeIndex)
+                if (meshGoupNamePair.second.m_meshIndex.IsValid()
+                    && meshGoupNamePair.second.m_meshIndex != meshNodeIndex)
                 {
                     const auto nodeName = graph.GetNodeName(meshGoupNamePair.second.m_meshIndex);
                     meshGroup->GetSceneNodeSelectionList().RemoveSelectedNode(nodeName.GetPath());


### PR DESCRIPTION
## What does this PR do?

When generating a procedural prefab, create entities for scene nodes with transform data that don't have a corresponding parent node with mesh data. This preserves the parent/child node hierarchy.

GHI https://github.com/o3de/o3de/issues/9808

## How was this PR tested?

Added a unit test. Manually instantiated procedural prefab in the Editor.
