### PR TITLE
Remove to_lower conversion of LuaEditor files CLI parameters

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorContext.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorContext.cpp
@@ -725,9 +725,6 @@ namespace LUAEditor
             {
                 AZStd::string inputValue = commandLine->GetSwitchValue(k_luaScriptFileString, i);
 
-                // Open the file(s)
-                AZStd::to_lower(const_cast<AZStd::string&>(inputValue).begin(), const_cast<AZStd::string&>(inputValue).end());
-
                 // Cache the files we want to open, we will open them when we activate the main window.
                 m_filesToOpen.push_back(inputValue);
             }


### PR DESCRIPTION
Fixes https://github.com/o3de/o3de/issues/9380

Signed-off-by: Lars Gleim <lgleim@users.noreply.github.com>

## What does this PR do?

LuaEditor by default casts all paths provided via the `-files` command line flag to lower case, which breaks paths on case-sensitive platforms (e.g. Linux)

## How was this PR tested?

Building the Editor & confirming that files provided via the `-files` flag are opened