### PR TITLE
Fix quaternion default value error

### DIFF
--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_TransformFunctions_FromRotationScaleAndTranslation.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_TransformFunctions_FromRotationScaleAndTranslation.names
@@ -1,0 +1,50 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_TransformFunctions_FromRotationScaleAndTranslation",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "From Rotation Scale And Translation",
+                "category": "Math/Transform"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_TransformFunctions_FromRotationScaleAndTranslation",
+                    "details": {
+                        "name": "From Rotation Scale And Translation",
+                        "tooltip": "Returns a transform from the rotation, scale and the translation."
+                    },
+                    "params": [
+                        {
+                            "typeid": "{73103120-3DD3-4873-BAB3-9713FA2804FB}",
+                            "details": {
+                                "name": "Rotation"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Scale"
+                            }
+                        },
+                        {
+                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "details": {
+                                "name": "Translation"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{5D9958E9-9F1E-4985-B532-FFFDE75FEDFD}",
+                            "details": {
+                                "name": "Transform"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.ScriptCanvasFunction.xml
@@ -18,16 +18,22 @@
             <Parameter Name ="Source"/>
         </Function>
         
-        <Function Name="FromRotationAndTranslation">
-            <Parameter Name ="Rotation"/>
-            <Parameter Name ="Translation"/>
-        </Function>
-        
         <Function Name="FromScale">
             <Parameter Name ="Scale"/>
         </Function>
         
         <Function Name="FromTranslation">
+            <Parameter Name ="Translation"/>
+        </Function>
+        
+        <Function Name="FromRotationAndTranslation">
+            <Parameter Name ="Rotation"/>
+            <Parameter Name ="Translation"/>
+        </Function>
+
+        <Function Name="FromRotationScaleAndTranslation">
+            <Parameter Name ="Rotation"/>
+            <Parameter Name ="Scale"/>
             <Parameter Name ="Translation"/>
         </Function>
         

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.cpp
@@ -29,11 +29,6 @@ namespace ScriptCanvas
             return TransformType::CreateFromQuaternion(rotation);
         }
 
-        TransformType FromRotationAndTranslation(QuaternionType rotation, Vector3Type translation)
-        {
-            return TransformType::CreateFromQuaternionAndTranslation(rotation, translation);
-        }
-
         TransformType FromScale(NumberType scale)
         {
             return TransformType::CreateUniformScale(static_cast<float>(scale));
@@ -42,6 +37,16 @@ namespace ScriptCanvas
         TransformType FromTranslation(Vector3Type translation)
         {
             return TransformType::CreateTranslation(translation);
+        }
+
+        TransformType FromRotationAndTranslation(QuaternionType rotation, Vector3Type translation)
+        {
+            return TransformType::CreateFromQuaternionAndTranslation(rotation, translation);
+        }
+
+        TransformType FromRotationScaleAndTranslation(QuaternionType rotation, NumberType scale, Vector3Type translation)
+        {
+            return TransformType(translation, rotation, aznumeric_cast<float>(scale));
         }
 
         Vector3Type GetRight(const TransformType& source, NumberType scale)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.h
@@ -22,11 +22,13 @@ namespace ScriptCanvas
 
         TransformType FromRotation(QuaternionType rotation);
 
-        TransformType FromRotationAndTranslation(QuaternionType rotation, Vector3Type translation);
-
         TransformType FromScale(NumberType scale);
 
         TransformType FromTranslation(Vector3Type translation);
+
+        TransformType FromRotationAndTranslation(QuaternionType rotation, Vector3Type translation);
+
+        TransformType FromRotationScaleAndTranslation(QuaternionType rotation, NumberType scale, Vector3Type translation);
 
         Vector3Type GetRight(const TransformType& source, NumberType scale);
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToLuaUtility.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToLuaUtility.cpp
@@ -309,7 +309,7 @@ namespace ScriptCanvas
             case Data::eType::Quaternion:
                 if (datum.IsDefaultValue())
                 {
-                    return "Quaternion()";
+                    return "Quaternion(0, 0, 0, 1)";
                 }
                 else
                 {

--- a/Gems/ScriptCanvas/Code/Tests/Libraries/Math/ScriptCanvasUnitTest_Transform.cpp
+++ b/Gems/ScriptCanvas/Code/Tests/Libraries/Math/ScriptCanvasUnitTest_Transform.cpp
@@ -43,6 +43,14 @@ namespace ScriptCanvasUnitTest
         EXPECT_EQ(actualResult.GetTranslation(), AZ::Vector3::CreateOne());
     }
 
+    TEST_F(ScriptCanvasUnitTestTransformFunctions, FromRotationScaleAndTranslation_Call_GetExpectedResult)
+    {
+        auto actualResult = TransformFunctions::FromRotationScaleAndTranslation(AZ::Quaternion::CreateIdentity(), 2.0, AZ::Vector3::CreateOne());
+        EXPECT_EQ(actualResult.GetUniformScale(), 2);
+        EXPECT_EQ(actualResult.GetRotation(), AZ::Quaternion::CreateIdentity());
+        EXPECT_EQ(actualResult.GetTranslation(), AZ::Vector3::CreateOne());
+    }
+
     TEST_F(ScriptCanvasUnitTestTransformFunctions, FromScale_Call_GetExpectedResult)
     {
         auto actualResult = TransformFunctions::FromScale(5);


### PR DESCRIPTION
Signed-off-by: onecent1101 <liug@amazon.com>

## What does this PR do?

1. Fix the error when passing default quaternion value, as core math quaternion class doesn't implement default constructor. Instead of using default constructor, we should pass specific identity value like Quaternion(0, 0, 0, 1)
2. Add support to create transform from rotation, scale and translation

## How was this PR tested?
Unit test, and tested through Editor
![transformnode](https://user-images.githubusercontent.com/5900509/186490370-c2835130-4781-461a-894d-6ca64b099993.PNG)

Get following output
```
(Script) - (x=1.0000000,y=0.0000000,z=0.0000000),(x=0.0000000,y=1.0000000,z=0.0000000),(x=0.0000000,y=0.0000000,z=1.0000000),(x=0.0000000,y=0.0000000,z=0.0000000)
(Script) - (x=1.0000000,y=0.0000000,z=0.0000000),(x=0.0000000,y=1.0000000,z=0.0000000),(x=0.0000000,y=0.0000000,z=1.0000000),(x=0.0000000,y=0.0000000,z=0.0000000)
(Script) - (x=2.0000000,y=0.0000000,z=0.0000000),(x=0.0000000,y=2.0000000,z=0.0000000),(x=0.0000000,y=0.0000000,z=2.0000000),(x=0.0000000,y=0.0000000,z=0.0000000)
```
