### PR TITLE
Add shortcut keys to Viewport Transform icon tooltips

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -155,9 +155,9 @@ namespace AzToolsFramework
     static const char* const DuplicateUndoRedoDesc = DuplicateTitle;
     static const char* const DeleteUndoRedoDesc = DeleteTitle;
 
-    static const char* const TransformModeClusterTranslateTooltip = "Switch to translate mode";
-    static const char* const TransformModeClusterRotateTooltip = "Switch to rotate mode";
-    static const char* const TransformModeClusterScaleTooltip = "Switch to scale mode";
+    static const char* const TransformModeClusterTranslateTooltip = "Switch to translate mode (1)";
+    static const char* const TransformModeClusterRotateTooltip = "Switch to rotate mode (2)";
+    static const char* const TransformModeClusterScaleTooltip = "Switch to scale mode (3)";
     static const char* const SpaceClusterWorldTooltip = "Toggle world space lock";
     static const char* const SpaceClusterParentTooltip = "Toggle parent space lock";
     static const char* const SpaceClusterLocalTooltip = "Toggle local space lock";


### PR DESCRIPTION
Signed-off-by: amzn-ahmadkrm <ahmadkrm@amazon.com>

## What does this PR do?

Adds shortcut keys to the tooltip descriptions of the Transform icons in the Viewport: 

![image](https://user-images.githubusercontent.com/105638312/183988016-387f810b-32be-4cb4-b631-786e30e28853.png)

This PR changes 3 strings in:
 AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp


