### PR TITLE
Implemented Terrain Layer Spawner and Height/Surface Gradient List wrapped nodes

### DIFF
--- a/Gems/LandscapeCanvas/Assets/LandscapeCanvas/StyleSheet/graphcanvas_style.json
+++ b/Gems/LandscapeCanvas/Assets/LandscapeCanvas/StyleSheet/graphcanvas_style.json
@@ -1755,6 +1755,13 @@
     "color": "#ffffff"
   },
   {
+    "selectors": [ "TerrainNodeTitlePalette" ],
+    "palette-style": "solid",
+    "line-color": "#8B572A",
+    "background-color": "#8B572A",
+    "color": "#ffffff"
+  },
+  {
     "selectors": [ "UtilityNodeTitlePalette" ],
     "palette-style": "solid",
     "line-color": "#FFFFFF",

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Core/Core.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Core/Core.h
@@ -44,6 +44,7 @@ namespace LandscapeCanvas
     static const QString GRADIENT_GENERATOR_TITLE = QObject::tr("Gradient");
     static const QString GRADIENT_MODIFIER_TITLE = QObject::tr("Gradient Modifier");
     static const QString VEGETATION_AREA_TITLE = QObject::tr("Vegetation Area");
+    static const QString TERRAIN_TITLE = QObject::tr("Terrain");
 
     // Connection slot labels
     static const QString PREVIEW_BOUNDS_SLOT_LABEL = QObject::tr("Preview Bounds");

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -107,6 +107,9 @@
 #include <Editor/Nodes/Shapes/ReferenceShapeNode.h>
 #include <Editor/Nodes/Shapes/SphereShapeNode.h>
 #include <Editor/Nodes/Shapes/TubeShapeNode.h>
+#include <Editor/Nodes/Terrain/TerrainHeightGradientListNode.h>
+#include <Editor/Nodes/Terrain/TerrainLayerSpawnerNode.h>
+#include <Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.h>
 #include <Editor/Nodes/UI/GradientPreviewThumbnailItem.h>
 #include <EditorLandscapeCanvasComponent.h>
 
@@ -389,6 +392,15 @@ namespace LandscapeCanvasEditor
         REGISTER_NODE_PALETTE_ITEM(shapeCategory, SphereShapeNode, editorId);
         REGISTER_NODE_PALETTE_ITEM(shapeCategory, TubeShapeNode, editorId);
 
+        // Don't give the Terrain options if the gem isn't present.
+        bool terrainGemIsPresent = AzToolsFramework::IsComponentWithServiceRegistered(AZ_CRC_CE("TerrainService"));
+        if (terrainGemIsPresent)
+        {
+            GraphCanvas::IconDecoratedNodePaletteTreeItem* terrainCategory = rootItem->CreateChildNode<GraphCanvas::IconDecoratedNodePaletteTreeItem>("Terrain", editorId);
+            terrainCategory->SetTitlePalette("TerrainNodeTitlePalette");
+            REGISTER_NODE_PALETTE_ITEM(terrainCategory, TerrainLayerSpawnerNode, editorId);
+        }
+
         GraphModelIntegration::AddCommonNodePaletteUtilities(rootItem, editorId);
 
         return rootItem;
@@ -445,6 +457,17 @@ namespace LandscapeCanvasEditor
                 category->DetachItem();
             }
         }
+
+        return rootItem;
+    }
+
+    GraphCanvas::GraphCanvasTreeItem* GetTerrainExtendersNodePaletteRoot(const GraphCanvas::EditorId& editorId, AZ::EntityId entityId)
+    {
+        using namespace LandscapeCanvas;
+        GraphCanvas::NodePaletteTreeItem* rootItem = aznew GraphCanvas::NodePaletteTreeItem("Root", editorId);
+
+        REGISTER_NODE_PALETTE_ITEM_UNIQUE(rootItem, TerrainHeightGradientListNode, editorId, entityId);
+        REGISTER_NODE_PALETTE_ITEM_UNIQUE(rootItem, TerrainSurfaceGradientListNode, editorId, entityId);
 
         return rootItem;
     }
