### PR TITLE
Reflect GetOnDisconnectedEvent Description plus typo fixes

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
@@ -61,7 +61,7 @@ namespace Multiplayer
 
     using ClientMigrationStartEvent = AZ::Event<ClientInputId>;
     using ClientMigrationEndEvent = AZ::Event<>;
-    using EndpointDisonnectedEvent = AZ::Event<MultiplayerAgentType>;
+    using EndpointDisconnectedEvent = AZ::Event<MultiplayerAgentType>;
     using NotifyClientMigrationEvent = AZ::Event<AzNetworking::ConnectionId, const HostId&, uint64_t, ClientInputId, NetEntityId>;
     using NotifyEntityMigrationEvent = AZ::Event<const ConstNetworkEntityHandle&, const HostId&>;
     using ConnectionAcquiredEvent = AZ::Event<MultiplayerAgentDatum>;
@@ -124,9 +124,9 @@ namespace Multiplayer
         //! @param handler The ClientMigrationEndEvent Handler to add
         virtual void AddClientMigrationEndEventHandler(ClientMigrationEndEvent::Handler& handler) = 0;
 
-        //! Adds a EndpointDisonnectedEvent Handler which is invoked on the client when a disconnection occurs.
-        //! @param handler The EndpointDisonnectedEvent Handler to add
-        virtual void AddEndpointDisonnectedHandler(EndpointDisonnectedEvent::Handler& handler) = 0;
+        //! Adds a EndpointDisconnectedEvent Handler which is invoked on the client when a disconnection occurs.
+        //! @param handler The EndpointDisconnectedEvent Handler to add
+        virtual void AddEndpointDisconnectedHandler(EndpointDisconnectedEvent::Handler& handler) = 0;
 
         //! Adds a NotifyClientMigrationEvent Handler which is invoked when a client migrates from one host to another.
         //! @param handler The NotifyClientMigrationEvent Handler to add

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -132,13 +132,13 @@ namespace Multiplayer
             behaviorContext->Class<MultiplayerSystemComponent>("MultiplayerSystemComponent")
                 ->Attribute(AZ::Script::Attributes::Module, "multiplayer")
                 ->Attribute(AZ::Script::Attributes::Category, "Multiplayer")
