### PR TITLE
Move MSVC-only flags to the Configurations_msvc file

### DIFF
--- a/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
@@ -158,3 +158,13 @@ else()
 endif()
 
 include(cmake/Platform/Common/TargetIncludeSystemDirectories_unsupported.cmake)
+
+if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS_EQUAL "10.0.19041.0")
+  # Suppresses warning C5105 which triggers with Windows 10 SDK 10.0.19041 and below when using the /Zc:preprocessor option
+  # https://developercommunity.visualstudio.com/t/stdc17-generates-warning-compiling-windowsh/1249671
+  ly_append_configurations_options(
+        COMPILATION
+            /wd5104
+            /wd5105
+    )
+endif()

--- a/cmake/Platform/Windows/Configurations_windows.cmake
+++ b/cmake/Platform/Windows/Configurations_windows.cmake
@@ -113,13 +113,3 @@ endif()
 if(NOT CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION MATCHES "10.0")
     message(FATAL_ERROR "Unsupported version of Windows SDK ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}, specify \"-DCMAKE_SYSTEM_VERSION=10.0\" when invoking cmake")
 endif()
-
-if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS_EQUAL "10.0.19041.0")
-  # Suppresses warning C5105 which triggers with Windows 10 SDK 10.0.19041 and below when using the /Zc:preprocessor option
-  # https://developercommunity.visualstudio.com/t/stdc17-generates-warning-compiling-windowsh/1249671
-  ly_append_configurations_options(
-        COMPILATION
-            -wd5104
-            -wd5105
-    )
-endif()


### PR DESCRIPTION
This moves command line flags that only apply to MSVC into the right place.

Signed-off-by: Chris Burel <burelc@amazon.com>