### PR TITLE
Add a set to ensure only unique instances get added to propagation queue

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -131,7 +131,7 @@ namespace AzToolsFramework
                 return entry == instance;
             });
 
-            m_uniqueInstancesForPropagation.erase(instance)
+            m_uniqueInstancesForPropagation.erase(instance);
         }
 
         void InstanceUpdateExecutor::LazyConnectGameModeEventHandler()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -38,7 +38,7 @@ namespace AzToolsFramework
             void AddInstanceToQueue(InstanceOptionalReference instance) override;
             void AddTemplateInstancesToQueue(TemplateId instanceTemplateId, InstanceOptionalConstReference instanceToExclude = AZStd::nullopt) override;
             bool UpdateTemplateInstancesInQueue() override;
-            void RemoveTemplateInstanceFromQueue(const Instance* instance) override;
+            void RemoveTemplateInstanceFromQueue(Instance* instance) override;
             void QueueRootPrefabLoadedNotificationForNextPropagation() override;
 
             void SetShouldPauseInstancePropagation(bool shouldPausePropagation) override;
@@ -52,11 +52,15 @@ namespace AzToolsFramework
             //! gets initialized after the PrefabSystemComponent.
             void LazyConnectGameModeEventHandler();
 
+            void AddInstanceToQueue(Instance* instance);
+
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
             TemplateInstanceMapperInterface* m_templateInstanceMapperInterface = nullptr;
             InstanceDomGeneratorInterface* m_instanceDomGeneratorInterface = nullptr;
             AZ::IO::Path m_rootPrefabInstanceSourcePath;
             AZStd::deque<Instance*> m_instancesUpdateQueue;
+            AZStd::unordered_set<Instance*> m_uniqueInstancesForPropagation;
+
             AZ::Event<GameModeState>::Handler m_GameModeEventHandler;
             int m_instanceCountToUpdateInBatch = 0;
             bool m_isRootPrefabInstanceLoaded = false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
@@ -38,7 +38,7 @@ namespace AzToolsFramework
 
             //! Removes an instance from the waiting queue.
             //! @param instance The instance to be removed from queue.
-            virtual void RemoveTemplateInstanceFromQueue(const Instance* instance) = 0;
+            virtual void RemoveTemplateInstanceFromQueue(Instance* instance) = 0;
 
             //! Sets the flag that tells whether root prefab instance is loaded to false.
             //! A notification OnRootPrefabInstanceLoaded will fire during the propagation if root


### PR DESCRIPTION
Signed-off-by: srikappa-amzn <82230713+srikappa-amzn@users.noreply.github.com>

## What does this PR do?

This PR ensures that only unique instances are added to the propagation queue. This prevents a lot of patch generation and additional logic for each duplicate instance in the queue.

## How was this PR tested?

Tested manually on large levels to ensure that locking and unlocking many entities at once doesn't cause significant slowdown or memory spike. Before this change, locking 1000 entities in a 3000 entity level took almost 2 mins to finish and memory spiked up to 50GB. After this the time came down to less than a second and memory only increased 0.2 GB. Created a follow up issue to see why memory is spiking for operations: https://github.com/o3de/o3de/issues/11401

Will run unit and automated tests that existing prefab workflows are happy with this change.
