### PR TITLE
{lyn14020} added Fetch to GraphObjectProxy

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
@@ -191,7 +191,6 @@ namespace AZ
                         ->Method("CastWithTypeName", &GraphObjectProxy::CastWithTypeName)
                         ->Method("Invoke", &GraphObjectProxy::Invoke)
                         ->Method("Fetch", &GraphObjectProxy::Fetch)
-                        ->Method("Assign", &GraphObjectProxy::Assign)
                         ->Method("GetClassInfo", [](GraphObjectProxy& self) -> Python::PythonBehaviorInfo*
                             {
                                 if (self.m_pythonBehaviorInfo)
@@ -265,38 +264,6 @@ namespace AZ
                 }
 
                 return InvokeBehaviorMethod(entry->second->m_getter, {});
-            }
-
-            void GraphObjectProxy::Assign(AZStd::string_view property, AZStd::any value)
-            {
-                if (!m_behaviorClass)
-                {
-                    AZ_Warning("SceneAPI", false, "Empty behavior class. Use the CastWithTypeName() to assign the concrete type of IGraphObject to Invoke().");
-                    return;
-                }
-
-                auto entry = m_behaviorClass->m_properties.find(property);
-                if (m_behaviorClass->m_properties.end() == entry)
-                {
-                    AZ_Warning("SceneAPI", false, "Missing property %.*s from class %s",
-                        aznumeric_cast<int>(property.size()),
-                        property.data(),
-                        m_behaviorClass->m_name.c_str());
-
-                    return;
-                }
-
-                if (!entry->second->m_setter)
-                {
-                    AZ_Warning("SceneAPI", false, "Property %.*s from class %s has a NULL setter",
-                        aznumeric_cast<int>(property.size()),
-                        property.data(),
-                        m_behaviorClass->m_name.c_str());
-
-                    return;
-                }
-
-                InvokeBehaviorMethod(entry->second->m_setter, { value });
             }
 
             AZStd::any GraphObjectProxy::InvokeBehaviorMethod(AZ::BehaviorMethod* behaviorMethod, AZStd::vector<AZStd::any> argList)

--- a/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
@@ -33,20 +33,26 @@ namespace AZ
         protected:
             bool IsMemberLike(const AZ::BehaviorMethod& method, const AZ::TypeId& typeId) const;
             AZStd::string FetchPythonType(const AZ::BehaviorParameter& param) const;
-            void WriteMethod(AZStd::string_view methodName, const AZ::BehaviorMethod& behaviorMethod);
+            void PrepareMethod(AZStd::string_view methodName, const AZ::BehaviorMethod& behaviorMethod);
+            void PrepareProperty(AZStd::string_view propertyName, const AZ::BehaviorProperty& behaviorProperty);
 
         private:
             const AZ::BehaviorClass* m_behaviorClass = nullptr;
             AZStd::vector<AZStd::string> m_methodList;
+            AZStd::vector<AZStd::string> m_propertyList;
         };
 
         PythonBehaviorInfo::PythonBehaviorInfo(const AZ::BehaviorClass* behaviorClass)
             : m_behaviorClass(behaviorClass)
         {
             AZ_Assert(m_behaviorClass, "PythonBehaviorInfo requires a valid behaviorClass pointer");
-            for (const auto& entry : behaviorClass->m_methods)
+            for (const auto& method : behaviorClass->m_methods)
             {
-                WriteMethod(entry.first, *entry.second);
+                PrepareMethod(method.first, *method.second);
+            }
+            for (const auto& property : behaviorClass->m_properties)
+            {
+                PrepareProperty(property.first, *property.second);
             }
         }
 
@@ -62,7 +68,9 @@ namespace AZ
                         { return self.m_behaviorClass->m_name; }, nullptr)
                     ->Property("classUuid", [](const PythonBehaviorInfo& self)
                         { return self.m_behaviorClass->m_typeId.ToString<AZStd::string>(); }, nullptr)
