### PR TITLE
{lyn13990} Fixing the Script Rule feature in the scene pipeline

### DIFF
--- a/AutomatedTesting/Editor/Scripts/scene_mesh_to_prefab.py
+++ b/AutomatedTesting/Editor/Scripts/scene_mesh_to_prefab.py
@@ -227,7 +227,7 @@ sceneJobHandler = None
 def on_update_manifest(args):
     try:
         scene = args[0]
-        return update_manifest(scene)
+        data = update_manifest(scene)
     except RuntimeError as err:
         print(f'ERROR - {err}')
         log_exception_traceback()
@@ -235,7 +235,9 @@ def on_update_manifest(args):
         log_exception_traceback()
 
     global sceneJobHandler
+    sceneJobHandler.disconnect()
     sceneJobHandler = None
+    return data
 
 
 # try to create SceneAPI handler for processing

--- a/Code/Tools/SceneAPI/SceneCore/Containers/Scene.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/Scene.cpp
@@ -115,6 +115,7 @@ namespace AZ
                     behaviorContext->Class<Scene>()
                         ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                         ->Attribute(AZ::Script::Attributes::Module, "scene")
+                        ->Constructor<const AZStd::string&>()
                         ->Property("name", BehaviorValueGetter(&Scene::m_name), nullptr)
                         ->Property("manifestFilename", BehaviorValueGetter(&Scene::m_manifestFilename), nullptr)
                         ->Property("sourceFilename", BehaviorValueGetter(&Scene::m_sourceFilename), nullptr)

--- a/Code/Tools/SceneAPI/SceneCore/Events/AssetImportRequest.h
+++ b/Code/Tools/SceneAPI/SceneCore/Events/AssetImportRequest.h
@@ -136,6 +136,20 @@ namespace AZ
             using AssetImportRequestBus = AZ::EBus<AssetImportRequest>;
 
             inline AssetImportRequest::~AssetImportRequest() = default;
+
+            //! Queue EBus to resolve events during the scene import phases
+            class SCENE_CORE_API AssetPostImportRequest
+                : public AZ::EBusTraits
+            {
+            public:
+                using MutexType = AZStd::recursive_mutex;
+                using EventQueueMutexType = AZStd::recursive_mutex;
+                static constexpr bool EnableEventQueue = true;
+
+                virtual void CallAfterSceneExport(AZStd::function<void()> callback) = 0;
+            };
+            using AssetPostImportRequestBus = AZ::EBus<AssetPostImportRequest>;
+
         } // namespace Events
     } // namespace SceneAPI
 } // namespace AZ

