### PR TITLE
chore: deprecate both ConvertEulerRadiansToQuaternion and ConvertEulerDegreesToQuaternion

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.h
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.h
@@ -299,10 +299,14 @@ namespace AZ
     //! @return A vector containing component-wise rotation angles in radians.
     Vector3 ConvertQuaternionToEulerRadians(const Quaternion& q);
 
+    //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+    //! @deprecated use Quaternion::CreateFromEulerRadiansXYZ
     //! @param eulerRadians A vector containing component-wise rotation angles in radians.
     //! @return a quaternion made from composition of rotations around principle axes.
     Quaternion ConvertEulerRadiansToQuaternion(const Vector3& eulerRadians);
 
+    //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+    //! @deprecated use Quaternion::CreateFromEulerDegreesXYZ
     //! @param eulerDegrees A vector containing component-wise rotation angles in degrees.
     //! @return a quaternion made from composition of rotations around principle axes.
     Quaternion ConvertEulerDegreesToQuaternion(const Vector3& eulerDegrees);

--- a/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
@@ -344,7 +344,7 @@ namespace UnitTest
         // for Euler -> quaternion -> Euler
         const AZ::Quaternion originalQuaternion = GetParam();
         const AZ::Vector3 euler = originalQuaternion.GetEulerRadians();
-        const AZ::Quaternion recoveredQuaternion = AZ::ConvertEulerRadiansToQuaternion(euler);
+        const AZ::Quaternion recoveredQuaternion = AZ::Quaternion::CreateFromEulerRadiansXYZ(euler);
         EXPECT_TRUE(recoveredQuaternion.IsClose(originalQuaternion) || recoveredQuaternion.IsClose(-originalQuaternion));
     }
 


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

just noticed these method are the same as Quaternion::CreateFromEulerRadiansXYZ. not too hard to also deprecate these as well and use the methods already in Quaternion.

## How was this PR tested?

should be covered by the unit test.
