### PR TITLE
Changing material builder settings and (AtomCore) AZ::Data::InstanceId to support material editor and canvas workflows

### DIFF
--- a/Code/Framework/AtomCore/AtomCore/Instance/InstanceId.cpp
+++ b/Code/Framework/AtomCore/AtomCore/Instance/InstanceId.cpp
@@ -14,8 +14,9 @@ namespace AZ
     {
         InstanceId InstanceId::CreateFromAsset(const Asset<AssetData>& asset)
         {
-            // Ideally this would use the asset creation token instead of the asset pointer. That requires the asset pointer to be valid
-            // beforehand. If the asset pointer is null this will be the same as CreateFromAssetId.
+            // Passing the asset data pointer in as a unique identifier for this version of the asset. Ideally this would use the asset
+            // creation token instead of the asset pointer but that requires the asset pointer to be valid beforehand. If the asset pointer
+            // is null this will be the same as CreateFromAssetId.
             return InstanceId(asset.GetId().m_guid, asset.GetId().m_subId, asset.Get());
         }
 
@@ -50,10 +51,10 @@ namespace AZ
         {
         }
 
-        InstanceId::InstanceId(const Uuid& guid, uint32_t subId, void* data)
+        InstanceId::InstanceId(const Uuid& guid, uint32_t subId, void* versionId)
             : m_guid{ guid }
             , m_subId{ subId }
-            , m_data{ data }
+            , m_versionId{ versionId }
         {
         }
 
@@ -64,12 +65,12 @@ namespace AZ
 
         bool InstanceId::operator==(const InstanceId& rhs) const
         {
-            return m_guid == rhs.m_guid && m_subId == rhs.m_subId && m_data == rhs.m_data;
+            return m_guid == rhs.m_guid && m_subId == rhs.m_subId && m_versionId == rhs.m_versionId;
         }
 
         bool InstanceId::operator!=(const InstanceId& rhs) const
         {
-            return m_guid != rhs.m_guid || m_subId != rhs.m_subId || m_data != rhs.m_data;
+            return m_guid != rhs.m_guid || m_subId != rhs.m_subId || m_versionId != rhs.m_versionId;
         }
     } // namespace Data
 } // namespace AZ

--- a/Code/Framework/AtomCore/AtomCore/Instance/InstanceId.cpp
+++ b/Code/Framework/AtomCore/AtomCore/Instance/InstanceId.cpp
@@ -12,6 +12,13 @@ namespace AZ
 {
     namespace Data
     {
+        InstanceId InstanceId::CreateFromAsset(const Asset<AssetData>& asset)
+        {
+            // Ideally this would use the asset creation token instead of the asset pointer. That requires the asset pointer to be valid
+            // beforehand. If the asset pointer is null this will be the same as CreateFromAssetId.
+            return InstanceId(asset.GetId().m_guid, asset.GetId().m_subId, asset.Get());
+        }
+
         InstanceId InstanceId::CreateFromAssetId(const AssetId& assetId)
         {
             return InstanceId(assetId.m_guid, assetId.m_subId);
@@ -33,27 +40,36 @@ namespace AZ
         }
 
         InstanceId::InstanceId(const Uuid& guid)
-            : m_guid{guid}
-        {}
+            : m_guid{ guid }
+        {
+        }
 
         InstanceId::InstanceId(const Uuid& guid, uint32_t subId)
-            : m_guid{guid}
-            , m_subId{subId}
-        {}
+            : m_guid{ guid }
+            , m_subId{ subId }
+        {
+        }
+
+        InstanceId::InstanceId(const Uuid& guid, uint32_t subId, void* data)
+            : m_guid{ guid }
+            , m_subId{ subId }
+            , m_data{ data }
+        {
+        }
 
         bool InstanceId::IsValid() const
         {
             return m_guid != AZ::Uuid::CreateNull();
         }
 
-        bool InstanceId::operator == (const InstanceId& rhs) const
+        bool InstanceId::operator==(const InstanceId& rhs) const
         {
-            return m_guid == rhs.m_guid && m_subId == rhs.m_subId;
+            return m_guid == rhs.m_guid && m_subId == rhs.m_subId && m_data == rhs.m_data;
         }
 
-        bool InstanceId::operator != (const InstanceId& rhs) const
+        bool InstanceId::operator!=(const InstanceId& rhs) const
         {
-            return m_guid != rhs.m_guid || m_subId != rhs.m_subId;
+            return m_guid != rhs.m_guid || m_subId != rhs.m_subId || m_data != rhs.m_data;
         }
-    }
-}
+    } // namespace Data
+} // namespace AZ

