### PR TITLE
Fixes ComponentApplication shutdown in Launcher

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -779,7 +779,7 @@ namespace AZ
         Sfmt::Destroy();
 
         // delete all descriptors left for application clean up
-        EBUS_EVENT(ComponentDescriptorBus, ReleaseDescriptor);
+        ComponentDescriptorBus::Broadcast(&ComponentDescriptorBus::Events::ReleaseDescriptor);
 
         // Disconnect from application and tick request buses
         ComponentApplicationBus::Handler::BusDisconnect();

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Component/Component.h>
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/std/string/fixed_string.h>
 #include <ScriptCanvas/Libraries/ScriptCanvasNodeRegistry.h>
@@ -171,6 +172,16 @@ namespace ScriptCanvas
 
     void AutoGenRegistryManager::UnregisterRegistry(const char* registryName)
     {
-        m_registries.erase(registryName);
+        auto it = m_registries.find(registryName);
+        if (it != m_registries.end())
+        {
+            auto componentDescriptors = it->second->GetComponentDescriptors();
+            for (auto descriptor : componentDescriptors)
+            {
+                descriptor->ReleaseDescriptor();
+            }
+
+            m_registries.erase(it);
+        }
     }
 } // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
@@ -172,16 +172,15 @@ namespace ScriptCanvas
 
     void AutoGenRegistryManager::UnregisterRegistry(const char* registryName)
     {
-        auto it = m_registries.find(registryName);
-        if (it != m_registries.end())
+        if (auto it = m_registries.find(registryName);
+            it != m_registries.end())
         {
-            auto componentDescriptors = it->second->GetComponentDescriptors();
-            for (auto descriptor : componentDescriptors)
+            for (AZ::ComponentDescriptor* descriptor : it->second->GetComponentDescriptors())
             {
                 descriptor->ReleaseDescriptor();
             }
-
             m_registries.erase(it);
         }
     }
+
 } // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
@@ -24,6 +24,15 @@ namespace ScriptCanvas
 
     static AZ::EnvironmentVariable<AutoGenRegistryManager> g_autogenRegistry;
 
+    void ScriptCanvasRegistry::ReleaseDescriptors()
+    {
+        for (AZ::ComponentDescriptor* descriptor : m_cachedDescriptors)
+        {
+            descriptor->ReleaseDescriptor();
+        }
+        m_cachedDescriptors = {};
+    }
+
     AutoGenRegistryManager::~AutoGenRegistryManager()
     {
         m_registries.clear();
@@ -175,10 +184,7 @@ namespace ScriptCanvas
         if (auto it = m_registries.find(registryName);
             it != m_registries.end())
         {
-            for (AZ::ComponentDescriptor* descriptor : it->second->GetCachedComponentDescriptors())
-            {
-                descriptor->ReleaseDescriptor();
-            }
+            it->second->ReleaseDescriptors();
             m_registries.erase(it);
         }
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
@@ -175,7 +175,7 @@ namespace ScriptCanvas
         if (auto it = m_registries.find(registryName);
             it != m_registries.end())
         {
-            for (AZ::ComponentDescriptor* descriptor : it->second->GetComponentDescriptors())
+            for (AZ::ComponentDescriptor* descriptor : it->second->GetCachedComponentDescriptors())
             {
                 descriptor->ReleaseDescriptor();
             }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
@@ -44,7 +44,6 @@ namespace ScriptCanvas
         virtual void Init(NodeRegistry* nodeRegistry) = 0;
         virtual void Reflect(AZ::ReflectContext* context) = 0;
         virtual AZStd::vector<AZ::ComponentDescriptor*> GetComponentDescriptors() = 0;
-
     protected:
         AZStd::vector<AZ::ComponentDescriptor*> m_cachedDescriptors;
     };

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
@@ -40,9 +40,13 @@ namespace ScriptCanvas
     class ScriptCanvasRegistry
     {
     public:
+        virtual ~ScriptCanvasRegistry() = default;
         virtual void Init(NodeRegistry* nodeRegistry) = 0;
         virtual void Reflect(AZ::ReflectContext* context) = 0;
         virtual AZStd::vector<AZ::ComponentDescriptor*> GetComponentDescriptors() = 0;
+
+    protected:
+        AZStd::vector<AZ::ComponentDescriptor*> m_cachedDescriptors;
     };
 
     //! AutoGenRegistryManager

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
@@ -44,6 +44,10 @@ namespace ScriptCanvas
         virtual void Init(NodeRegistry* nodeRegistry) = 0;
         virtual void Reflect(AZ::ReflectContext* context) = 0;
         virtual AZStd::vector<AZ::ComponentDescriptor*> GetComponentDescriptors() = 0;
+        AZStd::vector<AZ::ComponentDescriptor*> GetCachedComponentDescriptors()
+        {
+            return m_cachedDescriptors;
+        }
     protected:
         AZStd::vector<AZ::ComponentDescriptor*> m_cachedDescriptors;
     };

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
@@ -44,10 +44,7 @@ namespace ScriptCanvas
         virtual void Init(NodeRegistry* nodeRegistry) = 0;
         virtual void Reflect(AZ::ReflectContext* context) = 0;
         virtual AZStd::vector<AZ::ComponentDescriptor*> GetComponentDescriptors() = 0;
