### PR TITLE
Adding `[[maybe_unused]]` to fix unused variable warning.

### DIFF
--- a/Code/Legacy/CrySystem/AZCoreLogSink.h
+++ b/Code/Legacy/CrySystem/AZCoreLogSink.h
@@ -121,7 +121,7 @@ public:
 
         if (window == AZ::Debug::Trace::GetDefaultSystemWindow())
         {
-            auto WriteToStream = [message = AZStd::string_view(message)]
+            [[maybe_unused]] auto WriteToStream = [message = AZStd::string_view(message)]
             (AZ::IO::GenericStream& stream)
             {
                 constexpr AZStd::string_view newline = "\n";
@@ -134,7 +134,7 @@ public:
         }
         else
         {
-            auto WriteToStream = [window = AZStd::string_view(window), message = AZStd::string_view(message)]
+            [[maybe_unused]] auto WriteToStream = [window = AZStd::string_view(window), message = AZStd::string_view(message)]
             (AZ::IO::GenericStream& stream)
             {
                 constexpr AZStd::string_view windowMessageSeparator = " - ";
@@ -150,7 +150,7 @@ public:
             };
             CryOutputToCallback(ILog::eMessage, WriteToStream);
         }
-        
+
         return m_suppressSystemOutput;
     }
 


### PR DESCRIPTION
The CryOutputToCallback function is compiled out in Release builds.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
