### PR TITLE
Created an Alignment attribute in the DPE

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -104,6 +104,15 @@ namespace AZ::DocumentPropertyEditor::Nodes
         //! to the last column in the layout. Useful for things like the "add container entry" button.
         static constexpr auto SharePriorColumn = AttributeDefinition<bool>("SharePriorColumn");
 
+        //! Specifies the alignment options for a PropertyEditor that has the Alignment attribute.
+        enum class Align : AZ::u8
+        {
+            AlignLeft,
+            AlignRight
+        };
+        //! Specifies that this PropertyEditor should have a specific alignment within its own column.
+        static constexpr auto Alignment = AttributeDefinition<Align>("Alignment");
+
         static constexpr auto EnumType = TypeIdAttributeDefinition("EnumType");
         static constexpr auto EnumUnderlyingType = TypeIdAttributeDefinition("EnumUnderlyingType");
         static constexpr auto EnumValue = AttributeDefinition<Dom::Value>("EnumValue");

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -300,6 +300,7 @@ namespace AZ::DocumentPropertyEditor
                 if (!parentContainer->IsFixedSize())
                 {
                     m_builder.BeginPropertyEditor<Nodes::ContainerActionButton>();
+                    m_builder.Attribute(Nodes::PropertyEditor::Alignment, Nodes::PropertyEditor::Align::AlignRight);
                     m_builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::RemoveElement);
                     m_builder.AddMessageHandler(m_adapter, Nodes::ContainerActionButton::OnActivate.GetName());
                     m_builder.EndPropertyEditor();
@@ -376,11 +377,13 @@ namespace AZ::DocumentPropertyEditor
                     if (!container->IsFixedSize())
                     {
                         m_builder.BeginPropertyEditor<Nodes::ContainerActionButton>();
+                        m_builder.Attribute(Nodes::PropertyEditor::Alignment, Nodes::PropertyEditor::Align::AlignRight);
                         m_builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::AddElement);
                         m_builder.AddMessageHandler(m_adapter, Nodes::ContainerActionButton::OnActivate.GetName());
                         m_builder.EndPropertyEditor();
 
                         m_builder.BeginPropertyEditor<Nodes::ContainerActionButton>();
+                        m_builder.Attribute(Nodes::PropertyEditor::Alignment, Nodes::PropertyEditor::Align::AlignRight);
                         m_builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::Clear);
                         m_builder.AddMessageHandler(m_adapter, Nodes::ContainerActionButton::OnActivate.GetName());
                         m_builder.EndPropertyEditor();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -371,9 +371,18 @@ namespace AzToolsFramework
                 auto alignment = AZ::Dpe::Nodes::PropertyEditor::Alignment.ExtractFromDomNode(childValue);
                 if (alignment.has_value())
                 {
-                    (alignment.value() == AZ::Dpe::Nodes::PropertyEditor::Align::AlignRight
-                        ? m_columnLayout->insertWidget(priorColumnIndex + 1, addedWidget, 0, Qt::AlignRight)
-                        : m_columnLayout->insertWidget(priorColumnIndex + 1, addedWidget, 0, Qt::AlignLeft));
+                    Qt::Alignment widgetAlignment;
+                    switch (alignment.value())
+                    {
+                    case AZ::Dpe::Nodes::PropertyEditor::Align::AlignLeft:
+                        widgetAlignment = Qt::AlignLeft;
+                        break;
+                    case AZ::Dpe::Nodes::PropertyEditor::Align::AlignRight:
+                        widgetAlignment = Qt::AlignRight;
+                        break;
+                    }
+
+                    m_columnLayout->insertWidget(priorColumnIndex + 1, addedWidget, 0, widgetAlignment);
                 }
 
                 // insert after the found index; even if nothing were found and priorIndex is still -1,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -366,9 +366,22 @@ namespace AzToolsFramework
                 {
                     priorColumnIndex = m_columnLayout->indexOf(m_domOrderedChildren[searchIndex]);
                 }
+
+                // if the alignment attribute is present, insert the widget with the appropriate alignment
+                auto alignment = AZ::Dpe::Nodes::PropertyEditor::Alignment.ExtractFromDomNode(childValue);
+                if (alignment.has_value())
+                {
+                    (alignment.value() == AZ::Dpe::Nodes::PropertyEditor::Align::AlignRight
+                        ? m_columnLayout->insertWidget(priorColumnIndex + 1, addedWidget, 0, Qt::AlignRight)
+                        : m_columnLayout->insertWidget(priorColumnIndex + 1, addedWidget, 0, Qt::AlignLeft));
+                }
+
                 // insert after the found index; even if nothing were found and priorIndex is still -1,
                 // still insert one after it, at position 0
-                m_columnLayout->insertWidget(priorColumnIndex + 1, addedWidget);
+                else
+                {
+                    m_columnLayout->insertWidget(priorColumnIndex + 1, addedWidget);
+                }
             }
             AddDomChildWidget(domIndex, addedWidget);
         }


### PR DESCRIPTION
## What does this PR do?

Added an alignment attribute in the DPE, so that a PropertyEditor can be created with specific alignment.
Currently only supports AlignLeft and AlignRight. This is part of an effort to get the DPE Layout to look more similar to the RPE- Layout.

## How was this PR tested?

PR was tested by adding the alignment attribute to three different PropertyEditors.

Current view with alignment:
![image](https://user-images.githubusercontent.com/84731577/185697635-a379a935-815b-43df-a16c-125ba99c02e6.png)

Previous view without alignment:
![image](https://user-images.githubusercontent.com/84731577/185697069-09c8b3dd-4e55-4490-943e-4871825c7c99.png)


Signed-off-by: Daniel Tamkin <jotamkin@amazon.com>
