### PR TITLE
VS2022 Windows AR generator change

### DIFF
--- a/scripts/build/Platform/Android/build_config.json
+++ b/scripts/build/Platform/Android/build_config.json
@@ -83,7 +83,7 @@
     "PARAMETERS": {
         "CONFIGURATION":"profile",
         "OUTPUT_DIRECTORY":"build\\windows",
-        "CMAKE_OPTIONS":"-G \"Visual Studio 16 2019\" -DCMAKE_SYSTEM_VERSION=10.0",
+        "CMAKE_OPTIONS":"-DCMAKE_SYSTEM_VERSION=10.0",
         "CMAKE_LY_PROJECTS":"AutomatedTesting",
         "CMAKE_TARGET":"AssetProcessorBatch",
         "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo",

--- a/scripts/build/Platform/Android/pipeline.json
+++ b/scripts/build/Platform/Android/pipeline.json
@@ -1,7 +1,7 @@
 {
     "ENV": {
         "GRADLE_HOME": "C:/Gradle/gradle-7.0",
-        "NODE_LABEL": "windows-a4a28adb2",
+        "NODE_LABEL": "windows-8fe4037c",
         "LY_3RDPARTY_PATH": "D:/workspace/3rdParty",
         "LY_NDK_DIR": "C:/Android/android-sdk/ndk/21.4.7075529",
         "TIMEOUT": 30,

--- a/scripts/build/Platform/Linux/pipeline.json
+++ b/scripts/build/Platform/Linux/pipeline.json
@@ -1,6 +1,6 @@
 {
     "ENV": {
-        "NODE_LABEL": "linux-7cb44cc9e",
+        "NODE_LABEL": "linux-3234e23c",
         "LY_3RDPARTY_PATH": "/data/workspace/3rdParty",
         "TIMEOUT": 30,
         "WORKSPACE": "/data/workspace",

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -110,31 +110,28 @@
     "PARAMETERS": {
       "CONFIGURATION": "profile",
       "OUTPUT_DIRECTORY": "build\\windows",
+      "CMAKE_OPTIONS": "-DCMAKE_SYSTEM_VERSION=10.0 -DLY_TEST_IMPACT_INSTRUMENTATION_BIN=%TEST_IMPACT_WIN_BINARY%",
+      "CMAKE_LY_PROJECTS": "AutomatedTesting",
+      "CMAKE_TARGET": "ALL_BUILD",
+      "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo"
+    }
+  },
+  "profile_vs2019": {
+    "TAGS": [
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal"
+    ],
+    "COMMAND": "build_windows.cmd",
+    "PARAMETERS": {
+      "CONFIGURATION": "profile",
+      "OUTPUT_DIRECTORY": "build\\windows",
       "CMAKE_OPTIONS": "-G \"Visual Studio 16 2019\" -DCMAKE_SYSTEM_VERSION=10.0 -DLY_TEST_IMPACT_INSTRUMENTATION_BIN=%TEST_IMPACT_WIN_BINARY%",
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "ALL_BUILD",
       "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo"
     }
   },
-  "profile_vs2022": {
-    "TAGS": [
-      "periodic-incremental-daily",
-      "periodic-clean-weekly-internal"
-    ],
-    "PIPELINE_ENV":{
-      "NODE_LABEL":"windows-vs2022"
-    },
-    "COMMAND": "build_windows.cmd",
-    "PARAMETERS": {
-      "CONFIGURATION": "profile",
-      "OUTPUT_DIRECTORY": "build\\windows",
-      "CMAKE_OPTIONS": "-G \"Visual Studio 17 2022\" -DCMAKE_SYSTEM_VERSION=10.0 -DLY_TEST_IMPACT_INSTRUMENTATION_BIN=%TEST_IMPACT_WIN_BINARY%",
-      "CMAKE_LY_PROJECTS": "AutomatedTesting",
-      "CMAKE_TARGET": "ALL_BUILD",
-      "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo"
-    }
-  },
-  "profile_nounity": {
+  "profile_nounity_vs2019": {
     "TAGS": [
       "periodic-incremental-daily",
       "periodic-clean-weekly-internal",
@@ -159,7 +156,7 @@
     "PARAMETERS": {
       "CONFIGURATION": "profile",
       "OUTPUT_DIRECTORY": "build\\windows",
-      "CMAKE_OPTIONS": "-G \"Visual Studio 16 2019\" -DCMAKE_SYSTEM_VERSION=10.0",
+      "CMAKE_OPTIONS": "-DCMAKE_SYSTEM_VERSION=10.0",
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "TEST_SUITE_smoke TEST_SUITE_main",
       "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo",
@@ -220,7 +217,7 @@
     "PARAMETERS": {
       "CONFIGURATION": "profile",
       "OUTPUT_DIRECTORY": "build\\windows",
-      "CMAKE_OPTIONS": "-G \"Visual Studio 16 2019\" -DCMAKE_SYSTEM_VERSION=10.0",
+      "CMAKE_OPTIONS": "-DCMAKE_SYSTEM_VERSION=10.0",
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "AssetProcessorBatch",
       "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo",
@@ -352,26 +349,23 @@
     "PARAMETERS": {
       "CONFIGURATION": "release",
       "OUTPUT_DIRECTORY": "build\\windows",
-      "CMAKE_OPTIONS": "-G \"Visual Studio 16 2019\" -DCMAKE_SYSTEM_VERSION=10.0",
+      "CMAKE_OPTIONS": "-DCMAKE_SYSTEM_VERSION=10.0",
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "ALL_BUILD",
       "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo"
     }
   },
-  "release_vs2022": {
+  "release_vs2019": {
     "TAGS": [
       "periodic-incremental-daily",
       "weekly-build-metrics",
       "snapshot"
     ],
-    "PIPELINE_ENV":{
-      "NODE_LABEL":"windows-vs2022"
-    },
     "COMMAND": "build_windows.cmd",
     "PARAMETERS": {
       "CONFIGURATION": "release",
       "OUTPUT_DIRECTORY": "build\\windows",
-      "CMAKE_OPTIONS": "-G \"Visual Studio 17 2022\" -DCMAKE_SYSTEM_VERSION=10.0",
+      "CMAKE_OPTIONS": "-G \"Visual Studio 16 2019\" -DCMAKE_SYSTEM_VERSION=10.0",
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "ALL_BUILD",
       "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo"

--- a/scripts/build/Platform/Windows/pipeline.json
+++ b/scripts/build/Platform/Windows/pipeline.json
@@ -1,6 +1,6 @@
 {
     "ENV": {
-        "NODE_LABEL": "windows-b3c8994f1",
+        "NODE_LABEL": "windows-8fe4037c",
         "LY_3RDPARTY_PATH": "D:/workspace/3rdParty",
         "TIMEOUT": 30,
         "WORKSPACE": "D:/workspace",


### PR DESCRIPTION
## What does this PR do?

Removes the hardcoded generator for Windows AR builds to allow use of VS2022+. CMake uses a default list of generators starting from latest versions of VS2022 through a registry scan.

Nightly builds will be preserved on the VS2019 generator to allow for regression coverage.

## How was this PR tested?

Run successfully on a sandbox Jenkins instance, with a clean build
