### PR TITLE
TIAF: Python Test Selector

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Artifact/Factory/TestImpactTestEnumerationSuiteFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Artifact/Factory/TestImpactTestEnumerationSuiteFactory.h
@@ -19,6 +19,7 @@ namespace TestImpact
         //! @return The constructed list of test enumeration suite artifacts.
         AZStd::vector<TestEnumerationSuite> TestEnumerationSuitesFactory(const AZStd::string& testEnumerationData);
     } // namespace GTest
+	
     namespace Python
     {
         //! Pair containing a Python script name and a vector of the related TestEnumerationSuites

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Artifact/Factory/TestImpactTestEnumerationSuiteFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Artifact/Factory/TestImpactTestEnumerationSuiteFactory.h
@@ -19,7 +19,7 @@ namespace TestImpact
         //! @return The constructed list of test enumeration suite artifacts.
         AZStd::vector<TestEnumerationSuite> TestEnumerationSuitesFactory(const AZStd::string& testEnumerationData);
     } // namespace GTest
-	
+
     namespace Python
     {
         //! Pair containing a Python script name and a vector of the related TestEnumerationSuites

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Dependency/TestImpactDynamicDependencyMap.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Dependency/TestImpactDynamicDependencyMap.h
@@ -232,12 +232,10 @@ namespace TestImpact
                 else
                 {
                     AZ_Warning(
-                        "ReplaceSourceCoverage", false,
-                        AZStd::string::format(
-                            "Test target %s exists in the coverage data "
-                            "but has since been removed from the build system",
-                            unresolvedTestTarget.c_str())
-                            .c_str());
+                        "ReplaceSourceCoverage",
+                        false,
+                        "Test target %s exists in the coverage data but has since been removed from the build system",
+                        unresolvedTestTarget.c_str());
                 }
             }
 
@@ -491,17 +489,16 @@ namespace TestImpact
                         //
                         // Note: coverage will be deleted upon updating of coverage after test runs (if any)
                         //       see TestSelectorAndPrioritizer::SelectTestTargets for scenarios and actions
-                        AZ_Printf(
+                        AZ_Warning(
                             "DynamicDependencyMap",
-                            AZStd::string::format(
-                                "Source file '%s' is potentially an orphan (used by build targets "
-                                "without explicitly being added to the build system, e.g. an include directive pulling in a header from "
-                                "the "
-                                "repository). Running the covering tests for this file with instrumentation will confirm whether or nor "
-                                "this "
-                                "is the case.\n",
-                                updatedFile.c_str())
-                                .c_str());
+                            false,
+                            "Source file '%s' is potentially an orphan (used by build targets "
+                            "without explicitly being added to the build system, e.g. an include directive pulling in a header from "
+                            "the "
+                            "repository). Running the covering tests for this file with instrumentation will confirm whether or nor "
+                            "this "
+                            "is the case.\n",
+                            updatedFile.c_str());
 
                         updateDependencies.emplace_back(AZStd::move(*sourceDependency));
                     }

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Dependency/TestImpactDynamicDependencyMap.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Dependency/TestImpactDynamicDependencyMap.h
@@ -41,6 +41,15 @@ namespace TestImpact
         //! @param productionTarget The production target to retrieve the covering tests for.
         AZStd::vector<const TestTarget*> GetCoveringTestTargetsForProductionTarget(const ProductionTarget& productionTarget) const;
 
+        //! Returns the test targets that cover one or more sources in the repository.
+        AZStd::vector<const TestTarget*> GetCoveringTests() const;
+
+        //! Returns the test targets that do not cover any sources in the repository.
+        AZStd::vector<const TestTarget*> GetNotCoveringTests() const;
+
+        //! Returns all the production targets with test coverage.
+        AZStd::unordered_set<const TestTarget*> GetCoveredProductionTargets() const;
+
         //! Gets the source dependency for the specified source file.
         //! @note Autogen input source dependencies are the consolidated source dependencies of all of their generated output sources.
         //! @returns If found, the source dependency information for the specified source file, otherwise empty.
@@ -72,12 +81,6 @@ namespace TestImpact
 
         //! Removes the specified test target from all source coverage.
         void RemoveTestTargetFromSourceCoverage(const TestTarget* testTarget);
-
-        //! Returns the test targets that cover one or more sources in the repository.
-        AZStd::vector<const TestTarget*> GetCoveringTests() const;
-
-        //! Returns the test targets that do not cover any sources in the repository.
-        AZStd::vector<const TestTarget*> GetNotCoveringTests() const;
 
     private:
         //! Internal handler for ReplaceSourceCoverage where the pruning of parentless and coverageless source depenencies after the
@@ -408,22 +411,57 @@ namespace TestImpact
             {
                 if (sourceDependency->GetNumCoveringTestTargets())
                 {
+                    // Parent Targets: Yes or no
+                    // Coverage Data : Yes
+                    // Source Type   : Indeterminate
+                    //
+                    // Scenario
+                    // 1. This file previously existed in one or more source to target mapping artifacts
+                    // 2. The file has since been deleted yet no delete crud operation acted upon:
+                    //    a) The coverage data for this file was not deleted from the Source Covering Test List
+                    // 3. The file has since been recreated
+                    // 4. This file does not exist in any source to target mapping artifacts
+                    //
+                    // Action (handled prior by DynamicDependencyMap::ApplyAndResoveChangeList)
+                    // 1. Log Source Covering Test List compromised error
+                    // 2. Throw exception
                     const AZStd::string msg = AZStd::string::format(
                         "The newly-created file '%s' belongs to a build target yet "
                         "still has coverage data in the source covering test list implying that a delete CRUD operation has been "
                         "missed, thus the integrity of the source covering test list has been compromised.",
                         createdFile.c_str());
-                    AZ_Error("File Creation", false, msg.c_str());
+                    AZ_Error("DynamicDependencyMap", false, msg.c_str());
 
                     if (integrityFailurePolicy == Policy::IntegrityFailure::Abort)
                     {
                         throw DependencyException(msg);
                     }
-                }
 
-                if (sourceDependency->GetNumParentTargets())
+                    coverageToDelete.push_back(createdFile);
+                }
+                else if (sourceDependency->GetNumParentTargets())
                 {
+                    // Parent Targets: Yes
+                    // Coverage Data : No
+                    // Source Type   : Any
+                    //
+                    // Note: see TestSelectorAndPrioritizer::SelectTestTargets for scenarios and actions
                     createDependencies.emplace_back(AZStd::move(*sourceDependency));
+                }
+                else
+                {
+                    // Parent Targets: No
+                    // Coverage Data : No
+                    // Source Type   : Any
+                    //
+                    // Scenario
+                    // 1. The existing file has been modified
+                    // 2. This file does not exist in any source to target mapping artifacts
+                    // 3. There exists no coverage data for this file in the Source Covering Test List
+                    // 
+                    // Action
+                    // 1. Skip the file
+                    continue;
                 }
             }
         }
