### PR TITLE
Adding 20 minute pytest timeout

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,8 @@ norecursedirs = Python/2.7.* Python/3.7.5 BinTemp Cache SDKs JenkinsScripts cmak
 junit_family=legacy
 log_format=%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
 addopts='--tb=short' '--show-capture=log'
+# Setting pytest timeout defaulting to 20 minutes for a single test case (CMake timeout being 25 minutes)
+timeout=1200
 
 # primary suite markers which should appear on every filterable test and be mutually exclusive:
 markers = SUITE_smoke: Tiny, quick tests of fundamental operation (tests with no suite marker will also execute here in CI)


### PR DESCRIPTION
Signed-off-by: evanchia-ly-sdets <evanchia@amazon.com>

## What does this PR do?
Adds a 20 minute pytest timeout to the pytest.ini config file. This config file is used in AR and will apply its timeout to each test case. Timeout provides full stack trace on timeout.

## How was this PR tested?
Tested by using a short timeout locally.