### PR TITLE
Adding Settings Registry Adapter feature

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
@@ -96,6 +96,26 @@ namespace AZ
             Object
         };
 
+        //! Type of an integer
+        enum class Signedness
+        {
+            None,
+            Signed,
+            Unsigned
+        };
+
+        //! Encapsulate stored value and its signedness
+        struct SettingsType
+        {
+            operator Type() const
+            {
+                return m_type;
+            }
+
+            Type m_type{ Type::NoType };
+            Signedness m_signedness{ Signedness::None };
+        };
+
         //! The response to let the visit call know what to do next.
         enum class VisitResponse
         {
@@ -169,7 +189,7 @@ namespace AZ
         virtual ~SettingsRegistryInterface() = default;
 
         //! Returns the type of an entry in the Settings Registry or Type::None if there's no value or the path is invalid.
-        virtual Type GetType(AZStd::string_view path) const = 0;
+        virtual SettingsType GetType(AZStd::string_view path) const = 0;
         //! Traverses over the entries in the Settings Registry. Use this version to retrieve the values of entries as well.
         //! @param visitor An instance of a class derived from Visitor that will repeatedly be called as entries are encountered.
         //! @param path An offset at which traversal should start.

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
@@ -384,7 +384,7 @@ namespace AZ
         }
     }
 
-    SettingsRegistryInterface::Type SettingsRegistryImpl::GetType(AZStd::string_view path) const
+    SettingsRegistryInterface::SettingsType SettingsRegistryImpl::GetType(AZStd::string_view path) const
     {
         if (path.empty())
         {
@@ -400,11 +400,22 @@ namespace AZ
             AZStd::scoped_lock lock(m_settingMutex);
             if (const rapidjson::Value* value = pointer.Get(m_settings); value != nullptr)
             {
-                return SettingsRegistryImplInternal::RapidjsonToSettingsRegistryType(*value);
+                SettingsType type;
+                type.m_type = SettingsRegistryImplInternal::RapidjsonToSettingsRegistryType(*value);
+                if (value->IsInt64())
+                {
+                    type.m_signedness = Signedness::Signed;
+                }
+                else if (value->IsUint64())
+                {
+                    type.m_signedness = Signedness::Unsigned;
+                }
+                return type;
             }
         }
-        return Type::NoType;
+        return { Type::NoType, Signedness::None };
     }
+
 
     bool SettingsRegistryImpl::Get(bool& result, AZStd::string_view path) const
     {

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.h
@@ -45,7 +45,7 @@ namespace AZ
         void SetContext(SerializeContext* context);
         void SetContext(JsonRegistrationContext* context);
         
-        Type GetType(AZStd::string_view path) const override;
+        SettingsType GetType(AZStd::string_view path) const override;
         bool Visit(Visitor& visitor, AZStd::string_view path) const override;
         bool Visit(const VisitorCallback& callback, AZStd::string_view path) const override;
         [[nodiscard]] NotifyEventHandler RegisterNotifier(NotifyCallback callback) override;

--- a/Code/Framework/AzCore/AzCore/UnitTest/Mocks/MockSettingsRegistry.h
+++ b/Code/Framework/AzCore/AzCore/UnitTest/Mocks/MockSettingsRegistry.h
@@ -20,7 +20,7 @@ namespace AZ
         : public AZ::SettingsRegistryInterface
     {
     public:
-        MOCK_CONST_METHOD1(GetType, Type(AZStd::string_view));
+        MOCK_CONST_METHOD1(GetType, SettingsType(AZStd::string_view));
         MOCK_CONST_METHOD2(Visit, bool(Visitor&, AZStd::string_view));
         MOCK_CONST_METHOD2(Visit, bool(const VisitorCallback&, AZStd::string_view));
         MOCK_METHOD1(RegisterNotifier, NotifyEventHandler(NotifyCallback));

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.cpp
@@ -103,13 +103,13 @@ namespace AZ::DocumentPropertyEditor
                 {
                     int64_t domValue = valueFromEditor.GetInt64();
                     m_inEdit = true;
-                    settingsRegistry.Set(keyPath, domValue);
+                    settingsRegistry.Set(keyPath, static_cast<AZ::s64>(domValue));
                     m_inEdit = false;
                     return AZ::Dom::Value(domValue);
                 }
                 return {};
             };
-            m_builder.BeginPropertyEditor<Nodes::IntSpinBox>(Dom::Value(value));
+            m_builder.BeginPropertyEditor<Nodes::IntSpinBox>(Dom::Value(static_cast<int64_t>(value)));
             m_builder.AddMessageHandler(this, Nodes::PropertyEditor::OnChanged);
             SettingsRegistryDomData domData = { path, AZStd::move(UpdateSettingsRegistry) };
             m_fieldCallbackPrefixTree.SetValue(m_builder.GetCurrentPath(), domData);
@@ -131,13 +131,13 @@ namespace AZ::DocumentPropertyEditor
                 {
                     uint64_t domValue = valueFromEditor.GetUint64();
                     m_inEdit = true;
-                    settingsRegistry.Set(keyPath, domValue);
+                    settingsRegistry.Set(keyPath, static_cast<AZ::u64>(domValue));
                     m_inEdit = false;
                     return AZ::Dom::Value(domValue);
                 }
                 return {};
             };
-            m_builder.BeginPropertyEditor<Nodes::UintSpinBox>(Dom::Value(value));
+            m_builder.BeginPropertyEditor<Nodes::UintSpinBox>(Dom::Value(static_cast<uint64_t>(value)));
             m_builder.AddMessageHandler(this, Nodes::PropertyEditor::OnChanged);
             SettingsRegistryDomData domData = { path, AZStd::move(UpdateSettingsRegistry) };
             m_fieldCallbackPrefixTree.SetValue(m_builder.GetCurrentPath(), domData);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.cpp
