### PR TITLE
Enable prefab override authoring behind a flag

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -518,6 +518,11 @@ namespace AzToolsFramework::Prefab
         // Refresh the path and notify changes in case propagation updated any container names.
         RefreshInstanceFocusPath();
         PrefabFocusNotificationBus::Broadcast(&PrefabFocusNotifications::OnPrefabFocusRefreshed);
+
+        if (IsPrefabOverridesUxEnabled())
+        {
+            SwitchToEditScope();
+        }
     }
 
     void PrefabFocusHandler::OnPrefabTemplateDirtyFlagUpdated(TemplateId templateId, [[maybe_unused]] bool status)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -741,7 +741,6 @@ namespace AzToolsFramework
 
             if (patch.IsArray() && !patch.Empty() && beforeState.IsObject())
             {
-                bool isInstanceContainerEntity = IsInstanceContainerEntity(entityId) && !IsLevelInstanceContainerEntity(entityId);
                 bool isNewParentOwnedByDifferentInstance = false;
 
                 // Reparenting of entities happens before they are associated with their owning instances. So the owning instance
@@ -802,7 +801,7 @@ namespace AzToolsFramework
                     }
                 }
 
-                if (isInstanceContainerEntity)
+                if (isInFocusTree && !isOwnedByFocusedPrefabInstance)
                 {
                     if (isNewParentOwnedByDifferentInstance)
                     {


### PR DESCRIPTION
Signed-off-by: srikappa-amzn <82230713+srikappa-amzn@users.noreply.github.com>

## What does this PR do?

This PR enables override authoring for prefabs behind a flag(/O3DE/Preferences/Prefabs/EnableOverridesUx)

## How was this PR tested?

Tested manually that overrides authoring works. Will run existing tests before merging that when overrides ux is disabled, everything stays the same.
