### PR TITLE
[Terrain] Make Image Gradient configuration read-only while painting

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
@@ -166,7 +166,7 @@ namespace AzToolsFramework
             }
         }
 
-        bool ComponentModeDelegate::AddedToComponentMode()
+        bool ComponentModeDelegate::AddedToComponentMode() const
         {
             bool addedToComponentMode = false;
             ComponentModeSystemRequestBus::BroadcastResult(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.h
@@ -73,7 +73,7 @@ namespace AzToolsFramework
 
             /// Has this specific ComponentModeDelegate (for a specific Entity and Component)
             /// been added to ComponentMode.
-            bool AddedToComponentMode();
+            bool AddedToComponentMode() const;
             /// The function to call when this ComponentModeDelegate detects an event to enter ComponentMode.
             void SetAddComponentModeCallback(
                 const AZStd::function<void(const AZ::EntityComponentIdPair&)>& addComponentModeCallback);

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
@@ -75,8 +75,7 @@ namespace GradientSignal
 
         bool GetManualScaleVisibility() const;
 
-        bool GetImageOptionsVisibility() const;
-        void SetImageOptionsVisibility(bool setVisibility);
+        bool IsImageAssetReadOnly() const;
         bool AreImageOptionsReadOnly() const;
 
         AZStd::string GetImageAssetPropertyName() const;
@@ -101,8 +100,9 @@ namespace GradientSignal
 
         // Non-serialized properties used by the Editor for display purposes.
 
-        //! Show or hide the set of image options. (This is used when switching between image creation and image usage)
-        bool m_showImageOptions = true;
+        //! True if we're currently modifying the image, false if not.
+        bool m_imageModificationActive = false;
+
         //! Label to use for the image asset. This gets modified to show current asset loading/processing state.
         AZStd::string m_imageAssetPropertyLabel = "Image Asset";
     };

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -183,22 +183,17 @@ namespace GradientSignal
 
     bool ImageGradientConfig::GetManualScaleVisibility() const
     {
-        return ((m_customScaleType == CustomScaleType::Manual) && m_showImageOptions);
+        return (m_customScaleType == CustomScaleType::Manual);
     }
 
-    bool ImageGradientConfig::GetImageOptionsVisibility() const
+    bool ImageGradientConfig::IsImageAssetReadOnly() const
     {
-        return m_showImageOptions;
-    }
-
-    void ImageGradientConfig::SetImageOptionsVisibility(bool showOptions)
-    {
-        m_showImageOptions = showOptions;
+        return m_imageModificationActive;
     }
 
     bool ImageGradientConfig::AreImageOptionsReadOnly() const
     {
-        return !(m_imageAsset.GetId().IsValid());
+        return m_imageModificationActive || !(m_imageAsset.GetId().IsValid());
     }
 
     AZStd::string ImageGradientConfig::GetImageAssetPropertyName() const
@@ -728,6 +723,8 @@ namespace GradientSignal
 
     void ImageGradientComponent::StartImageModification()
     {
+        m_configuration.m_imageModificationActive = true;
+
         if (m_modifiedImageData.empty())
         {
             CreateImageModificationBuffer();
@@ -736,6 +733,7 @@ namespace GradientSignal
 
     void ImageGradientComponent::EndImageModification()
     {
+        m_configuration.m_imageModificationActive = false;
     }
 
     AZStd::vector<float>* ImageGradientComponent::GetImageModificationBuffer()

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.h
@@ -76,22 +76,27 @@ namespace GradientSignal
             CreateNewImage
         };
 
+        // EditorImageGradientRequestBus overrides ...
+        void StartImageModification() override;
+        void EndImageModification() override;
+        bool SaveImage() override;
 
         bool GetSaveLocation(AZ::IO::Path& fullPath, AZStd::string& relativePath);
         void CreateImage();
-        bool SaveImage() override;
         bool SaveImageInternal(
             AZ::IO::Path& fullPath, AZStd::string& relativePath,
             int imageResolutionX, int imageResolutionY, int channels, OutputFormat format, AZStd::span<const uint8_t> pixelBuffer);
 
         AZ::u32 RefreshCreationSelectionChoice();
         bool GetImageCreationVisibility() const;
+        AZ::Crc32 GetImageOptionsVisibility() const;
         AZ::Crc32 GetPaintModeVisibility() const;
+        bool GetImageOptionsReadOnly() const;
 
         bool RefreshImageAssetStatus();
         static bool ImageHasPendingJobs(const AZ::Data::AssetId& assetId);
 
-        bool InComponentMode();
+        bool InComponentMode() const;
 
         // PaintBrushNotificationBus overrides...
         // These are used to keep the paintbrush config in sync with the current manipulator.

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
@@ -43,6 +43,7 @@ namespace GradientSignal
         const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType)
         : EditorBaseComponentMode(entityComponentIdPair, componentType)
     {
+        EditorImageGradientRequestBus::Event(GetEntityId(), &EditorImageGradientRequests::StartImageModification);
         ImageGradientModificationBus::Event(GetEntityId(), &ImageGradientModifications::StartImageModification);
 
         AzToolsFramework::PaintBrushNotificationBus::Handler::BusConnect(entityComponentIdPair);
@@ -61,8 +62,10 @@ namespace GradientSignal
         AzToolsFramework::PaintBrushNotificationBus::Handler::BusDisconnect();
         m_brushManipulator->Unregister();
 
-        ImageGradientModificationBus::Event(GetEntityId(), &ImageGradientModifications::EndImageModification);
         EditorImageGradientRequestBus::Event(GetEntityId(), &EditorImageGradientRequests::SaveImage);
+
+        ImageGradientModificationBus::Event(GetEntityId(), &ImageGradientModifications::EndImageModification);
+        EditorImageGradientRequestBus::Event(GetEntityId(), &EditorImageGradientRequests::EndImageModification);
     }
 
     AZStd::vector<AzToolsFramework::ActionOverride> EditorImageGradientComponentMode::PopulateActionsImpl()

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientRequestBus.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientRequestBus.h
@@ -20,6 +20,8 @@ namespace GradientSignal
     public:
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
 
+        virtual void StartImageModification() = 0;
+        virtual void EndImageModification() = 0;
         virtual bool SaveImage() = 0;
     };
 


### PR DESCRIPTION
## What does this PR do?

The configuration parameters impact the underlying image data that's being painted, so they shouldn't be editable while in the midst of painting. Without this change, changing the parameters causes errors / asserts to be triggered and leaves things in a generally bad state.

## How was this PR tested?

Manually edited images in the Editor and verified that the fields became read-only and writeable as expected.

https://user-images.githubusercontent.com/82224783/186509082-52f4d8c7-6ed6-4b39-96f4-4715e3d1f8c1.mp4