-                    ->Property("methodList", BehaviorValueGetter(&PythonBehaviorInfo::m_methodList), nullptr);
+                    ->Property("methodList", BehaviorValueGetter(&PythonBehaviorInfo::m_methodList), nullptr)
+                    ->Property("propertyList", BehaviorValueGetter(&PythonBehaviorInfo::m_propertyList), nullptr)
+                    ;
             }
         }
 
@@ -82,7 +90,7 @@ namespace AZ
             return None;
         }
 
-        void PythonBehaviorInfo::WriteMethod(AZStd::string_view methodName, const AZ::BehaviorMethod& behaviorMethod)
+        void PythonBehaviorInfo::PrepareMethod(AZStd::string_view methodName, const AZ::BehaviorMethod& behaviorMethod)
         {
             // if the method is a static method then it is not a part of the abstract class
             const bool isMemberLike = IsMemberLike(behaviorMethod, m_behaviorClass->m_typeId);
@@ -136,6 +144,31 @@ namespace AZ
             AzFramework::StringFunc::Append(buffer, resultValue.c_str());
             m_methodList.emplace_back(buffer);
         }
+
+        void PythonBehaviorInfo::PrepareProperty(AZStd::string_view propertyName, const AZ::BehaviorProperty& behaviorProperty)
+        {
+            AZStd::string buffer;
+            AZStd::vector<AZStd::string> pythonArgs;
+
+            AzFramework::StringFunc::Append(buffer, propertyName.data());
+
+            AzFramework::StringFunc::Append(buffer, "(");
+            if (behaviorProperty.m_setter)
+            {
+                AZStd::string_view type = FetchPythonType(*behaviorProperty.m_setter->GetArgument(1));
+                AzFramework::StringFunc::Append(buffer, type.data());
+            }
+            AzFramework::StringFunc::Append(buffer, ")");
+
+            if (behaviorProperty.m_getter)
+            {
+                AZStd::string_view type = FetchPythonType(*behaviorProperty.m_getter->GetResult());
+                AzFramework::StringFunc::Append(buffer, "->");
+                AzFramework::StringFunc::Append(buffer, type.data());
+            }
+
+            m_propertyList.emplace_back(buffer);
+        }
     }
 
     namespace SceneAPI
@@ -157,6 +190,8 @@ namespace AZ
                         ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
                         ->Method("CastWithTypeName", &GraphObjectProxy::CastWithTypeName)
                         ->Method("Invoke", &GraphObjectProxy::Invoke)