-        AZStd::vector<AZ::ComponentDescriptor*> GetCachedComponentDescriptors()
-        {
-            return m_cachedDescriptors;
-        }
+        void ReleaseDescriptors();
     protected:
         AZStd::vector<AZ::ComponentDescriptor*> m_cachedDescriptors;
     };

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammarRegistry_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammarRegistry_Source.jinja
@@ -87,7 +87,9 @@ namespace ScriptCanvas
 
     AZStd::vector<AZ::ComponentDescriptor*> {{autogenTargetName}}GrammarRegistry::GetComponentDescriptors()
     {
-        return AZStd::vector<AZ::ComponentDescriptor*>({
+        if (m_cachedDescriptors.empty())
+        {
+            AZStd::vector<AZ::ComponentDescriptor*> descriptors({
 {% for ScriptCanvas in dataFiles %}
 {%     for Class in ScriptCanvas %}
 {%         set namespaceName = '::' %}
@@ -105,6 +107,9 @@ namespace ScriptCanvas
 {%         endif %}
 {%     endfor %}
 {% endfor %}
-        });
+            });
+            m_cachedDescriptors.insert(m_cachedDescriptors.end(), descriptors.begin(), descriptors.end());
+        }
+        return m_cachedDescriptors;
     }
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammarRegistry_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammarRegistry_Source.jinja
@@ -108,7 +108,7 @@ namespace ScriptCanvas
 {%     endfor %}
 {% endfor %}
             });
-            m_cachedDescriptors.insert(m_cachedDescriptors.end(), descriptors.begin(), descriptors.end());
+            m_cachedDescriptors = AZStd::move(descriptors);
         }
         return m_cachedDescriptors;
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammarRegistry_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammarRegistry_Source.jinja
@@ -89,7 +89,7 @@ namespace ScriptCanvas
     {
         if (m_cachedDescriptors.empty())
         {
-            AZStd::vector<AZ::ComponentDescriptor*> descriptors({
+            m_cachedDescriptors = {
 {% for ScriptCanvas in dataFiles %}
 {%     for Class in ScriptCanvas %}
 {%         set namespaceName = '::' %}
@@ -107,8 +107,7 @@ namespace ScriptCanvas
 {%         endif %}
 {%     endfor %}
 {% endfor %}
-            });
-            m_cachedDescriptors = AZStd::move(descriptors);
+            };
         }
         return m_cachedDescriptors;
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeableRegistry_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeableRegistry_Source.jinja
@@ -79,7 +79,7 @@ namespace ScriptCanvas
     {
         if (m_cachedDescriptors.empty())
         {
-            AZStd::vector<AZ::ComponentDescriptor*> descriptors({
+            m_cachedDescriptors = {
 {% for ScriptCanvas in dataFiles %}
 {%     for Class in ScriptCanvas %}
 {%         set nodeName = Class.attrib['Name'] %}
@@ -92,8 +92,7 @@ namespace ScriptCanvas
 {%         endif %}
 {%     endfor %}
 {% endfor %}
-            });
-            m_cachedDescriptors = AZStd::move(descriptors);
+            };
         }
         return m_cachedDescriptors;
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeableRegistry_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeableRegistry_Source.jinja
@@ -77,7 +77,9 @@ namespace ScriptCanvas
 
     AZStd::vector<AZ::ComponentDescriptor*> {{autogenTargetName}}NodeableRegistry::GetComponentDescriptors()
     {
-        return AZStd::vector<AZ::ComponentDescriptor*>({
+        if (m_cachedDescriptors.empty())
+        {
+            AZStd::vector<AZ::ComponentDescriptor*> descriptors({
 {% for ScriptCanvas in dataFiles %}
 {%     for Class in ScriptCanvas %}
 {%         set nodeName = Class.attrib['Name'] %}
@@ -90,6 +92,9 @@ namespace ScriptCanvas
 {%         endif %}
 {%     endfor %}
 {% endfor %}
-        });
+            });
+            m_cachedDescriptors.insert(m_cachedDescriptors.end(), descriptors.begin(), descriptors.end());
+        }
+        return m_cachedDescriptors;
     }
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeableRegistry_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeableRegistry_Source.jinja
@@ -93,7 +93,7 @@ namespace ScriptCanvas
 {%     endfor %}
 {% endfor %}
             });
