### PR TITLE
Tif/clean directories cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,10 @@ include(cmake/UnitTest.cmake)
 include(cmake/LYTestWrappers.cmake)
 include(cmake/Monolithic.cmake)
 include(cmake/SettingsRegistry.cmake)
-include(cmake/TestImpactFramework/LYTestImpactFramework.cmake)
 include(cmake/CMakeFiles.cmake)
 include(cmake/O3DEJson.cmake)
 include(cmake/Subdirectories.cmake)
+include(cmake/TestImpactFramework/LYTestImpactFramework.cmake)
 
 # Gather the list of o3de_manifest external Subdirectories
 # into the LY_EXTERNAL_SUBDIRS_O3DE_MANIFEST_PROPERTY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include(cmake/SettingsRegistry.cmake)
 include(cmake/CMakeFiles.cmake)
 include(cmake/O3DEJson.cmake)
 include(cmake/Subdirectories.cmake)
-include(cmake/TestImpactFramework/LYTestImpactFramework.cmake)
+include(cmake/TestImpactFramework/LYTestImpactFramework.cmake) # Put at end as nothing else depends on it
 
 # Gather the list of o3de_manifest external Subdirectories
 # into the LY_EXTERNAL_SUBDIRS_O3DE_MANIFEST_PROPERTY