@@ -1031,13 +1054,25 @@ namespace LandscapeCanvasEditor
         AZ::EntityId entityId = baseNode->GetVegetationEntityId();
 
         GraphCanvas::NodePaletteConfig config;
-        config.m_rootTreeItem = GetAreaExtendersNodePaletteRoot(GetEditorId(), entityId);
         config.m_editorId = GetEditorId();
         config.m_mimeType = LandscapeCanvas::MIME_EVENT_TYPE;
         config.m_isInContextMenu = true;
         config.m_saveIdentifier = LandscapeCanvas::CONTEXT_MENU_SAVE_IDENTIFIER;
 
-        // Create the Context Menu with embedded Node Palette for adding Filters/Modifiers to Layers
+        switch (baseNode->GetBaseNodeType())
+        {
+        case LandscapeCanvas::BaseNode::TerrainArea:
+            config.m_rootTreeItem = GetTerrainExtendersNodePaletteRoot(GetEditorId(), entityId);
+            break;
+        case LandscapeCanvas::BaseNode::VegetationArea:
+            config.m_rootTreeItem = GetAreaExtendersNodePaletteRoot(GetEditorId(), entityId);
+            break;
+        default:
+            AZ_Assert(false, "Unsupported node type: %d", baseNode->GetBaseNodeType());
+            return;
+        }
+
+        // Create the Context Menu with embedded Node Palette for adding extenders to the wrapped node
         // The ownership of this Node Palette is passed to the context menu
         LayerExtenderContextMenu menu(config, this);
         menu.exec(screenPoint);
@@ -1058,7 +1093,7 @@ namespace LandscapeCanvasEditor
                 GraphModel::NodePtr node;
                 GraphModelIntegration::GraphControllerRequestBus::EventResult(node, graphId, &GraphModelIntegration::GraphControllerRequests::GetNodeById, nodeId);
 
-                // Wrap the created Filter or Modifier node on its parent layer node.
+                // Wrap the extender node on its parent wrapped node.
                 AZ::u32 layoutOrder = GetWrappedNodeLayoutOrder(node);
                 GraphModelIntegration::GraphControllerRequestBus::Event(graphId, &GraphModelIntegration::GraphControllerRequests::WrapNodeOrdered, wrapperNode, node, layoutOrder);
             }
