### PR TITLE
Trace methods now must be accessed through the instance

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.cpp
@@ -138,7 +138,7 @@ namespace AZ::SettingsRegistryConsoleUtils
             });
         }
 
-        AZ::Debug::Trace::Output("SettingsRegistry", outputString.c_str());
+        AZ::Debug::Trace::Instance().Output("SettingsRegistry", outputString.c_str());
     }
 
     [[nodiscard]] ConsoleFunctorHandle RegisterAzConsoleCommands(SettingsRegistryOriginTracker& originTracker, AZ::IConsole& azConsole)


### PR DESCRIPTION
Broken when #11263 and #11028 merged together

Signed-off-by: Chris Burel <burelc@amazon.com>
