### PR TITLE
Fixed a cubemap preview issue when preview any .streamingimage asset …

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.cpp
@@ -260,11 +260,6 @@ namespace ImageProcessingAtom
             u32 mipLevels = imageDescriptor.m_mipLevels;
             u32 arraySize = imageDescriptor.m_arraySize;
 
-            if (imageDescriptor.m_isCubemap)
-            {
-                height *= 6;
-            }
-
             height *= arraySize;
 
             IImageObjectPtr outputImage = IImageObjectPtr(IImageObject::CreateImage(width, height, mipLevels, format));


### PR DESCRIPTION
…which is a cubemap.

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>

## What does this PR do?
Fixed a cubemap preview issue when preview any .streamingimage asset which is a cubemap.
The issue was introduced in a change which was to fix the preview of an image array asset. 

## How was this PR tested?

Preview some *_skyboxcm.streamingimage  *_ibl*.streamingimage files in Editor.
