### PR TITLE
associative containers: added method to retrieve a value by key and the ability to discern containers with mapped types from simple keyed containers

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -49,7 +49,7 @@ namespace AZStd
     template<class T>
     class shared_ptr;
 
-    namespace AssociativeInternal
+    inline namespace AssociativeInternal
     {
         // SFINAE expression to determine whether an associative container is an actual map with a corresponding value for each key,
         // or is simply a keyed container, like a set or an unordered_set

--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -48,6 +48,16 @@ namespace AZStd
     class intrusive_ptr;
     template<class T>
     class shared_ptr;
+
+    namespace AssociativeInternal
+    {
+        // SFINAE expression to determine whether an associative container is an actual map with a corresponding value for each key,
+        // or is simply a keyed container, like a set or an unordered_set
+        template<class T, class = void>
+        constexpr bool IsMapType_v = false;
+        template<class T>
+        constexpr bool IsMapType_v<T, enable_if_t<Internal::sfinae_trigger_v<typename T::mapped_type>>> = true;
+    }
 }
 
 namespace AZ
@@ -824,6 +834,31 @@ namespace AZ
                 T* containerPtr = reinterpret_cast<T*>(instance);
                 auto elementIterator = containerPtr->find(*reinterpret_cast<const KeyType*>(key));
                 return (elementIterator != containerPtr->end()) ? &(*elementIterator) : nullptr;
+            }
+
+            /// Get the mapped value's address by its key. If there is no mapped value (like in a set<>) the value returned is
+            /// the key itself
+            virtual void* GetValueByKey(void* instance, const void* key) override
+            {
+                void* value = nullptr;
+                T* containerPtr = reinterpret_cast<T*>(instance);
+                auto elementIterator = containerPtr->find(*reinterpret_cast<const KeyType*>(key));
+
+                if constexpr (AZStd::AssociativeInternal::IsMapType_v<T>)
+                {
+                    if (elementIterator != containerPtr->end())
+                    {
+                        value = &(elementIterator->second);
+                    }
+                }
+                else
+                {
+                    if (elementIterator != containerPtr->end())
+                    {
+                        value = &(*elementIterator);
+                    }
+                }
+                return value;
             }
 
             /// Store element

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
@@ -783,6 +783,8 @@ namespace AZ
                 virtual void*   GetElementByKey(void* instance, const ClassElement* classElement, const void* key) = 0;
                 /// Populates element with key (for associative containers). Not used for serialization.
                 virtual void    SetElementKey(void* element, void* key) = 0;
+                /// Get the mapped value's address by its key. If there is no mapped value (like in a set<>) the value returned is the key itself
+                virtual void* GetValueByKey(void* instance, const void* key) = 0;
             };
 
             /// Return default element generic name (used by most containers).


### PR DESCRIPTION
added method to discern between associative containers with mapped
values and simple containers with only keys. Added GetValueByKey to
retrieve values from associative containers by key.

Signed-off-by: Alex Montgomery <alexmont@amazon.com>

## What does this PR do?
added method to discern between associative containers with mapped
values and simple containers with only keys. Added GetValueByKey to
retrieve values from associative containers by key.

## How was this PR tested?
locally with Generic DOM code
