### PR TITLE
[Atom] Fix shader compilation error

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Edit/Utils.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Edit/Utils.h
@@ -64,7 +64,7 @@ namespace AZ
         template< size_t N >
         AZStd::string ByteToHexString(const unsigned char (&array)[N])
         {
-            AZStd::string result{ N * 2, '\0' };
+            AZStd::string result(N * 2, '\0');
             for (int i = 0; i < N; ++i)
             {
                 char msb = (array[i] >> 4) & 0x0F;


### PR DESCRIPTION
Signed-off-by: jiaweig <51759646+jiaweig-amzn@users.noreply.github.com>

## What does this PR do?

This was triggered by AsyncComputeShadow.shader in Atom Sample Viewer, which sets AddBuildArguments.debug = true.
 Same cause described below, but this one is more hidden because it's using a template.
https://github.com/o3de/o3de-atom-sampleviewer/pull/493

## How was this PR tested?

Tested AsyncComputeShadow.shader now it compiles.
