### PR TITLE
bugfix(Editor): correctly handle update fov settings from Global Preferences

### DIFF
--- a/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
@@ -218,11 +218,11 @@ void CEditorPreferencesPage_ViewportGeneral::OnApply()
     CDisplaySettings* ds = GetIEditor()->GetDisplaySettings();
 
     gSettings.viewports.fDefaultAspectRatio = m_general.m_defaultAspectRatio;
-    gSettings.viewports.fDefaultFov = m_general.m_defaultFOV;
     gSettings.viewports.bEnableContextMenu = m_general.m_contextMenuEnabled;
     gSettings.viewports.bSync2DViews = m_general.m_sync2DViews;
     SandboxEditor::SetStickySelectEnabled(m_general.m_stickySelectEnabled);
 
+    SandboxEditor::SetCameraDefaultFov(m_general.m_defaultFOV);
     SandboxEditor::SetCameraDefaultNearPlaneDistance(m_general.m_defaultNearPlane);
     SandboxEditor::SetCameraDefaultFarPlaneDistance(m_general.m_defaultFarPlane);
 
@@ -282,9 +282,10 @@ void CEditorPreferencesPage_ViewportGeneral::InitializeSettings()
     CDisplaySettings* ds = GetIEditor()->GetDisplaySettings();
 
     m_general.m_defaultAspectRatio = gSettings.viewports.fDefaultAspectRatio;
-    m_general.m_defaultFOV = gSettings.viewports.fDefaultFov;
     m_general.m_defaultNearPlane = SandboxEditor::CameraDefaultNearPlaneDistance();
     m_general.m_defaultFarPlane = SandboxEditor::CameraDefaultFarPlaneDistance();
+    m_general.m_defaultFOV = SandboxEditor::CameraDefaultFov();
+    
     m_general.m_contextMenuEnabled = gSettings.viewports.bEnableContextMenu;
     m_general.m_sync2DViews = gSettings.viewports.bSync2DViews;
     m_general.m_stickySelectEnabled = SandboxEditor::StickySelectEnabled();

--- a/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
@@ -84,7 +84,6 @@ void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& seria
         editContext->Class<General>("General Viewport Settings", "")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &General::m_sync2DViews, "Synchronize 2D Viewports", "Synchronize 2D Viewports")
             ->DataElement(AZ::Edit::UIHandlers::SpinBox, &General::m_defaultFOV, "Perspective View FOV", "Perspective View FOV")
-            ->Attribute("Multiplier", RAD2DEG(1))
             ->Attribute(AZ::Edit::Attributes::Min, 1.0f)
             ->Attribute(AZ::Edit::Attributes::Max, 120.0f)
             ->DataElement(AZ::Edit::UIHandlers::SpinBox, &General::m_defaultNearPlane, "Perspective Near Plane", "Perspective Near Plane")
@@ -222,7 +221,7 @@ void CEditorPreferencesPage_ViewportGeneral::OnApply()
     gSettings.viewports.bSync2DViews = m_general.m_sync2DViews;
     SandboxEditor::SetStickySelectEnabled(m_general.m_stickySelectEnabled);
 
-    SandboxEditor::SetCameraDefaultFovRadians(m_general.m_defaultFOV);
+    SandboxEditor::SetCameraDefaultFovDegrees(m_general.m_defaultFOV);
     SandboxEditor::SetCameraDefaultNearPlaneDistance(m_general.m_defaultNearPlane);
     SandboxEditor::SetCameraDefaultFarPlaneDistance(m_general.m_defaultFarPlane);
 
@@ -284,7 +283,7 @@ void CEditorPreferencesPage_ViewportGeneral::InitializeSettings()
     m_general.m_defaultAspectRatio = gSettings.viewports.fDefaultAspectRatio;
     m_general.m_defaultNearPlane = SandboxEditor::CameraDefaultNearPlaneDistance();
     m_general.m_defaultFarPlane = SandboxEditor::CameraDefaultFarPlaneDistance();
