### PR TITLE
bugfix(ScriptCanvas): correctly display labels in the Node Inspector used to display [0]

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.cpp
@@ -2109,6 +2109,8 @@ namespace ScriptCanvas
             {
                 editContext->Class<Datum>("Datum", "Datum")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "Datum")
+                    ->Attribute(AZ::Edit::Attributes::ChildNameLabelOverride, &Datum::GetLabel)
+                    ->Attribute(AZ::Edit::Attributes::NameLabelOverride, &Datum::GetLabel)
                     ->Attribute(AZ::Edit::Attributes::Visibility, &Datum::GetVisibility)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &Datum::m_storage, "Datum", "")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &Datum::GetDatumVisibility)


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

ref: https://github.com/o3de/o3de/issues/8060

## What does this PR do?

when viewing the node in the node inspector the label of the field will be displayed as [0]. this sets the override for the label so a proper display name is shown.

## How was this PR tested?

- open script in scriptcanvas and view node in node inspector.
- verify that the label text correctly displays a proper label.

![image](https://user-images.githubusercontent.com/854359/184524395-cc8d86d7-6ca9-45cd-b879-43dfd6f95cf3.png)

