### PR TITLE
Multiplayer Server Viewport Debug Text

### DIFF
--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.cpp
@@ -183,8 +183,9 @@ namespace Multiplayer
                 const auto dedicatedServerClientCount = AZStd::fixed_string<MaxMessageLength>::format(
                     DedicatedServerHostingClientCount, networkInterface->GetConnectionSet().GetConnectionCount());
 
-                DrawConnectionStatusLine(dedicatedServerClientCount.c_str(), AZ::Colors::Green);
-                DrawConnectionStatusLine(dedicatedServerHostingPort.c_str(), AZ::Colors::Green);
+                const AZ::Color serverHostStatusColor = networkInterface->GetConnectionSet().GetConnectionCount() > 0 ? AZ::Colors::Green : AZ::Colors::Yellow;
+                DrawConnectionStatusLine(dedicatedServerClientCount.c_str(), serverHostStatusColor);
+                DrawConnectionStatusLine(dedicatedServerHostingPort.c_str(), serverHostStatusColor);
                 DrawConnectionStatusLine(DedicatedServerStatusTitle, AZ::Colors::White);
                 break;
             }

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.cpp
@@ -11,6 +11,7 @@
 #include <Atom/RPI.Public/ViewportContextBus.h>
 #include <Atom/RPI.Public/ViewportContext.h>
 #include <AzCore/Console/IConsole.h>
+#include <AzCore/Console/ILogger.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzNetworking/Framework/INetworking.h>
 #include <Multiplayer/IMultiplayerSpawner.h>
@@ -21,14 +22,16 @@ namespace Multiplayer
     constexpr float defaultConnectionMessageFontSize = 0.7f;
     const AZ::Vector2 viewportConnectionBottomRightBorderPadding(-40.0f, -40.0f);
 
