### PR TITLE
Fix a Vulkan validation error that was spamming every frame

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphCompiler.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphCompiler.h
@@ -104,6 +104,7 @@ namespace AZ
             if (HasExplicitClear(scopeAttachment, scopeAttachment.GetDescriptor()))
             {
                 srcAccessFlags |= VK_ACCESS_TRANSFER_WRITE_BIT;
+                srcAccessFlags = RHI::FilterBits(srcAccessFlags, GetSupportedAccessFlags(srcPipelineStageFlags));
             }
         
             auto subresourceRange = GetSubresourceRange(scopeAttachment);


### PR DESCRIPTION
Signed-off-by: moudgils <47460854+moudgils@users.noreply.github.com>

## What does this PR do?

It fixes the following vulkan validation that is spamming each frame 
[Error] (vkDebugMessage) - [ERROR][Validation] Validation Error: [ VUID-vkCmdPipelineBarrier-srcAccessMask-02815 ] Object 0: handle = 0x20fa61bc598, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x24d88c2b | vkCmdPipelineBarrier(): .pImageMemoryBarriers[0].srcAccessMask bit VK_ACCESS_TRANSFER_WRITE_BIT is not supported by stage mask (VK_PIPELINE_STAGE_VERTEX_SHADER_BIT|VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT|VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT|VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT|VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT|VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT). The Vulkan spec states: The srcAccessMask member of each element of pMemoryBarriers must only include access flags that are supported by one or more of the pipeline stages in srcStageMask, as specified in the table of supported access types (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-vkCmdPipelineBarrier-srcAccessMask-02815)

The main issue was that we werent filtering out the source mask based on the supported shader stage.

## How was this PR tested?

Ran editor with validation enabled and ran full test suite on dx12 and Vk on pc
