### PR TITLE
Added Suffix to Edit reflection options for network auto-components

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
@@ -1112,6 +1112,9 @@ m_{{ LowerFirst(Property.attrib['Name']) }} = m_{{ LowerFirst(Property.attrib['N
 {%      if Property.attrib['ExposeToEditor'] | booleanTrue %}
 ->DataElement(AZ::Edit::UIHandlers::Default, &{{ ClassName }}::m_{{ LowerFirst(Property.attrib['Name']) }}, "{{ UpperFirst(Property.attrib['Name']) }}", "{{ Property.attrib['Desc'] }}")
 {%      endif %}
+{%      if Property.attrib['Suffix'] %}
+->Attribute(AZ::Edit::Attributes::Suffix, " {{ Property.attrib['Suffix'] }}")
+{%      endif %}
 {% endcall %}
 {% endmacro %}
 {#


### PR DESCRIPTION
Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>

## What does this PR do?

Allows one to specify `Suffix="units"` for an ArchetypeProperty in an auto-component XML definition. For example:
```
    <ArchetypeProperty Type="float" Name="Speed" ExposeToEditor="true" Suffix="world units per second" ....
```
Results in:
![image](https://user-images.githubusercontent.com/5432499/183767904-53f3139f-e65c-476c-986e-ad1a84dcdf12.png)

## How was this PR tested?

In o3de-multiplayersample using the following xml auto definition:

```
<?xml version="1.0"?>

<Component
    Name="EnergyBallComponent"
    Namespace="MultiplayerSample"
    OverrideComponent="false"
    OverrideController="true"
    OverrideInclude="Source/Components/Multiplayer/EnergyBallComponent.h"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

    <ComponentRelation Constraint="Required" HasController="true" Name="NetworkTransformComponent" Namespace="Multiplayer" Include="Multiplayer/Components/NetworkTransformComponent.h" />

    <ArchetypeProperty Type="float" Name="Speed" ExposeToEditor="true" Suffix="world units per second"
                       Description="The speed of the energy ball" />
</Component>
```
