### PR TITLE
Added a no-index GetSwitchValue overload to AZ::CommandLine

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/CommandLine.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/CommandLine.cpp
@@ -16,6 +16,7 @@ namespace AZ
 {
     namespace
     {
+        static const AZStd::string m_emptyValue;
         // helper utility to return a lower version of the string without altering the original.
         // regular to_lower operates directly on the input.
         AZStd::string ToLower(AZStd::string_view inStr)
@@ -157,13 +158,25 @@ namespace AZ
         {
             if (argv[i])
             {
-                AZStd::string currentArg = argv[i]; // this eats the / or -
+                AZStd::string_view currentArg = argv[i]; // this eats the / or -
                 AddArgument(currentArg, currentSwitch);
             }
         }
     }
 
     void CommandLine::Parse(const ParamContainer& commandLine)
+    {
+        m_allValues.clear();
+
+        // This version of Parse does not skip over 0th index
+        AZStd::string currentSwitch;
+        for (int i = 0; i < commandLine.size(); ++i)
+        {
+            AddArgument(commandLine[i], currentSwitch);
+        }
+    }
+
+    void CommandLine::Parse(AZStd::span<const AZStd::string_view> commandLine)
     {
         m_allValues.clear();
 
@@ -204,6 +217,12 @@ namespace AZ
     {
         return AZStd::count_if(m_allValues.begin(), m_allValues.end(),
             [optionName = ToLower(switchName)](const CommandArgument& argument) { return argument.m_option == optionName; });
+    }
+
+    const AZStd::string& CommandLine::GetSwitchValue(AZStd::string_view switchName) const
+    {
+        const AZStd::size_t switchCount = GetNumSwitchValues(switchName);
+        return switchCount > 0 ? GetSwitchValue(switchName, switchCount - 1) : m_emptyValue;
     }
 
     const AZStd::string& CommandLine::GetSwitchValue(AZStd::string_view switchName, AZStd::size_t index) const

--- a/Code/Framework/AzCore/AzCore/Settings/CommandLine.h
+++ b/Code/Framework/AzCore/AzCore/Settings/CommandLine.h
@@ -9,6 +9,7 @@
 
 #include <AzCore/base.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/std/containers/span.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/fixed_string.h>
 #include <AzCore/std/string/string.h>
@@ -58,6 +59,7 @@ namespace AZ
          * Unlike the ARGC/ARGV version above, this function doesn't skip over the first parameter
          * It allows for round trip conversion with the Dump() method
          */
+        void Parse(AZStd::span<const AZStd::string_view> commandLine);
         void Parse(const ParamContainer& commandLine);
 
         /**
@@ -88,8 +90,16 @@ namespace AZ
         /**
         * Get the actual value of a switch
         * @param switchName The switch to search for
+        * @return The last value of the switch. This is follows the standard command line workflow
+        * that the last one wins
+        */
+        const AZStd::string& GetSwitchValue(AZStd::string_view switchName) const;
+
+        /**
+        * Get the actual value of a switch
+        * @param switchName The switch to search for
         * @param index The 0-based index to retrieve the switch value for
-        * @return The value at that index.  This will Assert if you attempt to index out of bounds
+        * @return The value at that index. This will Assert if you attempt to index out of bounds
         */
         const AZStd::string& GetSwitchValue(AZStd::string_view switchName, AZStd::size_t index) const;
 
@@ -126,7 +136,6 @@ namespace AZ
         void ParseOptionArgument(AZStd::string_view newOption, AZStd::string_view newValue, CommandArgument* inProgressArgument);
 
         ArgumentVector m_allValues;
-        AZStd::string m_emptyValue;
 
         inline static constexpr size_t MaxCommandOptionPrefixes = 8;
         AZStd::fixed_string<MaxCommandOptionPrefixes> m_commandLineOptionPrefix;

--- a/Code/Framework/AzCore/Tests/Settings/CommandLineTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/CommandLineTests.cpp
@@ -410,4 +410,22 @@ namespace UnitTest
             EXPECT_STREQ("Bat", commandLine.GetMiscValue(1).c_str());
         }
     }
+
+    TEST_F(CommandLineTests, CommandLineParser_GetSwitchValue_WithNoArgument_ReturnsLastValue)
+    {
+        AZ::CommandLine commandLine{ "-" };
+
+        constexpr AZStd::string_view argValues[] =
+        {
+            "programname.exe", "--foo=1", "--foo", "2"
+        };
+
+        commandLine.Parse(argValues);
+
+        ASSERT_GE(commandLine.GetNumSwitchValues("foo"), 2);
+        EXPECT_STREQ("2", commandLine.GetSwitchValue("foo").c_str());
+        EXPECT_STREQ("2", commandLine.GetSwitchValue("foo", 1).c_str());
+        EXPECT_STREQ("1", commandLine.GetSwitchValue("foo", 0).c_str());
+
+    }
 }   // namespace UnitTest


### PR DESCRIPTION
The new GetSwitchValue overload which doesn't accept an index returns the last occurance of a command line option.

This helps to prevent user from coding to retrieve the first instance of a switch on a command.
Ex. `commandLine.GetSwitchValue("<switchName>", 0)`.
CLI argument parsing uses the last instance of the parameter as the value.
i.e `command -s 10 -s 20`, for the option for 's', if only one value is used, it should be the last one of 20

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Added a unit test for the new GetSwitchValue overload.