--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.h
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.h
@@ -58,7 +58,7 @@ namespace AZ
             class ExportProductList
             {
             public:
-                static void Reflect(ReflectContext* context);
+                SCENE_CORE_API static void Reflect(ReflectContext* context);
 
                 SCENE_CORE_API ExportProduct& AddProduct(const AZStd::string& filename, Uuid id, Data::AssetType assetType, AZStd::optional<u8> lod, AZStd::optional<u32> subId,
                     Data::ProductDependencyInfo::ProductDependencyFlags dependencyFlags = Data::ProductDependencyInfo::CreateFlags(Data::AssetLoadBehavior::NoLoad));

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
@@ -27,6 +27,7 @@
 #include <SceneAPI/SceneData/Rules/ScriptProcessorRule.h>
 #include <SceneAPI/SceneCore/Utilities/Reporting.h>
 #include <SceneAPI/SceneCore/Events/ExportProductList.h>
+#include <SceneAPI/SceneCore/Events/AssetImportRequest.h>
 
 namespace AZ::SceneAPI::Behaviors
 {
@@ -96,6 +97,7 @@ namespace AZ::SceneAPI::Behaviors
 
         AZStd::string OnUpdateManifest(Containers::Scene& scene) override
         {
+            ScriptScope onUpdateManifestScope(this);
             AZStd::string result;
             CallResult(result, FN_OnUpdateManifest, scene);
             ScriptBuildingNotificationBusHandler::BusDisconnect();
@@ -108,10 +110,30 @@ namespace AZ::SceneAPI::Behaviors
             AZStd::string_view platformIdentifier,
             const ExportProductList& productList) override
         {
+            ScriptScope onPrepareForExportScope(this);
             ExportProductList result;
             CallResult(result, FN_OnPrepareForExport, scene, outputDirectory, platformIdentifier, productList);
             ScriptBuildingNotificationBusHandler::BusDisconnect();
             return result;
+        }
+
+        AZStd::atomic_int m_count = 1;
+
+        static BehaviorEBusHandler* Create()
+        {
+            return aznew ScriptBuildingNotificationBusHandler();
+        }
+
+        static void Destroy(BehaviorEBusHandler* behaviorEBusHandler)
+        {
+            auto* handler =
+                static_cast<ScriptBuildingNotificationBusHandler*>(behaviorEBusHandler);
+
+            --handler->m_count;
+            if (handler->m_count == 0)
+            {
+                delete handler;
+            }
         }
 
         static void Reflect(AZ::ReflectContext* context)
@@ -119,13 +141,43 @@ namespace AZ::SceneAPI::Behaviors
             if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
             {
                 behaviorContext->EBus<ScriptBuildingNotificationBus>("ScriptBuildingNotificationBus")
-                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
                     ->Attribute(AZ::Script::Attributes::Module, "scene")
-                    ->Handler<ScriptBuildingNotificationBusHandler>()
+                    ->Handler<ScriptBuildingNotificationBusHandler>(&ScriptBuildingNotificationBusHandler::Create, &ScriptBuildingNotificationBusHandler::Destroy)
                     ->Event("OnUpdateManifest", &ScriptBuildingNotificationBus::Events::OnUpdateManifest)
                     ->Event("OnPrepareForExport", &ScriptBuildingNotificationBus::Events::OnPrepareForExport);
             }
         }
+
+        struct ScriptScope final
+        {
+            ScriptScope(ScriptBuildingNotificationBusHandler* self)
+                : m_self(self)
+            {
+                m_self->m_count++;
+            }
+
+            ~ScriptScope()
+            {
+                m_self->m_count--;
+                if (m_self->m_count == 0)
+                {
+                    // the script released the handler (i.e. set to None)
+                    BehaviorEBusHandler* self = m_self;
+                    AZStd::function<void()> destroySelf = [self]()
+                    {
+                        ScriptBuildingNotificationBusHandler::Destroy(self);
+                    };
+                    // Delay to delete self until the end of the scene pipeline
+                    m_self->m_count = 1;
+                    AZ::SceneAPI::Events::AssetPostImportRequestBus::QueueBroadcast(
+                        &AZ::SceneAPI::Events::AssetPostImportRequestBus::Events::CallAfterSceneExport, destroySelf);
+                }
+            }
+
+            ScriptBuildingNotificationBusHandler* m_self = {};
+        };
     };
 
     struct ScriptProcessorRuleBehavior::ExportEventHandler final

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.h
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.h
@@ -44,7 +44,7 @@ namespace AZ::SceneAPI::Behaviors
 
         SCENE_DATA_API void Activate() override;
         SCENE_DATA_API void Deactivate() override;
-        static void Reflect(ReflectContext* context);
+        SCENE_DATA_API static void Reflect(ReflectContext* context);
         
         // AssetImportRequestBus::Handler
         SCENE_DATA_API Events::ProcessingResult UpdateManifest(

--- a/Code/Tools/SceneAPI/SceneData/SceneData_testing_files.cmake
+++ b/Code/Tools/SceneAPI/SceneData/SceneData_testing_files.cmake
@@ -13,4 +13,5 @@ set(FILES
     Tests/GraphData/GraphDataBehaviorTests.cpp
     Tests/GraphData/RulesTests.cpp
     Tests/SceneManifest/SceneManifestRuleTests.cpp
+    Tests/SceneManifest/SceneScriptRuleTests.cpp
 )

--- a/Code/Tools/SceneAPI/SceneData/Tests/GraphData/GraphDataBehaviorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Tests/GraphData/GraphDataBehaviorTests.cpp
@@ -228,7 +228,7 @@ namespace AZ
                 }
             };
 
-            class GrapDatahBehaviorScriptTest
+            class GraphDataBehaviorScriptTest
                 : public UnitTest::AllocatorsFixture
             {
             public:
@@ -287,7 +287,7 @@ namespace AZ
                 }
             };
 
-            TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_MeshData_AccessWorks)
+            TEST_F(GraphDataBehaviorScriptTest, SceneGraph_MeshData_AccessWorks)
             {
                 ExpectExecute("meshData = MeshData()");
                 ExpectExecute("TestExpectTrue(meshData ~= nil)");
@@ -339,7 +339,7 @@ namespace AZ
                 ExpectExecute("TestExpectIntegerEquals(meshData:GetFaceInfo(0):GetVertexIndex(2), 2)");
             }
 
