### PR TITLE
{lyn14355} updating the AssetHandler::LoadAssetDataFromStream warning

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -2222,8 +2222,6 @@ namespace AZ::Data
         AZStd::shared_ptr<AssetDataStream> stream,
         const AssetFilterCB& assetLoadFilterCB)
     {
-        AZ_PROFILE_SCOPE(AzCore, "AssetHandler::LoadAssetData - %s", asset.GetHint().c_str());
-
 #ifdef AZ_ENABLE_TRACING
         auto start = AZStd::chrono::system_clock::now();
 #endif
@@ -2232,11 +2230,17 @@ namespace AZ::Data
 
 #ifdef AZ_ENABLE_TRACING
         auto loadMs = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(
-                      AZStd::chrono::system_clock::now() - start);
-        AZ_Warning("AssetDatabase", (!cl_assetLoadWarningEnable) ||
-                   loadMs <= AZStd::chrono::milliseconds(cl_assetLoadWarningMsThreshold),
-                   "Load time threshold exceeded: LoadAssetData call for %s took %" PRId64 " ms",
-                   asset.GetHint().c_str(), loadMs.count());
+            AZStd::chrono::system_clock::now() - start);
+        if (loadMs.count() > 0)
+        {
+            const double seconds = loadMs.count() / 1000.0;
+            const double kilobytes = stream->GetLoadedSize() / 1024.0;
+            const double rateKbps = kilobytes / seconds;
+            AZ_Warning("AssetDatabase", (!cl_assetLoadWarningEnable) ||
+                loadMs <= AZStd::chrono::milliseconds(cl_assetLoadWarningMsThreshold),
+                "Load time threshold exceeded: LoadAssetData call for %s took %" PRId64 " ms %8.4Lf KB/s rate %" PRId64 " size",
+                asset.GetHint().c_str(), loadMs.count(), rateKbps, stream->GetLoadedSize());
+        }
 #endif
 
         return result;

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -2238,7 +2238,7 @@ namespace AZ::Data
             const double rateKbps = kilobytes / seconds;
             AZ_Warning("AssetDatabase", (!cl_assetLoadWarningEnable) ||
                 loadMs <= AZStd::chrono::milliseconds(cl_assetLoadWarningMsThreshold),
-                "Load time threshold exceeded: LoadAssetData call for %s took %" PRId64 " ms %8.4Lf KB/s rate %" PRId64 " size",
+                "Load time threshold exceeded: LoadAssetData call for %s took %" PRId64 " ms %8.4Lf KB/s rate %" PRId64 " bytes",
                 asset.GetHint().c_str(), loadMs.count(), rateKbps, stream->GetLoadedSize());
         }
 #endif

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -2238,8 +2238,8 @@ namespace AZ::Data
             const double rateKbps = kilobytes / seconds;
             AZ_Warning("AssetDatabase", (!cl_assetLoadWarningEnable) ||
                 loadMs <= AZStd::chrono::milliseconds(cl_assetLoadWarningMsThreshold),
-                "Load time threshold exceeded: LoadAssetData call for %s took %" PRId64 " ms %8.4Lf KB/s rate %" PRId64 " size in bytes",
-                asset.GetHint().c_str(), loadMs.count(), rateKbps, stream->GetLoadedSize());
+                "Load time threshold exceeded: LoadAssetData call for %s took %" PRId64 " ms to load %" PRId64 " bytes (%8.4Lf KB/s)",
+                asset.GetHint().c_str(), loadMs.count(), stream->GetLoadedSize(), rateKbps);
         }
 #endif
 

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -2238,7 +2238,7 @@ namespace AZ::Data
             const double rateKbps = kilobytes / seconds;
             AZ_Warning("AssetDatabase", (!cl_assetLoadWarningEnable) ||
                 loadMs <= AZStd::chrono::milliseconds(cl_assetLoadWarningMsThreshold),
-                "Load time threshold exceeded: LoadAssetData call for %s took %" PRId64 " ms %8.4Lf KB/s rate %" PRId64 " bytes",
+                "Load time threshold exceeded: LoadAssetData call for %s took %" PRId64 " ms %8.4Lf KB/s rate %" PRId64 " size in bytes",
                 asset.GetHint().c_str(), loadMs.count(), rateKbps, stream->GetLoadedSize());
         }
 #endif


### PR DESCRIPTION
## What does this PR do?

* this gives the authors of these handlers more information around the deserialization warning

## How was this PR tested?

manual testing to see the message in the logs
