### PR TITLE
Fixed output of pthread create_thread errors on Linux and Android

### DIFF
--- a/Code/Framework/AzCore/Platform/Android/AzCore/AzCore_Traits_Android.h
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/AzCore_Traits_Android.h
@@ -94,7 +94,7 @@
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_MAINTHREAD AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_RENDERTHREAD AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_WORKERTHREADS AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
-#define AZ_TRAIT_THREAD_AFFINITY_MASK_ASSET_PROCESSOR_CONNECTION_THREAD 4
+#define AZ_TRAIT_THREAD_AFFINITY_MASK_ASSET_PROCESSOR_CONNECTION_THREAD AZStd::clamp(4, 0, static_cast<int>(AZStd::thread::hardware_concurrency()) - 1)
 #define AZ_TRAIT_THREAD_HARDWARE_CONCURRENCY_RETURN_VALUE static_cast<unsigned int>(sysconf(_SC_NPROCESSORS_ONLN));
 #define AZ_TRAIT_UNITTEST_NON_PREALLOCATED_HPHA_TEST 0
 #define AZ_TRAIT_USE_POSIX_STRERROR_R 1
@@ -106,7 +106,7 @@
 
 // wchar_t/char formatting
 // Reason: https://docs.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-160
-// The Z type character, and the behavior of the c, C, s, and S type characters when they're used with the printf and wprintf functions, 
+// The Z type character, and the behavior of the c, C, s, and S type characters when they're used with the printf and wprintf functions,
 // are Microsoft extensions. The ISO C standard uses c and s consistently for narrow characters and strings, and C and S for wide characters
 // and strings, in all formatting functions.
 #define AZ_TRAIT_FORMAT_STRING_PRINTF_CHAR "%c"

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/parallel/internal/thread_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/parallel/internal/thread_UnixLike.cpp
@@ -82,7 +82,7 @@ namespace AZStd
             pthread_t tId;
             int res = pthread_create(&tId, &attr, &thread_run_function, ti);
             (void)res;
-            AZ_Assert(res == 0, "pthread failed %s", strerror(errno));
+            AZ_Assert(res == 0, "pthread failed with code %d: %s", res, strerror(res));
             pthread_attr_destroy(&attr);
 
             // Platform specific post thread creation action (setting thread name on some, affinity on others)

--- a/Code/Framework/AzCore/Platform/Linux/AzCore/AzCore_Traits_Linux.h
+++ b/Code/Framework/AzCore/Platform/Linux/AzCore/AzCore_Traits_Linux.h
@@ -94,7 +94,7 @@
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_MAINTHREAD AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_RENDERTHREAD AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_WORKERTHREADS AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
-#define AZ_TRAIT_THREAD_AFFINITY_MASK_ASSET_PROCESSOR_CONNECTION_THREAD 4
+#define AZ_TRAIT_THREAD_AFFINITY_MASK_ASSET_PROCESSOR_CONNECTION_THREAD AZStd::clamp(4, 0, static_cast<int>(AZStd::thread::hardware_concurrency()) - 1)
 #define AZ_TRAIT_THREAD_HARDWARE_CONCURRENCY_RETURN_VALUE static_cast<unsigned int>(sysconf(_SC_NPROCESSORS_ONLN));
 #define AZ_TRAIT_UNITTEST_NON_PREALLOCATED_HPHA_TEST 0
 #define AZ_TRAIT_USE_POSIX_STRERROR_R 1
@@ -106,7 +106,7 @@
 
 // wchar_t/char formatting
 // Reason: https://docs.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-160
-// The Z type character, and the behavior of the c, C, s, and S type characters when they're used with the printf and wprintf functions, 
+// The Z type character, and the behavior of the c, C, s, and S type characters when they're used with the printf and wprintf functions,
 // are Microsoft extensions. The ISO C standard uses c and s consistently for narrow characters and strings, and C and S for wide characters
 // and strings, in all formatting functions.
 #define AZ_TRAIT_FORMAT_STRING_PRINTF_CHAR "%c"

--- a/Code/Framework/AzCore/Platform/Linux/AzCore/std/parallel/internal/thread_Linux.cpp
+++ b/Code/Framework/AzCore/Platform/Linux/AzCore/std/parallel/internal/thread_Linux.cpp
@@ -32,7 +32,7 @@ namespace AZStd
 
                 int result = pthread_attr_setaffinity_np(&attr, sizeof(cpuset), &cpuset);
                 (void)result;
-                AZ_Warning("System", result == 0, "pthread_setaffinity_np failed %s\n", strerror(errno));
+                AZ_Warning("System", result == 0, "pthread_setaffinity_np failed with code %d: %s\n", result, strerror(result));
             }
         }
 

