### PR TITLE
Material Canvas: Search and replace data change reverting O3DE_ prefix on node configuration tokens

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ExamplePBR/example_pbr.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ExamplePBR/example_pbr.materialcanvasnode
@@ -36,7 +36,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -57,7 +57,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -99,7 +99,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -125,7 +125,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ExamplePBR/example_pbr2.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ExamplePBR/example_pbr2.materialcanvasnode
@@ -36,7 +36,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -62,7 +62,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -83,7 +83,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -104,7 +104,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -125,7 +125,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -151,7 +151,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/abs.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/abs.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = abs(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = abs(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/acos.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/acos.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = acos(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = acos(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/add.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/add.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_NODEID_inValue1 + O3DE_NODEID_inValue2;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 + NODEID_inValue2;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/asfloat.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/asfloat.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = asfloat(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = asfloat(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/asin.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/asin.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = asin(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = asin(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/atan.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/atan.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = atan(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = atan(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/atan2.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/atan2.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = atan2(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = atan2(NODEID_inValue1, NODEID_inValue2);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ceil.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ceil.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = ceil(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = ceil(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/clamp.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/clamp.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -80,7 +80,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -104,7 +104,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = clamp(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2, O3DE_NODEID_inValue3);"
+                        "SLOTTYPE NODEID_SLOTNAME = clamp(NODEID_inValue1, NODEID_inValue2, NODEID_inValue3);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/clip.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/clip.materialcanvasnode
@@ -7,7 +7,7 @@
         "title": "clip",
         "settings": {
             "instructions": [
-                "clip(O3DE_NODEID_inValue);"
+                "clip(NODEID_inValue);"
             ]
         },
         "inputSlots": [
@@ -33,7 +33,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/combine.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/combine.materialcanvasnode
@@ -19,7 +19,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -36,7 +36,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -53,7 +53,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -70,7 +70,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -85,7 +85,7 @@
                 ],
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTTYPE(O3DE_NODEID_inX, O3DE_NODEID_inY, O3DE_NODEID_inZ, O3DE_NODEID_inW);"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTTYPE(NODEID_inX, NODEID_inY, NODEID_inZ, NODEID_inW);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/constant_color.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/constant_color.materialcanvasnode
@@ -24,7 +24,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -48,7 +48,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_NODEID_inValue;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/constant_float.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/constant_float.materialcanvasnode
@@ -15,7 +15,7 @@
                 ],
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -30,7 +30,7 @@
                 ],
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_NODEID_inValue;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/constant_float2.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/constant_float2.materialcanvasnode
@@ -15,7 +15,7 @@
                 ],
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -30,7 +30,7 @@
                 ],
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_NODEID_inValue;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/constant_float3.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/constant_float3.materialcanvasnode
@@ -15,7 +15,7 @@
                 ],
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -30,7 +30,7 @@
                 ],
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_NODEID_inValue;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/constant_float4.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/constant_float4.materialcanvasnode
@@ -15,7 +15,7 @@
                 ],
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -30,7 +30,7 @@
                 ],
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_NODEID_inValue;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/cos.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/cos.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = cos(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = cos(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/cosh.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/cosh.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = cosh(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = cosh(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/cross.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/cross.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = cross(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = cross(NODEID_inValue1, NODEID_inValue2);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddx.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddx.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = ddx(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = ddx(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddx_coarse.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddx_coarse.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = ddx_coarse(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = ddx_coarse(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddx_fine.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddx_fine.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = ddx_fine(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = ddx_fine(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddy.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddy.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = ddy(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = ddy(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddy_coarse.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddy_coarse.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = ddy_coarse(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = ddy_coarse(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddy_fine.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ddy_fine.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = ddy_fine(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = ddy_fine(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/degrees.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/degrees.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = degrees(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = degrees(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/distance.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/distance.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = distance(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = distance(NODEID_inValue1, NODEID_inValue2);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/divide.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/divide.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_NODEID_inValue1 / O3DE_NODEID_inValue2;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 / NODEID_inValue2;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/dot.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/dot.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = dot(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = dot(NODEID_inValue1, NODEID_inValue2);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/exp.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/exp.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = exp(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = exp(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/exp2.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/exp2.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = exp2(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = exp2(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/floor.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/floor.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = floor(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = floor(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/fmod.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/fmod.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = fmod(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = fmod(NODEID_inValue1, NODEID_inValue2);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/frac.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/frac.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = frac(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = frac(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/frexp.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/frexp.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = frexp(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = frexp(NODEID_inValue1, NODEID_inValue2);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/fwidth.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/fwidth.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = fwidth(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = fwidth(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ldexp.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/ldexp.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = ldexp(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = ldexp(NODEID_inValue1, NODEID_inValue2);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/length.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/length.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = length(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = length(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/lerp.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/lerp.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -80,7 +80,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -104,7 +104,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = lerp(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2, O3DE_NODEID_inValue3);"
+                        "SLOTTYPE NODEID_SLOTNAME = lerp(NODEID_inValue1, NODEID_inValue2, NODEID_inValue3);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/lit.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/lit.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -80,7 +80,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -104,7 +104,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = lit(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2, O3DE_NODEID_inValue3);"
+                        "SLOTTYPE NODEID_SLOTNAME = lit(NODEID_inValue1, NODEID_inValue2, NODEID_inValue3);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/log.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/log.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = log(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = log(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/log10.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/log10.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = log10(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = log10(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/log2.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/log2.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = log2(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = log2(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/mad.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/mad.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -80,7 +80,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -104,7 +104,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = mad(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2, O3DE_NODEID_inValue3);"
+                        "SLOTTYPE NODEID_SLOTNAME = mad(NODEID_inValue1, NODEID_inValue2, NODEID_inValue3);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/max.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/max.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = max(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = max(NODEID_inValue1, NODEID_inValue2);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/min.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/min.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = min(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = min(NODEID_inValue1, NODEID_inValue2);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/mul.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/mul.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = mul(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = mul(NODEID_inValue1, NODEID_inValue2);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/multiply.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/multiply.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_NODEID_inValue1 * O3DE_NODEID_inValue2;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 * NODEID_inValue2;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/noise.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/noise.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = noise(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = noise(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/normalize.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/normalize.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = normalize(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = normalize(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/pow.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/pow.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = pow(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = pow(NODEID_inValue1, NODEID_inValue2);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/radians.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/radians.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = radians(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = radians(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/rcp.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/rcp.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = rcp(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = rcp(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/reflect.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/reflect.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = reflect(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = reflect(NODEID_inValue1, NODEID_inValue2);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/refract.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/refract.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -80,7 +80,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -104,7 +104,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = refract(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2, O3DE_NODEID_inValue3);"
+                        "SLOTTYPE NODEID_SLOTNAME = refract(NODEID_inValue1, NODEID_inValue2, NODEID_inValue3);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/round.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/round.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = round(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = round(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/rsqrt.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/rsqrt.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = rsqrt(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = rsqrt(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sample_texture_2d.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sample_texture_2d.materialcanvasnode
@@ -26,7 +26,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -50,7 +50,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = 1.0;"
+                        "SLOTTYPE NODEID_SLOTNAME = 1.0;"
                     ]
                 }
             },
@@ -67,7 +67,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = 1.0;"
+                        "SLOTTYPE NODEID_SLOTNAME = 1.0;"
                     ]
                 }
             },
@@ -84,7 +84,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = 1.0;"
+                        "SLOTTYPE NODEID_SLOTNAME = 1.0;"
                     ]
                 }
             },
@@ -101,7 +101,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = 1.0;"
+                        "SLOTTYPE NODEID_SLOTNAME = 1.0;"
                     ]
                 }
             },
@@ -118,7 +118,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = 1.0;"
+                        "SLOTTYPE NODEID_SLOTNAME = 1.0;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/saturate.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/saturate.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = saturate(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = saturate(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sign.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sign.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = sign(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = sign(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sin.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sin.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = sin(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = sin(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sincos.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sincos.materialcanvasnode
@@ -7,9 +7,9 @@
         "title": "sincos",
         "settings": {
             "instructions": [
-                "float4 O3DE_NODEID_outValue1 = float4(0, 0, 0, 0);",
-                "float4 O3DE_NODEID_outValue2 = float4(0, 0, 0, 0);",
-                "sincos(O3DE_NODEID_inValue, O3DE_NODEID_outValue1, O3DE_NODEID_outValue2);"
+                "float4 NODEID_outValue1 = float4(0, 0, 0, 0);",
+                "float4 NODEID_outValue2 = float4(0, 0, 0, 0);",
+                "sincos(NODEID_inValue, NODEID_outValue1, NODEID_outValue2);"
             ]
         },
         "inputSlots": [
@@ -35,7 +35,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sinh.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sinh.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = sinh(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = sinh(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/smoothstep.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/smoothstep.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -80,7 +80,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -104,7 +104,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = smoothstep(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2, O3DE_NODEID_inValue3);"
+                        "SLOTTYPE NODEID_SLOTNAME = smoothstep(NODEID_inValue1, NODEID_inValue2, NODEID_inValue3);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/split.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/split.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -47,7 +47,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_NODEID_inValue.x;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.x;"
                     ]
                 }
             },
@@ -64,7 +64,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_NODEID_inValue.y;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.y;"
                     ]
                 }
             },
@@ -81,7 +81,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_NODEID_inValue.z;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.z;"
                     ]
                 }
             },
@@ -98,7 +98,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_NODEID_inValue.w;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.w;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sqrt.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/sqrt.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = sqrt(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = sqrt(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/step.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/step.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = step(O3DE_NODEID_inValue1, O3DE_NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = step(NODEID_inValue1, NODEID_inValue2);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/subtract.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/subtract.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             },
@@ -54,7 +54,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -78,7 +78,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_NODEID_inValue1 - O3DE_NODEID_inValue2;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue1 - NODEID_inValue2;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/tan.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/tan.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = tan(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = tan(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/tanh.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/tanh.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = tanh(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = tanh(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.material
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.material
@@ -1,0 +1,3 @@
+{
+    "materialType": "./test4.materialtype"
+}

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.materialtype
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.materialtype
@@ -1,0 +1,17 @@
+{
+    "description": "test4 Material Type Template.",
+    "version": 1,
+    "shaders": [
+        {
+            "file": "./test4_ForwardPass.shader"
+        },
+        {
+            "file": "Shaders/Shadow/Shadowmap.shader"
+        },
+        {
+            "file": "Shaders/Depth/DepthPass.shader"
+        }
+    ],
+    "functors": [
+    ]
+}

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4_ForwardPass.azsl
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4_ForwardPass.azsl
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <viewsrg.srgi>
+#include <Atom/Features/PBR/DefaultObjectSrg.azsli>
+#include <Atom/Features/PBR/ForwardPassSrg.azsli>
+#include <Atom/Features/PBR/ForwardPassOutput.azsli>
+#include <Atom/Features/PBR/AlphaUtils.azsli>
+#include <Atom/Features/SrgSemantics.azsli>
+#include <Atom/Features/ColorManagement/TransformColor.azsli>
+#include <Atom/Features/PBR/Lighting/StandardLighting.azsli>
+#include <Atom/Features/PBR/Decals.azsli>
+
+// Everything inside of the generated blocks will eventually be replaced in the generated files as the material graph is compiled. 
+
+// O3DE_GENERATED_INCLUDES_BEGIN
+// O3DE_GENERATED_INCLUDES_END
+
+struct VSInput
+{
+    float3 m_position : POSITION;
+    float3 m_normal : NORMAL;
+    float4 m_tangent : TANGENT; 
+    float3 m_bitangent : BITANGENT;
+
+    // O3DE_GENERATED_VSINPUT_BEGIN
+    // O3DE_GENERATED_VSINPUT_END
+};
+
+struct VSOutput
+{
+    precise linear centroid float4 m_position : SV_Position;
+    float3 m_normal: NORMAL;
+    float3 m_tangent : TANGENT; 
+    float3 m_bitangent : BITANGENT;
+    float3 m_worldPosition : UV0;
+};
+
+#include <Atom/Features/Vertex/VertexHelper.azsli>
+
+ShaderResourceGroup MaterialSrg : SRG_PerMaterial
+{
+    // O3DE_GENERATED_MATERIAL_SRG_BEGIN
+    // O3DE_GENERATED_MATERIAL_SRG_END
+}
+ 
+// O3DE_GENERATED_CLASSES_BEGIN
+// O3DE_GENERATED_CLASSES_END
+ 
+// O3DE_GENERATED_FUNCTIONS_BEGIN
+// O3DE_GENERATED_FUNCTIONS_END
+
+VSOutput test4_MainPassVS(VSInput IN)
+{
+    VSOutput OUT;
+ 
+    float3 worldPosition = mul(ObjectSrg::GetWorldMatrix(), float4(IN.m_position, 1.0)).xyz;
+ 
+    // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inPositionOffset
+    float4 inPositionOffset = float4(0.0, 0.0, 0.0, 0.0);
+    // O3DE_GENERATED_INSTRUCTIONS_END
+
+    VertexHelper(IN, OUT, worldPosition + inPositionOffset.xyz);
+
+    return OUT;
+}
+
+ForwardPassOutput test4_MainPassPS(VSOutput IN)
+{
+    // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inBaseColor, inEmissive, inMetallic, inRoughness, inSpecularF0Factor
+float2 node2_inUV = float2(0, 0);
+float4 node2_outColor = 1.0;
+float2 node3_inUV = float2(0, 0);
+float node3_outR = 1.0;
+float node3_outG = 1.0;
+float node3_outB = 1.0;
+float4 inBaseColor = node2_outColor;
+float inMetallic = node3_outR;
+float inSpecularF0Factor = node3_outG;
+float inRoughness = node3_outB;
+float4 inEmissive = float4(0, 0, 0, 1);
+    // O3DE_GENERATED_INSTRUCTIONS_END
+
+    // ------- Surface -------
+
+    Surface surface;
+    surface.position = IN.m_worldPosition.xyz;
+    surface.normal = normalize(IN.m_normal);
+    surface.vertexNormal = normalize(IN.m_normal);
+    surface.roughnessLinear = inRoughness;
+    surface.CalculateRoughnessA();
+    surface.SetAlbedoAndSpecularF0(inBaseColor.rgb, inSpecularF0Factor, inMetallic);
+    surface.clearCoat.InitializeToZero();
+
+    // ------- LightingData -------
+
+    LightingData lightingData;
+    lightingData.tileIterator.Init(IN.m_position, PassSrg::m_lightListRemapped, PassSrg::m_tileLightData);
+    lightingData.Init(surface.position, surface.normal, surface.roughnessLinear);
+    lightingData.specularResponse = FresnelSchlickWithRoughness(lightingData.NdotV, surface.specularF0, surface.roughnessLinear);
+    lightingData.diffuseResponse = 1.0f - lightingData.specularResponse;
+    lightingData.emissiveLighting = inEmissive;
+
+    // ------- Lighting Calculation -------
+
+    // Apply Decals
+    ApplyDecals(lightingData.tileIterator, surface);
+
+    // Apply Direct Lighting
+    ApplyDirectLighting(surface, lightingData, IN.m_position);
+
+    // Apply Image Based Lighting (IBL)
+    ApplyIBL(surface, lightingData);
+
+    // Finalize Lighting
+    lightingData.FinalizeLighting();
+
+    PbrLightingOutput lightingOutput = GetPbrLightingOutput(surface, lightingData, inBaseColor.a);
+
+    // ------- Output -------
+
+    ForwardPassOutput OUT;
+
+    OUT.m_diffuseColor = lightingOutput.m_diffuseColor;
+    OUT.m_diffuseColor.w = -1; // Subsurface scattering is disabled
+    OUT.m_specularColor = lightingOutput.m_specularColor;
+    OUT.m_specularF0 = lightingOutput.m_specularF0;
+    OUT.m_albedo = lightingOutput.m_albedo;
+    OUT.m_normal = lightingOutput.m_normal;
+
+    return OUT;
+}

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4_ForwardPass.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4_ForwardPass.shader
@@ -1,0 +1,42 @@
+{
+    "Source" : "./test4_ForwardPass.azsl",
+
+    "DepthStencilState" :
+    {
+        "Depth" :
+        {
+            "Enable" : true,
+            "CompareFunc" : "GreaterEqual"
+        },
+        "Stencil" :
+        {
+            "Enable" : true,
+            "ReadMask" : "0x00",
+            "WriteMask" : "0xFF",
+            "FrontFace" :
+            {
+                "Func" : "Always",
+                "DepthFailOp" : "Keep",
+                "FailOp" : "Keep",
+                "PassOp" : "Replace"
+            }
+        }
+    },
+
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "test4_MainPassVS",
+          "type": "Vertex"
+        },
+        {
+          "name": "test4_MainPassPS",
+          "type": "Fragment"
+        }
+      ]
+    },
+
+    "DrawList" : "forward"
+}

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.material
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.material
@@ -1,0 +1,3 @@
+{
+    "materialType": "./test5.materialtype"
+}

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.materialtype
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.materialtype
@@ -1,0 +1,17 @@
+{
+    "description": "test5 Material Type Template.",
+    "version": 1,
+    "shaders": [
+        {
+            "file": "./test5_ForwardPass.shader"
+        },
+        {
+            "file": "Shaders/Shadow/Shadowmap.shader"
+        },
+        {
+            "file": "Shaders/Depth/DepthPass.shader"
+        }
+    ],
+    "functors": [
+    ]
+}

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5_ForwardPass.azsl
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5_ForwardPass.azsl
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <viewsrg.srgi>
+#include <Atom/Features/PBR/DefaultObjectSrg.azsli>
+#include <Atom/Features/PBR/ForwardPassSrg.azsli>
+#include <Atom/Features/PBR/ForwardPassOutput.azsli>
+#include <Atom/Features/PBR/AlphaUtils.azsli>
+#include <Atom/Features/SrgSemantics.azsli>
+#include <Atom/Features/ColorManagement/TransformColor.azsli>
+#include <Atom/Features/PBR/Lighting/StandardLighting.azsli>
+#include <Atom/Features/PBR/Decals.azsli>
+
+// Everything inside of the generated blocks will eventually be replaced in the generated files as the material graph is compiled. 
+
+// O3DE_GENERATED_INCLUDES_BEGIN
+// O3DE_GENERATED_INCLUDES_END
+
+struct VSInput
+{
+    float3 m_position : POSITION;
+    float3 m_normal : NORMAL;
+    float4 m_tangent : TANGENT; 
+    float3 m_bitangent : BITANGENT;
+
+    // O3DE_GENERATED_VSINPUT_BEGIN
+    // O3DE_GENERATED_VSINPUT_END
+};
+
+struct VSOutput
+{
+    precise linear centroid float4 m_position : SV_Position;
+    float3 m_normal: NORMAL;
+    float3 m_tangent : TANGENT; 
+    float3 m_bitangent : BITANGENT;
+    float3 m_worldPosition : UV0;
+};
+
+#include <Atom/Features/Vertex/VertexHelper.azsli>
+
+ShaderResourceGroup MaterialSrg : SRG_PerMaterial
+{
+    // O3DE_GENERATED_MATERIAL_SRG_BEGIN
+    // O3DE_GENERATED_MATERIAL_SRG_END
+}
+ 
+// O3DE_GENERATED_CLASSES_BEGIN
+// O3DE_GENERATED_CLASSES_END
+ 
+// O3DE_GENERATED_FUNCTIONS_BEGIN
+// O3DE_GENERATED_FUNCTIONS_END
+
+VSOutput test5_MainPassVS(VSInput IN)
+{
+    VSOutput OUT;
+ 
+    float3 worldPosition = mul(ObjectSrg::GetWorldMatrix(), float4(IN.m_position, 1.0)).xyz;
+ 
+    // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inPositionOffset
+float4 inPositionOffset = float4(0, 0, 0, 0);
+    // O3DE_GENERATED_INSTRUCTIONS_END
+
+    VertexHelper(IN, OUT, worldPosition + inPositionOffset.xyz);
+
+    return OUT;
+}
+
+ForwardPassOutput test5_MainPassPS(VSOutput IN)
+{
+    // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inBaseColor, inEmissive, inMetallic, inRoughness, inSpecularF0Factor
+float node4_outTime = SceneSrg::m_time;
+float4 node9_inValue = node4_outTime;
+float4 node9_outValue = cos(node9_inValue);
+float4 node8_inValue1 = node9_outValue;
+float4 node8_inValue2 = node9_outValue;
+float4 node8_outValue = node8_inValue1 * node8_inValue2;
+float4 node2_inValue = float4(1, 1, 0, 10);
+float4 node2_outValue = node2_inValue;
+float4 node3_inValue = float4(0, 0.1, 1, 1);
+float4 node3_outValue = node3_inValue;
+float4 node5_inValue = node4_outTime;
+float4 node5_outValue = sin(node5_inValue);
+float4 node11_inValue = node5_outValue;
+float4 node11_outValue = ceil(node11_inValue);
+float4 node7_inValue = node5_outValue;
+float4 node7_outValue = abs(node7_inValue);
+float4 node6_inValue1 = node2_outValue;
+float4 node6_inValue2 = node3_outValue;
+float4 node6_inValue3 = node7_outValue;
+float4 node6_outValue = lerp(node6_inValue1, node6_inValue2, node6_inValue3);
+float4 inBaseColor = node6_outValue;
+float inMetallic = node8_outValue;
+float inSpecularF0Factor = 0;
+float inRoughness = node11_outValue;
+float4 inEmissive = float4(0, 0, 0, 1);
+    // O3DE_GENERATED_INSTRUCTIONS_END
+
+    // ------- Surface -------
+
+    Surface surface;
+    surface.position = IN.m_worldPosition.xyz;
+    surface.normal = normalize(IN.m_normal);
+    surface.vertexNormal = normalize(IN.m_normal);
+    surface.roughnessLinear = inRoughness;
+    surface.CalculateRoughnessA();
+    surface.SetAlbedoAndSpecularF0(inBaseColor.rgb, inSpecularF0Factor, inMetallic);
+    surface.clearCoat.InitializeToZero();
+
+    // ------- LightingData -------
+
+    LightingData lightingData;
+    lightingData.tileIterator.Init(IN.m_position, PassSrg::m_lightListRemapped, PassSrg::m_tileLightData);
+    lightingData.Init(surface.position, surface.normal, surface.roughnessLinear);
+    lightingData.specularResponse = FresnelSchlickWithRoughness(lightingData.NdotV, surface.specularF0, surface.roughnessLinear);
+    lightingData.diffuseResponse = 1.0f - lightingData.specularResponse;
+    lightingData.emissiveLighting = inEmissive;
+
+    // ------- Lighting Calculation -------
+
+    // Apply Decals
+    ApplyDecals(lightingData.tileIterator, surface);
+
+    // Apply Direct Lighting
+    ApplyDirectLighting(surface, lightingData, IN.m_position);
+
+    // Apply Image Based Lighting (IBL)
+    ApplyIBL(surface, lightingData);
+
+    // Finalize Lighting
+    lightingData.FinalizeLighting();
+
+    PbrLightingOutput lightingOutput = GetPbrLightingOutput(surface, lightingData, inBaseColor.a);
+
+    // ------- Output -------
+
+    ForwardPassOutput OUT;
+
+    OUT.m_diffuseColor = lightingOutput.m_diffuseColor;
+    OUT.m_diffuseColor.w = -1; // Subsurface scattering is disabled
+    OUT.m_specularColor = lightingOutput.m_specularColor;
+    OUT.m_specularF0 = lightingOutput.m_specularF0;
+    OUT.m_albedo = lightingOutput.m_albedo;
+    OUT.m_normal = lightingOutput.m_normal;
+
+    return OUT;
+}

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5_ForwardPass.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5_ForwardPass.shader
@@ -1,0 +1,42 @@
+{
+    "Source" : "./test5_ForwardPass.azsl",
+
+    "DepthStencilState" :
+    {
+        "Depth" :
+        {
+            "Enable" : true,
+            "CompareFunc" : "GreaterEqual"
+        },
+        "Stencil" :
+        {
+            "Enable" : true,
+            "ReadMask" : "0x00",
+            "WriteMask" : "0xFF",
+            "FrontFace" :
+            {
+                "Func" : "Always",
+                "DepthFailOp" : "Keep",
+                "FailOp" : "Keep",
+                "PassOp" : "Replace"
+            }
+        }
+    },
+
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "test5_MainPassVS",
+          "type": "Vertex"
+        },
+        {
+          "name": "test5_MainPassPS",
+          "type": "Fragment"
+        }
+      ]
+    },
+
+    "DrawList" : "forward"
+}

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/time.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/time.materialcanvasnode
@@ -19,7 +19,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = SceneSrg::m_time;"
+                        "SLOTTYPE NODEID_SLOTNAME = SceneSrg::m_time;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/trunc.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/trunc.materialcanvasnode
@@ -28,7 +28,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = O3DE_SLOTVALUE;"
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
                     ]
                 }
             }
@@ -52,7 +52,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "O3DE_SLOTTYPE O3DE_NODEID_O3DE_SLOTNAME = trunc(O3DE_NODEID_inValue);"
+                        "SLOTTYPE NODEID_SLOTNAME = trunc(NODEID_inValue);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -476,17 +476,17 @@ namespace MaterialCanvas
                 if (sourceSlot && targetSlot && sourceSlot != targetSlot && sourceSlot != slot)
                 {
                     ReplaceStringsInContainer(
-                        "O3DE_SLOTVALUE",
+                        "SLOTVALUE",
                         AZStd::string::format("node%u_%s", sourceSlot->GetParentNode()->GetId(), sourceSlot->GetName().c_str()),
                         instructionsForSlot);
                     break;
                 }
             }
 
-            ReplaceStringsInContainer("O3DE_NODEID", AZStd::string::format("node%u", node->GetId()), instructionsForSlot);
-            ReplaceStringsInContainer("O3DE_SLOTNAME", slot->GetName().c_str(), instructionsForSlot);
-            ReplaceStringsInContainer("O3DE_SLOTTYPE", ConvertSlotTypeToAZSL(slot->GetDataType()->GetDisplayName()), instructionsForSlot);
-            ReplaceStringsInContainer("O3DE_SLOTVALUE", ConvertSlotValueToAZSL(slot->GetValue()), instructionsForSlot);
+            ReplaceStringsInContainer("NODEID", AZStd::string::format("node%u", node->GetId()), instructionsForSlot);
+            ReplaceStringsInContainer("SLOTNAME", slot->GetName().c_str(), instructionsForSlot);
+            ReplaceStringsInContainer("SLOTTYPE", ConvertSlotTypeToAZSL(slot->GetDataType()->GetDisplayName()), instructionsForSlot);
+            ReplaceStringsInContainer("SLOTVALUE", ConvertSlotValueToAZSL(slot->GetValue()), instructionsForSlot);
         }
 
         return instructionsForSlot;
@@ -590,7 +590,7 @@ namespace MaterialCanvas
             // We might need separate blocks of instructions that can be processed before or after the slots are processed.
             AZStd::vector<AZStd::string> instructionsForNode;
             AtomToolsFramework::CollectDynamicNodeSettings(nodeConfig.m_settings, "instructions", instructionsForNode);
-            ReplaceStringsInContainer("O3DE_NODEID", AZStd::string::format("node%u", inputNode->GetId()), instructionsForNode);
+            ReplaceStringsInContainer("NODEID", AZStd::string::format("node%u", inputNode->GetId()), instructionsForNode);
             instructions.insert(instructions.end(), instructionsForNode.begin(), instructionsForNode.end());
         }
 


### PR DESCRIPTION
## What does this PR do?

Removed a prefix that was added in a prior PR after discussion, deciding that it was unnecessarily verbose because it's isolated to material canvas node configurations and makes them more difficult to read.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>

## How was this PR tested?
Manual material canvas testing opening existing test graphs