+                        ->Method("Fetch", &GraphObjectProxy::Fetch)
+                        ->Method("Assign", &GraphObjectProxy::Assign)
                         ->Method("GetClassInfo", [](GraphObjectProxy& self) -> Python::PythonBehaviorInfo*
                             {
                                 if (self.m_pythonBehaviorInfo)
@@ -200,35 +235,72 @@ namespace AZ
                 return false;
             }
 
-            AZStd::any GraphObjectProxy::Invoke(AZStd::string_view method, AZStd::vector<AZStd::any> argList)
+            AZStd::any GraphObjectProxy::Fetch(AZStd::string_view property)
             {
-                AZ::SerializeContext* serializeContext = nullptr;
-                AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
-                if (!serializeContext)
-                {
-                    AZ_Error("SceneAPI", false, "AZ::SerializeContext should be prepared.");
-                    return AZStd::any(false);
-                }
-
                 if (!m_behaviorClass)
                 {
-                    AZ_Warning("SceneAPI", false, "Use the CastWithTypeName() to assign the concrete type of IGraphObject to Invoke().");
+                    AZ_Warning("SceneAPI", false, "Empty behavior class. Use the CastWithTypeName() to assign the concrete type of IGraphObject to Invoke().");
                     return AZStd::any(false);
                 }
 
-                auto entry = m_behaviorClass->m_methods.find(method);
-                if (m_behaviorClass->m_methods.end() == entry)
+                auto entry = m_behaviorClass->m_properties.find(property);
+                if (m_behaviorClass->m_properties.end() == entry)
                 {
-                    AZ_Warning("SceneAPI", false, "Missing method %.*s from class %s",
-                        aznumeric_cast<int>(method.size()),
-                        method.data(),
+                    AZ_Warning("SceneAPI", false, "Missing property %.*s from class %s",
+                        aznumeric_cast<int>(property.size()),
+                        property.data(),
                         m_behaviorClass->m_name.c_str());
 
                     return AZStd::any(false);
                 }
 
-                AZ::BehaviorMethod* behaviorMethod = entry->second;
+                if (!entry->second->m_getter)
+                {
+                    AZ_Warning("SceneAPI", false, "Property %.*s from class %s has a NULL getter",
+                        aznumeric_cast<int>(property.size()),
+                        property.data(),
+                        m_behaviorClass->m_name.c_str());
 
+                    return AZStd::any(false);
+                }
+
+                return InvokeBehaviorMethod(entry->second->m_getter, {});
+            }
+
+            void GraphObjectProxy::Assign(AZStd::string_view property, AZStd::any value)
+            {
+                if (!m_behaviorClass)
+                {
+                    AZ_Warning("SceneAPI", false, "Empty behavior class. Use the CastWithTypeName() to assign the concrete type of IGraphObject to Invoke().");
+                    return;
+                }
+
+                auto entry = m_behaviorClass->m_properties.find(property);
+                if (m_behaviorClass->m_properties.end() == entry)
+                {
+                    AZ_Warning("SceneAPI", false, "Missing property %.*s from class %s",
+                        aznumeric_cast<int>(property.size()),
+                        property.data(),
+                        m_behaviorClass->m_name.c_str());
+
+                    return;
+                }
+
+                if (!entry->second->m_setter)
+                {
+                    AZ_Warning("SceneAPI", false, "Property %.*s from class %s has a NULL setter",
+                        aznumeric_cast<int>(property.size()),
+                        property.data(),
+                        m_behaviorClass->m_name.c_str());
+
+                    return;
+                }
+
+                InvokeBehaviorMethod(entry->second->m_setter, { value });
+            }
+
+            AZStd::any GraphObjectProxy::InvokeBehaviorMethod(AZ::BehaviorMethod* behaviorMethod, AZStd::vector<AZStd::any> argList)
+            {
                 constexpr size_t behaviorParamListSize = 8;
                 if (behaviorMethod->GetNumArguments() > behaviorParamListSize)
                 {
@@ -248,7 +320,7 @@ namespace AZ
                     hasSelfPointer = behaviorMethod->GetArgument(0)->m_typeId == m_behaviorClass->m_typeId;
                 }
 
-                // record the "this" pointer's metadata like its RTTI so that it can be
+                // record the "this" pointer's meta data like its RTTI so that it can be
                 // down casted to a parent class type if needed to invoke a parent method
                 if (const AZ::BehaviorParameter* thisInfo = behaviorMethod->GetArgument(0); hasSelfPointer)
                 {
@@ -320,7 +392,7 @@ namespace AZ
                     }
                 }
 
-                if (!entry->second->Call(behaviorParamList, paramCount, &returnBehaviorValue))
+                if (!behaviorMethod->Call(behaviorParamList, paramCount, &returnBehaviorValue))
                 {
                     return AZStd::any(false);
                 }
@@ -330,9 +402,39 @@ namespace AZ
                     return AZStd::any(true);
                 }
 
+                AZ::SerializeContext* serializeContext = nullptr;
+                AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
+                if (!serializeContext)
+                {
+                    AZ_Error("SceneAPI", false, "AZ::SerializeContext should be prepared.");
+                    return AZStd::any(false);
+                }
+
                 // Create temporary any to get its type info to construct a new AZStd::any with new data
                 AZStd::any tempAny = serializeContext->CreateAny(returnBehaviorValue.m_typeId);
                 return AZStd::move(AZStd::any(returnBehaviorValue.m_value, tempAny.get_type_info()));
+            }
+
+            AZStd::any GraphObjectProxy::Invoke(AZStd::string_view method, AZStd::vector<AZStd::any> argList)
+            {
+                if (!m_behaviorClass)
+                {
+                    AZ_Warning("SceneAPI", false, "Use the CastWithTypeName() to assign the concrete type of IGraphObject to Invoke().");
+                    return AZStd::any(false);
+                }
+
+                auto entry = m_behaviorClass->m_methods.find(method);
+                if (m_behaviorClass->m_methods.end() == entry)
+                {
+                    AZ_Warning("SceneAPI", false, "Missing method %.*s from class %s",
+                        aznumeric_cast<int>(method.size()),
+                        method.data(),
+                        m_behaviorClass->m_name.c_str());
+
+                    return AZStd::any(false);
+                }
+
+                return InvokeBehaviorMethod(entry->second, argList);
             }
 
             template <typename FROM, typename TO>

