### PR TITLE
{lyn14636} switching script buses to Automation

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Containers/Scene.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/Scene.cpp
@@ -113,7 +113,7 @@ namespace AZ
                 if (behaviorContext)
                 {
                     behaviorContext->Class<Scene>()
-                        ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                        ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
                         ->Attribute(AZ::Script::Attributes::Module, "scene")
                         ->Constructor<const AZStd::string&>()
                         ->Property("name", BehaviorValueGetter(&Scene::m_name), nullptr)

--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
@@ -64,7 +64,7 @@ namespace AZ
                 if (auto* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
                 {
                     behaviorContext->Class<ExportProduct>("ExportProduct")
-                        ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                        ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
                         ->Attribute(AZ::Script::Attributes::Module, "scene")
                         ->Property("filename", BehaviorValueProperty(&ExportProduct::m_filename))
                         ->Property("sourceId", BehaviorValueProperty(&ExportProduct::m_id))
@@ -75,7 +75,7 @@ namespace AZ
                             [](ExportProduct* self, u32 subId) { self->m_subId = AZStd::optional<u32>(subId); });
 
                     behaviorContext->Class<ExportProductList>("ExportProductList")
-                        ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                        ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
                         ->Attribute(AZ::Script::Attributes::Module, "scene")
                         ->Method("AddProduct", [](ExportProductList& self, ExportProduct& product)
                         {

--- a/Code/Tools/SceneAPI/SceneCore/Mocks/MockBehaviorUtils.h
+++ b/Code/Tools/SceneAPI/SceneCore/Mocks/MockBehaviorUtils.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzTest/AzTest.h>
+#include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/RTTI/ReflectionManager.h>
+#include <AzCore/Script/ScriptContextAttributes.h>
+
+namespace UnitTest
+{
+    void ScopeForUnitTest(AZ::AttributeArray& attributes)
+    {
+        using namespace AZ::Script;
+        attributes.erase(AZStd::remove_if(attributes.begin(), attributes.end(), [](const AZ::AttributePair& pair)
+            {
+                return pair.first == Attributes::Scope;
+            }));
+        auto* attributeData = aznew AZ::AttributeData<Attributes::ScopeFlags>(Attributes::ScopeFlags::Common);
+        attributes.push_back(AZStd::make_pair(Attributes::Scope, attributeData));
+    }
+}

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
@@ -22,6 +22,7 @@
 #include <SceneAPI/SceneCore/Containers/SceneGraph.h>
 #include <SceneAPI/SceneCore/DataTypes/IGraphObject.h>
 #include <SceneAPI/SceneCore/Mocks/DataTypes/MockIGraphObject.h>
+#include <SceneAPI/SceneCore/Mocks/MockBehaviorUtils.h>
 
 // the DLL entry point for SceneCore to reflect its behavior context
 extern "C" AZ_DLL_EXPORT void ReflectBehavior(AZ::BehaviorContext* context);
@@ -487,6 +488,9 @@ namespace AZ::SceneAPI::Containers
             ReflectBehavior(m_behaviorContext.get());
             ReflectTestTypes(m_behaviorContext.get());
             MockBuilder::Reflect(m_behaviorContext.get());
+            UnitTest::ScopeForUnitTest(m_behaviorContext->m_classes.find("Scene")->second->m_attributes);
+            UnitTest::ScopeForUnitTest(m_behaviorContext->m_classes.find("ExportProduct")->second->m_attributes);
+            UnitTest::ScopeForUnitTest(m_behaviorContext->m_classes.find("ExportProductList")->second->m_attributes);
 
             m_scriptContext = AZStd::make_unique<AZ::ScriptContext>();
             m_scriptContext->BindTo(m_behaviorContext.get());
@@ -763,6 +767,9 @@ namespace AZ::SceneAPI::Containers
             MockBuilder::Reflect(m_behaviorContext.get());
             MockManifestRule::Reflect(m_behaviorContext.get());
             ReflectBehavior(m_behaviorContext.get());
+            UnitTest::ScopeForUnitTest(m_behaviorContext->m_classes.find("Scene")->second->m_attributes);
+            UnitTest::ScopeForUnitTest(m_behaviorContext->m_classes.find("ExportProduct")->second->m_attributes);
+            UnitTest::ScopeForUnitTest(m_behaviorContext->m_classes.find("ExportProductList")->second->m_attributes);
 
             m_jsonRegistrationContext = AZStd::make_unique<AZ::JsonRegistrationContext>();
             AZ::JsonSystemComponent::Reflect(m_jsonRegistrationContext.get());

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneGraphTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneGraphTests.cpp
@@ -14,7 +14,6 @@
 #include <SceneAPI/SceneCore/DataTypes/IGraphObject.h>
 #include <SceneAPI/SceneCore/Mocks/DataTypes/MockIGraphObject.h>
 
-
 namespace AZ
 {
     namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneCore/scenecore_testing_files.cmake
+++ b/Code/Tools/SceneAPI/SceneCore/scenecore_testing_files.cmake
@@ -7,6 +7,7 @@
 #
 
 set(FILES
+    Mocks/MockBehaviorUtils.h
     Mocks/Containers/MockScene.h
     Mocks/DataTypes/GraphData/MockIMeshData.h
     Mocks/DataTypes/MockIGraphObject.h

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
@@ -141,7 +141,7 @@ namespace AZ::SceneAPI::Behaviors
             if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
             {
                 behaviorContext->EBus<ScriptBuildingNotificationBus>("ScriptBuildingNotificationBus")
-                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
                     ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
                     ->Attribute(AZ::Script::Attributes::Module, "scene")
                     ->Handler<ScriptBuildingNotificationBusHandler>(&ScriptBuildingNotificationBusHandler::Create, &ScriptBuildingNotificationBusHandler::Destroy)

--- a/Code/Tools/SceneAPI/SceneData/Tests/SceneManifest/SceneScriptRuleTests.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Tests/SceneManifest/SceneScriptRuleTests.cpp
@@ -16,12 +16,15 @@
 #include <SceneAPI/SceneData/Rules/CoordinateSystemRule.h>
 #include <SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.h>
 #include <SceneAPI/SceneCore/Events/ExportProductList.h>
+#include <SceneAPI/SceneCore/Mocks/MockBehaviorUtils.h>
 
 #include <AzCore/Math/MathReflection.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Name/NameDictionary.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/RTTI/ReflectionManager.h>
+#include <AzCore/Script/ScriptContextAttributes.h>
 #include <AzCore/Serialization/Json/JsonSystemComponent.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
@@ -81,10 +84,11 @@ namespace Testing
             m_behaviorContext->Method("TestExpectTrue", &TestExpectTrue);
             m_behaviorContext->Method("TestEqualNumbers", &TestEqualNumbers);
             m_behaviorContext->Method("TestEqualStrings", &TestEqualStrings);
+            UnitTest::ScopeForUnitTest(m_behaviorContext->m_classes.find("Scene")->second->m_attributes);
+            UnitTest::ScopeForUnitTest(m_behaviorContext->m_ebuses.find("ScriptBuildingNotificationBus")->second->m_attributes);
 
             m_scriptContext = AZStd::make_unique<AZ::ScriptContext>();
             m_scriptContext->BindTo(m_behaviorContext.get());
-
 
             using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
 


### PR DESCRIPTION
## What does this PR do?

Some EBuses are currently scoped to Common which causes the Lua script context to inspect and assert around data types that are not properly set up for Lua scripting. These errors and asserts are improperly logged during asset pipeline builds; this leads to confusion. Since the EBuses are only meant for Python automation they will be changed to Automation.

* from ScopeFlags::Common to ScopeFlags::Automation
* using UnitTest::ScopeForUnitTest() to fix up unit tests

## How was this PR tested?

Fixed the unit tests in SceneCore and SceneData.
