### PR TITLE
Multiplayer PyTest Util No Longer Parses Logs

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
@@ -160,24 +160,20 @@ class TestHelper:
         """
         Report.info("Entering game mode")
 
-        with Tracer() as section_tracer:
+        with MultiplayerHelper() as multiplayer_helper:
             # enter game-mode. 
             # game-mode in multiplayer will also launch ServerLauncher.exe and connect to the editor
             multiplayer.PythonEditorFuncs_enter_game_mode()
 
-            # make sure the server launcher binary exists
-            TestHelper.fail_if_log_line_found("MultiplayerEditor", "LaunchEditorServer failed! The ServerLauncher binary is missing!", section_tracer.errors, 0.5)
-
             # make sure the server launcher is running
-            waiter.wait_for(lambda: process_utils.process_exists("AutomatedTesting.ServerLauncher", ignore_extensions=True), timeout=5.0, exc=AssertionError("AutomatedTesting.ServerLauncher has NOT launched!"), interval=1.0)
+            TestHelper.wait_for_condition(lambda : multiplayer_helper.serverLaunched, 10.0)
+            waiter.wait_for(lambda: process_utils.process_exists("AutomatedTesting.ServerLauncher", ignore_extensions=True), timeout=5.0, exc=AssertionError("AutomatedTesting.ServerLauncher process is not running!"), interval=1.0)
 
-            TestHelper.succeed_if_log_line_found("MultiplayerEditor", "Editor has connected to the editor-server.", section_tracer.prints, 120.0)
+            TestHelper.wait_for_condition(lambda : multiplayer_helper.editorConnectionAttemptCount > 0, 10.0)
 
-            TestHelper.succeed_if_log_line_found("MultiplayerEditor", "Editor is sending the editor-server the level data packet.", section_tracer.prints, 5.0)
+            TestHelper.wait_for_condition(lambda : multiplayer_helper.editorSendingLevelData, 10.0)
 
-            TestHelper.succeed_if_log_line_found("EditorServer", "System: Editor Server completed receiving the editor's level assets, responding to Editor...", section_tracer.prints, 5.0)
-
-            TestHelper.succeed_if_log_line_found("MultiplayerEditorConnection", "Editor-server ready. Editor has successfully connected to the editor-server's network simulation.", section_tracer.prints, 5.0)
+            TestHelper.wait_for_condition(lambda : multiplayer_helper.connectToSimulationSuccess, 10.0)
 
         TestHelper.wait_for_condition(lambda : multiplayer.PythonEditorFuncs_is_in_game_mode(), 5.0)
         Report.critical_result(msgtuple_success_fail, multiplayer.PythonEditorFuncs_is_in_game_mode())
@@ -572,6 +568,53 @@ class AngleHelper:
         """
         return AngleHelper.is_angle_close(math.radians(x_deg), math.radians(y_deg), tolerance)
 
+'''
+Utility for receiving Multiplayer Editor notifications.
+Usage:
+
+    ...
+    with MultiplayerHelper() as multiplayer_helper:
+        # section were we are interested in capturing multiplayer editor notifications
+        TestHelper.wait_for_condition(lambda : multiplayer_helper.serverLaunched, 10.0)
+        ...
+'''
+class MultiplayerHelper:
+    def __init__(self):
+        self.handler = None
+        self.serverLaunched = False
+        self.editorConnectionAttemptCount = 0
+        self.editorSendingLevelData = False
+        self.connectToSimulationSuccess = False
+
+    def __enter__(self):
+        self.handler = azlmbr.multiplayer.MultiplayerEditorServerNotificationBusHandler()
+        self.handler.connect()
+        self.handler.add_callback("OnServerLaunched", self._on_server_launched)
+        self.handler.add_callback("OnEditorConnectionAttempt", self._on_editor_connection_attempt)
+        self.handler.add_callback("OnEditorSendingLevelData", self._on_editor_sending_level_data)
+        self.handler.add_callback("OnConnectToSimulationSuccess", self._on_connect_to_simulation_success)
+        return self
+        
+    def __exit__(self, type, value, traceback):
+        self.handler.disconnect()
+        self.handler = None
+        return False
+
+    def _on_server_launched(self, args):
+        self.serverLaunched = True
+        return False
+    
+    def _on_editor_connection_attempt(self, args):
+        self.editorConnectionAttemptCount = args[0]
+        return False
+    
+    def _on_editor_sending_level_data(self, args):
+        self.editorSendingLevelData = True
+        return False
+
+    def _on_connect_to_simulation_success(self, args):
+        self.connectToSimulationSuccess = True
+        return False
 
 def vector3_str(vector3):
     return "(x: {:.2f}, y: {:.2f}, z: {:.2f})".format(vector3.x, vector3.y, vector3.z)

