### PR TITLE
Applied secondary style to LogPanel, fixes tab close icon in AP & ME

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogPanel_Panel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogPanel_Panel.cpp
@@ -190,6 +190,8 @@ namespace AzToolsFramework
             if (newTab)
             {
                 int newTabIndex = m_impl->pTabWidget->addTab(newTab, QString::fromUtf8(settings.m_tabName.c_str()));
+                AzQtComponents::TabWidget::applySecondaryStyle(m_impl->pTabWidget);
+
                 m_impl->pTabWidget->setCurrentIndex(newTabIndex);
                 m_impl->settingsForTabs.insert(AZStd::make_pair(qobject_cast<QObject*>(newTab), settings));
                 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/StyledLogPanel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/StyledLogPanel.cpp
@@ -31,6 +31,8 @@ namespace AzToolsFramework
             setTabsClosable(true);
             setMovable(true);
 
+            AzQtComponents::TabWidget::applySecondaryStyle(this);
+
             QAction* pCopyAllAction = new QAction(QIcon(QStringLiteral(":/stylesheet/img/logging/copy.svg")), tr("Copy all"), this);
             addAction(pCopyAllAction);
 


### PR DESCRIPTION
The Logs window in the Asset Processor was showing the incorrect "X" icon for closing tabs. This change applies the secondary TabWidget style in order to get the correct icon.

Before:
![image](https://user-images.githubusercontent.com/58790905/186284889-663bfb0b-5318-4bcb-99ad-6080c13dee98.png)

After:
![image](https://user-images.githubusercontent.com/58790905/186286883-d5c387ba-0b53-4d51-afe7-cf4cba0a6949.png)

Material Editor:
![image](https://user-images.githubusercontent.com/58790905/186287818-c6bd26b2-7ac9-4008-824c-f133f4564777.png)

Closes #8607

Signed-off-by: Luis Sempé <58790905+lsemp3d@users.noreply.github.com>
