### PR TITLE
Fix for polygon prism single-thread deadlock.

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Shape/BoxShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/BoxShape.cpp
@@ -134,7 +134,7 @@ namespace LmbrCentral
     AZ::Aabb BoxShape::GetEncompassingAabb()
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, m_mutex, m_currentNonUniformScale);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, &m_mutex, m_currentNonUniformScale);
 
         return m_intersectionDataCache.m_aabb;
     }
@@ -149,7 +149,7 @@ namespace LmbrCentral
     bool BoxShape::IsPointInside(const AZ::Vector3& point)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, m_mutex, m_currentNonUniformScale);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, &m_mutex, m_currentNonUniformScale);
 
         if (m_intersectionDataCache.m_axisAligned)
         {
@@ -162,7 +162,7 @@ namespace LmbrCentral
     float BoxShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, m_mutex, m_currentNonUniformScale);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, &m_mutex, m_currentNonUniformScale);
 
         if (m_intersectionDataCache.m_axisAligned)
         {
@@ -175,7 +175,7 @@ namespace LmbrCentral
     bool BoxShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, m_mutex, m_currentNonUniformScale);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, &m_mutex, m_currentNonUniformScale);
 
         if (m_intersectionDataCache.m_axisAligned)
         {
@@ -200,7 +200,7 @@ namespace LmbrCentral
     AZ::Vector3 BoxShape::GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, m_mutex, m_currentNonUniformScale);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, &m_mutex, m_currentNonUniformScale);
 
         float x = 0;
         float y = 0;

--- a/Gems/LmbrCentral/Code/Source/Shape/CapsuleShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/CapsuleShape.cpp
@@ -120,7 +120,7 @@ namespace LmbrCentral
     CapsuleInternalEndPoints CapsuleShape::GetCapsulePoints()
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, &m_mutex);
 
         return { m_intersectionDataCache.m_basePlaneCenterPoint, m_intersectionDataCache.m_topPlaneCenterPoint };
     }
@@ -128,7 +128,7 @@ namespace LmbrCentral
     AZ::Aabb CapsuleShape::GetEncompassingAabb()
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, &m_mutex);
 
         const AZ::Aabb topAabb(AZ::Aabb::CreateCenterRadius(
             m_intersectionDataCache.m_topPlaneCenterPoint, m_intersectionDataCache.m_radius));
@@ -149,7 +149,7 @@ namespace LmbrCentral
     bool CapsuleShape::IsPointInside(const AZ::Vector3& point)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, &m_mutex);
 
         const float radiusSquared = powf(m_intersectionDataCache.m_radius, 2.0f);
 
@@ -180,7 +180,7 @@ namespace LmbrCentral
     float CapsuleShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, &m_mutex);
 
         const Lineseg lineSeg(
             AZVec3ToLYVec3(m_intersectionDataCache.m_basePlaneCenterPoint),
@@ -195,7 +195,7 @@ namespace LmbrCentral
     bool CapsuleShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, &m_mutex);
 
         if (m_intersectionDataCache.m_isSphere)
         {

--- a/Gems/LmbrCentral/Code/Source/Shape/CylinderShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/CylinderShape.cpp
@@ -129,7 +129,7 @@ namespace LmbrCentral
     AZ::Aabb CylinderShape::GetEncompassingAabb()
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, &m_mutex);
 
         const AZ::Vector3 base = m_intersectionDataCache.m_baseCenterPoint;
         const AZ::Vector3 top = m_intersectionDataCache.m_baseCenterPoint + m_intersectionDataCache.m_axisVector;
@@ -161,7 +161,7 @@ namespace LmbrCentral
     AZ::Vector3 CylinderShape::GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, &m_mutex);
 
         const float minAngle = 0.0f;
         const float maxAngle = AZ::Constants::TwoPi;
@@ -240,7 +240,7 @@ namespace LmbrCentral
     bool CylinderShape::IsPointInside(const AZ::Vector3& point)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, &m_mutex);
 
         return AZ::Intersect::PointCylinder(
             m_intersectionDataCache.m_baseCenterPoint,
@@ -253,7 +253,7 @@ namespace LmbrCentral
     float CylinderShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, &m_mutex);
 
         if (m_cylinderShapeConfig.m_height <= 0.0f || m_cylinderShapeConfig.m_radius <= 0.0f)
         {
@@ -269,7 +269,7 @@ namespace LmbrCentral
     bool CylinderShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, &m_mutex);
 
         float t1 = 0.0f, t2 = 0.0f;
         const bool intersection =

--- a/Gems/LmbrCentral/Code/Source/Shape/DiskShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/DiskShape.cpp
@@ -106,7 +106,7 @@ namespace LmbrCentral
     const AZ::Vector3& DiskShape::GetNormal()
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_diskShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_diskShapeConfig, &m_mutex);
 
         return m_intersectionDataCache.m_normal;
     }
@@ -114,7 +114,7 @@ namespace LmbrCentral
     AZ::Aabb DiskShape::GetEncompassingAabb()
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_diskShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_diskShapeConfig, &m_mutex);
 
         const AZ::Vector3& normal = m_intersectionDataCache.m_normal;
         const float radius = m_intersectionDataCache.m_radius;
@@ -143,7 +143,7 @@ namespace LmbrCentral
     float DiskShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_diskShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_diskShapeConfig, &m_mutex);
 
         // Find closest point to the plane the disk is on
         AZ::Plane plane = AZ::Plane::CreateFromNormalAndPoint(m_intersectionDataCache.m_normal, m_currentTransform.GetTranslation());
@@ -165,7 +165,7 @@ namespace LmbrCentral
     bool DiskShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_diskShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_diskShapeConfig, &m_mutex);
 
         return AZ::Intersect::IntersectRayDisk(
             src, dir, m_intersectionDataCache.m_position, m_intersectionDataCache.m_radius, m_intersectionDataCache.m_normal, distance);

