### PR TITLE
FindClosestPickIntersection API extension to detect optional results

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -365,12 +365,36 @@ namespace AzToolsFramework
     //! a mesh), that position is returned, otherwise a point projected defaultDistance from the
     //! origin of the ray will be returned.
     //! @note The intersection will only consider visible objects.
+    //! @param viewportId The id of the viewport the raycast into.
+    //! @param screenPoint The starting point of the ray in screen space. (The ray will cast into the screen)
+    //! @param rayLength The length of the ray in meters.
+    //! @param defaultDistance The distance to use for the result point if no hit is found.
+    //! @return The world position of the intersection point (either from a hit or from the default distance)
     AZ::Vector3 FindClosestPickIntersection(
         AzFramework::ViewportId viewportId, const AzFramework::ScreenPoint& screenPoint, float rayLength, float defaultDistance);
 
+    //! Performs an intersection test against meshes in the scene and returns the his position only if there
+    //! is a hit (the ray intersects a mesh).
+    //! @note The intersection will only consider visible objects.
+    //! @param viewportId The id of the viewport the raycast into.
+    //! @param screenPoint The starting point of the ray in screen space. (The ray will cast into the screen)
+    //! @param rayLength The length of the ray in meters.
+    //! @return The world position of the intersection if there is a hit, or nothing if not.
+    AZStd::optional<AZ::Vector3> FindClosestPickIntersection(
+        AzFramework::ViewportId viewportId, const AzFramework::ScreenPoint& screenPoint, float rayLength);
+
     //! Overload of FindClosestPickIntersection taking a RenderGeometry::RayRequest directly.
     //! @note rayRequest must contain a valid ray/line segment (start/endWorldPosition must not be at the same position).
+    //! @param rayRequest Information describing the start/end positions and which entities to raycast against.
+    //! @param defaultDistance The distance to use for the result point if no hit is found.
+    //! @return The world position of the intersection point (either from a hit or from the default distance)
     AZ::Vector3 FindClosestPickIntersection(const AzFramework::RenderGeometry::RayRequest& rayRequest, float defaultDistance);
+
+    //! Overload of FindClosestPickIntersection taking a RenderGeometry::RayRequest directly.
+    //! @note rayRequest must contain a valid ray/line segment (start/endWorldPosition must not be at the same position).
+    //! @param rayRequest Information describing the start/end positions and which entities to raycast against.
+    //! @return The world position of the intersection if there is a hit, or nothing if not.
+    AZStd::optional<AZ::Vector3> FindClosestPickIntersection(const AzFramework::RenderGeometry::RayRequest& rayRequest);
 
     //! Update the in/out parameter rayRequest based on the latest viewport ray.
     void RefreshRayRequest(


### PR DESCRIPTION
## What does this PR do?

This adds a new overload to the FindClosestPickIntersection API that lets you determine no hit was found, vs the previous version that always returned a hit point based on default distance if no hit was found.

This functionality will be needed by the upcoming paintbrush feature that projects the paintbrush into the viewport, but shouldn't show the paintbrush when no intersections are found.

## How was this PR tested?

Added new unit tests to verify both versions of the API, testing both the case that a point is hit and the case that no hit point is found.

Tested locally with paintbrush functionality to ensure that it works with the paintbrush use case.