### PR TITLE
Bump the version of CMake to 3.24.0 in the AR build nodes

### DIFF
--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
@@ -2,8 +2,8 @@
 
 # Build Tools Packages
 cmake/3.24.0-0kitware1ubuntu18.04.1     # For cmake
-clang-12                                # For Ninja Build System
-ninja-build                             # For the compiler and its dependencies
+clang-12                                # For the compiler and its dependencies
+ninja-build                             # For Ninja Build System
 java-11-amazon-corretto-jdk             # For Jenkins and Android
 
 # Build Libraries

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
@@ -1,9 +1,9 @@
 # Package list for Ubuntu 18.04
 
 # Build Tools Packages
-cmake/3.20.1-0kitware1ubuntu18.04.1     # For cmake
-clang-12                                # For the compiler and its dependencies
-ninja-build                             # For Ninja Build System
+cmake/3.24.0-0kitware1ubuntu18.04.1     # For cmake
+clang-12                                # For Ninja Build System
+ninja-build                             # For the compiler and its dependencies
 java-11-amazon-corretto-jdk             # For Jenkins and Android
 
 # Build Libraries
@@ -21,5 +21,3 @@ libxcb-xfixes0-dev                      # For mouse input
 libxcb-xinput-dev                       # For mouse input
 zlib1g-dev
 mesa-common-dev
-
-

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-focal.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-focal.txt
@@ -1,7 +1,7 @@
 # Package list for Ubuntu 20.04
 
 # Build Tools Packages
-cmake/3.21.1-0kitware1ubuntu20.04.1     # For cmake
+cmake/3.24.0-0kitware1ubuntu20.04.1     # For cmake
 clang-12                                # For the compiler and its dependencies
 ninja-build                             # For Ninja Build System
 java-11-amazon-corretto-jdk             # For Jenkins and Android

--- a/scripts/build/build_node/Platform/Mac/install-xcode.sh
+++ b/scripts/build/build_node/Platform/Mac/install-xcode.sh
@@ -43,4 +43,4 @@ echo "Enabling developer mode"
 sudo /usr/sbin/DevToolsSecurity --enable
 
 echo "Installing cmake"
-brew install cmake
+brew install cmake@3.24.0

--- a/scripts/build/build_node/Platform/Windows/install_utiltools.ps1
+++ b/scripts/build/build_node/Platform/Windows/install_utiltools.ps1
@@ -24,7 +24,7 @@ git config --global "credential.UseHttpPath" "true"
 choco install corretto8jdk -y --ia INSTALLDIR="c:\jdk8" # Custom directory to handle cases where whitespace in the path is not quote wrapped
 
 # Install CMake
-choco install cmake --version=3.23.2 -y --installargs 'ADD_CMAKE_TO_PATH=System'
+choco install cmake --version=3.24.0 -y --installargs 'ADD_CMAKE_TO_PATH=System'
 
 # Install Windows Installer XML toolkit (WiX)
 choco install wixtoolset -y


### PR DESCRIPTION
Signed-off-by: Mike Chang <changml@amazon.com>

## What does this PR do?

Bumps the version of CMake in the AR build nodes to 3.24.0. Addresses https://github.com/o3de/o3de/issues/10939 and allows generation of the VS2022 solution using the VS2022 msbuild 

## How was this PR tested?

Tested in a sandbox Jenkins instance
