### PR TITLE
Add 'Character' root node to skeleton outliner treeview (#10962)

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/Node.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Node.h
@@ -450,5 +450,7 @@ namespace EMotionFX
          * @param numNodes The integer containing the current node count. This counter will be increased during recursion.
          */
         void RecursiveCountChildNodes(size_t& numNodes);
+
+        friend class SkeletonModel;
     };
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Source/Editor/ColliderHelpers.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/ColliderHelpers.cpp
@@ -60,6 +60,11 @@ namespace EMotionFX
         AZStd::string contents;
         for (const QModelIndex& selectedIndex : modelIndices)
         {
+            if (SkeletonModel::IndexIsRootNode(selectedIndex))
+            {
+                continue;
+            }
+
             const Actor* actor = selectedIndex.data(SkeletonModel::ROLE_ACTOR_POINTER).value<Actor*>();
             const Node* joint = selectedIndex.data(SkeletonModel::ROLE_POINTER).value<Node*>();
 
@@ -92,6 +97,11 @@ namespace EMotionFX
 
         for (const QModelIndex& selectedIndex : modelIndices)
         {
+            if (SkeletonModel::IndexIsRootNode(selectedIndex))
+            {
+                continue;
+            }
+
             const Actor* actor = selectedIndex.data(SkeletonModel::ROLE_ACTOR_POINTER).value<Actor*>();
             const Node* joint = selectedIndex.data(SkeletonModel::ROLE_POINTER).value<Node*>();
 
@@ -119,6 +129,11 @@ namespace EMotionFX
 
         for (const QModelIndex& selectedIndex : modelIndices)
         {
+            if (SkeletonModel::IndexIsRootNode(selectedIndex))
+            {
+                continue;
+            }
+
             const Actor* actor = selectedIndex.data(SkeletonModel::ROLE_ACTOR_POINTER).value<Actor*>();
             const Node* joint = selectedIndex.data(SkeletonModel::ROLE_POINTER).value<Node*>();
 
@@ -158,6 +173,11 @@ namespace EMotionFX
 
         for (const QModelIndex& selectedIndex : modelIndices)
         {
+            if (SkeletonModel::IndexIsRootNode(selectedIndex))
+            {
+                continue;
+            }
+
             const Actor* actor = selectedIndex.data(SkeletonModel::ROLE_ACTOR_POINTER).value<Actor*>();
             const Node* joint = selectedIndex.data(SkeletonModel::ROLE_POINTER).value<Node*>();
 

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/Cloth/ClothJointInspectorPlugin.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/Cloth/ClothJointInspectorPlugin.cpp
@@ -77,6 +77,11 @@ namespace EMotionFX
             return;
         }
 
+        if (selectedRowIndices.size() == 1 && SkeletonModel::IndexIsRootNode(selectedRowIndices[0]))
+        {
+            return;
+        }
+
         const Actor* actor = selectedRowIndices[0].data(SkeletonModel::ROLE_ACTOR_POINTER).value<Actor*>();
         const AZStd::shared_ptr<PhysicsSetup>& physicsSetup = actor->GetPhysicsSetup();
         if (!physicsSetup)

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/HitDetection/HitDetectionJointInspectorPlugin.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/HitDetection/HitDetectionJointInspectorPlugin.cpp
@@ -63,6 +63,11 @@ namespace EMotionFX
             return;
         }
 
+        if (selectedRowIndices.size() == 1 && SkeletonModel::IndexIsRootNode(selectedRowIndices[0]))
+        {
+            return;
+        }
+
         const Actor* actor = selectedRowIndices[0].data(SkeletonModel::ROLE_ACTOR_POINTER).value<Actor*>();
         const AZStd::shared_ptr<PhysicsSetup>& physicsSetup = actor->GetPhysicsSetup();
         if (!physicsSetup)

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeInspectorPlugin.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeInspectorPlugin.cpp
@@ -85,6 +85,11 @@ namespace EMotionFX
             return;
         }
 
+        if (SkeletonModel::IndicesContainRootNode(selectedRowIndices) && selectedRowIndices.size() == 1)
+        {
+            return;
+        }
+
         const int numSelectedNodes = selectedRowIndices.count();
         int ragdollNodeCount = 0;
         for (const QModelIndex& modelIndex : selectedRowIndices)
@@ -175,6 +180,11 @@ namespace EMotionFX
 
         for (const QModelIndex& selectedIndex : modelIndices)
         {
+            if (SkeletonModel::IndexIsRootNode(selectedIndex))
+            {
+                continue;
+            }
+
             const Node* joint = selectedIndex.data(SkeletonModel::ROLE_POINTER).value<Node*>();
 
             jointNames.emplace_back(joint->GetNameString());
@@ -203,7 +213,13 @@ namespace EMotionFX
         AZStd::vector<AZStd::string> jointNamesToRemove;
         for (const QModelIndex& selectedIndex : modelIndices)
         {
+            if (SkeletonModel::IndexIsRootNode(selectedIndex))
+            {
+                continue;
+            }
+
             const Node* selectedJoint = selectedIndex.data(SkeletonModel::ROLE_POINTER).value<Node*>();
+
             jointNamesToRemove.emplace_back(selectedJoint->GetNameString());
         }
         const Actor* actor = modelIndices[0].data(SkeletonModel::ROLE_ACTOR_POINTER).value<Actor*>();
@@ -231,6 +247,11 @@ namespace EMotionFX
 
         for (const QModelIndex& selectedIndex : modelIndices)
         {
+            if (SkeletonModel::IndexIsRootNode(selectedIndex))
+            {
+                continue;
+            }
+
             const Actor* actor = selectedIndex.data(SkeletonModel::ROLE_ACTOR_POINTER).value<Actor*>();
             const Node* selectedJoint = selectedIndex.data(SkeletonModel::ROLE_POINTER).value<Node*>();
 
@@ -261,6 +282,11 @@ namespace EMotionFX
         const Actor* actor = modelIndices[0].data(SkeletonModel::ROLE_ACTOR_POINTER).value<Actor*>();
         for (const QModelIndex& selectedIndex : modelIndices)
         {
+            if (SkeletonModel::IndexIsRootNode(selectedIndex))
+            {
+                continue;
+            }
+
             const Node* joint = selectedIndex.data(SkeletonModel::ROLE_POINTER).value<Node*>();
             const AZStd::shared_ptr<PhysicsSetup>& physicsSetup = actor->GetPhysicsSetup();
 

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeWidget.cpp
@@ -126,7 +126,9 @@ namespace EMotionFX
     void RagdollNodeWidget::InternalReinit()
     {
         const QModelIndexList& selectedModelIndices = GetSelectedModelIndices();
-        if (selectedModelIndices.size() == 1)
+        Node* selectedNode = GetNode();
+
+        if (selectedModelIndices.size() == 1 && !SkeletonModel::IndexIsRootNode(selectedModelIndices[0]))
         {
             m_ragdollNodeEditor->ClearInstances(false);
 
@@ -168,7 +170,6 @@ namespace EMotionFX
                 {
                     PhysicsSetupManipulatorData physicsSetupManipulatorData;
                     ActorInstance* actorInstance = GetActorInstance();
-                    Node* selectedNode = GetNode();
                     if (GetActor() && actorInstance && selectedNode)
                     {
                         const Transform& nodeWorldTransform =

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/SkeletonOutliner/SkeletonOutlinerPlugin.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/SkeletonOutliner/SkeletonOutlinerPlugin.cpp
@@ -267,6 +267,11 @@ namespace EMotionFX
             return;
         }
 
+        if (selectedRowIndices.size() == 1 && SkeletonModel::IndexIsRootNode(selectedRowIndices[0]))
+        {
+            return;
+        }
+
         QMenu* contextMenu = new QMenu(m_mainWidget);
         contextMenu->setObjectName("EMFX.SkeletonOutlinerPlugin.ContextMenu");
 

--- a/Gems/EMotionFX/Code/Source/Editor/SimulatedObjectHelpers.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/SimulatedObjectHelpers.cpp
@@ -49,7 +49,13 @@ namespace EMotionFX
 
         for (const QModelIndex& selectedIndex : modelIndices)
         {
+            if (SkeletonModel::IndexIsRootNode(selectedIndex))
+            {
+                continue;
+            }
+
             const Node* joint = selectedIndex.data(SkeletonModel::ROLE_POINTER).value<Node*>();
+
             jointIndices.emplace_back(joint->GetNodeIndex());
         }
 

--- a/Gems/EMotionFX/Code/Source/Editor/SkeletonModel.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/SkeletonModel.cpp
@@ -28,6 +28,7 @@ namespace EMotionFX
         , m_skeleton(nullptr)
         , m_actor(nullptr)
         , m_actorInstance(nullptr)
+        , m_characterRootNode(Node::Create("Character", nullptr))
         , m_jointIcon(s_jointIconPath)
         , m_clothColliderIcon(s_clothColliderIconPath)
         , m_hitDetectionColliderIcon(s_hitDetectionColliderIconPath)
@@ -66,6 +67,8 @@ namespace EMotionFX
 
     SkeletonModel::~SkeletonModel()
     {
+        m_characterRootNode->Destroy();
+
         // Calling Reset will trigger the modelReset signal, thus notify other widgets to clear cached information about this model.
         Reset();
 
@@ -117,6 +120,18 @@ namespace EMotionFX
         {
             const Node* parentNode = static_cast<const Node*>(parent.internalPointer());
 
+            if (parentNode == m_characterRootNode) {
+                if (row >= static_cast<int>(m_skeleton->GetNumRootNodes()))
+                {
+                    AZ_Assert(false, "Cannot get model index. Row out of range.");
+                    return QModelIndex();
+                }
+
+                const size_t rootNodeIndex = m_skeleton->GetRootNodeIndex(row);
+                Node* rootNode = m_skeleton->GetNode(rootNodeIndex);
+                return createIndex(row, column, rootNode);
+            }
+
             if (row >= static_cast<int>(parentNode->GetNumChildNodes()))
             {
                 AZ_Assert(false, "Cannot get model index. Row out of range.");
@@ -129,15 +144,15 @@ namespace EMotionFX
         }
         else
         {
-            if (row >= static_cast<int>(m_skeleton->GetNumRootNodes()))
+            // The root node is now only the character root node, and all skeleton root nodes
+            // are its children. We never expect more than one node at the root level.
+            if (row >= 1)
             {
                 AZ_Assert(false, "Cannot get model index. Row out of range.");
                 return QModelIndex();
             }
 
-            const size_t rootNodeIndex = m_skeleton->GetRootNodeIndex(row);
-            Node* rootNode = m_skeleton->GetNode(rootNodeIndex);
-            return createIndex(row, column, rootNode);
+            return createIndex(row, column, m_characterRootNode);
         }
     }
 
@@ -151,33 +166,47 @@ namespace EMotionFX
 
         AZ_Assert(child.isValid(), "Expected valid child model index.");
         Node* childNode = static_cast<Node*>(child.internalPointer());
-        Node* parentNode = childNode->GetParentNode();
-        if (parentNode)
+
+        // The virtual character root node has no parent
+        if (childNode == m_characterRootNode)
         {
-            Node* grandParentNode = parentNode->GetParentNode();
-            if (grandParentNode)
+            return QModelIndex();
+        }
+
+        // Actual roots from the skeleton tree (nodes that have no parent node on the skeleton tree)
+        // are children of the virtual character root
+        Node* parentNode = childNode->GetParentNode();
+        if (!parentNode)
+        {
+            return createIndex(0, 0, m_characterRootNode);
+        }
+
+        // Children of skeleton root nodes have their parent node (GetParentNode()) as parent,
+        // and the row value is computed through GetNumRootNodes()/GetRootNodeIndex()
+        Node* grandParentNode = parentNode->GetParentNode();
+        if (!grandParentNode)
+        {
+            const int numRootNodes = aznumeric_caster(m_skeleton->GetNumRootNodes());
+            for (int i = 0; i < numRootNodes; ++i)
             {
-                const int numChildNodes = aznumeric_caster(grandParentNode->GetNumChildNodes());
-                for (int i = 0; i < numChildNodes; ++i)
+                const Node* rootNode = m_skeleton->GetNode(m_skeleton->GetRootNodeIndex(i));
+                if (rootNode == parentNode)
                 {
-                    const Node* grandParentChildNode = m_skeleton->GetNode(grandParentNode->GetChildIndex(i));
-                    if (grandParentChildNode == parentNode)
-                    {
-                        return createIndex(i, 0, parentNode);
-                    }
+                    return createIndex(i, 0, parentNode);
                 }
             }
-            else
+            AZ_Assert(false, "Cannot get parent model index. Skeleton invalid.");
+        }
+
+        // Other skeleton nodes nodes have their parent node (GetParentNode()) as parent,
+        // and the row value needs to be computed through GetNumChildNodes()/GetChildIndex() w.r.t. the parent
+        const int numChildNodes = aznumeric_caster(grandParentNode->GetNumChildNodes());
+        for (int i = 0; i < numChildNodes; ++i)
+        {
+            const Node* grandParentChildNode = m_skeleton->GetNode(grandParentNode->GetChildIndex(i));
+            if (grandParentChildNode == parentNode)
             {
-                const int numRootNodes = aznumeric_caster(m_skeleton->GetNumRootNodes());
-                for (int i = 0; i < numRootNodes; ++i)
-                {
-                    const Node* rootNode = m_skeleton->GetNode(m_skeleton->GetRootNodeIndex(i));
-                    if (rootNode == parentNode)
-                    {
-                        return createIndex(i, 0, parentNode);
-                    }
-                }
+                return createIndex(i, 0, parentNode);
             }
         }
 
@@ -194,11 +223,18 @@ namespace EMotionFX
         if (parent.isValid())
         {
             const Node* parentNode = static_cast<const Node*>(parent.internalPointer());
+
+            if (parentNode == m_characterRootNode)
+            {
+                return static_cast<int>(m_skeleton->GetNumRootNodes());
+            }
+
             return static_cast<int>(parentNode->GetNumChildNodes());
         }
         else
         {
-            return static_cast<int>(m_skeleton->GetNumRootNodes());
+            // We only have m_characterRootNode as root node, and all skeleton root nodes as their children, by construction.
+            return 1;
         }
     }
 
@@ -234,9 +270,43 @@ namespace EMotionFX
         Node* node = static_cast<Node*>(index.internalPointer());
         AZ_Assert(node, "Expected valid node pointer.");
 
+        const bool isRootNode = node == m_characterRootNode;
         const size_t nodeIndex = node->GetNodeIndex();
-        const NodeInfo& nodeInfo = m_nodeInfos[nodeIndex];
+        const NodeInfo& nodeInfo = GetNodeInfo(node);
 
+        // Handle roles for the special case with a root node
+        if (isRootNode)
+        {
+            switch (role)
+            {
+            case Qt::DecorationRole:
+                {
+                    switch (index.column())
+                    {
+                    case COLUMN_RAGDOLL_LIMIT:
+                    case COLUMN_RAGDOLL_COLLIDERS:
+                    case COLUMN_HITDETECTION_COLLIDERS:
+                    case COLUMN_CLOTH_COLLIDERS:
+                    case COLUMN_SIMULATED_JOINTS:
+                    case COLUMN_SIMULATED_COLLIDERS:
+                        return {};
+                    default:
+                        break;
+                    }
+                    break;
+                }
+            case ROLE_RAGDOLL:
+            case ROLE_HITDETECTION:
+            case ROLE_CLOTH:
+            case ROLE_SIMULATED_JOINT:
+            case ROLE_SIMULATED_OBJECT_COLLIDER:
+                return {};
+            default:
+                break;
+            }
+        }
+
+        // Handle roles for all other nodes
         switch (role)
         {
         case Qt::ToolTipRole:
@@ -390,6 +460,8 @@ namespace EMotionFX
         }
         case ROLE_NODE_INDEX:
             return qulonglong(nodeIndex);
+        case ROLE_IS_CHARACTER_ROOT_NODE:
+            return isRootNode;
         case ROLE_POINTER:
             return QVariant::fromValue(node);
         case ROLE_ACTOR_POINTER:
@@ -474,8 +546,7 @@ namespace EMotionFX
         Node* node = static_cast<Node*>(index.internalPointer());
         AZ_Assert(node, "Expected valid node pointer.");
 
-        const size_t nodeIndex = node->GetNodeIndex();
-        const NodeInfo& nodeInfo = m_nodeInfos[nodeIndex];
+        const NodeInfo& nodeInfo = GetNodeInfo(node);
 
         if (nodeInfo.m_checkable)
         {
@@ -496,8 +567,7 @@ namespace EMotionFX
         const Node* node = static_cast<Node*>(index.internalPointer());
         AZ_Assert(node, "Expected valid node pointer.");
 
-        const size_t nodeIndex = node->GetNodeIndex();
-        NodeInfo& nodeInfo = m_nodeInfos[nodeIndex];
+        NodeInfo& nodeInfo = GetNodeInfo(node);
 
         switch (role)
         {
@@ -520,6 +590,11 @@ namespace EMotionFX
         if (!node)
         {
             return QModelIndex();
+        }
+
+        if (node == m_characterRootNode)
+        {
+            return createIndex(0, 0, node);
         }
 
         Node* parentNode = node->GetParentNode();
@@ -607,6 +682,24 @@ namespace EMotionFX
         SetActorInstance(actorInstance);
     }
 
+    SkeletonModel::NodeInfo& SkeletonModel::GetNodeInfo(const Node* node)
+    {
+        if (node == m_characterRootNode)
+        {
+            return m_nodeInfos[0];
+        }
+        return m_nodeInfos[node->GetNodeIndex() + 1];
+    }
+
+    const SkeletonModel::NodeInfo& SkeletonModel::GetNodeInfo(const Node* node) const
+    {
+        if (node == m_characterRootNode)
+        {
+            return m_nodeInfos[0];
+        }
+        return m_nodeInfos[node->GetNodeIndex() + 1];
+    }
+
     void SkeletonModel::UpdateNodeInfos(Actor* actor)
     {
         if (!actor)
@@ -618,7 +711,13 @@ namespace EMotionFX
         const size_t numLodLevels = actor->GetNumLODLevels();
         const Skeleton* skeleton = actor->GetSkeleton();
         const size_t numNodes = skeleton->GetNumNodes();
-        m_nodeInfos.resize(numNodes);
+
+        // We need to keep NodeInfo information for the "virtual" character root node that we add in this model.
+        // That node is not coming from the skeleton so we need to manually make room for an extra NodeInfo struct
+        // and adjust indices accordingly.
+        // The info struct for the root node will be in m_nodeInfos[0] and all the other will be stored in
+        // m_nodeInfos[node.index + 1]
+        m_nodeInfos.resize(numNodes + 1);
 
         AZStd::vector<AZStd::vector<size_t> > boneListPerLodLevel;
         boneListPerLodLevel.resize(numLodLevels);
@@ -627,26 +726,40 @@ namespace EMotionFX
             actor->ExtractBoneList(lodLevel, &boneListPerLodLevel[lodLevel]);
         }
 
-        for (size_t nodeIndex = 0; nodeIndex < numNodes; ++nodeIndex)
+        // Starting from 1 to skip character root node info (we use default values for that node).
+        for (size_t nodeIndex = 1; nodeIndex < numNodes; ++nodeIndex)
         {
             NodeInfo& nodeInfo = m_nodeInfos[nodeIndex];
 
             // Is bone?
             nodeInfo.m_isBone = AZStd::any_of(begin(boneListPerLodLevel), end(boneListPerLodLevel), [nodeIndex](const AZStd::vector<size_t>& lodLevel)
             {
-                return AZStd::find(begin(lodLevel), end(lodLevel), nodeIndex) != end(lodLevel);
+                return AZStd::find(begin(lodLevel), end(lodLevel), nodeIndex - 1) != end(lodLevel);
             });
 
             // Has mesh?
             nodeInfo.m_hasMesh = false;
             for (size_t lodLevel = 0; lodLevel < numLodLevels; ++lodLevel)
             {
-                if (actor->GetMesh(lodLevel, nodeIndex))
+                if (actor->GetMesh(lodLevel, nodeIndex - 1))
                 {
                     nodeInfo.m_hasMesh = true;
                     break;
                 }
             }
         }
+    }
+
+    bool SkeletonModel::IndexIsRootNode(const QModelIndex& idx)
+    {
+        return idx.data(SkeletonModel::ROLE_IS_CHARACTER_ROOT_NODE).template value<bool>();
+    }
+
+    bool SkeletonModel::IndicesContainRootNode(const QModelIndexList& indices)
+    {
+        return AZStd::ranges::any_of(indices, [](const auto& index)
+        {
+            return index.data(SkeletonModel::ROLE_IS_CHARACTER_ROOT_NODE).template value<bool>();
+        });
     }
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Source/Editor/SkeletonModel.h
+++ b/Gems/EMotionFX/Code/Source/Editor/SkeletonModel.h
@@ -56,7 +56,8 @@ namespace EMotionFX
             ROLE_HITDETECTION,
             ROLE_CLOTH,
             ROLE_SIMULATED_JOINT,
-            ROLE_SIMULATED_OBJECT_COLLIDER
+            ROLE_SIMULATED_OBJECT_COLLIDER,
+            ROLE_IS_CHARACTER_ROOT_NODE,
         };
 
         SkeletonModel();
@@ -99,6 +100,9 @@ namespace EMotionFX
         static const char* s_simulatedJointIconPath;
         static const char* s_simulatedColliderIconPath;
 
+        static bool IndexIsRootNode(const QModelIndex& idx);
+        static bool IndicesContainRootNode(const QModelIndexList& indices);
+
     private:
         struct NodeInfo
         {
@@ -112,6 +116,8 @@ namespace EMotionFX
         void SetActorInstance(ActorInstance* actorInstance);
         void UpdateNodeInfos(Actor* actor);
         void Reset();
+        NodeInfo& GetNodeInfo(const Node* node);
+        const NodeInfo& GetNodeInfo(const Node* node) const;
 
         static int s_columnCount;
 
@@ -120,6 +126,7 @@ namespace EMotionFX
         Actor* m_actor;
         ActorInstance* m_actorInstance;
         QItemSelectionModel m_selectionModel;
+        Node* m_characterRootNode;
 
         QIcon m_jointIcon;
         QIcon m_clothColliderIcon;

--- a/Gems/EMotionFX/Code/Source/Editor/SkeletonModelJointWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/SkeletonModelJointWidget.cpp
@@ -96,7 +96,8 @@ namespace EMotionFX
 
         if (GetActor())
         {
-            if (!selectedModelIndices.isEmpty())
+            bool onlyRootSelected = selectedModelIndices.size() == 1 && SkeletonModel::IndicesContainRootNode(selectedModelIndices);
+            if (!selectedModelIndices.isEmpty() && !onlyRootSelected)
             {
                 if (selectedModelIndices.size() == 1)
                 {

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/Ragdoll/CanCopyPasteColliders.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/Ragdoll/CanCopyPasteColliders.cpp
@@ -118,7 +118,7 @@ namespace EMotionFX
         ASSERT_TRUE(skeletonOutlinerPlugin) << "Skeleton outliner plugin not found.";
 
         SkeletonModel* model = skeletonOutlinerPlugin->GetModel();
-        const QModelIndex rootIndex = model->index(0, 0);
+        const QModelIndex rootIndex = model->index(0, 0, model->index(0, 0));
         const QModelIndex joint1Index = model->index(0, 0, rootIndex);
         const QModelIndex joint2Index = model->index(0, 0, joint1Index);
         const QModelIndex joint3Index = model->index(0, 0, joint2Index);

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/Ragdoll/CanCopyPasteJointLimits.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/Ragdoll/CanCopyPasteJointLimits.cpp
@@ -94,7 +94,7 @@ namespace EMotionFX
         ASSERT_TRUE(skeletonOutlinerPlugin) << "Skeleton outliner plugin not found.";
 
         SkeletonModel* model = skeletonOutlinerPlugin->GetModel();
-        const QModelIndex rootIndex = model->index(0, 0);
+        const QModelIndex rootIndex = model->index(0, 0, model->index(0, 0));
         const QModelIndex joint1Index = model->index(0, 0, rootIndex);
         const QModelIndex joint2Index = model->index(0, 0, joint1Index);
         const QModelIndex joint3Index = model->index(0, 0, joint2Index);

--- a/Gems/EMotionFX/Code/Tests/UI/CanAddJointAndChildren.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanAddJointAndChildren.cpp
@@ -59,7 +59,7 @@ namespace EMotionFX
         QTreeView* treeView = skeletonOutliner->GetDockWidget()->findChild<QTreeView*>("EMFX.SkeletonOutlinerPlugin.SkeletonOutlinerTreeView");
         const QAbstractItemModel* model = treeView->model();
 
-        const QModelIndex rootJointIndex = model->index(0, 0);
+        const QModelIndex rootJointIndex = model->index(0, 0, model->index(0, 0));
         ASSERT_TRUE(rootJointIndex.isValid()) << "Unable to find a model index for the root joint of the actor";
 
         treeView->selectionModel()->select(rootJointIndex, QItemSelectionModel::Select | QItemSelectionModel::Rows);

--- a/Gems/EMotionFX/Code/Tests/UI/CanAddSimulatedObject.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanAddSimulatedObject.cpp
@@ -176,7 +176,7 @@ namespace EMotionFX
         QTreeView* treeView = skeletonOutliner->GetDockWidget()->findChild<QTreeView*>("EMFX.SkeletonOutlinerPlugin.SkeletonOutlinerTreeView");
         const QAbstractItemModel* model = treeView->model();
 
-        const QModelIndex rootJointIndex = model->index(0, 0);
+        const QModelIndex rootJointIndex = model->index(0, 0, model->index(0, 0));
         ASSERT_TRUE(rootJointIndex.isValid()) << "Unable to find a model index for the root joint of the actor";
 
         treeView->selectionModel()->select(rootJointIndex, QItemSelectionModel::Select | QItemSelectionModel::Rows);
@@ -233,7 +233,7 @@ namespace EMotionFX
         const QAbstractItemModel* model = treeView->model();
 
         // Find the 3rd joint in the TreeView and select it
-        const QModelIndex jointIndex = model->index(0, 3);
+        const QModelIndex jointIndex = model->index(0, 3, model->index(0, 0));
         ASSERT_TRUE(jointIndex.isValid()) << "Unable to find a model index for the root joint of the actor";
 
         treeView->selectionModel()->select(jointIndex, QItemSelectionModel::Select | QItemSelectionModel::Rows);
@@ -289,7 +289,7 @@ namespace EMotionFX
         const QAbstractItemModel* model = treeView->model();
 
         // Find the 3rd joint in the TreeView and select it
-        const QModelIndex jointIndex = model->index(0, 3);
+        const QModelIndex jointIndex = model->index(0, 3, model->index(0, 0));
         ASSERT_TRUE(jointIndex.isValid()) << "Unable to find a model index for the root joint of the actor";
 
         treeView->selectionModel()->select(jointIndex, QItemSelectionModel::Select | QItemSelectionModel::Rows);
@@ -382,7 +382,7 @@ namespace EMotionFX
         const QAbstractItemModel* model = treeView->model();
 
         QModelIndexList indexList;
-        RecursiveGetAllChildren(treeView, model->index(0, 0), indexList);
+        RecursiveGetAllChildren(treeView, model->index(0, 0, model->index(0, 0)), indexList);
 
         SelectIndexes(indexList, treeView, 3, 3);
 
@@ -437,7 +437,7 @@ namespace EMotionFX
         const QAbstractItemModel* model = treeView->model();
 
         QModelIndexList indexList;
-        RecursiveGetAllChildren(treeView, model->index(0, 0), indexList);
+        RecursiveGetAllChildren(treeView, model->index(0, 0, model->index(0, 0)), indexList);
 
         SelectIndexes(indexList, treeView, 3, 5);
 
@@ -485,7 +485,7 @@ namespace EMotionFX
 
         m_indexList.clear();
 
-        m_skeletonTreeView->RecursiveGetAllChildren(m_skeletonTreeView->model()->index(0, 0), m_indexList);
+        m_skeletonTreeView->RecursiveGetAllChildren(m_skeletonModel->index(0, 0, m_skeletonModel->index(0, 0)), m_indexList);
 
         // Add colliders to two joints.
         AddCapsuleColliderToJointIndex(3);
@@ -496,7 +496,7 @@ namespace EMotionFX
 
         m_indexList.clear();
 
-        m_skeletonTreeView->RecursiveGetAllChildren(m_skeletonTreeView->model()->index(0, 0), m_indexList);
+        m_skeletonTreeView->RecursiveGetAllChildren(m_skeletonModel->index(0, 0, m_skeletonModel->index(0, 0)), m_indexList);
 
         // Reselect joint 3 and pop up the context menu for it.
         m_skeletonTreeView->selectionModel()->clearSelection();

--- a/Gems/EMotionFX/Code/Tests/UI/CanAddToSimulatedObject.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanAddToSimulatedObject.cpp
@@ -62,7 +62,7 @@ namespace EMotionFX
         const QAbstractItemModel* skeletonModel = skeletonTreeView->model();
 
         QModelIndexList indexList;
-        skeletonTreeView->RecursiveGetAllChildren(skeletonModel->index(0, 0), indexList);
+        skeletonTreeView->RecursiveGetAllChildren(skeletonModel->index(0, 0, skeletonModel->index(0, 0)), indexList);
         EXPECT_EQ(indexList.size(), 7);
 
         SelectIndexes(indexList, skeletonTreeView, 2, 4);
@@ -177,7 +177,7 @@ namespace EMotionFX
         const QAbstractItemModel* skeletonModel = skeletonTreeView->model();
 
         QModelIndexList indexList;
-        skeletonTreeView->RecursiveGetAllChildren(skeletonModel->index(0, 0), indexList);
+        skeletonTreeView->RecursiveGetAllChildren(skeletonModel->index(0, 0, skeletonModel->index(0, 0)), indexList);
         EXPECT_EQ(indexList.size(), 7);
 
         SelectIndexes(indexList, skeletonTreeView, 2, 4);

--- a/Gems/EMotionFX/Code/Tests/UI/CanChangeParametersInSimulatedObject.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanChangeParametersInSimulatedObject.cpp
@@ -60,7 +60,7 @@ namespace EMotionFX
         const QAbstractItemModel* skeletonModel = skeletonTreeView->model();
 
         QModelIndexList indexList;
-        skeletonTreeView->RecursiveGetAllChildren(skeletonModel->index(0, 0), indexList);
+        skeletonTreeView->RecursiveGetAllChildren(skeletonModel->index(0, 0, skeletonModel->index(0, 0)), indexList);
         EXPECT_EQ(indexList.size(), 7);
 
         SelectIndexes(indexList, skeletonTreeView, 2, 4);

--- a/Gems/EMotionFX/Code/Tests/UI/ClothColliderTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/ClothColliderTests.cpp
@@ -70,7 +70,7 @@ namespace EMotionFX
             m_treeView = m_skeletonOutliner->GetDockWidget()->findChild<ReselectingTreeView*>("EMFX.SkeletonOutlinerPlugin.SkeletonOutlinerTreeView");
 
             m_indexList.clear();
-            m_treeView->RecursiveGetAllChildren(m_treeView->model()->index(0, 0), m_indexList);
+            m_treeView->RecursiveGetAllChildren(m_treeView->model()->index(0, 0, m_treeView->model()->index(0, 0)), m_indexList);
         }
 
     protected:

--- a/Gems/EMotionFX/Code/Tests/UI/RagdollEditTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/RagdollEditTests.cpp
@@ -84,7 +84,7 @@ namespace EMotionFX
             m_treeView = m_skeletonOutliner->GetDockWidget()->findChild<ReselectingTreeView*>("EMFX.SkeletonOutlinerPlugin.SkeletonOutlinerTreeView");
 
             m_indexList.clear();
-            m_treeView->RecursiveGetAllChildren(m_treeView->model()->index(0, 0), m_indexList);
+            m_treeView->RecursiveGetAllChildren(m_treeView->model()->index(0, 0, m_treeView->model()->index(0, 0)), m_indexList);
         }
 
     protected:


### PR DESCRIPTION
## What does this PR do?

- Adds a new "Character" root node to skeleton outliner treeview.
- Adds special behaviour for that node: no context menu on right click, and special handling when that node is part of a multiple selection

## How was this PR tested?

Manually interacted with the treeview making sure that the model was consistent (selection/hover/etc. behave as expected).
Checked that the items in the context menu were behaving as expected.
Checked that changing selection on the treeview triggered changes on the details dockwidgets as expected.
Succesfully run autotests (EMotionFX.Editor.Tests).