### PR TITLE
Add several unit tests for NetworkEntity in Multiplayer Gem

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetBindComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetBindComponent.h
@@ -216,6 +216,7 @@ namespace Multiplayer
         friend class HierarchyTests;
         friend class HierarchyBenchmarkBase;
         friend class MultiplayerSystemTests;
+        friend class NetworkEntityTests;
     };
 
     bool NetworkRoleHasController(NetEntityRole networkRole);

--- a/Gems/Multiplayer/Code/Include/Multiplayer/NetworkEntity/NetworkEntityUpdateMessage.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/NetworkEntity/NetworkEntityUpdateMessage.h
@@ -55,8 +55,8 @@ namespace Multiplayer
         //! @return the current value of NetworkRole
         NetEntityRole GetNetworkRole() const;
 
-        //! Gets the entities networkId.
-        //! @return the entities networkId
+        //! Gets the entity's networkId.
+        //! @return the entity's networkId
         NetEntityId GetEntityId() const;
 
         //! Gets the current value of IsDelete (true if this represents a DeleteProxy message).

--- a/Gems/Multiplayer/Code/Source/MultiplayerStats.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerStats.cpp
@@ -58,7 +58,7 @@ namespace Multiplayer
         else
         {
             AZ_Warning("MultiplayerStats", false,
-                "Component ID %u has fewer than %u propertyIndex. Mismatch by caller suspected.", netComponentIndex, propertyIndex);
+                "Component ID %u has fewer than %u sent propertyIndex. Mismatch by caller suspected.", netComponentIndex, propertyIndex);
         }
 
         m_events.m_propertySent.Signal(netComponentId, propertyId, totalBytes);
@@ -78,7 +78,7 @@ namespace Multiplayer
         else
         {
             AZ_Warning("MultiplayerStats", false,
-                "Component ID %u has fewer than %u propertyIndex. Mismatch by caller suspected.", netComponentIndex, propertyIndex);
+                "Component ID %u has fewer than %u receive propertyIndex. Mismatch by caller suspected.", netComponentIndex, propertyIndex);
         }
 
         m_events.m_propertyReceived.Signal(netComponentId, propertyId, totalBytes);
@@ -99,7 +99,7 @@ namespace Multiplayer
         else
         {
             AZ_Warning("MultiplayerStats", false,
-                "Component ID %u has fewer than %u rpcIndex. Mismatch by caller suspected.", netComponentIndex, rpcIndex);
+                "Component ID %u has fewer than %u sent rpcIndex. Mismatch by caller suspected.", netComponentIndex, rpcIndex);
         }
 
         m_events.m_rpcSent.Signal(entityId, entityName, netComponentId, rpcId, totalBytes);
@@ -119,7 +119,7 @@ namespace Multiplayer
         else
         {
             AZ_Warning("MultiplayerStats", false,
-                "Component ID %u has fewer than %u rpcIndex. Mismatch by caller suspected.", netComponentIndex, rpcIndex);
+                "Component ID %u has fewer than %u receive rpcIndex. Mismatch by caller suspected.", netComponentIndex, rpcIndex);
         }
 
         m_events.m_rpcReceived.Signal(entityId, entityName, netComponentId, rpcId, totalBytes);

--- a/Gems/Multiplayer/Code/Source/MultiplayerStats.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerStats.cpp
@@ -48,10 +48,18 @@ namespace Multiplayer
     {
         const uint16_t netComponentIndex = aznumeric_cast<uint16_t>(netComponentId);
         const uint16_t propertyIndex = aznumeric_cast<uint16_t>(propertyId);
-        m_componentStats[netComponentIndex].m_propertyUpdatesSent[propertyIndex].m_totalCalls++;
-        m_componentStats[netComponentIndex].m_propertyUpdatesSent[propertyIndex].m_totalBytes += totalBytes;
-        m_componentStats[netComponentIndex].m_propertyUpdatesSent[propertyIndex].m_callHistory[m_recordMetricIndex]++;
-        m_componentStats[netComponentIndex].m_propertyUpdatesSent[propertyIndex].m_byteHistory[m_recordMetricIndex] += totalBytes;
+        if (m_componentStats[netComponentIndex].m_propertyUpdatesSent.size() > propertyIndex)
+        {
+            m_componentStats[netComponentIndex].m_propertyUpdatesSent[propertyIndex].m_totalCalls++;
+            m_componentStats[netComponentIndex].m_propertyUpdatesSent[propertyIndex].m_totalBytes += totalBytes;
+            m_componentStats[netComponentIndex].m_propertyUpdatesSent[propertyIndex].m_callHistory[m_recordMetricIndex]++;
+            m_componentStats[netComponentIndex].m_propertyUpdatesSent[propertyIndex].m_byteHistory[m_recordMetricIndex] += totalBytes;
+        }
+        else
+        {
+            AZ_Warning("MultiplayerStats", false,
+                "Component ID %u has fewer than %u propertyIndex. Mismatch by caller suspected.", netComponentIndex, propertyIndex);
+        }
 
         m_events.m_propertySent.Signal(netComponentId, propertyId, totalBytes);
     }
@@ -60,10 +68,18 @@ namespace Multiplayer
     {
         const uint16_t netComponentIndex = aznumeric_cast<uint16_t>(netComponentId);
         const uint16_t propertyIndex = aznumeric_cast<uint16_t>(propertyId);
-        m_componentStats[netComponentIndex].m_propertyUpdatesRecv[propertyIndex].m_totalCalls++;
-        m_componentStats[netComponentIndex].m_propertyUpdatesRecv[propertyIndex].m_totalBytes += totalBytes;
-        m_componentStats[netComponentIndex].m_propertyUpdatesRecv[propertyIndex].m_callHistory[m_recordMetricIndex]++;
-        m_componentStats[netComponentIndex].m_propertyUpdatesRecv[propertyIndex].m_byteHistory[m_recordMetricIndex] += totalBytes;
+        if (m_componentStats[netComponentIndex].m_propertyUpdatesRecv.size() > propertyIndex)
+        {
+            m_componentStats[netComponentIndex].m_propertyUpdatesRecv[propertyIndex].m_totalCalls++;
+            m_componentStats[netComponentIndex].m_propertyUpdatesRecv[propertyIndex].m_totalBytes += totalBytes;
+            m_componentStats[netComponentIndex].m_propertyUpdatesRecv[propertyIndex].m_callHistory[m_recordMetricIndex]++;
+            m_componentStats[netComponentIndex].m_propertyUpdatesRecv[propertyIndex].m_byteHistory[m_recordMetricIndex] += totalBytes;
+        }
+        else
+        {
+            AZ_Warning("MultiplayerStats", false,
+                "Component ID %u has fewer than %u propertyIndex. Mismatch by caller suspected.", netComponentIndex, propertyIndex);
+        }
 
         m_events.m_propertyReceived.Signal(netComponentId, propertyId, totalBytes);
     }
