### PR TITLE
Exposed ToolBar ActionManager APIs to Python

### DIFF
--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
@@ -9,6 +9,7 @@
 #include <ActionManager/PythonActionManagerHandler.h>
 
 #include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
+#include <AzToolsFramework/ActionManager/ToolBar/ToolBarManagerInterface.h>
 #include <Source/PythonCommon.h>
 #include <pybind11/pybind11.h>
 
@@ -30,6 +31,13 @@ namespace EditorPythonBindings
         {
             MenuManagerRequestBus::Handler::BusConnect();
         }
+
+        m_toolBarManagerInterface = AZ::Interface<AzToolsFramework::ToolBarManagerInterface>::Get();
+
+        if (m_toolBarManagerInterface)
+        {
+            ToolBarManagerRequestBus::Handler::BusConnect();
+        }
     }
 
     PythonActionManagerHandler::~PythonActionManagerHandler()
@@ -43,6 +51,11 @@ namespace EditorPythonBindings
         if (m_menuManagerInterface)
         {
             MenuManagerRequestBus::Handler::BusDisconnect();
+        }
+
+        if (m_toolBarManagerInterface)
+        {
+            ToolBarManagerRequestBus::Handler::BusDisconnect();
         }
     }
     
@@ -81,6 +94,23 @@ namespace EditorPythonBindings
                 ->Event("AddActionToMenu", &MenuManagerRequestBus::Handler::AddActionToMenu)
                 ->Event("AddSeparatorToMenu", &MenuManagerRequestBus::Handler::AddSeparatorToMenu)
                 ->Event("AddSubMenuToMenu", &MenuManagerRequestBus::Handler::AddSubMenuToMenu)
+                ;
+
+            behaviorContext
+                ->EBus<ToolBarManagerRequestBus>("ToolBarManagerPythonRequestBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Category, "Action")
+                ->Attribute(AZ::Script::Attributes::Module, "action")
+                ->Event("RegisterToolBar", &ToolBarManagerRequests::RegisterToolBar)
+                ->Event("AddActionToToolBar", &ToolBarManagerRequests::AddActionToToolBar)
+                ->Event("AddActionWithSubMenuToToolBar", &ToolBarManagerRequests::AddActionWithSubMenuToToolBar)
+                ->Event("AddActionsToToolBar", &ToolBarManagerRequests::AddActionsToToolBar)
+                ->Event("RemoveActionFromToolBar", &ToolBarManagerRequests::RemoveActionFromToolBar)
+                ->Event("RemoveActionsFromToolBar", &ToolBarManagerRequests::RemoveActionsFromToolBar)
+                ->Event("AddSeparatorToToolBar", &ToolBarManagerRequests::AddSeparatorToToolBar)
+                ->Event("AddWidgetToToolBar", &ToolBarManagerRequests::AddWidgetToToolBar)
+                ->Event("GetSortKeyOfActionInToolBar", &ToolBarManagerRequests::GetSortKeyOfActionInToolBar)
+                ->Event("GetSortKeyOfWidgetInToolBar", &ToolBarManagerRequests::GetSortKeyOfWidgetInToolBar)
                 ;
         }
     }
