### PR TITLE
XCB: Reset cursor state if Focus-In is not paired with Focus-Out (Fix hidden cursor bug when "Play Game")

### DIFF
--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
@@ -542,6 +542,11 @@ namespace AzFramework
                 const xcb_focus_in_event_t* focusInEvent = reinterpret_cast<const xcb_focus_in_event_t*>(event);
                 if (m_focusWindow != focusInEvent->event)
                 {
+                    if (m_focusWindow != XCB_WINDOW_NONE)
+                    {
+                        HandleCursorState(m_focusWindow, SystemCursorState::UnconstrainedAndVisible);
+                    }
+
                     m_focusWindow = focusInEvent->event;
                     HandleCursorState(m_focusWindow, m_systemCursorState);
                 }


### PR DESCRIPTION
## What does this PR do?

This commit fixes a bug on Ubuntu 22.04.1 (X display server - XCB input).

### Old behavior

When launching "Play Game" using top menu the cursor disappears and does not appear again when changing window
(for example Alt-Tabbing) or after exiting "Play Game" mode. In order for cursor to show up again the Editor should close.
Launching game using hotkey "Ctrl+G" doesn't face this problem.

### Understanding the behavior (Bug)

XCB input implementation tries to keep cursor behavior for itself. This is why when Focus Out (`XCB_FOCUS_OUT`) event 
happens system default cursor behavior is set while when Focus In (`XCB_FOCUS_IN`) the needed behavior is set. However an Focus In event can arrive without an Focus Out just before (I don't know exactly why this happen, my knowledge on XCB is not great). As a result windows in which cursor Hide option is set get "lost". When cursor should Show those "lost" windows keep it hidden. When pressing "Play Game" menu button (from my understanding) there are some not paired Focus-In events and some windows with hidden cursor get "lost".

### The bugfix

This bugfix reset the cursor state of the so-far focused window when a Focus-In event happen.
By checking `m_focusWindow != XCB_WINDOW_NONE` we actually find if the Focus-In event is not paired with an previous Focus-Out event.

## How was this PR tested?

By compiling and testing on a simple project.
The behavior of the cursor is now as it should be. When Alt-Tabbing or stop "Play Game" by pressing "Esc" the cursor appear.

Feel free to edit, add changes and criticize the PR as a whole.