@@ -436,14 +474,25 @@ namespace TestImpact
             {
                 if (sourceDependency->GetNumParentTargets())
                 {
+                    // Parent Targets: Yes
+                    // Coverage Data : Yes or no
+                    // Source Type   : Any
+                    //
+                    // Note: see TestSelectorAndPrioritizer::SelectTestTargets for scenarios and actions
                     updateDependencies.emplace_back(AZStd::move(*sourceDependency));
                 }
                 else
                 {
                     if (sourceDependency->GetNumCoveringTestTargets())
                     {
+                        // Parent Targets: No
+                        // Coverage Data : Yes
+                        // Source Type   : Indeterminate
+                        //
+                        // Note: coverage will be deleted upon updating of coverage after test runs (if any)
+                        //       see TestSelectorAndPrioritizer::SelectTestTargets for scenarios and actions
                         AZ_Printf(
-                            "File Update",
+                            "DynamicDependencyMap",
                             AZStd::string::format(
                                 "Source file '%s' is potentially an orphan (used by build targets "
                                 "without explicitly being added to the build system, e.g. an include directive pulling in a header from "
@@ -455,7 +504,21 @@ namespace TestImpact
                                 .c_str());
 
                         updateDependencies.emplace_back(AZStd::move(*sourceDependency));
-                        coverageToDelete.push_back(updatedFile);
+                    }
+                    else
+                    {
+                        // Parent Targets: No
+                        // Coverage Data : No
+                        // Source Type   : Indeterminate
+                        //
+                        // Scenario
+                        // 1. The existing file has been modified
+                        // 2. This file does not exist in any source to target mapping artifacts
+                        // 3. There exists no coverage data for this file in the Source Covering Test List
+                        //
+                        // Action (handled prior by DynamicDependencyMap::ApplyAndResoveChangeList)
+                        // 1. Skip the file
+                        continue;
                     }
                 }
             }
@@ -472,40 +535,67 @@ namespace TestImpact
 
             if (sourceDependency->GetNumParentTargets())
             {
-                if (sourceDependency->GetNumCoveringTestTargets())
-                {
-                    const AZStd::string msg = AZStd::string::format(
-                        "The deleted file '%s' still belongs to a build target and still "
-                        "has coverage data in the source covering test list, implying that the integrity of both the source to target "
-                        "mappings and the source covering test list has been compromised.",
-                        deletedFile.c_str());
-                    AZ_Error("File Delete", false, msg.c_str());
+                // Parent Targets: Yes
+                // Coverage Data : Yes or no
+                // Source Type   : Irrelevant
+                //
+                // Scenario
+                // 1. The existing file has been deleted.
+                // 2. This file still exists in one or more source to target mapping artifacts
+                // 3. There may or not exist coverage data for this file in the Source Covering Test List
+                //
+                // Action
+                // 1. Log source to target mapping and Source Covering Test List integrity compromised error
+                // 2. Throw exception
 
-                    if (integrityFailurePolicy == Policy::IntegrityFailure::Abort)
-                    {
-                        throw DependencyException(msg);
-                    }
-                }
-                else
-                {
-                    const AZStd::string msg = AZStd::string::format(
-                        "The deleted file '%s' still belongs to a build target implying "
-                        "that the integrity of the source to target mappings has been compromised.",
-                        deletedFile.c_str());
-                    AZ_Error("File Delete", false, msg.c_str());
+                const AZStd::string msg = AZStd::string::format(
+                    "The deleted file '%s' still belongs to a build target implying "
+                    "that the integrity of the source to target mappings has been compromised.",
+                    deletedFile.c_str());
+                AZ_Error("DynamicDependencyMap", false, msg.c_str());
 
-                    if (integrityFailurePolicy == Policy::IntegrityFailure::Abort)
-                    {
-                        throw DependencyException(msg);
-                    }
+                if (integrityFailurePolicy == Policy::IntegrityFailure::Abort)
+                {
+                    throw DependencyException(msg);
                 }
+
+                coverageToDelete.push_back(deletedFile);
             }
             else
             {
                 if (sourceDependency->GetNumCoveringTestTargets())
                 {
+                    // Parent Targets: No
+                    // Coverage Data : Yes
+                    // Source Type   : Indeterminate
+                    //
+                    // Scenario
+                    // 1. The file has been deleted.
+                    // 2. This file previously existed in one or more source to target mapping artifacts
+                    // 3. This file no longer exists in any source to target mapping artifacts
+                    // 4. The coverage data for this file was has yet to be deleted from the Source Covering Test List
+                    //
+                    // Action
+                    // 1. Select all test targets covering this file.
+                    // 2. Delete the existing coverage data from the Source Covering Test List
+                    //
+                    // Note: coverage will be deleted upon updating of coverage after test runs (if any)
                     deleteDependencies.emplace_back(AZStd::move(*sourceDependency));
-                    coverageToDelete.push_back(deletedFile);
+                }
+                else
+                {
+                    // Parent Targets: No
+                    // Coverage Data : No
+                    // Source Type   : Indeterminate
+                    //
+                    // Scenario
+                    // 1. The file has been deleted
+                    // 2. This file does not exist in any source to target mapping artifacts
+                    // 3. There exists no coverage data for this file in the Source Covering Test List
+                    //
+                    // Action
+                    // 1. Skip the file
+                    continue;
                 }
             }
         }
@@ -567,5 +657,20 @@ namespace TestImpact
         }
 
         return notCovering;
+    }
+
+    template<typename ProductionTarget, typename TestTarget>
+    AZStd::unordered_set<const TestTarget*> DynamicDependencyMap<ProductionTarget, TestTarget>::GetCoveredProductionTargets() const
+    {
+        AZStd::unordered_set coveredProductionTargets;
+        for (const auto& [source, dependencyData] : m_sourceDependencyMap)
+        {
+            for(const auto* parentTarget : dependencyData.GetParentTargets())
+            {
+                coveredProductionTargets.insert(parentTarget);
+            }
+        }
+
+        return coveredProductionTargets;
     }
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Dependency/TestImpactTestSelectorAndPrioritizer.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Dependency/TestImpactTestSelectorAndPrioritizer.h
@@ -463,11 +463,9 @@ namespace TestImpact
                     AZ_Warning(
                         "TestSelectorAndPrioritizer",
                         false,
-                        AZStd::string::format(
-                            "Create operation for file with no parent targets but coverage data was not expected to be handled here for "
-                            "file '%s'",
-                            sourceDependency.GetPath().c_str())
-                            .c_str());
+                        "Create operation for file with no parent targets but coverage data was not expected to be handled here for "
+                        "file '%s'",
+                        sourceDependency.GetPath().c_str());
                     continue;
                 }
                 else
@@ -485,11 +483,9 @@ namespace TestImpact
                     AZ_Warning(
                         "TestSelectorAndPrioritizer",
                         false,
-                        AZStd::string::format(
-                            "Create operation for file with no parent targets or coverage data was not expected to be handled here for "
-                            "file '%s'",
-                            sourceDependency.GetPath().c_str())
-                            .c_str());
+                        "Create operation for file with no parent targets or coverage data was not expected to be handled here for "
+                        "file '%s'",
+                        sourceDependency.GetPath().c_str());
                     continue;
                 }
             }
