### PR TITLE
Scene settings button padding

### DIFF
--- a/Code/Tools/SceneAPI/SceneUI/RowWidgets/ManifestVectorWidget.ui
+++ b/Code/Tools/SceneAPI/SceneUI/RowWidgets/ManifestVectorWidget.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>AZ::SceneAPI::UI::ManifestVectorWidget</class>
  <widget class="QWidget" name="AZ::SceneAPI::UI::ManifestVectorWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>142</width>
-    <height>41</height>
-   </rect>
-  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
     <horstretch>0</horstretch>

--- a/Code/Tools/SceneAPI/SceneUI/RowWidgets/ManifestVectorWidget.ui
+++ b/Code/Tools/SceneAPI/SceneUI/RowWidgets/ManifestVectorWidget.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>AZ::SceneAPI::UI::ManifestVectorWidget</class>
  <widget class="QWidget" name="AZ::SceneAPI::UI::ManifestVectorWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>142</width>
+    <height>41</height>
+   </rect>
+  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
     <horstretch>0</horstretch>
@@ -56,7 +64,7 @@
         <item>
          <widget class="QLabel" name="m_containerTitle">
           <property name="text">
-           <string></string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -75,6 +83,9 @@
         </item>
         <item>
          <widget class="QPushButton" name="m_addObjectButton">
+          <property name="styleSheet">
+           <string notr="true">padding: 6px;</string>
+          </property>
           <property name="text">
            <string>Add Object</string>
           </property>


### PR DESCRIPTION
## What does this PR do?

Fixes padding on the "Add Modifier" button in scene settings

![image](https://user-images.githubusercontent.com/4838196/184995766-5a674cda-52da-4adb-b4b1-426eada2bb1e.png)


## How was this PR tested?

Manual testing, visual verification.
