### PR TITLE
Fix a crash for morph target window

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/MorphTargetGroupWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/MorphTargetGroupWidget.cpp
@@ -211,6 +211,11 @@ namespace EMStudio
         AzQtComponents::SliderDoubleCombo* floatSlider = static_cast<AzQtComponents::SliderDoubleCombo*>(sender());
         const int morphTargetIndex = floatSlider->property("MorphTargetIndex").toInt();
         EMotionFX::MorphTarget* morphTarget = m_morphTargets[morphTargetIndex].m_morphTarget;
+        if (!morphTarget)
+        {
+            return;
+        }
+
         EMotionFX::MorphSetupInstance::MorphTarget* morphTargetInstance = m_morphTargets[morphTargetIndex].m_morphTargetInstance;
 
         // set the old weight to have the undo correct


### PR DESCRIPTION
Signed-off-by: rhhong <rhhong@amazon.com>

## What does this PR do?

Add a null guard in morphTargetWindow. A potential solution of https://github.com/o3de/o3de/issues/8584 (for the crash in UI).

## How was this PR tested?

Perform repo steps in https://github.com/o3de/o3de/issues/8584