--- a/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerEditorServerBus.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerEditorServerBus.h
@@ -10,6 +10,11 @@
 
 #include <AzCore/EBus/EBus.h>
 
+namespace AzNetworking
+{
+    class IConnection;
+}
+
 namespace Multiplayer
 {
     class MultiplayerEditorServerRequests : public AZ::EBusTraits

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorAutomation.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorAutomation.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "MultiplayerEditorAutomation.h"
+
+namespace Multiplayer::Automation
+{
+    void MultiplayerEditorAutomationHandler::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* behaviorContext = azdynamic_cast<AZ::BehaviorContext*>(context))
+        {
+            // Exposes bus handler to Python automation in the form of azlmbr.<module name>.<ebus name>Handler()
+            // Example Python code:
+            //     handler = azlmbr.multiplayer.MultiplayerEditorServerNotificationBusHandler()
+            //     handler.connect()
+            //     handler.add_callback("OnServerLaunched", _on_server_launched)
+            behaviorContext->EBus<MultiplayerEditorServerNotificationBus>("MultiplayerEditorServerNotificationBus")
+                ->Attribute(AZ::Script::Attributes::Module, "multiplayer")
+                ->Attribute(AZ::Script::Attributes::Category, "Multiplayer")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Handler<MultiplayerEditorAutomationHandler>();
+        }
+    }
+
+    void MultiplayerEditorAutomationHandler::OnServerLaunched()
+    {
+        Call(FN_OnServerLaunched);
+    }
+
+    void MultiplayerEditorAutomationHandler::OnServerLaunchFail()
+    {
+        Call(FN_OnServerLaunchFail);
+    }
+
+    void MultiplayerEditorAutomationHandler::OnEditorConnectionAttempt(uint16_t connectionAttempts, uint16_t maxAttempts)
+    {
+        Call(FN_OnEditorConnectionAttempt, connectionAttempts, maxAttempts);
+    }
+
+    void MultiplayerEditorAutomationHandler::OnEditorConnectionAttemptsFailed(uint16_t failedAttempts)
+    {
+        Call(FN_OnEditorConnectionAttemptsFailed, failedAttempts);
+    }
+
+    void MultiplayerEditorAutomationHandler::OnEditorSendingLevelData()
+    {
+        Call(FN_OnEditorSendingLevelData);
+    }
+
+    void MultiplayerEditorAutomationHandler::OnConnectToSimulationSuccess()
+    {
+        Call(FN_OnConnectToSimulationSuccess);
+    }
+
+    void MultiplayerEditorAutomationHandler::OnConnectToSimulationFail(uint16_t serverPort)
+    {
+        Call(FN_OnConnectToSimulationFail, serverPort);
+    }
+
+    void MultiplayerEditorAutomationHandler::OnPlayModeEnd()
+    {
+        Call(FN_OnPlayModeEnd);
+    }
+
+    void MultiplayerEditorAutomationHandler::OnEditorServerProcessStoppedUnexpectedly()
+    {
+        Call(FN_OnEditorServerProcessStoppedUnexpectedly);
+    }
+} // namespace Multiplayer::Automation

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorAutomation.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorAutomation.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Memory/Memory.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <Multiplayer/MultiplayerEditorServerBus.h>
+
+namespace Multiplayer::Automation
+{
+    //! Multiplayer Editor event handler for python automation
+    //! This class will pick up Multiplayer Editor notifications and make sure they are forwarded and available for python automation tests
+    class MultiplayerEditorAutomationHandler
+        : public MultiplayerEditorServerNotificationBus::Handler
+        , public AZ::BehaviorEBusHandler
+    {
+    public:
+        AZ_EBUS_BEHAVIOR_BINDER(
+            MultiplayerEditorAutomationHandler, "{CBA9A03D-ED7C-472E-B79F-1CCAB22D048C}", AZ::SystemAllocator,
+            OnServerLaunched,
+            OnServerLaunchFail,
+            OnEditorConnectionAttempt,
+            OnEditorConnectionAttemptsFailed,
+            OnEditorSendingLevelData,
+            OnConnectToSimulationSuccess,
+            OnConnectToSimulationFail,
+            OnPlayModeEnd,
+            OnEditorServerProcessStoppedUnexpectedly);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+    private:
+        //! MultiplayerEditorServerNotificationBus::Handler
+        //! @{
+        void OnServerLaunched() override;
+        void OnServerLaunchFail() override;
+        void OnEditorConnectionAttempt(uint16_t connectionAttempts, uint16_t maxAttempts) override;
+        void OnEditorConnectionAttemptsFailed(uint16_t failedAttempts) override;
+        void OnEditorSendingLevelData() override;
+        void OnConnectToSimulationSuccess() override;
+        void OnConnectToSimulationFail(uint16_t serverPort) override;
+        void OnPlayModeEnd() override;
+        void OnEditorServerProcessStoppedUnexpectedly() override;
+        //! @}
+    };
+
+} // namespace Multiplayer::Automation

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -13,6 +13,7 @@
 
 #include <MultiplayerSystemComponent.h>
 #include <PythonEditorEventsBus.h>
