### PR TITLE
Make FeatureProcessorManagement test use a scoped temp directory

### DIFF
--- a/Gems/Atom/RPI/Code/Tests/Common/RPITestFixture.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Common/RPITestFixture.cpp
@@ -69,19 +69,6 @@ namespace UnitTest
         assetPath /= "Cache";
         AZ::IO::FileIOBase::GetInstance()->SetAlias("@products@", assetPath.c_str());
 
-        // Remark, AZ::Utils::GetProjectPath() is not used when defining "user" folder,
-        // instead We use AZ::Test::GetEngineRootPath();.
-        // Reason:
-        // When running unit tests, using AZ::Utils::GetProjectPath() will resolve to something like:
-        // "/data/workspace/o3de/build/linux/External/Atom-9a4d112b/RPI/Code/Cache"
-        // The ShaderMetricSystem.cpp writes to the @user@ folder and the following runtime error occurs:
-        // "You may not alter data inside the asset cache.  Please check the call stack and consider writing into the source asset folder instead."
-        // "Attempted write location: /data/workspace/o3de/build/linux/External/Atom-9a4d112b/RPI/Code/Cache/user/shadermetrics.json"
-        // To avoid the error We use AZ::Test::GetEngineRootPath();
-        AZ::IO::Path userPath = AZ::Test::GetEngineRootPath();
-        userPath /= "user";
-        AZ::IO::FileIOBase::GetInstance()->SetAlias("@user@", userPath.c_str());
-
         m_jsonRegistrationContext = AZStd::make_unique<AZ::JsonRegistrationContext>();
         m_jsonSystemComponent = AZStd::make_unique<AZ::JsonSystemComponent>();
         m_jsonSystemComponent->Reflect(m_jsonRegistrationContext.get());

--- a/Gems/Atom/RPI/Code/Tests/System/SceneTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/System/SceneTests.cpp
@@ -71,6 +71,9 @@ namespace UnitTest
     */
     TEST_F(SceneTests, FeatureProcessorManagement)
     {
+        AZ::Test::ScopedAutoTempDirectory tempDirectory;
+        AZ::IO::FileIOBase::GetInstance()->SetAlias("@user@", tempDirectory.GetDirectory());
+
         // Create scene with two test feature processors
         SceneDescriptor sceneDesc;
         sceneDesc.m_featureProcessorNames.push_back(AZStd::string(TestFeatureProcessor1::RTTI_TypeName()));


### PR DESCRIPTION
Signed-off-by: srikappa-amzn <82230713+srikappa-amzn@users.noreply.github.com>

## What does this PR do?

This PR fixes intermittent unit test failure for FeatureProcessorManagement test

It is possible for ShaderMetrics.json ( a file created for each test) file to be corrupted from a previous run and make the test fail for subsequent runs. To prevent this, the PR uses a scoped directory which gets destroyed after the end of the test. So, even if the file gets corruped in one run, it wouldn't affect subsequent runs. I've also moved the user folder registration from the test fixture to the only test that needs it. Leaving it in the text fixture will make it possible for the same issue to reoccur when tests run in parallel.

Thanks to @lawsonamzn  for the suggestion to use scoped directory.
## How was this PR tested?

1. Before these changes, I put bad json in my {enginepath}\user\ShaderMetrics.json file and ran the test to ensure it would fail.
2. Made the changes and saw that tests pass. The bad json file stayed in the same state but it didn't affect the state.