@@ -1254,13 +1289,30 @@ namespace LandscapeCanvasEditor
         } break;
         case LandscapeCanvas::LandscapeCanvasDataTypeEnum::Gradient:
         {
-            propertyPath = GradientEntityIdPropertyPath;
+            GraphModel::NodePtr targetNode = slot->GetParentNode();
+            auto targetBaseNode = static_cast<LandscapeCanvas::BaseNode*>(targetNode.get());
+            auto targetBaseNodeType = targetBaseNode->GetBaseNodeType();
+
+            if (targetBaseNodeType != LandscapeCanvas::BaseNode::TerrainExtender)
+            {
+                propertyPath = GradientEntityIdPropertyPath;
+            }
 
             // Special case handling of some gradient properties for extendable gradient mixers
             // and the position modifier which are nested under group elements
             if (slot->SupportsExtendability())
             {
-                propertyPath.prepend(QString("Layers|[%1]|").arg(elementIndex));
+                QString gradientListName;
+                if (targetBaseNodeType == LandscapeCanvas::BaseNode::TerrainExtender)
+                {
+                    gradientListName = "Gradient Entities|[%1]";
+                }
+                else
+                {
+                    gradientListName = "Layers|[%1]|";
+                }
+
+                propertyPath.prepend(gradientListName.arg(elementIndex));
             }
             else if (slotName == LandscapeCanvas::BaseAreaModifierNode::INBOUND_GRADIENT_X_SLOT_ID
                 || slotName == LandscapeCanvas::BaseAreaModifierNode::INBOUND_GRADIENT_Y_SLOT_ID
@@ -1268,14 +1320,13 @@ namespace LandscapeCanvasEditor
             {
                 // The X/Y/Z supported nodes are Position/Rotation modifiers, so we need
                 // to figure out which one this is to get the right property path
-                GraphModel::NodePtr node = slot->GetParentNode();
-                if (node)
+                if (targetNode)
                 {
                     // The node titles are "Position Modifier" or "Rotation Modifier", and
                     // the property path is expecting Position/Rotation|Gradient|Gradient Entity Id
                     // so we need to parse the "Position"/"Rotation" out of the title to use
                     // in the property path
-                    QStringList parts = QString(node->GetTitle()).split(' ');
+                    QStringList parts = QString(targetNode->GetTitle()).split(' ');
                     AZ_Assert(!parts.empty(), "Unrecognized node title");
                     propertyPath.prepend(QString("%1 %2|").arg(parts[0]).arg(slotName.back()));
                 }
@@ -3059,7 +3110,7 @@ namespace LandscapeCanvasEditor
             GradientPreviewThumbnailItem* previewThumbnail = new GradientPreviewThumbnailItem(gradientEntityId);
             GraphModelIntegration::GraphControllerRequestBus::Event(graphId, &GraphModelIntegration::GraphControllerRequests::SetThumbnailOnNode, node, previewThumbnail);
         }
-        else if (nodeType == LandscapeCanvas::BaseNode::VegetationArea)
+        else if ((nodeType == LandscapeCanvas::BaseNode::VegetationArea || nodeType == LandscapeCanvas::BaseNode::TerrainArea) && (node->GetNodeType() == GraphModel::NodeType::WrapperNode))
         {
             GraphModelIntegration::GraphControllerRequestBus::Event(graphId, &GraphModelIntegration::GraphControllerRequests::SetWrapperNodeActionString, node, QObject::tr("Add Extenders").toUtf8().constData());
         }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/BaseAreaFilterNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/BaseAreaFilterNode.h
@@ -34,12 +34,5 @@ namespace LandscapeCanvas
         {
             return BaseNode::VegetationAreaFilter;
         }
-
-        const bool ShouldShowEntityName() const override
-        {
-            // Don't show the entity name for Area Filters since they will
-            // be wrapped on a Vegetation Area it would be redundant
-            return false;
-        }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/BaseAreaModifierNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/BaseAreaModifierNode.h
@@ -49,12 +49,5 @@ namespace LandscapeCanvas
         {
             return BaseNode::VegetationAreaModifier;
         }
-
-        const bool ShouldShowEntityName() const override
-        {
-            // Don't show the entity name for Area Modifiers since they will
-            // be wrapped on a Vegetation Area it would be redundant
-            return false;
-        }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaSelectors/AssetWeightSelectorNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaSelectors/AssetWeightSelectorNode.cpp
@@ -56,13 +56,6 @@ namespace LandscapeCanvas
         return BaseNode::VegetationAreaSelector;
     }
 
-    const bool AssetWeightSelectorNode::ShouldShowEntityName() const
-    {
-        // Don't show the entity name for Area Selectors since they will
-        // be wrapped on a Vegetation Area it would be redundant
-        return false;
-    }
-
     const char* AssetWeightSelectorNode::GetTitle() const
     {
         return TITLE.toUtf8().constData();

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaSelectors/AssetWeightSelectorNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaSelectors/AssetWeightSelectorNode.h
@@ -35,7 +35,6 @@ namespace LandscapeCanvas
         explicit AssetWeightSelectorNode(GraphModel::GraphPtr graph);
 
         const BaseNodeType GetBaseNodeType() const override;
-        const bool ShouldShowEntityName() const override;
 
         static const QString TITLE;
         const char* GetTitle() const override;

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/BaseNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/BaseNode.cpp
@@ -97,6 +97,7 @@ namespace LandscapeCanvas
         return baseNodeType == LandscapeCanvas::BaseNode::VegetationAreaModifier
             || baseNodeType == LandscapeCanvas::BaseNode::VegetationAreaFilter
             || baseNodeType == LandscapeCanvas::BaseNode::VegetationAreaSelector
+            || baseNodeType == LandscapeCanvas::BaseNode::TerrainExtender
             ;
     }
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/BaseNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/BaseNode.h
@@ -45,6 +45,8 @@ namespace LandscapeCanvas
             Gradient,
             GradientGenerator,
             GradientModifier,
+            TerrainArea,
+            TerrainExtender,
             VegetationAreaModifier,
             VegetationAreaFilter,
             VegetationAreaSelector
@@ -66,10 +68,6 @@ namespace LandscapeCanvas
         /// Retrieve a pointer to the Component on the respective Entity that
         /// this Node represents
         AZ::Component* GetComponent() const;
-
-        /// By default our Landscape Canvas nodes will have a property display
-        /// to show the name of the Entity the component lives on
-        virtual const bool ShouldShowEntityName() const { return true; }
 
         /// Returns whether or not this node is a Vegetation Area Extender (Filter/Modifier/Selector)
         bool IsAreaExtender() const;

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainHeightGradientListNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainHeightGradientListNode.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// Qt
+#include <QObject>
+
+// AZ
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+// Graph Model
+#include <GraphModel/Integration/Helpers.h>
+#include <GraphModel/Model/Slot.h>
+
+// Landscape Canvas
+#include "TerrainHeightGradientListNode.h"
+#include <Editor/Core/GraphContext.h>
+
+namespace LandscapeCanvas
+{
+    void TerrainHeightGradientListNode::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<TerrainHeightGradientListNode, BaseNode>()
+                ->Version(0)
+                ;
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<TerrainHeightGradientListNode>("TerrainHeightGradientListNode", "")->
+                    ClassElement(AZ::Edit::ClassElements::EditorData, "")->
+                    Attribute(GraphModelIntegration::Attributes::TitlePaletteOverride, "TerrainNodeTitlePalette")
+                    ;
+            }
+        }
+    }
+
+    const QString TerrainHeightGradientListNode::TITLE = QObject::tr("Terrain Height Gradient List");
+
+    TerrainHeightGradientListNode::TerrainHeightGradientListNode(GraphModel::GraphPtr graph)
+        : BaseNode(graph)
+    {
+        RegisterSlots();
+        CreateSlotData();
+    }
+
+    const BaseNode::BaseNodeType TerrainHeightGradientListNode::GetBaseNodeType() const
+    {
+        return BaseNode::TerrainExtender;
+    }
+
+    const char* TerrainHeightGradientListNode::GetTitle() const
+    {
+        return TITLE.toUtf8().constData();
+    }
+
+    void TerrainHeightGradientListNode::RegisterSlots()
+    {
+        GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
+
+        GraphModel::ExtendableSlotConfiguration slotConfig;
+        slotConfig.m_addButtonLabel = "Add Gradient";
+        slotConfig.m_addButtonTooltip = "Add a gradient height provider";
+        RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
+            INBOUND_GRADIENT_SLOT_ID,
+            INBOUND_GRADIENT_SLOT_LABEL.toUtf8().constData(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
+            INBOUND_GRADIENT_INPUT_SLOT_DESCRIPTION.toUtf8().constData(),
+            &slotConfig));
+    }
+} // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainHeightGradientListNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainHeightGradientListNode.cpp
@@ -18,8 +18,8 @@
 #include <GraphModel/Model/Slot.h>
 
 // Landscape Canvas