@@ -265,7 +265,7 @@ namespace AZ::DocumentPropertyEditor
             domData.m_callback = [](AZStd::string_view, const AZ::Dom::Value&) -> AZ::Dom::Value
             {
                 // When support for adding for objects/array types
-                // are implemented, This function will need to prompty the user
+                // are implemented, This function will need to prompt the user
                 // for the name of the new field(objects only) and the value type of the field
                 return {};
             };

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Interface/Interface.h>
+#include <AzFramework/DocumentPropertyEditor/AdapterBuilder.h>
+#include <AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryOriginTracker.h>
+#include <AzCore/Settings/SettingsRegistryVisitorUtils.h>
+#include <AzCore/JSON/rapidjson.h>
+
+namespace AZ::DocumentPropertyEditor
+{
+    SettingsRegistryAdapter::SettingsRegistryAdapter()
+    {
+    }
+
+    SettingsRegistryAdapter::~SettingsRegistryAdapter()
+    {
+    }
+
+    bool SettingsRegistryAdapter::BuildField(
+        AZStd::string_view path, AZStd::string_view fieldName, AZ::SettingsRegistryInterface::Type type)
+    {
+        auto settingsRegistryOriginTracker = AZ::Interface<AZ::SettingsRegistryOriginTracker>::Get();
+        AZ::SettingsRegistryInterface& settingsRegistry = settingsRegistryOriginTracker->GetSettingsRegistry();
+        auto visitorCallback = [this](AZStd::string_view path, AZStd::string_view fieldName, AZ::SettingsRegistryInterface::Type type)
+        {
+            BuildField(path, fieldName, type);
+        };
+        m_builder.BeginRow();
+        m_builder.Label(fieldName);
+        if (type == AZ::SettingsRegistryInterface::Type::Boolean)
+        {
+            bool value;
+            settingsRegistry.Get(value, path);
+            m_builder.BeginPropertyEditor<Nodes::CheckBox>(Dom::Value(value));
+            m_builder.EndPropertyEditor();
+        }
+        else if (type == AZ::SettingsRegistryInterface::Type::Integer)
+        {
+            AZ::s64 value;
+            settingsRegistry.Get(value, path);
+            m_builder.BeginPropertyEditor<Nodes::IntSpinBox>(Dom::Value(value));
+            m_builder.EndPropertyEditor();
+        }
+        else if (type == AZ::SettingsRegistryInterface::Type::FloatingPoint)
+        {
+            m_builder.BeginPropertyEditor<Nodes::DoubleSlider>(Dom::Value(1.0));
+            m_builder.EndPropertyEditor();
+        }
+        else if (type == AZ::SettingsRegistryInterface::Type::String)
+        {
+            AZStd::string value;
+            settingsRegistry.Get(value, path);
+            m_builder.BeginPropertyEditor<Nodes::LineEdit>(Dom::Value(AZStd::string_view(value), true));
+            m_builder.Attribute(Nodes::PropertyEditor::ValueType, AZ::Dom::Utils::TypeIdToDomValue(azrtti_typeid<AZStd::string>()));
+            m_builder.EndPropertyEditor();
+        }
+        else if (type == AZ::SettingsRegistryInterface::Type::Object || type == AZ::SettingsRegistryInterface::Type::Array)
+        {
+            AZ::SettingsRegistryVisitorUtils::VisitField(settingsRegistry, visitorCallback, path);
+            m_builder.Label("");
+        }
+        AZ::IO::Path originPath;
+        if (settingsRegistryOriginTracker->FindLastOrigin(originPath, path))
+        {
+            m_builder.Label(originPath.FixedMaxPathString());
+        }
+        m_builder.EndRow();
+        return true;
+    }
+
+    Dom::Value SettingsRegistryAdapter::GenerateContents()
+    {
+        m_builder.BeginAdapter();
+
+        auto settingsRegistryOriginTracker = AZ::Interface<AZ::SettingsRegistryOriginTracker>::Get();
+        AZ::SettingsRegistryInterface& settingsRegistry = settingsRegistryOriginTracker->GetSettingsRegistry();
+        if (settingsRegistryOriginTracker != nullptr)
+        {
+            BuildField("", "", settingsRegistry.GetType(""));
+        }
+        m_builder.EndAdapter();
+        return m_builder.FinishAndTakeResult();
+    }
+}

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.cpp
@@ -7,17 +7,35 @@
  */
 
 #include <AzCore/Interface/Interface.h>
+#include <AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h>
 #include <AzFramework/DocumentPropertyEditor/AdapterBuilder.h>
 #include <AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Settings/SettingsRegistryOriginTracker.h>
 #include <AzCore/Settings/SettingsRegistryVisitorUtils.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
