### PR TITLE
Prefab | Remove warning on identifying link id patch during template propagation

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -428,14 +428,7 @@ namespace AzToolsFramework
                         {
                             patchesMetadata.m_shouldReloadContainerEntity = true;
                         }
-                        else
-                        {
-                            AZ_Warning(
-                                "Prefab", false,
-                                "A patch targeting '%.*s' is identified. Patches must be routed to Entities, Instances, or "
-                                "ContainerEntity.",
-                                AZ_STRING_ARG(patchPath));
-                        }
+                        // Skips other path prefix types (e.g. /LinkId/{someString}/).
                     }
                 }
                 return AZStd::move(patchesMetadata);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -378,6 +378,7 @@ namespace AzToolsFramework
                     {
                         AZStd::string_view patchPath = patchEntryIterator->value.GetString();
 
+                        // Entities
                         if (patchPath == PathMatchingEntities) // Path is /Entities
                         {
                             patchesMetadata.m_clearAndLoadAllEntities = true;
@@ -401,6 +402,7 @@ namespace AzToolsFramework
                                     patchEntry, patchesMetadata.m_entitiesToReload, patchesMetadata.m_entitiesToRemove, AZStd::move(patchPath));
                             }
                         }
+                        // Instances
                         else if (patchPath == PathMatchingInstances) // Path is /Instances
                         {
                             patchesMetadata.m_clearAndLoadAllInstances = true;
@@ -424,11 +426,25 @@ namespace AzToolsFramework
                                     patchEntry, patchesMetadata.m_instancesToAdd, patchesMetadata.m_instancesToRemove, AZStd::move(patchPath));
                             }
                         }
+                        // ContainerEntity
                         else if (patchPath.starts_with(PathMatchingContainerEntity)) // Path begins with /ContainerEntity
                         {
                             patchesMetadata.m_shouldReloadContainerEntity = true;
                         }
