### PR TITLE
Fix ImGui Server Option 'Launch Local Client' to Auto-Connect on Windows and Linux

### DIFF
--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -1330,8 +1330,7 @@ namespace Multiplayer
         }
         
         AzFramework::ProcessLauncher::ProcessLaunchInfo processLaunchInfo;
-        processLaunchInfo.m_processExecutableString = gameLauncherPath.String();
-        processLaunchInfo.m_commandlineParameters = "--cl_connect_onstartup=true";
+        processLaunchInfo.m_commandlineParameters = AZStd::string::format("%s --cl_connect_onstartup true", gameLauncherPath.c_str());
         processLaunchInfo.m_processPriority = AzFramework::ProcessPriority::PROCESSPRIORITY_NORMAL;
         
         // Launch GameLauncher and connect to this server


### PR DESCRIPTION
## What does this PR do?
Fixes the ImGui server option to "Launch Local Client". It would previously launch the client, but wouldn't auto-connect.

Fixes #11187 

## How was this PR tested?
Opened ImGui and tested "Launch Local Client" on both Linux and Windows