-                ->Method("GetOnEndpointDisonnectedEvent", [](AZ::EntityId id) -> EndpointDisonnectedEvent*
+                ->Method("GetOnEndpointDisconnectedEvent", [](AZ::EntityId id) -> EndpointDisconnectedEvent*
                 {
                     AZ::Entity* entity = AZ::Interface<AZ::ComponentApplicationRequests>::Get()->FindEntity(id);
                     if (!entity)
                     {
                         AZ_Warning("Multiplayer Property", false,
-                            "MultiplayerSystemComponent GetOnEndpointDisonnectedEvent failed."
+                            "MultiplayerSystemComponent GetOnEndpointDisconnectedEvent failed."
                             "The entity with id %s doesn't exist, please provide a valid entity id.",
                             id.ToString().c_str());
                         return nullptr;
@@ -148,14 +148,16 @@ namespace Multiplayer
                     if (!mpComponent)
                     {
                         AZ_Warning("Multiplayer Property", false,
-                            "MultiplayerSystemComponent GetOnEndpointDisonnectedEvent failed."
+                            "MultiplayerSystemComponent GetOnEndpointDisconnectedEvent failed."
                             "Entity '%s' (id: %s) is missing MultiplayerSystemComponent, be sure to add MultiplayerSystemComponent to this entity.",
                             entity->GetName().c_str(), id.ToString().c_str());
                         return nullptr;
                     }
 
-                    return &mpComponent->m_endpointDisonnectedEvent;
+                    return &mpComponent->m_endpointDisconnectedEvent;
                 })
+                    ->Attribute(AZ::Script::Attributes::AzEventDescription,
+                        AZ::BehaviorAzEventDescription{"On Endpoint Disconnected Event", {"Type of Multiplayer Agent that disconnected"}})
                 ->Method("ClearAllEntities", [](AZ::EntityId id)
                 {
                     AZ::Entity* entity = AZ::Interface<AZ::ComponentApplicationRequests>::Get()->FindEntity(id);
@@ -934,7 +936,7 @@ namespace Multiplayer
             }
         }
 
-        m_endpointDisonnectedEvent.Signal(m_agentType);
+        m_endpointDisconnectedEvent.Signal(m_agentType);
 
         // Clean up any multiplayer connection data we've bound to this connection instance
         if (connection->GetUserData() != nullptr)
@@ -1040,9 +1042,9 @@ namespace Multiplayer
         handler.Connect(m_clientMigrationEndEvent);
     }
 
-    void MultiplayerSystemComponent::AddEndpointDisonnectedHandler(EndpointDisonnectedEvent::Handler& handler)
+    void MultiplayerSystemComponent::AddEndpointDisconnectedHandler(EndpointDisconnectedEvent::Handler& handler)
     {
-        handler.Connect(m_endpointDisonnectedEvent);
+        handler.Connect(m_endpointDisconnectedEvent);
     }
 
     void MultiplayerSystemComponent::AddNotifyClientMigrationHandler(NotifyClientMigrationEvent::Handler& handler)

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -114,7 +114,7 @@ namespace Multiplayer
         void Terminate(AzNetworking::DisconnectReason reason) override;
         void AddClientMigrationStartEventHandler(ClientMigrationStartEvent::Handler& handler) override;
         void AddClientMigrationEndEventHandler(ClientMigrationEndEvent::Handler& handler) override;
-        void AddEndpointDisonnectedHandler(EndpointDisonnectedEvent::Handler& handler) override;
+        void AddEndpointDisconnectedHandler(EndpointDisconnectedEvent::Handler& handler) override;
         void AddNotifyClientMigrationHandler(NotifyClientMigrationEvent::Handler& handler) override;
         void AddNotifyEntityMigrationEventHandler(NotifyEntityMigrationEvent::Handler& handler) override;
         void AddConnectionAcquiredHandler(ConnectionAcquiredEvent::Handler& handler) override;
@@ -169,7 +169,7 @@ namespace Multiplayer
         SessionShutdownEvent m_shutdownEvent;
         ConnectionAcquiredEvent m_connectionAcquiredEvent;
         ServerAcceptanceReceivedEvent m_serverAcceptanceReceivedEvent;
-        EndpointDisonnectedEvent m_endpointDisonnectedEvent;
+        EndpointDisconnectedEvent m_endpointDisconnectedEvent;
         ClientMigrationStartEvent m_clientMigrationStartEvent;
         ClientMigrationEndEvent m_clientMigrationEndEvent;
         NotifyClientMigrationEvent m_notifyClientMigrationEvent;

--- a/Gems/Multiplayer/Code/Tests/CommonBenchmarkSetup.h
+++ b/Gems/Multiplayer/Code/Tests/CommonBenchmarkSetup.h
@@ -303,7 +303,7 @@ namespace Multiplayer
         bool StartHosting([[maybe_unused]] uint16_t port, [[maybe_unused]] bool isDedicated) override { return {}; }
         bool Connect([[maybe_unused]] const AZStd::string& remoteAddress, [[maybe_unused]] uint16_t port) override { return {}; }
         void Terminate([[maybe_unused]] AzNetworking::DisconnectReason reason) override {}
-        void AddEndpointDisonnectedHandler([[maybe_unused]] EndpointDisonnectedEvent::Handler& handler) override {}
+        void AddEndpointDisconnectedHandler([[maybe_unused]] EndpointDisconnectedEvent::Handler& handler) override {}
         void AddConnectionAcquiredHandler([[maybe_unused]] ConnectionAcquiredEvent::Handler& handler) override {}
         void AddServerAcceptanceReceivedHandler([[maybe_unused]] ServerAcceptanceReceivedEvent::Handler& handler) override {}
         void AddSessionInitHandler([[maybe_unused]] SessionInitEvent::Handler& handler) override {}

--- a/Gems/Multiplayer/Code/Tests/MockInterfaces.h
+++ b/Gems/Multiplayer/Code/Tests/MockInterfaces.h
@@ -27,7 +27,7 @@ namespace UnitTest
         MOCK_METHOD1(Terminate, void(AzNetworking::DisconnectReason));
         MOCK_METHOD1(AddClientMigrationStartEventHandler, void(Multiplayer::ClientMigrationStartEvent::Handler&));
         MOCK_METHOD1(AddClientMigrationEndEventHandler, void(Multiplayer::ClientMigrationEndEvent::Handler&));
-        MOCK_METHOD1(AddEndpointDisonnectedHandler, void(Multiplayer::EndpointDisonnectedEvent::Handler&));
+        MOCK_METHOD1(AddEndpointDisconnectedHandler, void(Multiplayer::EndpointDisconnectedEvent::Handler&));
         MOCK_METHOD1(AddNotifyClientMigrationHandler, void(Multiplayer::NotifyClientMigrationEvent::Handler&));
         MOCK_METHOD1(AddNotifyEntityMigrationEventHandler, void(Multiplayer::NotifyEntityMigrationEvent::Handler&));
         MOCK_METHOD1(AddConnectionAcquiredHandler, void(Multiplayer::ConnectionAcquiredEvent::Handler&));

--- a/Gems/Multiplayer/Code/Tests/MultiplayerSystemTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/MultiplayerSystemTests.cpp
@@ -56,8 +56,8 @@ namespace Multiplayer
             m_mpComponent->AddSessionShutdownHandler(m_shutdownHandler);
             m_connAcquiredHandler = Multiplayer::ConnectionAcquiredEvent::Handler([this](Multiplayer::MultiplayerAgentDatum value) { TestConnectionAcquiredEvent(value); });
             m_mpComponent->AddConnectionAcquiredHandler(m_connAcquiredHandler);
-            m_endpointDisonnectedHandler = Multiplayer::EndpointDisonnectedEvent::Handler([this](Multiplayer::MultiplayerAgentType value) { TestEndpointDisonnectedEvent(value); });
-            m_mpComponent->AddEndpointDisonnectedHandler(m_endpointDisonnectedHandler);
+            m_endpointDisconnectedHandler = Multiplayer::EndpointDisconnectedEvent::Handler([this](Multiplayer::MultiplayerAgentType value) { TestEndpointDisconnectedEvent(value); });
+            m_mpComponent->AddEndpointDisconnectedHandler(m_endpointDisconnectedHandler);
             m_mpComponent->Activate();
         }
 
