### PR TITLE
Deleted deprecated file

### DIFF
--- a/Assets/Engine/textures/default_icon.png
+++ b/Assets/Engine/textures/default_icon.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:42599f353d119059328941baa147c40b7948b3bf969feba5f9ec1857cd381af6
-size 31595


### PR DESCRIPTION
## What does this PR do?
Fixes #10639 
Deleted unused legacy Lumberyard icon.

## How was this PR tested?
Ran the editor and the Lumberyard icon no longer appears in the Asset Browser.

Signed-off-by: Daniel Tamkin <jotamkin@amazon.com>
