### PR TITLE
Fix a leak within Vulkan backend

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferMemoryPageAllocator.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferMemoryPageAllocator.cpp
@@ -37,26 +37,20 @@ namespace AZ
             bufferDescriptor.m_sharedQueueMask = m_descriptor.m_sharedQueueMask;
             bufferDescriptor.m_bindFlags = m_descriptor.m_bindFlags;
 
-            VkBuffer vkBuffer = GetDevice().CreateBufferResouce(bufferDescriptor);
-            VkMemoryRequirements memoryRequirements = {};
-            GetDevice().GetContext().GetBufferMemoryRequirements(GetDevice().GetNativeDevice(), vkBuffer, &memoryRequirements);
-
+            VkMemoryRequirements memoryRequirements = GetDevice().GetBufferMemoryRequirements(bufferDescriptor);
             RHI::HeapMemoryUsage& heapMemoryUsage = *m_descriptor.m_getHeapMemoryUsageFunction();
             if (!heapMemoryUsage.TryReserveMemory(memoryRequirements.size))
             {
-                GetDevice().DestroyBufferResource(vkBuffer);
                 return nullptr;
             }
 
             AZ_PROFILE_SCOPE(RHI, "Create BufferMemory Page");
 
             RHI::Ptr<BufferMemory> bufferMemory;
-
             const VkMemoryPropertyFlags flags = ConvertHeapMemoryLevel(m_descriptor.m_heapMemoryLevel) | m_descriptor.m_additionalMemoryPropertyFlags;
             RHI::Ptr<Memory> memory = GetDevice().AllocateMemory(memoryRequirements.size, memoryRequirements.memoryTypeBits, flags, m_descriptor.m_bindFlags);
             if (memory)
             {
-                
                 bufferMemory = BufferMemory::Create();
                 RHI::ResultCode result = bufferMemory->Init(GetDevice(), MemoryView(memory, 0, memoryRequirements.size, 0, MemoryAllocationType::Unique), bufferDescriptor);
                 if (result != RHI::ResultCode::Success)
@@ -72,7 +66,6 @@ namespace AZ
             }
             else
             {
-                GetDevice().DestroyBufferResource(vkBuffer);
                 heapMemoryUsage.m_reservedInBytes -= memoryRequirements.size;
             }
 


### PR DESCRIPTION
Signed-off-by: moudgils <47460854+moudgils@users.noreply.github.com>

## What does this PR do?

Fix a leak related to not deleting the VkBuffer after checking for it's memory requirements. It does this by removing the manual creation and destruction(incorrectly) of the VkBuffer and instead calling the Device::GetBufferMemoryRequirements which handles caching as well as creation/destruction of the VkBuffer properly. 

## How was this PR tested?

Tested by running full test suite (modified slightly) on pc using vulkan backend 
