### PR TITLE
No overlap when drawing rotate gizmo and draw start / end segments

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/AngularManipulatorCircleViewFeedback.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/AngularManipulatorCircleViewFeedback.cpp
@@ -78,7 +78,9 @@ namespace AzToolsFramework
         const auto angle = m_mostRecentAction.m_current.m_deltaRadians;
         const auto initialPointToCenter = (initialPointOnPlane - manipulatorState.m_localPosition).GetNormalized();
         const auto angleSign = Sign(angle);
-        for (auto step = 0.0f; step < AZ::GetAbs(angle); step += stepIncrement)
+        const auto maxAngle =
+            AZ::GetMin(AZ::GetAbs(angle), AZ::Constants::TwoPi);
+        for (auto step = 0.0f; step < maxAngle; step += stepIncrement)
         {
             const auto first = AZ::Quaternion::CreateFromAxisAngle(fixedAxis, step * angleSign).TransformVector(initialPointToCenter);
             const auto second =
@@ -88,6 +90,17 @@ namespace AzToolsFramework
                 manipulatorState.m_localPosition + first * view->m_radius * viewScale,
                 manipulatorState.m_localPosition + second * view->m_radius * viewScale);
         }
+
+        debugDisplay.SetColor(AZ::Color(1.f));
+
+        const auto drawRadiusSegment = [&](float angle)
+        {
+            const auto direction = AZ::Quaternion::CreateFromAxisAngle(fixedAxis, angle).TransformVector(initialPointToCenter);
+            debugDisplay.DrawLine(
+                manipulatorState.m_localPosition, manipulatorState.m_localPosition + direction * view->m_radius * viewScale);
+        };
+        drawRadiusSegment(0.f);
+        drawRadiusSegment(angle);
 
         debugDisplay.PopMatrix();
         debugDisplay.DepthTestOn();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/AngularManipulatorCircleViewFeedback.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/AngularManipulatorCircleViewFeedback.cpp
@@ -27,6 +27,14 @@ AZ_CVAR(
     AZ::ConsoleFunctorFlags::Null,
     "The color to use for the Angular Manipulator circle feedback display");
 
+AZ_CVAR(
+    AZ::Color,
+    ed_angularManipulatorCircleFeedbackRadiusSegmentColor,
+    AZ::Color::CreateFromRgba(255, 255, 255, 255),
+    nullptr,
+    AZ::ConsoleFunctorFlags::Null,
+    "The color to use for the begin / end angle radius segments in the Angular Manipulator circle feedback display");
+
 namespace AzToolsFramework
 {
     void AngularManipulatorCircleViewFeedback::Display(
@@ -91,9 +99,10 @@ namespace AzToolsFramework
                 manipulatorState.m_localPosition + second * view->m_radius * viewScale);
         }
 
-        debugDisplay.SetColor(AZ::Color(1.f));
+        debugDisplay.SetColor(ed_angularManipulatorCircleFeedbackRadiusSegmentColor);
 
-        const auto drawRadiusSegment = [&](float angle)
+        const auto drawRadiusSegment =
+            [&debugDisplay, &fixedAxis, &initialPointToCenter, &manipulatorState, view, viewScale](float angle)
         {
             const auto direction = AZ::Quaternion::CreateFromAxisAngle(fixedAxis, angle).TransformVector(initialPointToCenter);
             debugDisplay.DrawLine(


### PR DESCRIPTION
Signed-off-by: guillaume-haerinck <guillaume.haerinck@outlook.com>

## What does this PR do?

Fix for https://github.com/o3de/o3de/issues/11308

1. Limit rotation circle drawing to 2Pi to prevent overlap (else the alpha of the color is increased)
2. Draw start and end radius segments for better feedback

Note : In blender 2.8+, colors overlaps with further rotation. It stays visible as the radius segments have a bigger width, might be a good future change.

## How was this PR tested?

Checked with all angles of the gizmo

![Fix in action](https://user-images.githubusercontent.com/19243508/186710391-8a989d4e-13e5-445e-8f82-ef517094b4c9.gif)

