### PR TITLE
Fixed crash in GroupElementToggle when the hidden attribute was added

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
@@ -515,7 +515,7 @@ namespace AzToolsFramework
 
                     // Initialized normally if the group does not have a member variable attached to it,
                     // otherwise initialize it as a group that will have a toggle switch.
-                    if (groupElementData->IsClassElement())
+                    if (groupElementData->IsClassElement() || !groupSourceNode)
                     {
                         widgetEntry->Initialize(groupName, parent, depth, m_propertyLabelWidth);
                     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
@@ -513,7 +513,8 @@ namespace AzToolsFramework
                     widgetEntry = CreateOrPullFromPool();
                     widgetEntry->SetFilterString(m_editor->GetFilterString());
 
-                    // Initialized normally if the group does not have a member variable attached to it,
+                    // Initialized normally if the group does not have a member variable attached to it
+                    // or if the source node for the toggle group is null,
                     // otherwise initialize it as a group that will have a toggle switch.
                     if (groupElementData->IsClassElement() || !groupSourceNode)
                     {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
@@ -171,7 +171,7 @@ namespace AzToolsFramework
         InstanceDataHierarchy::ValueComparisonFunction m_valueComparisonFunction;
         ReflectedPropertyEditor::WidgetList m_widgets;
         ReflectedPropertyEditor::WidgetList m_specialGroupWidgets;
-        InstanceDataNode* groupSourceNode = nullptr;
+        InstanceDataNode* m_groupSourceNode = nullptr;
         RowContainerType m_widgetsInDisplayOrder;
         UserWidgetToDataMap m_userWidgetsToData;
         VisibilityCallback m_visibilityCallback;
@@ -516,19 +516,19 @@ namespace AzToolsFramework
                     // Initialized normally if the group does not have a member variable attached to it
                     // or if the source node for the toggle group is null,
                     // otherwise initialize it as a group that will have a toggle switch.
-                    if (groupElementData->IsClassElement() || !groupSourceNode)
+                    if (groupElementData->IsClassElement() || !m_groupSourceNode)
                     {
                         widgetEntry->Initialize(groupName, parent, depth, m_propertyLabelWidth);
                     }
                     else
                     {
-                        widgetEntry->InitializeToggleGroup(groupName, parent, depth, groupSourceNode, m_propertyLabelWidth);
+                        widgetEntry->InitializeToggleGroup(groupName, parent, depth, m_groupSourceNode, m_propertyLabelWidth);
                         QWidget* toggleSwitch = widgetEntry->GetToggle();
                         PropertyHandlerBase* pHandler = widgetEntry->GetHandler();
-                        m_userWidgetsToData[toggleSwitch] = groupSourceNode;
-                        m_specialGroupWidgets[groupSourceNode] = widgetEntry;
-                        pHandler->ConsumeAttributes_Internal(toggleSwitch, groupSourceNode);
-                        pHandler->ReadValuesIntoGUI_Internal(toggleSwitch, groupSourceNode);
+                        m_userWidgetsToData[toggleSwitch] = m_groupSourceNode;
+                        m_specialGroupWidgets[m_groupSourceNode] = widgetEntry;
+                        pHandler->ConsumeAttributes_Internal(toggleSwitch, m_groupSourceNode);
+                        pHandler->ReadValuesIntoGUI_Internal(toggleSwitch, m_groupSourceNode);
                         widgetEntry->OnValuesUpdated();
                         isToggleGroup = true;
                     }
@@ -539,7 +539,7 @@ namespace AzToolsFramework
 
                     for (const AZ::Edit::AttributePair& attribute : groupElementData->m_attributes)
                     {
-                        InstanceDataNode* readerNode = (isToggleGroup) ? groupSourceNode : node;
+                        InstanceDataNode* readerNode = (isToggleGroup) ? m_groupSourceNode : node;
                         PropertyAttributeReader reader(readerNode->GetParent()->FirstInstance(), attribute.second);
                         QString descriptionOut;
                         bool foundDescription = false;
@@ -795,7 +795,7 @@ namespace AzToolsFramework
                 // Save the last InstanceDataNode that is a Group ClassElement so that we can use it as the source node for its widget.
                 if (node->GetElementEditMetadata() && (node->GetElementEditMetadata()->m_elementId == AZ::Edit::ClassElements::Group))
                 {
-                    groupSourceNode = node;
+                    m_groupSourceNode = node;
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Daniel Tamkin <jotamkin@amazon.com>

## What does this PR do?

Fixes #11232
Added null dereference to prevent crash when the source node is null in a GroupElementToggle

## How was this PR tested?
Ran the editor to make sure it didn't crash when the hidden visibility attribute was added