-#include "TerrainHeightGradientListNode.h"
 #include <Editor/Core/GraphContext.h>
+#include <Editor/Nodes/Terrain/TerrainHeightGradientListNode.h>
 
 namespace LandscapeCanvas
 {

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainHeightGradientListNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainHeightGradientListNode.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+// Qt
+#include <QString>
+
+// Landscape Canvas
+#include <Editor/Core/Core.h>
+#include <Editor/Nodes/BaseNode.h>
+
+namespace AZ
+{
+    class ReflectContext;
+}
+
+namespace LandscapeCanvas
+{
+    class TerrainHeightGradientListNode
+        : public BaseNode
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(TerrainHeightGradientListNode, AZ::SystemAllocator, 0);
+        AZ_RTTI(TerrainHeightGradientListNode, "{10BE90E1-C508-403B-B1BE-AFB8D8C1BFFE}", BaseNode);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        TerrainHeightGradientListNode() = default;
+        explicit TerrainHeightGradientListNode(GraphModel::GraphPtr graph);
+
+        const BaseNodeType GetBaseNodeType() const override;
+
+        static const QString TITLE;
+        const char* GetTitle() const override;
+
+    protected:
+        void RegisterSlots() override;
+    };
+}

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// Qt
+#include <QObject>
+
+// AZ
+#include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+// Graph Model
+#include <GraphModel/Integration/Helpers.h>
+#include <GraphModel/Model/Slot.h>
+
+// Landscape Canvas
+#include "TerrainLayerSpawnerNode.h"
+#include <Editor/Core/GraphContext.h>
+
+#include <LmbrCentral/Shape/ReferenceShapeComponentBus.h>
+
+namespace LandscapeCanvas
+{
+    void TerrainLayerSpawnerNode::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<TerrainLayerSpawnerNode, BaseNode>()
+                ->Version(0)
+                ;
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<TerrainLayerSpawnerNode>("TerrainLayerSpawnerNode", "")->
+                    ClassElement(AZ::Edit::ClassElements::EditorData, "")->
+                    Attribute(GraphModelIntegration::Attributes::TitlePaletteOverride, "TerrainNodeTitlePalette")
+                    ;
+            }
+        }
+    }
+
+    const QString TerrainLayerSpawnerNode::TITLE = QObject::tr("Terrain Layer Spawner");
+
+    TerrainLayerSpawnerNode::TerrainLayerSpawnerNode(GraphModel::GraphPtr graph)
+        : BaseNode(graph)
+    {
+        RegisterSlots();
+        CreateSlotData();
+    }
+
+    const char* TerrainLayerSpawnerNode::GetTitle() const
+    {
+        return TITLE.toUtf8().constData();
+    }
+
+    const char* TerrainLayerSpawnerNode::GetSubTitle() const
+    {
+        return LandscapeCanvas::TERRAIN_TITLE.toUtf8().constData();
+    }
+
+    GraphModel::NodeType TerrainLayerSpawnerNode::GetNodeType() const
+    {
+        return GraphModel::NodeType::WrapperNode;
+    }
+
+    const BaseNode::BaseNodeType TerrainLayerSpawnerNode::GetBaseNodeType() const
+    {
+        return BaseNode::TerrainArea;
+    }
+
+    void TerrainLayerSpawnerNode::RegisterSlots()
+    {
+        CreateEntityNameSlot();
+    }
+} // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.cpp
@@ -20,8 +20,8 @@
 #include <GraphModel/Model/Slot.h>
 
 // Landscape Canvas
