### PR TITLE
Added support for Shape Reference node

### DIFF
--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -104,6 +104,7 @@
 #include <Editor/Nodes/Shapes/CylinderShapeNode.h>
 #include <Editor/Nodes/Shapes/DiskShapeNode.h>
 #include <Editor/Nodes/Shapes/PolygonPrismShapeNode.h>
+#include <Editor/Nodes/Shapes/ReferenceShapeNode.h>
 #include <Editor/Nodes/Shapes/SphereShapeNode.h>
 #include <Editor/Nodes/Shapes/TubeShapeNode.h>
 #include <Editor/Nodes/UI/GradientPreviewThumbnailItem.h>
@@ -384,6 +385,7 @@ namespace LandscapeCanvasEditor
         REGISTER_NODE_PALETTE_ITEM(shapeCategory, CylinderShapeNode, editorId);
         REGISTER_NODE_PALETTE_ITEM(shapeCategory, DiskShapeNode, editorId);
         REGISTER_NODE_PALETTE_ITEM(shapeCategory, PolygonPrismShapeNode, editorId);
+        REGISTER_NODE_PALETTE_ITEM(shapeCategory, ReferenceShapeNode, editorId);
         REGISTER_NODE_PALETTE_ITEM(shapeCategory, SphereShapeNode, editorId);
         REGISTER_NODE_PALETTE_ITEM(shapeCategory, TubeShapeNode, editorId);
 

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/ReferenceShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/ReferenceShapeNode.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <QObject>
+
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+#include <GraphModel/Integration/Helpers.h>
+#include <GraphModel/Model/Slot.h>
+
+#include "ReferenceShapeNode.h"
+#include <Editor/Core/Core.h>
+#include <Editor/Core/GraphContext.h>
+#include <Editor/Nodes/Shapes/BaseShapeNode.h>
+
+namespace LandscapeCanvas
+{
+    void ReferenceShapeNode::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<ReferenceShapeNode, BaseNode>()
+                ->Version(0)
+                ;
+
+            if (auto editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<ReferenceShapeNode>("ReferenceShapeNode", "")->
+                    ClassElement(AZ::Edit::ClassElements::EditorData, "")->
+                    Attribute(GraphModelIntegration::Attributes::TitlePaletteOverride, "ShapeNodeTitlePalette")
+                    ;
+            }
+        }
+    }
+
+    const QString ReferenceShapeNode::TITLE = QObject::tr("Shape Reference");
+
+    ReferenceShapeNode::ReferenceShapeNode(GraphModel::GraphPtr graph)
+        : BaseNode(graph)
+    {
+        RegisterSlots();
+        CreateSlotData();
+    }
+
+    const char* ReferenceShapeNode::GetTitle() const
+    {
+        return TITLE.toUtf8().constData();
+    }
+
+    const char* ReferenceShapeNode::GetSubTitle() const
+    {
+        return BaseShapeNode::SHAPE_CATEGORY_TITLE.toUtf8().constData();
+    }
+
+    const BaseNode::BaseNodeType ReferenceShapeNode::GetBaseNodeType() const
+    {
+        return BaseNode::Shape;
+    }
+
+    void ReferenceShapeNode::RegisterSlots()
+    {
+        CreateEntityNameSlot();
+
+        GraphModel::DataTypePtr boundsDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Bounds);
+
+        RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
+            INBOUND_SHAPE_SLOT_ID,
+            INBOUND_SHAPE_SLOT_LABEL.toUtf8().constData(),
+            { boundsDataType },
+            AZStd::any(AZ::EntityId()),
+            INBOUND_SHAPE_INPUT_SLOT_DESCRIPTION.toUtf8().constData()));
+
+        RegisterSlot(GraphModel::SlotDefinition::CreateOutputData(
+            BaseShapeNode::BOUNDS_SLOT_ID,
+            BaseShapeNode::BOUNDS_SLOT_LABEL.toUtf8().constData(),
+            boundsDataType,
+            BaseShapeNode::BOUNDS_OUTPUT_SLOT_DESCRIPTION.toUtf8().constData()));
+    }
+} // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/ReferenceShapeNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/ReferenceShapeNode.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Editor/Nodes/BaseNode.h>
+
+namespace LandscapeCanvas
+{
+    class ReferenceShapeNode : public BaseNode
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(ReferenceShapeNode, AZ::SystemAllocator, 0);
+        AZ_RTTI(ReferenceShapeNode, "{DD8E2150-A80C-4740-9EA5-26B7BC3C1993}", BaseNode);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        ReferenceShapeNode() = default;
+        explicit ReferenceShapeNode(GraphModel::GraphPtr graph);
+
+        static const QString TITLE;
+        const char* GetTitle() const override;
+        const char* GetSubTitle() const override;
+        const BaseNodeType GetBaseNodeType() const override;
+
+    protected:
+        void RegisterSlots() override;
+    };
+}

