### PR TITLE
Fix a heap memory validataion issue when memory budget is set to 0.

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryUsage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryUsage.h
@@ -70,7 +70,7 @@ namespace AZ
                 if (Validation::IsEnabled())
                 {
                     AZ_Assert(
-                        m_budgetInBytes >= m_reservedInBytes,
+                        m_budgetInBytes >= m_reservedInBytes || m_budgetInBytes == 0,
                         "Reserved memory is larger than memory budget. Memory budget %zu Reserved %zu", m_budgetInBytes, m_reservedInBytes.load());
                     AZ_Assert(
                         m_reservedInBytes >= m_residentInBytes,
@@ -79,7 +79,7 @@ namespace AZ
 
                     
                     AZ_Assert(
-                        m_budgetInBytes >= m_totalResidentInBytes,
+                        m_budgetInBytes >= m_totalResidentInBytes || m_budgetInBytes == 0,
                         "Total resident memory is larger than memory budget. Memory budget %zu Total resident %zu", m_budgetInBytes, m_totalResidentInBytes.load());
                     AZ_Assert(
                         m_totalResidentInBytes >= m_usedResidentInBytes,


### PR DESCRIPTION
Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>

## What does this PR do?
Fixed a false asset issue when memory budget was set to 0.

## How was this PR tested?

Open loft scene with setreg  "O3DE/Autoexec/ConsoleCommands/bg_assertsAutoBreak" value set to 'true'