### PR TITLE
Prefabs UI | Fix Outliner code to correctly expand ancestors of current focus

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -92,7 +92,6 @@ namespace AzToolsFramework
     EntityOutlinerListModel::~EntityOutlinerListModel()
     {
         FocusModeNotificationBus::Handler::BusDisconnect();
-        Prefab::PrefabFocusNotificationBus::Handler::BusDisconnect();
         ContainerEntityNotificationBus::Handler::BusDisconnect();
         EditorEntityInfoNotificationBus::Handler::BusDisconnect();
         EditorEntityContextNotificationBus::Handler::BusDisconnect();
@@ -116,7 +115,6 @@ namespace AzToolsFramework
             editorEntityContextId, &AzToolsFramework::EditorEntityContextRequestBus::Events::GetEditorEntityContextId);
 
         ContainerEntityNotificationBus::Handler::BusConnect(editorEntityContextId);
-        Prefab::PrefabFocusNotificationBus::Handler::BusConnect(editorEntityContextId);
         FocusModeNotificationBus::Handler::BusConnect(editorEntityContextId);
 
         m_editorEntityUiInterface = AZ::Interface<AzToolsFramework::EditorEntityUiInterface>::Get();
@@ -1240,18 +1238,6 @@ namespace AzToolsFramework
 
         // Always expand containers
         QueueEntityToExpand(entityId, true);
-    }
-
-    void EntityOutlinerListModel::OnInstanceOpened(AZ::EntityId containerEntityId)
-    {
-        QueueEntityToExpand(containerEntityId, true);
-    }
-
-    void EntityOutlinerListModel::OnPrefabFocusChanged(
-        [[maybe_unused]] AZ::EntityId previousContainerEntityId, [[maybe_unused]] AZ::EntityId newContainerEntityId)
-    {
-        QueueEntityToExpand(previousContainerEntityId, false);
-        QueueEntityToExpand(newContainerEntityId, true);
     }
 
     void EntityOutlinerListModel::OnEntityInfoUpdatedRemoveChildBegin([[maybe_unused]] AZ::EntityId parentId, [[maybe_unused]] AZ::EntityId childId)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.hxx
@@ -22,7 +22,6 @@
 #include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
 #include <AzToolsFramework/Entity/EditorEntityRuntimeActivationBus.h>
 #include <AzToolsFramework/FocusMode/FocusModeNotificationBus.h>
-#include <AzToolsFramework/Prefab/PrefabFocusNotificationBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorLockComponentBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorVisibilityBus.h>
 #include <AzToolsFramework/UI/Outliner/EntityOutlinerSearchWidget.h>
@@ -58,7 +57,6 @@ namespace AzToolsFramework
         , private ToolsApplicationEvents::Bus::Handler
         , private EntityCompositionNotificationBus::Handler
         , private EditorEntityRuntimeActivationChangeNotificationBus::Handler
-        , private Prefab::PrefabFocusNotificationBus::Handler
         , private AZ::EntitySystemBus::Handler
         , private ContainerEntityNotificationBus::Handler
     {
@@ -153,10 +151,6 @@ namespace AzToolsFramework
         bool FilterEntity(const AZ::EntityId& entityId);
 
         void EnableAutoExpand(bool enable);
-
-        // PrefabFocusNotificationBus overrides ...
-        void OnPrefabFocusChanged(AZ::EntityId previousContainerEntityId, AZ::EntityId newContainerEntityId) override;
-        void OnInstanceOpened(AZ::EntityId containerEntityId) override;
 
         AZStd::string GetFilterString() const
         {


### PR DESCRIPTION
## What does this PR do?

Removes some redundant code in the Entity Outliner that prevents the previously focused prefab container from being forcefully collapsed. The previous logic relied on the false assumption that the previously focused prefab needs to be collapsed, which is not true when the new focus is a descendant of the previous one. Also, other existing notifications already enforce the correct handling of expanded states for the prefab hierarchy.

![FocusExpandedState](https://user-images.githubusercontent.com/82231674/184755524-fbc143a6-9480-454f-b0b9-eda583d025c8.gif)

Fixes #11272 

## How was this PR tested?

Manual testing to verify the issue above no longer reproduces.
