### PR TITLE
feat(ScriptCanvas): add vector2/3/4 and color to multiply node

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorMul.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorMul.cpp
@@ -51,7 +51,11 @@ namespace ScriptCanvas
                     Data::Type::Quaternion(),
                     Data::Type::Transform(),
                     Data::Type::Matrix3x3(),
-                    Data::Type::Matrix4x4()
+                    Data::Type::Matrix4x4(),
+                    Data::Type::Vector2(),
+                    Data::Type::Vector3(),
+                    Data::Type::Vector4(),
+                    Data::Type::Color()
                 };
             }
 
@@ -76,18 +80,22 @@ namespace ScriptCanvas
                 case Data::eType::Matrix4x4:
                     OperatorEvaluator::Evaluate<Data::Matrix4x4Type>(OperatorMulImpl<Data::Matrix4x4Type>(), operands, result);
                     break;
+                case Data::eType::Vector2:
+                    OperatorEvaluator::Evaluate<Data::Vector2Type>(OperatorMulImpl<Data::Vector2Type>(), operands, result);
+                    break;
+                case Data::eType::Vector3:
+                    OperatorEvaluator::Evaluate<Data::Vector3Type>(OperatorMulImpl<Data::Vector3Type>(), operands, result);
+                    break;
+                case Data::eType::Vector4:
+                    OperatorEvaluator::Evaluate<Data::Vector4Type>(OperatorMulImpl<Data::Vector4Type>(), operands, result);
+                    break;
+                case Data::eType::Color:
+                    OperatorEvaluator::Evaluate<Data::ColorType>(OperatorMulImpl<Data::ColorType>(), operands, result);
+                    break;
                 default:
                     AZ_Assert(false, "Multiplication operator not defined for type: %s", Data::ToAZType(type).ToString<AZStd::string>().c_str());
                     break;
                 }
-            }
-
-            void OperatorMul::InitializeSlot(const SlotId& slotId, [[maybe_unused]] const ScriptCanvas::Data::Type& dataType)
-            {
-                ModifiableDatumView datumView;
-                FindModifiableDatumView(slotId, datumView);
-
-                OnResetDatumToDefaultValue(datumView);
             }
 
             bool OperatorMul::IsValidArithmeticSlot(const SlotId& slotId) const
@@ -102,47 +110,16 @@ namespace ScriptCanvas
                         return !AZ::IsClose((*datum->GetAs<Data::NumberType>()), Data::NumberType(1.0), ScriptCanvas::Data::ToleranceEpsilon());
                     case Data::eType::Quaternion:
                         return !datum->GetAs<Data::QuaternionType>()->IsIdentity();
+                    case Data::eType::Matrix3x3:
+                        return !datum->GetAs<Data::Matrix3x3Type>()->IsClose(Data::Matrix3x3Type::CreateIdentity());
+                    case Data::eType::Matrix4x4:
+                        return !datum->GetAs<Data::Matrix4x4Type>()->IsClose(Data::Matrix4x4Type::CreateIdentity());
                     default:
                         break;
                     }
                 }
 
                 return (datum != nullptr);
-            }
-
-            void OperatorMul::OnResetDatumToDefaultValue(ModifiableDatumView& datumView)
-            {
-                Data::Type displayType = GetDisplayType(GetArithmeticDynamicTypeGroup());
-
-                if (datumView.IsValid() && displayType.IsValid())
-                {
-                    switch (displayType.GetType())
-                    {
-                    case Data::eType::Number:
-                        datumView.SetAs(ScriptCanvas::Data::One());
-                        break;
-                    case Data::eType::Vector2:
-                        datumView.SetAs(Data::Vector2Type::CreateOne());
-                        break;
-                    case Data::eType::Vector3:
-                        datumView.SetAs(Data::Vector3Type::CreateOne());
-                        break;
-                    case Data::eType::Vector4:
-                        datumView.SetAs(Data::Vector4Type::CreateOne());
-                        break;
-                    case Data::eType::Quaternion:
-                        datumView.SetAs(Data::QuaternionType::CreateIdentity());
-                        break;
-                    case Data::eType::Matrix3x3:
-                        datumView.SetAs(Data::Matrix3x3Type::CreateIdentity());
-                        break;
-                    case Data::eType::Matrix4x4:
-                        datumView.SetAs(Data::Matrix4x4Type::CreateIdentity());
-                        break;
-                    default:
-                        break;
-                    };
-                }
             }
         }
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorMul.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorMul.h
@@ -33,10 +33,7 @@ namespace ScriptCanvas
 
             protected:
 
-                void InitializeSlot(const SlotId& slotId, const ScriptCanvas::Data::Type& dataType) override;
                 bool IsValidArithmeticSlot(const SlotId& slotId) const override;
-
-                void OnResetDatumToDefaultValue(ModifiableDatumView& datum) override;
             };
         }
     }