@@ -176,6 +206,69 @@ namespace EditorPythonBindings
         const AZStd::string& menuIdentifier, const AZStd::string& subMenuIdentifier, int sortIndex)
     {
         return m_menuManagerInterface->AddSubMenuToMenu(menuIdentifier, subMenuIdentifier, sortIndex);
+    }
+
+    AzToolsFramework::ToolBarManagerOperationResult PythonActionManagerHandler::RegisterToolBar(
+        const AZStd::string& toolBarIdentifier, const AzToolsFramework::ToolBarProperties& properties)
+    {
+        return m_toolBarManagerInterface->RegisterToolBar(toolBarIdentifier, properties);
+    }
+
+    AzToolsFramework::ToolBarManagerOperationResult PythonActionManagerHandler::AddActionToToolBar(
+        const AZStd::string& toolBarIdentifier, const AZStd::string& actionIdentifier, int sortIndex)
+    {
+        return m_toolBarManagerInterface->AddActionToToolBar(toolBarIdentifier, actionIdentifier, sortIndex);
+    }
+
+    AzToolsFramework::ToolBarManagerOperationResult PythonActionManagerHandler::AddActionWithSubMenuToToolBar(
+        const AZStd::string& toolBarIdentifier,
+        const AZStd::string& actionIdentifier,
+        const AZStd::string& subMenuIdentifier,
+        int sortIndex)
+    {
+        return m_toolBarManagerInterface->AddActionWithSubMenuToToolBar(toolBarIdentifier, actionIdentifier, subMenuIdentifier, sortIndex);
+    }
+
+    AzToolsFramework::ToolBarManagerOperationResult PythonActionManagerHandler::AddActionsToToolBar(
+        const AZStd::string& toolBarIdentifier, const AZStd::vector<AZStd::pair<AZStd::string, int>>& actions)
+    {
+        return m_toolBarManagerInterface->AddActionsToToolBar(toolBarIdentifier, actions);
+    }
+
+    AzToolsFramework::ToolBarManagerOperationResult PythonActionManagerHandler::RemoveActionFromToolBar(
+        const AZStd::string& toolBarIdentifier, const AZStd::string& actionIdentifier)
+    {
+        return m_toolBarManagerInterface->RemoveActionFromToolBar(toolBarIdentifier, actionIdentifier);
+    }
+
+    AzToolsFramework::ToolBarManagerOperationResult PythonActionManagerHandler::RemoveActionsFromToolBar(
+        const AZStd::string& toolBarIdentifier, const AZStd::vector<AZStd::string>& actionIdentifiers)
+    {
+        return m_toolBarManagerInterface->RemoveActionsFromToolBar(toolBarIdentifier, actionIdentifiers);
+    }
+
+    AzToolsFramework::ToolBarManagerOperationResult PythonActionManagerHandler::AddSeparatorToToolBar(
+        const AZStd::string& toolBarIdentifier, int sortIndex)
+    {
+        return m_toolBarManagerInterface->AddSeparatorToToolBar(toolBarIdentifier, sortIndex);
+    }
+
+    AzToolsFramework::ToolBarManagerOperationResult PythonActionManagerHandler::AddWidgetToToolBar(
+        const AZStd::string& toolBarIdentifier, const AZStd::string& widgetActionIdentifier, int sortIndex)
+    {
+        return m_toolBarManagerInterface->AddWidgetToToolBar(toolBarIdentifier, widgetActionIdentifier, sortIndex);
+    }
+
+    AzToolsFramework::ToolBarManagerIntegerResult PythonActionManagerHandler::GetSortKeyOfActionInToolBar(
+        const AZStd::string& toolBarIdentifier, const AZStd::string& actionIdentifier) const
+    {
+        return m_toolBarManagerInterface->GetSortKeyOfActionInToolBar(toolBarIdentifier, actionIdentifier);
+    }
+
+    AzToolsFramework::ToolBarManagerIntegerResult PythonActionManagerHandler::GetSortKeyOfWidgetInToolBar(
+        const AZStd::string& toolBarIdentifier, const AZStd::string& widgetActionIdentifier) const
+    {
+        return m_toolBarManagerInterface->GetSortKeyOfWidgetInToolBar(toolBarIdentifier, widgetActionIdentifier);
     }
 
     EditorPythonBindings::CustomTypeBindingNotifications::AllocationHandle PythonActionManagerHandler::AllocateDefault()

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
@@ -101,16 +101,16 @@ namespace EditorPythonBindings
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
                 ->Attribute(AZ::Script::Attributes::Category, "Action")
                 ->Attribute(AZ::Script::Attributes::Module, "action")