-#include <AzCore/IO/ByteContainerStream.h>
 #include <AzCore/JSON/rapidjson.h>
 
 namespace AZ::DocumentPropertyEditor
 {
+    SettingsRegistryAdapter::SettingsNotificationHandler::SettingsNotificationHandler(SettingsRegistryAdapter& adapter)
+        : m_settingsRegistryAdapter(adapter)
+    {
+    }
+
+    SettingsRegistryAdapter::SettingsNotificationHandler::~SettingsNotificationHandler() = default;
+
+    void SettingsRegistryAdapter::SettingsNotificationHandler::operator()(
+        const AZ::SettingsRegistryInterface::NotifyEventArgs&)
+    {
+        // If the settings registry adapter message handler is updating the Settings Registry
+        // prevent recursive loop by protecthing against the NotifyResetDocument call
+        if (!m_settingsRegistryAdapter.m_inEdit)
+        {
+            m_settingsRegistryAdapter.NotifyResetDocument();
+        }
+    }
+
     SettingsRegistryAdapter::SettingsRegistryAdapter()
         : SettingsRegistryAdapter(AZ::Interface<AZ::SettingsRegistryOriginTracker>::Get())
     {
@@ -36,75 +54,202 @@ namespace AZ::DocumentPropertyEditor
     SettingsRegistryAdapter::~SettingsRegistryAdapter() = default;
 
     SettingsRegistryOriginTracker* SettingsRegistryAdapter::GetSettingsRegistryOriginTracker()
+    {
         return m_originTracker;
     }
 
-    SettingsRegistryAdapter::SettingsNotificationHandler::SettingsNotificationHandler(SettingsRegistryAdapter& adapter)
-        : m_settingsRegistryAdapter(adapter)
+    const SettingsRegistryOriginTracker* SettingsRegistryAdapter::GetSettingsRegistryOriginTracker() const
     {
+        return m_originTracker;
     }
 
-    SettingsRegistryAdapter::SettingsNotificationHandler::~SettingsNotificationHandler() = default;
-
-    void SettingsRegistryAdapter::SettingsNotificationHandler::operator()(
-        const AZ::SettingsRegistryInterface::NotifyEventArgs&)
+    bool SettingsRegistryAdapter::BuildBool(AZStd::string_view path)
     {
-        m_settingsRegistryAdapter.NotifyResetDocument();
+        AZ::SettingsRegistryInterface& settingsRegistry = m_originTracker->GetSettingsRegistry();
+        if (bool value; settingsRegistry.Get(value, path))
+        {
+            auto UpdateSettingsRegistry = [this, &settingsRegistry](
+                AZStd::string_view keyPath, const AZ::Dom::Value& valueFromEditor) -> AZ::Dom::Value
+            {
+                if (valueFromEditor.IsBool())
+                {
+                    bool domValue = valueFromEditor.GetBool();
+                    m_inEdit = true;
+                    settingsRegistry.Set(keyPath, domValue);
+                    m_inEdit = false;
+                    return AZ::Dom::Value(domValue);
+                }
+                return {};
+            };
+            m_builder.BeginPropertyEditor<Nodes::CheckBox>(Dom::Value(value));
+            m_builder.AddMessageHandler(this, Nodes::PropertyEditor::OnChanged);
+            SettingsRegistryDomData domData = { path, AZStd::move(UpdateSettingsRegistry) };
+            m_fieldCallbackPrefixTree.SetValue(m_builder.GetCurrentPath(), domData);
+            m_builder.EndPropertyEditor();
+            return true;
+        }
+        return false;
+    }
+
+    bool SettingsRegistryAdapter::BuildInt64(AZStd::string_view path)
+    {
+        AZ::SettingsRegistryInterface& settingsRegistry = m_originTracker->GetSettingsRegistry();
+        if (AZ::s64 value;settingsRegistry.Get(value, path))
+        {
+            auto UpdateSettingsRegistry =  [this, &settingsRegistry](
+                AZStd::string_view keyPath, const AZ::Dom::Value& valueFromEditor) -> AZ::Dom::Value
+            {
+                if (valueFromEditor.IsInt())
+                {
+                    int64_t domValue = valueFromEditor.GetInt64();
+                    m_inEdit = true;
+                    settingsRegistry.Set(keyPath, domValue);
+                    m_inEdit = false;
+                    return AZ::Dom::Value(domValue);
+                }
+                return {};
+            };
+            m_builder.BeginPropertyEditor<Nodes::IntSpinBox>(Dom::Value(value));
+            m_builder.AddMessageHandler(this, Nodes::PropertyEditor::OnChanged);
+            SettingsRegistryDomData domData = { path, AZStd::move(UpdateSettingsRegistry) };
+            m_fieldCallbackPrefixTree.SetValue(m_builder.GetCurrentPath(), domData);
+            m_builder.EndPropertyEditor();
+            return true;
+        }
+        return false;
+    }
+
+    bool SettingsRegistryAdapter::BuildUInt64(AZStd::string_view path)
+    {
+        AZ::SettingsRegistryInterface& settingsRegistry = m_originTracker->GetSettingsRegistry();
+        if (AZ::u64 value; settingsRegistry.Get(value, path))
+        {
+            auto UpdateSettingsRegistry = [this, &settingsRegistry](
+                AZStd::string_view keyPath, const AZ::Dom::Value& valueFromEditor) -> AZ::Dom::Value
+            {
+                if (valueFromEditor.IsUint())
+                {
+                    uint64_t domValue = valueFromEditor.GetUint64();
+                    m_inEdit = true;
+                    settingsRegistry.Set(keyPath, domValue);
+                    m_inEdit = false;
+                    return AZ::Dom::Value(domValue);
+                }
+                return {};
+            };
+            m_builder.BeginPropertyEditor<Nodes::UintSpinBox>(Dom::Value(value));
+            m_builder.AddMessageHandler(this, Nodes::PropertyEditor::OnChanged);
+            SettingsRegistryDomData domData = { path, AZStd::move(UpdateSettingsRegistry) };
+            m_fieldCallbackPrefixTree.SetValue(m_builder.GetCurrentPath(), domData);
+            m_builder.EndPropertyEditor();
+            return true;
+        }
+        return false;
+    }
+
+    bool SettingsRegistryAdapter::BuildFloat(AZStd::string_view path)
+    {
+        AZ::SettingsRegistryInterface& settingsRegistry = m_originTracker->GetSettingsRegistry();
+        if (double value; settingsRegistry.Get(value, path))
+        {
+            auto UpdateSettingsRegistry = [this, &settingsRegistry](
+                AZStd::string_view keyPath, const AZ::Dom::Value& valueFromEditor) -> AZ::Dom::Value
+            {
+                if (valueFromEditor.IsDouble())
+                {
+                    double domValue = valueFromEditor.GetDouble();
+                    m_inEdit = true;
+                    settingsRegistry.Set(keyPath, domValue);
+                    m_inEdit = false;
+                    return AZ::Dom::Value(domValue);
+                }
+                return {};
+            };
+            m_builder.BeginPropertyEditor<Nodes::DoubleSpinBox>(Dom::Value(value));
+            m_builder.AddMessageHandler(this, Nodes::PropertyEditor::OnChanged);
+            SettingsRegistryDomData domData = { path, AZStd::move(UpdateSettingsRegistry) };
+            m_fieldCallbackPrefixTree.SetValue(m_builder.GetCurrentPath(), domData);
+            m_builder.EndPropertyEditor();
+            return true;
+        }
+        return false;
+    }
+
+    bool SettingsRegistryAdapter::BuildString(AZStd::string_view path)
+    {
+        AZ::SettingsRegistryInterface& settingsRegistry = m_originTracker->GetSettingsRegistry();
+        if (AZStd::string value; settingsRegistry.Get(value, path))
+        {
+            auto UpdateSettingsRegistry = [this, &settingsRegistry](
+                AZStd::string_view keyPath, const AZ::Dom::Value& valueFromEditor) -> AZ::Dom::Value
+            {
+                if (valueFromEditor.IsString())
+                {
+                    AZStd::string_view domValue = valueFromEditor.GetString();
+                    m_inEdit = true;
+                    settingsRegistry.Set(keyPath, domValue);
+                    m_inEdit = false;
+                    return AZ::Dom::Value(domValue, true);
+                }
+                return {};
+            };
+            m_builder.BeginPropertyEditor<Nodes::LineEdit>(Dom::Value(AZStd::string_view(value), true));
+            m_builder.Attribute(Nodes::PropertyEditor::ValueType, AZ::Dom::Utils::TypeIdToDomValue(azrtti_typeid<AZStd::string>()));
+            m_builder.AddMessageHandler(this, Nodes::PropertyEditor::OnChanged);
+            SettingsRegistryDomData domData = { path, AZStd::move(UpdateSettingsRegistry) };
+            m_fieldCallbackPrefixTree.SetValue(m_builder.GetCurrentPath(), domData);
+            m_builder.EndPropertyEditor();
+            return true;
+        }
+        return false;
     }
 
     bool SettingsRegistryAdapter::BuildField(
         AZStd::string_view path, AZStd::string_view fieldName, AZ::SettingsRegistryInterface::Type type)
     {
-        AZ::SettingsRegistryInterface& settingsRegistry = m_originTracker->GetSettingsRegistry();
-        m_builder.BeginRow();
+        struct ScopedAdapterBuilderRowCreation
+        {
+            ScopedAdapterBuilderRowCreation(AZ::DocumentPropertyEditor::AdapterBuilder& adapterBuilder)
+                : m_adapterBuilder(adapterBuilder)
+            {
+                m_adapterBuilder.BeginRow();
+            }
+            ~ScopedAdapterBuilderRowCreation()
+            {
+                m_adapterBuilder.EndRow();
+            }
+        private:
+            AZ::DocumentPropertyEditor::AdapterBuilder& m_adapterBuilder;
+        };
+
+        ScopedAdapterBuilderRowCreation scopedBuilderRow(m_builder);
         m_builder.Label(fieldName);
         if (type == AZ::SettingsRegistryInterface::Type::Boolean)
         {
-            bool value;
-            if (settingsRegistry.Get(value, path))
-            {
-                m_builder.BeginPropertyEditor<Nodes::CheckBox>(Dom::Value(value));
-                m_builder.EndPropertyEditor();
-            }
+            BuildBool(path);
         }
         else if (type == AZ::SettingsRegistryInterface::Type::Integer)
         {
             using SettingsType = AZ::SettingsRegistryInterface::SettingsType;
 
+            AZ::SettingsRegistryInterface& settingsRegistry = m_originTracker->GetSettingsRegistry();
             const SettingsType settingsType = settingsRegistry.GetType(path);
             if (settingsType.m_signedness == AZ::SettingsRegistryInterface::Signedness::Signed)
             {
-                if (AZ::s64 value; settingsRegistry.Get(value, path))
-                {
-                    m_builder.BeginPropertyEditor<Nodes::IntSpinBox>(Dom::Value(value));
-                    m_builder.EndPropertyEditor();
-                }
+                BuildInt64(path);
             }
             else
             {
-                if (AZ::u64 value; settingsRegistry.Get(value, path))
-                {
-                    m_builder.BeginPropertyEditor<Nodes::UintSpinBox>(Dom::Value(value));
-                    m_builder.EndPropertyEditor();
-                }
+                BuildUInt64(path);
             }
         }
         else if (type == AZ::SettingsRegistryInterface::Type::FloatingPoint)
         {
-            if (double value; settingsRegistry.Get(value, path))
-            {
-                m_builder.BeginPropertyEditor<Nodes::DoubleSpinBox>(Dom::Value(value));
-                m_builder.EndPropertyEditor();
-            }
+            BuildFloat(path);
         }
         else if (type == AZ::SettingsRegistryInterface::Type::String)
         {
-            if (AZStd::string value; settingsRegistry.Get(value, path))
-            {
-                m_builder.BeginPropertyEditor<Nodes::LineEdit>(Dom::Value(value, true));
-                m_builder.Attribute(Nodes::PropertyEditor::ValueType, AZ::Dom::Utils::TypeIdToDomValue(azrtti_typeid<AZStd::string>()));
-                m_builder.EndPropertyEditor();
-            }
+            BuildString(path);
         }
         else if (type == AZ::SettingsRegistryInterface::Type::Object || type == AZ::SettingsRegistryInterface::Type::Array)
         {
@@ -112,8 +257,23 @@ namespace AZ::DocumentPropertyEditor
             {
                 BuildField(path, fieldName, type);
             };
+            AZ::SettingsRegistryInterface& settingsRegistry = m_originTracker->GetSettingsRegistry();
             AZ::SettingsRegistryVisitorUtils::VisitField(settingsRegistry, visitorCallback, path);
             m_builder.Label("");
+            SettingsRegistryDomData domData;
+            domData.m_settingsKeyPath = path;
+            domData.m_callback = [](AZStd::string_view, const AZ::Dom::Value&) -> AZ::Dom::Value
+            {
+                // When support for adding for objects/array types
+                // are implemented, This function will need to prompty the user
+                // for the name of the new field(objects only) and the value type of the field
+                return {};
+            };
+            m_fieldCallbackPrefixTree.SetValue(m_builder.GetCurrentPath(), domData);
+        }
+        else
+        {
+            return false;
         }
 
         AZ::IO::Path originPath;
@@ -121,21 +281,56 @@ namespace AZ::DocumentPropertyEditor
         {
             m_builder.Label(originPath.Native());
         }
-        m_builder.EndRow();
         return true;
     }
 
     Dom::Value SettingsRegistryAdapter::GenerateContents()
     {
-        m_builder.BeginAdapter();
         if (m_originTracker != nullptr)
         {
+            m_builder.BeginAdapter();
             // Start from the root key of the Settings Registry
             AZ::SettingsRegistryInterface& settingsRegistry = m_originTracker->GetSettingsRegistry();
             BuildField("", "", settingsRegistry.GetType(""));
+            m_builder.EndAdapter();
         }
 
-        m_builder.EndAdapter();
         return m_builder.FinishAndTakeResult();
+    }
+
+    Dom::Value SettingsRegistryAdapter::HandleMessage(const AdapterMessage& message)
+    {
+        using ValueChangeType = Nodes::ValueChangeType;
+        auto handlePropertyEditorChanged = [messageOrigin = message.m_messageOrigin, this](
+            const Dom::Value& valueFromEditor,
+            ValueChangeType changeType)
+        {
+            if (changeType == ValueChangeType::FinishedEdit)
+            {
+                if (SettingsRegistryDomData* domData =
+                    m_fieldCallbackPrefixTree.ValueAtPath(messageOrigin, AZ::Dom::PrefixTreeMatch::ExactPath);
+                    domData != nullptr)
+                {
+                    if (domData->m_callback)
+                    {
+                        Dom::Value newValue = domData->m_callback(domData->m_settingsKeyPath, valueFromEditor);
+                        NotifyContentsChanged({ Dom::PatchOperation::ReplaceOperation(messageOrigin / "Value", newValue) });
+                    }
+                }
+            }
+        };
+
+        auto handleTreeUpdate = [this](Nodes::PropertyRefreshLevel)
+        {
+            // For now just trigger a soft reset.
+            // This will still only send the view patches for what's actually changed.
+            NotifyResetDocument();
+        };
+
+        return message.Match(
+            Nodes::PropertyEditor::OnChanged,
+            handlePropertyEditorChanged,
+            Nodes::PropertyEditor::RequestTreeUpdate,
+            handleTreeUpdate);
     }
 }

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.h
@@ -10,6 +10,7 @@
 
 #include <AzFramework/DocumentPropertyEditor/DocumentAdapter.h>
 #include <AzFramework/DocumentPropertyEditor/AdapterBuilder.h>
+#include <AzCore/DOM/DomPrefixTree.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Settings/SettingsRegistryOriginTracker.h>
 
@@ -33,8 +34,28 @@ namespace AZ::DocumentPropertyEditor
         SettingsRegistryOriginTracker* GetSettingsRegistryOriginTracker();
         const SettingsRegistryOriginTracker* GetSettingsRegistryOriginTracker() const;
 
+        bool BuildBool(AZStd::string_view path);
+
+        bool BuildInt64(AZStd::string_view path);
+
+        bool BuildUInt64(AZStd::string_view path);
+
+        bool BuildFloat(AZStd::string_view path);
+
+        bool BuildString(AZStd::string_view path);
+
+        struct SettingsRegistryDomData
+        {
+            AZStd::string m_settingsKeyPath;
+            // Maps to the DOM Property Editor OnChanged callback which is sent
+            // when an edit changes a field
+            using FieldChangeCallback = AZStd::function<Dom::Value(AZStd::string_view keyPath, const Dom::Value&)>;
+            FieldChangeCallback m_callback;
+        };
+
     protected:
         Dom::Value GenerateContents() override;
+        Dom::Value HandleMessage(const AdapterMessage& message) override;
 
     private:
         struct SettingsNotificationHandler
@@ -51,5 +72,7 @@ namespace AZ::DocumentPropertyEditor
         AdapterBuilder m_builder;
         AZ::SettingsRegistryOriginTracker* m_originTracker = nullptr;
         AZ::SettingsRegistryInterface::NotifyEventHandler m_notifyHandler;
+        AZ::Dom::DomPrefixTree<SettingsRegistryDomData> m_fieldCallbackPrefixTree;
+        bool m_inEdit = false;
     };
 }

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.h
@@ -27,14 +27,29 @@ namespace AZ::DocumentPropertyEditor
         ~SettingsRegistryAdapter();
 
         // Recurses through the Settings Registry associated with the supplied Settings Registry Origin Tracker
