### PR TITLE
Show prefab's button "Exit Focus Mode" even when prefab is empty

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
@@ -340,7 +340,6 @@ namespace AzToolsFramework
     void PrefabUiHandler::PaintItemForeground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
     {
         AZ::EntityId entityId = GetEntityIdFromIndex(index);
-        const QPoint offset = QPoint(-18, 3);
         QModelIndex firstColumnIndex = index.siblingAtColumn(EntityOutlinerListModel::ColumnName);
         const int iconSize = 16;
         const int editIconSize = 10;
@@ -360,7 +359,7 @@ namespace AzToolsFramework
         {
             if (isFirstColumn && (option.state & QStyle::State_Enabled))
             {
-                // Only show the close icon if the prefab is expanded.
+                // Only show the close icon if the prefab is expanded or empty.
                 // This allows the prefab container to be opened if it was collapsed during propagation.
                 if (isExpanded || noChild)
                 {
@@ -377,12 +376,12 @@ namespace AzToolsFramework
 
                     // Paint a rect to cover up the expander.
                     QRect rect = QRect(0, 0, 16, 16);
-                    rect.translate(option.rect.topLeft() + offset);
+                    rect.translate(option.rect.topLeft() + m_expanderOffset);
                     painter->fillRect(rect, editIconBackgroundColor);
 
                     // Paint the icon.
                     QIcon closeIcon = QIcon(m_prefabEditCloseIconPath);
-                    painter->drawPixmap(option.rect.topLeft() + offset, closeIcon.pixmap(iconSize));
+                    painter->drawPixmap(option.rect.topLeft() + m_expanderOffset, closeIcon.pixmap(iconSize));
                 }
             }
         }
@@ -392,7 +391,7 @@ namespace AzToolsFramework
             if (isFirstColumn && isHovered && !isContainerOpen)
             {
                 QIcon openIcon = QIcon(m_prefabEditOpenIconPath);
-                painter->drawPixmap(option.rect.topRight() + QPoint(-13, 7), openIcon.pixmap(editIconSize));
+                painter->drawPixmap(option.rect.topRight() + m_editIconOffset, openIcon.pixmap(editIconSize));
             }
         }
 
@@ -444,13 +443,12 @@ namespace AzToolsFramework
     {
         AZ::EntityId entityId = GetEntityIdFromIndex(index);
 
-        const QPoint expenderOffset = QPoint(-18, 3);
-        QRect expenderRect = QRect(0, 0, 16, 16);
-        expenderRect.translate(option.rect.topLeft() + expenderOffset);
+        QRect expanderRect = QRect(0, 0, 16, 16);
+        expanderRect.translate(option.rect.topLeft() + m_expanderOffset);
 
         const QPoint textOffset = QPoint(0, 3);
         QRect filenameRect = QRect(0, 0, 12, 10);
-        filenameRect.translate(option.rect.topRight() + QPoint(-13, 7) + textOffset);
+        filenameRect.translate(option.rect.topRight() + m_editIconOffset + textOffset);
         if (filenameRect.contains(position))
         {
             if (!m_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityId))
@@ -462,7 +460,7 @@ namespace AzToolsFramework
             // Don't propagate event.
             return true;
         }
-        else if (expenderRect.contains(position))
+        else if (expanderRect.contains(position))
         {
             if (m_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityId))
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
@@ -9,12 +9,12 @@
 #include <AzToolsFramework/UI/Prefab/PrefabUiHandler.h>
 
 #include <AzFramework/API/ApplicationAPI.h>
+#include <AzQtComponents/Utilities/ScreenUtilities.h>
+#include <AzQtComponents/Utilities/TextUtilities.h>
 #include <AzToolsFramework/ContainerEntity/ContainerEntityInterface.h>
 #include <AzToolsFramework/Prefab/PrefabFocusPublicInterface.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <AzToolsFramework/UI/Outliner/EntityOutlinerListModel.hxx>
-#include <AzQtComponents/Utilities/ScreenUtilities.h>
-#include <AzQtComponents/Utilities/TextUtilities.h>
 #include <QAbstractItemModel>
 #include <QApplication>
 #include <QFont>
@@ -72,9 +72,9 @@ namespace AzToolsFramework
             }
 
             infoString = QObject::tr("<table style=\"font-size: 10px;\"><tr><td>%1%2</td><td width=\"%3\"></td></tr></table>")
-                .arg(path.Filename().Native().data())
-                .arg(saveFlag)
-                .arg(m_prefabFileNameFontSize);
+                             .arg(path.Filename().Native().data())
+                             .arg(saveFlag)
+                             .arg(m_prefabFileNameFontSize);
         }
 
         return infoString;
@@ -126,8 +126,7 @@ namespace AzToolsFramework
         const bool isFirstColumn = index.column() == EntityOutlinerListModel::ColumnName;
         const bool isLastColumn = index.column() == EntityOutlinerListModel::ColumnLockToggle;
         QModelIndex firstColumnIndex = index.siblingAtColumn(EntityOutlinerListModel::ColumnName);
