### PR TITLE
bugfix: fix compiling errors with azvsnprintf for linux

### DIFF
--- a/Code/Framework/AzCore/AzCore/base.h
+++ b/Code/Framework/AzCore/AzCore/base.h
@@ -13,6 +13,8 @@
 
 #include <AzCore/AzCore_Traits_Platform.h>
 
+#include <cstdio>
+
 /// Return an array size for static arrays.
 namespace AZ::Internal
 {


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

not sure how this is failing to pass AR when it fails to compile on my linux machine. I attached my ubuntu system in the description if that is any use. snprintf is a dependency is stdio. 

```
Distributor ID:	Ubuntu
Description:	Ubuntu 22.04.1 LTS
Release:	22.04
Codename:	jammy
```