+#include <Editor/MultiplayerEditorAutomation.h>
 #include <Editor/MultiplayerEditorSystemComponent.h>
 
 #include <AzCore/Console/IConsole.h>
@@ -93,6 +94,8 @@ namespace Multiplayer
     
     void MultiplayerEditorSystemComponent::Reflect(AZ::ReflectContext* context)
     {
+        Automation::MultiplayerEditorAutomationHandler::Reflect(context);
+
         if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<MultiplayerEditorSystemComponent, AZ::Component>()

--- a/Gems/Multiplayer/Code/multiplayer_editor_shared_files.cmake
+++ b/Gems/Multiplayer/Code/multiplayer_editor_shared_files.cmake
@@ -11,6 +11,8 @@ set(FILES
     Source/MultiplayerGem.h
     Source/Editor/MultiplayerEditorGem.cpp
     Source/Editor/MultiplayerEditorGem.h
+    Source/Editor/MultiplayerEditorAutomation.cpp
+    Source/Editor/MultiplayerEditorAutomation.h
     Source/Editor/MultiplayerEditorSystemComponent.cpp
     Source/Editor/MultiplayerEditorSystemComponent.h
     Include/Multiplayer/Editor/MultiplayerPythonEditorEventsBus.h


### PR DESCRIPTION
## What does this PR do?
Util.py multiplayer util no longer reads through log events. Instead there is a bus handler (MultiplayerEditorServerNotificationBusHandler) which can listen for important multiplayer editor notifications.
Multiplayer pytest have been flaky in the past, so I wanted to rule out the possibility that parsing logs was causing the flakiness. With 1000's of spam lines to read through, it possible that parsing logs were causing the tests to time out. 

Note: This is only part 1 for fixing #10673. 
Remaining work:
1. Individual tests themselves are still parsing logs, these need to change by listening for specific multiplayer events.
2. Individual tests were built using script canvas which periodically need updating and are unusually large (13Mb); we want to move these tests to C++ to rule out any possibility of flakiness

## How was this PR tested?
Ran sandbox to make sure tests still ran successfully