--- a/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.h
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.h
@@ -48,7 +48,6 @@ namespace AZ
 
                 AZStd::any Invoke(AZStd::string_view method, AZStd::vector<AZStd::any> argList);
                 AZStd::any Fetch(AZStd::string_view property);
-                void Assign(AZStd::string_view property, AZStd::any value);
                 AZStd::any InvokeBehaviorMethod(AZ::BehaviorMethod* behaviorMethod, AZStd::vector<AZStd::any> argList);
 
             private:

--- a/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.h
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.h
@@ -15,6 +15,7 @@ namespace AZ
     struct BehaviorParameter;
     struct BehaviorArgument;
     class BehaviorClass;
+    class BehaviorMethod;
 
     namespace Python
     {
@@ -41,10 +42,14 @@ namespace AZ
                 ~GraphObjectProxy();
 
                 bool CastWithTypeName(const AZStd::string& classTypeName);
-                AZStd::any Invoke(AZStd::string_view method, AZStd::vector<AZStd::any> argList);
 
             protected:
                 bool Convert(AZStd::any& input, const AZ::BehaviorParameter* argBehaviorInfo, AZ::BehaviorArgument& behaviorParam);
+
+                AZStd::any Invoke(AZStd::string_view method, AZStd::vector<AZStd::any> argList);
+                AZStd::any Fetch(AZStd::string_view property);
+                void Assign(AZStd::string_view property, AZStd::any value);
+                AZStd::any InvokeBehaviorMethod(AZ::BehaviorMethod* behaviorMethod, AZStd::vector<AZStd::any> argList);
 
             private:
                 AZStd::shared_ptr<const DataTypes::IGraphObject> m_graphObject;

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
@@ -154,6 +154,7 @@ namespace AZ::SceneAPI::Containers
                     {
                         return self.m_scene.get();
                     });
+
             }
         }
     };
@@ -448,7 +449,8 @@ namespace AZ::SceneAPI::Containers
                     ->Method("AddAndSet", [](DataTypes::MockIGraphObject& self, int lhs, int rhs)
                     {
                         self.m_id = lhs + rhs;
-                    });
+                    })
+                    ->Property("id", BehaviorValueProperty(&AZ::SceneAPI::DataTypes::MockIGraphObject::m_id));
 
                 behaviorContext->Class<MockIGraphObjectTester>("MockIGraphObjectTester")
                     ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
@@ -511,7 +513,7 @@ namespace AZ::SceneAPI::Containers
         void SetupEditorPythonConsoleInterface()
         {
             EXPECT_CALL(*m_editorPythonConsoleInterface, FetchPythonTypeName(::testing::_))
-                .Times(4)
+                .Times(6)
                 .WillRepeatedly(::testing::Invoke([](const AZ::BehaviorParameter&) {return "int"; }));
         }
 
@@ -727,6 +729,44 @@ namespace AZ::SceneAPI::Containers
         ExpectExecute("TestExpectEquals(productList:GetSize(), 2)");
         ExpectExecute("exportProductList:AddDependencyToProduct(exportProduct.filename, exportProductDep)");
         ExpectExecute("TestExpectEquals(productList:Front().productDependencies:GetSize(), 1)");
