### PR TITLE
Making remote templates visible

### DIFF
--- a/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.cpp
@@ -135,8 +135,8 @@ namespace O3DE::ProjectManager
             auto remoteTemplatesResult = PythonBindingsInterface::Get()->GetProjectTemplatesForAllRepos();
             if (remoteTemplatesResult.IsSuccess() && !remoteTemplatesResult.GetValue().isEmpty())
             {
-                QVector<ProjectTemplateInfo>& remoteTemplates = remoteTemplatesResult.GetValue();
-                for (ProjectTemplateInfo& remoteTemplate : remoteTemplates)
+                const QVector<ProjectTemplateInfo>& remoteTemplates = remoteTemplatesResult.GetValue();
+                for (const ProjectTemplateInfo& remoteTemplate : remoteTemplates)
                 {
                     const auto found = AZStd::ranges::find_if(m_templates,
                         [remoteTemplate](const ProjectTemplateInfo& value)
@@ -148,8 +148,6 @@ namespace O3DE::ProjectManager
                         m_templates.append(remoteTemplate);
                     }
                 }
-
-
             }
 
             // sort alphabetically by display name (but putting Standard first) because they could be in any order

--- a/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.cpp
@@ -130,6 +130,29 @@ namespace O3DE::ProjectManager
         {
             m_templates = templatesResult.GetValue();
 
+            // Add in remote templates
+            auto remoteTemplatesResult = PythonBindingsInterface::Get()->GetProjectTemplatesForAllRepos();
+            if (remoteTemplatesResult.IsSuccess() && !remoteTemplatesResult.GetValue().isEmpty())
+            {
+                QVector<ProjectTemplateInfo>& remoteTemplates = remoteTemplatesResult.GetValue();
+                for (ProjectTemplateInfo& remoteTemplate : remoteTemplates)
+                {
+                    auto rem = AZStd::find_if(
+                        m_templates.begin(),
+                        m_templates.end(),
+                        [remoteTemplate](const ProjectTemplateInfo& value)
+                        {
+                            return remoteTemplate.m_name == value.m_name;
+                        });
+                    if (rem == m_templates.end())
+                    {
+                        m_templates.append(remoteTemplate);
+                    }
+                }
+
+
+            }
+
             // sort alphabetically by display name (but putting Standard first) because they could be in any order
             std::sort(m_templates.begin(), m_templates.end(), [](const ProjectTemplateInfo& arg1, const ProjectTemplateInfo& arg2)
             {
@@ -157,6 +180,7 @@ namespace O3DE::ProjectManager
                     projectPreviewPath = ":/DefaultTemplate.png";
                 }
                 TemplateButton* templateButton = new TemplateButton(projectPreviewPath, projectTemplate.m_displayName, this);
+                templateButton->SetIsRemote(projectTemplate.m_isRemote);
                 templateButton->setCheckable(true);
                 templateButton->setProperty(k_templateIndexProperty, index);
                 

--- a/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.cpp
@@ -19,6 +19,7 @@
 #include <ProjectUtils.h>
 
 #include <AzCore/Math/Uuid.h>
+#include <AzCore/std/ranges/ranges_algorithm.h>
 #include <AzQtComponents/Components/FlowLayout.h>
 
 #include <QVBoxLayout>
@@ -137,14 +138,12 @@ namespace O3DE::ProjectManager
                 QVector<ProjectTemplateInfo>& remoteTemplates = remoteTemplatesResult.GetValue();
                 for (ProjectTemplateInfo& remoteTemplate : remoteTemplates)
                 {
-                    auto rem = AZStd::find_if(
-                        m_templates.begin(),
-                        m_templates.end(),
+                    const auto found = AZStd::ranges::find_if(m_templates,
                         [remoteTemplate](const ProjectTemplateInfo& value)
                         {
                             return remoteTemplate.m_name == value.m_name;
                         });
-                    if (rem == m_templates.end())
+                    if (found == m_templates.end())
                     {
                         m_templates.append(remoteTemplate);
                     }

--- a/Code/Tools/ProjectManager/Source/ProjectTemplateInfo.h
+++ b/Code/Tools/ProjectManager/Source/ProjectTemplateInfo.h
@@ -30,5 +30,6 @@ namespace O3DE::ProjectManager
         QStringList m_includedGems;
         QStringList m_canonicalTags;
         QStringList m_userTags;
+        bool m_isRemote = false;
     };
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -1138,6 +1138,36 @@ namespace O3DE::ProjectManager
         }
     }
 
+    AZ::Outcome<QVector<ProjectTemplateInfo>> PythonBindings::GetProjectTemplatesForAllRepos(const QString& projectPath)
+    {
+        QVector<ProjectTemplateInfo> templates;
+
+        bool result = ExecuteWithLock(
+            [&]
+            {
+                auto templatePaths = m_repo.attr("get_template_json_paths_from_all_cached_repos")();
+
+                if (pybind11::isinstance<pybind11::set>(templatePaths))
+                {
+                    for (auto path : templatePaths)
+                    {
+                        ProjectTemplateInfo remoteTemplate = ProjectTemplateInfoFromPath(path, QString_To_Py_Path(projectPath));
+                        remoteTemplate.m_isRemote = true;
+                        templates.push_back(remoteTemplate);
+                    }
+                }
+            });
+
+        if (!result)
+        {
+            return AZ::Failure();
+        }
+        else
+        {
+            return AZ::Success(AZStd::move(templates));
+        }
+    }
+
     AZ::Outcome<void, AZStd::string> PythonBindings::RefreshGemRepo(const QString& repoUri)
     {
         bool refreshResult = false;

--- a/Code/Tools/ProjectManager/Source/PythonBindings.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.h
@@ -61,6 +61,7 @@ namespace O3DE::ProjectManager
 
         // ProjectTemplate
         AZ::Outcome<QVector<ProjectTemplateInfo>> GetProjectTemplates(const QString& projectPath = {}) override;
+        AZ::Outcome<QVector<ProjectTemplateInfo>> GetProjectTemplatesForAllRepos(const QString& projectPath = {}) override;
 
         // Gem Repos
         AZ::Outcome<void, AZStd::string> RefreshGemRepo(const QString& repoUri) override;

--- a/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
@@ -210,6 +210,12 @@ namespace O3DE::ProjectManager
          */
         virtual AZ::Outcome<QVector<ProjectTemplateInfo>> GetProjectTemplates(const QString& projectPath = {}) = 0;
 
+        /**
+         * Gathers all project templates for all gems registered from repos.
+         * @return A list of all ProjectTemplateInfos on success
+         */
+        virtual AZ::Outcome<QVector<ProjectTemplateInfo>> GetProjectTemplatesForAllRepos(const QString& projectPath = {}) = 0;
+
         // Gem Repos
 
         /**

--- a/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
@@ -211,7 +211,7 @@ namespace O3DE::ProjectManager
         virtual AZ::Outcome<QVector<ProjectTemplateInfo>> GetProjectTemplates(const QString& projectPath = {}) = 0;
 
         /**
-         * Gathers all project templates for all gems registered from repos.
+         * Gathers all project templates for all templates registered from repos.
          * @return A list of all ProjectTemplateInfos on success
          */
         virtual AZ::Outcome<QVector<ProjectTemplateInfo>> GetProjectTemplatesForAllRepos(const QString& projectPath = {}) = 0;

--- a/Code/Tools/ProjectManager/Source/TemplateButtonWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/TemplateButtonWidget.cpp
@@ -9,10 +9,13 @@
 #include <TemplateButtonWidget.h>
 #include <ProjectManagerDefs.h>
 
+#include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QLabel>
 #include <QPixmap>
 #include <QAbstractButton>
+#include <QProgressBar>
+#include <QSpacerItem>
 #include <QStyle>
 #include <QVariant>
 
@@ -41,7 +44,91 @@ namespace O3DE::ProjectManager
         label->setWordWrap(true);
         vLayout->addWidget(label);
 
+        // Create an overlay for remote templates
+        QGridLayout* overlayLayout = new QGridLayout();
+        overlayLayout->setAlignment(Qt::AlignTop);
+        overlayLayout->setSpacing(0);
+        overlayLayout->setContentsMargins(0, 0, 0, 0);
+
+        // Dark overlay to make text clearer
+        m_darkenOverlay = new QLabel(this);
+        m_darkenOverlay->setObjectName("labelButtonOverlay");
+        m_darkenOverlay->setFixedSize(ProjectTemplateImageWidth, ProjectTemplateImageWidth);
+        m_darkenOverlay->setVisible(false);
+        overlayLayout->addWidget(m_darkenOverlay,0,0);
+
+        QVBoxLayout* contentsLayout = new QVBoxLayout();
+        contentsLayout->setSpacing(0);
+        contentsLayout->setContentsMargins(0, 0, 0, 0);
+        contentsLayout->setAlignment(Qt::AlignTop);
+        overlayLayout->addLayout(contentsLayout, 0, 0);
+
+        // Top status icons
+        QHBoxLayout* statusIconsLayout = new QHBoxLayout();
+        statusIconsLayout->setSpacing(0);
+        statusIconsLayout->setContentsMargins(0, 0, 0, 0);
+        statusIconsLayout->addStretch();
+        m_cloudIcon = new QLabel(this);
+        m_cloudIcon->setObjectName("projectCloudIconOverlay");
+        m_cloudIcon->setPixmap(QIcon(":/Download.svg").pixmap(24, 24));
+        m_cloudIcon->setVisible(false);
+        statusIconsLayout->addWidget(m_cloudIcon);
+        statusIconsLayout->addSpacing(5);
+        image->setLayout(overlayLayout);
+
+        QWidget* statusIconArea = new QWidget();
+        statusIconArea->setFixedSize(ProjectTemplateImageWidth, 24);
+        statusIconArea->setLayout(statusIconsLayout);
+        contentsLayout->addWidget(statusIconArea);
+
+        QWidget* templateCenter = new QWidget();
+        templateCenter->setFixedSize(ProjectTemplateImageWidth, 35);
+
+        // Center area for download information
+        QVBoxLayout* centerBlock = new QVBoxLayout();
+        templateCenter->setLayout(centerBlock);
+
+        QHBoxLayout* downloadProgressTextBlock = new QHBoxLayout();
+        m_progressMessageLabel = new QLabel(tr("0%"), this);
+        m_progressMessageLabel->setAlignment(Qt::AlignRight);
+        m_progressMessageLabel->setVisible(false);
+        downloadProgressTextBlock->addWidget(m_progressMessageLabel);
+        centerBlock->addLayout(downloadProgressTextBlock);
+
+        QHBoxLayout* downloadProgressBlock = new QHBoxLayout();
+        m_progessBar = new QProgressBar(this);
+        m_progessBar->setValue(100);
+        m_progessBar->setVisible(false);
+
+        downloadProgressBlock->addSpacing(10);
+        downloadProgressBlock->addWidget(m_progessBar);
+        downloadProgressBlock->addSpacing(10);
+        centerBlock->addLayout(downloadProgressBlock);
+        contentsLayout->addWidget(templateCenter);
+
+        QSpacerItem* spacer =
+            new QSpacerItem(ProjectTemplateImageWidth, ProjectTemplateImageWidth - 35 - 24, QSizePolicy::Fixed, QSizePolicy::Fixed);
+        contentsLayout->addSpacerItem(spacer);
+
         connect(this, &QAbstractButton::toggled, this, &TemplateButton::onToggled);
+    }
+
+    void TemplateButton::SetIsRemote(bool isRemote)
+    {
+        m_cloudIcon->setVisible(isRemote);
+    }
+
+    void TemplateButton::ShowDownloadProgress(bool showProgress)
+    {
+        m_progessBar->setVisible(showProgress);
+        m_progressMessageLabel->setVisible(showProgress);
+        m_darkenOverlay->setVisible(showProgress);
+    }
+
+    void TemplateButton::SetProgressPercentage(float percentage)
+    {
+        m_progessBar->setValue(percentage);
+        m_progressMessageLabel->setText(QString("%1%").arg(static_cast<int>(percentage)));
     }
 
     void TemplateButton::onToggled()

--- a/Code/Tools/ProjectManager/Source/TemplateButtonWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/TemplateButtonWidget.cpp
@@ -127,7 +127,7 @@ namespace O3DE::ProjectManager
 
     void TemplateButton::SetProgressPercentage(float percentage)
     {
-        m_progessBar->setValue(percentage);
+        m_progessBar->setValue(static_cast<int>(percentage));
         m_progressMessageLabel->setText(QString("%1%").arg(static_cast<int>(percentage)));
     }
 

--- a/Code/Tools/ProjectManager/Source/TemplateButtonWidget.h
+++ b/Code/Tools/ProjectManager/Source/TemplateButtonWidget.h
@@ -12,6 +12,8 @@
 #include <QPushButton>
 #endif
 
+QT_FORWARD_DECLARE_CLASS(QProgressBar)
+
 namespace O3DE::ProjectManager
 {
     class TemplateButton
@@ -23,7 +25,17 @@ namespace O3DE::ProjectManager
         explicit TemplateButton(const QString& imagePath, const QString& labelText, QWidget* parent = nullptr);
         ~TemplateButton() = default;
 
+        void SetIsRemote(bool isRemote);
+        void ShowDownloadProgress(bool showProgress);
+        void SetProgressPercentage(float percent);
+
     protected slots:
         void onToggled();
+
+    private:
+        QLabel* m_cloudIcon = nullptr;
+        QLabel* m_darkenOverlay = nullptr;
+        QLabel* m_progressMessageLabel = nullptr;
+        QProgressBar* m_progessBar = nullptr;
     };
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/TemplateButtonWidget.h
+++ b/Code/Tools/ProjectManager/Source/TemplateButtonWidget.h
@@ -12,6 +12,7 @@
 #include <QPushButton>
 #endif
 
+QT_FORWARD_DECLARE_CLASS(QLabel)
 QT_FORWARD_DECLARE_CLASS(QProgressBar)
 
 namespace O3DE::ProjectManager

--- a/scripts/o3de/o3de/manifest.py
+++ b/scripts/o3de/o3de/manifest.py
@@ -550,6 +550,7 @@ def get_gem_json_data(gem_name: str = None, gem_path: str or pathlib.Path = None
     if gem_name and not gem_path:
         gem_path = get_registered(gem_name=gem_name, project_path=project_path)
 
+    # Call get_json_data_file if the path is an existing file as get_json_data appends gem.json
     if pathlib.Path(gem_path).is_file():
         return get_json_data_file(gem_path, 'gem', validation.valid_o3de_gem_json)
     else:
@@ -565,6 +566,7 @@ def get_template_json_data(template_name: str = None, template_path: str or path
     if template_name and not template_path:
         template_path = get_registered(template_name=template_name, project_path=project_path)
 
+    # Call get_json_data_file if the path is an existing file as get_json_data appends template.json
     if pathlib.Path(template_path).is_file():
         return get_json_data_file(template_path, 'template', validation.valid_o3de_template_json)
     else:

--- a/scripts/o3de/o3de/manifest.py
+++ b/scripts/o3de/o3de/manifest.py
@@ -565,7 +565,10 @@ def get_template_json_data(template_name: str = None, template_path: str or path
     if template_name and not template_path:
         template_path = get_registered(template_name=template_name, project_path=project_path)
 
-    return get_json_data('template', template_path, validation.valid_o3de_template_json)
+    if pathlib.Path(template_path).is_file():
+        return get_json_data_file(template_path, 'template', validation.valid_o3de_template_json)
+    else:
+        return get_json_data('template', template_path, validation.valid_o3de_template_json)
 
 
 def get_restricted_json_data(restricted_name: str = None, restricted_path: str or pathlib.Path = None,


### PR DESCRIPTION
Making remote templates appear in the templates list and adding status icons and progress bars for downloading. The functionality for using this will be covered in a follow up PR once the PR for the refactor of the download controller has been merged.

![remoteTemplateButton](https://user-images.githubusercontent.com/70403342/184694669-8e79cf53-83ea-4492-87af-526ffeb1bb7c.PNG)


Signed-off-by: AMZN-Phil <pconroy@amazon.com>