-                        // Skips other path prefix types (e.g. /LinkId/{someString}/).
+                        // LinkId
+                        else if (patchPath == PathMatchingLinkId) // Path is /LinkId
+                        {
+                            continue;
+                        }
+                        else
+                        {
+                            AZ_Warning(
+                                "Prefab",
+                                false,
+                                "A patch targeting '%.*s' is identified. Patches must be routed to Entities, Instances, "
+                                "ContainerEntity, or LinkId.",
+                                AZ_STRING_ARG(patchPath));
+                        }
                     }
                 }
                 return AZStd::move(patchesMetadata);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -374,79 +374,82 @@ namespace AzToolsFramework
                 for (const PrefabDomValue& patchEntry : patches.GetArray())
                 {
                     PrefabDomValue::ConstMemberIterator patchEntryIterator = patchEntry.FindMember("path");
-                    if (patchEntryIterator != patchEntry.MemberEnd())
+                    if (patchEntryIterator == patchEntry.MemberEnd())
                     {
-                        AZStd::string_view patchPath = patchEntryIterator->value.GetString();
+                        continue;
+                    }
+                
+                    AZStd::string_view patchPath = patchEntryIterator->value.GetString();
 
-                        // Entities
-                        if (patchPath == PathMatchingEntities) // Path is /Entities
-                        {
-                            patchesMetadata.m_clearAndLoadAllEntities = true;
-                        }
-                        else if (patchPath.starts_with(PathStartingWithEntities)) // Path begins with /Entities/
-                        {
-                            if (patchesMetadata.m_clearAndLoadAllEntities)
-                            {
-                                continue;
-                            }
-
-                            patchPath.remove_prefix(strlen(PathStartingWithEntities));
-                            AZStd::size_t pathSeparatorIndex = patchPath.find('/');
-                            if (pathSeparatorIndex != AZStd::string::npos) // Path begins with /Entities/{someString}/
-                            {
-                                patchesMetadata.m_entitiesToReload.emplace(patchPath.substr(0, pathSeparatorIndex));
-                            }
-                            else // Path is with /Entities/{someString}
-                            {
-                                Internal::IdentifyInstanceMembersToAddAndRemove(
-                                    patchEntry, patchesMetadata.m_entitiesToReload, patchesMetadata.m_entitiesToRemove, AZStd::move(patchPath));
-                            }
-                        }
-                        // Instances
-                        else if (patchPath == PathMatchingInstances) // Path is /Instances
-                        {
-                            patchesMetadata.m_clearAndLoadAllInstances = true;
-                        }
-                        else if (patchPath.starts_with(PathStartingWithInstances))// Path begins with /Instances/
-                        {
-                            if (patchesMetadata.m_clearAndLoadAllInstances)
-                            {
-                                continue;
-                            }
-
-                            patchPath.remove_prefix(strlen(PathStartingWithInstances));
-                            AZStd::size_t pathSeparatorIndex = patchPath.find('/');
-                            if (pathSeparatorIndex != AZStd::string::npos) // Path begins with /Instances/{someString}/
-                            {
-                                patchesMetadata.m_instancesToReload.emplace(patchPath.substr(0, pathSeparatorIndex));
-                            }
-                            else // Path is /Instances/{someString}
-                            {
-                                Internal::IdentifyInstanceMembersToAddAndRemove(
-                                    patchEntry, patchesMetadata.m_instancesToAdd, patchesMetadata.m_instancesToRemove, AZStd::move(patchPath));
-                            }
-                        }
-                        // ContainerEntity
-                        else if (patchPath.starts_with(PathMatchingContainerEntity)) // Path begins with /ContainerEntity
-                        {
-                            patchesMetadata.m_shouldReloadContainerEntity = true;
-                        }
-                        // LinkId
-                        else if (patchPath == PathMatchingLinkId) // Path is /LinkId
+                    // Entities
+                    if (patchPath == PathMatchingEntities) // Path is /Entities
+                    {
+                        patchesMetadata.m_clearAndLoadAllEntities = true;
+                    }
+                    else if (patchPath.starts_with(PathStartingWithEntities)) // Path begins with /Entities/
+                    {
+                        if (patchesMetadata.m_clearAndLoadAllEntities)
                         {
                             continue;
                         }
-                        else
+
+                        patchPath.remove_prefix(strlen(PathStartingWithEntities));
+                        AZStd::size_t pathSeparatorIndex = patchPath.find('/');
+                        if (pathSeparatorIndex != AZStd::string::npos) // Path begins with /Entities/{someString}/
                         {
-                            AZ_Warning(
-                                "Prefab",
-                                false,
-                                "A patch targeting '%.*s' is identified. Patches must be routed to Entities, Instances, "
-                                "ContainerEntity, or LinkId.",
-                                AZ_STRING_ARG(patchPath));
+                            patchesMetadata.m_entitiesToReload.emplace(patchPath.substr(0, pathSeparatorIndex));
+                        }
+                        else // Path is with /Entities/{someString}
+                        {
+                            Internal::IdentifyInstanceMembersToAddAndRemove(
+                                patchEntry, patchesMetadata.m_entitiesToReload, patchesMetadata.m_entitiesToRemove, AZStd::move(patchPath));
                         }
                     }
+                    // Instances
+                    else if (patchPath == PathMatchingInstances) // Path is /Instances
+                    {
+                        patchesMetadata.m_clearAndLoadAllInstances = true;
+                    }
+                    else if (patchPath.starts_with(PathStartingWithInstances))// Path begins with /Instances/
+                    {
+                        if (patchesMetadata.m_clearAndLoadAllInstances)
+                        {
+                            continue;
+                        }
+
+                        patchPath.remove_prefix(strlen(PathStartingWithInstances));
+                        AZStd::size_t pathSeparatorIndex = patchPath.find('/');
+                        if (pathSeparatorIndex != AZStd::string::npos) // Path begins with /Instances/{someString}/
+                        {
+                            patchesMetadata.m_instancesToReload.emplace(patchPath.substr(0, pathSeparatorIndex));
+                        }
+                        else // Path is /Instances/{someString}
+                        {
+                            Internal::IdentifyInstanceMembersToAddAndRemove(
+                                patchEntry, patchesMetadata.m_instancesToAdd, patchesMetadata.m_instancesToRemove, AZStd::move(patchPath));
+                        }
+                    }
+                    // ContainerEntity
+                    else if (patchPath.starts_with(PathMatchingContainerEntity)) // Path begins with /ContainerEntity
+                    {
+                        patchesMetadata.m_shouldReloadContainerEntity = true;
+                    }
+                    // LinkId
+                    else if (patchPath == PathMatchingLinkId) // Path is /LinkId
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        AZ_Warning(
+                            "Prefab",
+                            false,
+                            "A patch targeting '%.*s' is identified. Patches must be routed to Entities, Instances, "
+                            "ContainerEntity, or LinkId.",
+                            AZ_STRING_ARG(patchPath));
+                    }
                 }
+
                 return AZStd::move(patchesMetadata);
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -31,11 +31,13 @@ namespace AzToolsFramework
             inline static constexpr const char* ComponentsName = "Components";
             inline static constexpr const char* EntityOrderName = "Child Entity Order";
             inline static constexpr const char* TypeName = "$type";
-            inline static constexpr const char* PathMatchingEntities = "/Entities";
-            inline static constexpr const char* PathMatchingInstances = "/Instances";
+
             inline static constexpr const char* PathStartingWithEntities = "/Entities/";
             inline static constexpr const char* PathStartingWithInstances = "/Instances/";
+            inline static constexpr const char* PathMatchingEntities = "/Entities";
+            inline static constexpr const char* PathMatchingInstances = "/Instances";
             inline static constexpr const char* PathMatchingContainerEntity = "/ContainerEntity";
+            inline static constexpr const char* PathMatchingLinkId = "/LinkId";
 
             /**
             * Find Prefab value from given parent value and target value's name.


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

This PR removes an unnecessary warning on identifying other path prefix types (e.g. `/LinkId/{someString}/`) in prefab template propagation (during selective deserialization).

As we have forced template propagation when entering and exiting prefab focus mode (#11120), which frequently updates link id in instance DOM, we should remove the warning statement so it won't pollute editor console.

![image](https://user-images.githubusercontent.com/11157226/184463474-c9ad8d42-05f7-4bde-aeae-cfc0f1626ac0.png)

There is no impact because we already skipped processing any patches like this. The warning is just for debugging purpose.

## How was this PR tested?

- [X] Verified in editor console
- [x] Passed unit tests
- [ ] AR
