### PR TITLE
Removing default image pool budget caps. Each projects may overwrite …

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/HeapAllocator.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/HeapAllocator.cpp
@@ -51,6 +51,7 @@ namespace AZ
             RHI::HeapMemoryUsage* heapMemoryUsage = m_descriptor.m_getHeapMemoryUsageFunction();
             if (!heapMemoryUsage->CanAllocate(m_descriptor.m_pageSizeInBytes))
             {
+                AZ_Warning("HeapFactory", false, "Heap allocation failed: reach the memory budget");
                 return nullptr;
             }
            
@@ -65,6 +66,7 @@ namespace AZ
                 return heap.Get();
             }
 
+            AZ_Warning("HeapFactory", false, "Heap allocation failed: failed to create a dx12 heap");
             return nullptr;
         }
 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/TileAllocator.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/TileAllocator.cpp
@@ -96,7 +96,7 @@ namespace AZ
                     if (!heap)
                     {
                         // Return directly if we can't create more heaps
-                        AZ_Error("TileAllocator", false, "Failed to create a heap page");
+                        AZ_Warning("TileAllocator", false, "Failed to create a heap page");
                         return tilesList;
                     }
 

--- a/Gems/Atom/RPI/Registry/atom_rpi.setreg
+++ b/Gems/Atom/RPI/Registry/atom_rpi.setreg
@@ -5,9 +5,9 @@
                 "Initialization": {
                     "CommonSrgsShaderAssetPath": "shaders/sceneandviewsrgs.azshader",
                     "ImageSystemDescriptor": {
-                        "AssetStreamingImagePoolSize": 2147483648, // 2 * 1024 * 1024 * 1024
+                        "AssetStreamingImagePoolSize": 0,
                         "SystemStreamingImagePoolSize": 134217728, // 128 * 1024 * 1024
-                        "SystemAttachmentImagePoolSize": 536870912 // 512 * 1024 * 1024
+                        "SystemAttachmentImagePoolSize": 0 
                     },
                     "GpuQuerySystemDescriptor": {
                         "OcclusionQueryCount": 128,

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -336,10 +336,15 @@ namespace AZ::Render
         float imagePoolUsedAllocatedMB = static_cast<float>(imagePoolMemoryUsage.m_usedResidentInBytes) / MB;
         float imagePoolTotalAllocatedMB = static_cast<float>(imagePoolMemoryUsage.m_totalResidentInBytes) / MB;
         float imagePoolBudgetMB = static_cast<float>(imagePoolMemoryUsage.m_budgetInBytes) / MB;
+        AZ::Color fontColor = AZ::Colors::White;
+        if (imagePoolTotalAllocatedMB > 0.99f * imagePoolBudgetMB && imagePoolBudgetMB > 0)
+        {
+            fontColor = AZ::Colors::Red;
+        }
 
         DrawLine(
-            AZStd::string::format("RPI AssetStreamingImagePool (used/total): %.2f / %.2f MiB", imagePoolUsedAllocatedMB, imagePoolTotalAllocatedMB),
-            (imagePoolTotalAllocatedMB > 0.99f * imagePoolBudgetMB) ? AZ::Colors::Red : AZ::Colors::White
+            AZStd::string::format("RPI AssetStreamingImagePool (used/allocated/budget): %.2f / %.2f/%.2f MiB", imagePoolUsedAllocatedMB, imagePoolTotalAllocatedMB, imagePoolBudgetMB),
+            fontColor
         );
     }
 


### PR DESCRIPTION
…the budget values based on their needs.

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>

## What does this PR do?

Removing default image pool budget caps for default asset streaming image pool and attachment image pool. 
Update the memory usage display for streaming image pool

## How was this PR tested?

Open loft level in Editor