-            TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_MeshVertexColorData_AccessWorks)
+            TEST_F(GraphDataBehaviorScriptTest, SceneGraph_MeshVertexColorData_AccessWorks)
             {
                 ExpectExecute("meshVertexColorData = MeshVertexColorData()");
                 ExpectExecute("TestExpectTrue(meshVertexColorData ~= nil)");
@@ -357,7 +357,7 @@ namespace AZ
                 ExpectExecute("TestExpectFloatEquals(colorOne.alpha, 0.8)");
             }
 
-            TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_MeshVertexUVData_AccessWorks)
+            TEST_F(GraphDataBehaviorScriptTest, SceneGraph_MeshVertexUVData_AccessWorks)
             {
                 ExpectExecute("meshVertexUVData = MeshVertexUVData()");
                 ExpectExecute("TestExpectTrue(meshVertexUVData ~= nil)");
@@ -371,7 +371,7 @@ namespace AZ
                 ExpectExecute("TestExpectFloatEquals(uvOne.y, 0.4)");
             }
 
-            TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_MeshVertexBitangentData_AccessWorks)
+            TEST_F(GraphDataBehaviorScriptTest, SceneGraph_MeshVertexBitangentData_AccessWorks)
             {
                 ExpectExecute("meshVertexBitangentData = MeshVertexBitangentData()");
                 ExpectExecute("TestExpectTrue(meshVertexBitangentData ~= nil)");
@@ -388,7 +388,7 @@ namespace AZ
                 ExpectExecute("TestExpectTrue(meshVertexBitangentData:GetGenerationMethod(), MeshVertexBitangentData.FromSourceScene)");
             }
 
-            TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_MeshVertexTangentData_AccessWorks)
+            TEST_F(GraphDataBehaviorScriptTest, SceneGraph_MeshVertexTangentData_AccessWorks)
             {
                 ExpectExecute("meshVertexTangentData = MeshVertexTangentData()");
                 ExpectExecute("TestExpectTrue(meshVertexTangentData ~= nil)");
@@ -407,7 +407,7 @@ namespace AZ
                 ExpectExecute("TestExpectTrue(meshVertexTangentData:GetGenerationMethod(), MeshVertexTangentData.MikkT)");
             }
 
-            TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_AnimationData_AccessWorks)
+            TEST_F(GraphDataBehaviorScriptTest, SceneGraph_AnimationData_AccessWorks)
             {
                 ExpectExecute("animationData = AnimationData()");
                 ExpectExecute("TestExpectTrue(animationData ~= nil)");
@@ -419,7 +419,7 @@ namespace AZ
                 ExpectExecute("TestExpectFloatEquals(animationData:GetKeyFrame(2).basisX.z, 3.0)");
             }
 
-            TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_BlendShapeAnimationData_AccessWorks)
+            TEST_F(GraphDataBehaviorScriptTest, SceneGraph_BlendShapeAnimationData_AccessWorks)
             {
                 ExpectExecute("blendShapeAnimationData = BlendShapeAnimationData()");
                 ExpectExecute("TestExpectTrue(blendShapeAnimationData ~= nil)");
@@ -432,7 +432,7 @@ namespace AZ
                 ExpectExecute("TestExpectFloatEquals(blendShapeAnimationData:GetTimeStepBetweenFrames(), 4.0)");
             }
 
-            TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_BlendShapeData_AccessWorks)
+            TEST_F(GraphDataBehaviorScriptTest, SceneGraph_BlendShapeData_AccessWorks)
             {
                 ExpectExecute("blendShapeData = BlendShapeData()");
                 ExpectExecute("TestExpectTrue(blendShapeData ~= nil)");
@@ -517,7 +517,7 @@ namespace AZ
                 ExpectExecute("TestExpectFloatEquals(blendShapeData:GetBitangent(2).z, 0.4)");
             }
 
-            TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_MaterialData_AccessWorks)
+            TEST_F(GraphDataBehaviorScriptTest, SceneGraph_MaterialData_AccessWorks)
             {
                 ExpectExecute("materialData = MaterialData()");
                 ExpectExecute("TestExpectTrue(materialData ~= nil)");
@@ -560,7 +560,7 @@ namespace AZ
                 ExpectExecute("TestExpectTrue(materialData:GetTexture(MaterialData.Specular) == 'specular')");
             }
 