-    m_general.m_defaultFOV = SandboxEditor::CameraDefaultFovRadians();
+    m_general.m_defaultFOV = SandboxEditor::CameraDefaultFovDegrees();
     
     m_general.m_contextMenuEnabled = gSettings.viewports.bEnableContextMenu;
     m_general.m_sync2DViews = gSettings.viewports.bSync2DViews;

--- a/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
@@ -222,7 +222,7 @@ void CEditorPreferencesPage_ViewportGeneral::OnApply()
     gSettings.viewports.bSync2DViews = m_general.m_sync2DViews;
     SandboxEditor::SetStickySelectEnabled(m_general.m_stickySelectEnabled);
 
-    SandboxEditor::SetCameraDefaultFov(m_general.m_defaultFOV);
+    SandboxEditor::SetCameraDefaultFovRadians(m_general.m_defaultFOV);
     SandboxEditor::SetCameraDefaultNearPlaneDistance(m_general.m_defaultNearPlane);
     SandboxEditor::SetCameraDefaultFarPlaneDistance(m_general.m_defaultFarPlane);
 
@@ -284,7 +284,7 @@ void CEditorPreferencesPage_ViewportGeneral::InitializeSettings()
     m_general.m_defaultAspectRatio = gSettings.viewports.fDefaultAspectRatio;
     m_general.m_defaultNearPlane = SandboxEditor::CameraDefaultNearPlaneDistance();
     m_general.m_defaultFarPlane = SandboxEditor::CameraDefaultFarPlaneDistance();
-    m_general.m_defaultFOV = SandboxEditor::CameraDefaultFov();
+    m_general.m_defaultFOV = SandboxEditor::CameraDefaultFovRadians();
     
     m_general.m_contextMenuEnabled = gSettings.viewports.bEnableContextMenu;
     m_general.m_sync2DViews = gSettings.viewports.bSync2DViews;

--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -62,7 +62,7 @@ namespace SandboxEditor
     constexpr AZStd::string_view CameraDefaultStartingYaw = "/Amazon/Preferences/Editor/Camera/DefaultStartingYaw";
     constexpr AZStd::string_view CameraNearPlaneDistanceSetting = "/Amazon/Preferences/Editor/Camera/NearPlaneDistance";
     constexpr AZStd::string_view CameraFarPlaneDistanceSetting = "/Amazon/Preferences/Editor/Camera/FarPlaneDistance";