@@ -563,11 +559,9 @@ namespace TestImpact
                     AZ_Warning(
                         "TestSelectorAndPrioritizer",
                         false,
-                        AZStd::string::format(
-                            "Update operation for file with no parent targets or coverage data was not expected to be handled here for "
-                            "file '%s'",
-                            sourceDependency.GetPath().c_str())
-                            .c_str());
+                        "Update operation for file with no parent targets or coverage data was not expected to be handled here for "
+                        "file '%s'",
+                        sourceDependency.GetPath().c_str());
                     continue;
                 }
             }
@@ -595,11 +589,9 @@ namespace TestImpact
                     AZ_Warning(
                         "TestSelectorAndPrioritizer",
                         false,
-                        AZStd::string::format(
-                            "Delete operation for file with parent targets and coverage data was not expected to be handled here for "
-                            "file '%s'",
-                            sourceDependency.GetPath().c_str())
-                            .c_str());
+                        "Delete operation for file with parent targets and coverage data was not expected to be handled here for "
+                        "file '%s'",
+                        sourceDependency.GetPath().c_str());
                     continue;
                 }
                 else
@@ -619,11 +611,9 @@ namespace TestImpact
                     AZ_Warning(
                         "TestSelectorAndPrioritizer",
                         false,
-                        AZStd::string::format(
-                            "Delete operation for file with parent targets but no coverage data was not expected to be handled here for "
-                            "file '%s'",
-                            sourceDependency.GetPath().c_str())
-                            .c_str());
+                        "Delete operation for file with parent targets but no coverage data was not expected to be handled here for "
+                        "file '%s'",
+                        sourceDependency.GetPath().c_str());
                     continue;
                 }
             }

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Dependency/TestImpactTestSelectorAndPrioritizer.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Dependency/TestImpactTestSelectorAndPrioritizer.h
@@ -43,10 +43,10 @@ namespace TestImpact
         AZStd::vector<const TestTarget*> SelectTestTargets(
             const ChangeDependencyList<ProductionTarget, TestTarget>& changeDependencyList, Policy::TestPrioritization testSelectionStrategy);
 
-    private:
+    protected:
         //! Map of selected test targets and the production targets they cover for the given set of source changes.
         using SelectedTestTargetAndDependerMap = AZStd::unordered_map<const TestTarget*, AZStd::unordered_set<const ProductionTarget*>>;
-
+    private:
         //! Selects the test targets covering the set of source changes in the change dependency list.
         //! @param changeDependencyList The change dependency list containing the CRUD source changes to select tests for.
         //! @returns The selected tests and their covering production targets for the given set of source changes.
@@ -59,44 +59,68 @@ namespace TestImpact
         AZStd::vector<const TestTarget*> PrioritizeSelectedTestTargets(
             const SelectedTestTargetAndDependerMap& selectedTestTargetAndDependerMap, Policy::TestPrioritization testSelectionStrategy);
 
-        const DynamicDependencyMap<ProductionTarget, TestTarget>* m_dynamicDependencyMap;
-
     protected:
+        //! Result of source dependency action.
+        enum class SourceOperationActionResult : AZ::u8
+        {
+            Continue, //!< Continue with actions for this CRUD operation.
+            ConcludeSelection, //!< Conclude selection (no further actions).
+        };
+        
+        //! Iterate over the production and test targets for newly created sources with no coverage and act on them.
+        [[nodiscard]] virtual SourceOperationActionResult IterateCreateParentedSourcesWithNoCoverage(
+            const SourceDependency<ProductionTarget, TestTarget>& sourceDependency,
+            SelectedTestTargetAndDependerMap& selectedTestTargetMap);
+        
+        //! Iterate over the production and test targets for updated sources with coverage and act on them.
+        [[nodiscard]] virtual SourceOperationActionResult IterateUpdateParentedSourcesWithCoverage(
+            const SourceDependency<ProductionTarget, TestTarget>& sourceDependency,
+            SelectedTestTargetAndDependerMap& selectedTestTargetMap);
+        
+        //! Iterate over the production and test targets for updated sources with no coverage and act on them.
+        [[nodiscard]] virtual SourceOperationActionResult IterateUpdateParentedSourcesWithoutCoverage(
+            const SourceDependency<ProductionTarget, TestTarget>& sourceDependency,
+            SelectedTestTargetAndDependerMap& selectedTestTargetMap);
+
         //! Action to perform when production sources are created.
-        virtual void CreateProductionSourceAction(const ProductionTarget* target, SelectedTestTargetAndDependerMap& selectedTestTargetMap);
+        [[nodiscard]] virtual SourceOperationActionResult CreateProductionSourceWithoutCoverageAction(
+            const ProductionTarget* target, SelectedTestTargetAndDependerMap& selectedTestTargetMap);
 
         //! Action to perform when test sources are created.
-        virtual void CreateTestSourceAction(const TestTarget* target, SelectedTestTargetAndDependerMap& selectedTestTargetMap);
+        [[nodiscard]] virtual SourceOperationActionResult CreateTestSourceCreateProductionSourceWithoutCoverageAction(
+            const TestTarget* target, SelectedTestTargetAndDependerMap& selectedTestTargetMap);
 
         //! Action to perform when production sources with coverage are updated.