-#include "TerrainLayerSpawnerNode.h"
 #include <Editor/Core/GraphContext.h>
+#include <Editor/Nodes/Terrain/TerrainLayerSpawnerNode.h>
 
 #include <LmbrCentral/Shape/ReferenceShapeComponentBus.h>
 

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+// Landscape Canvas
+#include <Editor/Core/Core.h>
+#include <Editor/Nodes/BaseNode.h>
+
+namespace AZ
+{
+    class ReflectContext;
+}
+
+namespace LandscapeCanvas
+{
+    class TerrainLayerSpawnerNode : public BaseNode
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(TerrainLayerSpawnerNode, AZ::SystemAllocator, 0);
+        AZ_RTTI(TerrainLayerSpawnerNode, "{C901635B-4EC8-40A1-8D67-4138C7567C3E}", BaseNode);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        TerrainLayerSpawnerNode() = default;
+        explicit TerrainLayerSpawnerNode(GraphModel::GraphPtr graph);
+
+        static const QString TITLE;
+        const char* GetTitle() const override;
+        const char* GetSubTitle() const override;
+        GraphModel::NodeType GetNodeType() const override;
+        const BaseNodeType GetBaseNodeType() const override;
+
+    protected:
+        void RegisterSlots() override;
+    };
+}

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.cpp
@@ -18,8 +18,8 @@
 #include <GraphModel/Model/Slot.h>
 
 // Landscape Canvas