-    constexpr AZStd::string_view CameraFovSetting = "/Amazon/Preferences/Editor/Camera/FovRadians";
+    constexpr AZStd::string_view CameraFovSetting = "/Amazon/Preferences/Editor/Camera/FovDegrees";
 
     struct EditorViewportSettingsCallbacksImpl : public EditorViewportSettingsCallbacks
     {
@@ -609,22 +609,22 @@ namespace SandboxEditor
 
     float CameraDefaultFovRadians()
     {
-        return aznumeric_caster(AzToolsFramework::GetRegistry(CameraFovSetting, aznumeric_cast<double>(AZ::DegToRad(60.0))));
+        return AZ::DegToRad(CameraDefaultFovDegrees());
     }
 
     void SetCameraDefaultFovRadians(float fovRadians)
-    {
-        AzToolsFramework::SetRegistry(CameraFovSetting, aznumeric_cast<double>(fovRadians));
+    {       
+        SetCameraDefaultFovDegrees(AZ::RadToDeg(fovRadians));
     }
 
     float CameraDefaultFovDegrees()
     {
-        return AZ::RadToDeg(CameraDefaultFovRadians());
+        return aznumeric_caster(AzToolsFramework::GetRegistry(CameraFovSetting, aznumeric_cast<double>(60.0)));
     }
 
     void SetCameraDefaultFovDegrees(float fovDegrees)
     {
-        SetCameraDefaultFovRadians(AZ::DegToRad(fovDegrees));
+        AzToolsFramework::SetRegistry(CameraFovSetting, aznumeric_cast<double>(fovDegrees));
     }
 
 } // namespace SandboxEditor

--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -112,9 +112,9 @@ namespace SandboxEditor
                 );
 
                 m_perspectiveNotifyEventHandler = registry->RegisterNotifier(
-                    [this](const AZStd::string_view path, [[maybe_unused]] const AZ::SettingsRegistryInterface::Type type)
+                    [this](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
                     {
-                        if (IsPathAncestorDescendantOrEqual(CameraFovSetting, path))
+                        if (IsPathAncestorDescendantOrEqual(CameraFovSetting, notifyEventArgs.m_jsonKeyPath))
                         {
                             m_perspectiveChanged.Signal();
                         }

--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -8,6 +8,7 @@
 
 #include <EditorViewportSettings.h>
 
+#include <AzCore/Math/MathUtils.h>
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
@@ -61,7 +62,7 @@ namespace SandboxEditor
     constexpr AZStd::string_view CameraDefaultStartingYaw = "/Amazon/Preferences/Editor/Camera/DefaultStartingYaw";
     constexpr AZStd::string_view CameraNearPlaneDistanceSetting = "/Amazon/Preferences/Editor/Camera/NearPlaneDistance";
     constexpr AZStd::string_view CameraFarPlaneDistanceSetting = "/Amazon/Preferences/Editor/Camera/FarPlaneDistance";
-    constexpr AZStd::string_view CameraFovSetting = "/Amazon/Preferences/Editor/Camera/DefaultFOV";
+    constexpr AZStd::string_view CameraFovSetting = "/Amazon/Preferences/Editor/Camera/FovRadians";
 
     struct EditorViewportSettingsCallbacksImpl : public EditorViewportSettingsCallbacks
     {
@@ -608,12 +609,22 @@ namespace SandboxEditor
 
     float CameraDefaultFovRadians()
     {
-        return aznumeric_caster(AzToolsFramework::GetRegistry(CameraFovSetting, 90.0));
+        return aznumeric_caster(AzToolsFramework::GetRegistry(CameraFovSetting, aznumeric_cast<double>(AZ::DegToRad(60.0))));
     }
 
-    void SetCameraDefaultFovRadians(float fov)
+    void SetCameraDefaultFovRadians(float fovRadians)
     {
-        AzToolsFramework::SetRegistry(CameraFovSetting, aznumeric_cast<double>(fov));
+        AzToolsFramework::SetRegistry(CameraFovSetting, aznumeric_cast<double>(fovRadians));
+    }
+
+    float CameraDefaultFovDegrees()
+    {
+        return AZ::RadToDeg(CameraDefaultFovRadians());
+    }
+
+    void SetCameraDefaultFovDegrees(float fovDegrees)
+    {
+        SetCameraDefaultFovRadians(AZ::DegToRad(fovDegrees));
     }
 
 } // namespace SandboxEditor

--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -117,7 +117,7 @@ namespace SandboxEditor
                     {
                         if (IsPathAncestorDescendantOrEqual(CameraFovSetting, notifyEventArgs.m_jsonKeyPath))
                         {
-                            m_perspectiveChanged.Signal();
+                            m_perspectiveChanged.Signal(CameraDefaultFovRadians());
                         }
                     });
             }

--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -606,12 +606,12 @@ namespace SandboxEditor
         AzToolsFramework::SetRegistry(CameraFarPlaneDistanceSetting, aznumeric_cast<double>(distance));
     }
 
-    float CameraDefaultFov()
+    float CameraDefaultFovRadians()
     {
         return aznumeric_caster(AzToolsFramework::GetRegistry(CameraFovSetting, 90.0));
     }
 