-        // populates PropertyEditorNOdes
+        // populates PropertyEditorNodes
         bool BuildField(AZStd::string_view path, AZStd::string_view fieldName, AZ::SettingsRegistryInterface::Type type);
+
+        SettingsRegistryOriginTracker* GetSettingsRegistryOriginTracker();
+        const SettingsRegistryOriginTracker* GetSettingsRegistryOriginTracker() const;
 
     protected:
         Dom::Value GenerateContents() override;
 
     private:
+        struct SettingsNotificationHandler
+        {
+            SettingsNotificationHandler(SettingsRegistryAdapter& adapter);
+            ~SettingsNotificationHandler();
+
+            void operator()(const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs);
+
+        private:
+            SettingsRegistryAdapter& m_settingsRegistryAdapter;
+        };
+
         AdapterBuilder m_builder;
         AZ::SettingsRegistryOriginTracker* m_originTracker = nullptr;
+        AZ::SettingsRegistryInterface::NotifyEventHandler m_notifyHandler;
     };
 }

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzFramework/DocumentPropertyEditor/DocumentAdapter.h>
+#include <AzFramework/DocumentPropertyEditor/AdapterBuilder.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryOriginTracker.h>
+
+namespace AZ::DocumentPropertyEditor
+{
+    class SettingsRegistryAdapter : public DocumentAdapter
+    {
+    public:
+        SettingsRegistryAdapter();
+        ~SettingsRegistryAdapter();
+
+        bool BuildField(AZStd::string_view path, AZStd::string_view fieldName, AZ::SettingsRegistryInterface::Type type);
+
+    protected:
+        Dom::Value GenerateContents() override;
+
+    private:
+        AdapterBuilder m_builder;
+       /* AZ::SettingsRegistryInterface& m_settingsRegistry;
+        AZ::SettingsRegistryOriginTracker& m_originTracker;
+        AZStd::unique_ptr<AZ::SettingsRegistryOriginTracker> m_originTracker;*/
+    };
+}

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.h
@@ -18,9 +18,16 @@ namespace AZ::DocumentPropertyEditor
     class SettingsRegistryAdapter : public DocumentAdapter
     {
     public:
+        //! Default constructs a Settings Registry adapter that uses the globally registered
+        //! SettingsRegistryOriginTracker instance
         SettingsRegistryAdapter();
+
+        //! Constructs a Settings Registry adapter using the supplied SettingsRegistry Origin Tracker instance
+        explicit SettingsRegistryAdapter(AZ::SettingsRegistryOriginTracker* originTracker);
         ~SettingsRegistryAdapter();
 
+        // Recurses through the Settings Registry associated with the supplied Settings Registry Origin Tracker
+        // populates PropertyEditorNOdes
         bool BuildField(AZStd::string_view path, AZStd::string_view fieldName, AZ::SettingsRegistryInterface::Type type);
 
     protected:
@@ -28,8 +35,6 @@ namespace AZ::DocumentPropertyEditor
 
     private:
         AdapterBuilder m_builder;
-       /* AZ::SettingsRegistryInterface& m_settingsRegistry;
-        AZ::SettingsRegistryOriginTracker& m_originTracker;
-        AZStd::unique_ptr<AZ::SettingsRegistryOriginTracker> m_originTracker;*/
+        AZ::SettingsRegistryOriginTracker* m_originTracker = nullptr;
     };
 }

