### PR TITLE
Bug fix for Aabb assert in Recast Navigation unit tests in Debug

### DIFF
--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationPhysXProviderComponentController.cpp
@@ -318,6 +318,7 @@ namespace RecastNavigation
 
                 AZStd::shared_ptr<TileGeometry> geometryData = AZStd::make_unique<TileGeometry>();
                 geometryData->m_worldBounds = tileVolume;
+                geometryData->m_scanBounds = scanVolume;
                 AppendColliderGeometry(*geometryData, results);
 
                 geometryData->m_tileX = x;


### PR DESCRIPTION
Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>

## What does this PR do?

Fixes #11418

## How was this PR tested?

```
[==========] Running 24 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 24 tests from NavigationTest
[ RUN      ] NavigationTest.GetNativeNavMesh
[       OK ] NavigationTest.GetNativeNavMesh (39 ms)
[ RUN      ] NavigationTest.TestAgainstEmptyPhysicalBody
[       OK ] NavigationTest.TestAgainstEmptyPhysicalBody (103 ms)
[ RUN      ] NavigationTest.BlockingTest
[       OK ] NavigationTest.BlockingTest (23 ms)
[ RUN      ] NavigationTest.BlockingTestWithDebugDraw
[       OK ] NavigationTest.BlockingTestWithDebugDraw (20 ms)
[ RUN      ] NavigationTest.BlockingNonIndexedWithDebugDraw
[       OK ] NavigationTest.BlockingNonIndexedWithDebugDraw (20 ms)
[ RUN      ] NavigationTest.BlockingTestRerun
[       OK ] NavigationTest.BlockingTestRerun (22 ms)
[ RUN      ] NavigationTest.BlockingOnEmptyRerun
[       OK ] NavigationTest.BlockingOnEmptyRerun (24 ms)
[ RUN      ] NavigationTest.BlockingTestNonIndexedGeometry
[       OK ] NavigationTest.BlockingTestNonIndexedGeometry (27 ms)
[ RUN      ] NavigationTest.TickingDebugDraw
[       OK ] NavigationTest.TickingDebugDraw (22 ms)
[ RUN      ] NavigationTest.DirectTestOnDebugDrawQuad
[       OK ] NavigationTest.DirectTestOnDebugDrawQuad (9 ms)
[ RUN      ] NavigationTest.DirectTestOnDebugDrawLines
[       OK ] NavigationTest.DirectTestOnDebugDrawLines (8 ms)
[ RUN      ] NavigationTest.DirectTestOnDebugDrawWithoutDebugDisplayRequests
[       OK ] NavigationTest.DirectTestOnDebugDrawWithoutDebugDisplayRequests (8 ms)
[ RUN      ] NavigationTest.FindPathTestDetaultDetourSettings
[       OK ] NavigationTest.FindPathTestDetaultDetourSettings (21 ms)
[ RUN      ] NavigationTest.FindPathTest
[       OK ] NavigationTest.FindPathTest (22 ms)
[ RUN      ] NavigationTest.FindPathToOutOfBoundsDestination
[       OK ] NavigationTest.FindPathToOutOfBoundsDestination (21 ms)
[ RUN      ] NavigationTest.FindPathOnEmptyNavMesh
[       OK ] NavigationTest.FindPathOnEmptyNavMesh (20 ms)
[ RUN      ] NavigationTest.FindPathBetweenInvalidEntities
[       OK ] NavigationTest.FindPathBetweenInvalidEntities (22 ms)
[ RUN      ] NavigationTest.FindPathBetweenEntitiesOnEmptyNavMesh
[       OK ] NavigationTest.FindPathBetweenEntitiesOnEmptyNavMesh (20 ms)
[ RUN      ] NavigationTest.RecastNavigationMeshComponentControllerTests
[       OK ] NavigationTest.RecastNavigationMeshComponentControllerTests (12 ms)
[ RUN      ] NavigationTest.RecastNavigationNotificationHandler
[       OK ] NavigationTest.RecastNavigationNotificationHandler (9 ms)
[ RUN      ] NavigationTest.RecastNavigationPhysXProviderComponentController
[       OK ] NavigationTest.RecastNavigationPhysXProviderComponentController (16 ms)
[ RUN      ] NavigationTest.CollectGeometryCornerCaseZeroTileSize
[       OK ] NavigationTest.CollectGeometryCornerCaseZeroTileSize (21 ms)
[ RUN      ] NavigationTest.DetourSetNavMeshEntity
[       OK ] NavigationTest.DetourSetNavMeshEntity (22 ms)
[ RUN      ] NavigationTest.NavUpdateThenDeleteCollidersThenUpdateAgainThenFindPathShouldFail
[       OK ] NavigationTest.NavUpdateThenDeleteCollidersThenUpdateAgainThenFindPathShouldFail (22 ms)
[----------] 24 tests from NavigationTest (566 ms total)

[----------] Global test environment tear-down
[==========] 24 tests from 1 test case ran. (568 ms total)
[  PASSED  ] 24 tests.
```