-            TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_BoneData_AccessWorks)
+            TEST_F(GraphDataBehaviorScriptTest, SceneGraph_BoneData_AccessWorks)
             {
                 ExpectExecute("boneData = BoneData()");
                 ExpectExecute("TestExpectTrue(boneData ~= nil)");
@@ -579,7 +579,7 @@ namespace AZ
                 ExpectExecute("TestExpectFloatEquals(boneData:GetWorldTransform():GetRow(2).w, 0.0)");
             }
 
-            TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_CustomPropertyData_AccessWorks)
+            TEST_F(GraphDataBehaviorScriptTest, SceneGraph_CustomPropertyData_AccessWorks)
             {
                 ExpectExecute("customPropertyData = CustomPropertyData()");
                 ExpectExecute("TestExpectTrue(customPropertyData ~= nil)");
@@ -592,7 +592,7 @@ namespace AZ
                 ExpectExecute("TestExpectFloatEquals(customPropertyData:GetPropertyMap():At('a_double'), 0.1234)");
             }
 
-            TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_RootBoneData_AccessWorks)
+            TEST_F(GraphDataBehaviorScriptTest, SceneGraph_RootBoneData_AccessWorks)
             {
                 ExpectExecute("rootBoneData = RootBoneData()");
                 ExpectExecute("TestExpectTrue(rootBoneData ~= nil)");
@@ -611,7 +611,7 @@ namespace AZ
                 ExpectExecute("TestExpectFloatEquals(rootBoneData:GetWorldTransform():GetRow(2).w, 0.0)");
             }
 