-    void SetCameraDefaultFov(float fov)
+    void SetCameraDefaultFovRadians(float fov)
     {
         AzToolsFramework::SetRegistry(CameraFovSetting, aznumeric_cast<double>(fov));
     }

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -20,7 +20,7 @@ namespace SandboxEditor
 {
     using AngleSnappingChangedEvent = AZ::Event<bool>;
     using GridSnappingChangedEvent = AZ::Event<bool>;
-    using PerspectiveChangedEvent = AZ::Event<>;
+    using PerspectiveChangedEvent = AZ::Event<float>;
     using NearFarPlaneChangedEvent = AZ::Event<float>;
 
     //! Set callbacks to listen for editor settings change events.

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -169,6 +169,6 @@ namespace SandboxEditor
     SANDBOX_API float CameraDefaultFarPlaneDistance();
     SANDBOX_API void SetCameraDefaultFarPlaneDistance(float distance);
 
-    SANDBOX_API float CameraDefaultFov();
-    SANDBOX_API void SetCameraDefaultFov(float fov);
+    SANDBOX_API float CameraDefaultFovRadians();
+    SANDBOX_API void SetCameraDefaultFovRadians(float fov);
 } // namespace SandboxEditor

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -170,5 +170,8 @@ namespace SandboxEditor
     SANDBOX_API void SetCameraDefaultFarPlaneDistance(float distance);
 
     SANDBOX_API float CameraDefaultFovRadians();
-    SANDBOX_API void SetCameraDefaultFovRadians(float fov);
+    SANDBOX_API void SetCameraDefaultFovRadians(float fovRadians);
+
+    SANDBOX_API float CameraDefaultFovDegrees();
+    SANDBOX_API void SetCameraDefaultFovDegrees(float fovDegrees);
 } // namespace SandboxEditor

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -20,6 +20,7 @@ namespace SandboxEditor
 {
     using AngleSnappingChangedEvent = AZ::Event<bool>;
     using GridSnappingChangedEvent = AZ::Event<bool>;
+    using PerspectiveChangedEvent = AZ::Event<>;
     using NearFarPlaneChangedEvent = AZ::Event<float>;
 
     //! Set callbacks to listen for editor settings change events.
@@ -31,6 +32,7 @@ namespace SandboxEditor
         virtual void SetAngleSnappingChangedEvent(AngleSnappingChangedEvent::Handler& handler) = 0;
         virtual void SetGridSnappingChangedEvent(GridSnappingChangedEvent::Handler& handler) = 0;
         virtual void SetFarPlaneDistanceChangedEvent(NearFarPlaneChangedEvent::Handler& handler) = 0;
+        virtual void SetPerspectiveChangedEvent(PerspectiveChangedEvent::Handler& handler) = 0;
         virtual void SetNearPlaneDistanceChangedEvent(NearFarPlaneChangedEvent::Handler& handler) = 0;
     };
 
@@ -166,4 +168,7 @@ namespace SandboxEditor
 
     SANDBOX_API float CameraDefaultFarPlaneDistance();
     SANDBOX_API void SetCameraDefaultFarPlaneDistance(float distance);