-                ->Event("RegisterToolBar", &ToolBarManagerRequests::RegisterToolBar)
-                ->Event("AddActionToToolBar", &ToolBarManagerRequests::AddActionToToolBar)
-                ->Event("AddActionWithSubMenuToToolBar", &ToolBarManagerRequests::AddActionWithSubMenuToToolBar)
-                ->Event("AddActionsToToolBar", &ToolBarManagerRequests::AddActionsToToolBar)
-                ->Event("RemoveActionFromToolBar", &ToolBarManagerRequests::RemoveActionFromToolBar)
-                ->Event("RemoveActionsFromToolBar", &ToolBarManagerRequests::RemoveActionsFromToolBar)
-                ->Event("AddSeparatorToToolBar", &ToolBarManagerRequests::AddSeparatorToToolBar)
-                ->Event("AddWidgetToToolBar", &ToolBarManagerRequests::AddWidgetToToolBar)
-                ->Event("GetSortKeyOfActionInToolBar", &ToolBarManagerRequests::GetSortKeyOfActionInToolBar)
-                ->Event("GetSortKeyOfWidgetInToolBar", &ToolBarManagerRequests::GetSortKeyOfWidgetInToolBar)
+                ->Event("RegisterToolBar", &ToolBarManagerRequestBus::Handler::RegisterToolBar)
+                ->Event("AddActionToToolBar", &ToolBarManagerRequestBus::Handler::AddActionToToolBar)
+                ->Event("AddActionWithSubMenuToToolBar", &ToolBarManagerRequestBus::Handler::AddActionWithSubMenuToToolBar)
+                ->Event("AddActionsToToolBar", &ToolBarManagerRequestBus::Handler::AddActionsToToolBar)
+                ->Event("RemoveActionFromToolBar", &ToolBarManagerRequestBus::Handler::RemoveActionFromToolBar)
+                ->Event("RemoveActionsFromToolBar", &ToolBarManagerRequestBus::Handler::RemoveActionsFromToolBar)
+                ->Event("AddSeparatorToToolBar", &ToolBarManagerRequestBus::Handler::AddSeparatorToToolBar)
+                ->Event("AddWidgetToToolBar", &ToolBarManagerRequestBus::Handler::AddWidgetToToolBar)
+                ->Event("GetSortKeyOfActionInToolBar", &ToolBarManagerRequestBus::Handler::GetSortKeyOfActionInToolBar)
+                ->Event("GetSortKeyOfWidgetInToolBar", &ToolBarManagerRequestBus::Handler::GetSortKeyOfWidgetInToolBar)
                 ;
         }
     }