@@ -72,10 +88,19 @@ namespace Multiplayer
     {
         const uint16_t netComponentIndex = aznumeric_cast<uint16_t>(netComponentId);
         const uint16_t rpcIndex = aznumeric_cast<uint16_t>(rpcId);
-        m_componentStats[netComponentIndex].m_rpcsSent[rpcIndex].m_totalCalls++;
-        m_componentStats[netComponentIndex].m_rpcsSent[rpcIndex].m_totalBytes += totalBytes;
-        m_componentStats[netComponentIndex].m_rpcsSent[rpcIndex].m_callHistory[m_recordMetricIndex]++;
-        m_componentStats[netComponentIndex].m_rpcsSent[rpcIndex].m_byteHistory[m_recordMetricIndex] += totalBytes;
+
+        if (m_componentStats[netComponentIndex].m_rpcsSent.size() > rpcIndex)
+        {
+            m_componentStats[netComponentIndex].m_rpcsSent[rpcIndex].m_totalCalls++;
+            m_componentStats[netComponentIndex].m_rpcsSent[rpcIndex].m_totalBytes += totalBytes;
+            m_componentStats[netComponentIndex].m_rpcsSent[rpcIndex].m_callHistory[m_recordMetricIndex]++;
+            m_componentStats[netComponentIndex].m_rpcsSent[rpcIndex].m_byteHistory[m_recordMetricIndex] += totalBytes;
+        }
+        else
+        {
+            AZ_Warning("MultiplayerStats", false,
+                "Component ID %u has fewer than %u rpcIndex. Mismatch by caller suspected.", netComponentIndex, rpcIndex);
+        }
 
         m_events.m_rpcSent.Signal(entityId, entityName, netComponentId, rpcId, totalBytes);
     }
@@ -84,10 +109,18 @@ namespace Multiplayer
     {
         const uint16_t netComponentIndex = aznumeric_cast<uint16_t>(netComponentId);
         const uint16_t rpcIndex = aznumeric_cast<uint16_t>(rpcId);
-        m_componentStats[netComponentIndex].m_rpcsRecv[rpcIndex].m_totalCalls++;
-        m_componentStats[netComponentIndex].m_rpcsRecv[rpcIndex].m_totalBytes += totalBytes;
-        m_componentStats[netComponentIndex].m_rpcsRecv[rpcIndex].m_callHistory[m_recordMetricIndex]++;
-        m_componentStats[netComponentIndex].m_rpcsRecv[rpcIndex].m_byteHistory[m_recordMetricIndex] += totalBytes;
+        if (m_componentStats[netComponentIndex].m_rpcsRecv.size() > rpcIndex)
+        {
+            m_componentStats[netComponentIndex].m_rpcsRecv[rpcIndex].m_totalCalls++;
+            m_componentStats[netComponentIndex].m_rpcsRecv[rpcIndex].m_totalBytes += totalBytes;
+            m_componentStats[netComponentIndex].m_rpcsRecv[rpcIndex].m_callHistory[m_recordMetricIndex]++;
+            m_componentStats[netComponentIndex].m_rpcsRecv[rpcIndex].m_byteHistory[m_recordMetricIndex] += totalBytes;
+        }
+        else
+        {
+            AZ_Warning("MultiplayerStats", false,
+                "Component ID %u has fewer than %u rpcIndex. Mismatch by caller suspected.", netComponentIndex, rpcIndex);
+        }
 
         m_events.m_rpcReceived.Signal(entityId, entityName, netComponentId, rpcId, totalBytes);
     }

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
@@ -280,12 +280,19 @@ namespace Multiplayer
             }
         }
 
-        const AzNetworking::PacketId sentId = m_replicationWindow->SendEntityUpdateMessages(entityUpdates);
-
-        // Update the sent things with the packet id
-        for (EntityReplicator* replicator : replicatorUpdatedList)
+        if (m_replicationWindow)
         {
-            replicator->FinalizeSerialization(sentId);
+            const AzNetworking::PacketId sentId = m_replicationWindow->SendEntityUpdateMessages(entityUpdates);
+
+            // Update the sent things with the packet id
+            for (EntityReplicator* replicator : replicatorUpdatedList)
+            {
+                replicator->FinalizeSerialization(sentId);
+            }
+        }
+        else
+        {
+            AZ_Assert(false, "Failed to send entity update message, replication window does not exist");
         }
     }
 
@@ -325,13 +332,23 @@ namespace Multiplayer
                 rpcMessages.pop_front();
             }
 
-            m_replicationWindow->SendEntityRpcs(entityRpcs, reliable);
+            if (m_replicationWindow)
+            {
+                m_replicationWindow->SendEntityRpcs(entityRpcs, reliable);
+            }
+            else
+            {
+                AZ_Assert(false, "Failed to send entity rpc, replication window does not exist");
+            }
         }
     }
 
     void EntityReplicationManager::SendEntityResets()
     {
-        m_replicationWindow->SendEntityResets(m_replicatorsPendingReset);
+        if (m_replicationWindow)
+        {
+            m_replicationWindow->SendEntityResets(m_replicatorsPendingReset);
+        }
         m_replicatorsPendingReset.clear();
     }
 
@@ -573,7 +590,7 @@ namespace Multiplayer
             }
         }
 