-    AZ_CVAR_SCOPED(bool, cl_viewportConnectionStatus, true, nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
+    AZ_CVAR_SCOPED(bool, bg_viewportConnectionStatus, true, nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
         "This will enable displaying connection status in the client's viewport while running multiplayer.");
 
-    AZ_CVAR_SCOPED(float, cl_viewportConnectionMessageFontSize, defaultConnectionMessageFontSize, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, 
+    AZ_CVAR_SCOPED(float, bg_viewportConnectionMessageFontSize, defaultConnectionMessageFontSize, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, 
         "The font size used for displaying updates on screen while the multiplayer editor is connecting to the server.");
 
     AZ_CVAR_SCOPED(int, cl_viewportConnectionStatusMaxDrawCount, 4, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, 
         "Limits the number of connect statuses seen in the viewport. Generally, clients are connected to 1 server, but defining a max draw count in case other connections are established.");
+
+    AZ_CVAR_EXTERNED(bool, sv_isDedicated);
 
     void MultiplayerConnectionViewportMessageSystemComponent::Reflect(AZ::ReflectContext* context)
     {
@@ -59,7 +62,7 @@ namespace Multiplayer
 
     void MultiplayerConnectionViewportMessageSystemComponent::OnRenderTick()
     {
-        if (!cl_viewportConnectionStatus)
+        if (!bg_viewportConnectionStatus)
         {
             return;
         }
@@ -83,7 +86,7 @@ namespace Multiplayer
         }
 
         m_drawParams.m_drawViewportId = viewport->GetId();
-        m_drawParams.m_scale = AZ::Vector2(cl_viewportConnectionMessageFontSize);
+        m_drawParams.m_scale = AZ::Vector2(bg_viewportConnectionMessageFontSize);
         m_lineSpacing = 0.5f*m_fontDrawInterface->GetTextSize(m_drawParams, " ").GetY();
 
         AzFramework::WindowSize viewportSize = viewport->GetViewportSize();
@@ -111,24 +114,39 @@ namespace Multiplayer
 
         // Build the connection status string (just show client connected or disconnected status for now)
         const auto multiplayerSystemComponent = AZ::Interface<IMultiplayer>::Get();
-        MultiplayerAgentType agentType = multiplayerSystemComponent->GetAgentType();        
-        if (agentType == MultiplayerAgentType::Client)
-        {        
-            // Display the connection status in the bottom-right viewport
-            m_drawParams.m_hAlign = AzFramework::TextHorizontalAlignment::Right;
-            m_drawParams.m_position = AZ::Vector3(aznumeric_cast<float>(viewportSize.m_width), aznumeric_cast<float>(viewportSize.m_height), 1.0f) + AZ::Vector3(viewportConnectionBottomRightBorderPadding) * viewport->GetDpiScalingFactor();
+        MultiplayerAgentType agentType = multiplayerSystemComponent->GetAgentType();
 
-            if (AzNetworking::INetworkInterface* networkInterface = AZ::Interface<AzNetworking::INetworking>::Get()->RetrieveNetworkInterface(AZ::Name(MpNetworkInterfaceName)))
+        // Display the connection status in the bottom-right viewport
+        m_drawParams.m_hAlign = AzFramework::TextHorizontalAlignment::Right;
+        m_drawParams.m_position = AZ::Vector3(aznumeric_cast<float>(viewportSize.m_width), aznumeric_cast<float>(viewportSize.m_height), 1.0f) + AZ::Vector3(viewportConnectionBottomRightBorderPadding) * viewport->GetDpiScalingFactor();
+
+        AzNetworking::INetworkInterface* networkInterface = AZ::Interface<AzNetworking::INetworking>::Get()->RetrieveNetworkInterface(AZ::Name(MpNetworkInterfaceName));
+        switch (agentType)
+        {
+        case MultiplayerAgentType::Uninitialized:
+            if (sv_isDedicated)
             {
+                DrawConnectionStatusLine(DedicatedServerNotHosting, AZ::Colors::Red);
+                DrawConnectionStatusLine(DedicatedServerStatusTitle, AZ::Colors::White);
+            }
+            break;
+        case MultiplayerAgentType::Client:
+            {
+                if (!networkInterface)
+                {
+                    break;
+                }
+
                 AzNetworking::IConnectionSet& connectionSet = networkInterface->GetConnectionSet();
                 m_currentConnectionsDrawCount = 0;
                 if (connectionSet.GetConnectionCount() > 0)
                 {
-                    connectionSet.VisitConnections([this](AzNetworking::IConnection& connection)
-                    {
-                        m_hostIpAddress = connection.GetRemoteAddress();
-                        this->DrawConnectionStatus(connection.GetConnectionState(), m_hostIpAddress);
-                    });
+                    connectionSet.VisitConnections(
+                        [this](AzNetworking::IConnection& connection)
+                        {
+                            m_hostIpAddress = connection.GetRemoteAddress();
+                            this->DrawConnectionStatus(connection.GetConnectionState(), m_hostIpAddress);
+                        });
                 }
                 else
                 {
@@ -137,6 +155,44 @@ namespace Multiplayer
                     DrawConnectionStatus(AzNetworking::ConnectionState::Disconnected, m_hostIpAddress);
                 }
             }
+            break;
+        case MultiplayerAgentType::ClientServer:
+            {
+                if (!networkInterface)
+                {
+                    break;
+                }
+                const auto clientServerHostingPort =
+                    AZStd::fixed_string<MaxMessageLength>::format(ServerHostingPort, networkInterface->GetPort());
+                const auto clientServerClientCount = AZStd::fixed_string<MaxMessageLength>::format(
+                    ClientServerHostingClientCount, 1+networkInterface->GetConnectionSet().GetConnectionCount());
+
+                DrawConnectionStatusLine(clientServerClientCount.c_str(), AZ::Colors::Green);
+                DrawConnectionStatusLine(clientServerHostingPort.c_str(), AZ::Colors::Green);
+                DrawConnectionStatusLine(ClientServerStatusTitle, AZ::Colors::White);
+                break;
+            }
+        case MultiplayerAgentType::DedicatedServer:
+            {
+                if (!networkInterface)
+                {
+                    break;
+                }
+                const auto dedicatedServerHostingPort = AZStd::fixed_string<MaxMessageLength>::format(
+                    ServerHostingPort, networkInterface->GetPort());
+                const auto dedicatedServerClientCount = AZStd::fixed_string<MaxMessageLength>::format(
+                    DedicatedServerHostingClientCount, networkInterface->GetConnectionSet().GetConnectionCount());
+
+                DrawConnectionStatusLine(dedicatedServerClientCount.c_str(), AZ::Colors::Green);
+                DrawConnectionStatusLine(dedicatedServerHostingPort.c_str(), AZ::Colors::Green);
+                DrawConnectionStatusLine(DedicatedServerStatusTitle, AZ::Colors::White);
+                break;
+            }
+        default:
+            AZLOG_ERROR(
+                "MultiplayerConnectionViewportMessageSystemComponent doesn't supported multiplayer agent type %s. Please update code to support the new agent type.",
+                GetEnumString(agentType));
+            break;
         }
     }
 

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.cpp
@@ -191,7 +191,7 @@ namespace Multiplayer
             }
         default:
             AZLOG_ERROR(
-                "MultiplayerConnectionViewportMessageSystemComponent doesn't supported multiplayer agent type %s. Please update code to support the new agent type.",
+                "MultiplayerConnectionViewportMessageSystemComponent doesn't support drawing status for multiplayer agent type %s. Please update code to support the new agent type.",
                 GetEnumString(agentType));
             break;
         }

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.h
@@ -25,6 +25,8 @@ namespace Multiplayer
     {
     public:
         static constexpr int MaxMessageLength = 256;
+
+        // Messaging for clients
         static constexpr char CenterViewportDebugTitle[] = "Multiplayer Editor";
         static constexpr char ClientStatusTitle[] = "Multiplayer Client Status:";
         static constexpr char OnServerLaunchedMessage[] = "(1/3) Launching server...";
@@ -34,6 +36,18 @@ namespace Multiplayer
         static constexpr char OnEditorSendingLevelDataMessage[] = "(3/3) Editor is sending the editor-server the level data packet.";
         static constexpr char OnConnectToSimulationFailMessage[] = "EditorServerReady packet was received, but connecting to the editor-server's network simulation failed! Is the editor and server using the same sv_port (%i)?";
         static constexpr char OnEditorServerStoppedUnexpectedly[] ="Editor server has unexpectedly stopped running!";
+
+        // Messaging common for both dedicated server and client-server
+        static constexpr char ServerHostingPort[] = "Hosting on port %i";
+
+        // Messaging for dedicated server
+        static constexpr char DedicatedServerStatusTitle[] = "Multiplayer Dedicated Server Status:";
+        static constexpr char DedicatedServerNotHosting[] = "Not Hosting";
+        static constexpr char DedicatedServerHostingClientCount[] = "%i client(s)";
+
+        // Messaging for client-server
+        static constexpr char ClientServerStatusTitle[] = "Multiplayer Client-Server Status:";
+        static constexpr char ClientServerHostingClientCount[] = "%i client(s) (including self)";
 
         AZ_COMPONENT(MultiplayerConnectionViewportMessageSystemComponent, "{7600cfcf-e380-4876-aa90-8120e57205e9}");
 


### PR DESCRIPTION
## What does this PR do?
Adds multiplayer viewport debug messaging on the server. Making it easier for users to tell (1) servers and client apps apart and (2) quickly seeing how many clients are connected to a server.

_Dedicated server not hosting_
![image](https://user-images.githubusercontent.com/32776221/184053497-fd6d24a5-e55c-4a07-a9e4-c5ee99f8e0f3.png)

_Dedicated server hosting but not yet connected to any clients_
![image](https://user-images.githubusercontent.com/32776221/184053515-76d40b84-65f8-43b3-8cee-212332fe7fc1.png)

_Dedicated server hosting with clients in the game_
![image](https://user-images.githubusercontent.com/32776221/184052259-501b97ef-3675-4374-b93b-d3e51f039f19.png)

Resolves #9514 

## How was this PR tested?

Running ServerLauncher.exe, connecting clients, disconnecting clients and seeing debug text update
Running GameLauncher.exe, starting a client-server, connecting clients, disconnecting clients and seeing debug text update