@@ -257,6 +257,11 @@ namespace EditorPythonBindings
         const AZStd::string& toolBarIdentifier, const AZStd::string& widgetActionIdentifier, int sortIndex)
     {
         return m_toolBarManagerInterface->AddWidgetToToolBar(toolBarIdentifier, widgetActionIdentifier, sortIndex);
+    }
+
+    QToolBar* PythonActionManagerHandler::GetToolBar(const AZStd::string& toolBarIdentifier)
+    {
+        return m_toolBarManagerInterface->GetToolBar(toolBarIdentifier);
     }
 
     AzToolsFramework::ToolBarManagerIntegerResult PythonActionManagerHandler::GetSortKeyOfActionInToolBar(

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.h
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.h
@@ -9,11 +9,13 @@
 #include <EditorPythonBindings/CustomTypeBindingBus.h>
 #include <Source/ActionManager/ActionManagerBus.h>
 #include <Source/ActionManager/MenuManagerBus.h>
+#include <Source/ActionManager/ToolBarManagerBus.h>
 
 namespace AzToolsFramework
 {
     class ActionManagerInterface;
     class MenuManagerInterface;
+    class ToolBarManagerInterface;
 }
 
 namespace EditorPythonBindings
@@ -24,6 +26,7 @@ namespace EditorPythonBindings
     class PythonActionManagerHandler final
         : public ActionManagerRequestBus::Handler
         , public MenuManagerRequestBus::Handler
+        , public ToolBarManagerRequestBus::Handler
         , private EditorPythonBindings::CustomTypeBindingNotificationBus::Handler
     {
     public:
@@ -61,6 +64,31 @@ namespace EditorPythonBindings
         AzToolsFramework::MenuManagerOperationResult AddSubMenuToMenu(
             const AZStd::string& menuIdentifier, const AZStd::string& subMenuIdentifier, int sortIndex) override;
 
+        // ToolBarManagerRequestBus overrides ...
+        AzToolsFramework::ToolBarManagerOperationResult RegisterToolBar(
+            const AZStd::string& toolBarIdentifier, const AzToolsFramework::ToolBarProperties& properties) override;
+        AzToolsFramework::ToolBarManagerOperationResult AddActionToToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::string& actionIdentifier, int sortIndex) override;
+        AzToolsFramework::ToolBarManagerOperationResult AddActionWithSubMenuToToolBar(
+            const AZStd::string& toolBarIdentifier,
+            const AZStd::string& actionIdentifier,
+            const AZStd::string& subMenuIdentifier,
+            int sortIndex) override;
+        AzToolsFramework::ToolBarManagerOperationResult AddActionsToToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::vector<AZStd::pair<AZStd::string, int>>& actions) override;
+        AzToolsFramework::ToolBarManagerOperationResult RemoveActionFromToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::string& actionIdentifier) override;
+        AzToolsFramework::ToolBarManagerOperationResult RemoveActionsFromToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::vector<AZStd::string>& actionIdentifiers) override;
+        AzToolsFramework::ToolBarManagerOperationResult AddSeparatorToToolBar(
+            const AZStd::string& toolBarIdentifier, int sortIndex) override;
+        AzToolsFramework::ToolBarManagerOperationResult AddWidgetToToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::string& widgetActionIdentifier, int sortIndex) override;
+        AzToolsFramework::ToolBarManagerIntegerResult GetSortKeyOfActionInToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::string& actionIdentifier) const override;
+        AzToolsFramework::ToolBarManagerIntegerResult GetSortKeyOfWidgetInToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::string& widgetActionIdentifier) const override;
+
     private:
         AZStd::unordered_map<void*, AZ::TypeId> m_allocationMap;
 
@@ -90,6 +118,7 @@ namespace EditorPythonBindings
 
         AzToolsFramework::ActionManagerInterface* m_actionManagerInterface = nullptr;
         AzToolsFramework::MenuManagerInterface* m_menuManagerInterface = nullptr;
+        AzToolsFramework::ToolBarManagerInterface* m_toolBarManagerInterface = nullptr;
     };
 
 } // namespace EditorPythonBindings

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.h
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.h
@@ -84,6 +84,7 @@ namespace EditorPythonBindings
             const AZStd::string& toolBarIdentifier, int sortIndex) override;
         AzToolsFramework::ToolBarManagerOperationResult AddWidgetToToolBar(
             const AZStd::string& toolBarIdentifier, const AZStd::string& widgetActionIdentifier, int sortIndex) override;
