### PR TITLE
Fix bugs with the Error icon on the Asset Picker Widget.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -618,6 +618,7 @@ namespace AzToolsFramework
 
     void PropertyAssetCtrl::ClearAssetInternal()
     {
+        ClearErrorButton();
         SetCurrentAssetHint(AZStd::string());
         SetSelectedAssetID(AZ::Data::AssetId());
         // To clear the asset we only need to refresh the values.
@@ -1074,6 +1075,17 @@ namespace AzToolsFramework
                             ClearErrorButton();
                         }
                         break;
+                    }
+                }
+                else
+                {
+                    // If there aren't any jobs and the asset ID is valid, the asset must have been removed.
+                    if (assetID.IsValid())
+                    {
+                        UpdateErrorButtonWithMessage(AZStd::string::format(
+                            "Asset has been removed.\n\nID: %s\nHint:%s",
+                            assetID.ToString<AZStd::string>().c_str(),
+                            GetCurrentAssetHint().c_str()));
                     }
                 }
 


### PR DESCRIPTION
## What does this PR do?
This fixes some Asset Picker Widget error states. 
* If an asset is removed while the widget is active, it now displays an error icon showing that it has been removed. (Previously, you had to restart the Editor to get the error icon)
* If the asset reference is cleared while the error icon is shown, the error icon is now cleared. (Previously, the error icon remained)

Closes #11346 .

## How was this PR tested?

Ran through the repro steps on #11346 .
