### PR TITLE
Disable UserSettings Save in a test fixture

### DIFF
--- a/Gems/ScriptAutomation/Code/Tests/ScriptAutomationApplicationFixture.cpp
+++ b/Gems/ScriptAutomation/Code/Tests/ScriptAutomationApplicationFixture.cpp
@@ -11,6 +11,7 @@
 #include <ScriptAutomation/ScriptAutomationBus.h>
 
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/UserSettings/UserSettingsComponent.h>
 
 #include <AzFramework/IO/LocalFileIO.h>
 
@@ -83,6 +84,8 @@ namespace UnitTest
         }
 
         m_application->Start(appDesc);
+
+        AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
 
         return m_application;
     }


### PR DESCRIPTION
- Error was reported about failure to write to UserSettings.xml
- Added a call to DisableSaveOnFinalize to avoid the error

## What does this PR do?

Attempts to eliminate an error that was produced in a recent unit test. May not solve the issue in the (apparently) flaky test, but we've seen this cause problems in the past and this is the remedy.

## How was this PR tested?

Built and ran `ScriptAutomation.Tests`.