+        QToolBar* GetToolBar(const AZStd::string& toolBarIdentifier) override;
         AzToolsFramework::ToolBarManagerIntegerResult GetSortKeyOfActionInToolBar(
             const AZStd::string& toolBarIdentifier, const AZStd::string& actionIdentifier) const override;
         AzToolsFramework::ToolBarManagerIntegerResult GetSortKeyOfWidgetInToolBar(

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/ToolBarManagerBus.h
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/ToolBarManagerBus.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Outcome/Outcome.h>
+#include <AzCore/std/string/string.h>
+
+#include <AzToolsFramework/ActionManager/ToolBar/ToolBarManagerInterface.h>
+
+namespace EditorPythonBindings
+{
+    //! ToolBarManagerRequestBus
+    //! Bus to register and manage ToolBars in the Editor via Python.
+    //! If writing C++ code, use the ToolBarManagerInterface instead.
+    class ToolBarManagerRequests : public AZ::EBusTraits
+    {
+    public:
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+
+        //! Register a new ToolBar to the ToolBar Manager.
+        virtual AzToolsFramework::ToolBarManagerOperationResult RegisterToolBar(
+            const AZStd::string& toolBarIdentifier, const AzToolsFramework::ToolBarProperties& properties) = 0;
+
+        //! Add an Action to a ToolBar.
+        virtual AzToolsFramework::ToolBarManagerOperationResult AddActionToToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::string& actionIdentifier, int sortIndex) = 0;
+
+        //! Add an Action with a submenu to a ToolBar.
+        virtual AzToolsFramework::ToolBarManagerOperationResult AddActionWithSubMenuToToolBar(
+            const AZStd::string& toolBarIdentifier,
+            const AZStd::string& actionIdentifier,
+            const AZStd::string& subMenuIdentifier,
+            int sortIndex) = 0;
+
+        //! Add multiple Actions to a ToolBar. Saves time as it only updates the toolbar once at the end.
+        virtual AzToolsFramework::ToolBarManagerOperationResult AddActionsToToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::vector<AZStd::pair<AZStd::string, int>>& actions) = 0;
+
+        //! Removes an Action from a ToolBar.
+        virtual AzToolsFramework::ToolBarManagerOperationResult RemoveActionFromToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::string& actionIdentifier) = 0;
+
+        //! Removes multiple Actions from a Menu.
+        virtual AzToolsFramework::ToolBarManagerOperationResult RemoveActionsFromToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::vector<AZStd::string>& actionIdentifiers) = 0;
+
+        //! Add a Separator to a ToolBar.
+        virtual AzToolsFramework::ToolBarManagerOperationResult AddSeparatorToToolBar(
+            const AZStd::string& toolBarIdentifier, int sortIndex) = 0;
+
+        //! Add a Widget to a ToolBar.
+        virtual AzToolsFramework::ToolBarManagerOperationResult AddWidgetToToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::string& widgetActionIdentifier, int sortIndex) = 0;
+
+        //! Retrieve the sort key of an action in a toolbar from its identifier.
+        virtual AzToolsFramework::ToolBarManagerIntegerResult GetSortKeyOfActionInToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::string& actionIdentifier) const = 0;
+
+        //! Retrieve the sort key of a widget action in a toolbar from its identifier.
+        virtual AzToolsFramework::ToolBarManagerIntegerResult GetSortKeyOfWidgetInToolBar(
+            const AZStd::string& toolBarIdentifier, const AZStd::string& widgetActionIdentifier) const = 0;
+    };
+
+    using ToolBarManagerRequestBus = AZ::EBus<ToolBarManagerRequests>;
+
+} // namespace EditorPythonBindings

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/ToolBarManagerBus.h
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/ToolBarManagerBus.h
@@ -23,51 +23,7 @@ namespace EditorPythonBindings
     {
     public:
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
-
-        //! Register a new ToolBar to the ToolBar Manager.
-        virtual AzToolsFramework::ToolBarManagerOperationResult RegisterToolBar(
-            const AZStd::string& toolBarIdentifier, const AzToolsFramework::ToolBarProperties& properties) = 0;
-
-        //! Add an Action to a ToolBar.
-        virtual AzToolsFramework::ToolBarManagerOperationResult AddActionToToolBar(
-            const AZStd::string& toolBarIdentifier, const AZStd::string& actionIdentifier, int sortIndex) = 0;
-
-        //! Add an Action with a submenu to a ToolBar.
-        virtual AzToolsFramework::ToolBarManagerOperationResult AddActionWithSubMenuToToolBar(
-            const AZStd::string& toolBarIdentifier,
-            const AZStd::string& actionIdentifier,
-            const AZStd::string& subMenuIdentifier,
-            int sortIndex) = 0;
-
-        //! Add multiple Actions to a ToolBar. Saves time as it only updates the toolbar once at the end.
-        virtual AzToolsFramework::ToolBarManagerOperationResult AddActionsToToolBar(
-            const AZStd::string& toolBarIdentifier, const AZStd::vector<AZStd::pair<AZStd::string, int>>& actions) = 0;
-
-        //! Removes an Action from a ToolBar.
-        virtual AzToolsFramework::ToolBarManagerOperationResult RemoveActionFromToolBar(
-            const AZStd::string& toolBarIdentifier, const AZStd::string& actionIdentifier) = 0;
-
-        //! Removes multiple Actions from a Menu.
-        virtual AzToolsFramework::ToolBarManagerOperationResult RemoveActionsFromToolBar(
-            const AZStd::string& toolBarIdentifier, const AZStd::vector<AZStd::string>& actionIdentifiers) = 0;
-
-        //! Add a Separator to a ToolBar.
-        virtual AzToolsFramework::ToolBarManagerOperationResult AddSeparatorToToolBar(
-            const AZStd::string& toolBarIdentifier, int sortIndex) = 0;
-
-        //! Add a Widget to a ToolBar.
-        virtual AzToolsFramework::ToolBarManagerOperationResult AddWidgetToToolBar(
-            const AZStd::string& toolBarIdentifier, const AZStd::string& widgetActionIdentifier, int sortIndex) = 0;
-
-        //! Retrieve the sort key of an action in a toolbar from its identifier.
-        virtual AzToolsFramework::ToolBarManagerIntegerResult GetSortKeyOfActionInToolBar(
-            const AZStd::string& toolBarIdentifier, const AZStd::string& actionIdentifier) const = 0;
-
-        //! Retrieve the sort key of a widget action in a toolbar from its identifier.
-        virtual AzToolsFramework::ToolBarManagerIntegerResult GetSortKeyOfWidgetInToolBar(
-            const AZStd::string& toolBarIdentifier, const AZStd::string& widgetActionIdentifier) const = 0;
     };
 
