### PR TITLE
Minor fix for close window save corner case

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -902,13 +902,13 @@ namespace ScriptCanvasEditor
 
             if (shouldSaveResults == UnsavedChangesOptions::SAVE)
             {
-                if (assetId.IsDescriptionValid())
+                if (fileState == Tracker::ScriptCanvasFileState::NEW)
                 {
-                    SaveAssetImpl(assetId, Save::InPlace);
+                    SaveAssetImpl(assetId, Save::As);
                 }
                 else
                 {
-                    SaveAssetImpl(assetId, Save::As);
+                    SaveAssetImpl(assetId, Save::InPlace);
                 }
                 event->ignore();
                 return;


### PR DESCRIPTION
Signed-off-by: onecent1101 <liug@amazon.com>

## What does this PR do?
To fix https://github.com/o3de/o3de/issues/11547

For above case, source handle won't get information about the relative path of the graph (which loaded when opening graph). So instead of using source handle to check whether graph is new, we can use tab metadata information to check whether graph is new.

## How was this PR tested?
Tested through Editor to confirm the corner case has been fixed.