-            TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_TransformData_AccessWorks)
+            TEST_F(GraphDataBehaviorScriptTest, SceneGraph_TransformData_AccessWorks)
             {
                 ExpectExecute("transformData = TransformData()");
                 ExpectExecute("TestExpectTrue(transformData ~= nil)");

--- a/Code/Tools/SceneAPI/SceneData/Tests/SceneManifest/SceneScriptRuleTests.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Tests/SceneManifest/SceneScriptRuleTests.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzTest/AzTest.h>
+
+#include <SceneAPI/SceneCore/Containers/SceneManifest.h>
+#include <SceneAPI/SceneCore/Containers/Scene.h>
+#include <SceneAPI/SceneCore/DataTypes/Rules/IScriptProcessorRule.h>
+#include <SceneAPI/SceneCore/Containers/Utilities/Filters.h>
+#include <SceneAPI/SceneData/ReflectionRegistrar.h>
+#include <SceneAPI/SceneData/Rules/CoordinateSystemRule.h>
+#include <SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.h>
+#include <SceneAPI/SceneCore/Events/ExportProductList.h>
+
+#include <AzCore/Math/MathReflection.h>
+#include <AzCore/Math/Quaternion.h>
+#include <AzCore/Name/NameDictionary.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/RTTI/ReflectionManager.h>
+#include <AzCore/Serialization/Json/JsonSystemComponent.h>
+#include <AzCore/Serialization/Json/JsonUtils.h>
+#include <AzCore/Serialization/Json/RegistrationContext.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/UnitTest/Mocks/MockSettingsRegistry.h>
+#include <AzCore/UnitTest/TestTypes.h>
+
+namespace Testing
+{
+    struct SceneScriptTest
+        : public UnitTest::AllocatorsFixture
+    {
+        static void TestExpectTrue(bool value)
+        {
+            EXPECT_TRUE(value);
+        }
+
+        static void TestEqualNumbers(AZ::s64 lhs, AZ::s64 rhs)
+        {
+            EXPECT_EQ(lhs, rhs);
+        }
+
+        static void TestEqualStrings(AZStd::string_view lhs, AZStd::string_view rhs)
+        {
+            EXPECT_STRCASEEQ(lhs.data(), rhs.data());
+        }
+
+        void ExpectExecute(AZStd::string_view script)
+        {
+            EXPECT_TRUE(m_scriptContext->Execute(script.data()));
+        }
+
+        void ReflectTypes(AZ::ReflectContext* context)
+        {
+            AZ::SceneAPI::Containers::Scene::Reflect(context);
+            AZ::SceneAPI::Containers::SceneManifest::Reflect(context);
+            AZ::SceneAPI::DataTypes::IManifestObject::Reflect(context);
+            AZ::SceneAPI::Behaviors::ScriptProcessorRuleBehavior::Reflect(context);
+            AZ::SceneAPI::Events::ExportProductList::Reflect(context);
+        }
+
+        void SetUp() override
+        {
+            UnitTest::AllocatorsFixture::SetUp();
+            AZ::NameDictionary::Create();
+            m_data.reset(new DataMembers);
+
+            m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
+            m_serializeContext->Class<AZ::SceneAPI::DataTypes::IRule, AZ::SceneAPI::DataTypes::IManifestObject>()->Version(1);
+            AZ::SceneAPI::RegisterDataTypeReflection(m_serializeContext.get());
+            ReflectTypes(m_serializeContext.get());
+
+            m_behaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
+            ReflectTypes(m_behaviorContext.get());
+            AZ::MathReflect(m_behaviorContext.get());
+            m_behaviorContext->Method("TestExpectTrue", &TestExpectTrue);
+            m_behaviorContext->Method("TestEqualNumbers", &TestEqualNumbers);
+            m_behaviorContext->Method("TestEqualStrings", &TestEqualStrings);
+
+            m_scriptContext = AZStd::make_unique<AZ::ScriptContext>();
+            m_scriptContext->BindTo(m_behaviorContext.get());
+
+
+            using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
+
+            ON_CALL(m_data->m_settings, Get(::testing::Matcher<FixedValueString&>(::testing::_), testing::_))
+                .WillByDefault([](FixedValueString& value, AZStd::string_view) -> bool
+                    {
+                        value = "mock_path";
+                        return true;
+                    });
+
+            AZ::SettingsRegistry::Register(&m_data->m_settings);
+        }
+
+        void TearDown() override
+        {
+            m_scriptContext.reset();
+            m_serializeContext.reset();
+            m_behaviorContext.reset();
+
+            AZ::SettingsRegistry::Unregister(&m_data->m_settings);
+            m_data.reset();
+
+            AZ::NameDictionary::Destroy();
+            UnitTest::AllocatorsFixture::TearDown();
+        }
+
+        struct DataMembers
+        {
+            int m_count = 0;
+            AZ::NiceSettingsRegistrySimpleMock m_settings;
+        };
+
+        AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
+        AZStd::unique_ptr<AZ::ScriptContext> m_scriptContext;
+        AZStd::unique_ptr<AZ::BehaviorContext> m_behaviorContext;
+        AZStd::unique_ptr<DataMembers> m_data;
+    };
+
+    TEST_F(SceneScriptTest, Scene_ScriptBuildingNotificationBus_Exists)
+    {
+        ExpectExecute("TestExpectTrue(ScriptBuildingNotificationBus ~= nil)");
+        ExpectExecute("self = {}");
+        ExpectExecute("self.handler = ScriptBuildingNotificationBus.Connect(self)");
+        ExpectExecute("TestExpectTrue(self.handler ~= nil)");
+    }
+
+    TEST_F(SceneScriptTest, Scene_ScriptBuildingNotificationBus_OnUpdateManifestCalled)
+    {
+        const char* handlerScript = R"LUA(
+            local ScriptSample = {
+                OnUpdateManifest = function (self, scene)
+                    TestEqualStrings(scene.name, 'test')
+                    return ''
+                end
+            }
+            scene = Scene('test')
+            ScriptSample.handler = ScriptBuildingNotificationBus.Connect(ScriptSample)
+            manifest = ScriptBuildingNotificationBus.Broadcast.OnUpdateManifest(scene)
+            ScriptSample.handler:Disconnect()
+            )LUA";
+
+        ExpectExecute(handlerScript);
+    }
+
+    TEST_F(SceneScriptTest, Scene_ScriptBuildingNotificationBus_OnUpdateManifestClearsHandler)
+    {
+        const char* handlerScript = R"LUA(
+            local ScriptSample = {
+                OnUpdateManifest = function (self, scene)
+                    TestEqualStrings(scene.name, 'test')
+                    self.handler:Disconnect()
+                    self.handler = nil
+                    return ''
+                end
+            }
+            scene = Scene('test')
+            ScriptSample.handler = ScriptBuildingNotificationBus.Connect(ScriptSample)
+            manifest = ScriptBuildingNotificationBus.Broadcast.OnUpdateManifest(scene)
+            )LUA";
+
+        ExpectExecute(handlerScript);
+        AZ::SceneAPI::Events::AssetPostImportRequestBus::ExecuteQueuedEvents();
+    }
+}


### PR DESCRIPTION
## What does this PR do?

* guarding the script hanlder life time between C++ and Python
* it is now possible to cleanly disconnect and clear out the handler in Python callback without affecting the C++ allocation

## How was this PR tested?

* added unit tests to regress the script rule feature
* did some manual testing as well to make sure the plumbing works 
