### PR TITLE
Add NTP sync to Ubuntu build nodes

### DIFF
--- a/scripts/build/build_node/Platform/Linux/install-ubuntu.sh
+++ b/scripts/build/build_node/Platform/Linux/install-ubuntu.sh
@@ -18,6 +18,17 @@ echo Configuring environment settings
 # Enable coredumps - Will be written to /var/lib/apport/coredump
 ulimit -c unlimited
 
+# Configure NTP sync - This is necessary to prevent mtime drift between input and output files 
+systemctl stop systemd-timesyncd
+systemctl disable systemd-timesyncd
+apt install -y chrony
+
+if [ $(curl -LI http://169.254.169.254/latest/meta-data/ -o /dev/null -w '%{http_code}\n' -s) == "200" ]; then
+    echo EC2 instance detected. Setting NTP address to AWS NTP
+    sed -i '1s/^/server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4\n/' /etc/chrony/chrony.conf
+fi
+/etc/init.d/chrony restart
+
 echo Installing packages and tools for O3DE development
 
 # Install awscli


### PR DESCRIPTION
Signed-off-by: Mike Chang <changml@amazon.com>

## What does this PR do?

Adds Chrony to the Ubuntu build nodes to ensure that the time is synced to a higher resolution than the default (previously > 500ms). This ensures the target build files are in sync during the skew correction system task

## How was this PR tested?

Run in a sandbox Jenkins instance
