### PR TITLE
Fix rendering to a single mip-level of a texture with vulkan

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Framebuffer.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Framebuffer.h
@@ -72,9 +72,11 @@ namespace AZ
 
             bool AreResourcesReady() const;
             void Invalidate();
+            void SetSizeFromAttachment();
 
             VkFramebuffer m_nativeFramebuffer = VK_NULL_HANDLE;
             AZStd::vector<RHI::ConstPtr<ImageView>> m_attachments;
+            RHI::Size   m_size;
             RHI::ConstPtr<RenderPass> m_renderPass;
         };
     }


### PR DESCRIPTION

Signed-off-by: Karl Haubenwallner <karl.haubenwallner@huawei.com>

## What does this PR do?

The resolution for the Vulkan Framebuffer object is currently taken directly from the original image of the rendertarget - ImageView, even if the ImageView only points to a single mip-level of the image.
This leads to the Vulkan Validation error that the bound rendertarget has a size mismatch with the framebuffer, an eventually causes a device lost.

## How was this PR tested?

'manually' fill the mip-levels of a texture with separate Renderpasses. 
Currently only tested on Windows with Vulkan, i did not tested with DirectX. 