### PR TITLE
Fix close editor with an invalid graph file

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -902,7 +902,14 @@ namespace ScriptCanvasEditor
 
             if (shouldSaveResults == UnsavedChangesOptions::SAVE)
             {
-                SaveAssetImpl(assetId, Save::InPlace);
+                if (assetId.IsDescriptionValid())
+                {
+                    SaveAssetImpl(assetId, Save::InPlace);
+                }
+                else
+                {
+                    SaveAssetImpl(assetId, Save::As);
+                }
                 event->ignore();
                 return;
             }


### PR DESCRIPTION
Signed-off-by: onecent1101 <liug@amazon.com>

## What does this PR do?
Problem is closing scriptcanvas editor with a non-existing file, the default behavior is to save in place.
The fix is to check whether asset is valid, if not, then we have to save as new file.

To fix https://github.com/o3de/o3de/issues/11479

## How was this PR tested?
Tested in editor, there will be save as dialogue popup in this case.
