### PR TITLE
Use new class AxisAlignedBoxShapeComponentMode to have the correct display name in subedit

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponent.cpp
@@ -10,11 +10,11 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Serialization/EditContext.h>
-#include <AzToolsFramework/ComponentModes/BoxComponentMode.h>
 #include <AzToolsFramework/Maths/TransformUtils.h>
 
 #include "AxisAlignedBoxShapeComponent.h"
 #include "EditorAxisAlignedBoxShapeComponent.h"
+#include "EditorAxisAlignedBoxShapeComponentMode.h"
 #include "EditorShapeComponentConverters.h"
 #include "ShapeDisplay.h"
 
@@ -68,7 +68,7 @@ namespace LmbrCentral
 
         // ComponentMode
         m_componentModeDelegate.ConnectWithSingleComponentMode<
-            EditorAxisAlignedBoxShapeComponent, AzToolsFramework::BoxComponentMode>(
+            EditorAxisAlignedBoxShapeComponent, EditorAxisAlignedBoxShapeComponentMode>(
                 AZ::EntityComponentIdPair(GetEntityId(), GetId()), this);
     }
 

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponentMode.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponentMode.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "EditorAxisAlignedBoxShapeComponentMode.h"
+
+namespace LmbrCentral
+{
+    AZ_CLASS_ALLOCATOR_IMPL(EditorAxisAlignedBoxShapeComponentMode, AZ::SystemAllocator, 0)
+
+    EditorAxisAlignedBoxShapeComponentMode::EditorAxisAlignedBoxShapeComponentMode(
+        const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType)
+        : BoxComponentMode(entityComponentIdPair, componentType)
+    {
+    }
+
+    AZStd::string EditorAxisAlignedBoxShapeComponentMode::GetComponentModeName() const
+    {
+        return "Axis Aligned Box Edit Mode";
+    }
+} // namespace LmbrCentral

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponentMode.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponentMode.h
@@ -19,6 +19,7 @@ namespace LmbrCentral
 
         EditorAxisAlignedBoxShapeComponentMode(const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType);
 
+        //! AzToolsFramework::BoxComponentMode overrides ...
         AZStd::string GetComponentModeName() const override;
     };
-}
+} // namespace LmbrCentral

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponentMode.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponentMode.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzToolsFramework/ComponentModes/BoxComponentMode.h>
+
+namespace LmbrCentral
+{
+    class EditorAxisAlignedBoxShapeComponentMode : public AzToolsFramework::BoxComponentMode
+    {
+    public:
+        AZ_CLASS_ALLOCATOR_DECL
+
+        EditorAxisAlignedBoxShapeComponentMode(const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType);
+
+        AZStd::string GetComponentModeName() const override;
+    };
+}

--- a/Gems/LmbrCentral/Code/lmbrcentral_editor_files.cmake
+++ b/Gems/LmbrCentral/Code/lmbrcentral_editor_files.cmake
@@ -51,6 +51,8 @@ set(FILES
     Source/Shape/EditorBoxShapeComponent.cpp
     Source/Shape/EditorAxisAlignedBoxShapeComponent.h
     Source/Shape/EditorAxisAlignedBoxShapeComponent.cpp
+    Source/Shape/EditorAxisAlignedBoxShapeComponentMode.h
+    Source/Shape/EditorAxisAlignedBoxShapeComponentMode.cpp
     Source/Shape/EditorCylinderShapeComponent.h
     Source/Shape/EditorCylinderShapeComponent.cpp
     Source/Shape/EditorCapsuleShapeComponent.h


### PR DESCRIPTION
Signed-off-by: guillaume-haerinck <guillaume.haerinck@outlook.com>

## What does this PR do?

Fix https://github.com/o3de/o3de/issues/10937

Created a new class which inherit the base behavior, the only override is for the name

## How was this PR tested?

Added an axis-aligned box component in an entity and enter subedit