+    }
+
+    TEST_F(SceneGraphBehaviorScriptTest, GraphObjectProxy_Fetch_GetsValue)
+    {
+        ExpectExecute("builder = MockBuilder()");
+        ExpectExecute("builder:BuildSceneGraph()");
+        ExpectExecute("scene = builder:GetScene()");
+        ExpectExecute("nodeG = scene.graph:FindWithPath('A.C.E.G')");
+        ExpectExecute("proxy = scene.graph:GetNodeContent(nodeG)");
+        ExpectExecute("TestExpectTrue(proxy:CastWithTypeName('MockIGraphObject'))");
+        ExpectExecute("id = proxy:Fetch('id')");
+        ExpectExecute("TestExpectEquals(id, 7)");
+    }
+
+    TEST_F(SceneGraphBehaviorScriptTest, GraphObjectProxy_Assign_SetsValue)
+    {
+        ExpectExecute("builder = MockBuilder()");
+        ExpectExecute("builder:BuildSceneGraph()");
+        ExpectExecute("scene = builder:GetScene()");
+        ExpectExecute("nodeG = scene.graph:FindWithPath('A.C.E.G')");
+        ExpectExecute("proxy = scene.graph:GetNodeContent(nodeG)");
+        ExpectExecute("TestExpectTrue(proxy:CastWithTypeName('MockIGraphObject'))");
+        ExpectExecute("proxy:Assign('id', 70)");
+        ExpectExecute("TestExpectEquals(proxy:Fetch('id'), 70)");
+    }
+
+    TEST_F(SceneGraphBehaviorScriptTest, GraphObjectProxy_GetClassInfo_HasProperties)
+    {
+        SetupEditorPythonConsoleInterface();
+
+        ExpectExecute("builder = MockBuilder()");
+        ExpectExecute("builder:BuildSceneGraph()");
+        ExpectExecute("scene = builder:GetScene()");
+        ExpectExecute("nodeG = scene.graph:FindWithPath('A.C.E.G')");
+        ExpectExecute("proxy = scene.graph:GetNodeContent(nodeG)");
+        ExpectExecute("TestExpectTrue(proxy:CastWithTypeName('MockIGraphObject'))");
+        ExpectExecute("info = proxy:GetClassInfo()");
+        ExpectExecute("TestExpectTrue(info.propertyList[1] == 'id(int)->int')");
     }
 
     //

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
@@ -743,18 +743,6 @@ namespace AZ::SceneAPI::Containers
         ExpectExecute("TestExpectEquals(id, 7)");
     }
 
-    TEST_F(SceneGraphBehaviorScriptTest, GraphObjectProxy_Assign_SetsValue)
-    {
-        ExpectExecute("builder = MockBuilder()");
-        ExpectExecute("builder:BuildSceneGraph()");
-        ExpectExecute("scene = builder:GetScene()");
-        ExpectExecute("nodeG = scene.graph:FindWithPath('A.C.E.G')");
-        ExpectExecute("proxy = scene.graph:GetNodeContent(nodeG)");
-        ExpectExecute("TestExpectTrue(proxy:CastWithTypeName('MockIGraphObject'))");
-        ExpectExecute("proxy:Assign('id', 70)");
-        ExpectExecute("TestExpectEquals(proxy:Fetch('id'), 70)");
-    }
-
     TEST_F(SceneGraphBehaviorScriptTest, GraphObjectProxy_GetClassInfo_HasProperties)
     {
         SetupEditorPythonConsoleInterface();


### PR DESCRIPTION
## What does this PR do?

This adds methods to fetch and assign data in the GraphObject node.

## How was this PR tested?

Added unit tests:
- SceneGraphBehaviorScriptTest.GraphObjectProxy_Fetch_GetsValue
- SceneGraphBehaviorScriptTest.GraphObjectProxy_GetClassInfo_HasProperties
