### PR TITLE
Adding missing includes to fix Windows VS2022 and Android non-unity build

### DIFF
--- a/Code/Framework/AzCore/Platform/Android/AzCore/Debug/Trace_Android.cpp
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/Debug/Trace_Android.cpp
@@ -8,6 +8,7 @@
 
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/std/string/string_view.h>
+#include <AzCore/std/string/fixed_string.h>
 
 #include <android/log.h>
 

--- a/Code/Legacy/CryCommon/StlUtils.h
+++ b/Code/Legacy/CryCommon/StlUtils.h
@@ -24,6 +24,7 @@
 
 #define STATIC_ASSERT(condition, errMessage) static_assert(condition, errMessage)
 
+#include <cctype>
 #include <map>
 #include <set>
 #include <algorithm>


### PR DESCRIPTION

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Built the TEST_SUITE_main and Editor target using VS2022 successfully
Built the AzFramework target using Android.