-        return true;
+        return shouldDeleteEntity;
     }
 
     bool EntityReplicationManager::HandlePropertyChangeMessage

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityTracker.h
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityTracker.h
@@ -18,7 +18,7 @@ namespace Multiplayer
     class NetBindComponent;
 
     //! @class NetworkEntityTracker
-    //! @brief The responsibly of this class is to allow entity netEntityId's to be looked up.
+    //! @brief This class allows entity netEntityIds to be looked up.
     class NetworkEntityTracker
     {
     public:

--- a/Gems/Multiplayer/Code/Tests/CommonNetworkEntitySetup.h
+++ b/Gems/Multiplayer/Code/Tests/CommonNetworkEntitySetup.h
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <IMultiplayerConnectionMock.h>
+#include <MockInterfaces.h>
+#include <AzCore/Component/Entity.h>
+#include <AzCore/EBus/EventSchedulerSystemComponent.h>
+#include <AzCore/Console/Console.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/Name/Name.h>
+#include <AzCore/Name/NameDictionary.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/UnitTest/UnitTest.h>
+#include <AzCore/UnitTest/Mocks/MockITime.h>
+#include <AzFramework/Components/TransformComponent.h>
+#include <AzNetworking/Serialization/NetworkInputSerializer.h>
+#include <AzNetworking/Serialization/NetworkOutputSerializer.h>
+#include <AzTest/AzTest.h>
+#include <Multiplayer/IMultiplayer.h>
+#include <Multiplayer/Components/NetBindComponent.h>
+#include <Multiplayer/Components/NetworkHierarchyChildComponent.h>
+#include <Multiplayer/Components/NetworkHierarchyRootComponent.h>
+#include <Multiplayer/Components/NetworkTransformComponent.h>
+#include <Multiplayer/NetworkEntity/EntityReplication/EntityReplicationManager.h>
+#include <Multiplayer/NetworkEntity/EntityReplication/EntityReplicator.h>
+#include <Source/NetworkEntity/NetworkEntityManager.h>
+#include <NetworkEntity/NetworkEntityAuthorityTracker.h>
+#include <NetworkEntity/NetworkEntityTracker.h>
+#include <Tests/TestMultiplayerComponent.h>
+
+namespace Multiplayer
+{
+    using namespace testing;
+    using namespace ::UnitTest;
+
+    class NetworkEntityTests
+        : public AllocatorsFixture
+    {
+    public:
+        void SetUp() override
+        {
+            SetupAllocator();
+            AZ::NameDictionary::Create();
+
+            m_mockComponentApplicationRequests = AZStd::make_unique<NiceMock<MockComponentApplicationRequests>>();
+            AZ::Interface<AZ::ComponentApplicationRequests>::Register(m_mockComponentApplicationRequests.get());
+
+            ON_CALL(*m_mockComponentApplicationRequests, AddEntity(_)).WillByDefault(Invoke(this, &NetworkEntityTests::AddEntity));
+            ON_CALL(*m_mockComponentApplicationRequests, FindEntity(_)).WillByDefault(Invoke(this, &NetworkEntityTests::FindEntity));
+
+            // register components involved in testing
+            m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
+
+            m_transformDescriptor.reset(AzFramework::TransformComponent::CreateDescriptor());
+            m_transformDescriptor->Reflect(m_serializeContext.get());
+
+            m_netBindDescriptor.reset(NetBindComponent::CreateDescriptor());
+            m_netBindDescriptor->Reflect(m_serializeContext.get());
+
+            m_netTransformDescriptor.reset(NetworkTransformComponent::CreateDescriptor());
+            m_netTransformDescriptor->Reflect(m_serializeContext.get());
+
+            m_testMultiplayerComponentDescriptor.reset(MultiplayerTest::TestMultiplayerComponent::CreateDescriptor());
+            m_testMultiplayerComponentDescriptor->Reflect(m_serializeContext.get());
+
+            m_testInputDriverComponentDescriptor.reset(MultiplayerTest::TestInputDriverComponent::CreateDescriptor());
+            m_testInputDriverComponentDescriptor->Reflect(m_serializeContext.get());
+
+            m_mockMultiplayer = AZStd::make_unique<NiceMock<MockMultiplayer>>();
+            AZ::Interface<IMultiplayer>::Register(m_mockMultiplayer.get());
+
+            EXPECT_NE(AZ::Interface<IMultiplayer>::Get(), nullptr);
+
+            // Create space for replication stats
+            // Without Multiplayer::RegisterMultiplayerComponents() the stats go to invalid id, which is fine for unit tests
+            GetMultiplayer()->GetStats().ReserveComponentStats(Multiplayer::InvalidNetComponentId, 50, 0);
+
+            m_networkEntityManager = AZStd::make_unique<NetworkEntityManager>();
+
+            m_mockTime = AZStd::make_unique<AZ::NiceTimeSystemMock>();
+
+            m_eventScheduler = AZStd::make_unique<AZ::EventSchedulerSystemComponent>();
+
+            m_mockNetworkTime = AZStd::make_unique<NiceMock<MockNetworkTime>>();
+            AZ::Interface<INetworkTime>::Register(m_mockNetworkTime.get());
+
+            ON_CALL(*m_mockMultiplayer, GetNetworkEntityManager()).WillByDefault(Return(m_networkEntityManager.get()));
+            EXPECT_NE(AZ::Interface<IMultiplayer>::Get()->GetNetworkEntityManager(), nullptr);
+
+            const IpAddress address("localhost", 1, ProtocolType::Udp);
+            m_mockConnection = AZStd::make_unique<NiceMock<IMultiplayerConnectionMock>>(ConnectionId{ 1 }, address, ConnectionRole::Connector);
+            m_mockConnectionListener = AZStd::make_unique<MockConnectionListener>();
+
+            m_entityReplicationManager = AZStd::make_unique<EntityReplicationManager>(*m_mockConnection, *m_mockConnectionListener, EntityReplicationManager::Mode::LocalClientToRemoteServer);
+
+            m_console.reset(aznew AZ::Console());
+            AZ::Interface<AZ::IConsole>::Register(m_console.get());
+            m_console->LinkDeferredFunctors(AZ::ConsoleFunctorBase::GetDeferredHead());
+
+            m_multiplayerComponentRegistry = AZStd::make_unique<MultiplayerComponentRegistry>();
+            RegisterMultiplayerComponents();
+            MultiplayerTest::RegisterMultiplayerComponents();
+        }
+
+        void TearDown() override
+        {
+            m_multiplayerComponentRegistry.reset();
+
+            AZ::Interface<AZ::IConsole>::Unregister(m_console.get());
+            m_console.reset();
+
+            m_entities.clear();
+
+            m_entityReplicationManager.reset();
+
+            m_mockConnection.reset();
+            m_mockConnectionListener.reset();
+
+            AZ::Interface<INetworkTime>::Unregister(m_mockNetworkTime.get());
+            AZ::Interface<IMultiplayer>::Unregister(m_mockMultiplayer.get());
+            AZ::Interface<AZ::ComponentApplicationRequests>::Unregister(m_mockComponentApplicationRequests.get());
+
+            m_eventScheduler.reset();
+            m_mockTime.reset();
+
+            m_networkEntityManager.reset();
+            m_mockMultiplayer.reset();
+
+            m_testInputDriverComponentDescriptor.reset();
+            m_testMultiplayerComponentDescriptor.reset();
+            m_transformDescriptor.reset();
+            m_netTransformDescriptor.reset();
+            m_hierarchyRootDescriptor.reset();
+            m_hierarchyChildDescriptor.reset();
+            m_netBindDescriptor.reset();
+            m_serializeContext.reset();
+            m_mockComponentApplicationRequests.reset();
+
+            AZ::NameDictionary::Destroy();
+            TeardownAllocator();
+        }
+
+        AZStd::unique_ptr<AZ::IConsole> m_console;
+
+        AZStd::unique_ptr<NiceMock<MockComponentApplicationRequests>> m_mockComponentApplicationRequests;
+        AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
+        AZStd::unique_ptr<AZ::ComponentDescriptor> m_transformDescriptor;
+        AZStd::unique_ptr<AZ::ComponentDescriptor> m_netBindDescriptor;
+        AZStd::unique_ptr<AZ::ComponentDescriptor> m_hierarchyRootDescriptor;
+        AZStd::unique_ptr<AZ::ComponentDescriptor> m_hierarchyChildDescriptor;
+        AZStd::unique_ptr<AZ::ComponentDescriptor> m_netTransformDescriptor;
+        AZStd::unique_ptr<AZ::ComponentDescriptor> m_testMultiplayerComponentDescriptor;
+        AZStd::unique_ptr<AZ::ComponentDescriptor> m_testInputDriverComponentDescriptor;
+
+        AZStd::unique_ptr<NiceMock<MockMultiplayer>> m_mockMultiplayer;
+        AZStd::unique_ptr<NetworkEntityManager> m_networkEntityManager;
+        AZStd::unique_ptr<AZ::EventSchedulerSystemComponent> m_eventScheduler;
+        AZStd::unique_ptr<AZ::NiceTimeSystemMock> m_mockTime;
+        AZStd::unique_ptr<NiceMock<MockNetworkTime>> m_mockNetworkTime;
+
+        AZStd::unique_ptr<NiceMock<IMultiplayerConnectionMock>> m_mockConnection;
+        AZStd::unique_ptr<MockConnectionListener> m_mockConnectionListener;
+
+        AZStd::unique_ptr<EntityReplicationManager> m_entityReplicationManager;
+
+        AZStd::unique_ptr<MultiplayerComponentRegistry> m_multiplayerComponentRegistry;;
+
+        AZStd::map<AZ::EntityId, AZ::Entity*> m_entities;
+
+        bool AddEntity(AZ::Entity* entity)
+        {
+            m_entities[entity->GetId()] = entity;
+            return true;
+        }
+
+        AZ::Entity* FindEntity(AZ::EntityId entityId)
+        {
+            const auto iterator = m_entities.find(entityId);
+            if (iterator != m_entities.end())
+            {
+                return iterator->second;
+            }
+
+            return nullptr;
+        }
+
+        void SetupEntity(const AZStd::unique_ptr<AZ::Entity>& entity, NetEntityId netId, NetEntityRole role)
+        {
+            if (const auto netBindComponent = entity->FindComponent<Multiplayer::NetBindComponent>())
+            {
+                netBindComponent->PreInit(entity.get(), PrefabEntityId{ AZ::Name("test"), 1 }, netId, role);
+                entity->Init();
+            }
+        }
+
+        static void StopEntity(const AZStd::unique_ptr<AZ::Entity>& entity)
+        {
+            if (const auto netBindComponent = entity->FindComponent<Multiplayer::NetBindComponent>())
+            {
+                netBindComponent->StopEntity();
+            }
+        }
+
+        static void StopAndDeactivateEntity(AZStd::unique_ptr<AZ::Entity>& entity)
+        {
+            if (entity)
+            {
+                StopEntity(entity);
+                entity->Deactivate();
+                entity.reset();
+            }
+        }
+
+        struct EntityInfo
+        {
+            enum class Role
+            {
+                Root,
+                Child,
+                None
+            };
+
+            EntityInfo(AZ::u64 entityId, const char* entityName, NetEntityId netId, Role role)
+                : m_entity(AZStd::make_unique<AZ::Entity>(AZ::EntityId(entityId), entityName))
+                , m_netId(netId)
+                , m_role(role)
+            {
+            }
+
+            ~EntityInfo()
+            {
+                StopAndDeactivateEntity(m_entity);
+            }
+
+            AZStd::unique_ptr<AZ::Entity> m_entity;
+            NetEntityId m_netId;
+            AZStd::unique_ptr<EntityReplicator> m_replicator;
+            Role m_role = Role::None;
+        };
+
+        void PopulateHierarchicalEntity(const EntityInfo& entityInfo)
+        {
+            entityInfo.m_entity->CreateComponent<AzFramework::TransformComponent>();
+            entityInfo.m_entity->CreateComponent<NetBindComponent>();
+            entityInfo.m_entity->CreateComponent<NetworkTransformComponent>();
+            entityInfo.m_entity->CreateComponent<MultiplayerTest::TestMultiplayerComponent>();
+            entityInfo.m_entity->CreateComponent<MultiplayerTest::TestInputDriverComponent>();
+
+            switch (entityInfo.m_role)
+            {
+            case EntityInfo::Role::Root:
+                entityInfo.m_entity->CreateComponent<NetworkHierarchyRootComponent>();
+                break;
+            case EntityInfo::Role::Child:
+                entityInfo.m_entity->CreateComponent<NetworkHierarchyChildComponent>();
+                break;
+            case EntityInfo::Role::None:
+                break;
+            }
+        }
+    };
+}

--- a/Gems/Multiplayer/Code/Tests/NetworkEntityTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/NetworkEntityTests.cpp
@@ -71,9 +71,6 @@ namespace Multiplayer
         AZStd::unique_ptr<EntityInfo> m_root;
     };
 