-        const bool hasVisibleChildren =
-            firstColumnIndex.data(EntityOutlinerListModel::ExpandedRole).value<bool>() &&
+        const bool hasVisibleChildren = firstColumnIndex.data(EntityOutlinerListModel::ExpandedRole).value<bool>() &&
             firstColumnIndex.model()->hasChildren(firstColumnIndex);
 
         QColor backgroundColor = m_prefabCapsuleColor;
@@ -173,7 +172,7 @@ namespace AzToolsFramework
                 bottomRect.setTop(bottomRect.top() + (bottomRect.height() / 2));
                 backgroundPath.addRect(bottomRect);
             }
-            
+
             // Regular rect, half height, to square the opposite border
             QRect squareRect = tempRect;
             if (isFirstColumn)
@@ -197,8 +196,8 @@ namespace AzToolsFramework
         painter->restore();
     }
 
-    void PrefabUiHandler::PaintDescendantBackground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index,
-        const QModelIndex& descendantIndex) const
+    void PrefabUiHandler::PaintDescendantBackground(
+        QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index, const QModelIndex& descendantIndex) const
     {
         if (!painter)
         {
@@ -213,7 +212,7 @@ namespace AzToolsFramework
         {
             return;
         }
-        
+
         QColor borderColor = m_prefabCapsuleDisabledColor;
         if (m_prefabFocusPublicInterface->IsOwningPrefabInFocusHierarchy(entityId))
         {
@@ -244,7 +243,11 @@ namespace AzToolsFramework
     }
 
     void PrefabUiHandler::PaintDescendantBorder(
-        QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index, const QModelIndex& descendantIndex, const QColor borderColor) const
+        QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index,
+        const QModelIndex& descendantIndex,
+        const QColor borderColor) const
     {
         const QTreeView* outlinerTreeView(qobject_cast<const QTreeView*>(option.widget));
         const int ancestorLeft = outlinerTreeView->visualRect(index).left() + (m_prefabBorderThickness / 2) - 1;
@@ -292,7 +295,6 @@ namespace AzToolsFramework
                 curvedCorner.arcTo(curveRect, 180, 90);
                 curvedCorner.lineTo(fullRect.bottomRight());
                 painter->drawPath(curvedCorner);
-
             }
             else if (isLastColumn)
             {
@@ -345,8 +347,7 @@ namespace AzToolsFramework
         const bool isHovered = (option.state & QStyle::State_MouseOver);
         const bool isSelected = index.data(EntityOutlinerListModel::SelectedRole).template value<bool>();
         const bool isFirstColumn = index.column() == EntityOutlinerListModel::ColumnName;
-        const bool isExpanded =
-            firstColumnIndex.data(EntityOutlinerListModel::ExpandedRole).value<bool>() &&
+        const bool isExpanded = firstColumnIndex.data(EntityOutlinerListModel::ExpandedRole).value<bool>() &&
             firstColumnIndex.model()->hasChildren(firstColumnIndex);
         const bool noChild = !index.model()->hasChildren(index);
 
@@ -505,4 +506,4 @@ namespace AzToolsFramework
         // Don't propagate event.
         return true;
     }
-}
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
@@ -442,8 +442,12 @@ namespace AzToolsFramework
     bool PrefabUiHandler::OnOutlinerItemClick(const QPoint& position, const QStyleOptionViewItem& option, const QModelIndex& index) const
     {
         AZ::EntityId entityId = GetEntityIdFromIndex(index);
-        const QPoint textOffset = QPoint(0, 3);
 
+        const QPoint expenderOffset = QPoint(-18, 3);
+        QRect expenderRect = QRect(0, 0, 16, 16);
+        expenderRect.translate(option.rect.topLeft() + expenderOffset);
+
+        const QPoint textOffset = QPoint(0, 3);
         QRect filenameRect = QRect(0, 0, 12, 10);
         filenameRect.translate(option.rect.topRight() + QPoint(-13, 7) + textOffset);
         if (filenameRect.contains(position))
@@ -452,6 +456,17 @@ namespace AzToolsFramework
             {
                 // Focus on this prefab.
                 m_prefabFocusPublicInterface->FocusOnOwningPrefab(entityId);
+            }
+
+            // Don't propagate event.
+            return true;
+        }
+        else if (expenderRect.contains(position))
+        {
+            if (m_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityId))
+            {
+                // Close this prefab and focus on the parent
+                m_prefabFocusPublicInterface->FocusOnParentOfFocusedPrefab(s_editorEntityContextId);
             }
 
             // Don't propagate event.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
