### PR TITLE
Fix memory leak in NodePaletteSortFilterProxyModel

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
@@ -19,7 +19,8 @@ namespace GraphCanvas
     // NodePaletteAutoCompleteModel
     /////////////////////////////////
 
-    NodePaletteAutoCompleteModel::NodePaletteAutoCompleteModel()
+    NodePaletteAutoCompleteModel::NodePaletteAutoCompleteModel(QObject* parent)
+        : QAbstractItemModel(parent)
     {
     }
 
@@ -112,8 +113,8 @@ namespace GraphCanvas
 
     NodePaletteSortFilterProxyModel::NodePaletteSortFilterProxyModel(QObject* parent)
         : QSortFilterProxyModel(parent)
-        , m_unfilteredAutoCompleteModel(aznew NodePaletteAutoCompleteModel())
-        , m_sourceSlotAutoCompleteModel(aznew NodePaletteAutoCompleteModel())
+        , m_unfilteredAutoCompleteModel(aznew NodePaletteAutoCompleteModel(this))
+        , m_sourceSlotAutoCompleteModel(aznew NodePaletteAutoCompleteModel(this))
         , m_hasSourceSlotFilter(false)
     {
         m_unfilteredCompleter.setModel(m_unfilteredAutoCompleteModel);

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.h
@@ -32,7 +32,7 @@ namespace GraphCanvas
 
         AZ_CLASS_ALLOCATOR(NodePaletteAutoCompleteModel, AZ::SystemAllocator, 0);
 
-        NodePaletteAutoCompleteModel();
+        NodePaletteAutoCompleteModel(QObject* parent = nullptr);
         ~NodePaletteAutoCompleteModel() = default;
 
         QModelIndex index(int row, int column, const QModelIndex& parent = QModelIndex()) const override;


### PR DESCRIPTION
NodePaletteAutoCompleteModel didn't have a proper parent set up so it
was left dangling after NodePaletteSFPM was destroyed.

Signed-off-by: Miłosz Kosobucki <milosz@kosobucki.pl>

## What does this PR do?

Completer model didn't have parent set so it leaked.

## How was this PR tested?

This was found when I started using GraphCanvas in EMotionFX (#10963) and ran the test suite. After applying the patch, no more leaks were reported by tests.