--- a/Code/Framework/AzCore/Platform/Mac/AzCore/AzCore_Traits_Mac.h
+++ b/Code/Framework/AzCore/Platform/Mac/AzCore/AzCore_Traits_Mac.h
@@ -94,7 +94,7 @@
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_MAINTHREAD AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_RENDERTHREAD AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_WORKERTHREADS AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
-#define AZ_TRAIT_THREAD_AFFINITY_MASK_ASSET_PROCESSOR_CONNECTION_THREAD 4
+#define AZ_TRAIT_THREAD_AFFINITY_MASK_ASSET_PROCESSOR_CONNECTION_THREAD AZStd::clamp(4, 0, static_cast<int>(AZStd::thread::hardware_concurrency()) - 1)
 #define AZ_TRAIT_THREAD_HARDWARE_CONCURRENCY_RETURN_VALUE static_cast<unsigned int>(sysconf(_SC_NPROCESSORS_ONLN));
 #define AZ_TRAIT_UNITTEST_NON_PREALLOCATED_HPHA_TEST 0
 #define AZ_TRAIT_USE_POSIX_STRERROR_R 1
@@ -106,7 +106,7 @@
 
 // wchar_t/char formatting
 // Reason: https://docs.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-160
-// The Z type character, and the behavior of the c, C, s, and S type characters when they're used with the printf and wprintf functions, 
+// The Z type character, and the behavior of the c, C, s, and S type characters when they're used with the printf and wprintf functions,
 // are Microsoft extensions. The ISO C standard uses c and s consistently for narrow characters and strings, and C and S for wide characters
 // and strings, in all formatting functions.
 #define AZ_TRAIT_FORMAT_STRING_PRINTF_CHAR "%c"

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/AzCore_Traits_Windows.h
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/AzCore_Traits_Windows.h
@@ -94,7 +94,7 @@
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_MAINTHREAD AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_RENDERTHREAD AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_WORKERTHREADS AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
-#define AZ_TRAIT_THREAD_AFFINITY_MASK_ASSET_PROCESSOR_CONNECTION_THREAD 4
+#define AZ_TRAIT_THREAD_AFFINITY_MASK_ASSET_PROCESSOR_CONNECTION_THREAD AZStd::clamp(4, 0, static_cast<int>(AZStd::thread::hardware_concurrency()) - 1)
 #define AZ_TRAIT_THREAD_HARDWARE_CONCURRENCY_RETURN_VALUE INVALID_RETURN_VALUE
 #define AZ_TRAIT_UNITTEST_NON_PREALLOCATED_HPHA_TEST 1
 #define AZ_TRAIT_USE_POSIX_STRERROR_R 0
@@ -106,7 +106,7 @@
 
 // wchar_t/char formatting
 // Reason: https://docs.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-160
-// The Z type character, and the behavior of the c, C, s, and S type characters when they're used with the printf and wprintf functions, 
+// The Z type character, and the behavior of the c, C, s, and S type characters when they're used with the printf and wprintf functions,
 // are Microsoft extensions. The ISO C standard uses c and s consistently for narrow characters and strings, and C and S for wide characters
 // and strings, in all formatting functions.
 #define AZ_TRAIT_FORMAT_STRING_PRINTF_CHAR "%c"

--- a/Code/Framework/AzCore/Platform/iOS/AzCore/AzCore_Traits_iOS.h
+++ b/Code/Framework/AzCore/Platform/iOS/AzCore/AzCore_Traits_iOS.h
@@ -95,7 +95,7 @@
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_MAINTHREAD AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_RENDERTHREAD AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
 #define AZ_TRAIT_THREAD_AFFINITY_MASK_WORKERTHREADS AZ_TRAIT_THREAD_AFFINITY_MASK_ALLTHREADS
-#define AZ_TRAIT_THREAD_AFFINITY_MASK_ASSET_PROCESSOR_CONNECTION_THREAD 4
+#define AZ_TRAIT_THREAD_AFFINITY_MASK_ASSET_PROCESSOR_CONNECTION_THREAD AZStd::clamp(4, 0, static_cast<int>(AZStd::thread::hardware_concurrency()) - 1)
 #define AZ_TRAIT_THREAD_HARDWARE_CONCURRENCY_RETURN_VALUE static_cast<unsigned int>(sysconf(_SC_NPROCESSORS_ONLN));
 #define AZ_TRAIT_UNITTEST_NON_PREALLOCATED_HPHA_TEST 0
 #define AZ_TRAIT_USE_POSIX_STRERROR_R 1
@@ -107,7 +107,7 @@
 
 // wchar_t/char formatting
 // Reason: https://docs.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-160
-// The Z type character, and the behavior of the c, C, s, and S type characters when they're used with the printf and wprintf functions, 
+// The Z type character, and the behavior of the c, C, s, and S type characters when they're used with the printf and wprintf functions,
 // are Microsoft extensions. The ISO C standard uses c and s consistently for narrow characters and strings, and C and S for wide characters
 // and strings, in all formatting functions.
 #define AZ_TRAIT_FORMAT_STRING_PRINTF_CHAR "%c"


### PR DESCRIPTION
The pthread library does not set the `errno` global when errors occur and instead returns the error code as the return value.

Clamped the hardcoded thread affinity for the Send and Recv thread for connecting to the AP

Every platform hardcodes the cpu affinity to 4, which would set the AP Send and Recv thread to try to be spawn on the 5th cpu.

This causes an issue on Linux with thread creation, if the machine only has less than 5 logical cores and the `nosmt` kernel flag is used to turn off simultaneous multithreading.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
