### PR TITLE
[Environment] Allow for move-only and copy-only types to be stored in environment variables

### DIFF
--- a/Code/Framework/AzCore/AzCore/Module/Environment.h
+++ b/Code/Framework/AzCore/AzCore/Module/Environment.h
@@ -8,13 +8,15 @@
 #ifndef AZCORE_ENVIRONMENT_INCLUDE_H
 #define AZCORE_ENVIRONMENT_INCLUDE_H 1
 
-#include <AzCore/std/smart_ptr/sp_convertible.h>
+#include <AzCore/std/parallel/lock.h>
 #include <AzCore/std/parallel/mutex.h>
 #include <AzCore/std/parallel/spin_mutex.h>
-#include <AzCore/std/parallel/lock.h>
-#include <AzCore/std/typetraits/alignment_of.h>
-#include <AzCore/std/typetraits/has_virtual_destructor.h>
+#include <AzCore/std/smart_ptr/sp_convertible.h>
 #include <AzCore/std/typetraits/aligned_storage.h>
+#include <AzCore/std/typetraits/alignment_of.h>
+#include <AzCore/std/typetraits/config.h>
+#include <AzCore/std/typetraits/has_virtual_destructor.h>
+#include <AzCore/std/concepts/concepts_assignable.h>
 
 namespace AZ
 {
@@ -426,14 +428,10 @@ namespace AZ
             return *reinterpret_cast<T*>(&m_data->m_value);
         }
 
-        void Set(const T& value)
+        template<typename U>
+        auto Set(U&& value) -> AZStd::enable_if_t<AZStd::assignable_from<T&, U>>
         {
-            Get() = value;
-        }
-
-        void Set(T&& value)
-        {
-            Get() = AZStd::move(value);
+            Get() = AZStd::forward<U>(value);
         }
 
         explicit operator bool() const


### PR DESCRIPTION
This disables the `Set()` functions of an `EnvironmentVariable` if a type
doesn't support move assignment or copy assignment.

Signed-off-by: Chris Burel <burelc@amazon.com>