### PR TITLE
Fixed Name::SetNameLiteral on Android

### DIFF
--- a/Code/Framework/AzCore/AzCore/Name/Name.cpp
+++ b/Code/Framework/AzCore/AzCore/Name/Name.cpp
@@ -19,7 +19,7 @@
 
 namespace AZ
 {
-    static AZStd::thread::id InvalidThreadId;
+    static const AZStd::thread::id InvalidThreadId;
 
     AZStd::thread::id Name::s_staticNameListThread;
 
@@ -227,7 +227,7 @@ namespace AZ
             return;
         }
 
-        AZStd::thread::id thisThreadId = AZStd::this_thread::get_id();
+        const AZStd::thread::id thisThreadId = AZStd::this_thread::get_id();
 
         if (s_staticNameListThread == InvalidThreadId)
         {

--- a/Code/Framework/AzCore/AzCore/Name/Name.cpp
+++ b/Code/Framework/AzCore/AzCore/Name/Name.cpp
@@ -19,10 +19,6 @@
 
 namespace AZ
 {
-    static const AZStd::thread::id InvalidThreadId;
-
-    AZStd::thread::id Name::s_staticNameListThread;
-
     Name* Name::s_staticNameBegin = nullptr;
 
     NameRef::NameRef(Name name)
@@ -227,15 +223,6 @@ namespace AZ
             return;
         }
 
-        const AZStd::thread::id thisThreadId = AZStd::this_thread::get_id();
-
-        if (s_staticNameListThread == InvalidThreadId)
-        {
-            s_staticNameListThread = thisThreadId;
-        }
-        AZ_Assert(s_staticNameListThread == thisThreadId,
-                  "Attempted to construct name literal '%.*s' on a different thread from the first initialized static name, this is unsafe",
-                  AZ_STRING_ARG(name));
         m_view = name;
         if (nameDictionary != nullptr)
         {

--- a/Code/Framework/AzCore/AzCore/Name/Name.h
+++ b/Code/Framework/AzCore/AzCore/Name/Name.h
@@ -223,7 +223,6 @@ namespace AZ
         //! Pointer to NameData in the NameDictionary. This holds both the hash and string pair.
         AZStd::intrusive_ptr<Internal::NameData> m_data;
 
-        static AZStd::thread::id s_staticNameListThread;
         //! Describes the begin of the static list of Names that were initialized before the NameDictionary was available.
         //! On module initialization, these names are linked into the NameDictionary's static pool and created.
         static Name* s_staticNameBegin;

--- a/Code/Framework/AzCore/Platform/Android/AzCore/std/parallel/config_Android.h
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/std/parallel/config_Android.h
@@ -29,7 +29,7 @@ namespace AZStd
 
     // Thread
     using native_thread_id_type = pthread_t;
-    static constexpr pthread_t native_thread_invalid_id = LONG_MIN;
+    static constexpr pthread_t native_thread_invalid_id = 0;
     using native_thread_data_type = pthread_t;
     using native_thread_handle_type = pthread_t;
 }


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Fixes #10608

Sets `native_thread_invalid_id` to 0 to match the same invalid value as linux.

What was happening is that due to the way the variables were initialized `s_staticNameListThread` arrived with value 0 and it wasn't the same as `native_thread_invalid_id` (value used by `AZStd::thread::id` in its default constructor), so it never got to assign `s_staticNameListThread` to the current thread id.

## How was this PR tested?

Build and run default level on pc and android without crashing.
