### PR TITLE
Adding newline back to the debug console for Windows and Android

### DIFF
--- a/Code/Legacy/CrySystem/Log.cpp
+++ b/Code/Legacy/CrySystem/Log.cpp
@@ -1283,6 +1283,10 @@ void CLog::LogStringToFile(AZStd::string_view message, ELogType logType, bool ap
             AZ::Debug::Platform::OutputToDebugger({}, timeStr);
         }
         AZ::Debug::Platform::OutputToDebugger({}, message);
+        if (!message.ends_with('\n'))
+        {
+            AZ::Debug::Platform::OutputToDebugger({}, "\n");
+        }
     }
 
     if (!bIsMainThread)


### PR DESCRIPTION
This was incorrectly removed in #11301 for the path that uses the old
CLog behavior of `LogStringToFile` for formatting string output.

Only the new `LogWithCallback` function which performs no formatting of
the message should not automatically add the newline.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>


## How was this PR tested?

Validated the debug console output in Visual Studio were separated with newlines.