-    constexpr float BLEND_FACTOR_SCALE = 1.1f;
-    constexpr uint32_t TIME_SCALE = 10;
-
     TEST_F(MultiplayerNetworkEntityTests, ConstNetworkEntityHandleTest)
     {
         ConstNetworkEntityHandle handle(m_root->m_entity.get(), m_networkEntityManager->GetNetworkEntityTracker());

--- a/Gems/Multiplayer/Code/Tests/NetworkEntityTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/NetworkEntityTests.cpp
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <CommonNetworkEntitySetup.h>
+#include <MockInterfaces.h>
+#include <TestMultiplayerComponent.h>
+#include <Source/NetworkEntity/NetworkEntityManager.h>
+#include <Source/NetworkEntity/EntityReplication/PropertyPublisher.h>
+#include <Source/EntityDomains/FullOwnershipEntityDomain.h>
+#include <Source/EntityDomains/NullEntityDomain.h>
+#include <Source/ReplicationWindows/NullReplicationWindow.h>
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Console/Console.h>
+#include <AzCore/Name/Name.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/UnitTest/UnitTest.h>
+#include <AzFramework/Components/TransformComponent.h>
+#include <AzNetworking/Serialization/StringifySerializer.h>
+#include <AzNetworking/UdpTransport/UdpPacketHeader.h>
+#include <AzTest/AzTest.h>
+#include <Multiplayer/Components/NetBindComponent.h>
+#include <Multiplayer/NetworkEntity/EntityReplication/EntityReplicator.h>
+#include <Multiplayer/NetworkInput/NetworkInput.h>
+#include <Multiplayer/NetworkInput/NetworkInputArray.h>
+#include <Multiplayer/NetworkInput/NetworkInputHistory.h>
+#include <Multiplayer/NetworkInput/NetworkInputMigrationVector.h>
+
+namespace Multiplayer
+{
+    using namespace testing;
+    using namespace ::UnitTest;
+
+    class MultiplayerNetworkEntityTests : public NetworkEntityTests
+    {
+    public:
+        void SetUp() override
+        {
+            NetworkEntityTests::SetUp();
+
+            m_root = AZStd::make_unique<EntityInfo>(1, "root", NetEntityId{ 1 }, EntityInfo::Role::Root);
+
+            PopulateNetworkEntity(*m_root);
+            SetupEntity(m_root->m_entity, m_root->m_netId, NetEntityRole::Authority);
+
+            // Create an entity replicator for the root entity
+            const NetworkEntityHandle rootHandle(m_root->m_entity.get(), m_networkEntityManager->GetNetworkEntityTracker());
+            m_root->m_replicator = AZStd::make_unique<EntityReplicator>(
+                *m_entityReplicationManager, m_mockConnection.get(), NetEntityRole::Client, rootHandle);
+            m_root->m_replicator->Initialize(rootHandle);
+            m_root->m_replicator->ActivateNetworkEntity();
+        }
+
+        void TearDown() override
+        {
+            m_root.reset();
+
+            NetworkEntityTests::TearDown();
+        }
+
+        void PopulateNetworkEntity(const EntityInfo& entityInfo)
+        {
+            entityInfo.m_entity->CreateComponent<AzFramework::TransformComponent>();
+            entityInfo.m_entity->CreateComponent<NetBindComponent>();
+            entityInfo.m_entity->CreateComponent<NetworkTransformComponent>();
+        }
+
+        AZStd::unique_ptr<EntityInfo> m_root;
+    };
+
+    constexpr float BLEND_FACTOR_SCALE = 1.1f;
+    constexpr uint32_t TIME_SCALE = 10;
+
+    TEST_F(MultiplayerNetworkEntityTests, ConstNetworkEntityHandleTest)
+    {
+        ConstNetworkEntityHandle handle(m_root->m_entity.get(), m_networkEntityManager->GetNetworkEntityTracker());
+
+        EXPECT_TRUE(handle.Exists());
+        EXPECT_NE(handle.GetEntity(), nullptr);
+        EXPECT_NE(handle.GetNetBindComponent(), nullptr);
+        EXPECT_NE(handle.GetNetEntityId(), InvalidNetEntityId);
+
+        EXPECT_TRUE(handle == handle.GetEntity());
+        EXPECT_TRUE(handle.GetEntity() == handle);
+        EXPECT_FALSE(handle != handle.GetEntity());
+        EXPECT_FALSE(handle.GetEntity() != handle);
+        EXPECT_FALSE(handle == nullptr);
+        EXPECT_FALSE(nullptr == handle);
+        EXPECT_TRUE(handle != nullptr);
+        EXPECT_TRUE(nullptr != handle);
+
+        EXPECT_TRUE(handle == handle);
+        EXPECT_FALSE(handle != handle);
+        EXPECT_FALSE(handle < handle);
+
+        EXPECT_NE(handle.FindComponent<NetworkTransformComponent>(), nullptr);
+        EXPECT_NE(handle.FindComponent(NetworkTransformComponent::RTTI_Type()), nullptr);
+        EXPECT_EQ(handle.FindComponent<NetworkHierarchyChildComponent>(), nullptr);
+        EXPECT_EQ(handle.FindComponent(NetworkHierarchyChildComponent::RTTI_Type()), nullptr);
+        handle.Reset(handle);
+        EXPECT_NE(handle, nullptr);
+        handle.Reset();
+        EXPECT_EQ(handle, nullptr);
+        EXPECT_EQ(handle.GetNetBindComponent(), nullptr);
+    }
+
+    TEST_F(MultiplayerNetworkEntityTests, NetworkEntityHandleTest)
+    {
+        NetworkEntityHandle handle(m_root->m_entity.get(), m_networkEntityManager->GetNetworkEntityTracker());
+
+        EXPECT_NE(handle.FindComponent(NetworkTransformComponent::RTTI_Type()), nullptr);
+        EXPECT_NE(handle.FindController(NetworkTransformComponent::RTTI_Type()), nullptr);
+    }
+
+    TEST_F(MultiplayerNetworkEntityTests, TestEntityAuthorityTracker)
+    {
+        ConstNetworkEntityHandle handle(m_root->m_entity.get(), m_networkEntityManager->GetNetworkEntityTracker());
+        const HostId localhost = HostId("127.0.0.1", 6777, ProtocolType::Udp);
+
+        m_networkEntityManager->Initialize(localhost, AZStd::make_unique<NullEntityDomain>());
+        NetworkEntityAuthorityTracker* netEntityAuthorityTracker = m_networkEntityManager->GetNetworkEntityAuthorityTracker();
+        
+        netEntityAuthorityTracker->AddEntityAuthorityManager(handle, localhost);
+        EXPECT_TRUE(netEntityAuthorityTracker->DoesEntityHaveOwner(handle));
+        netEntityAuthorityTracker->RemoveEntityAuthorityManager(handle, localhost);
+        // Succeeds on authority role
+        EXPECT_TRUE(netEntityAuthorityTracker->DoesEntityHaveOwner(handle));
+        netEntityAuthorityTracker->SetTimeoutTimeMs(AZ::TimeMs(33));
+    }
+
+    TEST_F(MultiplayerNetworkEntityTests, TestNullDomain)
+    {
+        ConstNetworkEntityHandle handle(m_root->m_entity.get(), m_networkEntityManager->GetNetworkEntityTracker());
+        const HostId localhost = HostId("127.0.0.1", 6777, ProtocolType::Udp);
+
+        m_networkEntityManager->Initialize(localhost, AZStd::make_unique<NullEntityDomain>());
+        EXPECT_TRUE(m_networkEntityManager->IsInitialized());
+        IEntityDomain* domain = m_networkEntityManager->GetEntityDomain();
+        EXPECT_NE(domain, nullptr);
+        EXPECT_EQ(domain->GetAabb(), AZ::Aabb::CreateNull());
+        EXPECT_FALSE(domain->IsInDomain(handle));
+        domain->SetAabb(AZ::Aabb::CreateFromMinMax(AZ::Vector3(1, 1, 1), AZ::Vector3(2, 2, 2)));
+        EXPECT_EQ(domain->GetAabb(), AZ::Aabb::CreateNull());
+        domain->HandleLossOfAuthoritativeReplicator(handle);
+        EXPECT_TRUE(m_networkEntityManager->IsMarkedForRemoval(handle));
+        domain->DebugDraw();
+    }
+
+    TEST_F(MultiplayerNetworkEntityTests, TestFullOwnershipDomain)
+    {
+        ConstNetworkEntityHandle handle(m_root->m_entity.get(), m_networkEntityManager->GetNetworkEntityTracker());
+        const HostId localhost = HostId("127.0.0.1", 6777, ProtocolType::Udp);
+
+        m_networkEntityManager->Initialize(localhost, AZStd::make_unique<FullOwnershipEntityDomain>());
+        EXPECT_TRUE(m_networkEntityManager->IsInitialized());
+        IEntityDomain* domain = m_networkEntityManager->GetEntityDomain();
+        EXPECT_NE(domain, nullptr);
+        EXPECT_EQ(domain->GetAabb(), AZ::Aabb::CreateNull());
+        EXPECT_TRUE(domain->IsInDomain(handle));
+        domain->SetAabb(AZ::Aabb::CreateFromMinMax(AZ::Vector3(1, 1, 1), AZ::Vector3(2, 2, 2)));
+        EXPECT_EQ(domain->GetAabb(), AZ::Aabb::CreateNull());
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        domain->HandleLossOfAuthoritativeReplicator(handle);
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        domain->DebugDraw();
+    }
+
+    TEST_F(MultiplayerNetworkEntityTests, TestNetworkEntityTracker)
+    {
+        const NetworkEntityTracker* constNetEntityTracker = m_networkEntityManager->GetNetworkEntityTracker();
+
+        EXPECT_EQ(constNetEntityTracker->GetNetBindComponent(nullptr), nullptr);
+        uint8_t entityCount = 0;
+        for (NetworkEntityTracker::const_iterator it = constNetEntityTracker->begin(); it != constNetEntityTracker->end(); ++it)
+        {
+            ++entityCount;
+        }
+        EXPECT_EQ(entityCount, constNetEntityTracker->size());
+
+        NetworkEntityTracker* netEntityTracker = m_networkEntityManager->GetNetworkEntityTracker();
+
+        Multiplayer::NetEntityId netId = netEntityTracker->Get(m_root->m_entity->GetId());
+        NetworkEntityHandle handle = netEntityTracker->Get(netId);
+        EXPECT_NE(handle.GetEntity(), nullptr);
+        AZ::EntityId InvalidId = AZ::EntityId();
+        EXPECT_EQ(netEntityTracker->Get(InvalidId), InvalidNetEntityId);
+        ConstNetworkEntityHandle constHandle = constNetEntityTracker->Get(netId);
+        EXPECT_EQ(handle, constHandle);
+
+        EXPECT_TRUE(netEntityTracker->Exists(netId));
+
+        NetworkEntityTracker::iterator it = netEntityTracker->begin();
+        AZ::Entity* entity = netEntityTracker->Move(it);
+        EXPECT_NE(entity, nullptr);
+        netEntityTracker->Add(it->first, entity);
+        netEntityTracker->erase(it->first);
+        EXPECT_FALSE(netEntityTracker->Exists(netId));
+    }
+
+    TEST_F(MultiplayerNetworkEntityTests, TestReplicatorPendingDeletion)
+    {
+        m_root->m_replicator->SetPendingRemoval(AZ::TimeMs(100));
+        EXPECT_TRUE(m_root->m_replicator->IsPendingRemoval());
+        m_root->m_replicator->ClearPendingRemoval();
+        EXPECT_FALSE(m_root->m_replicator->IsPendingRemoval());
+        EXPECT_FALSE(m_root->m_replicator->IsDeletionAcknowledged());
+    }
+
+    struct TestRpcStruct : public Multiplayer::IRpcParamStruct
+    {
+        TestRpcStruct()
+        {
+        }
+
+        TestRpcStruct(const AZ::Vector3& impulse, const AZ::Vector3& worldPoint)
+            : m_impulse(impulse)
+            , m_worldPoint(worldPoint)
+        {
+            ;
+        }
+
+        bool Serialize(AzNetworking::ISerializer& serializer) override
+        {
+            bool ret(true);
+            ret &= serializer.Serialize(m_impulse, "impulse");
+            ret &= serializer.Serialize(m_worldPoint, "worldPoint");
+            return ret;
+        };
+
+        AZ::Vector3 m_impulse;
+        AZ::Vector3 m_worldPoint;
+    };
+
+    TEST_F(MultiplayerNetworkEntityTests, TestNetworkEntityRpcMessage)
+    {
+        ConstNetworkEntityHandle handle(m_root->m_entity.get(), m_networkEntityManager->GetNetworkEntityTracker());
+
+        NetworkEntityRpcMessage message = NetworkEntityRpcMessage(
+            RpcDeliveryType::AuthorityToClient,
+            handle.GetNetEntityId(),
+            handle.FindComponent<NetworkTransformComponent>()->GetNetComponentId(),
+            RpcIndex(0),
+            ReliabilityType::Unreliable);
+
+        // Test getters
+        TestRpcStruct params;
+        EXPECT_FALSE(message.GetRpcParams(params));
+        message.SetRpcParams(params);
+        EXPECT_EQ(message.GetComponentId(), handle.FindComponent<NetworkTransformComponent>()->GetNetComponentId());
+        EXPECT_EQ(message.GetEntityId(), handle.GetNetEntityId());
+        EXPECT_EQ(message.GetReliability(), ReliabilityType::Unreliable);
+        EXPECT_EQ(message.GetRpcDeliveryType(), RpcDeliveryType::AuthorityToClient);
+        EXPECT_EQ(message.GetRpcIndex(), RpcIndex(0));
+        EXPECT_TRUE(message.GetRpcParams(params));
+
+        // Test setters
+        message.SetReliability(ReliabilityType::Reliable);
+        EXPECT_EQ(message.GetReliability(), ReliabilityType::Reliable);
+        message.SetRpcDeliveryType(RpcDeliveryType::AuthorityToAutonomous);
+        EXPECT_EQ(message.GetRpcDeliveryType(), RpcDeliveryType::AuthorityToAutonomous);
+
+        const NetworkEntityRpcMessage constMessage = NetworkEntityRpcMessage(
+            RpcDeliveryType::AuthorityToClient,
+            handle.GetNetEntityId(),
+            handle.FindComponent<NetworkTransformComponent>()->GetNetComponentId(),
+            RpcIndex(1),
+            ReliabilityType::Unreliable);
+
+        // Test ctors, assignment and comparisons (const and non const versions)
+        NetworkEntityRpcMessage message2(AZStd::move(message));
+        EXPECT_EQ(message, message2);
+        EXPECT_TRUE(message != constMessage);
+        message = constMessage;
+        EXPECT_EQ(message, constMessage);
+        message = NetworkEntityRpcMessage(constMessage);
+        EXPECT_EQ(message, constMessage);
+
+        NetworkEntityRpcMessage message3 = constMessage;
+        message3 = message;
+        EXPECT_EQ(message, message3);
+
+        const NetworkEntityRpcMessage constMessage2(message2);
+        NetworkEntityRpcMessage message4 = constMessage;
+        message4 = constMessage2;
+
+        AzNetworking::StringifySerializer serializer;
+        EXPECT_TRUE(message.Serialize(serializer));
+        EXPECT_EQ(message.GetEstimatedSerializeSize(), 15);
+
+        m_entityReplicationManager->AddDeferredRpcMessage(message);
+        m_entityReplicationManager->AddDeferredRpcMessage(message2);
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        m_entityReplicationManager->SendUpdates();
+        AZ_TEST_STOP_TRACE_SUPPRESSION(3);
+
+        m_entityReplicationManager->SetReplicationWindow(AZStd::make_unique<NullReplicationWindow>(m_mockConnection.get()));
+        m_entityReplicationManager->AddDeferredRpcMessage(message);
+        m_entityReplicationManager->AddDeferredRpcMessage(message2);
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        m_entityReplicationManager->SendUpdates();
+        AZ_TEST_STOP_TRACE_SUPPRESSION(0);
+        NetworkEntityRpcVector rpcVector;
+        rpcVector.push_back(message);
+        m_entityReplicationManager->HandleEntityRpcMessages(m_mockConnection.get(), rpcVector);
+    }
+
+    TEST_F(MultiplayerNetworkEntityTests, TestNetworkEntityUpdateMessage)
+    {
+        ConstNetworkEntityHandle handle(m_root->m_entity.get(), m_networkEntityManager->GetNetworkEntityTracker());
+
+        NetworkEntityUpdateMessage message = NetworkEntityUpdateMessage();
+
+        // Test getters
+        EXPECT_EQ(message.GetNetworkRole(), NetEntityRole::InvalidRole);
+        EXPECT_EQ(message.GetData(), nullptr);
+        EXPECT_EQ(message.GetEntityId(), InvalidNetEntityId);
+        EXPECT_FALSE(message.GetHasValidPrefabId());
+        EXPECT_FALSE(message.GetIsDelete());
+        EXPECT_TRUE(message.GetPrefabEntityId().m_prefabName.IsEmpty());
+        EXPECT_FALSE(message.GetWasMigrated());
+
+        // Test setters
+        PrefabEntityId prefabId;
+        prefabId.m_entityOffset = 0;
+        prefabId.m_prefabName = AZ::Name("Test");
+        message.SetPrefabEntityId(prefabId);
+        EXPECT_NE(message.GetPrefabEntityId().m_prefabName.GetCStr(), "");
+        message.SetData(message.ModifyData());
+        EXPECT_NE(message.GetData(), nullptr);
+
+        AzNetworking::StringifySerializer serializer;
+        EXPECT_TRUE(message.Serialize(serializer));
+        EXPECT_EQ(message.GetEstimatedSerializeSize(), 17);
+
+        // Test ctors, assignment and comparisons (const and non const versions)
+        message = NetworkEntityUpdateMessage(m_root->m_netId, false);
+        EXPECT_EQ(m_root->m_netId, message.GetEntityId());
+        message = NetworkEntityUpdateMessage(NetEntityRole::Authority, m_root->m_netId);
+        EXPECT_EQ(message.GetNetworkRole(), NetEntityRole::Authority);
+        message = NetworkEntityUpdateMessage(NetEntityRole::Authority, m_root->m_netId, prefabId);
+        AzNetworking::PacketEncodingBuffer buffer;
+        EXPECT_NE(message.GetPrefabEntityId().m_prefabName.GetCStr(), "");
+        message.SetData(buffer);
+        NetworkEntityUpdateMessage message2(AZStd::move(message));
+        EXPECT_EQ(message, message2);
+        EXPECT_TRUE(m_root->m_replicator->GetPropertyPublisher()->PrepareSerialization());
+        const NetworkEntityUpdateMessage constMessage = m_root->m_replicator->GenerateUpdatePacket();
+        EXPECT_TRUE(message != constMessage);
+        message = constMessage;
+        EXPECT_EQ(message, constMessage);
+        message = NetworkEntityUpdateMessage(constMessage);
+        EXPECT_EQ(message, constMessage);
+
+        NetworkEntityUpdateMessage message3 = constMessage;
+        message3 = message;
+        EXPECT_EQ(message, message3);
+
+        const NetworkEntityUpdateMessage constMessage2(message2);
+        NetworkEntityUpdateMessage message4 = constMessage;
+        message4 = constMessage2;
+
+        UdpPacketHeader header(PacketType{ 11111 }, InvalidSequenceId, SequenceId{ 1 }, InvalidSequenceId, 0xF8000FFF, SequenceRolloverCount{ 0 });
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        EXPECT_FALSE(m_entityReplicationManager->HandleEntityUpdateMessage(m_mockConnection.get(), header, message));
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        EXPECT_FALSE(m_entityReplicationManager->HandleEntityDeleteMessage(m_root->m_replicator.get(), header, message));
+        EXPECT_TRUE(m_entityReplicationManager->HandleEntityUpdateMessage(m_mockConnection.get(), header, constMessage));
+    }
+
+} // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Tests/ServerHierarchyTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/ServerHierarchyTests.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/UnitTest/UnitTest.h>
 #include <AzFramework/Components/TransformComponent.h>
+#include <AzNetworking/Serialization/StringifySerializer.h>
 #include <AzTest/AzTest.h>
 #include <Multiplayer/Components/NetBindComponent.h>
 #include <Multiplayer/Components/NetworkHierarchyChildComponent.h>
@@ -306,6 +307,10 @@ namespace Multiplayer
                 m_root->m_entity->FindComponent<NetworkHierarchyRootComponent>()->GetHierarchicalEntities()[2],
                 m_childOfChild->m_entity.get()
             );