-#include "TerrainSurfaceGradientListNode.h"
 #include <Editor/Core/GraphContext.h>
+#include <Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.h>
 
 namespace LandscapeCanvas
 {

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// Qt
+#include <QObject>
+
+// AZ
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+// Graph Model
+#include <GraphModel/Integration/Helpers.h>
+#include <GraphModel/Model/Slot.h>
+
+// Landscape Canvas
+#include "TerrainSurfaceGradientListNode.h"
+#include <Editor/Core/GraphContext.h>
+
+namespace LandscapeCanvas
+{
+    void TerrainSurfaceGradientListNode::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<TerrainSurfaceGradientListNode, BaseNode>()
+                ->Version(0)
+                ;
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<TerrainSurfaceGradientListNode>("TerrainSurfaceGradientListNode", "")->
+                    ClassElement(AZ::Edit::ClassElements::EditorData, "")->
+                    Attribute(GraphModelIntegration::Attributes::TitlePaletteOverride, "TerrainNodeTitlePalette")
+                    ;
+            }
+        }
+    }
+
+    const QString TerrainSurfaceGradientListNode::TITLE = QObject::tr("Terrain Surface Gradient List");
+
+    TerrainSurfaceGradientListNode::TerrainSurfaceGradientListNode(GraphModel::GraphPtr graph)
+        : BaseNode(graph)
+    {
+        RegisterSlots();
+        CreateSlotData();
+    }
+
+    const BaseNode::BaseNodeType TerrainSurfaceGradientListNode::GetBaseNodeType() const
+    {
+        return BaseNode::TerrainExtender;
+    }
+
+    const char* TerrainSurfaceGradientListNode::GetTitle() const
+    {
+        return TITLE.toUtf8().constData();
+    }
+
+    void TerrainSurfaceGradientListNode::RegisterSlots()
+    {
+        GraphModel::DataTypePtr gradientDataType = GetGraphContext()->GetDataType(LandscapeCanvasDataTypeEnum::Gradient);
+
+        GraphModel::ExtendableSlotConfiguration slotConfig;
+        slotConfig.m_addButtonLabel = "Add Gradient";
+        slotConfig.m_addButtonTooltip = "Add a gradient surface provider";
+        RegisterSlot(GraphModel::SlotDefinition::CreateInputData(
+            INBOUND_GRADIENT_SLOT_ID,
+            INBOUND_GRADIENT_SLOT_LABEL.toUtf8().constData(),
+            { gradientDataType },
+            AZStd::any(AZ::EntityId()),
+            INBOUND_GRADIENT_INPUT_SLOT_DESCRIPTION.toUtf8().constData(),
+            &slotConfig));
+    }
+} // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+// Qt
+#include <QString>
+
+// Landscape Canvas
+#include <Editor/Core/Core.h>
+#include <Editor/Nodes/BaseNode.h>
+
+namespace AZ
+{
+    class ReflectContext;
+}
+
+namespace LandscapeCanvas
+{
+    class TerrainSurfaceGradientListNode
+        : public BaseNode
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(TerrainSurfaceGradientListNode, AZ::SystemAllocator, 0);
+        AZ_RTTI(TerrainSurfaceGradientListNode, "{9414099F-A3BB-432E-86B8-3FB2C44D2529}", BaseNode);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        TerrainSurfaceGradientListNode() = default;
+        explicit TerrainSurfaceGradientListNode(GraphModel::GraphPtr graph);
+
+        const BaseNodeType GetBaseNodeType() const override;
+
+        static const QString TITLE;
+        const char* GetTitle() const override;
+
+    protected:
+        void RegisterSlots() override;
+    };
+}

--- a/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.cpp
@@ -78,6 +78,9 @@
 #include <Editor/Nodes/Shapes/ReferenceShapeNode.h>
 #include <Editor/Nodes/Shapes/SphereShapeNode.h>
 #include <Editor/Nodes/Shapes/TubeShapeNode.h>