--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -152,6 +152,8 @@ set(FILES
     DocumentPropertyEditor/CvarAdapter.h
     DocumentPropertyEditor/RoutingAdapter.cpp
     DocumentPropertyEditor/RoutingAdapter.h
+    DocumentPropertyEditor/SettingsRegistryAdapter.cpp
+    DocumentPropertyEditor/SettingsRegistryAdapter.h
     DocumentPropertyEditor/ReflectionAdapter.cpp
     DocumentPropertyEditor/ReflectionAdapter.h
     DocumentPropertyEditor/Reflection/Attribute.h

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/SettingsRegistryAdapterTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/SettingsRegistryAdapterTests.cpp
@@ -110,6 +110,5 @@ namespace AZ::DocumentPropertyEditor::Tests
                }
            }
        )"));
-
     }
 }

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/SettingsRegistryAdapterTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/SettingsRegistryAdapterTests.cpp
@@ -90,10 +90,10 @@ namespace AZ::DocumentPropertyEditor::Tests
                     }
                }
            }
-       )"));
+        )"));
         ASSERT_TRUE(CreateTestFile(filePath2, R"(
            {
-            "O3DE": {
+               "O3DE": {
                     "ArrayValue": [
                         27,
                         39
@@ -105,7 +105,7 @@ namespace AZ::DocumentPropertyEditor::Tests
                     "DoubleValue": 4.0
                 }
            }
-       )"));
+        )"));
         m_settingsRegistry->MergeSettingsFile(
             filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
         m_settingsRegistry->MergeSettingsFile(

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/SettingsRegistryAdapterTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/SettingsRegistryAdapterTests.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/IO/SystemFile.h>
+
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryImpl.h>
+#include <AzCore/Settings/SettingsRegistryOriginTracker.h>
+#include <AzCore/Interface/Interface.h>
+#include <AzFramework/DocumentPropertyEditor/AdapterBuilder.h>
+#include <AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.h>
+#include <AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h>
+#include <Tests/DocumentPropertyEditor/DocumentPropertyEditorFixture.h>
+#include <AzCore/JSON/document.h>
+#include <AzCore/JSON/writer.h>
+
+
+namespace AZ::DocumentPropertyEditor::Tests
+{
+    class SettingsRegistryAdapterDpeFixture : public DocumentPropertyEditorTestFixture
+    {
+    public:
+        void SetUp() override
+        {
+            DocumentPropertyEditorTestFixture::SetUp();
+            m_settingsRegistry = AZStd::make_unique<SettingsRegistryImpl>();
+            m_settingsRegistryOriginTracker = AZStd::make_unique<SettingsRegistryOriginTracker>(*m_settingsRegistry);
+            AZ::Interface<AZ::SettingsRegistryOriginTracker>::Register(m_settingsRegistryOriginTracker.get());
+            m_adapter = AZStd::make_unique<SettingsRegistryAdapter>();
+        }
+
+        void TearDown() override
+        {
+            m_adapter.reset();
+            AZ::Interface<AZ::SettingsRegistryOriginTracker>::Unregister(m_settingsRegistryOriginTracker.get());
+            m_settingsRegistryOriginTracker.reset();
+            m_settingsRegistry.reset();
+            DocumentPropertyEditorTestFixture::TearDown();
+        }
+
+        static bool CreateTestFile(const AZ::IO::FixedMaxPath& testPath, AZStd::string_view content)
+        {
+            AZ::IO::SystemFile file;
+            if (!file.Open(
+                    testPath.c_str(),
+                    AZ::IO::SystemFile::OpenMode::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH |
+                        AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY))
+            {
+                AZ_Assert(false, "Unable to open test file for writing: %s", testPath.c_str());
+                return false;
+            }
+
+            if (file.Write(content.data(), content.size()) != content.size())
+            {
+                AZ_Assert(false, "Unable to write content to test file: %s", testPath.c_str());
+                return false;
+            }
+
+            return true;
+        }
+
+    protected:
+        AZStd::unique_ptr<AZ::SettingsRegistryInterface> m_settingsRegistry;
+        AZStd::unique_ptr<AZ::SettingsRegistryOriginTracker> m_settingsRegistryOriginTracker;
+        AZStd::unique_ptr<SettingsRegistryAdapter> m_adapter;
+        AZ::Test::ScopedAutoTempDirectory m_testFolder;
+    };
+
+    TEST_F(SettingsRegistryAdapterDpeFixture, GenerateContent_MergedSettingsFiles_Displayed)
+    {
+        auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
+        AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.json";
+        AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.json";
+        ASSERT_TRUE(CreateTestFile(filePath1, R"(
+           {
+               "O3DE": {
+                   "Settings": {
+                       "ArrayValue": [
+                           3,
+                           7,
+                           4000
+                       ],
+                       "ObjectValue": {
+                           "StringKey1": "Hello",
+                           "BoolKey1": true
+                       }
+                   }
+               }
+           }
+       )"));
+        ASSERT_TRUE(CreateTestFile(filePath2, R"(
+           {
+               "O3DE": {
+                   "Settings": {
+                       "ArrayValue": [
+                           27,
+                           39
+                       ],
+                       "ObjectValue": {
+                           "StringKey1": "Hi",
+                           "IntKey2": 9001,
+                        },
+                       "DoubleValue": 4.0
+                   }
+               }
+           }
+       )"));
+
+    }
+}

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/SettingsRegistryAdapterTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/SettingsRegistryAdapterTests.cpp
@@ -79,36 +79,42 @@ namespace AZ::DocumentPropertyEditor::Tests
         ASSERT_TRUE(CreateTestFile(filePath1, R"(
            {
                "O3DE": {
-                   "Settings": {
-                       "ArrayValue": [
-                           3,
-                           7,
-                           4000
-                       ],
-                       "ObjectValue": {
-                           "StringKey1": "Hello",
-                           "BoolKey1": true
-                       }
-                   }
+                    "ArrayValue": [
+                        3,
+                        7,
+                        4000
+                    ],
+                    "ObjectValue": {
+                        "StringKey1": "Hello",
+                        "BoolKey1": true
+                    }
                }
            }
        )"));
         ASSERT_TRUE(CreateTestFile(filePath2, R"(
            {
-               "O3DE": {
-                   "Settings": {
-                       "ArrayValue": [
-                           27,
-                           39
-                       ],
-                       "ObjectValue": {
-                           "StringKey1": "Hi",
-                           "IntKey2": 9001,
-                        },
-                       "DoubleValue": 4.0
-                   }
-               }
+            "O3DE": {
+                    "ArrayValue": [
+                        27,
+                        39
+                    ],
+                    "ObjectValue": {
+                        "StringKey1": "Hi",
+                        "IntKey2": 9001,
+                    },
+                    "DoubleValue": 4.0
+                }
            }
        )"));
+        m_settingsRegistry->MergeSettingsFile(
+            filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
+        m_settingsRegistry->MergeSettingsFile(
+            filePath2.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
+
+        Dom::Value result = m_adapter->GetContents();
+        AZStd::string_view stringKey1Path = "/O3DE/ObjectValue/StringKey1";
+        AZStd::string_view stringKey1NewValue = R"(Greetings)";
+        ASSERT_TRUE(m_settingsRegistry->Set(stringKey1Path, stringKey1NewValue));
+        result = m_adapter->GetContents();
     }
 }

--- a/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
+++ b/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
@@ -37,4 +37,5 @@ set(FILES
     DocumentPropertyEditor/AdapterBuilderTests.cpp
     DocumentPropertyEditor/SchemaTests.cpp
     DocumentPropertyEditor/CvarAdapterTests.cpp
+    DocumentPropertyEditor/SettingsRegistryAdapterTests.cpp
 )

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -33,6 +33,7 @@
 #include <AzCore/DOM/Backends/JSON/JsonBackend.h>
 #include <AzFramework/DocumentPropertyEditor/CvarAdapter.h>
 #include <AzFramework/DocumentPropertyEditor/ReflectionAdapter.h>
+#include <AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.h>
 #include <AzQtComponents/DPEDebugViewStandalone/ExampleAdapter.h>
 #include <AzToolsFramework/UI/DPEDebugViewer/DPEDebugWindow.h>
 
@@ -226,6 +227,7 @@ int main(int argc, char** argv)
     debugViewer->AddAdapterToList("CVar Adapter", AZStd::make_shared<AZ::DocumentPropertyEditor::CvarAdapter>());
     debugViewer->AddAdapterToList("Example Adapter", AZStd::make_shared<AZ::DocumentPropertyEditor::ExampleAdapter>());
     debugViewer->AddAdapterToList("Reflection Adapter", AZStd::make_shared<AZ::DocumentPropertyEditor::ReflectionAdapter>(&testContainer, azrtti_typeid<DPEDebugView::TestContainer>()));
+    debugViewer->AddAdapterToList("Settings Registry Adapter", AZStd::make_shared<AZ::DocumentPropertyEditor::SettingsRegistryAdapter>());
 
     debugViewer->show();
     dpeInstance->show();

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -166,20 +166,11 @@ namespace AZ
 
 namespace DPEDebugView
 {
-    class DPEDebugApplication : public AzToolsFramework::ToolsApplication
+    class DPEDebugApplication
+        : public AzToolsFramework::ToolsApplication
     {
     public:
-        DPEDebugApplication(int* argc = nullptr, char*** argv = nullptr)
-            : AzToolsFramework::ToolsApplication(argc, argv)
-        {
-            AZ::NameDictionary::Create();
-            AZ::AllocatorInstance<AZ::Dom::ValueAllocator>::Create();
-        }
-
-        virtual ~DPEDebugApplication()
-        {
-            AZ::AllocatorInstance<AZ::Dom::ValueAllocator>::Destroy();
-        }
+        using AzToolsFramework::ToolsApplication::ToolsApplication;
 
         void Reflect(AZ::ReflectContext* context) override
         {
@@ -218,7 +209,8 @@ int main(int argc, char** argv)
     QPointer<AzToolsFramework::DPEDebugWindow> debugViewer = new AzToolsFramework::DPEDebugWindow(nullptr);
 
     // create a real DPE to track the same adapter selected for the debug tool
-    AzToolsFramework::DocumentPropertyEditor* dpeInstance = new AzToolsFramework::DocumentPropertyEditor(nullptr);
+    QPointer<AzToolsFramework::DocumentPropertyEditor> dpeInstance = new AzToolsFramework::DocumentPropertyEditor(nullptr);
+    dpeInstance->setAttribute(Qt::WA_DeleteOnClose);
     dpeInstance->SetSpawnDebugView(false); // don't allow this DPE to spawn debug views, as we've made our own
     QObject::connect(
         debugViewer.data(), &AzToolsFramework::DPEDebugWindow::AdapterChanged, dpeInstance,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DPEDebugViewer/DPEDebugModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DPEDebugViewer/DPEDebugModel.cpp
@@ -326,6 +326,13 @@ namespace AzToolsFramework
     void DPEDebugModel::SetAdapter(AZ::DocumentPropertyEditor::DocumentAdapterPtr theAdapter)
     {
         m_adapter = theAdapter;
+        if (m_adapter == nullptr)
+        {
+            // Clear out the event handlers when a nullptr DocumentAdapter is suppleid
+            m_resetHandler = {};
+            m_changedHandler = {};
+            return;
+        };
         m_resetHandler = AZ::DocumentPropertyEditor::DocumentAdapter::ResetEvent::Handler(
             [this]()
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DPEDebugViewer/DPEDebugTextView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DPEDebugViewer/DPEDebugTextView.cpp
@@ -18,6 +18,14 @@ namespace AzToolsFramework
     void DPEDebugTextView::SetAdapter(AZ::DocumentPropertyEditor::DocumentAdapterPtr adapter)
     {
         m_adapter = AZStd::move(adapter);
+        if (m_adapter == nullptr)
+        {
+            // Clear out the event handlers when a nullptr DocumentAdapter is suppleid
+            m_resetHandler = {};
+            m_changeHandler = {};
+            return;
+        };
+
         m_resetHandler = AZ::DocumentPropertyEditor::DocumentAdapter::ResetEvent::Handler(
             [this]()
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DPEDebugViewer/DPEDebugWindow.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DPEDebugViewer/DPEDebugWindow.cpp
@@ -16,6 +16,7 @@ namespace AzToolsFramework
     DPEDebugWindow::DPEDebugWindow(QWidget* parentWidget)
         : QMainWindow(parentWidget)
     {
+        setAttribute(Qt::WA_DeleteOnClose);
         m_ui = new Ui::DPEDebugWindow;
         m_ui->setupUi(this);
 
@@ -28,6 +29,8 @@ namespace AzToolsFramework
                 SetAdapter(m_adapters[m_ui->adapterSelector->currentIndex()]);
             });
     }
+
+    DPEDebugWindow::~DPEDebugWindow() = default;
 
     void DPEDebugWindow::SetAdapter(AZ::DocumentPropertyEditor::DocumentAdapterPtr adapter)
     {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DPEDebugViewer/DPEDebugWindow.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DPEDebugViewer/DPEDebugWindow.h
@@ -35,6 +35,7 @@ namespace AzToolsFramework
         Q_OBJECT
     public:
         explicit DPEDebugWindow(QWidget* parentWidget);
+        ~DPEDebugWindow() override;
         void SetAdapter(AZ::DocumentPropertyEditor::DocumentAdapterPtr adapter);
         AZ::DocumentPropertyEditor::DocumentAdapterPtr GetAdapter();
         void AddAdapterToList(const QString& adapterName, AZ::DocumentPropertyEditor::DocumentAdapterPtr adapter);


### PR DESCRIPTION
## What does this PR do?

Integrates @noortor work for implementing a Settings Registry Adapter that can view and edit the associated Settings Registry.

The Settings Registry Adapter can be played in the [DPEDebugViewStandalone](https://github.com/o3de/o3de/blob/development/Code/Framework/AzQtComponents/CMakeLists.txt#L79-L91) application under the AzQtComponents folder.

The Settings Registry Adapter can modify existing fundamental type fields of objects and arrays which are string, bool, float and int, but currently cannot add or remove fields from an array or object.

Added the WM_DeleteOnClose attribute the [DPEDebugWindow class and DocumentPropertyEditor](https://github.com/o3de/o3de/blob/development/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp#L217-L220) to fix shutdown crash in the DPEDebugViewStandalone application.

relates #2218

## How was this PR tested?

Manual testing of the Settings Registry Adapter in the DPEDebugViewStandalone application.
![image](https://user-images.githubusercontent.com/56135373/185512429-a6a8c55c-607a-4dd7-968a-ff6f3fe0e4a4.png)