-        virtual void UpdateProductionSourceWithCoverageAction(
+        [[nodiscard]] virtual SourceOperationActionResult UpdateProductionSourceWithCoverageAction(
             const ProductionTarget* target,
             SelectedTestTargetAndDependerMap& selectedTestTargetMap,
             const SourceDependency<ProductionTarget, TestTarget>& sourceDependency);
 
         //! Action to perform when test sources with coverage are updated.
-        virtual void UpdateTestSourceWithCoverageAction(
+        [[nodiscard]] virtual SourceOperationActionResult UpdateTestSourceWithCoverageAction(
             const TestTarget* target,
             SelectedTestTargetAndDependerMap& selectedTestTargetMap);
 
         //! Action to perform when production sources without coverage are updated.
-        virtual void UpdateProductionSourceWithoutCoverageAction(
+        [[nodiscard]] virtual SourceOperationActionResult UpdateProductionSourceWithoutCoverageAction(
             const ProductionTarget* target,
             SelectedTestTargetAndDependerMap& selectedTestTargetMap);
 
         //! Action to perform when test sources without coverage are updated.
-        virtual void UpdateTestSourceWithoutCoverageAction(
+        [[nodiscard]] virtual SourceOperationActionResult UpdateTestSourceWithoutCoverageAction(
             const TestTarget* target,
             SelectedTestTargetAndDependerMap& selectedTestTargetMap);
 
-        //! Action to perform when sources that cannot be determined to be production or test sources without coverage are updated.
-        virtual void UpdateIndeterminateSourceWithoutCoverageAction(
+        //! Action to perform when sources that cannot be determined to be production or test sources with coverage are updated.
+        [[nodiscard]] virtual SourceOperationActionResult UpdateIndeterminateSourceWithCoverageAction(
             SelectedTestTargetAndDependerMap& selectedTestTargetMap,
             const SourceDependency<ProductionTarget, TestTarget>& sourceDependency);
 
-        //! Action to perform when sources that cannot be determined to be production or test sources without coverage are deleted.
-        virtual void DeleteIndeterminateSourceWithoutCoverageAction(
+        //! Action to perform when sources that cannot be determined to be production or test sources with coverage are deleted.
+        [[nodiscard]] virtual SourceOperationActionResult DeleteIndeterminateSourceWithCoverageAction(
             SelectedTestTargetAndDependerMap& selectedTestTargetMap, const SourceDependency<ProductionTarget, TestTarget>& sourceDependency);
+
+        const DynamicDependencyMap<ProductionTarget, TestTarget>* m_dynamicDependencyMap;
     };
 
     template<typename ProductionTarget, typename TestTarget>
@@ -116,7 +140,143 @@ namespace TestImpact
     }
 
     template<typename ProductionTarget, typename TestTarget>
-    void TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::CreateProductionSourceAction(
+    typename TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::SourceOperationActionResult
+    TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::IterateCreateParentedSourcesWithNoCoverage(
+        const SourceDependency<ProductionTarget, TestTarget>& sourceDependency,
+        SelectedTestTargetAndDependerMap& selectedTestTargetMap)
+    {
+        for (const auto& parentTarget : sourceDependency.GetParentTargets())
+        {
+            if (parentTarget.GetTarget()->GetType() == TargetType::ProductionTarget)
+            {
+                // Parent Targets: Yes
+                // Coverage Data : No
+                // Source Type   : Production
+                //
+                // Scenario
+                // 1. The file has been newly created
+                // 2. This file exists in one or more source to production target mapping artifacts
+                // 3. There exists no coverage data for this file in the source covering test list
+                if (SourceOperationActionResult::ConcludeSelection ==
+                    CreateProductionSourceWithoutCoverageAction(parentTarget.GetProductionTarget(), selectedTestTargetMap))
+                {
+                    return SourceOperationActionResult::ConcludeSelection;
+                }
+            }
+            else
+            {
+                // Parent Targets: Yes
+                // Coverage Data : No
+                // Source Type   : Test
+                //
+                // Scenario
+                // 1. The file has been newly created
+                // 2. This file exists in one or more source to test target mapping artifacts
+                // 3. There exists no coverage data for this file in the source covering test list
+                if (SourceOperationActionResult::ConcludeSelection ==
+                    CreateTestSourceCreateProductionSourceWithoutCoverageAction(parentTarget.GetTestTarget(), selectedTestTargetMap))
+                {
+                    return SourceOperationActionResult::ConcludeSelection;
+                }
+            }
+        }
+    
+        return SourceOperationActionResult::Continue;
+    }
+    
+    template<typename ProductionTarget, typename TestTarget>
+    typename TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::SourceOperationActionResult
+    TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::IterateUpdateParentedSourcesWithCoverage(
+        const SourceDependency<ProductionTarget, TestTarget>& sourceDependency,
+        SelectedTestTargetAndDependerMap& selectedTestTargetMap)
+    {
+        for (const auto& parentTarget : sourceDependency.GetParentTargets())
+        {
+            if (parentTarget.GetTarget()->GetType() == TargetType::ProductionTarget)
+            {
+                // Parent Targets: Yes
+                // Coverage Data : Yes
+                // Source Type   : Production
+                //
+                // Scenario
+                // 1. The existing file has been modified
+                // 2. This file exists in one or more source to production target mapping artifacts
+                // 3. There exists coverage data for this file in the source covering test list
+                if (SourceOperationActionResult::ConcludeSelection ==
+                    UpdateProductionSourceWithCoverageAction(parentTarget.GetProductionTarget(), selectedTestTargetMap, sourceDependency))
+                {
+                    return SourceOperationActionResult::ConcludeSelection;
+                }
+            }
+            else
+            {
+                // Parent Targets: Yes
+                // Coverage Data : Yes
+                // Source Type   : Test
+                //
+                // Scenario
+                // 1. The existing file has been modified
+                // 2. This file exists in one or more source to test target mapping artifacts
+                // 3. There exists coverage data for this file in the source covering test list
+                if (SourceOperationActionResult::ConcludeSelection ==
+                    UpdateTestSourceWithCoverageAction(parentTarget.GetTestTarget(), selectedTestTargetMap))
+                {
+                    return SourceOperationActionResult::ConcludeSelection;
+                }
+            }
+        }
+    
+        return SourceOperationActionResult::Continue;
+    }
+    
+    template<typename ProductionTarget, typename TestTarget>
+    typename TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::SourceOperationActionResult
+    TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::IterateUpdateParentedSourcesWithoutCoverage(
+        const SourceDependency<ProductionTarget, TestTarget>& sourceDependency,
+        SelectedTestTargetAndDependerMap& selectedTestTargetMap)
+    {
+        for (const auto& parentTarget : sourceDependency.GetParentTargets())
+        {
+            if (parentTarget.GetTarget()->GetType() == TargetType::ProductionTarget)
+            {
+                // Parent Targets: Yes
+                // Coverage Data : No
+                // Source Type   : Production
+                //
+                // Scenario
+                // 1. The existing file has been modified
+                // 2. This file exists in one or more source to test target mapping artifacts
+                // 3. There exists no coverage data for this file in the source covering test list
+                if (SourceOperationActionResult::ConcludeSelection ==
+                    UpdateProductionSourceWithoutCoverageAction(parentTarget.GetProductionTarget(), selectedTestTargetMap))
+                {
+                    return SourceOperationActionResult::ConcludeSelection;
+                }
+            }
+            else
+            {
+                // Parent Targets: Yes
+                // Coverage Data : No
+                // Source Type   : Test
+                //
+                // Scenario
+                // 1. The existing file has been modified
+                // 2. This file exists in one or more source to test target mapping artifacts
+                // 3. There exists no coverage data for this file in the source covering test list
+                if (SourceOperationActionResult::ConcludeSelection ==
+                    UpdateTestSourceWithoutCoverageAction(parentTarget.GetTestTarget(), selectedTestTargetMap))
+                {
+                    return SourceOperationActionResult::ConcludeSelection;
+                }
+            }
+        }
+    
+        return SourceOperationActionResult::Continue;
+    }
+
+    template<typename ProductionTarget, typename TestTarget>
+    typename TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::SourceOperationActionResult
+    TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::CreateProductionSourceWithoutCoverageAction(
         const ProductionTarget* target, SelectedTestTargetAndDependerMap& selectedTestTargetMap)
     {
         // Action
@@ -126,19 +286,26 @@ namespace TestImpact
         {
             selectedTestTargetMap[testTarget].insert(target);
         }
+
+        return SourceOperationActionResult::Continue;
     }
 
     template<typename ProductionTarget, typename TestTarget>
-    void TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::CreateTestSourceAction(
+    typename TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::SourceOperationActionResult
+    TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::CreateTestSourceCreateProductionSourceWithoutCoverageAction(
         const TestTarget* target, SelectedTestTargetAndDependerMap& selectedTestTargetMap)
     {
         // Action
         // 1. Select all parent test targets
         selectedTestTargetMap.insert(target);
+
+        return SourceOperationActionResult::Continue;
     }
 
     template<typename ProductionTarget, typename TestTarget>
-    void TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::UpdateProductionSourceWithCoverageAction(
+    typename TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::SourceOperationActionResult
+    TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::
+        UpdateProductionSourceWithCoverageAction(
         const ProductionTarget* target,
         SelectedTestTargetAndDependerMap& selectedTestTargetMap,
         const SourceDependency<ProductionTarget, TestTarget>& sourceDependency)
@@ -149,61 +316,81 @@ namespace TestImpact
         {
             selectedTestTargetMap[testTarget].insert(target);
         }
+
+        return SourceOperationActionResult::Continue;
     }
 
     template<typename ProductionTarget, typename TestTarget>
-    void TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::UpdateTestSourceWithCoverageAction(
+    typename TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::SourceOperationActionResult
+    TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::
+        UpdateTestSourceWithCoverageAction(
         const TestTarget* target, SelectedTestTargetAndDependerMap& selectedTestTargetMap)
     {
         // Action
         // 1. Select the parent test targets for this file
         selectedTestTargetMap.insert(target);
+
+        return SourceOperationActionResult::Continue;
     }
 
     template<typename ProductionTarget, typename TestTarget>
-    void TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::UpdateProductionSourceWithoutCoverageAction(
+    typename TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::SourceOperationActionResult
+    TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::
+        UpdateProductionSourceWithoutCoverageAction(
         [[maybe_unused]] const ProductionTarget* target,
         [[maybe_unused]] SelectedTestTargetAndDependerMap& selectedTestTargetMap)
     {
         // Action
-        // 1. Do nothing
+        // 1. Skip the file
+        return SourceOperationActionResult::Continue;
     }
 
     template<typename ProductionTarget, typename TestTarget>
-    void TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::UpdateTestSourceWithoutCoverageAction(
+    typename TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::SourceOperationActionResult
+    TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::
+        UpdateTestSourceWithoutCoverageAction(
         const TestTarget* target, SelectedTestTargetAndDependerMap& selectedTestTargetMap)
     {
         // Action
         // 1. Select the parent test targets for this file
         selectedTestTargetMap.insert(target);
+
+        return SourceOperationActionResult::Continue;
     }
 
     template<typename ProductionTarget, typename TestTarget>
-    void TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::UpdateIndeterminateSourceWithoutCoverageAction(
+    typename TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::SourceOperationActionResult
+    TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::
+        UpdateIndeterminateSourceWithCoverageAction(
         SelectedTestTargetAndDependerMap& selectedTestTargetMap, const SourceDependency<ProductionTarget, TestTarget>& sourceDependency)
     {
         // Action
-        // 1. Log potential orphaned source file warning (handled prior by DynamicDependencyMap)
+        // 1. Log potential orphaned source file warning (handled prior by DynamicDependencyMap::ApplyAndResoveChangeList)
         // 2. Select all test targets covering this file
-        // 3. Delete the existing coverage data from the source covering test list (handled prior by DynamicDependencyMap)
+        // 3. Delete the existing coverage data from the source covering test list (handled prior by DynamicDependencyMap::ApplyAndResoveChangeList)
 
         for (const auto* testTarget : sourceDependency.GetCoveringTestTargets())
         {
             selectedTestTargetMap.insert(testTarget);
         }
+
+        return SourceOperationActionResult::Continue;
     }
 
     template<typename ProductionTarget, typename TestTarget>
-    void TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::DeleteIndeterminateSourceWithoutCoverageAction(
+    typename TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::SourceOperationActionResult
+    TestSelectorAndPrioritizer<ProductionTarget, TestTarget>::DeleteIndeterminateSourceWithCoverageAction(
         SelectedTestTargetAndDependerMap& selectedTestTargetMap, const SourceDependency<ProductionTarget, TestTarget>& sourceDependency)
     {
         // Action
         // 1. Select all test targets covering this file
-        // 2. Delete the existing coverage data from the source covering test list (handled prior by DynamicDependencyMap)
+        // 2. Delete the existing coverage data from the source covering test list (handled prior by DynamicDependencyMap::ApplyAndResoveChangeList)
         for (const auto* testTarget : sourceDependency.GetCoveringTestTargets())
         {
             selectedTestTargetMap.insert(testTarget);
         }
+
+        return SourceOperationActionResult::Continue;
     }
 
     template<typename ProductionTarget, typename TestTarget>
@@ -215,32 +402,95 @@ namespace TestImpact
         // Create operations
         for (const auto& sourceDependency : changeDependencyList.GetCreateSourceDependencies())
         {
-            for (const auto& parentTarget : sourceDependency.GetParentTargets())
+            if (sourceDependency.GetNumParentTargets())
             {
-
-                if (parentTarget.GetTarget()->GetType() == TargetType::ProductionTarget)
+                if (sourceDependency.GetNumCoveringTestTargets())
                 {
                     // Parent Targets: Yes
-                    // Coverage Data : No
-                    // Source Type   : Production
+                    // Coverage Data : Yes
+                    // Source Type   : Irrelevant
                     //
                     // Scenario
-                    // 1. The file has been newly created
-                    // 2. This file exists in one or more source to production target mapping artifacts
-                    // 3. There exists no coverage data for this file in the source covering test list
-                    CreateProductionSourceAction(parentTarget.GetProductionTarget(), selectedTestTargetMap);
+                    // 1. This file previously existed in one or more source to target mapping artifacts
+                    // 2. The file has since been deleted yet no delete crud operation acted upon:
+                    //    a) The coverage data for this file was not deleted from the Source Covering Test List
+                    // 3. The file has since been recreated
+                    // 4. This file exists in one or more source to target mapping artifacts
+                    //
+                    // Action (handled prior by DynamicDependencyMap::ApplyAndResoveChangeList)
+                    // 1. Log Source Covering Test List compromised error
+                    // 2. Throw exception
+                    AZ_Warning(
+                        "TestSelectorAndPrioritizer",
+                        false,
+                        AZStd::string::format(
+                            "Create operation for file with parent targets and coverage data was not expected to be handled here for "
+                            "file '%s'",
+                            sourceDependency.GetPath().c_str())
+                            .c_str());
+                    continue;
                 }
                 else
                 {
                     // Parent Targets: Yes
                     // Coverage Data : No
-                    // Source Type   : Test
+                    // Source Type   : Production or test
+                    if (SourceOperationActionResult::ConcludeSelection ==
+                        IterateCreateParentedSourcesWithNoCoverage(sourceDependency, selectedTestTargetMap))
+                    {
+                        return selectedTestTargetMap;
+                    }
+                }
+            }
+            else
+            {
+                if (sourceDependency.GetNumCoveringTestTargets())
+                {
+                    // Parent Targets: No
+                    // Coverage Data : Yes
+                    // Source Type   : Indeterminate
+                    //
+                    // Scenario
+                    // 1. This file previously existed in one or more source to target mapping artifacts
+                    // 2. The file has since been deleted yet no delete crud operation acted upon:
+                    //    a) The coverage data for this file was not deleted from the Source Covering Test List
+                    // 3. The file has since been recreated
+                    // 4. This file does not exist in any source to target mapping artifacts
+                    //
+                    // Action (handled prior by DynamicDependencyMap::ApplyAndResoveChangeList)
+                    // 1. Log Source Covering Test List compromised error
+                    // 2. Throw exception
+                    AZ_Warning(
+                        "TestSelectorAndPrioritizer",
+                        false,
+                        AZStd::string::format(
+                            "Create operation for file with no parent targets but coverage data was not expected to be handled here for "
+                            "file '%s'",
+                            sourceDependency.GetPath().c_str())
+                            .c_str());
+                    continue;
+                }
+                else
+                {
+                    // Parent Targets: No
+                    // Coverage Data : No
+                    // Source Type   : Irrelevant
                     //
                     // Scenario
                     // 1. The file has been newly created
-                    // 2. This file exists in one or more source to test target mapping artifacts
-                    // 3. There exists no coverage data for this file in the source covering test list
-                    CreateTestSourceAction(parentTarget.GetTestTarget(), selectedTestTargetMap);
+                    // 2. This file does not exists in any source to target mapping artifacts.
+                    //
+                    // Action
+                    // 1. Skip the file
+                    AZ_Warning(
+                        "TestSelectorAndPrioritizer",
+                        false,
+                        AZStd::string::format(
+                            "Create operation for file with no parent targets or coverage data was not expected to be handled here for "
+                            "file '%s'",
+                            sourceDependency.GetPath().c_str())
+                            .c_str());
+                    continue;
                 }
             }
         }
@@ -252,98 +502,178 @@ namespace TestImpact
             {
                 if (sourceDependency.GetNumCoveringTestTargets())
                 {
-                    for (const auto& parentTarget : sourceDependency.GetParentTargets())
+                    // Parent Targets: Yes
+                    // Coverage Data : Yes
+                    // Source Type   : Production or test
+                    if (SourceOperationActionResult::ConcludeSelection ==
+                        IterateUpdateParentedSourcesWithCoverage(sourceDependency, selectedTestTargetMap))
                     {
-                        if (parentTarget.GetTarget()->GetType() == TargetType::ProductionTarget)
-                        {
-                            // Parent Targets: Yes
-                            // Coverage Data : Yes
-                            // Source Type   : Production
-                            //
-                            // Scenario
-                            // 1. The existing file has been modified
-                            // 2. This file exists in one or more source to production target mapping artifacts
-                            // 3. There exists coverage data for this file in the source covering test list
-                            UpdateProductionSourceWithCoverageAction(parentTarget.GetProductionTarget(), selectedTestTargetMap, sourceDependency);
-                        }
-                        else
-                        {
-                            // Parent Targets: Yes
-                            // Coverage Data : Yes
-                            // Source Type   : Test
-                            //
-                            // Scenario
-                            // 1. The existing file has been modified
-                            // 2. This file exists in one or more source to test target mapping artifacts
-                            // 3. There exists coverage data for this file in the source covering test list
-                            UpdateTestSourceWithCoverageAction(parentTarget.GetTestTarget(), selectedTestTargetMap);
-                        }
+                        return selectedTestTargetMap;
                     }
                 }
                 else
                 {
-                    for (const auto& parentTarget : sourceDependency.GetParentTargets())
+                    // Parent Targets: Yes
+                    // Coverage Data : No
+                    // Source Type   : Production or test
+                    if (SourceOperationActionResult::ConcludeSelection ==
+                        IterateUpdateParentedSourcesWithoutCoverage(sourceDependency, selectedTestTargetMap))
                     {
-                        if (parentTarget.GetTarget()->GetType() == TargetType::ProductionTarget)
-                        {
-                            // Parent Targets: Yes
-                            // Coverage Data : No
-                            // Source Type   : Production
-                            //
-                            // Scenario
-                            // 1. The existing file has been modified
-                            // 2. This file exists in one or more source to test target mapping artifacts
-                            // 3. There exists no coverage data for this file in the source covering test list
-                            UpdateProductionSourceWithoutCoverageAction(parentTarget.GetProductionTarget(), selectedTestTargetMap);
-                        }
-                        else
-                        {
-                            // Parent Targets: Yes
-                            // Coverage Data : No
-                            // Source Type   : Test
-                            //
-                            // Scenario
-                            // 1. The existing file has been modified
-                            // 2. This file exists in one or more source to test target mapping artifacts
-                            // 3. There exists no coverage data for this file in the source covering test list
-                            UpdateTestSourceWithoutCoverageAction(parentTarget.GetTestTarget(), selectedTestTargetMap);
-                        }
+                        return selectedTestTargetMap;
                     }
                 }
             }
             else
             {
-                // Parent Targets: No
-                // Coverage Data : Yes
-                // Source Type   : Indeterminate
-                //
-                // Scenario
-                // 1. The existing file has been modified
-                // 2. Either:
-                //  a) This file previously existed in one or more source to target mapping artifacts
-                //  b) This file no longer exists in any source to target mapping artifacts
-                //  c) The coverage data for this file was has yet to be deleted from the source covering test list
-                // 3. Or:
-                //  a) The file is being used by build targets but has erroneously not been explicitly added to the build
-                //     system (e.g. include directive pulling in a header from the repository that has not been added to
-                //     any build targets due to an oversight)
-                UpdateIndeterminateSourceWithoutCoverageAction(selectedTestTargetMap, sourceDependency);
+                if (sourceDependency.GetNumCoveringTestTargets())
+                {
+                    // Parent Targets: No
+                    // Coverage Data : Yes
+                    // Source Type   : Indeterminate
+                    //
+                    // Scenario
+                    // 1. The existing file has been modified
+                    // 2. Either:
+                    //  a) This file previously existed in one or more source to target mapping artifacts
+                    //  b) This file no longer exists in any source to target mapping artifacts
+                    //  c) The coverage data for this file was has yet to be deleted from the source covering test list
+                    // 3. Or:
+                    //  a) The file is being used by build targets but has erroneously not been explicitly added to the build
+                    //     system (e.g. include directive pulling in a header from the repository that has not been added to
+                    //     any build targets due to an oversight)
+                    if (SourceOperationActionResult::ConcludeSelection ==
+                        UpdateIndeterminateSourceWithCoverageAction(selectedTestTargetMap, sourceDependency))
+                    {
+                        return selectedTestTargetMap;
+                    }
+                }
+                else
+                {
+                    // Parent Targets: No
+                    // Coverage Data : No
+                    // Source Type   : Indeterminate
+                    //
+                    // Scenario
+                    // 1. The existing file has been modified
+                    // 2. This file does not exist in any source to target mapping artifacts
+                    // 3. There exists no coverage data for this file in the Source Covering Test List
+                    //
+                    // Action (handled prior by DynamicDependencyMap::ApplyAndResoveChangeList)
+                    // 1. Skip the file
+                    AZ_Warning(
+                        "TestSelectorAndPrioritizer",
+                        false,
+                        AZStd::string::format(
+                            "Update operation for file with no parent targets or coverage data was not expected to be handled here for "
+                            "file '%s'",
+                            sourceDependency.GetPath().c_str())
+                            .c_str());
+                    continue;
+                }
             }
         }
 
         // Delete operations
         for (const auto& sourceDependency : changeDependencyList.GetDeleteSourceDependencies())
         {
-            // Parent Targets: No
-            // Coverage Data : Yes
-            // Source Type   : Indeterminate
-            //
-            // Scenario
-            // 1. The existing file has been deleted
-            // 2. This file previously existed in one or more source to target mapping artifacts
-            // 2. This file does not exist in any source to target mapping artifacts
-            // 4. The coverage data for this file was has yet to be deleted from the source covering test list
-            DeleteIndeterminateSourceWithoutCoverageAction(selectedTestTargetMap, sourceDependency);
+            if (sourceDependency.GetNumParentTargets())
+            {
+                if (sourceDependency.GetNumCoveringTestTargets())
+                {
+                    // Parent Targets: Yes
+                    // Coverage Data : Yes
+                    // Source Type   : Irrelevant
+                    //
+                    // Scenario
+                    // 1. The file has been deleted.
+                    // 2. This file still exists in one or more source to target mapping artifacts
+                    // 2. There exists coverage data for this file in the Source Covering Test List
+                    //
+                    // Action (handled prior by DynamicDependencyMap::ApplyAndResoveChangeList)
+                    // 1. Log source to target mapping and Source Covering Test List integrity compromised error
+                    // 2. Throw exception
+                    AZ_Warning(
+                        "TestSelectorAndPrioritizer",
+                        false,
+                        AZStd::string::format(
+                            "Delete operation for file with parent targets and coverage data was not expected to be handled here for "
+                            "file '%s'",
+                            sourceDependency.GetPath().c_str())
+                            .c_str());
+                    continue;
+                }
+                else
+                {
+                    // Parent Targets: Yes
+                    // Coverage Data : No
+                    // Source Type   : Irrelevant
+                    //
+                    // Scenario
+                    // 1. The file has been deleted.
+                    // 2. This file still exists in one or more source to target mapping artifacts
+                    // 2. There exists no coverage data for this file in the Source Covering Test List
+                    //
+                    // Action (handled prior by DynamicDependencyMap::ApplyAndResoveChangeList)
+                    // 1. Log source to target mapping and Source Covering Test List integrity compromised error
+                    // 2. Throw exception
+                    AZ_Warning(
+                        "TestSelectorAndPrioritizer",
+                        false,
+                        AZStd::string::format(
+                            "Delete operation for file with parent targets but no coverage data was not expected to be handled here for "
+                            "file '%s'",
+                            sourceDependency.GetPath().c_str())
+                            .c_str());
+                    continue;
+                }
+            }
+            else
+            {
+                if (sourceDependency.GetNumCoveringTestTargets())
+                {
+                    // Parent Targets: No
+                    // Coverage Data : Yes
+                    // Source Type   : Indeterminate
+                    //
+                    // Scenario
+                    // 1. The existing file has been deleted
+                    // 2. This file previously existed in one or more source to target mapping artifacts
+                    // 2. This file does not exist in any source to target mapping artifacts
+                    // 4. The coverage data for this file was has yet to be deleted from the source covering test list
+                    //
+                    // Action (handled prior by DynamicDependencyMap::ApplyAndResoveChangeList)
+                    // 1. Delete the existing coverage data from the Source Covering Test List
+                    // 2. Skip the file
+                    if (SourceOperationActionResult::ConcludeSelection ==
+                        DeleteIndeterminateSourceWithCoverageAction(selectedTestTargetMap, sourceDependency))
+                    {
+                        return selectedTestTargetMap;
+                    }
+                }
+                else
+                {
+                    // Parent Targets: No
+                    // Coverage Data : No
+                    // Source Type   : Indeterminate
+                    //
+                    // Scenario
+                    // 1. The file has been deleted
+                    // 2. This file does not exist in any source to target mapping artifacts
+                    // 3. There exists no coverage data for this file in the Source Covering Test List
+                    //
+                    // Action (handled prior by DynamicDependencyMap::ApplyAndResoveChangeList)
+                    // 1. Skip the file
+                    AZ_Warning(
+                        "TestSelectorAndPrioritizer",
+                        false,
+                        AZStd::string::format(
+                            "Delete operation for file with no parent targets or coverage data was not expected to be handled here for "
+                            "file '%s'",
+                            sourceDependency.GetPath().c_str())
+                            .c_str());
+                    continue;
+                }
+            }
         }
 
         return selectedTestTargetMap;

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Include/TestImpactFramework/Python/TestImpactPythonRuntime.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Include/TestImpactFramework/Python/TestImpactPythonRuntime.h
@@ -21,6 +21,7 @@ namespace TestImpact
     class PythonTestTarget;
     class PythonProductionTarget;
     class SourceCoveringTestsList;
+    class PythonTestSelectorAndPrioritizer;
 
     //! The python API exposed to the client responsible for all test runs and persistent data management.
     class PythonRuntime
@@ -141,7 +142,7 @@ namespace TestImpact
         Policy::TargetOutputCapture m_targetOutputCapture;
         AZStd::unique_ptr<BuildTargetList<ProductionTarget, TestTarget>> m_buildTargets;
         AZStd::unique_ptr<DynamicDependencyMap<ProductionTarget, TestTarget>> m_dynamicDependencyMap;
-        AZStd::unique_ptr<TestSelectorAndPrioritizer<ProductionTarget, TestTarget>> m_testSelectorAndPrioritizer;
+        AZStd::unique_ptr<PythonTestSelectorAndPrioritizer> m_testSelectorAndPrioritizer;
         AZStd::unique_ptr<TestEngine> m_testEngine;
         AZStd::unique_ptr<TestTargetExclusionList<TestTarget>> m_testTargetExcludeList;
         AZStd::unordered_set<const TestTarget*> m_previouslyFailingTestTargets;

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Dependency/TestImpactPythonTestSelectorAndPrioritizer.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Dependency/TestImpactPythonTestSelectorAndPrioritizer.h
@@ -14,6 +14,7 @@
 
 namespace TestImpact
 {
+    //! Test selector and prioritizer for the Python tests.
     class PythonTestSelectorAndPrioritizer
         : public TestSelectorAndPrioritizer<PythonProductionTarget, PythonTestTarget>
     {

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Dependency/TestImpactPythonTestSelectorAndPrioritizer.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Dependency/TestImpactPythonTestSelectorAndPrioritizer.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Dependency/TestImpactTestSelectorAndPrioritizer.h>
+#include <Target/Python/TestImpactPythonProductionTarget.h>
+#include <Target/Python/TestImpactPythonTestTarget.h>
+
+namespace TestImpact
+{
+    class PythonTestSelectorAndPrioritizer
+        : public TestSelectorAndPrioritizer<PythonProductionTarget, PythonTestTarget>
+    {
+        using ProductionTarget = PythonProductionTarget;
+        using TestTarget = PythonTestTarget;
+        using TestSelectorAndPrioritizerBase = TestSelectorAndPrioritizer<ProductionTarget, TestTarget>;
+    public:
+        using TestSelectorAndPrioritizerBase::TestSelectorAndPrioritizer;
+
+    protected:
+        // TestSelectorAndPrioritizer overrides ...
+        [[nodiscard]] SourceOperationActionResult CreateProductionSourceWithoutCoverageAction(
+            const ProductionTarget* target, SelectedTestTargetAndDependerMap& selectedTestTargetMap) override;
+        [[nodiscard]] SourceOperationActionResult UpdateProductionSourceWithoutCoverageAction(
+            const ProductionTarget* target, SelectedTestTargetAndDependerMap& selectedTestTargetMap) override;
+        [[nodiscard]] virtual SourceOperationActionResult UpdateProductionSourceWithCoverageAction(
+            const ProductionTarget* target,
+            SelectedTestTargetAndDependerMap& selectedTestTargetMap,
+            const SourceDependency<ProductionTarget, TestTarget>& sourceDependency) override;
+    };
+
+    typename PythonTestSelectorAndPrioritizer::SourceOperationActionResult
+    PythonTestSelectorAndPrioritizer::CreateProductionSourceWithoutCoverageAction(
+        const ProductionTarget* target, SelectedTestTargetAndDependerMap& selectedTestTargetMap)
+    {
+        if (m_dynamicDependencyMap->GetCoveringTestTargetsForProductionTarget(*target).empty())
+        {
+            // Parent Targets      : Yes
+            // Coverage Data       : No
+            // Parent Coverage Data: Mixed to None
+            // Source Type         : Production
+            //
+            // Scenario
+            // 1. The file has been newly created
+            // 2. This file exists in one or more source to production target mapping artifacts
+            // 3. There exists no coverage data for this file in the Source Covering Test List
+            // 4. One or more parent targets do not have coverage data in the Source Covering Test List
+            //
+            // Action
+            // 1. Select all test targets
+            for (const auto& testTarget : m_dynamicDependencyMap->GetBuildTargetList()->GetTestTargetList().GetTargets())
+            {
+                selectedTestTargetMap.insert(&testTarget);
+            }
+
+            return SourceOperationActionResult::ConcludeSelection;
+        }
+
+        return TestSelectorAndPrioritizerBase::CreateProductionSourceWithoutCoverageAction(target, selectedTestTargetMap);
+    }
+
+    typename PythonTestSelectorAndPrioritizer::SourceOperationActionResult
+        PythonTestSelectorAndPrioritizer::UpdateProductionSourceWithoutCoverageAction(
+            const ProductionTarget* target, SelectedTestTargetAndDependerMap& selectedTestTargetMap)
+    {
+        if (m_dynamicDependencyMap->GetCoveringTestTargetsForProductionTarget(*target).empty())
+        {
+            // Parent Targets      : Yes
+            // Coverage Data       : No
+            // Parent Coverage Data: Mixed to None
+            // Source Type         : Production
+            //
+            // Scenario
+            // 1. The file has been modifed
+            // 2. This file exists in one or more source to production target mapping artifacts
+            // 3. There exists no coverage data for this file in the Source Covering Test List
+            // 4. One or more parent targets do not have coverage data in the Source Covering Test List
+            //
+            // Action
+            // 1. Select all test targets
+            for (const auto& testTarget : m_dynamicDependencyMap->GetBuildTargetList()->GetTestTargetList().GetTargets())
+            {
+                selectedTestTargetMap.insert(&testTarget);
+            }
+
+            return SourceOperationActionResult::ConcludeSelection;
+        }
+
+        return TestSelectorAndPrioritizerBase::UpdateProductionSourceWithoutCoverageAction(target, selectedTestTargetMap);
+    }
+
+    typename PythonTestSelectorAndPrioritizer::SourceOperationActionResult
+        PythonTestSelectorAndPrioritizer::UpdateProductionSourceWithCoverageAction(
+        const ProductionTarget* target,
+        SelectedTestTargetAndDependerMap& selectedTestTargetMap,
+        const SourceDependency<ProductionTarget, TestTarget>& sourceDependency)
+    {
+        if (m_dynamicDependencyMap->GetCoveringTestTargetsForProductionTarget(*target).empty())
+        {
+            // Parent Targets      : Yes
+            // Coverage Data       : Yes
+            // Parent Coverage Data: Mixed to None
+            // Source Type         : Production
+            //
+            // Scenario
+            // 1. The file has been modifed
+            // 2. This file exists in one or more source to production target mapping artifacts
+            // 3. There exists coverage data for this file in the Source Covering Test List
+            // 4. One or more parent targets do not have coverage data in the Source Covering Test List
+            //
+            // Action
+            // 1. Select all test targets
+            for (const auto& testTarget : m_dynamicDependencyMap->GetBuildTargetList()->GetTestTargetList().GetTargets())
+            {
+                selectedTestTargetMap.insert(&testTarget);
+            }
+
+            return SourceOperationActionResult::ConcludeSelection;
+        }
+
+        return TestSelectorAndPrioritizerBase::UpdateProductionSourceWithCoverageAction(target, selectedTestTargetMap, sourceDependency);
+    }
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestImpactPythonRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestImpactPythonRuntime.cpp
@@ -12,6 +12,7 @@
 #include <TestImpactRuntimeUtils.h>
 #include <Artifact/Static/TestImpactPythonTestTargetMeta.h>
 #include <Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.h>
+#include <Dependency/TestImpactPythonTestSelectorAndPrioritizer.h>
 #include <Dependency/TestImpactSourceCoveringTestsSerializer.h>
 #include <Dependency/TestImpactTestSelectorAndPrioritizer.h>
 #include <Target/Python/TestImpactPythonProductionTarget.h>
@@ -67,7 +68,7 @@ namespace TestImpact
         m_dynamicDependencyMap = AZStd::make_unique<DynamicDependencyMap<ProductionTarget, TestTarget>>(m_buildTargets.get());
 
         // Construct the test selector and prioritizer from the dependency graph data (NOTE: currently not implemented)
-        m_testSelectorAndPrioritizer = AZStd::make_unique<TestSelectorAndPrioritizer<ProductionTarget, TestTarget>>(*m_dynamicDependencyMap.get());
+        m_testSelectorAndPrioritizer = AZStd::make_unique<PythonTestSelectorAndPrioritizer>(*m_dynamicDependencyMap.get());
 
         // Construct the target exclude list from the exclude file if provided, otherwise use target configuration data
         if (!testsToExclude.empty())

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/testimpactframework_runtime_python_files.cmake
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/testimpactframework_runtime_python_files.cmake
@@ -12,6 +12,7 @@ set(FILES
     Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.cpp
     Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.h
     Source/Artifact/Static/TestImpactPythonTestTargetMeta.h
+    Source/Dependency/TestImpactPythonTestSelectorAndPrioritizer.h
     Source/Target/Python/TestImpactPythonProductionTarget.h
     Source/Target/Python/TestImpactPythonTestTarget.cpp
     Source/Target/Python/TestImpactPythonTestTarget.h


### PR DESCRIPTION
Signed-off-by: John <jonawals@amazon.co.uk>

## What does this PR do?

This PR adds the Python test selector. Currently, there is no test coverage as this selector has yet to be integrated into the runtime.

Note: the `continue` statements map to an internal rule rubric that will eventually be part of the dev docs, hence why these noops are left there.