+#include <Editor/Nodes/Terrain/TerrainHeightGradientListNode.h>
+#include <Editor/Nodes/Terrain/TerrainLayerSpawnerNode.h>
+#include <Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.h>
 
 namespace LandscapeCanvas
 {
@@ -86,6 +89,15 @@ namespace LandscapeCanvas
         // The FastNoise gem is optional, so we need to keep track of its component type ID
         // ourselves since we can't rely on the headers being there.
         static constexpr const char* EditorFastNoiseGradientComponentTypeId = "{FD018DE5-5EB4-4219-9D0C-CB3C55DE656B}";
+
+        // The Terrain gem is optional, so we need to keep track of the component type IDs
+        // ourselves since we can't rely on the headers being there.
+        namespace Terrain
+        {
+            static constexpr const char* EditorTerrainHeightGradientListComponentTypeId = "{2D945B90-ADAB-4F9A-A113-39E714708068}";
+            static constexpr const char* EditorTerrainLayerSpawnerComponentTypeId = "{9403FC94-FA38-4387-BEFD-A728C7D850C1}";
+            static constexpr const char* EditorTerrainSurfaceGradientListComponentTypeId = "{49831E91-A11F-4EFF-A824-6D85C284B934}";
+        }
 
         // The Vegetation gem is optional, so we need to keep track of the component type IDs
         // ourselves since we can't rely on the headers being there.
@@ -144,6 +156,10 @@ namespace LandscapeCanvas
     VISITOR_FUNCTION<ReferenceShapeNode>(LmbrCentral::EditorReferenceShapeComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<SphereShapeNode>(LmbrCentral::EditorSphereShapeComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<TubeShapeNode>(LmbrCentral::EditorTubeShapeComponentTypeId, ##__VA_ARGS__);     \
+    /* Terrain nodes */    \
+    VISITOR_FUNCTION<TerrainHeightGradientListNode>(Internal::Terrain::EditorTerrainHeightGradientListComponentTypeId, ##__VA_ARGS__);     \
+    VISITOR_FUNCTION<TerrainLayerSpawnerNode>(Internal::Terrain::EditorTerrainLayerSpawnerComponentTypeId, ##__VA_ARGS__);     \
+    VISITOR_FUNCTION<TerrainSurfaceGradientListNode>(Internal::Terrain::EditorTerrainSurfaceGradientListComponentTypeId, ##__VA_ARGS__);     \
     /* Gradient generator nodes */    \
     VISITOR_FUNCTION<FastNoiseGradientNode>(Internal::EditorFastNoiseGradientComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<PerlinNoiseGradientNode>(GradientSignal::EditorPerlinGradientComponentTypeId, ##__VA_ARGS__);     \

--- a/Gems/LandscapeCanvas/Code/landscapecanvas_editor_static_files.cmake
+++ b/Gems/LandscapeCanvas/Code/landscapecanvas_editor_static_files.cmake
@@ -122,6 +122,12 @@ set(FILES
     Source/Editor/Nodes/Shapes/SphereShapeNode.h
     Source/Editor/Nodes/Shapes/TubeShapeNode.cpp
     Source/Editor/Nodes/Shapes/TubeShapeNode.h
+    Source/Editor/Nodes/Terrain/TerrainHeightGradientListNode.cpp
+    Source/Editor/Nodes/Terrain/TerrainHeightGradientListNode.h
+    Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.cpp
+    Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.h
+    Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.cpp
+    Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.h
     Source/Editor/Nodes/UI/GradientPreviewThumbnailItem.cpp
     Source/Editor/Nodes/UI/GradientPreviewThumbnailItem.h
 )


### PR DESCRIPTION
## What does this PR do?

Added support for the Terrain Layer Spawner node, as well as Height and Surface Gradient List wrapped nodes that extend the spawner. As part of this PR had to make some modifications to Landscape Canvas that assumed there would only be Vegetation wrapped nodes.

![TerrainLayerSpawnerAndHeightGradientList](https://user-images.githubusercontent.com/7519264/185994776-6e18524a-8c3b-47f6-8239-3fdc03fc8915.gif)

## How was this PR tested?

Ran Landscape Canvas automated tests. Also tested the vegetation wrapper nodes to make sure they still function as expected.
