### PR TITLE
WIP support for adding toolbar to certain area

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -177,6 +177,7 @@ EditorActionsHandler::~EditorActionsHandler()
     {
         AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusDisconnect();
+        AzToolsFramework::ToolBarManagerNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorEventsBus::Handler::BusDisconnect();
     }
@@ -1555,6 +1556,8 @@ void EditorActionsHandler::InitializeMenus()
 
 void EditorActionsHandler::InitializeToolBars()
 {
+    AzToolsFramework::ToolBarManagerNotificationBus::Handler::BusConnect();
+
     // Initialize ToolBars
     {
         AzToolsFramework::ToolBarProperties toolBarProperties;
@@ -1568,10 +1571,6 @@ void EditorActionsHandler::InitializeToolBars()
         m_toolBarManagerInterface->RegisterToolBar(PlayControlsToolBarIdentifier, toolBarProperties);
     }
 
-    // Set the toolbars
-    m_mainWindow->addToolBar(Qt::ToolBarArea::TopToolBarArea, m_toolBarManagerInterface->GetToolBar(ToolsToolBarIdentifier));
-    m_mainWindow->addToolBar(Qt::ToolBarArea::TopToolBarArea, m_toolBarManagerInterface->GetToolBar(PlayControlsToolBarIdentifier));
-    
     // Add actions to each toolbar
 
     // Play Controls
@@ -1673,6 +1672,14 @@ void EditorActionsHandler::OnEntityStreamLoadSuccess()
     if (!m_isPrefabSystemEnabled)
     {
         m_actionManagerInterface->TriggerActionUpdater(LevelLoadedUpdaterIdentifier);
+    }
+}
+
+void EditorActionsHandler::OnToolBarRegistered(const AZStd::string& toolBarIdentifier, const AzToolsFramework::ToolBarProperties& properties)
+{
+    if (m_mainWindow)
+    {
+        m_mainWindow->addToolBar(properties.m_area, m_toolBarManagerInterface->GetToolBar(toolBarIdentifier));
     }
 }
 

--- a/Code/Editor/Core/EditorActionsHandler.h
+++ b/Code/Editor/Core/EditorActionsHandler.h
@@ -11,6 +11,7 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
 
+#include <AzToolsFramework/ActionManager/ToolBar/ToolBarManagerNotificationBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
@@ -34,6 +35,7 @@ namespace AzToolsFramework
 class EditorActionsHandler
     : private AzToolsFramework::EditorEventsBus::Handler
     , private AzToolsFramework::EditorEntityContextNotificationBus::Handler
+    , private AzToolsFramework::ToolBarManagerNotificationBus::Handler
     , private AzToolsFramework::ToolsApplicationNotificationBus::Handler
     , private AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Handler
 {
@@ -61,6 +63,9 @@ private:
     void OnStartPlayInEditor() override;
     void OnStopPlayInEditor() override;
     void OnEntityStreamLoadSuccess() override;
+
+    // ToolBarManagerNotificationBus overrides ...
+    void OnToolBarRegistered(const AZStd::string& toolBarIdentifier, const AzToolsFramework::ToolBarProperties& properties) override;
 
     // ToolsApplicationNotificationBus overrides ...
     void AfterEntitySelectionChanged(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManager.cpp
@@ -13,6 +13,7 @@
 
 #include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
 #include <AzToolsFramework/ActionManager/Action/ActionManagerInternalInterface.h>
+#include <AzToolsFramework/ActionManager/ToolBar/ToolBarManagerNotificationBus.h>
 
 #include <QWidget>
 
@@ -63,6 +64,8 @@ namespace AzToolsFramework
                 EditorToolBar(properties.m_name)
             }
         );
+
+        ToolBarManagerNotificationBus::Broadcast(&ToolBarManagerNotifications::OnToolBarRegistered, toolBarIdentifier, properties);
 
         return AZ::Success();
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManagerInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManagerInterface.h
@@ -11,6 +11,8 @@
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
+#include <QMainWindow>
+
 class QToolBar;
 
 namespace AzToolsFramework
@@ -28,6 +30,9 @@ namespace AzToolsFramework
         virtual ~ToolBarProperties() = default;
 
         AZStd::string m_name = "";