--- a/Code/Framework/AtomCore/AtomCore/Instance/InstanceId.h
+++ b/Code/Framework/AtomCore/AtomCore/Instance/InstanceId.h
@@ -26,6 +26,13 @@ namespace AZ
             AZ_TYPE_INFO(InstanceId, "{0E59A635-07E8-419F-A0F2-90E0CE9C0AD6}");
 
             /**
+             * Creates an instance id from an asset. The instance id will share the same guid,
+             * sub id, and an opaque pointer value to a specific version of an asset. This is
+             * an explicit create method rather than a constructor in order to make it explicit.
+             */
+            static InstanceId CreateFromAsset(const Asset<AssetData>& asset);
+
+            /**
              * Creates an instance id from an asset id. The two will share the same guid and
              * sub id. This is an explicit create method rather than a constructor in order
              * to make it explicit.
@@ -52,6 +59,7 @@ namespace AZ
 
             explicit InstanceId(const Uuid& guid);
             explicit InstanceId(const Uuid& guid, uint32_t subId);
+            explicit InstanceId(const Uuid& guid, uint32_t subId, void* data);
 
             bool IsValid() const;
 
@@ -65,7 +73,8 @@ namespace AZ
             void ToString(StringType& result) const;
 
             Uuid m_guid = Uuid::CreateNull();
-            uint32_t  m_subId = 0;
+            uint32_t m_subId = 0;
+            void* m_data = nullptr;
         };
 
         template<class StringType>
@@ -79,22 +88,26 @@ namespace AZ
         template<class StringType>
         inline void InstanceId::ToString(StringType& result) const
         {
-            result = StringType::format("%s:%x", m_guid.ToString<StringType>().c_str(), m_subId);
+            result = StringType::format("%s:%x:%p", m_guid.ToString<StringType>().c_str(), m_subId, m_data);
         }
-    }
-}
+    } // namespace Data
+} // namespace AZ
 
 namespace AZStd
 {
     // hash specialization
-    template <>
+    template<>
     struct hash<AZ::Data::InstanceId>
     {
-        typedef AZ::Uuid    argument_type;
-        typedef size_t      result_type;
-        AZ_FORCE_INLINE size_t operator()(const AZ::Data::InstanceId& id) const
+        using argument_type = AZ::Data::InstanceId;
+        using result_type = size_t;
+
+        result_type operator()(const argument_type& id) const
         {
-            return id.m_guid.GetHash() ^ static_cast<size_t>(id.m_subId);
+            size_t h = id.m_guid.GetHash();
+            hash_combine(h, id.m_subId);
+            hash_combine(h, id.m_data);
+            return h;
         }
     };
-}
+} // namespace AZStd

--- a/Code/Framework/AtomCore/AtomCore/Instance/InstanceId.h
+++ b/Code/Framework/AtomCore/AtomCore/Instance/InstanceId.h
@@ -27,14 +27,14 @@ namespace AZ
 
             /**
              * Creates an instance id from an asset. The instance id will share the same guid,
-             * sub id, and an opaque pointer value to a specific version of an asset. This is
-             * an explicit create method rather than a constructor in order to make it explicit.
+             * sub id, and an opaque pointer value to identify a specific version of an asset. This is
+             * a create method rather than a constructor in order to make it explicit.
              */
             static InstanceId CreateFromAsset(const Asset<AssetData>& asset);
 
             /**
              * Creates an instance id from an asset id. The two will share the same guid and
-             * sub id. This is an explicit create method rather than a constructor in order
+             * sub id. This is a create method rather than a constructor in order
              * to make it explicit.
              */
             static InstanceId CreateFromAssetId(const AssetId& assetId);
@@ -59,7 +59,7 @@ namespace AZ
 
             explicit InstanceId(const Uuid& guid);
             explicit InstanceId(const Uuid& guid, uint32_t subId);
-            explicit InstanceId(const Uuid& guid, uint32_t subId, void* data);
+            explicit InstanceId(const Uuid& guid, uint32_t subId, void* versionId);
 
             bool IsValid() const;
 
@@ -74,7 +74,10 @@ namespace AZ
 
             Uuid m_guid = Uuid::CreateNull();
             uint32_t m_subId = 0;
-            void* m_data = nullptr;
+
+            // Pointer used to uniquely identify a version of the data, usually an asset. It is not intended to be
+            // dereferenced or used to access asset data.
+            void* m_versionId = nullptr; 
         };
 
         template<class StringType>
@@ -88,7 +91,7 @@ namespace AZ
         template<class StringType>
         inline void InstanceId::ToString(StringType& result) const
         {
-            result = StringType::format("%s:%x:%p", m_guid.ToString<StringType>().c_str(), m_subId, m_data);
+            result = StringType::format("%s:%x:%p", m_guid.ToString<StringType>().c_str(), m_subId, m_versionId);
         }
     } // namespace Data
 } // namespace AZ
