### PR TITLE
Material Canvas: Fix cut, copy, paste, duplicate clipboard operations

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNode.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNode.h
@@ -31,7 +31,6 @@ namespace AtomToolsFramework
         const char* GetSubTitle() const override;
 
         using Node::PostLoadSetup;
-        void PostLoadSetup(GraphModel::GraphPtr ownerGraph, GraphModel::NodeId id) override;
 
         // Get the ID of the dynamic node config used to create this node
         const AZStd::string& GetConfigId() const;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNode.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNode.h
@@ -30,8 +30,6 @@ namespace AtomToolsFramework
         const char* GetTitle() const override;
         const char* GetSubTitle() const override;
 
-        using Node::PostLoadSetup;
-
         // Get the ID of the dynamic node config used to create this node
         const AZStd::string& GetConfigId() const;
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNode.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNode.cpp
@@ -33,21 +33,8 @@ namespace AtomToolsFramework
         , m_toolId(toolId)
         , m_configId(configId)
     {
-        m_config = {};
-        AtomToolsFramework::DynamicNodeManagerRequestBus::EventResult(
-            m_config, m_toolId, &AtomToolsFramework::DynamicNodeManagerRequestBus::Events::GetConfig, m_configId);
-
         RegisterSlots();
         CreateSlotData();
-    }
-
-    void DynamicNode::PostLoadSetup(GraphModel::GraphPtr ownerGraph, GraphModel::NodeId id)
-    {
-        m_config = {};
-        AtomToolsFramework::DynamicNodeManagerRequestBus::EventResult(
-            m_config, m_toolId, &AtomToolsFramework::DynamicNodeManagerRequestBus::Events::GetConfig, m_configId);
-
-        Node::PostLoadSetup(ownerGraph, id);
     }
 
     const char* DynamicNode::GetTitle() const
@@ -72,6 +59,10 @@ namespace AtomToolsFramework
 
     void DynamicNode::RegisterSlots()
     {
+        m_config = {};
+        AtomToolsFramework::DynamicNodeManagerRequestBus::EventResult(
+            m_config, m_toolId, &AtomToolsFramework::DynamicNodeManagerRequestBus::Events::GetConfig, m_configId);
+
         // Register all of the input data slots with the dynamic node
         for (const auto& slotConfig : m_config.m_inputSlots)
         {


### PR DESCRIPTION
## What does this PR do?

Graph model graph controller implements its own serialization that sits on top of what graph canvas does for serializing clipboard data. Whenever graph model nodes are deserialized from the clipboard they need to rebuild their non serialized slot data. Material canvas dynamic nodes were not reinitializing their slot definitions from the slot configurations whenever this happened which left them blank and without values.

https://github.com/o3de/o3de/issues/10910
https://github.com/o3de/sig-graphics-audio/issues/51
Signed-off-by: Guthrie Adams <guthadam@amazon.com>

## How was this PR tested?

Manually tested clipboard operations in material canvas graph view