### PR TITLE
Early return when failed to create skinnedMeshInstance in atomActorInstance to prevent crash.

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -595,6 +595,12 @@ namespace AZ::Render
 
     void AtomActorInstance::RegisterActor()
     {
+        if (!m_skinnedMeshInstance)
+        {
+            AZ_Error("AtomActorInstance", m_skinnedMeshInstance, "SkinnedMeshInstance must be created before register this actor. ");
+            return;
+        }
+        
         MaterialAssignmentMap materials;
         MaterialComponentRequestBus::EventResult(materials, m_entityId, &MaterialComponentRequests::GetMaterialMap);
         CreateRenderProxy(materials);

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -597,7 +597,7 @@ namespace AZ::Render
     {
         if (!m_skinnedMeshInstance)
         {
-            AZ_Error("AtomActorInstance", m_skinnedMeshInstance, "SkinnedMeshInstance must be created before register this actor. ");
+            AZ_Error("AtomActorInstance", m_skinnedMeshInstance, "SkinnedMeshInstance must be created before register this actor.");
             return;
         }
         


### PR DESCRIPTION
Signed-off-by: rhhong <rhhong@amazon.com>

## What does this PR do?

Address the issue in https://github.com/o3de/o3de/issues/9700
The asset in the ticket will not create skinnedMeshInstance due to another issue (source asset must contain one bone and a skinned mesh). That issue has been addressed and now produce a warning msg in the log.
However, when the skinnedMeshInstance is missing, AtomActorInstance registerActor function will crash because it cannot find the instance. This change will do an early return on the registerActor() function, thus prevent the crash. 

## How was this PR tested?

Tested with repo steps in https://github.com/o3de/o3de/issues/9700