--- a/Gems/LmbrCentral/Code/Source/Shape/PolygonPrismShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/PolygonPrismShape.cpp
@@ -368,7 +368,8 @@ namespace LmbrCentral
     AZ::Aabb PolygonPrismShape::GetEncompassingAabb()
     {
         PolygonPrismSharedLockGuard lock(m_mutex, m_uniqueLockThreadId);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, *m_polygonPrism, m_mutex, m_currentNonUniformScale);
+        m_intersectionDataCache.UpdateIntersectionParams(
+            m_currentTransform, *m_polygonPrism, lock.GetMutexForIntersectionDataCache(), m_currentNonUniformScale);
 
         return m_intersectionDataCache.m_aabb;
     }
@@ -386,7 +387,8 @@ namespace LmbrCentral
     bool PolygonPrismShape::IsPointInside(const AZ::Vector3& point)
     {
         PolygonPrismSharedLockGuard lock(m_mutex, m_uniqueLockThreadId);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, *m_polygonPrism, m_mutex, m_currentNonUniformScale);
+        m_intersectionDataCache.UpdateIntersectionParams(
+            m_currentTransform, *m_polygonPrism, lock.GetMutexForIntersectionDataCache(), m_currentNonUniformScale);
 
         // initial early aabb rejection test
         // note: will implicitly do height test too
@@ -401,7 +403,8 @@ namespace LmbrCentral
     float PolygonPrismShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
     {
         PolygonPrismSharedLockGuard lock(m_mutex, m_uniqueLockThreadId);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, *m_polygonPrism, m_mutex, m_currentNonUniformScale);
+        m_intersectionDataCache.UpdateIntersectionParams(
+            m_currentTransform, *m_polygonPrism, lock.GetMutexForIntersectionDataCache(), m_currentNonUniformScale);
 
         return PolygonPrismUtil::DistanceSquaredFromPoint(*m_polygonPrism, point, m_currentTransform);
     }
@@ -409,7 +412,8 @@ namespace LmbrCentral
     bool PolygonPrismShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
     {
         PolygonPrismSharedLockGuard lock(m_mutex, m_uniqueLockThreadId);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, *m_polygonPrism, m_mutex, m_currentNonUniformScale);
+        m_intersectionDataCache.UpdateIntersectionParams(
+            m_currentTransform, *m_polygonPrism, lock.GetMutexForIntersectionDataCache(), m_currentNonUniformScale);
 
         return PolygonPrismUtil::IntersectRay(m_intersectionDataCache.m_triangles, m_currentTransform, src, dir, distance);
     }

--- a/Gems/LmbrCentral/Code/Source/Shape/QuadShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/QuadShape.cpp
@@ -147,7 +147,7 @@ namespace LmbrCentral
     const AZ::Quaternion& QuadShape::GetQuadOrientation()
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_quadShapeConfig, m_mutex, m_currentNonUniformScale);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_quadShapeConfig, &m_mutex, m_currentNonUniformScale);
 
         return m_intersectionDataCache.m_quaternion;
     }
@@ -184,7 +184,7 @@ namespace LmbrCentral
     float QuadShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_quadShapeConfig, m_mutex, m_currentNonUniformScale);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_quadShapeConfig, &m_mutex, m_currentNonUniformScale);
 
         // translate and rotate the point into the space of the quad.
         AZ::Vector3 tPoint = m_currentTransform.GetRotation().GetInverseFull().TransformVector(point - m_currentTransform.GetTranslation());

--- a/Gems/LmbrCentral/Code/Source/Shape/SphereShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/SphereShape.cpp
@@ -99,7 +99,7 @@ namespace LmbrCentral
     AZ::Aabb SphereShape::GetEncompassingAabb()
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_sphereShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_sphereShapeConfig, &m_mutex);
 
         return AZ::Aabb::CreateCenterRadius(m_currentTransform.GetTranslation(), m_intersectionDataCache.m_radius);
     }
@@ -114,7 +114,7 @@ namespace LmbrCentral
     bool SphereShape::IsPointInside(const AZ::Vector3& point)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_sphereShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_sphereShapeConfig, &m_mutex);
 
         return AZ::Intersect::PointSphere(
             m_intersectionDataCache.m_position, powf(m_intersectionDataCache.m_radius, 2.0f), point);
@@ -123,7 +123,7 @@ namespace LmbrCentral
     float SphereShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_sphereShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_sphereShapeConfig, &m_mutex);
 
         const AZ::Vector3 pointToSphereCenter = m_intersectionDataCache.m_position - point;
         const float distance = pointToSphereCenter.GetLength() - m_intersectionDataCache.m_radius;
@@ -133,7 +133,7 @@ namespace LmbrCentral
     bool SphereShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
     {
         AZStd::shared_lock lock(m_mutex);
-        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_sphereShapeConfig, m_mutex);
+        m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_sphereShapeConfig, &m_mutex);
 
         return AZ::Intersect::IntersectRaySphere(
             src, dir, m_intersectionDataCache.m_position, m_intersectionDataCache.m_radius, distance) > 0;


### PR DESCRIPTION
## What does this PR do?

The polygon prism has a complex scheme for managing its shared mutex so that it doesn't get double-locked on the same thread, which can cause a deadlock. However, the scheme was getting bypassed when the shared mutex was passed directly into the IntersectionDataCache. It needed a bit more logic to *not* pass the shared mutex in the case that it was already exclusively locked.

Closes #11372 .

## How was this PR tested?

Ran through the steps in 11372 and verified that they no longer lock up the Editor. Also tried adding / removing / modifying vertices in the same situation and verified they all worked.
