### PR TITLE
Reword desktop shortcut creation message

### DIFF
--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -256,7 +256,7 @@ namespace O3DE::ProjectManager
                                     .arg(createShortcutResult.GetError()));
             }
 
-            return AZ::Success(QObject::tr("Desktop shortcut created at<br><a href=\"%1\">%2</a>").arg(desktopPath).arg(shortcutPath));
+            return AZ::Success(QObject::tr("A desktop shortcut has been successfully created.<br>You can view the file <a href=\"%1\">here</a>.").arg(desktopPath));
         }
     } // namespace ProjectUtils
 } // namespace O3DE::ProjectManager


### PR DESCRIPTION
Signed-off-by: Sondre Agledahl <sondre@sondre.io>

## What does this PR do?
Trivial rewording of message dialog that pops up when creating a desktop shortcut for a project, following UX suggestions from @amzn-leenguy in #7780.

## How was this PR tested?
Verified updated message is displayed and links to desktop. Ran `RUN_TESTS` target.