+            EXPECT_EQ(
+                m_child->m_entity->FindComponent<NetworkHierarchyChildComponent>()->GetHierarchicalEntities()[2],
+                m_childOfChild->m_entity.get()
+            );
         }
     }
 
@@ -458,6 +463,12 @@ namespace Multiplayer
 
         m_child->m_entity->FindComponent<AzFramework::TransformComponent>()->SetParent(AZ::EntityId());
         m_child->m_entity->FindComponent<AzFramework::TransformComponent>()->SetParent(m_root->m_entity->GetId());
+    }
+
+    TEST_F(ServerDeepHierarchyTests, SerializeHierarchyCorrection)
+    {
+        AzNetworking::StringifySerializer serializer;
+        EXPECT_TRUE(m_root->m_entity->FindComponent<NetworkHierarchyRootComponent>()->SerializeEntityCorrection(serializer));
     }
 
     /*

--- a/Gems/Multiplayer/Code/multiplayer_tests_files.cmake
+++ b/Gems/Multiplayer/Code/multiplayer_tests_files.cmake
@@ -16,12 +16,14 @@ set(FILES
     Tests/ClientHierarchyTests.cpp
     Tests/ServerHierarchyBenchmarks.cpp
     Tests/CommonHierarchySetup.h
+    Tests/CommonNetworkEntitySetup.h
     Tests/CommonBenchmarkSetup.h
     Tests/IMultiplayerConnectionMock.h
     Tests/IMultiplayerSpawnerMock.h
     Tests/Main.cpp
     Tests/MockInterfaces.h
     Tests/MultiplayerSystemTests.cpp
+    Tests/NetworkEntityTests.cpp
     Tests/NetworkInputTests.cpp
     Tests/NetworkTransformTests.cpp
     Tests/RewindableContainerTests.cpp


### PR DESCRIPTION
Signed-off-by: puvvadar <puvvadar@amazon.com>

## What does this PR do?

This change introduces a significant number of unit tests to the Multiplayer Gem. These units cover various pieces of basic functionality across the NetworkEntity classes in addition to shoring up a few other areas.

## How was this PR tested?

Ran Multiplayer.Tests and verified completeness with OpenCppCoverage.
