### PR TITLE
Added Vulkan Validation Smoke Test (run on nightly build)

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
@@ -73,6 +73,19 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED)
             Atom
     )
     ly_add_pytest(
+        NAME AutomatedTesting::Atom_TestSuite_Smoke_GPU
+        TEST_SUITE smoke
+        TEST_REQUIRES gpu
+        TEST_SERIAL
+        PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Smoke_GPU.py
+        RUNTIME_DEPENDENCIES
+            AssetProcessor
+            AutomatedTesting.Assets
+            Editor
+        COMPONENT
+            Atom
+    )
+    ly_add_pytest(
         NAME AutomatedTesting::Atom_TestSuite_Main_GPU
         TEST_SUITE main
         TEST_REQUIRES gpu

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Smoke_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Smoke_GPU.py
@@ -1,0 +1,25 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+import os
+import pytest
+
+from ly_test_tools.o3de.editor_test import EditorSingleTest, EditorTestSuite, EditorBatchedTest
+
+@pytest.mark.SUITE_smoke
+@pytest.mark.REQUIRES_gpu
+@pytest.mark.parametrize("project", ["AutomatedTesting"])
+@pytest.mark.parametrize("launcher_platform", ['windows_editor'])
+class TestAutomation_RHIValidation_Vulkan(EditorTestSuite):
+    # Remove -BatchMode from global_extra_cmdline_args since we need rendering for these tests.
+    global_extra_cmdline_args = ["-autotest_mode","-rhi=vulkan","-rhi-device-validation=enable"]  # Default is ["-BatchMode", "-autotest_mode"]
+    use_null_renderer = False  # Default is True
+
+    # File with the list of vulkan validation errors to ignore
+    # can be found in 'tests\rhi_validation\vulkan_skip_errors.py'
+
+    class test_RHIValidation_Vulkan_DefaultLevel(EditorBatchedTest):
+        from .tests.rhi_validation import RHIValidation_Vulkan_DefaultLevel as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Smoke_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Smoke_GPU.py
@@ -9,17 +9,38 @@ import pytest
 
 from ly_test_tools.o3de.editor_test import EditorSingleTest, EditorTestSuite, EditorBatchedTest
 
+# File with the list of vulkan validation errors to ignore
+# can be found in 'tests\rhi_validation\vulkan_skip_errors.py'
+
 @pytest.mark.SUITE_smoke
 @pytest.mark.REQUIRES_gpu
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
 class TestAutomation_RHIValidation_Vulkan(EditorTestSuite):
     # Remove -BatchMode from global_extra_cmdline_args since we need rendering for these tests.
-    global_extra_cmdline_args = ["-autotest_mode","-rhi=vulkan","-rhi-device-validation=enable"]  # Default is ["-BatchMode", "-autotest_mode"]
+    global_extra_cmdline_args = [
+        "-autotest_mode",
+        "-rhi=vulkan",
+        "-rhi-device-validation=enable"
+        ]  # Default is ["-BatchMode", "-autotest_mode"]
     use_null_renderer = False  # Default is True
 
-    # File with the list of vulkan validation errors to ignore
-    # can be found in 'tests\rhi_validation\vulkan_skip_errors.py'
+    class test_RHIValidation_Vulkan_DefaultLevel(EditorBatchedTest):
+        from .tests.rhi_validation import RHIValidation_Vulkan_DefaultLevel as test_module
+
+@pytest.mark.SUITE_smoke
+@pytest.mark.REQUIRES_gpu
+@pytest.mark.parametrize("project", ["AutomatedTesting"])
+@pytest.mark.parametrize("launcher_platform", ['windows_editor'])
+class TestAutomation_RHIValidation_Vulkan_LowEndPipeline(EditorTestSuite):
+    # Remove -BatchMode from global_extra_cmdline_args since we need rendering for these tests.
+    global_extra_cmdline_args = [
+        "-autotest_mode",
+        "-rhi=vulkan",
+        "-rhi-device-validation=enable",
+        "--r_default_pipeline_name=passes/LowEndRenderPipeline.azasset"
+        ]  # Default is ["-BatchMode", "-autotest_mode"]
+    use_null_renderer = False  # Default is True
 
     class test_RHIValidation_Vulkan_DefaultLevel(EditorBatchedTest):
         from .tests.rhi_validation import RHIValidation_Vulkan_DefaultLevel as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/rhi_validation/RHIValidation_Vulkan_DefaultLevel.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/rhi_validation/RHIValidation_Vulkan_DefaultLevel.py
@@ -1,0 +1,52 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+class Checks:
+    enter_game_mode                = ("Entered game mode",              "Failed to enter game mode")
+    no_rhi_validation_errors_found = ("No RHI validation errors found", "Found RHI validation errors")
+    exit_game_mode                 = ("Exited game mode",               "Failed to exit game mode")
+
+def RHIValidation_DefaultLevel():
+    
+    import azlmbr.legacy.general as general
+    
+    from editor_python_test_tools.utils import Report
+    from editor_python_test_tools.utils import TestHelper as helper
+    from editor_python_test_tools.utils import Tracer
+    
+    from vulkan_skip_errors import VulkanValidationErrors
+    
+    # Constants
+    FRAMES_IN_GAME_MODE = 200
+
+    # 1) Start the Tracer to catch any errors and warnings
+    with Tracer() as section_tracer:
+        helper.init_idle()
+
+        # 2) Load the level
+        helper.open_level("", "DefaultLevel")
+
+        # 3) Enter game mode
+        helper.enter_game_mode(Checks.enter_game_mode)
+        
+        # 4) Wait in game mode some frames to let cloth simulation run
+        general.idle_wait_frames(FRAMES_IN_GAME_MODE)
+        
+        # 5) Exit game mode
+        helper.exit_game_mode(Checks.exit_game_mode)
+
+    # 5) Verify there are no rhi validation errors in the logs
+    has_rhi_validation_errors = False
+    for error_msg in section_tracer.errors:
+        if VulkanValidationErrors.CheckError(error_msg.window, f"{error_msg}"):
+            has_rhi_validation_errors = True
+            Report.info(f"RHI Validation error found: {error_msg}")
+    Report.result(Checks.no_rhi_validation_errors_found, not has_rhi_validation_errors)
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(RHIValidation_DefaultLevel)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/rhi_validation/RHIValidation_Vulkan_DefaultLevel.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/rhi_validation/RHIValidation_Vulkan_DefaultLevel.py
@@ -10,7 +10,7 @@ class Checks:
     no_rhi_validation_errors_found = ("No RHI validation errors found", "Found RHI validation errors")
     exit_game_mode                 = ("Exited game mode",               "Failed to exit game mode")
 
-def RHIValidation_DefaultLevel():
+def RHIValidation_Vulkan_DefaultLevel():
     
     import azlmbr.legacy.general as general
     
@@ -49,4 +49,4 @@ def RHIValidation_DefaultLevel():
 
 if __name__ == "__main__":
     from editor_python_test_tools.utils import Report
-    Report.start_test(RHIValidation_DefaultLevel)
+    Report.start_test(RHIValidation_Vulkan_DefaultLevel)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/rhi_validation/vulkan_skip_errors.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/rhi_validation/vulkan_skip_errors.py
@@ -1,0 +1,26 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+class VulkanValidationErrors:
+    identifiers = ["vkDebugMessage"]
+
+    # List to add vulkan validation errors that will be ignored.
+    errors_to_skip = [
+        #"VUID-VkDescriptorImageInfo-imageLayout-00344", # GHI-xxx
+        #"VUID-vkCmdDraw-None-02699", # GHI-xxx
+        #"VUID-VkMemoryAllocateInfo-flags-03331", # GHI-xxx
+        #"UNASSIGNED-CoreValidation-Shader-InconsistentSpirv"  # GHI-xxx
+        ]
+
+    def CheckError(error_id, error_msg):
+        if error_id in VulkanValidationErrors.identifiers:
+            for error_to_skip in VulkanValidationErrors.errors_to_skip:
+                if error_to_skip in error_msg:
+                    return False # Skip error
+            return True # Found error
+        return False # Not a Vulkan error
+        

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/rhi_validation/vulkan_skip_errors.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/rhi_validation/vulkan_skip_errors.py
@@ -9,11 +9,15 @@ class VulkanValidationErrors:
     identifiers = ["vkDebugMessage"]
 
     # List to add vulkan validation errors that will be ignored.
+    # For example, to ignore the following error
+    #
+    # [vkDebugMessage] [ERROR][Validation] Validation Error: [ VUID-VkMemoryAllocateInfo-flags-03331 ] Object 0: handle = 0x24c6516baa0, 
+    # type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xf972dfbf | If VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT is set, bufferDeviceAddress must be enabled. 
+    # The Vulkan spec states: If VkMemoryAllocateFlagsInfo::flags includes VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT, the bufferDeviceAddress feature
+    # must be enabled (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkMemoryAllocateInfo-flags-03331)
+    #
+    # The entry "VUID-VkMemoryAllocateInfo-flags-03331" can be added to the list.
     errors_to_skip = [
-        #"VUID-VkDescriptorImageInfo-imageLayout-00344", # GHI-xxx
-        #"VUID-vkCmdDraw-None-02699", # GHI-xxx
-        #"VUID-VkMemoryAllocateInfo-flags-03331", # GHI-xxx
-        #"UNASSIGNED-CoreValidation-Shader-InconsistentSpirv"  # GHI-xxx
         ]
 
     def CheckError(error_id, error_msg):

--- a/AutomatedTesting/Levels/DefaultLevel/DefaultLevel.prefab
+++ b/AutomatedTesting/Levels/DefaultLevel/DefaultLevel.prefab
@@ -1,0 +1,554 @@
+{
+    "ContainerEntity": {
+        "Id": "Entity_[1146574390643]",
+        "Name": "Level",
+        "Components": {
+            "Component_[10518628887662025558]": {
+                "$type": "LocalViewBookmarkComponent",
+                "Id": 10518628887662025558,
+                "LocalBookmarkFileName": "DefaultLevel_1578751178548.setreg"
+            },
+            "Component_[10641544592923449938]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 10641544592923449938
+            },
+            "Component_[12039882709170782873]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 12039882709170782873
+            },
+            "Component_[12265484671603697631]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12265484671603697631
+            },
+            "Component_[14126657869720434043]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 14126657869720434043,
+                "Child Entity Order": [
+                    "Entity_[1176639161715]"
+                ]
+            },
+            "Component_[15230859088967841193]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 15230859088967841193,
+                "Parent Entity": ""
+            },
+            "Component_[16239496886950819870]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 16239496886950819870
+            },
+            "Component_[5688118765544765547]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 5688118765544765547
+            },
+            "Component_[7247035804068349658]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 7247035804068349658
+            },
+            "Component_[9307224322037797205]": {
+                "$type": "EditorLockComponent",
+                "Id": 9307224322037797205
+            },
+            "Component_[9562516168917670048]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 9562516168917670048
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[1155164325235]": {
+            "Id": "Entity_[1155164325235]",
+            "Name": "Sun",
+            "Components": {
+                "Component_[13620450453324765907]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13620450453324765907
+                },
+                "Component_[2134313378593666258]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 2134313378593666258
+                },
+                "Component_[234010807770404186]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 234010807770404186
+                },
+                "Component_[2970359110423865725]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2970359110423865725
+                },
+                "Component_[3722854130373041803]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3722854130373041803
+                },
+                "Component_[5992533738676323195]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5992533738676323195
+                },
+                "Component_[7378860763541895402]": {
+                    "$type": "AZ::Render::EditorDirectionalLightComponent",
+                    "Id": 7378860763541895402,
+                    "Controller": {
+                        "Configuration": {
+                            "Intensity": 1.0,
+                            "CameraEntityId": "",
+                            "ShadowFilterMethod": 1
+                        }
+                    }
+                },
+                "Component_[7892834440890947578]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7892834440890947578,
+                    "Parent Entity": "Entity_[1176639161715]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            13.487043380737305
+                        ],
+                        "Rotate": [
+                            -76.13099670410156,
+                            -0.847000002861023,
+                            -15.8100004196167
+                        ]
+                    }
+                },
+                "Component_[8599729549570828259]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 8599729549570828259
+                },
+                "Component_[952797371922080273]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 952797371922080273
+                }
+            }
+        },
+        "Entity_[1159459292531]": {
+            "Id": "Entity_[1159459292531]",
+            "Name": "Ground",
+            "Components": {
+                "Component_[12260880513256986252]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12260880513256986252
+                },
+                "Component_[13711420870643673468]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13711420870643673468
+                },
+                "Component_[138002849734991713]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 138002849734991713
+                },
+                "Component_[16578565737331764849]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16578565737331764849,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[16919232076966545697]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16919232076966545697
+                },
+                "Component_[5182430712893438093]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 5182430712893438093
+                },
+                "Component_[5245524694917323904]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5245524694917323904,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                512.0,
+                                512.0,
+                                1.0
+                            ]
+                        }
+                    },
+                    "DebugDrawSettings": {
+                        "LocallyEnabled": false
+                    }
+                },
+                "Component_[5675108321710651991]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 5675108321710651991,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{0CD745C0-6AA8-569A-A68A-73A3270986C4}",
+                                    "subId": 277889906
+                                },
+                                "assetHint": "objects/groudplane/groundplane_512x512m.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[5681893399601237518]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5681893399601237518
+                },
+                "Component_[592692962543397545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 592692962543397545
+                },
+                "Component_[7090012899106946164]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7090012899106946164
+                },
+                "Component_[9410832619875640998]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9410832619875640998
+                }
+            }
+        },
+        "Entity_[1163754259827]": {
+            "Id": "Entity_[1163754259827]",
+            "Name": "Camera",
+            "Components": {
+                "Component_[11895140916889160460]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11895140916889160460
+                },
+                "Component_[16880285896855930892]": {
+                    "$type": "{CA11DA46-29FF-4083-B5F6-E02C3A8C3A3D} EditorCameraComponent",
+                    "Id": 16880285896855930892,
+                    "Controller": {
+                        "Configuration": {
+                            "Field of View": 55.0,
+                            "EditorEntityId": 8929576024571800510
+                        }
+                    }
+                },
+                "Component_[17187464423780271193]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17187464423780271193
+                },
+                "Component_[17495696818315413311]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17495696818315413311
+                },
+                "Component_[18086214374043522055]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18086214374043522055,
+                    "Parent Entity": "Entity_[1176639161715]",
+                    "Transform Data": {
+                        "Translate": [
+                            -2.3000001907348633,
+                            -3.9368600845336914,
+                            1.0
+                        ],
+                        "Rotate": [
+                            -2.050307512283325,
+                            1.9552897214889526,
+                            -43.623355865478516
+                        ]
+                    }
+                },
+                "Component_[2654521436129313160]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2654521436129313160
+                },
+                "Component_[5265045084611556958]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5265045084611556958
+                },
+                "Component_[7169798125182238623]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7169798125182238623
+                },
+                "Component_[7255796294953281766]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 7255796294953281766,
+                    "m_template": {
+                        "$type": "FlyCameraInputComponent"
+                    }
+                },
+                "Component_[8866210352157164042]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8866210352157164042
+                },
+                "Component_[9129253381063760879]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9129253381063760879
+                }
+            }
+        },
+        "Entity_[1168049227123]": {
+            "Id": "Entity_[1168049227123]",
+            "Name": "Grid",
+            "Components": {
+                "Component_[11443347433215807130]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11443347433215807130
+                },
+                "Component_[14249419413039427459]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14249419413039427459
+                },
+                "Component_[15448581635946161318]": {
+                    "$type": "AZ::Render::EditorGridComponent",
+                    "Id": 15448581635946161318,
+                    "Controller": {
+                        "Configuration": {
+                            "primarySpacing": 4.0,
+                            "primaryColor": [
+                                0.501960813999176,
+                                0.501960813999176,
+                                0.501960813999176
+                            ],
+                            "secondarySpacing": 0.5,
+                            "secondaryColor": [
+                                0.250980406999588,
+                                0.250980406999588,
+                                0.250980406999588
+                            ]
+                        }
+                    }
+                },
+                "Component_[1843303322527297409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1843303322527297409
+                },
+                "Component_[380249072065273654]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 380249072065273654,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[7476660583684339787]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7476660583684339787
+                },
+                "Component_[7557626501215118375]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 7557626501215118375
+                },
+                "Component_[7984048488947365511]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7984048488947365511
+                },
+                "Component_[8118181039276487398]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8118181039276487398
+                },
+                "Component_[9189909764215270515]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9189909764215270515
+                }
+            }
+        },
+        "Entity_[1172344194419]": {
+            "Id": "Entity_[1172344194419]",
+            "Name": "Shader Ball",
+            "Components": {
+                "Component_[10789351944715265527]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10789351944715265527
+                },
+                "Component_[12037033284781049225]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 12037033284781049225
+                },
+                "Component_[13759153306105970079]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13759153306105970079
+                },
+                "Component_[14135560884830586279]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14135560884830586279
+                },
+                "Component_[16247165675903986673]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 16247165675903986673
+                },
+                "Component_[18082433625958885247]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 18082433625958885247
+                },
+                "Component_[6472623349872972660]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6472623349872972660,
+                    "Parent Entity": "Entity_[1176639161715]",
+                    "Transform Data": {
+                        "Rotate": [
+                            0.0,
+                            0.10000000149011612,
+                            180.0
+                        ]
+                    }
+                },
+                "Component_[6495255223970673916]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 6495255223970673916,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{FD340C30-755C-5911-92A3-19A3F7A77931}",
+                                    "subId": 281415304
+                                },
+                                "assetHint": "objects/shaderball/shaderball_default_1m.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[8550141614185782969]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8550141614185782969
+                },
+                "Component_[9439770997198325425]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9439770997198325425
+                }
+            }
+        },
+        "Entity_[1176639161715]": {
+            "Id": "Entity_[1176639161715]",
+            "Name": "Atom Default Environment",
+            "Components": {
+                "Component_[10757302973393310045]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10757302973393310045,
+                    "Parent Entity": "Entity_[1146574390643]"
+                },
+                "Component_[14505817420424255464]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14505817420424255464,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10757302973393310045
+                        }
+                    ]
+                },
+                "Component_[14988041764659020032]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14988041764659020032
+                },
+                "Component_[15900837685796817138]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15900837685796817138
+                },
+                "Component_[3298767348226484884]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3298767348226484884
+                },
+                "Component_[4076975109609220594]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4076975109609220594
+                },
+                "Component_[5679760548946028854]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5679760548946028854
+                },
+                "Component_[5855590796136709437]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5855590796136709437,
+                    "Child Entity Order": [
+                        "Entity_[1155164325235]",
+                        "Entity_[1180934129011]",
+                        "Entity_[1172344194419]",
+                        "Entity_[1168049227123]",
+                        "Entity_[1163754259827]",
+                        "Entity_[1159459292531]"
+                    ]
+                },
+                "Component_[9277695270015777859]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9277695270015777859
+                }
+            }
+        },
+        "Entity_[1180934129011]": {
+            "Id": "Entity_[1180934129011]",
+            "Name": "Global Sky",
+            "Components": {
+                "Component_[11231930600558681245]": {
+                    "$type": "AZ::Render::EditorHDRiSkyboxComponent",
+                    "Id": 11231930600558681245,
+                    "Controller": {
+                        "Configuration": {
+                            "CubemapAsset": {
+                                "assetId": {
+                                    "guid": "{215E47FD-D181-5832-B1AB-91673ABF6399}",
+                                    "subId": 1000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_skyboxcm.exr.streamingimage"
+                            }
+                        }
+                    }
+                },
+                "Component_[1428633914413949476]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1428633914413949476
+                },
+                "Component_[14936200426671614999]": {
+                    "$type": "AZ::Render::EditorImageBasedLightComponent",
+                    "Id": 14936200426671614999,
+                    "Controller": {
+                        "Configuration": {
+                            "diffuseImageAsset": {
+                                "assetId": {
+                                    "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                                    "subId": 3000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_ibldiffuse.exr.streamingimage"
+                            },
+                            "specularImageAsset": {
+                                "assetId": {
+                                    "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                                    "subId": 2000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_iblspecular.exr.streamingimage"
+                            }
+                        }
+                    }
+                },
+                "Component_[14994774102579326069]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14994774102579326069
+                },
+                "Component_[15417479889044493340]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15417479889044493340
+                },
+                "Component_[15826613364991382688]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15826613364991382688
+                },
+                "Component_[1665003113283562343]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1665003113283562343
+                },
+                "Component_[3704934735944502280]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3704934735944502280
+                },
+                "Component_[5698542331457326479]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5698542331457326479
+                },
+                "Component_[6644513399057217122]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6644513399057217122,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[931091830724002070]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 931091830724002070
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Added smoke test suite to Atom tests. it includes 2 tests:
1. Run editor with vulkan and validation enabled and fail if vulkan validation tests were detected.
2. Same but running editor with low end pipeline, useful to detect errors when using the low render pipeline (used by mobile devices).

There is a list to add vulkan errors that for some reason we will like to ignore (maybe to fix later if they are harmless).

The smoke gpu tests will run as part of "test_gpu_profile" job in aws nightly build.

## How was this PR tested?

Run test locally on nVidia GPU: tests passed
Run test locally with vulkan errors present, it failed correctly and tested adding the error to the ignore list to make it pass.
Run job "test_gpu_profile" on jenkins: smoke tests added passed
```
[2022-08-23T13:26:04.137Z]     Start 168: AutomatedTesting::Atom_TestSuite_Smoke_GPU.smoke::TEST_RUN
[2022-08-23T13:27:25.508Z] 3/6 Test #168: AutomatedTesting::Atom_TestSuite_Smoke_GPU.smoke::TEST_RUN ........   Passed   75.74 sec
```