### PR TITLE
Change build label for CMake/VS2022 update

### DIFF
--- a/scripts/build/Platform/Android/pipeline.json
+++ b/scripts/build/Platform/Android/pipeline.json
@@ -1,7 +1,7 @@
 {
     "ENV": {
         "GRADLE_HOME": "C:/Gradle/gradle-7.0",
-        "NODE_LABEL": "windows-a4a28adb2",
+        "NODE_LABEL": "windows-8fe4037c",
         "LY_3RDPARTY_PATH": "D:/workspace/3rdParty",
         "LY_NDK_DIR": "C:/Android/android-sdk/ndk/21.4.7075529",
         "TIMEOUT": 30,

--- a/scripts/build/Platform/Linux/pipeline.json
+++ b/scripts/build/Platform/Linux/pipeline.json
@@ -1,6 +1,6 @@
 {
     "ENV": {
-        "NODE_LABEL": "linux-7cb44cc9e",
+        "NODE_LABEL": "linux-3234e23c",
         "LY_3RDPARTY_PATH": "/data/workspace/3rdParty",
         "TIMEOUT": 30,
         "WORKSPACE": "/data/workspace",

--- a/scripts/build/Platform/Windows/pipeline.json
+++ b/scripts/build/Platform/Windows/pipeline.json
@@ -1,6 +1,6 @@
 {
     "ENV": {
-        "NODE_LABEL": "windows-b3c8994f1",
+        "NODE_LABEL": "windows-8fe4037c",
         "LY_3RDPARTY_PATH": "D:/workspace/3rdParty",
         "TIMEOUT": 30,
         "WORKSPACE": "D:/workspace",


### PR DESCRIPTION
Signed-off-by: Mike Chang <changml@amazon.com>

## What does this PR do?

Switches the CI build label for Windows and Android builds to an image that contains VS2019, VS2022, and CMake 3.24. Prevents issues with CMake pathing for CI builds prior to CMake 3.24, but requires a clean build

## How was this PR tested?

Tested in a sandbox instance, with a clean build