-    using ToolBarManagerRequestBus = AZ::EBus<ToolBarManagerRequests>;
-
+    using ToolBarManagerRequestBus = AZ::EBus<AzToolsFramework::ToolBarManagerInterface, ToolBarManagerRequests>;
 } // namespace EditorPythonBindings

--- a/Gems/EditorPythonBindings/Code/editorpythonbindings_common_files.cmake
+++ b/Gems/EditorPythonBindings/Code/editorpythonbindings_common_files.cmake
@@ -16,6 +16,7 @@ set(FILES
     Source/ActionManager/PythonActionManagerHandler.h
     Source/ActionManager/PythonEditorAction.cpp
     Source/ActionManager/PythonEditorAction.h
+    Source/ActionManager/ToolBarManagerBus.h
     Source/PythonCommon.h
     Source/PythonLogSymbolsComponent.cpp
     Source/PythonLogSymbolsComponent.h


### PR DESCRIPTION
## What does this PR do?

Exposed the `ToolBarManagerInterface` APIs from the `ActionManager` to python.

## How was this PR tested?

Tested the APIs via test scripts to verify they worked. Here is a simple example of it in action:

```
import azlmbr.bus as bus
from azlmbr.action import ToolBarManagerPythonRequestBus

toolbar_id = "o3de.toolbar.editor.tools"

ToolBarManagerPythonRequestBus(bus.Broadcast, 'AddSeparatorToToolBar', toolbar_id, 700)

ToolBarManagerPythonRequestBus(bus.Broadcast, 'AddActionToToolBar', toolbar_id, "o3de.action.edit.undo", 701)
ToolBarManagerPythonRequestBus(bus.Broadcast, 'AddActionToToolBar', toolbar_id, "o3de.action.edit.snap.toggleGridSnapping", 702)
ToolBarManagerPythonRequestBus(bus.Broadcast, 'AddActionToToolBar', toolbar_id, "o3de.action.edit.snap.toggleAngleSnapping", 703)
```

![ExposeToolBarAPIToPython](https://user-images.githubusercontent.com/7519264/186269060-cff9ea69-9a44-41a7-839b-595f13a5be15.gif)

This adds existing actions that have been migrated to the new action manager (undo, toggle grid snapping, toggle angle snapping) onto one of the toolbars. The `Undo` action doesn't have an icon associated with it, so that's why its toolbar button is just text.

NOTE: You need to enable the new Action Manager via setreg with this value `/O3DE/ActionManager/EnableNewActionManager`

Signed-off-by: Chris Galvan <chgalvan@amazon.com>