### PR TITLE
Initialize field in IconDecoratedNodePaletteTreeItem

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/TreeItems/IconDecoratedNodePaletteTreeItem.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/TreeItems/IconDecoratedNodePaletteTreeItem.h
@@ -38,6 +38,6 @@ namespace GraphCanvas
 
     private:
         PaletteIconConfiguration m_paletteConfiguration;
-        const QPixmap* m_iconPixmap;
+        const QPixmap* m_iconPixmap = nullptr;
     };
 }


### PR DESCRIPTION
Methods of this class check for null on m_iconPixmap so we should
initialize it as such.

This fixes crashes when this class is used but icon is not actually set.

Signed-off-by: Miłosz Kosobucki <milosz@kosobucki.pl>

## What does this PR do?

Initializes a pointer field to nullptr.

## How was this PR tested?

By running the debugger.
