### PR TITLE
[Terrain] Revert debugger camera behavior.

### DIFF
--- a/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.cpp
@@ -301,10 +301,8 @@ namespace Terrain
                 AZ::RPI::ViewportContextPtr viewportContext = viewportContextRequests->GetViewportContextById(viewportInfo.m_viewportId);
                 const AZ::Transform cameraTransform = viewportContext->GetCameraTransform();
 
-                // Get our camera's center point, but then extend the center point out further along the camera's "forward"
-                // direction by half the total distance to try and get as much of our total query area as possible visible
-                // in front of the camera so that we don't waste any of our query points.
-                centerPos = cameraTransform.GetTranslation() + (viewportContext->GetCameraTransform().GetBasisY() * halfDistance);
+                // Get our camera's center point
+                centerPos = cameraTransform.GetTranslation();
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

The extra code to push the camera center point forward made some users confused, so this switches it back to the previous behavior of just using the camera's center as-is.

Closes #11020 .

## How was this PR tested?

Verified in-Editor that the new behavior works as expected.
