### PR TITLE
Removed a couple of "chatty" profile markers.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetDataStream.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetDataStream.cpp
@@ -272,7 +272,6 @@ namespace AZ::Data
 
     void AssetDataStream::Seek(AZ::IO::OffsetType bytes, AZ::IO::GenericStream::SeekMode mode)
     {
-        AZ_PROFILE_FUNCTION(AzCore);
         AZ::IO::OffsetType requestedOffset = 0;
 
         switch (mode)
@@ -302,7 +301,6 @@ namespace AZ::Data
 
     AZ::IO::SizeType AssetDataStream::Read(AZ::IO::SizeType bytes, void* oBuffer)
     {
-        AZ_PROFILE_FUNCTION(AzCore);
         if (m_curOffset >= m_loadedSize)
         {
             return 0;

--- a/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
@@ -800,8 +800,6 @@ namespace AZ
                 // Serializable leaf element.
                 else if (classData->m_serializer)
                 {
-                    AZ_PROFILE_SCOPE(AzCore, "ObjectStreamImpl::LoadClass Load");
-
                     // Wrap the stream
                     IO::GenericStream* currentStream = &m_inStream;
                     IO::MemoryStream memStream(m_inStream.GetData()->data(), 0, element.m_dataSize);


### PR DESCRIPTION
## What does this PR do?

This removes the profile markers from AssetDataStream::Read and Seek, and from ObjectStreamImpl::LoadClass. These methods can get called potentially on a byte-by-byte basis when serializing in assets, which makes the overhead of the markers far greater than the value they provide.

These markers were previously added when using a different profiling system, where the markers consumed far less overhead. They now consume more overhead, making these markers relatively expensive without being useful.

## How was this PR tested?

Ran PIX and verified that the markers no longer show up.

Before:
![image](https://user-images.githubusercontent.com/82224783/185258924-9a7816fe-5d4f-42f1-806c-c26cd8697f82.png)
![image](https://user-images.githubusercontent.com/82224783/185259009-506dc7b7-8c4c-4f6b-9d76-44e453db39d5.png)

After:
![image](https://user-images.githubusercontent.com/82224783/185259293-e0968658-cef3-41aa-8235-4bd409514728.png)
![image](https://user-images.githubusercontent.com/82224783/185259524-79d7dcef-84e2-4be2-bbf0-4d4a8febbee6.png)