+
+    SANDBOX_API float CameraDefaultFov();
+    SANDBOX_API void SetCameraDefaultFov(float fov);
 } // namespace SandboxEditor

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -948,11 +948,10 @@ void EditorViewportWidget::SetViewportId(int id)
     m_editorViewportSettingsCallbacks->SetAngleSnappingChangedEvent(m_angleSnappingHandler);
 
     m_perspectiveChangeHandler = SandboxEditor::PerspectiveChangedEvent::Handler(
-        [this]()
+        [this](const float fovRadians)
         {
             if (m_viewSourceType == ViewSourceType::None)
             {
-                const float fovRadians = SandboxEditor::CameraDefaultFovRadians();
                 if (m_viewPane)
                 {
                     m_viewPane->OnFOVChanged(fovRadians);

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -947,6 +947,21 @@ void EditorViewportWidget::SetViewportId(int id)
     );
     m_editorViewportSettingsCallbacks->SetAngleSnappingChangedEvent(m_angleSnappingHandler);
 
+    m_perspectiveChangeHandler = SandboxEditor::PerspectiveChangedEvent::Handler(
+        [this]()
+        {
+            if (m_viewSourceType == ViewSourceType::None)
+            {
+                const float fov = SandboxEditor::CameraDefaultFov();
+                if (m_viewPane)
+                {
+                    m_viewPane->OnFOVChanged(fov);
+                }
+                SetFOV(fov);
+            }
+        });
+    m_editorViewportSettingsCallbacks->SetPerspectiveChangedEvent(m_perspectiveChangeHandler);
+
     m_nearPlaneDistanceHandler = SandboxEditor::NearFarPlaneChangedEvent::Handler(
         [this]([[maybe_unused]] float nearPlaneDistance)
         {
@@ -1938,7 +1953,7 @@ void EditorViewportWidget::SetDefaultCamera()
     // synchronize the configured editor viewport FOV to the default camera
     if (m_viewPane)
     {
-        const float fov = gSettings.viewports.fDefaultFov;
+        const float fov = SandboxEditor::CameraDefaultFov();
         m_viewPane->OnFOVChanged(fov);
         SetFOV(fov);
     }

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -952,7 +952,7 @@ void EditorViewportWidget::SetViewportId(int id)
         {
             if (m_viewSourceType == ViewSourceType::None)
             {
-                const float fov = SandboxEditor::CameraDefaultFov();
+                const float fov = SandboxEditor::CameraDefaultFovRadians();
                 if (m_viewPane)
                 {
                     m_viewPane->OnFOVChanged(fov);
@@ -1953,7 +1953,7 @@ void EditorViewportWidget::SetDefaultCamera()
     // synchronize the configured editor viewport FOV to the default camera
     if (m_viewPane)
     {
-        const float fov = SandboxEditor::CameraDefaultFov();
+        const float fov = SandboxEditor::CameraDefaultFovRadians();
         m_viewPane->OnFOVChanged(fov);
         SetFOV(fov);
     }

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -952,12 +952,12 @@ void EditorViewportWidget::SetViewportId(int id)
         {
             if (m_viewSourceType == ViewSourceType::None)
             {
-                const float fov = SandboxEditor::CameraDefaultFovRadians();
+                const float fovRadians = SandboxEditor::CameraDefaultFovRadians();
                 if (m_viewPane)
                 {
-                    m_viewPane->OnFOVChanged(fov);
+                    m_viewPane->OnFOVChanged(fovRadians);
                 }
-                SetFOV(fov);
+                SetFOV(fovRadians);
             }
         });
     m_editorViewportSettingsCallbacks->SetPerspectiveChangedEvent(m_perspectiveChangeHandler);
@@ -1953,9 +1953,9 @@ void EditorViewportWidget::SetDefaultCamera()
     // synchronize the configured editor viewport FOV to the default camera
     if (m_viewPane)
     {
-        const float fov = SandboxEditor::CameraDefaultFovRadians();
-        m_viewPane->OnFOVChanged(fov);
-        SetFOV(fov);
+        const float fovRadians = SandboxEditor::CameraDefaultFovRadians();
+        m_viewPane->OnFOVChanged(fovRadians);
+        SetFOV(fovRadians);
     }
 
     // Update camera matrix according to near / far values

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -406,6 +406,7 @@ private:
     SandboxEditor::GridSnappingChangedEvent::Handler m_gridSnappingHandler;
     SandboxEditor::NearFarPlaneChangedEvent::Handler m_nearPlaneDistanceHandler;
     SandboxEditor::NearFarPlaneChangedEvent::Handler m_farPlaneDistanceHandler;
+    SandboxEditor::PerspectiveChangedEvent::Handler m_perspectiveChangeHandler;
     AZStd::unique_ptr<SandboxEditor::EditorViewportSettingsCallbacks> m_editorViewportSettingsCallbacks;
 
     // Used for some legacy logic which lets the widget release a grabbed keyboard at the right times

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -130,7 +130,7 @@ SEditorSettings::SEditorSettings()
     viewports.bAlwaysShowRadiuses = false;
     viewports.bSync2DViews = false;
     viewports.fDefaultAspectRatio = 800.0f / 600.0f;
-    viewports.fDefaultFov = DEG2RAD(60); // 60 degrees (to fit with current game)
+    
     viewports.bShowSafeFrame = false;
     viewports.bHighlightSelectedGeometry = false;
     viewports.bHighlightSelectedVegetation = true;
@@ -471,7 +471,6 @@ void SEditorSettings::Save(bool isEditorClosing)
     //////////////////////////////////////////////////////////////////////////
     SaveValue("Settings", "AlwaysShowRadiuses", viewports.bAlwaysShowRadiuses);
     SaveValue("Settings", "Sync2DViews", viewports.bSync2DViews);
-    SaveValue("Settings", "DefaultFov", viewports.fDefaultFov);
     SaveValue("Settings", "AspectRatio", viewports.fDefaultAspectRatio);
     SaveValue("Settings", "ShowSafeFrame", viewports.bShowSafeFrame);
     SaveValue("Settings", "HighlightSelectedGeometry", viewports.bHighlightSelectedGeometry);
@@ -667,7 +666,6 @@ void SEditorSettings::Load()
     //////////////////////////////////////////////////////////////////////////
     LoadValue("Settings", "AlwaysShowRadiuses", viewports.bAlwaysShowRadiuses);
     LoadValue("Settings", "Sync2DViews", viewports.bSync2DViews);
-    LoadValue("Settings", "DefaultFov", viewports.fDefaultFov);
     LoadValue("Settings", "AspectRatio", viewports.fDefaultAspectRatio);
     LoadValue("Settings", "ShowSafeFrame", viewports.bShowSafeFrame);
     LoadValue("Settings", "HighlightSelectedGeometry", viewports.bHighlightSelectedGeometry);

--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -116,8 +116,6 @@ struct SViewportsSettings
     bool bAlwaysShowRadiuses;
     //! True if 2D viewports will be synchronized with same view and origin.
     bool bSync2DViews;
-    //! Camera FOV for perspective View.
-    float fDefaultFov;
     //! Camera Aspect Ratio for perspective View.
     float fDefaultAspectRatio;
     //! Show safe frame.

--- a/Code/Editor/ViewPane.cpp
+++ b/Code/Editor/ViewPane.cpp
@@ -41,6 +41,7 @@
 #include "MainWindow.h"
 #include "QtViewPaneManager.h"
 #include "EditorViewportWidget.h"
+#include <Editor/EditorViewportSettings.h>
 
 //////////////////////////////////////////////////////////////////////////
 // ViewportTitleExpanderWatcher
@@ -318,7 +319,7 @@ void CLayoutViewPane::AttachViewport(QWidget* pViewport)
         }
         else
         {
-            OnFOVChanged(gSettings.viewports.fDefaultFov);
+            OnFOVChanged(SandboxEditor::CameraDefaultFov());
         }
 
         m_viewportTitleDlg.OnViewportSizeChanged(pViewport->width(), pViewport->height());
@@ -329,7 +330,7 @@ void CLayoutViewPane::AttachViewport(QWidget* pViewport)
 void CLayoutViewPane::DetachViewport()
 {
     DisconnectRenderViewportInteractionRequestBus();
-    OnFOVChanged(gSettings.viewports.fDefaultFov);
+    OnFOVChanged(SandboxEditor::CameraDefaultFov());
     m_viewport = nullptr;
 }
 
@@ -465,7 +466,7 @@ void CLayoutViewPane::SetViewportFOV(const float fovDegrees)
         // if viewport camera is active, make selected fov new default
         if (pRenderViewport->GetViewManager()->GetCameraObjectId() == GUID_NULL)
         {
-            gSettings.viewports.fDefaultFov = fovRadians;
+            SandboxEditor::SetCameraDefaultFov(fovRadians);
         }
 
         OnFOVChanged(fovRadians);

--- a/Code/Editor/ViewPane.cpp
+++ b/Code/Editor/ViewPane.cpp
@@ -319,7 +319,7 @@ void CLayoutViewPane::AttachViewport(QWidget* pViewport)
         }
         else
         {
-            OnFOVChanged(SandboxEditor::CameraDefaultFov());
+            OnFOVChanged(SandboxEditor::CameraDefaultFovRadians());
         }
 
         m_viewportTitleDlg.OnViewportSizeChanged(pViewport->width(), pViewport->height());
@@ -330,7 +330,7 @@ void CLayoutViewPane::AttachViewport(QWidget* pViewport)
 void CLayoutViewPane::DetachViewport()
 {
     DisconnectRenderViewportInteractionRequestBus();
-    OnFOVChanged(SandboxEditor::CameraDefaultFov());
+    OnFOVChanged(SandboxEditor::CameraDefaultFovRadians());
     m_viewport = nullptr;
 }
 
@@ -466,7 +466,7 @@ void CLayoutViewPane::SetViewportFOV(const float fovDegrees)
         // if viewport camera is active, make selected fov new default
         if (pRenderViewport->GetViewManager()->GetCameraObjectId() == GUID_NULL)
         {
-            SandboxEditor::SetCameraDefaultFov(fovRadians);
+            SandboxEditor::SetCameraDefaultFovRadians(fovRadians);
         }
 
         OnFOVChanged(fovRadians);

--- a/Code/Editor/Viewport.cpp
+++ b/Code/Editor/Viewport.cpp
@@ -129,7 +129,7 @@ void QtViewport::dragLeaveEvent(QDragLeaveEvent* event)
 //////////////////////////////////////////////////////////////////////////
 float CViewport::GetFOV() const
 {
-    return SandboxEditor::CameraDefaultFov();
+    return SandboxEditor::CameraDefaultFovRadians();
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1235,7 +1235,7 @@ void QtViewport::OnRawInput([[maybe_unused]] UINT wParam, HRAWINPUT lParam)
 //////////////////////////////////////////////////////////////////////////
 float QtViewport::GetFOV() const
 {
-    return SandboxEditor::CameraDefaultFov();
+    return SandboxEditor::CameraDefaultFovRadians();
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/Viewport.cpp
+++ b/Code/Editor/Viewport.cpp
@@ -32,6 +32,7 @@
 #include "PluginManager.h"
 #include "GameEngine.h"
 #include "Settings.h"
+#include <Editor/EditorViewportSettings.h>
 
 #ifdef LoadCursor
 #undef LoadCursor
@@ -128,7 +129,7 @@ void QtViewport::dragLeaveEvent(QDragLeaveEvent* event)
 //////////////////////////////////////////////////////////////////////////
 float CViewport::GetFOV() const
 {
-    return gSettings.viewports.fDefaultFov;
+    return SandboxEditor::CameraDefaultFov();
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1234,7 +1235,7 @@ void QtViewport::OnRawInput([[maybe_unused]] UINT wParam, HRAWINPUT lParam)
 //////////////////////////////////////////////////////////////////////////
 float QtViewport::GetFOV() const
 {
-    return gSettings.viewports.fDefaultFov;
+    return SandboxEditor::CameraDefaultFov();
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/ViewportTitleDlg.cpp
+++ b/Code/Editor/ViewportTitleDlg.cpp
@@ -619,7 +619,7 @@ void CViewportTitleDlg::AddFOVMenus(QMenu* menu, std::function<void(float)> call
                 break;
             }
 
-            float fov = gSettings.viewports.fDefaultFov;
+            float fov = SandboxEditor::CameraDefaultFov();
             bool ok;
             float f = customPreset.toFloat(&ok);
             if (ok)

--- a/Code/Editor/ViewportTitleDlg.cpp
+++ b/Code/Editor/ViewportTitleDlg.cpp
@@ -619,7 +619,7 @@ void CViewportTitleDlg::AddFOVMenus(QMenu* menu, std::function<void(float)> call
                 break;
             }
 
-            float fov = SandboxEditor::CameraDefaultFov();
+            float fov = SandboxEditor::CameraDefaultFovRadians();
             bool ok;
             float f = customPreset.toFloat(&ok);
             if (ok)


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/11253

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

I made the fov apart of the default preferences and correctly handle updating the fov in the ui and updating the fov for the viewport. Changing the fov in the global prefrences also updates the fov value when viewing the fov in the dropdown for the camera in the viewport. 

## How was this PR tested?

- update the fov in the global preferences
- verify fov value when selecting the camera icon in the viewport
![image](https://user-images.githubusercontent.com/854359/184505053-b2403a28-d440-42d4-8a50-e8f0c7a39776.png)
- do the reverse operation to compare the values.
- verify the fov correctly applies to the viewport

