### PR TITLE
Material Canvas: Fixing code generation failures caused by line endings

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -777,7 +777,7 @@ namespace MaterialCanvas
                         [&]([[maybe_unused]] const AZStd::string& blockHeader)
                         {
                             AZStd::vector<AZStd::string> inputSlotNames;
-                            AZ::StringFunc::Tokenize(blockHeader, inputSlotNames, ";:, \t\n", false, false);
+                            AZ::StringFunc::Tokenize(blockHeader, inputSlotNames, ";:, \t\n\r\\/", false, false);
                             return GetInstructionsFromConnectedNodes(currentNode, inputSlotNames);
                         },
                         templateLines);


### PR DESCRIPTION
## What does this PR do?

This change resolves problems with material canvas code generation discovered after doing a clean pull from GH. The code generation logic searches for lines containing special markers denoting that code or data can be inserted at that point. The markers for inserting shader code instructions include a list of expected variables that’s parsed from that line. After performing a clean grab from GH, the last variable name on the line included an extra line ending character which caused the variable name to not be recognized and not have code generated for it. The additional line ending characters and other delimiters were added for tokenizing.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

tested changes on multiple local machines
automated tests are scheduled to be written when the features and data are less volatile