--- a/Gems/ScriptCanvasTesting/Assets/ScriptCanvas/UnitTests/LY_SC_UnitTest_OperatorMul.scriptcanvas
+++ b/Gems/ScriptCanvasTesting/Assets/ScriptCanvas/UnitTests/LY_SC_UnitTest_OperatorMul.scriptcanvas
@@ -5,7 +5,7 @@
     "ClassData": {
         "m_scriptCanvas": {
             "Id": {
-                "id": 372323446511662
+                "id": 614861405339
             },
             "Name": "scriptcanvas/unittests/ly_sc_unittest_operatormul.scriptcanvas",
             "Components": {
@@ -16,23 +16,99 @@
                         "m_nameVariableMap": [
                             {
                                 "Key": {
-                                    "m_id": "{728BB162-4632-4425-BBDD-46EC9737FEA4}"
+                                    "m_id": "{25709E60-3517-4C56-B76D-DF11705E8C6B}"
                                 },
                                 "Value": {
                                     "Datum": {
                                         "isOverloadedStorage": false,
                                         "scriptCanvasType": {
-                                            "m_type": 3
+                                            "m_type": 8
                                         },
                                         "isNullPointer": false,
-                                        "$type": "double",
-                                        "value": 24.0,
-                                        "label": "Number"
+                                        "$type": "Vector3",
+                                        "value": [
+                                            1.0,
+                                            1.0,
+                                            1.0
+                                        ]
                                     },
                                     "VariableId": {
-                                        "m_id": "{728BB162-4632-4425-BBDD-46EC9737FEA4}"
+                                        "m_id": "{25709E60-3517-4C56-B76D-DF11705E8C6B}"
                                     },
-                                    "VariableName": "Twenty four"
+                                    "VariableName": "One3"
+                                }
+                            },
+                            {
+                                "Key": {
+                                    "m_id": "{2DEC1D51-AFFF-4364-9961-EAFEB55FE3DB}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "isOverloadedStorage": false,
+                                        "scriptCanvasType": {
+                                            "m_type": 12
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "Color",
+                                        "value": [
+                                            1.0,
+                                            1.0,
+                                            1.0,
+                                            1.0
+                                        ]
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{2DEC1D51-AFFF-4364-9961-EAFEB55FE3DB}"
+                                    },
+                                    "VariableName": "color1"
+                                }
+                            },
+                            {
+                                "Key": {
+                                    "m_id": "{84C8A9CA-1D63-4402-9C95-AAD4707DF984}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "isOverloadedStorage": false,
+                                        "scriptCanvasType": {
+                                            "m_type": 9
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "Vector2",
+                                        "value": [
+                                            1.0,
+                                            1.0
+                                        ]
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{84C8A9CA-1D63-4402-9C95-AAD4707DF984}"
+                                    },
+                                    "VariableName": "One2"
+                                }
+                            },
+                            {
+                                "Key": {
+                                    "m_id": "{84DD3ADE-B0F9-4288-B23E-6A62031A83ED}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "isOverloadedStorage": false,
+                                        "scriptCanvasType": {
+                                            "m_type": 10
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "Vector4",
+                                        "value": [
+                                            1.0,
+                                            1.0,
+                                            1.0,
+                                            1.0
+                                        ]
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{84DD3ADE-B0F9-4288-B23E-6A62031A83ED}"
+                                    },
+                                    "VariableName": "One4"
                                 }
                             },
                             {
@@ -66,17 +142,17 @@
                         "m_nodes": [
                             {
                                 "Id": {
-                                    "id": 372332036446254
+                                    "id": 666401012891
                                 },
-                                "Name": "SC Node(GetVariable)",
+                                "Name": "SC-Node(OperatorMul)",
                                 "Components": {
-                                    "Component_[15518600411530667193]": {
-                                        "$type": "GetVariableNode",
-                                        "Id": 15518600411530667193,
+                                    "Component_[10837765620875665056]": {
+                                        "$type": "OperatorMul",
+                                        "Id": 10837765620875665056,
                                         "Slots": [
                                             {
                                                 "id": {
-                                                    "m_id": "{4F6F80C0-D94E-4048-A01C-750200320420}"
+                                                    "m_id": "{B49D89EC-47AC-4025-8F62-C6B5EBB33576}"
                                                 },
                                                 "contracts": [
                                                     {
@@ -84,7 +160,6 @@
                                                     }
                                                 ],
                                                 "slotName": "In",
-                                                "toolTip": "When signaled sends the property referenced by this node to a Data Output slot",
                                                 "Descriptor": {
                                                     "ConnectionType": 1,
                                                     "SlotType": 1
@@ -92,7 +167,7 @@
                                             },
                                             {
                                                 "id": {
-                                                    "m_id": "{EF8AC8FC-8176-4771-80EB-7887D943B7C3}"
+                                                    "m_id": "{651E972F-58BF-4412-A721-DFE3DDFBDEEE}"
                                                 },
                                                 "contracts": [
                                                     {
@@ -100,7 +175,6 @@
                                                     }
                                                 ],
                                                 "slotName": "Out",
-                                                "toolTip": "Signaled after the referenced property has been pushed to the Data Output slot",
                                                 "Descriptor": {
                                                     "ConnectionType": 2,
                                                     "SlotType": 1
@@ -108,35 +182,1223 @@
                                             },
                                             {
                                                 "id": {
-                                                    "m_id": "{1EBF514C-FEAB-4D87-A43F-A99954D9B2B2}"
+                                                    "m_id": "{D93D7CF0-3A99-4D94-BAAC-C51FF2567F6E}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Color 0",
+                                                "toolTip": "An operand to use in performing the specified Operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 12
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1,
+                                                "IsReference": true,
+                                                "VariableReference": {
+                                                    "m_id": "{2DEC1D51-AFFF-4364-9961-EAFEB55FE3DB}"
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{AD12B344-E583-487F-810F-E779CCD89E9B}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Color 1",
+                                                "toolTip": "An operand to use in performing the specified Operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 12
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{186C022F-10BF-4F80-A7FF-515CF59B00A0}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Result",
+                                                "toolTip": "The result of the specified operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 12
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 12
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Color",
+                                                "value": [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0,
+                                                    1.0
+                                                ],
+                                                "label": "Color 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 12
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Color",
+                                                "value": [
+                                                    0.49803921580314636,
+                                                    0.49803921580314636,
+                                                    0.49803921580314636,
+                                                    1.0
+                                                ],
+                                                "label": "Color 1"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 653516111003
+                                },
+                                "Name": "SC-Node(OperatorMul)",
+                                "Components": {
+                                    "Component_[10837765620875665056]": {
+                                        "$type": "OperatorMul",
+                                        "Id": 10837765620875665056,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{B49D89EC-47AC-4025-8F62-C6B5EBB33576}"
                                                 },
                                                 "contracts": [
                                                     {
                                                         "$type": "SlotTypeContract"
                                                     }
                                                 ],
-                                                "slotName": "Number",
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{651E972F-58BF-4412-A721-DFE3DDFBDEEE}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{D93D7CF0-3A99-4D94-BAAC-C51FF2567F6E}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Vector2 0",
+                                                "toolTip": "An operand to use in performing the specified Operation",
                                                 "DisplayDataType": {
-                                                    "m_type": 3
+                                                    "m_type": 9
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1,
+                                                "IsReference": true,
+                                                "VariableReference": {
+                                                    "m_id": "{84C8A9CA-1D63-4402-9C95-AAD4707DF984}"
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{AD12B344-E583-487F-810F-E779CCD89E9B}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Vector2 1",
+                                                "toolTip": "An operand to use in performing the specified Operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 9
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{186C022F-10BF-4F80-A7FF-515CF59B00A0}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Result",
+                                                "toolTip": "The result of the specified operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 9
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
                                                 },
                                                 "Descriptor": {
                                                     "ConnectionType": 2,
                                                     "SlotType": 2
-                                                }
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{260BFD66-DCD2-48CF-9AAE-70DE82BC1768}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Vector2 2",
+                                                "toolTip": "An operand to use in performing the specified Operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 9
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
                                             }
                                         ],
-                                        "m_variableId": {
-                                            "m_id": "{728BB162-4632-4425-BBDD-46EC9737FEA4}"
-                                        },
-                                        "m_variableDataOutSlotId": {
-                                            "m_id": "{1EBF514C-FEAB-4D87-A43F-A99954D9B2B2}"
-                                        }
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 9
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector2",
+                                                "value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "label": "Vector2 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 9
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector2",
+                                                "value": [
+                                                    2.0,
+                                                    4.0
+                                                ],
+                                                "label": "Vector2 1"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 9
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector2",
+                                                "value": [
+                                                    3.0,
+                                                    3.0
+                                                ],
+                                                "label": "Vector2 2"
+                                            }
+                                        ]
                                     }
                                 }
                             },
                             {
                                 "Id": {
-                                    "id": 372327741478958
+                                    "id": 657811078299
+                                },
+                                "Name": "SC-Node(OperatorMul)",
+                                "Components": {
+                                    "Component_[10837765620875665056]": {
+                                        "$type": "OperatorMul",
+                                        "Id": 10837765620875665056,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{B49D89EC-47AC-4025-8F62-C6B5EBB33576}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{651E972F-58BF-4412-A721-DFE3DDFBDEEE}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{D93D7CF0-3A99-4D94-BAAC-C51FF2567F6E}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Vector3 0",
+                                                "toolTip": "An operand to use in performing the specified Operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 8
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1,
+                                                "IsReference": true,
+                                                "VariableReference": {
+                                                    "m_id": "{25709E60-3517-4C56-B76D-DF11705E8C6B}"
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{AD12B344-E583-487F-810F-E779CCD89E9B}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Vector3 1",
+                                                "toolTip": "An operand to use in performing the specified Operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 8
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{186C022F-10BF-4F80-A7FF-515CF59B00A0}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Result",
+                                                "toolTip": "The result of the specified operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 8
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{0778E2FC-9D1B-4FBF-A66C-145EDA13B154}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Vector3 2",
+                                                "toolTip": "An operand to use in performing the specified Operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 8
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 8
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector3",
+                                                "value": [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "label": "Vector3 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 8
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector3",
+                                                "value": [
+                                                    3.0,
+                                                    4.0,
+                                                    5.0
+                                                ],
+                                                "label": "Vector3 1"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 8
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector3",
+                                                "value": [
+                                                    1.0,
+                                                    3.0,
+                                                    5.0
+                                                ],
+                                                "label": "Vector3 2"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 640631209115
+                                },
+                                "Name": "SC-Node(OperatorMul)",
+                                "Components": {
+                                    "Component_[15407664143887369635]": {
+                                        "$type": "OperatorMul",
+                                        "Id": 15407664143887369635,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{38EBA543-66D4-4526-B7BB-3E9F469A79B8}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{0FD3C672-B0CC-4755-8B3D-C52BB1FA4B97}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{69994974-7CAE-479F-84C7-D9DA3F984B5A}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Vector4 0",
+                                                "toolTip": "An operand to use in performing the specified Operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 10
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1,
+                                                "IsReference": true,
+                                                "VariableReference": {
+                                                    "m_id": "{84DD3ADE-B0F9-4288-B23E-6A62031A83ED}"
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{607EAD05-239B-417D-BD85-5AC1E6BAA9BF}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Vector4 1",
+                                                "toolTip": "An operand to use in performing the specified Operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 10
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{AED8C003-1B29-4882-8B8A-123161C4B90A}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Result",
+                                                "toolTip": "The result of the specified operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 10
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{E5733CB5-6967-4293-B5B0-F3746714BFA3}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "OperatorType": "Multiply",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Vector4 2",
+                                                "toolTip": "An operand to use in performing the specified Operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 10
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 10
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector4",
+                                                "value": [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "label": "Vector4 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 10
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector4",
+                                                "value": [
+                                                    2.0,
+                                                    3.0,
+                                                    4.0,
+                                                    5.0
+                                                ],
+                                                "label": "Vector4 1"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 10
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector4",
+                                                "value": [
+                                                    5.0,
+                                                    6.0,
+                                                    1.0,
+                                                    2.0
+                                                ],
+                                                "label": "Vector4 2"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 644926176411
                                 },
                                 "Name": "SC-Node(Start)",
                                 "Components": {
@@ -166,7 +1428,809 @@
                             },
                             {
                                 "Id": {
-                                    "id": 372340626380846
+                                    "id": 632041274523
+                                },
+                                "Name": "SC-Node(Expect Equal)",
+                                "Components": {
+                                    "Component_[17364724952310731553]": {
+                                        "$type": "MethodOverloaded",
+                                        "Id": 17364724952310731553,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{F2EB58CA-D065-4A50-B745-4B12C6C49596}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "EntityID: 0",
+                                                "DisplayDataType": {
+                                                    "m_type": 1
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "IsOverload": true,
+                                                "id": {
+                                                    "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "Candidate",
+                                                "toolTip": "left of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 12
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "IsOverload": true,
+                                                "id": {
+                                                    "m_id": "{E8524D8D-D942-4A2D-9F08-0B25A7B40B2C}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "Reference",
+                                                "toolTip": "right of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 12
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A472CE45-6192-4C25-BB96-E6E7F750F282}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{B43BC4FB-F2A6-4D69-B8BF-63E311B9A81E}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{D89CC575-5CC1-4847-91A2-2FD0EEA5D136}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 1
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "EntityId",
+                                                "value": {
+                                                    "id": 4276206253
+                                                },
+                                                "label": "EntityID: 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 12
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Color",
+                                                "value": [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0,
+                                                    1.0
+                                                ],
+                                                "label": "Candidate"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 12
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Color",
+                                                "value": [
+                                                    0.49803921580314636,
+                                                    0.49803921580314636,
+                                                    0.49803921580314636,
+                                                    1.0
+                                                ],
+                                                "label": "Reference"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Expect Equal",
+                                        "className": "Unit Testing",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
+                                        "prettyClassName": "Unit Testing",
+                                        "orderedInputSlotIds": [
+                                            {
+                                                "m_id": "{F2EB58CA-D065-4A50-B745-4B12C6C49596}"
+                                            },
+                                            {
+                                                "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                            },
+                                            {
+                                                "m_id": "{E8524D8D-D942-4A2D-9F08-0B25A7B40B2C}"
+                                            },
+                                            {
+                                                "m_id": "{A472CE45-6192-4C25-BB96-E6E7F750F282}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 636336241819
+                                },
+                                "Name": "SC-Node(Expect Equal)",
+                                "Components": {
+                                    "Component_[17364724952310731553]": {
+                                        "$type": "MethodOverloaded",
+                                        "Id": 17364724952310731553,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{F2EB58CA-D065-4A50-B745-4B12C6C49596}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "EntityID: 0",
+                                                "DisplayDataType": {
+                                                    "m_type": 1
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "IsOverload": true,
+                                                "id": {
+                                                    "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "Candidate",
+                                                "toolTip": "left of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 9
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "IsOverload": true,
+                                                "id": {
+                                                    "m_id": "{E8524D8D-D942-4A2D-9F08-0B25A7B40B2C}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "Reference",
+                                                "toolTip": "right of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 9
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A472CE45-6192-4C25-BB96-E6E7F750F282}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{B43BC4FB-F2A6-4D69-B8BF-63E311B9A81E}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{D89CC575-5CC1-4847-91A2-2FD0EEA5D136}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 1
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "EntityId",
+                                                "value": {
+                                                    "id": 4276206253
+                                                },
+                                                "label": "EntityID: 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 9
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector2",
+                                                "value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "label": "Candidate"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 9
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector2",
+                                                "value": [
+                                                    6.0,
+                                                    12.0
+                                                ],
+                                                "label": "Reference"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Expect Equal",
+                                        "className": "Unit Testing",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
+                                        "prettyClassName": "Unit Testing",
+                                        "orderedInputSlotIds": [
+                                            {
+                                                "m_id": "{F2EB58CA-D065-4A50-B745-4B12C6C49596}"
+                                            },
+                                            {
+                                                "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                            },
+                                            {
+                                                "m_id": "{E8524D8D-D942-4A2D-9F08-0B25A7B40B2C}"
+                                            },
+                                            {
+                                                "m_id": "{A472CE45-6192-4C25-BB96-E6E7F750F282}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 627746307227
+                                },
+                                "Name": "SC-Node(Expect Equal)",
+                                "Components": {
+                                    "Component_[17364724952310731553]": {
+                                        "$type": "MethodOverloaded",
+                                        "Id": 17364724952310731553,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{F2EB58CA-D065-4A50-B745-4B12C6C49596}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "EntityID: 0",
+                                                "DisplayDataType": {
+                                                    "m_type": 1
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "IsOverload": true,
+                                                "id": {
+                                                    "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "Candidate",
+                                                "toolTip": "left of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 8
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "IsOverload": true,
+                                                "id": {
+                                                    "m_id": "{E8524D8D-D942-4A2D-9F08-0B25A7B40B2C}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "Reference",
+                                                "toolTip": "right of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 8
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A472CE45-6192-4C25-BB96-E6E7F750F282}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{B43BC4FB-F2A6-4D69-B8BF-63E311B9A81E}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{D89CC575-5CC1-4847-91A2-2FD0EEA5D136}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 1
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "EntityId",
+                                                "value": {
+                                                    "id": 4276206253
+                                                },
+                                                "label": "EntityID: 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 8
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector3",
+                                                "value": [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "label": "Candidate"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 8
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector3",
+                                                "value": [
+                                                    3.0,
+                                                    12.0,
+                                                    25.0
+                                                ],
+                                                "label": "Reference"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Expect Equal",
+                                        "className": "Unit Testing",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
+                                        "prettyClassName": "Unit Testing",
+                                        "orderedInputSlotIds": [
+                                            {
+                                                "m_id": "{F2EB58CA-D065-4A50-B745-4B12C6C49596}"
+                                            },
+                                            {
+                                                "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                            },
+                                            {
+                                                "m_id": "{E8524D8D-D942-4A2D-9F08-0B25A7B40B2C}"
+                                            },
+                                            {
+                                                "m_id": "{A472CE45-6192-4C25-BB96-E6E7F750F282}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 623451339931
+                                },
+                                "Name": "SC-Node(Expect Equal)",
+                                "Components": {
+                                    "Component_[17364724952310731553]": {
+                                        "$type": "MethodOverloaded",
+                                        "Id": 17364724952310731553,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{F2EB58CA-D065-4A50-B745-4B12C6C49596}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "EntityID: 0",
+                                                "DisplayDataType": {
+                                                    "m_type": 1
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "IsOverload": true,
+                                                "id": {
+                                                    "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "Candidate",
+                                                "toolTip": "left of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 10
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "IsOverload": true,
+                                                "id": {
+                                                    "m_id": "{E8524D8D-D942-4A2D-9F08-0B25A7B40B2C}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "Reference",
+                                                "toolTip": "right of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 10
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A472CE45-6192-4C25-BB96-E6E7F750F282}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    null
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{B43BC4FB-F2A6-4D69-B8BF-63E311B9A81E}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{D89CC575-5CC1-4847-91A2-2FD0EEA5D136}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 1
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "EntityId",
+                                                "value": {
+                                                    "id": 4276206253
+                                                },
+                                                "label": "EntityID: 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 10
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector4",
+                                                "value": [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "label": "Candidate"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 10
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector4",
+                                                "value": [
+                                                    10.0,
+                                                    18.0,
+                                                    4.0,
+                                                    10.0
+                                                ],
+                                                "label": "Reference"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Expect Equal",
+                                        "className": "Unit Testing",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
+                                        "prettyClassName": "Unit Testing",
+                                        "orderedInputSlotIds": [
+                                            {
+                                                "m_id": "{F2EB58CA-D065-4A50-B745-4B12C6C49596}"
+                                            },
+                                            {
+                                                "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                            },
+                                            {
+                                                "m_id": "{E8524D8D-D942-4A2D-9F08-0B25A7B40B2C}"
+                                            },
+                                            {
+                                                "m_id": "{A472CE45-6192-4C25-BB96-E6E7F750F282}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 619156372635
                                 },
                                 "Name": "SC-Node(Expect Equal)",
                                 "Components": {
@@ -318,7 +2382,7 @@
                                                 },
                                                 "isNullPointer": false,
                                                 "$type": "double",
-                                                "value": 0.0,
+                                                "value": 24.0,
                                                 "label": "Reference"
                                             },
                                             {
@@ -358,7 +2422,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 372349216315438
+                                    "id": 670695980187
                                 },
                                 "Name": "SC-Node(Mark Complete)",
                                 "Components": {
@@ -466,87 +2530,17 @@
                             },
                             {
                                 "Id": {
-                                    "id": 372344921348142
-                                },
-                                "Name": "SC Node(GetVariable)",
-                                "Components": {
-                                    "Component_[4002678987210505391]": {
-                                        "$type": "GetVariableNode",
-                                        "Id": 4002678987210505391,
-                                        "Slots": [
-                                            {
-                                                "id": {
-                                                    "m_id": "{3F00B99D-0C6C-4118-A678-2C7B032F8AD3}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "In",
-                                                "toolTip": "When signaled sends the property referenced by this node to a Data Output slot",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{76F90219-AE17-4B61-BFB4-264364512E78}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Out",
-                                                "toolTip": "Signaled after the referenced property has been pushed to the Data Output slot",
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{11FA1D00-FEC0-4DB5-8355-A9C4F8EB0A32}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Number",
-                                                "DisplayDataType": {
-                                                    "m_type": 3
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 2
-                                                }
-                                            }
-                                        ],
-                                        "m_variableId": {
-                                            "m_id": "{FCD90ACD-882A-4EF8-83DB-21849C345B1B}"
-                                        },
-                                        "m_variableDataOutSlotId": {
-                                            "m_id": "{11FA1D00-FEC0-4DB5-8355-A9C4F8EB0A32}"
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 372336331413550
+                                    "id": 25469837147291
                                 },
                                 "Name": "SC-Node(OperatorMul)",
                                 "Components": {
-                                    "Component_[7651091130694342179]": {
+                                    "Component_[3702702445851007829]": {
                                         "$type": "OperatorMul",
-                                        "Id": 7651091130694342179,
+                                        "Id": 3702702445851007829,
                                         "Slots": [
                                             {
                                                 "id": {
-                                                    "m_id": "{ABE93105-9659-4831-AE14-CE4A08335949}"
+                                                    "m_id": "{B4287015-3815-4686-BADB-ED526F83107B}"
                                                 },
                                                 "contracts": [
                                                     {
@@ -561,7 +2555,7 @@
                                             },
                                             {
                                                 "id": {
-                                                    "m_id": "{B98EE124-EE65-43BB-8D46-0D66C53953A8}"
+                                                    "m_id": "{362F0853-E1D9-4F21-B4F3-6ED8EB1DA0BF}"
                                                 },
                                                 "contracts": [
                                                     {
@@ -576,14 +2570,13 @@
                                             },
                                             {
                                                 "id": {
-                                                    "m_id": "{79C7213B-7C82-4264-8B53-F1C63144A29A}"
+                                                    "m_id": "{A006A1E6-B48B-4A64-A840-124BD1E6CF6B}"
                                                 },
                                                 "DynamicTypeOverride": 3,
                                                 "contracts": [
                                                     {
                                                         "$type": "SlotTypeContract"
                                                     },
-                                                    null,
                                                     {
                                                         "$type": "MathOperatorContract",
                                                         "OperatorType": "Multiply",
@@ -598,6 +2591,18 @@
                                                                 "m_type": 7
                                                             },
                                                             {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
                                                                 "m_type": 14
                                                             },
                                                             {
@@ -606,7 +2611,7 @@
                                                         ]
                                                     }
                                                 ],
-                                                "slotName": "Number",
+                                                "slotName": "Number 0",
                                                 "toolTip": "An operand to use in performing the specified Operation",
                                                 "DisplayDataType": {
                                                     "m_type": 3
@@ -620,18 +2625,22 @@
                                                 },
                                                 "DynamicGroup": {
                                                     "Value": 1114760223
+                                                },
+                                                "DataType": 1,
+                                                "IsReference": true,
+                                                "VariableReference": {
+                                                    "m_id": "{FCD90ACD-882A-4EF8-83DB-21849C345B1B}"
                                                 }
                                             },
                                             {
                                                 "id": {
-                                                    "m_id": "{BFE373FC-C8FE-4B57-ABB2-F365C08CC949}"
+                                                    "m_id": "{24C6EFF2-3029-496F-A4F9-719281CB891B}"
                                                 },
                                                 "DynamicTypeOverride": 3,
                                                 "contracts": [
                                                     {
                                                         "$type": "SlotTypeContract"
                                                     },
-                                                    null,
                                                     {
                                                         "$type": "MathOperatorContract",
                                                         "OperatorType": "Multiply",
@@ -646,6 +2655,18 @@
                                                                 "m_type": 7
                                                             },
                                                             {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
                                                                 "m_type": 14
                                                             },
                                                             {
@@ -654,7 +2675,7 @@
                                                         ]
                                                     }
                                                 ],
-                                                "slotName": "Number",
+                                                "slotName": "Number 1",
                                                 "toolTip": "An operand to use in performing the specified Operation",
                                                 "DisplayDataType": {
                                                     "m_type": 3
@@ -668,11 +2689,12 @@
                                                 },
                                                 "DynamicGroup": {
                                                     "Value": 1114760223
-                                                }
+                                                },
+                                                "DataType": 1
                                             },
                                             {
                                                 "id": {
-                                                    "m_id": "{5220C5F8-1D07-4120-A5CB-B58444FB9FA7}"
+                                                    "m_id": "{D0AEF817-E62E-46D0-882E-61C1E366330E}"
                                                 },
                                                 "DynamicTypeOverride": 3,
                                                 "contracts": [
@@ -691,6 +2713,18 @@
                                                             },
                                                             {
                                                                 "m_type": 7
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
                                                             },
                                                             {
                                                                 "m_type": 14
@@ -715,18 +2749,18 @@
                                                 },
                                                 "DynamicGroup": {
                                                     "Value": 1114760223
-                                                }
+                                                },
+                                                "DataType": 1
                                             },
                                             {
                                                 "id": {
-                                                    "m_id": "{1F2FB250-5E4E-4426-9F6D-A9A0D00657F6}"
+                                                    "m_id": "{84FDED63-B54D-4563-9A3E-44CC85B06BD8}"
                                                 },
                                                 "DynamicTypeOverride": 3,
                                                 "contracts": [
                                                     {
                                                         "$type": "SlotTypeContract"
                                                     },
-                                                    null,
                                                     {
                                                         "$type": "MathOperatorContract",
                                                         "OperatorType": "Multiply",
@@ -741,6 +2775,18 @@
                                                                 "m_type": 7
                                                             },
                                                             {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
                                                                 "m_type": 14
                                                             },
                                                             {
@@ -749,7 +2795,7 @@
                                                         ]
                                                     }
                                                 ],
-                                                "slotName": "Number",
+                                                "slotName": "Number 2",
                                                 "toolTip": "An operand to use in performing the specified Operation",
                                                 "DisplayDataType": {
                                                     "m_type": 3
@@ -763,18 +2809,18 @@
                                                 },
                                                 "DynamicGroup": {
                                                     "Value": 1114760223
-                                                }
+                                                },
+                                                "DataType": 1
                                             },
                                             {
                                                 "id": {
-                                                    "m_id": "{73A47333-24CC-4C04-9289-5B9E380BD720}"
+                                                    "m_id": "{88790B51-DB22-41D4-B647-F931D8CCDCDB}"
                                                 },
                                                 "DynamicTypeOverride": 3,
                                                 "contracts": [
                                                     {
                                                         "$type": "SlotTypeContract"
                                                     },
-                                                    null,
                                                     {
                                                         "$type": "MathOperatorContract",
                                                         "OperatorType": "Multiply",
@@ -789,6 +2835,18 @@
                                                                 "m_type": 7
                                                             },
                                                             {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
                                                                 "m_type": 14
                                                             },
                                                             {
@@ -797,7 +2855,7 @@
                                                         ]
                                                     }
                                                 ],
-                                                "slotName": "Number",
+                                                "slotName": "Number 3",
                                                 "toolTip": "An operand to use in performing the specified Operation",
                                                 "DisplayDataType": {
                                                     "m_type": 3
@@ -811,7 +2869,8 @@
                                                 },
                                                 "DynamicGroup": {
                                                     "Value": 1114760223
-                                                }
+                                                },
+                                                "DataType": 1
                                             }
                                         ],
                                         "Datums": [
@@ -822,8 +2881,8 @@
                                                 },
                                                 "isNullPointer": false,
                                                 "$type": "double",
-                                                "value": 1.0,
-                                                "label": "Number"
+                                                "value": 0.0,
+                                                "label": "Number 0"
                                             },
                                             {
                                                 "isOverloadedStorage": false,
@@ -833,7 +2892,7 @@
                                                 "isNullPointer": false,
                                                 "$type": "double",
                                                 "value": 2.0,
-                                                "label": "Number"
+                                                "label": "Number 1"
                                             },
                                             {
                                                 "isOverloadedStorage": false,
@@ -843,7 +2902,7 @@
                                                 "isNullPointer": false,
                                                 "$type": "double",
                                                 "value": 3.0,
-                                                "label": "Number"
+                                                "label": "Number 2"
                                             },
                                             {
                                                 "isOverloadedStorage": false,
@@ -853,7 +2912,7 @@
                                                 "isNullPointer": false,
                                                 "$type": "double",
                                                 "value": 4.0,
-                                                "label": "Number"
+                                                "label": "Number 3"
                                             }
                                         ]
                                     }
@@ -863,27 +2922,27 @@
                         "m_connections": [
                             {
                                 "Id": {
-                                    "id": 372353511282734
+                                    "id": 696465783963
                                 },
-                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Mark Complete: In)",
+                                "Name": "srcEndpoint=(Multiply (*): Out), destEndpoint=(Multiply (*): In)",
                                 "Components": {
-                                    "Component_[2042907371241714919]": {
+                                    "Component_[1371824767822275843]": {
                                         "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 2042907371241714919,
+                                        "Id": 1371824767822275843,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 372340626380846
+                                                "id": 653516111003
                                             },
                                             "slotId": {
-                                                "m_id": "{D89CC575-5CC1-4847-91A2-2FD0EEA5D136}"
+                                                "m_id": "{651E972F-58BF-4412-A721-DFE3DDFBDEEE}"
                                             }
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 372349216315438
+                                                "id": 657811078299
                                             },
                                             "slotId": {
-                                                "m_id": "{76D0BB2A-077E-4ED4-AC30-A58947DD542A}"
+                                                "m_id": "{B49D89EC-47AC-4025-8F62-C6B5EBB33576}"
                                             }
                                         }
                                     }
@@ -891,27 +2950,27 @@
                             },
                             {
                                 "Id": {
-                                    "id": 372357806250030
+                                    "id": 700760751259
                                 },
-                                "Name": "srcEndpoint=(Multiply (*): Result), destEndpoint=(Expect Equal: Candidate :-()",
+                                "Name": "srcEndpoint=(Multiply (*): Out), destEndpoint=(Multiply (*): In)",
                                 "Components": {
-                                    "Component_[1415392759669527684]": {
+                                    "Component_[32530462525624753]": {
                                         "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 1415392759669527684,
+                                        "Id": 32530462525624753,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 372336331413550
+                                                "id": 657811078299
                                             },
                                             "slotId": {
-                                                "m_id": "{5220C5F8-1D07-4120-A5CB-B58444FB9FA7}"
+                                                "m_id": "{651E972F-58BF-4412-A721-DFE3DDFBDEEE}"
                                             }
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 372340626380846
+                                                "id": 666401012891
                                             },
                                             "slotId": {
-                                                "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                                "m_id": "{B49D89EC-47AC-4025-8F62-C6B5EBB33576}"
                                             }
                                         }
                                     }
@@ -919,27 +2978,27 @@
                             },
                             {
                                 "Id": {
-                                    "id": 372362101217326
+                                    "id": 705055718555
                                 },
-                                "Name": "srcEndpoint=(Multiply (*): Out), destEndpoint=(Get Variable: In)",
+                                "Name": "srcEndpoint=(Multiply (*): Out), destEndpoint=(Multiply (*): In)",
                                 "Components": {
-                                    "Component_[3505733106273633233]": {
+                                    "Component_[11063883024752747699]": {
                                         "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 3505733106273633233,
+                                        "Id": 11063883024752747699,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 372336331413550
+                                                "id": 666401012891
                                             },
                                             "slotId": {
-                                                "m_id": "{B98EE124-EE65-43BB-8D46-0D66C53953A8}"
+                                                "m_id": "{651E972F-58BF-4412-A721-DFE3DDFBDEEE}"
                                             }
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 372332036446254
+                                                "id": 640631209115
                                             },
                                             "slotId": {
-                                                "m_id": "{4F6F80C0-D94E-4048-A01C-750200320420}"
+                                                "m_id": "{38EBA543-66D4-4526-B7BB-3E9F469A79B8}"
                                             }
                                         }
                                     }
@@ -947,24 +3006,24 @@
                             },
                             {
                                 "Id": {
-                                    "id": 372366396184622
+                                    "id": 709350685851
                                 },
-                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(Expect Equal: In)",
+                                "Name": "srcEndpoint=(Multiply (*): Out), destEndpoint=(Expect Equal: In)",
                                 "Components": {
-                                    "Component_[5439287961643695957]": {
+                                    "Component_[2831900961465356425]": {
                                         "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 5439287961643695957,
+                                        "Id": 2831900961465356425,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 372332036446254
+                                                "id": 640631209115
                                             },
                                             "slotId": {
-                                                "m_id": "{EF8AC8FC-8176-4771-80EB-7887D943B7C3}"
+                                                "m_id": "{0FD3C672-B0CC-4755-8B3D-C52BB1FA4B97}"
                                             }
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 372340626380846
+                                                "id": 619156372635
                                             },
                                             "slotId": {
                                                 "m_id": "{B43BC4FB-F2A6-4D69-B8BF-63E311B9A81E}"
@@ -975,27 +3034,27 @@
                             },
                             {
                                 "Id": {
-                                    "id": 372370691151918
+                                    "id": 713645653147
                                 },
-                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(Expect Equal: Reference :-()",
+                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Expect Equal: In)",
                                 "Components": {
-                                    "Component_[4326183115498183620]": {
+                                    "Component_[17310967651576580145]": {
                                         "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 4326183115498183620,
+                                        "Id": 17310967651576580145,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 372332036446254
+                                                "id": 619156372635
                                             },
                                             "slotId": {
-                                                "m_id": "{1EBF514C-FEAB-4D87-A43F-A99954D9B2B2}"
+                                                "m_id": "{D89CC575-5CC1-4847-91A2-2FD0EEA5D136}"
                                             }
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 372340626380846
+                                                "id": 636336241819
                                             },
                                             "slotId": {
-                                                "m_id": "{E8524D8D-D942-4A2D-9F08-0B25A7B40B2C}"
+                                                "m_id": "{B43BC4FB-F2A6-4D69-B8BF-63E311B9A81E}"
                                             }
                                         }
                                     }
@@ -1003,16 +3062,296 @@
                             },
                             {
                                 "Id": {
-                                    "id": 372374986119214
+                                    "id": 717940620443
                                 },
-                                "Name": "srcEndpoint=(On Graph Start: Out), destEndpoint=(Get Variable: In)",
+                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Expect Equal: In)",
                                 "Components": {
-                                    "Component_[8295329216536680548]": {
+                                    "Component_[5102518129493834933]": {
                                         "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 8295329216536680548,
+                                        "Id": 5102518129493834933,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 372327741478958
+                                                "id": 636336241819
+                                            },
+                                            "slotId": {
+                                                "m_id": "{D89CC575-5CC1-4847-91A2-2FD0EEA5D136}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 627746307227
+                                            },
+                                            "slotId": {
+                                                "m_id": "{B43BC4FB-F2A6-4D69-B8BF-63E311B9A81E}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 722235587739
+                                },
+                                "Name": "srcEndpoint=(Multiply (*): Result), destEndpoint=(Expect Equal: Candidate)",
+                                "Components": {
+                                    "Component_[2902722216048202647]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 2902722216048202647,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 653516111003
+                                            },
+                                            "slotId": {
+                                                "m_id": "{186C022F-10BF-4F80-A7FF-515CF59B00A0}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 636336241819
+                                            },
+                                            "slotId": {
+                                                "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 726530555035
+                                },
+                                "Name": "srcEndpoint=(Multiply (*): Result), destEndpoint=(Expect Equal: Candidate)",
+                                "Components": {
+                                    "Component_[8715447510328951972]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 8715447510328951972,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 657811078299
+                                            },
+                                            "slotId": {
+                                                "m_id": "{186C022F-10BF-4F80-A7FF-515CF59B00A0}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 627746307227
+                                            },
+                                            "slotId": {
+                                                "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 730825522331
+                                },
+                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Expect Equal: In)",
+                                "Components": {
+                                    "Component_[12700008467650454581]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 12700008467650454581,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 627746307227
+                                            },
+                                            "slotId": {
+                                                "m_id": "{D89CC575-5CC1-4847-91A2-2FD0EEA5D136}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 632041274523
+                                            },
+                                            "slotId": {
+                                                "m_id": "{B43BC4FB-F2A6-4D69-B8BF-63E311B9A81E}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 735120489627
+                                },
+                                "Name": "srcEndpoint=(Multiply (*): Result), destEndpoint=(Expect Equal: Candidate)",
+                                "Components": {
+                                    "Component_[7662682531129125729]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 7662682531129125729,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 666401012891
+                                            },
+                                            "slotId": {
+                                                "m_id": "{186C022F-10BF-4F80-A7FF-515CF59B00A0}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 632041274523
+                                            },
+                                            "slotId": {
+                                                "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 739415456923
+                                },
+                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Expect Equal: In)",
+                                "Components": {
+                                    "Component_[14912378511008706450]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 14912378511008706450,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 632041274523
+                                            },
+                                            "slotId": {
+                                                "m_id": "{D89CC575-5CC1-4847-91A2-2FD0EEA5D136}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 623451339931
+                                            },
+                                            "slotId": {
+                                                "m_id": "{B43BC4FB-F2A6-4D69-B8BF-63E311B9A81E}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 743710424219
+                                },
+                                "Name": "srcEndpoint=(Multiply (*): Result), destEndpoint=(Expect Equal: Candidate)",
+                                "Components": {
+                                    "Component_[17912423236092885884]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 17912423236092885884,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 640631209115
+                                            },
+                                            "slotId": {
+                                                "m_id": "{AED8C003-1B29-4882-8B8A-123161C4B90A}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 623451339931
+                                            },
+                                            "slotId": {
+                                                "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 748005391515
+                                },
+                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Mark Complete: In)",
+                                "Components": {
+                                    "Component_[17131484547163960909]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 17131484547163960909,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 623451339931
+                                            },
+                                            "slotId": {
+                                                "m_id": "{D89CC575-5CC1-4847-91A2-2FD0EEA5D136}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 670695980187
+                                            },
+                                            "slotId": {
+                                                "m_id": "{76D0BB2A-077E-4ED4-AC30-A58947DD542A}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 28287335693467
+                                },
+                                "Name": "srcEndpoint=(Multiply (*): Out), destEndpoint=(Multiply (*): In)",
+                                "Components": {
+                                    "Component_[5111680134587623072]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 5111680134587623072,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 25469837147291
+                                            },
+                                            "slotId": {
+                                                "m_id": "{362F0853-E1D9-4F21-B4F3-6ED8EB1DA0BF}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 653516111003
+                                            },
+                                            "slotId": {
+                                                "m_id": "{B49D89EC-47AC-4025-8F62-C6B5EBB33576}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 28789846867099
+                                },
+                                "Name": "srcEndpoint=(Multiply (*): Result), destEndpoint=(Expect Equal: Candidate)",
+                                "Components": {
+                                    "Component_[9748489578038502120]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 9748489578038502120,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 25469837147291
+                                            },
+                                            "slotId": {
+                                                "m_id": "{D0AEF817-E62E-46D0-882E-61C1E366330E}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 619156372635
+                                            },
+                                            "slotId": {
+                                                "m_id": "{32E369D2-90D7-48E6-BB9D-4743AA89F052}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 29979552808091
+                                },
+                                "Name": "srcEndpoint=(On Graph Start: Out), destEndpoint=(Multiply (*): In)",
+                                "Components": {
+                                    "Component_[8644927018211127551]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 8644927018211127551,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 644926176411
                                             },
                                             "slotId": {
                                                 "m_id": "{CC5808F3-2F02-47F1-AB85-15A91B5FE983}"
@@ -1020,66 +3359,10 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 372344921348142
+                                                "id": 25469837147291
                                             },
                                             "slotId": {
-                                                "m_id": "{3F00B99D-0C6C-4118-A678-2C7B032F8AD3}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 372379281086510
-                                },
-                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(Multiply (*): In)",
-                                "Components": {
-                                    "Component_[1132167285820244072]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 1132167285820244072,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 372344921348142
-                                            },
-                                            "slotId": {
-                                                "m_id": "{76F90219-AE17-4B61-BFB4-264364512E78}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 372336331413550
-                                            },
-                                            "slotId": {
-                                                "m_id": "{ABE93105-9659-4831-AE14-CE4A08335949}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 372383576053806
-                                },
-                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(Multiply (*): Value)",
-                                "Components": {
-                                    "Component_[4099181117764060793]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 4099181117764060793,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 372344921348142
-                                            },
-                                            "slotId": {
-                                                "m_id": "{11FA1D00-FEC0-4DB5-8355-A9C4F8EB0A32}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 372336331413550
-                                            },
-                                            "slotId": {
-                                                "m_id": "{79C7213B-7C82-4264-8B53-F1C63144A29A}"
+                                                "m_id": "{B4287015-3815-4686-BADB-ED526F83107B}"
                                             }
                                         }
                                     }
@@ -1093,20 +3376,20 @@
                         "_runtimeVersion": 1,
                         "_fileVersion": 1
                     },
-                    "m_variableCounter": 16,
+                    "m_variableCounter": 20,
                     "GraphCanvasData": [
                         {
                             "Key": {
-                                "id": 372323446511662
+                                "id": 614861405339
                             },
                             "Value": {
                                 "ComponentData": {
                                     "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
                                         "$type": "SceneComponentSaveData",
                                         "ViewParams": {
-                                            "Scale": 0.7373292,
-                                            "AnchorX": 104.43096160888672,
-                                            "AnchorY": -725.591796875
+                                            "Scale": 0.8045690547866451,
+                                            "AnchorX": -111.86112213134766,
+                                            "AnchorY": -811.6146240234375
                                         }
                                     }
                                 }
@@ -1114,94 +3397,13 @@
                         },
                         {
                             "Key": {
-                                "id": 372327741478958
+                                "id": 619156372635
                             },
                             "Value": {
                                 "ComponentData": {
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "TimeNodeTitlePalette"
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
                                     },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            340.0,
-                                            -580.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".time"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{9C20F353-185D-4DCB-9246-4EA8FFCE3976}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 372332036446254
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "GetVariableNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1000.0,
-                                            -520.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".getVariable"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{B308D127-CBAE-4C39-B56B-CE1FF32B0843}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 372336331413550
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MathNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            640.0,
-                                            -580.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".math"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{64EE6CD9-D7B7-4274-A2C7-0BA42FB44488}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 372340626380846
-                            },
-                            "Value": {
-                                "ComponentData": {
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
                                         "PaletteOverride": "MethodNodeTitlePalette"
@@ -1209,8 +3411,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            1220.0,
-                                            -340.0
+                                            760.0,
+                                            -480.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1226,38 +3428,13 @@
                         },
                         {
                             "Key": {
-                                "id": 372344921348142
+                                "id": 623451339931
                             },
                             "Value": {
                                 "ComponentData": {
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
                                     },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            500.0,
-                                            -560.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".getVariable"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{25112950-2D32-459D-B39A-0718ABE562F2}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 372349216315438
-                            },
-                            "Value": {
-                                "ComponentData": {
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
                                         "PaletteOverride": "MethodNodeTitlePalette"
@@ -1265,8 +3442,283 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            1580.0,
-                                            -260.0
+                                            2940.0,
+                                            -480.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{C4F27DD3-BAC0-4717-8410-355BA7987A6C}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 627746307227
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1700.0,
+                                            -480.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{029F6EC1-5179-4B30-BDB3-48CC3CBD072D}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 632041274523
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2360.0,
+                                            -460.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{00E18932-3461-421F-8877-0A084659D274}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 636336241819
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1220.0,
+                                            -460.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{AD40CAC5-E791-4CA2-939F-0E545A4E3FD5}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 640631209115
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MathNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2360.0,
+                                            -760.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{D5188D29-7FB0-47B3-A22F-DA1336DB25DD}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 644926176411
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "TimeNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            0.0,
+                                            -760.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".time"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{9C20F353-185D-4DCB-9246-4EA8FFCE3976}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 653516111003
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MathNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            760.0,
+                                            -760.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{CFA0247B-579B-468D-9B55-3AC8C02BB35D}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 657811078299
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MathNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1220.0,
+                                            -760.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{0A5BC439-68D3-43A4-B8D5-955E19E4EF8C}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 666401012891
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MathNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1700.0,
+                                            -760.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{014333DB-33AB-47C9-98E6-2F3D7B5A7CE0}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 670695980187
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            3460.0,
+                                            -460.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1279,33 +3731,55 @@
                                     }
                                 }
                             }
+                        },
+                        {
+                            "Key": {
+                                "id": 25469837147291
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MathNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            240.0,
+                                            -760.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{0E2F2D00-4624-4B8D-A489-357773EC3A5F}"
+                                    }
+                                }
+                            }
                         }
                     ],
                     "StatisticsHelper": {
                         "InstanceCounter": [
                             {
-                                "Key": 524494764786010043,
-                                "Value": 1
+                                "Key": 4053150093067829293,
+                                "Value": 5
                             },
                             {
                                 "Key": 4199610336680704683,
                                 "Value": 1
                             },
                             {
-                                "Key": 6840657073857873079,
-                                "Value": 1
-                            },
-                            {
-                                "Key": 11905347379560322424,
+                                "Key": 10204019744198319120,
                                 "Value": 1
                             },
                             {
                                 "Key": 12702286953450386850,
-                                "Value": 1
-                            },
-                            {
-                                "Key": 17735830108414649474,
-                                "Value": 1
+                                "Value": 5
                             }
                         ]
                     }


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

adds support to vector2/3/4 and color to multiply node. 

## How was this PR tested?

add script canvas unit test for multiply just not sure how to run the test for the script canvas