@@ -92,7 +92,7 @@ namespace Multiplayer
             m_connectionAcquiredCount += aznumeric_cast<uint32_t>(datum.m_id);
         }
 
-        void TestEndpointDisonnectedEvent([[maybe_unused]] Multiplayer::MultiplayerAgentType value)
+        void TestEndpointDisconnectedEvent([[maybe_unused]] Multiplayer::MultiplayerAgentType value)
         {
             ++m_endpointDisconnectedCount;
         }
@@ -119,7 +119,7 @@ namespace Multiplayer
         Multiplayer::SessionInitEvent::Handler m_initHandler;
         Multiplayer::SessionShutdownEvent::Handler m_shutdownHandler;
         Multiplayer::ConnectionAcquiredEvent::Handler m_connAcquiredHandler;
-        Multiplayer::EndpointDisonnectedEvent::Handler m_endpointDisonnectedHandler;
+        Multiplayer::EndpointDisconnectedEvent::Handler m_endpointDisconnectedHandler;
 
         AzNetworking::NetworkingSystemComponent* m_netComponent = nullptr;
         Multiplayer::MultiplayerSystemComponent* m_mpComponent = nullptr;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EventHandlerTranslationUtility.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EventHandlerTranslationUtility.h
@@ -132,9 +132,9 @@ namespace ScriptCanvas
                         }
                         else if (executionSlot.GetId() == HandlerPropertyType::GetDisconnectSlotId(&handler))
                         {
-                            if (auto disonnectedSlot = HandlerPropertyType::GetOnDisconnectedSlot(&handler))
+                            if (auto disconnectedSlot = HandlerPropertyType::GetOnDisconnectedSlot(&handler))
                             {
-                                executionSlots.push_back(disonnectedSlot);
+                                executionSlots.push_back(disconnectedSlot);
                             }
                             else
                             {


### PR DESCRIPTION
Signed-off-by: puvvadar <puvvadar@amazon.com>

## What does this PR do?

Adds an `AzEventDescription` to `GetOnEndpointDisconnectedEvent` in `MultiplayerSystemComponent.cpp`. Additionally fixes several typos of `Disonnected` -> `Disconnected`

## How was this PR tested?

Launched Material Editor and did not observe an error around reflection of the event.