### PR TITLE
Fixes a build error in development

### DIFF
--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -92,9 +92,9 @@ namespace SandboxEditor
                 );
 
                 m_farPlaneDistanceNotifyEventHandler = registry->RegisterNotifier(
-                    [this](const AZStd::string_view path, [[maybe_unused]] const AZ::SettingsRegistryInterface::Type type)
+                    [this](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
                     {
-                        if (IsPathAncestorDescendantOrEqual(CameraFarPlaneDistanceSetting, path))
+                        if (IsPathAncestorDescendantOrEqual(CameraFarPlaneDistanceSetting, notifyEventArgs.m_jsonKeyPath))
                         {
                             m_farPlaneChanged.Signal(CameraDefaultFarPlaneDistance());
                         }
@@ -102,9 +102,9 @@ namespace SandboxEditor
                 );
 
                 m_nearPlaneDistanceNotifyEventHandler = registry->RegisterNotifier(
-                    [this](const AZStd::string_view path, [[maybe_unused]] const AZ::SettingsRegistryInterface::Type type)
+                    [this](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
                     {
-                        if (IsPathAncestorDescendantOrEqual(CameraNearPlaneDistanceSetting, path))
+                        if (IsPathAncestorDescendantOrEqual(CameraNearPlaneDistanceSetting, notifyEventArgs.m_jsonKeyPath))
                         {
                             m_nearPlaneChanged.Signal(CameraDefaultNearPlaneDistance());
                         }

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.cpp
@@ -126,7 +126,7 @@ namespace AZ::SettingsRegistryConsoleUtils
     static void ConsoleDumpSettingsFileOriginValue(SettingsRegistryOriginTracker& settingsRegistryOriginTracker, const ConsoleCommandContainer& commandArgs)
     {
         AZStd::string outputString;
-        for (AZStd::string_view settingsKeyToDump : (commandArgs.empty() ? AZStd::vector<AZStd::string_view>{""} : commandArgs))
+        for (AZStd::string_view settingsKeyToDump : (commandArgs.empty() ? ConsoleCommandContainer{""} : commandArgs))
         {
             settingsRegistryOriginTracker.VisitOrigins(settingsKeyToDump, [&outputString](const AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin& settingsRegistryOrigin)
             {

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.cpp
@@ -137,7 +137,7 @@ namespace AZ::SettingsRegistryConsoleUtils
                     return true;
             });
         }
-    
+
         AZ::Debug::Trace::Output("SettingsRegistry", outputString.c_str());
     }
 


### PR DESCRIPTION
- Use a compatible type in both cases of ternary statement
- Updated event handlers to be of the correct signature

## What does this PR do?

Fixes a compile error introduced to `development` branch.

## How was this PR tested?

Local build