-            m_cachedDescriptors.insert(m_cachedDescriptors.end(), descriptors.begin(), descriptors.end());
+            m_cachedDescriptors = AZStd::move(descriptors);
         }
         return m_cachedDescriptors;
     }

--- a/Gems/ScriptCanvas/Code/Source/ScriptCanvasCommonGem.cpp
+++ b/Gems/ScriptCanvas/Code/Source/ScriptCanvasCommonGem.cpp
@@ -36,7 +36,7 @@ namespace ScriptCanvas
         m_descriptors.insert(m_descriptors.end(), {
             // System Component
             ScriptCanvas::SystemComponent::CreateDescriptor(),
-            
+
             // Components
             ScriptCanvas::Connection::CreateDescriptor(),
             ScriptCanvas::Node::CreateDescriptor(),
@@ -44,11 +44,11 @@ namespace ScriptCanvas
             ScriptCanvas::Graph::CreateDescriptor(),
             ScriptCanvas::GraphVariableManagerComponent::CreateDescriptor(),
             ScriptCanvas::RuntimeComponent::CreateDescriptor(),
-            
+
             // ScriptCanvasBuilder
             ScriptCanvas::RuntimeAssetSystemComponent::CreateDescriptor(),
         });
-        
+
         ScriptCanvas::InitLibraries();
         AZStd::vector<AZ::ComponentDescriptor*> libraryDescriptors = ScriptCanvas::GetLibraryDescriptors();
         m_descriptors.insert(m_descriptors.end(), libraryDescriptors.begin(), libraryDescriptors.end());
@@ -72,9 +72,9 @@ namespace ScriptCanvas
         ScriptCanvas::ResetLibraries();
         ResetDataRegistry();
     }
-    
+
     AZ::ComponentTypeList ScriptCanvasModuleCommon::GetCommonSystemComponents() const
-    {   
+    {
         return std::initializer_list<AZ::Uuid> {
             azrtti_typeid<ScriptCanvas::SystemComponent>(),
             azrtti_typeid<ScriptCanvas::RuntimeAssetSystemComponent>(),

--- a/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
@@ -123,6 +123,9 @@ namespace ScriptCanvasTests
 
         static void TearDownTestCase()
         {
+            ScriptCanvas::AutoGenRegistryManager::GetInstance()->UnregisterRegistry("ScriptCanvasTestingEditorStaticFunctionRegistry");
+            ScriptCanvas::AutoGenRegistryManager::GetInstance()->UnregisterRegistry("ScriptCanvasTestingEditorStaticNodeableRegistry");
+
             // don't hang on to dangling assets
             AZ::Data::AssetManager::Instance().DispatchEvents();
 
@@ -177,7 +180,7 @@ namespace ScriptCanvasTests
                 GetApplication()->UnregisterComponentDescriptor(componentDescriptor);
             }
 
-            m_descriptors.clear();            
+            m_descriptors.clear();
         }
 
         ScriptCanvas::Graph* CreateGraph()
@@ -193,7 +196,7 @@ namespace ScriptCanvasTests
 
         TestNodes::ConfigurableUnitTestNode* CreateConfigurableNode(AZStd::string entityName = "ConfigurableNodeEntity")
         {
-            AZ::Entity* configurableNodeEntity = new AZ::Entity(entityName.c_str());         
+            AZ::Entity* configurableNodeEntity = new AZ::Entity(entityName.c_str());
             auto configurableNode = configurableNodeEntity->CreateComponent<TestNodes::ConfigurableUnitTestNode>();
 
             if (m_graph == nullptr)


### PR DESCRIPTION
- AutoGen ScriptCanvas components weren't being properly unregistered
  from the Component Application.
- Cache component descriptors so when a node registry is unregistered it
  can unregister the descriptors too.

## What does this PR do?

fixes #11004 

## How was this PR tested?

Ran AutomatedTesting.GameLauncher, open Console, type "quit".  Ensured clean shutdown.