### PR TITLE
Fix mac compile error related to assigning a non-const to a const reference

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -379,7 +379,7 @@ namespace AzToolsFramework::Prefab
 
         {
             // Climb up the instance hierarchy from this instance until you hit the focused prefab instance.
-            InstanceOptionalConstReference instance = owningInstance;
+            InstanceOptionalReference instance = owningInstance;
             AZStd::vector<InstanceOptionalConstReference> instancePath;
 
             auto climbUpResult = PrefabInstanceUtils::ClimbUpToTargetOrRootInstance(&instance->get(), &focusedPrefabInstance->get());


### PR DESCRIPTION
## What does this PR do?

Fixes the following compile error on Mac:

```
In file included from /Users/spham/github/o3de/build/mac/Code/Framework/AzToolsFramework/CMakeFiles/AzToolsFramework.dir/Unity/unity_34_cxx.cxx:13:
/Users/spham/github/o3de/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp:382:44: error: no viable conversion from 'optional<reference_wrapper<AzToolsFramework::Prefab::Instance>>' to 'optional<reference_wrapper<const AzToolsFramework::Prefab::Instance>>'
            InstanceOptionalConstReference instance = owningInstance;
                                           ^          ~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/include/c++/v1/optional:689:41: note: candidate constructor not viable: no known conversion from 'AzToolsFramework::Prefab::InstanceOptionalReference' (aka 'optional<AZStd::reference_wrapper<Instance>>') to 'const std::optional<std::reference_wrapper<const AzToolsFramework::Prefab::Instance>> &' for 1st argument
    _LIBCPP_INLINE_VISIBILITY constexpr optional(const optional&) = default;
```

## How was this PR tested?
Was able to compile on Mac successfully


