### PR TITLE
Use container card header in EmotionFX

### DIFF
--- a/Gems/EMotionFX/Assets/Editor/Images/Icons/ArrowRightGray.png
+++ b/Gems/EMotionFX/Assets/Editor/Images/Icons/ArrowRightGray.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f82eaab55bd3cba448084c405110995925ece87dfe41dc72c11c98c13280a0f7
-size 156

--- a/Gems/EMotionFX/Code/MysticQt/Source/DialogStack.h
+++ b/Gems/EMotionFX/Code/MysticQt/Source/DialogStack.h
@@ -23,6 +23,10 @@ QT_FORWARD_DECLARE_CLASS(QMouseEvent)
 QT_FORWARD_DECLARE_CLASS(QResizeEvent)
 QT_FORWARD_DECLARE_CLASS(QSplitter)
 
+namespace AzQtComponents
+{
+    class CardHeader;
+}
 
 namespace MysticQt
 {
@@ -51,12 +55,12 @@ namespace MysticQt
         void resizeEvent(QResizeEvent* event) override;
 
     protected slots:
-        void OnHeaderButton();
+        void OnExpandedChanged(bool expanded);
 
     private:
         struct Dialog
         {
-            QPushButton*    m_button = nullptr;
+            AzQtComponents::CardHeader* m_header = nullptr;
             QWidget*        m_frame = nullptr;
             QWidget*        m_widget = nullptr;
             QWidget*        m_dialogWidget = nullptr;
@@ -71,9 +75,9 @@ namespace MysticQt
         };
 
     private:
-        size_t FindDialog(QPushButton* pushButton);
-        void Open(QPushButton* button);
-        void Close(QPushButton* button);
+        size_t FindDialog(AzQtComponents::CardHeader* header);
+        void Open(AzQtComponents::CardHeader* header);
+        void Close(AzQtComponents::CardHeader* button);
         void UpdateScrollBars();
 
     private:


### PR DESCRIPTION
Arrow image asset could be removed because it's not used anywhere
anymore.

Fixes #10960

Signed-off-by: Miłosz Kosobucki <milosz@kosobucki.pl>

## What does this PR do?

Implements new Container Card headers in EmotionFX instead of regular push buttons

## How was this PR tested?

Clicked around in Animation Editor around elements that use the DialogStack.

Current look:
![image](https://user-images.githubusercontent.com/104767/183626766-c4b6d8e9-1d43-47e4-8792-6226b176af66.png)
![image](https://user-images.githubusercontent.com/104767/183626804-dac6d1fa-b793-43f3-8031-1f4eed8eb79f.png)

