### PR TITLE
Fix translation for class property and file name issue

### DIFF
--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AWSMetrics_AttributesSubmissionList.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AWSMetrics_AttributesSubmissionList.names
@@ -11,6 +11,7 @@
             "methods": [
                 {
                     "base": "Getattributes",
+                    "context": "Getter",
                     "details": {
                         "name": "Get Attributes"
                     },
@@ -33,6 +34,7 @@
                 },
                 {
                     "base": "Setattributes",
+                    "context": "Setter",
                     "details": {
                         "name": "Set Attributes"
                     },

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AWSMetrics_MetricsAttribute.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AWSMetrics_MetricsAttribute.names
@@ -11,14 +11,13 @@
             "methods": [
                 {
                     "base": "SetName",
-                    "context": "AWSMetrics_MetricsAttribute",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke SetName"
+                        "tooltip": "When signaled, this will invoke Set Name"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after SetName is invoked"
+                        "tooltip": "Signaled after Set Name is invoked"
                     },
                     "details": {
                         "name": "Set Name"
@@ -33,21 +32,21 @@
                         {
                             "typeid": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}",
                             "details": {
-                                "name": "Name"
+                                "name": "Name",
+                                "tooltip": "Name of the metrics attribute."
                             }
                         }
                     ]
                 },
                 {
                     "base": "SetStrValue",
-                    "context": "AWSMetrics_MetricsAttribute",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke SetStrValue"
+                        "tooltip": "When signaled, this will invoke Set Str Value"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after SetStrValue is invoked"
+                        "tooltip": "Signaled after Set Str Value is invoked"
                     },
                     "details": {
                         "name": "Set String Value"
@@ -62,21 +61,21 @@
                         {
                             "typeid": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}",
                             "details": {
-                                "name": "Name"
+                                "name": "Value",
+                                "tooltip": "String value of the metrics attribute."
                             }
                         }
                     ]
                 },
                 {
                     "base": "SetIntValue",
-                    "context": "AWSMetrics_MetricsAttribute",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke SetIntValue"
+                        "tooltip": "When signaled, this will invoke Set Int Value"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after SetIntValue is invoked"
+                        "tooltip": "Signaled after Set Int Value is invoked"
                     },
                     "details": {
                         "name": "Set Int Value"
@@ -91,21 +90,21 @@
                         {
                             "typeid": "{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}",
                             "details": {
-                                "name": "Value"
+                                "name": "Value",
+                                "tooltip": "Integer value of the metrics attribute."
                             }
                         }
                     ]
                 },
                 {
                     "base": "SetDoubleValue",
-                    "context": "AWSMetrics_MetricsAttribute",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke SetDoubleValue"
+                        "tooltip": "When signaled, this will invoke Set Double Value"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after SetDoubleValue is invoked"
+                        "tooltip": "Signaled after Set Double Value is invoked"
                     },
                     "details": {
                         "name": "Set Double Value"
@@ -120,7 +119,8 @@
                         {
                             "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
                             "details": {
-                                "name": "Value"
+                                "name": "Value",
+                                "tooltip": "Double value of the metrics attribute."
                             }
                         }
                     ]

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
@@ -378,21 +378,20 @@ namespace ScriptCanvasEditor::Nodes
         GraphCanvas::TranslationRequests::Details methodDetails;
         methodDetails.m_name = methodName; // fallback
         key << "methods";
-        AZStd::string updatedMethodName = methodName;
-        if (isAccessor)
+
+        AZStd::string updatedMethodName = "";
+        if (methodNode->GetMethodType() == ScriptCanvas::MethodType::Getter || isAccessor)
         {
-            if (methodNode->GetMethodType() == ScriptCanvas::MethodType::Getter || isFreeMethod)
-            {
-                updatedMethodName = "Get";
-                methodContext = "Getter";
-            }
-            else
-            {
-                updatedMethodName = "Set";
-                methodContext = "Setter";
-            }
-            updatedMethodName.append(methodName);
+            updatedMethodName = "Get";
+            methodContext = "Getter";
         }
+        else if (methodNode->GetMethodType() == ScriptCanvas::MethodType::Setter)
+        {
+            updatedMethodName = "Set";
+            methodContext = "Setter";
+        }
+        updatedMethodName.append(methodName);
+
         key << updatedMethodName << methodContext;
         GraphCanvas::TranslationRequestBus::BroadcastResult(methodDetails, &GraphCanvas::TranslationRequests::GetDetails, key + ".details", methodDetails);
 
@@ -443,16 +442,13 @@ namespace ScriptCanvasEditor::Nodes
                     key.clear();
                     key << context << className << "methods" << updatedMethodName;
 
-                    if (isAccessor)
+                    if (methodNode->GetMethodType() == ScriptCanvas::MethodType::Getter || isAccessor)
                     {
-                        if (methodNode->GetMethodType() == ScriptCanvas::MethodType::Getter || isFreeMethod)
-                        {
-                            key << "Getter";
-                        }
-                        else
-                        {
-                            key << "Setter";
-                        }
+                        key << "Getter";
+                    }
+                    else if (methodNode->GetMethodType() == ScriptCanvas::MethodType::Setter)
+                    {
+                        key << "Setter";
                     }
 
                     if (slot.IsInput())

--- a/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.cpp
@@ -111,7 +111,7 @@ namespace ScriptCanvasEditor::TranslationHelper
         AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
             success, &AzToolsFramework::AssetSystem::AssetSystemRequest::GetAssetSafeFolders, scanFolders);
         auto fileIO = AZ::IO::FileIOBase::GetInstance();
-        
+
         if (fileIO && success && !fileName.empty())
         {
             AZStd::string fileNameWithExtension = AZStd::string::format("%s.names", fileName.c_str());

--- a/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Translation/TranslationHelper.cpp
@@ -111,7 +111,7 @@ namespace ScriptCanvasEditor::TranslationHelper
         AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
             success, &AzToolsFramework::AssetSystem::AssetSystemRequest::GetAssetSafeFolders, scanFolders);
         auto fileIO = AZ::IO::FileIOBase::GetInstance();
-
+        
         if (fileIO && success && !fileName.empty())
         {
             AZStd::string fileNameWithExtension = AZStd::string::format("%s.names", fileName.c_str());

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
@@ -126,7 +126,7 @@ namespace ScriptCanvasEditor
 
     AZ::IO::Path ClassMethodEventPaletteTreeItem::GetTranslationDataPath() const
     {
-        AZStd::string fileName = GetClassMethodName();
+        AZStd::string fileName = GraphCanvas::TranslationKey::Sanitize(GetClassMethodName());
         return ScriptCanvasEditor::TranslationHelper::GetTranslationFilePath(fileName);
     }
 


### PR DESCRIPTION
## What does this PR do?
1. Fix translation for behavior class property node. Both class property and global constant getter should follow the same translation file format.
2. Fix translation file name inconsistency for behavior class node. While retrieving translation file, it should use the same sanitize function as the one used for creating translation file.
3. Update AWSMetrics node translation file by following correct format for closing https://github.com/o3de/o3de/issues/8581

## How was this PR tested?
Tested in Editor to make sure ScriptCanvas Node can be created with expected name

Signed-off-by: onecent1101 <liug@amazon.com>