### PR TITLE
Prefab | Fix prefab save issue in create entity

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -655,6 +655,9 @@ namespace AzToolsFramework
                 AZ::TransformBus::Event(entityId, &AZ::TransformInterface::SetWorldTM, transform);
             }
 
+            m_prefabUndoCache.UpdateCache(entityId);
+            m_prefabUndoCache.UpdateCache(parentId);
+
             // Get the alias of the parent entity in the owning template's DOM.
             AZStd::string parentEntityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(parentId);
             PrefabDomPath entityPathInOwningTemplate(parentEntityAliasPath.c_str());


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

Try to fix #11452 and related #11489

This PR puts up a fix for the save issue happening after create-entity. It updates the cache for the new entity and its parent entity. So, the DOMs in undo cache are correct.

**Next Step (long-term fix):**

Remove DOM cache in Prefab Undo Cache as the previous state can be retrieved from template DOM. It helps avoid more similar issues that might occur other public workflows (e.g. delete, instantiate).

## How was this PR tested?

- [x] Verified the issue goes away in editor and no new issues were observed
- [x] Passed prefab unit tests
- [x] Passed prefab auto tests
- [ ] AR