--- a/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.cpp
@@ -21,6 +21,7 @@
 #include <LmbrCentral/Shape/CylinderShapeComponentBus.h>
 #include <LmbrCentral/Shape/DiskShapeComponentBus.h>
 #include <LmbrCentral/Shape/PolygonPrismShapeComponentBus.h>
+#include <LmbrCentral/Shape/ReferenceShapeComponentBus.h>
 #include <LmbrCentral/Shape/SphereShapeComponentBus.h>
 #include <LmbrCentral/Shape/TubeShapeComponentBus.h>
 
@@ -74,6 +75,7 @@
 #include <Editor/Nodes/Shapes/CylinderShapeNode.h>
 #include <Editor/Nodes/Shapes/DiskShapeNode.h>
 #include <Editor/Nodes/Shapes/PolygonPrismShapeNode.h>
+#include <Editor/Nodes/Shapes/ReferenceShapeNode.h>
 #include <Editor/Nodes/Shapes/SphereShapeNode.h>
 #include <Editor/Nodes/Shapes/TubeShapeNode.h>
 
@@ -139,6 +141,7 @@ namespace LandscapeCanvas
     VISITOR_FUNCTION<CylinderShapeNode>(LmbrCentral::EditorCylinderShapeComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<DiskShapeNode>(LmbrCentral::EditorDiskShapeComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<PolygonPrismShapeNode>(LmbrCentral::EditorPolygonPrismShapeComponentTypeId, ##__VA_ARGS__);     \
+    VISITOR_FUNCTION<ReferenceShapeNode>(LmbrCentral::EditorReferenceShapeComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<SphereShapeNode>(LmbrCentral::EditorSphereShapeComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<TubeShapeNode>(LmbrCentral::EditorTubeShapeComponentTypeId, ##__VA_ARGS__);     \
     /* Gradient generator nodes */    \

--- a/Gems/LandscapeCanvas/Code/landscapecanvas_editor_static_files.cmake
+++ b/Gems/LandscapeCanvas/Code/landscapecanvas_editor_static_files.cmake
@@ -116,6 +116,8 @@ set(FILES
     Source/Editor/Nodes/Shapes/DiskShapeNode.h
     Source/Editor/Nodes/Shapes/PolygonPrismShapeNode.cpp
     Source/Editor/Nodes/Shapes/PolygonPrismShapeNode.h
+    Source/Editor/Nodes/Shapes/ReferenceShapeNode.cpp
+    Source/Editor/Nodes/Shapes/ReferenceShapeNode.h
     Source/Editor/Nodes/Shapes/SphereShapeNode.cpp
     Source/Editor/Nodes/Shapes/SphereShapeNode.h
     Source/Editor/Nodes/Shapes/TubeShapeNode.cpp


### PR DESCRIPTION
## What does this PR do?

Added Landscape Canvas support for the `Shape Reference` node. This shape node is unique in that it takes an input shape bounds which is what it forwards on as its shape bounds to other listeners.

![ShapeReferenceNode](https://user-images.githubusercontent.com/7519264/185197977-79a056fe-6b71-4858-a91e-1bf4617db845.gif)

## How was this PR tested?

Tested created and graphing existing entities with the Shape Reference component. Verified changing the inbounds shape connections in the graph resulted in the appropriate input shape being referenced by listeners.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>