### PR TITLE
Fixed race condition in the NameData::release function

### DIFF
--- a/Code/Framework/AzCore/AzCore/Name/Internal/NameData.cpp
+++ b/Code/Framework/AzCore/AzCore/Name/Internal/NameData.cpp
@@ -37,12 +37,16 @@ namespace AZ::Internal
         // this could be released after we decrement the counter, therefore we will
         // base the release on the hash which is stable
         Hash hash = m_hash;
+        // Once the use count goes to zero, it is no longer
+        // safe to access any member of the NameData class
+        // therefore copy the name dictionary pointer into a local variable
+        NameDictionary* nameDictionary = m_nameDictionary;
         AZ_Assert(m_useCount > 0, "m_useCount is already 0!");
         if (m_useCount.fetch_sub(1) == 1)
         {
-            if (m_nameDictionary)
+            if (nameDictionary)
             {
-                m_nameDictionary->TryReleaseName(hash);
+                nameDictionary->TryReleaseName(hash);
             }
         }
     }

--- a/Code/Framework/AzCore/AzCore/Name/NameDictionary.h
+++ b/Code/Framework/AzCore/AzCore/Name/NameDictionary.h
@@ -81,6 +81,10 @@ namespace AZ
         Name FindName(Name::Hash hash) const;
 
         NameDictionary();
+        //! Constructs a NameDictionary with a fixed amount of hash slots
+        //! @param maxHashSlots exclusive max for the hashValue that be calculated. Can be used to generate more hash collisoins
+        //! @precondition maxHashSlots value are [1, 2^64-1)
+        explicit NameDictionary(AZ::u64 maxHashSlots);
         ~NameDictionary();
 
         //! Loads a list of names, starting at a given list head, and ensures they're all created and linked
@@ -135,5 +139,11 @@ namespace AZ
         //! so we keep track of them here to ensure their name data gets correctly cleaned up
         //! when this dictionary is shut down.
         Name m_deferredHead;
+
+        //! Set the maximum number of hash slots to 2^32
+        //! hash values will be mapped between [0, m_maxHashSlots)
+        //! Can only be configured at construction time and cannot change
+        //! value cannot be 0
+        const AZ::u64 m_maxHashSlots{ static_cast<AZ::u64>(AZStd::numeric_limits<Name::Hash>::max()) + 1 };
     };
 }


### PR DESCRIPTION
The NameDictionary
`NameTest.ConcurrencyDataTest_EachThreadRepeatedlyCreatesAndReleasesOneName_NoCollision`
was sporadically failing due to a race condition in `NameData::release`,
where the m_useCount member could be decremented to 0, followed another
thread invoking `NameDictionary::FindName` to locate that NameData
instance and initialize an AZ::Name with it which increments
the m_useCount back up to 1 and then that same thread can
have that AZ::Name instance go out of scope causing the m_useCount to
decrement back to 0.

What then occurs, is that one of threads can invoke
`NameDictionary::TryReleaseName` which deletes the name data instance,
while another thread could attempt to access the deleted
`m_nameDictionary` member of the NameData class.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