+
+        // TODO: Might want to create our own enum for this for ease of serialization?
+        Qt::ToolBarArea m_area = Qt::ToolBarArea::TopToolBarArea;
     };
 
     //! ToolBarManagerInterface

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManagerNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManagerNotificationBus.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/std/string/string.h>
+
+#include <AzToolsFramework/ActionManager/ToolBar/ToolBarManagerInterface.h>
+
+namespace AzToolsFramework
+{
+    //! Used to notify changes in the ToolBar Manager.
+    class ToolBarManagerNotifications : public AZ::EBusTraits
+    {
+    public:
+        // EBusTraits overrides ...
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+
+        //! Triggered when a ToolBar has been registered.
+        virtual void OnToolBarRegistered([[maybe_unused]] const AZStd::string& toolBarIdentifier, [[maybe_unused]] const ToolBarProperties& properties) {}
+
+    protected:
+        ~ToolBarManagerNotifications() = default;
+    };
+
+    using ToolBarManagerNotificationBus = AZ::EBus<ToolBarManagerNotifications>;
+
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -37,6 +37,7 @@ set(FILES
     ActionManager/ToolBar/ToolBarManager.h
     ActionManager/ToolBar/ToolBarManagerInterface.h
     ActionManager/ToolBar/ToolBarManagerInternalInterface.h
+    ActionManager/ToolBar/ToolBarManagerNotificationBus.h
     AssetEditor/AssetEditorBus.cpp
     AssetEditor/AssetEditorBus.h
     AssetEditor/AssetEditorToolbar.ui

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
@@ -97,6 +97,15 @@ namespace EditorPythonBindings
                 ;
 
             behaviorContext
+                ->Class<AzToolsFramework::ToolBarProperties>("ToolBarProperties")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Category, "Action")
+                ->Attribute(AZ::Script::Attributes::Module, "action")
+                ->Property("name", BehaviorValueProperty(&AzToolsFramework::ToolBarProperties::m_name))
+                ->Property("area", BehaviorValueProperty(&AzToolsFramework::ToolBarProperties::m_area))
+                ;
+
+            behaviorContext
                 ->EBus<ToolBarManagerRequestBus>("ToolBarManagerPythonRequestBus")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
                 ->Attribute(AZ::Script::Attributes::Category, "Action")


### PR DESCRIPTION
## What does this PR do?

This is a WIP to add support for adding toolbars to a certain area on the main window. Currently, this is done explicitly in `EditorActionsHandler::InitializeToolBars()`, but this doesn't allow other users of the action manager to add their own custom toolbars (e.g. from a gem or from python).

This proof of concept adds a toolbar notifications bus which has an `OnToolBarRegistered` event, which can be consumed when toolbars are registered to actually add them to the main window. Some potential issues with this approach would be:
- As-is wouldn't expand to support adding toolbars to other tools besides the main Editor (e.g. in Script Canvas)
- Only allows to be placed in an area of the window, but doesn't allow control of `I want to put ToolBar B in between ToolBar A and C` if `ToolBar B` was registered last.

This does however prove out that we can register custom toolbars from python and add custom actions to them.

## How was this PR tested?

Tested with a script that creates a new custom action and registers it to a new custom toolbar. Also included adding an existing action to the new custom toolbar. Here is the script:

```
from PySide2.QtCore import Qt

import azlmbr.bus as bus
import azlmbr.editor as editor
import azlmbr.entity as entity
from azlmbr.action import ActionProperties, ActionManagerPythonRequestBus, ToolBarManagerPythonRequestBus, ToolBarProperties

custom_toolbar_id = "o3de.toolbar.editor.custom"

toolbar_properties = ToolBarProperties()
toolbar_properties.name = "My Custom ToolBar"

# Temporary hack to convert the Qt.ToolBarArea to an int for ease of marshaling
toolbar_properties.area = int(Qt.BottomToolBarArea)

ToolBarManagerPythonRequestBus(bus.Broadcast, 'RegisterToolBar', custom_toolbar_id, toolbar_properties)

# Add an existing action to the custom toolbar
ToolBarManagerPythonRequestBus(bus.Broadcast, 'AddActionToToolBar', custom_toolbar_id, "o3de.action.edit.undo", 100)

# Register a custom action that will create a new entity
def foo():
    print("Created an entity!")

    editor.ToolsApplicationRequestBus(bus.Broadcast, 'CreateNewEntity', entity.EntityId())

# Configure the new custom action
context_id = "o3de.context.editor.mainwindow"
custom_action_id = "o3de.action.my.custom.action"
action_properties = ActionProperties()
action_properties.name = "Cool Thing"
action_properties.description = "Do a cool thing"

# Icons can be assigned to an action with a qrc path
action_properties.iconPath = ":/Gallery/Add.svg"

# Register the new custom action
ActionManagerPythonRequestBus(bus.Broadcast, 'RegisterAction', context_id, custom_action_id, action_properties, foo)

# Add the custom action to the custom toolbar
ToolBarManagerPythonRequestBus(bus.Broadcast, 'AddActionToToolBar', custom_toolbar_id, custom_action_id, 101)
```

Here is a gif of it in action:

![CustomToolBarAndAction](https://user-images.githubusercontent.com/7519264/186744401-bff9d631-1b06-4294-8871-c252fc370ca3.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>