@@ -26,6 +26,9 @@
 
 namespace AzToolsFramework
 {
+    static const QPoint ExpanderOffset = { -18, 3 };
+    static const QPoint EditIconOffset = { -13, 7 };
+
     AzFramework::EntityContextId PrefabUiHandler::s_editorEntityContextId = AzFramework::EntityContextId::CreateNull();
 
     PrefabUiHandler::PrefabUiHandler()
@@ -376,12 +379,12 @@ namespace AzToolsFramework
 
                     // Paint a rect to cover up the expander.
                     QRect rect = QRect(0, 0, 16, 16);
-                    rect.translate(option.rect.topLeft() + m_expanderOffset);
+                    rect.translate(option.rect.topLeft() + ExpanderOffset);
                     painter->fillRect(rect, editIconBackgroundColor);
 
                     // Paint the icon.
                     QIcon closeIcon = QIcon(m_prefabEditCloseIconPath);
-                    painter->drawPixmap(option.rect.topLeft() + m_expanderOffset, closeIcon.pixmap(iconSize));
+                    painter->drawPixmap(option.rect.topLeft() + ExpanderOffset, closeIcon.pixmap(iconSize));
                 }
             }
         }
@@ -391,7 +394,7 @@ namespace AzToolsFramework
             if (isFirstColumn && isHovered && !isContainerOpen)
             {
                 QIcon openIcon = QIcon(m_prefabEditOpenIconPath);
-                painter->drawPixmap(option.rect.topRight() + m_editIconOffset, openIcon.pixmap(editIconSize));
+                painter->drawPixmap(option.rect.topRight() + EditIconOffset, openIcon.pixmap(editIconSize));
             }
         }
 
@@ -444,11 +447,11 @@ namespace AzToolsFramework
         AZ::EntityId entityId = GetEntityIdFromIndex(index);
 
         QRect expanderRect = QRect(0, 0, 16, 16);
-        expanderRect.translate(option.rect.topLeft() + m_expanderOffset);
+        expanderRect.translate(option.rect.topLeft() + ExpanderOffset);
 
         const QPoint textOffset = QPoint(0, 3);
         QRect filenameRect = QRect(0, 0, 12, 10);
-        filenameRect.translate(option.rect.topRight() + m_editIconOffset + textOffset);
+        filenameRect.translate(option.rect.topRight() + EditIconOffset + textOffset);
         if (filenameRect.contains(position))
         {
             if (!m_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityId))

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
@@ -348,6 +348,7 @@ namespace AzToolsFramework
         const bool isExpanded =
             firstColumnIndex.data(EntityOutlinerListModel::ExpandedRole).value<bool>() &&
             firstColumnIndex.model()->hasChildren(firstColumnIndex);
+        const bool noChild = !index.model()->hasChildren(index);
 
         bool isContainerOpen = m_containerEntityInterface->IsContainerOpen(entityId);
 
@@ -360,7 +361,7 @@ namespace AzToolsFramework
             {
                 // Only show the close icon if the prefab is expanded.
                 // This allows the prefab container to be opened if it was collapsed during propagation.
-                if (isExpanded)
+                if (isExpanded || noChild)
                 {
                     // Use the same color as the background.
                     QColor editIconBackgroundColor = m_backgroundColor;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
@@ -84,8 +84,5 @@ namespace AzToolsFramework
         QString m_prefabEditIconPath = QString(":/Entity/prefab_edit.svg");
         QString m_prefabEditOpenIconPath = QString(":/Entity/prefab_edit_open.svg");
         QString m_prefabEditCloseIconPath = QString(":/Entity/prefab_edit_close.svg");
-
-        const QPoint m_expanderOffset = { -18, 3 };
-        const QPoint m_editIconOffset = { -13, 7 };
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
@@ -20,10 +20,9 @@ namespace AzToolsFramework
     {
         class PrefabFocusPublicInterface;
         class PrefabPublicInterface;
-    };
+    }; // namespace Prefab
 
-    class PrefabUiHandler
-        : public EditorEntityUiHandlerBase
+    class PrefabUiHandler : public EditorEntityUiHandlerBase
     {
     public:
         AZ_CLASS_ALLOCATOR(PrefabUiHandler, AZ::SystemAllocator, 0);
@@ -85,5 +84,8 @@ namespace AzToolsFramework
         QString m_prefabEditIconPath = QString(":/Entity/prefab_edit.svg");
         QString m_prefabEditOpenIconPath = QString(":/Entity/prefab_edit_open.svg");
         QString m_prefabEditCloseIconPath = QString(":/Entity/prefab_edit_close.svg");
+
+        const QPoint m_expanderOffset = { -18, 3 };
+        const QPoint m_editIconOffset = { -13, 7 };
     };
 } // namespace AzToolsFramework


### PR DESCRIPTION
## What does this PR do?

Fix the issue https://github.com/o3de/o3de/issues/11332

1. Display the icon if the prefab has no children (previous condition would only check if the item was collapsed)
2. Handle click on the icon when item has no children (as OnOutlinerItemCollapse will not be called in this disposition)
3. Move 2 local variables into constants to prevent future mismatch
4. Auto format the files with the o3de clang format

Can be seen as a follow-up to 52112be1acaa4c10c5dbc3e7e2a0f5d87ea34148

## How was this PR tested?

Used the same repro steps as the issue.

![Fix in action](https://user-images.githubusercontent.com/19243508/186639564-e7be318e-211e-4f87-a6ef-6cc88a1ca814.gif)

