### PR TITLE
Disable unstable self-tests of EditorTest

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/editor_test_testing/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/editor_test_testing/CMakeLists.txt
@@ -6,17 +6,18 @@
 #
 #
 
-if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
-   ly_add_pytest(
-       NAME AutomatedTesting::EditorTestTesting
-       TEST_SUITE main
-       TEST_SERIAL
-       PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Main.py
-       RUNTIME_DEPENDENCIES
-           Legacy::Editor
-           AZ::AssetProcessor
-           AutomatedTesting.Assets
-       COMPONENT
-           TestTools
-   )
-endif()
+# disabled to investigate https://github.com/o3de/o3de/issues/11528
+# if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
+#    ly_add_pytest(
+#        NAME AutomatedTesting::EditorTestTesting
+#        TEST_SUITE main
+#        TEST_SERIAL
+#        PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Main.py
+#        RUNTIME_DEPENDENCIES
+#            Legacy::Editor
+#            AZ::AssetProcessor
+#            AutomatedTesting.Assets
+#        COMPONENT
+#            TestTools
+#    )
+# endif()


### PR DESCRIPTION
EditorTest's self testing modules have become unstable, likely as a side effect of the Python 3.10 update: https://github.com/o3de/o3de/issues/11528

This appears to not affect tests using EditorTest, which do not use the same pytest-within-a-pytest trickery. Disabling these tests while investigation is pending, to help prevent wasting build resources in Automated Review.

Signed-off-by: Kadino <sweeneys@amazon.com>