@@ -106,7 +109,7 @@ namespace AZStd
         {
             size_t h = id.m_guid.GetHash();
             hash_combine(h, id.m_subId);
-            hash_combine(h, id.m_data);
+            hash_combine(h, id.m_versionId);
             return h;
         }
     };

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialUtils.h
@@ -75,6 +75,7 @@ namespace AZ
             //! Materials assets can either be finalized during asset-processing time or when materials are loaded at runtime.
             //! Finalizing during asset processing reduces load times and obfuscates the material data.
             //! Waiting to finalize at load time reduces dependencies on the material type data, resulting in fewer asset rebuilds and less time spent processing assets.
+            //! Removing the dependency on the material type data will require special handling of material type asset dependencies when loading and reloading materials.
             bool BuildersShouldFinalizeMaterialAssets();
         }
     }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialAsset.h
@@ -154,7 +154,7 @@ namespace AZ
 
             static const char* s_debugTraceName;
 
-            Data::Asset<MaterialTypeAsset> m_materialTypeAsset;
+            Data::Asset<MaterialTypeAsset> m_materialTypeAsset = { AZ::Data::AssetLoadBehavior::PreLoad };
 
             //! Holds values for each material property, used to initialize Material instances.
             //! This is indexed by MaterialPropertyIndex and aligns with entries in m_materialPropertiesLayout.

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -85,7 +85,10 @@ namespace AZ
 
         bool MaterialBuilder::ShouldOutputAllPropertiesMaterial() const
         {
-            bool value = true;
+            // Enable this setting to generate a default source material file containing an explicit list of all properties and their
+            // default values. This is primarily used by artists and developers scraping data from the materials and should only be enabled
+            // as needed by those users.
+            bool value = false;
             if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
             {
                 settingsRegistry->Get(value, "/O3DE/Atom/RPI/MaterialTypeBuilder/CreateAllPropertiesMaterial");
@@ -145,7 +148,7 @@ namespace AZ
                         // If we aren't finalizing material assets, then a normal job dependency isn't needed because the MaterialTypeAsset data won't be used.
                         // However, we do still need at least an OrderOnce dependency to ensure the Asset Processor knows about the material type asset so the builder can get it's AssetId.
                         // This can significantly reduce AP processing time when a material type or its shaders are edited.
-                        if (forceOrderOnce || currentFileIsMaterial && referencedFileIsMaterialType && !shouldFinalizeMaterialAssets)
+                        if (forceOrderOnce || (currentFileIsMaterial && referencedFileIsMaterialType && !shouldFinalizeMaterialAssets))
                         {
                             jobDependency.m_type = AssetBuilderSDK::JobDependencyType::OrderOnce;
                         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MaterialAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MaterialAssetBuilderComponent.cpp
@@ -95,11 +95,17 @@ namespace AZ
                 // material properties will be validated at runtime when the material is loaded, so the job dependency is needed only for
                 // first-time processing to set up the initial MaterialAsset. This speeds up AP processing time when a materialtype file is
                 // edited (e.g. 10s when editing StandardPBR.materialtype on AtomTest project from 45s).
-                
-                // If we aren't finalizing material assets, then a normal job dependency isn't needed because the MaterialTypeAsset data won't be used.
-                // However, we do still need at least an OrderOnce dependency to ensure the Asset Processor knows about the material type asset so the builder can get it's AssetId.
-                // This can significantly reduce AP processing time when a material type or its shaders are edited.
-                jobDependency.m_type = MaterialUtils::BuildersShouldFinalizeMaterialAssets() ? AssetBuilderSDK::JobDependencyType::Order : AssetBuilderSDK::JobDependencyType::OrderOnce;
+
+                // If we aren't finalizing material assets, then a normal job dependency isn't needed because the MaterialTypeAsset data
+                // won't be used. However, we do still need at least an OrderOnce dependency to ensure the Asset Processor knows about the
+                // material type asset so the builder can get it's AssetId. This can significantly reduce AP processing time when a material
+                // type or its shaders are edited.
+
+                // Note that without the normal job dependencies, materials may not load or reload consistently or in sync with shader and
+                // material type changes without manually monitoring and handling dependency changes.
+                jobDependency.m_type = MaterialUtils::BuildersShouldFinalizeMaterialAssets()
+                    ? AssetBuilderSDK::JobDependencyType::Order
+                    : AssetBuilderSDK::JobDependencyType::OrderOnce;
 
                 jobDependencyList.push_back(jobDependency);
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialUtils.cpp
@@ -206,9 +206,13 @@ namespace AZ
             
             bool BuildersShouldFinalizeMaterialAssets()
             {
-                // We default to the faster workflow for developers. Enable this registry setting when releasing the
-                // game for faster load times and obfuscation of material assets.
-                bool shouldFinalize = false;
+                // Disable this registry setting to improve iteration times when making changes to widely used shaders and material types,
+                // like standard PBR, that require a large number of model assets to be reprocessed by the AP. Disabling finalization will
+                // also disable build dependencies between materials and material types. Without those dependencies in place, loading and
+                // reloading material assets will require special handling because typical asset notifications will not be sent when
+                // dependencies are changed. Before finalization is disabled by default, we should explore options for handling dependencies
+                // on standard PBR differently at the model builder level.
+                bool shouldFinalize = true;
 
                 if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
                 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialUtils.cpp
@@ -210,8 +210,10 @@ namespace AZ
                 // like standard PBR, that require a large number of model assets to be reprocessed by the AP. Disabling finalization will
                 // also disable build dependencies between materials and material types. Without those dependencies in place, loading and
                 // reloading material assets will require special handling because typical asset notifications will not be sent when
-                // dependencies are changed. Before finalization is disabled by default, we should explore options for handling dependencies
-                // on standard PBR differently at the model builder level.
+                // dependencies are changed. Before, this option was disabled by default because of the long iteration times, but caused hot
+                // reload problems so we enabled it again. We should explore options for handling dependencies on standard PBR differently
+                // at the model builder level, and hopefully improve the iteration times that way. In that case, we should come back and
+                // remove the deferred-finalize option entirely.
                 bool shouldFinalize = true;
 
                 if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -33,15 +33,12 @@ namespace AZ
         Data::Instance<Material> Material::FindOrCreate(const Data::Asset<MaterialAsset>& materialAsset)
         {
             return Data::InstanceDatabase<Material>::Instance().FindOrCreate(
-                Data::InstanceId::CreateFromAssetId(materialAsset.GetId()),
-                materialAsset);
+                Data::InstanceId::CreateFromAsset(materialAsset), materialAsset);
         }
 
         Data::Instance<Material> Material::Create(const Data::Asset<MaterialAsset>& materialAsset)
         {
-            return Data::InstanceDatabase<Material>::Instance().FindOrCreate(
-                Data::InstanceId::CreateRandom(),
-                materialAsset);
+            return Data::InstanceDatabase<Material>::Instance().FindOrCreate(Data::InstanceId::CreateRandom(), materialAsset);
         }
 
         AZ::Data::Instance<Material> Material::CreateInternal(MaterialAsset& materialAsset)
@@ -252,9 +249,7 @@ namespace AZ
         {
             ShaderReloadDebugTracker::ScopedSection reloadSection("{%p}->Material::OnAssetReloaded %s", this, asset.GetHint().c_str());
 
-            Data::Asset<MaterialAsset> newMaterialAsset = Data::static_pointer_cast<MaterialAsset>(asset);
-
-            if (newMaterialAsset)
+            if (Data::Asset<MaterialAsset> newMaterialAsset = asset)
             {
                 Init(*newMaterialAsset);
                 MaterialReloadNotificationBus::Event(newMaterialAsset.GetId(), &MaterialReloadNotifications::OnMaterialReinitialized, this);


### PR DESCRIPTION
## What does this PR do?
This PR attempts to address issues with material related workflows, hot reloading, material editor and canvas.

The material system and builder provide user settings to control whether materials and their connections to material types are fully baked in the AP or when the assets are loaded in the editor/game. These settings also control asset dependencies between materials and material types. This can help preview times while making iterative changes to shaders and material types because it stops the AP from rebuilding all of the materials and models that reference the modified assets. However, it also breaks the expected dependencies between materials and material types, leading to atypical handling of material related assets, requiring manual dependency tracking, and prevents asset system notifications from being sent for materials when those dependencies change. Special hot reloading handling was implemented in the material asset, material type asset, and material instance classes but they require holding on to an instance. The material editor, material canvas, material component, material component instance inspector, and material thumbnails/previews require normal asset system notifications to update properly.

The material builder provides an additional setting that will generate material source files that have a complete list of all properties and default values. This was implemented to help technical artists enumerate all of the properties for their scripts. The settings being disabled by default and should be enabled by any artist or user that requires the extra data.

The instance database instance ID was updated with a new member, constructor, and create function that includes the asset data pointer as part of the ID. This will allow systems that manage their own assets to create a new instance whenever one of their managed assets changes. This is currently only being used in the material instance database.

https://github.com/o3de/o3de/pull/11325

Signed-off-by: Guthrie Adams <guthadam@amazon.com>

## How was this PR tested?

Testing with material editor autosave and hot reloading, material canvas previews updating, asset browser thumbnails updating
ASV tests past except for shader hot reload tests with subtle image differences, which were failing prior to these changes.