--- a/cmake/TestImpactFramework/ConsoleFrontendConfig.in
+++ b/cmake/TestImpactFramework/ConsoleFrontendConfig.in
@@ -52,7 +52,7 @@
     "workspace": {
       "temp": {
         "root": "${native_temp_dir}",
-        "run_artifact_dir": "${GTEST_XML_OUTPUT_DIR}",
+        "run_artifact_dir": "${LY_TEST_IMPACT_NATIVE_TEST_RUN_DIR}",
         "coverage_artifact_dir": "${native_temp_dir}/Coverage",
         "enumeration_cache_dir": "${native_temp_dir}/EnumerationCache"
       },
@@ -101,7 +101,7 @@
     "workspace": {
       "temp": {
         "root": "${python_temp_dir}",
-        "run_artifact_dir": "${PYTEST_XML_OUTPUT_DIR}",
+        "run_artifact_dir": "${LY_TEST_IMPACT_PYTHON_TEST_RUN_DIR}",
         "coverage_artifact_dir": "${python_temp_dir}/Coverage",
         "enumeration_cache_dir": "${python_temp_dir}/EnumerationCache"
       },

--- a/cmake/TestImpactFramework/LYTestImpactFramework.cmake
+++ b/cmake/TestImpactFramework/LYTestImpactFramework.cmake
@@ -38,7 +38,7 @@ set(LY_TEST_IMPACT_RUNTIME_PERSISTENT_DIR "${LY_TEST_IMPACT_WORKING_DIR}/$<CONFI
 
 # Directory for static artifacts produced as part of the build system generation process
 set(LY_TEST_IMPACT_ARTIFACT_DIR "${LY_TEST_IMPACT_WORKING_DIR}/Artifact")
-    
+
 # Directory for source to build target mappings
 set(LY_TEST_IMPACT_SOURCE_TARGET_MAPPING_DIR "${LY_TEST_IMPACT_ARTIFACT_DIR}/Mapping")
 
@@ -77,7 +77,7 @@ if(LY_TEST_IMPACT_INSTRUMENTATION_BIN)
 else()
     set(LY_TEST_IMPACT_ACTIVE false)
 endif()
-    
+
 #! ly_test_impact_rebase_file_to_repo_root: rebases the relative and/or absolute path to be relative to repo root directory and places the resulting path in quotes.
 #
 # \arg:INPUT_FILE the file to rebase

--- a/cmake/TestImpactFramework/LYTestImpactFramework.cmake
+++ b/cmake/TestImpactFramework/LYTestImpactFramework.cmake
@@ -63,6 +63,12 @@ set(LY_TEST_IMPACT_CONFIG_FILE_PATH_DEFINITION "LY_TEST_IMPACT_DEFAULT_CONFIG_FI
 # Path to file used to store data required by TIAF tests
 set(LY_TEST_IMPACT_PYTEST_FILE_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>")
 
+# Path to the directory that the result of GTest runs will be stored in.
+set(LY_TEST_IMPACT_NATIVE_TEST_RUN_DIR "${GTEST_XML_OUTPUT_DIR}")
+
+# Path to the directory that the result of Pytest runs will be stored in.
+set(LY_TEST_IMPACT_PYTHON_TEST_RUN_DIR "${PYTEST_XML_OUTPUT_DIR}")
+
 # If we are not provided a path to the Instrumentation bin,
 # set LY_TEST_IMPACT to false so that our tests don't get added
 # and TIAF doesn't get built.
@@ -71,7 +77,7 @@ if(LY_TEST_IMPACT_INSTRUMENTATION_BIN)
 else()
     set(LY_TEST_IMPACT_ACTIVE false)
 endif()
-
+    
 #! ly_test_impact_rebase_file_to_repo_root: rebases the relative and/or absolute path to be relative to repo root directory and places the resulting path in quotes.
 #
 # \arg:INPUT_FILE the file to rebase
@@ -586,18 +592,39 @@ function(ly_test_impact_write_pytest_file CONFIGURATION_FILE)
 
 endfunction()
 
+#! ly_test_impact_clean_directories: Removes the artifact directory, test output directory, temp directory
+#! and the persistent directories containing TIAF configs for each build configuration.
+function(ly_test_impact_clean_directories)
+
+    file(REMOVE_RECURSE ${LY_TEST_IMPACT_NATIVE_TEST_RUN_DIR})
+    message("${LY_TEST_IMPACT_NATIVE_TEST_RUN_DIR}")
+    file(REMOVE_RECURSE ${LY_TEST_IMPACT_PYTHON_TEST_RUN_DIR})
+    message("${LY_TEST_IMPACT_PYTHON_TEST_RUN_DIR}")
+    file(REMOVE_RECURSE ${LY_TEST_IMPACT_RUNTIME_PERSISTENT_DIR})
+    message("${LY_TEST_IMPACT_RUNTIME_PERSISTENT_DIR}")
+
+    # For each build configuration type, delete the persistent and temp folders
+    foreach(config_type ${LY_CONFIGURATION_TYPES})
+        file(REMOVE_RECURSE "${LY_TEST_IMPACT_WORKING_DIR}/${config_type}/${LY_TEST_IMPACT_PERSISTENT_DIR}")
+        file(REMOVE_RECURSE "${LY_TEST_IMPACT_WORKING_DIR}/${config_type}/${LY_TEST_IMPACT_TEMP_DIR}")
+    endforeach()
+    
+
+    # Erase any existing artifact and non-persistent data to avoid getting test impact framework out of sync with current repo state
+    file(REMOVE_RECURSE "${LY_TEST_IMPACT_ARTIFACT_DIR}")
+endfunction()
+
 #! ly_test_impact_post_step: runs the post steps to be executed after all other cmake scripts have been executed.
 function(ly_test_impact_post_step)
     if(NOT LY_TEST_IMPACT_ACTIVE)
         return()
     endif()
 
+    # Clean temporary and persistent directories
+    ly_test_impact_clean_directories()
+
     # Directory for binaries built for this profile
     set(bin_dir "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>")
-
-    # Erase any existing artifact and non-persistent data to avoid getting test impact framework out of sync with current repo state
-    file(REMOVE_RECURSE "${LY_TEST_IMPACT_RUNTIME_TEMP_DIR}")
-    file(REMOVE_RECURSE "${LY_TEST_IMPACT_ARTIFACT_DIR}")
 
     # Export the soruce to target mapping files
     ly_test_impact_export_source_target_mappings(

--- a/cmake/TestImpactFramework/LYTestImpactFramework.cmake
+++ b/cmake/TestImpactFramework/LYTestImpactFramework.cmake
@@ -38,7 +38,7 @@ set(LY_TEST_IMPACT_RUNTIME_PERSISTENT_DIR "${LY_TEST_IMPACT_WORKING_DIR}/$<CONFI
 
 # Directory for static artifacts produced as part of the build system generation process
 set(LY_TEST_IMPACT_ARTIFACT_DIR "${LY_TEST_IMPACT_WORKING_DIR}/Artifact")
-
+    
 # Directory for source to build target mappings
 set(LY_TEST_IMPACT_SOURCE_TARGET_MAPPING_DIR "${LY_TEST_IMPACT_ARTIFACT_DIR}/Mapping")
 
@@ -608,7 +608,6 @@ function(ly_test_impact_clean_directories)
         file(REMOVE_RECURSE "${LY_TEST_IMPACT_WORKING_DIR}/${config_type}/${LY_TEST_IMPACT_TEMP_DIR}")
     endforeach()
     
-
     # Erase any existing artifact and non-persistent data to avoid getting test impact framework out of sync with current repo state
     file(REMOVE_RECURSE "${LY_TEST_IMPACT_ARTIFACT_DIR}")
 endfunction()

--- a/cmake/TestImpactFramework/LYTestImpactFramework.cmake
+++ b/cmake/TestImpactFramework/LYTestImpactFramework.cmake
@@ -63,10 +63,10 @@ set(LY_TEST_IMPACT_CONFIG_FILE_PATH_DEFINITION "LY_TEST_IMPACT_DEFAULT_CONFIG_FI
 # Path to file used to store data required by TIAF tests
 set(LY_TEST_IMPACT_PYTEST_FILE_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>")
 
-# Path to the directory that the result of GTest runs will be stored in.
+# Path to the directory that the result of native runs will be stored in.
 set(LY_TEST_IMPACT_NATIVE_TEST_RUN_DIR "${GTEST_XML_OUTPUT_DIR}")
 
-# Path to the directory that the result of Pytest runs will be stored in.
+# Path to the directory that the result of python runs will be stored in.
 set(LY_TEST_IMPACT_PYTHON_TEST_RUN_DIR "${PYTEST_XML_OUTPUT_DIR}")
 
 # If we are not provided a path to the Instrumentation bin,
@@ -596,7 +596,7 @@ endfunction()
 #! and the persistent directories containing TIAF configs for each build configuration.
 function(ly_test_impact_clean_directories)
 
-    # Clean the output folders of GTest and Pytest to ensure only the most current run is in there.
+    # Clean the output folders of native and python tests to ensure only the most current run is in there.
     file(REMOVE_RECURSE ${LY_TEST_IMPACT_NATIVE_TEST_RUN_DIR})
     message("${LY_TEST_IMPACT_NATIVE_TEST_RUN_DIR}")
     file(REMOVE_RECURSE ${LY_TEST_IMPACT_PYTHON_TEST_RUN_DIR})

--- a/cmake/TestImpactFramework/LYTestImpactFramework.cmake
+++ b/cmake/TestImpactFramework/LYTestImpactFramework.cmake
@@ -596,12 +596,11 @@ endfunction()
 #! and the persistent directories containing TIAF configs for each build configuration.
 function(ly_test_impact_clean_directories)
 
+    # Clean the output folders of GTest and Pytest to ensure only the most current run is in there.
     file(REMOVE_RECURSE ${LY_TEST_IMPACT_NATIVE_TEST_RUN_DIR})
     message("${LY_TEST_IMPACT_NATIVE_TEST_RUN_DIR}")
     file(REMOVE_RECURSE ${LY_TEST_IMPACT_PYTHON_TEST_RUN_DIR})
     message("${LY_TEST_IMPACT_PYTHON_TEST_RUN_DIR}")
-    file(REMOVE_RECURSE ${LY_TEST_IMPACT_RUNTIME_PERSISTENT_DIR})
-    message("${LY_TEST_IMPACT_RUNTIME_PERSISTENT_DIR}")
 
     # For each build configuration type, delete the persistent and temp folders
     foreach(config_type ${LY_CONFIGURATION_TYPES})


### PR DESCRIPTION
## What does this PR do?

This PR adds a step to the ly_test_impact_post_step function that cleans temporary and persistent directories so that data is up to date.

## How was this PR tested?

Manual testing.
