### PR TITLE
bugfix(ScriptCanvas): prevent multiple prompts when providing a key

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx
@@ -175,8 +175,8 @@ namespace AzToolsFramework
 
         virtual void paintEvent(QPaintEvent* event) override;
         int m_updateDepth = 0;
-        bool m_releasePrompt = false;
-
+    signals:
+        void releasePrompt();
     private slots:
         void OnPropertyRowExpandedOrContracted(PropertyRowWidget* widget, InstanceDataNode* node, bool expanded, bool fromUserInteraction);
         void DoRefresh();


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/11193

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

this handles releasing the last prompt if one is already open when setting a key for a variable in the canvas.

## How was this PR tested?

follow the instructions in the referenced ticket.

https://user-images.githubusercontent.com/854359/184549797-7f8c88cf-feda-41f8-a700-69f2219fef9b.mp4


