### PR TITLE
Add the DiffuseProbeGridUpdatePass after the DepthPrePass

### DIFF
--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -705,6 +705,20 @@ namespace AZ
 
         void DiffuseProbeGridFeatureProcessor::OnRenderPipelinePassesChanged([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
         {
+            // change the attachment on the AuxGeom pass to use the output of the visualization pass
+            RPI::PassFilter auxGeomPassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("AuxGeomPass"), renderPipeline);
+            RPI::Pass* auxGeomPass = RPI::PassSystemInterface::Get()->FindFirstPass(auxGeomPassFilter);
+            RPI::PassFilter visualizationPassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("DiffuseProbeGridVisualizationPass"), renderPipeline);
+            RPI::Pass* visualizationPass = RPI::PassSystemInterface::Get()->FindFirstPass(visualizationPassFilter);
+
+            if (auxGeomPass && visualizationPass && visualizationPass->GetInputOutputCount())
+            {
+                RPI::PassAttachmentBinding& visualizationBinding = visualizationPass->GetInputOutputBinding(0);
+
+                RPI::PassAttachmentBinding* auxGeomBinding = auxGeomPass->FindAttachmentBinding(AZ::Name("ColorInputOutput"));
+                auxGeomBinding->SetAttachment(visualizationBinding.GetAttachment());
+            }
+
             UpdatePasses();
             m_needUpdatePipelineStates = true;
         }
@@ -725,26 +739,19 @@ namespace AZ
 
             if (!diffuseProbeGridUpdatePass)
             {
-                AddPassRequest(renderPipeline.get(), "Passes/DiffuseProbeGridUpdatePassRequest.azasset", "RayTracingAccelerationStructurePass");
+                AddPassRequest(renderPipeline.get(), "Passes/DiffuseProbeGridUpdatePassRequest.azasset", "DepthPrePass");
                 AddPassRequest(renderPipeline.get(), "Passes/DiffuseProbeGridRenderPassRequest.azasset", "ForwardSubsurface");
-                AddPassRequest(renderPipeline.get(), "Passes/DiffuseProbeGridVisualizationPassRequest.azasset", "PostProcessPass");
+
+                // only add the visualization pass if there's an AuxGeom pass in the pipeline
+                RPI::PassFilter auxGeomPassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("AuxGeomPass"), renderPipeline.get());
+                RPI::Pass* auxGeomPass = RPI::PassSystemInterface::Get()->FindFirstPass(auxGeomPassFilter);
+                if (auxGeomPass)
+                {
+                    AddPassRequest(renderPipeline.get(), "Passes/DiffuseProbeGridVisualizationPassRequest.azasset", "PostProcessPass");
+                }
 
                 // disable the DiffuseGlobalFullscreenPass if it exists, since it is replaced with a DiffuseProbeGrid composite pass
                 diffuseGlobalFullscreenPass->SetEnabled(false);
-            }
-
-            // change the attachment on the AuxGeom pass to use the output of the visualization pass
-            RPI::PassFilter visualizationPassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("DiffuseProbeGridVisualizationPass"), renderPipeline.get());
-            RPI::Pass* visualizationPass = RPI::PassSystemInterface::Get()->FindFirstPass(visualizationPassFilter);
-            RPI::PassFilter auxGeomPassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("AuxGeomPass"), renderPipeline.get());
-            RPI::Pass* auxGeomPass = RPI::PassSystemInterface::Get()->FindFirstPass(auxGeomPassFilter);
-
-            if (auxGeomPass && visualizationPass && visualizationPass->GetInputOutputCount())
-            {
-                RPI::PassAttachmentBinding& visualizationBinding = visualizationPass->GetInputOutputBinding(0);
-
-                RPI::PassAttachmentBinding* auxGeomBinding = auxGeomPass->FindAttachmentBinding(AZ::Name("ColorInputOutput"));
-                auxGeomBinding->SetAttachment(visualizationBinding.GetAttachment());
             }
 
             UpdatePasses();
@@ -793,7 +800,7 @@ namespace AZ
             bool success = renderPipeline->AddPassAfter(newPass, AZ::Name(insertionPointPassName));
             if (!success)
             {
-                AZ_Error("DiffuseProbeGridFeatureProcessor", false, "Failed to add pass [%s] to render pipeline [%s]", newPass->GetName().GetCStr(), renderPipeline->GetId().GetCStr());
+                AZ_Warning("DiffuseProbeGridFeatureProcessor", false, "Failed to add pass [%s] to render pipeline [%s]", newPass->GetName().GetCStr(), renderPipeline->GetId().GetCStr());
             }
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -714,9 +714,11 @@ namespace AZ
             if (auxGeomPass && visualizationPass && visualizationPass->GetInputOutputCount())
             {
                 RPI::PassAttachmentBinding& visualizationBinding = visualizationPass->GetInputOutputBinding(0);
-
                 RPI::PassAttachmentBinding* auxGeomBinding = auxGeomPass->FindAttachmentBinding(AZ::Name("ColorInputOutput"));
-                auxGeomBinding->SetAttachment(visualizationBinding.GetAttachment());
+                if (auxGeomBinding)
+                {
+                    auxGeomBinding->SetAttachment(visualizationBinding.GetAttachment());
+                }
             }
 
             UpdatePasses();


### PR DESCRIPTION
Add the DiffuseProbeGridUpdatePass after the DepthPrePass instead of the RayTracingAccelerationStructurePass.
Only add the DiffuseProbeGridVisualizationPass if the pipeline has an AuxGeom pass.

This allows the DiffuseProbeGridFeatureProcessor to handle pipelines that do not have the RayTracingAccelerationStructurePass and/or the AuxGeom pass.

Tested AtomSampleViewer DX12/Vulkan
Tested Editor DX12/Vulkan

Signed-off-by: dmcdiarmid-ly <63674186+dmcdiarmid-ly@users.noreply.github.com>

