### PR TITLE
Atom Tools: Fixed issue with properties disappearing from inspector if multiple documents are open and closed

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentInspector.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentInspector.h
@@ -46,6 +46,8 @@ namespace AtomToolsFramework
         void OnDocumentObjectInfoChanged(const AZ::Uuid& documentId, const DocumentObjectInfo& objectInfo, bool rebuilt) override;
         void OnDocumentObjectInfoInvalidated(const AZ::Uuid& documentId) override;
         void OnDocumentModified(const AZ::Uuid& documentId) override;
+        void OnDocumentCleared(const AZ::Uuid& documentId) override;
+        void OnDocumentError(const AZ::Uuid& documentId) override;
 
         // AzToolsFramework::IPropertyEditorNotify overrides...
         void BeforePropertyModified(AzToolsFramework::InstanceDataNode* pNode) override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
@@ -77,11 +77,14 @@ namespace AtomToolsFramework
         //! Insert items into the tab context menu for the document ID
         virtual void PopulateTabContextMenu(const AZ::Uuid& documentId, QMenu& menu);
 
-        //! Requests a source and target path for creating a new document based on another
-        virtual bool GetCreateDocumentParams(AZStd::string& openPath, AZStd::string& savePath);
+        //! Select the target path where a document will be saved.
+        virtual AZStd::string GetSaveDocumentParams(const AZStd::string& initialPath) const;
+
+        //! Requests source and target paths for creating a new document based on another
+        virtual bool GetCreateDocumentParams(AZStd::string& openPath, AZStd::string& savePath) const;
 
         //! Prompts the user for a selection of documents to open
-        virtual AZStd::vector<AZStd::string> GetOpenDocumentParams();
+        virtual AZStd::vector<AZStd::string> GetOpenDocumentParams() const;
 
         // AtomToolsMainWindowRequestBus::Handler overrides...
         void CreateMenus(QMenuBar* menuBar) override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentInspector.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentInspector.cpp
@@ -74,6 +74,22 @@ namespace AtomToolsFramework
         }
     }
 
+    void AtomToolsDocumentInspector::OnDocumentCleared(const AZ::Uuid& documentId)
+    {
+        if (m_documentId == documentId)
+        {
+            Reset();
+        }
+    }
+
+    void AtomToolsDocumentInspector::OnDocumentError(const AZ::Uuid& documentId)
+    {
+        if (m_documentId == documentId)
+        {
+            Reset();
+        }
+    }
+
     void AtomToolsDocumentInspector::BeforePropertyModified([[maybe_unused]] AzToolsFramework::InstanceDataNode* pNode)
     {
         if (!m_editInProgress)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -117,7 +117,7 @@ namespace AtomToolsFramework
             bool result = false;
             AtomToolsDocumentSystemRequestBus::EventResult(
                 result, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsCopy, documentId,
-                GetSaveFilePath(documentPath.toUtf8().constData()));
+                GetSaveDocumentParams(documentPath.toUtf8().constData()));
             if (!result)
             {
                 SetStatusError(tr("Document save failed: %1").arg(documentPath));
@@ -131,7 +131,7 @@ namespace AtomToolsFramework
             bool result = false;
             AtomToolsDocumentSystemRequestBus::EventResult(
                 result, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsChild, documentId,
-                GetSaveFilePath(documentPath.toUtf8().constData()));
+                GetSaveDocumentParams(documentPath.toUtf8().constData()));
             if (!result)
             {
                 SetStatusError(tr("Document save failed: %1").arg(documentPath));
@@ -494,7 +494,12 @@ namespace AtomToolsFramework
         })->setEnabled(m_tabWidget->tabBar()->count() > 1);
     }
 
-    bool AtomToolsDocumentMainWindow::GetCreateDocumentParams(AZStd::string& openPath, AZStd::string& savePath)
+    AZStd::string AtomToolsDocumentMainWindow::GetSaveDocumentParams(const AZStd::string& initialPath) const
+    {
+        return GetSaveFilePath(initialPath);
+    }
+
+    bool AtomToolsDocumentMainWindow::GetCreateDocumentParams(AZStd::string& openPath, AZStd::string& savePath) const
     {
         DocumentTypeInfoVector documentTypes;
         AtomToolsDocumentSystemRequestBus::EventResult(
@@ -515,7 +520,14 @@ namespace AtomToolsFramework
             }
 
             bool result = false;
-            QString item = QInputDialog::getItem(this, tr("Select Document Type"), tr("Select document type to create"), items, 0, false, &result);
+            QString item = QInputDialog::getItem(
+                const_cast<AtomToolsDocumentMainWindow*>(this),
+                tr("Select Document Type"),
+                tr("Select document type to create"),
+                items,
+                0,
+                false,
+                &result);
             if (!result || item.isEmpty())
             {
                 return false;
@@ -525,7 +537,10 @@ namespace AtomToolsFramework
         }
 
         const auto& documentType = documentTypes[documentTypeIndex];
-        CreateDocumentDialog dialog(documentType, AZStd::string::format("%s/Assets", AZ::Utils::GetProjectPath().c_str()).c_str(), this);
+        CreateDocumentDialog dialog(
+            documentType,
+            AZStd::string::format("%s/Assets", AZ::Utils::GetProjectPath().c_str()).c_str(),
+            const_cast<AtomToolsDocumentMainWindow*>(this));
         dialog.adjustSize();
 
         if (dialog.exec() == QDialog::Accepted && !dialog.m_sourcePath.isEmpty() && !dialog.m_targetPath.isEmpty())
@@ -537,7 +552,7 @@ namespace AtomToolsFramework
         return false;
     }
 
-    AZStd::vector<AZStd::string> AtomToolsDocumentMainWindow::GetOpenDocumentParams()
+    AZStd::vector<AZStd::string> AtomToolsDocumentMainWindow::GetOpenDocumentParams() const
     {
         DocumentTypeInfoVector documentTypes;
         AtomToolsDocumentSystemRequestBus::EventResult(

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -918,8 +918,8 @@ namespace MaterialCanvas
                     propertyGroup = materialTypeSourceData.AddPropertyGroup(propertyGroupName);
 
                     // The unmodified text value will be used as the display name and description for now
-                    propertyGroup->SetDisplayName(materialInputGroupSlot->GetValue<AZStd::string>());
-                    propertyGroup->SetDescription(materialInputGroupSlot->GetValue<AZStd::string>());
+                    propertyGroup->SetDisplayName(AtomToolsFramework::GetDisplayNameFromPath(propertyGroupName));
+                    propertyGroup->SetDescription(AtomToolsFramework::GetDisplayNameFromPath(propertyGroupName));
                 }
 
                 // Get the symbol for the material input based on the node and the property name. This will be used as both the

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
@@ -103,18 +103,6 @@ namespace MaterialCanvas
         m_documentInspector->SetDocumentId(documentId);
     }
 
-    void MaterialCanvasMainWindow::OnDocumentCleared(const AZ::Uuid& documentId)
-    {
-        Base::OnDocumentCleared(documentId);
-        m_documentInspector->SetDocumentId(documentId);
-    }
-
-    void MaterialCanvasMainWindow::OnDocumentError(const AZ::Uuid& documentId)
-    {
-        Base::OnDocumentError(documentId);
-        m_documentInspector->SetDocumentId(documentId);
-    }
-
     void MaterialCanvasMainWindow::ResizeViewportRenderTarget(uint32_t width, uint32_t height)
     {
         QSize requestedViewportSize = QSize(width, height) / devicePixelRatioF();

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.h
@@ -47,8 +47,6 @@ namespace MaterialCanvas
 
         // AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler overrides...
         void OnDocumentOpened(const AZ::Uuid& documentId) override;
-        void OnDocumentCleared(const AZ::Uuid& documentId) override;
-        void OnDocumentError(const AZ::Uuid& documentId) override;
 
         // AtomToolsFramework::AtomToolsDocumentMainWindow overrides...
         AZStd::string GetHelpDialogText() const override;

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
@@ -630,13 +630,22 @@ namespace MaterialEditor
                 AZStd::shared_ptr<AtomToolsFramework::DynamicPropertyGroup> dynamicPropertyGroup;
                 dynamicPropertyGroup.reset(aznew AtomToolsFramework::DynamicPropertyGroup);
 
-                // Copy details about this property group from the material type property group definition.
-                dynamicPropertyGroup->m_description = propertyGroup->GetDescription();
-
-                // Recombined the group name and display name vectors so that the complete hierarchy will be displayed in the UI and
-                // available for creating property IDs.
+                // Copy details about this property group from the material type property group definition. Recombine the group name and
+                // display name vectors so that the complete hierarchy will be displayed in the UI and available for creating property IDs.
                 AzFramework::StringFunc::Join(dynamicPropertyGroup->m_name, groupNameVector.begin(), groupNameVector.end(), ".");
                 AzFramework::StringFunc::Join(dynamicPropertyGroup->m_displayName, groupDisplayNameVector.begin(), groupDisplayNameVector.end(), " | ");
+
+                if (dynamicPropertyGroup->m_displayName.empty())
+                {
+                    dynamicPropertyGroup->m_displayName =
+                        !propertyGroup->GetDisplayName().empty() ? propertyGroup->GetDisplayName() : propertyGroup->GetName();
+                }
+
+                dynamicPropertyGroup->m_description = propertyGroup->GetDescription();
+                if (dynamicPropertyGroup->m_description.empty())
+                {
+                    dynamicPropertyGroup->m_description = dynamicPropertyGroup->m_displayName;
+                }
 
                 // All of the material type properties must be adapted for display in the ui. This is done by converting them into a dynamic
                 // property class that can be used to display and edit multiple types.

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.cpp
@@ -62,18 +62,6 @@ namespace MaterialEditor
         m_documentInspector->SetDocumentId(documentId);
     }
 
-    void MaterialEditorMainWindow::OnDocumentCleared(const AZ::Uuid& documentId)
-    {
-        Base::OnDocumentCleared(documentId);
-        m_documentInspector->SetDocumentId(documentId);
-    }
-
-    void MaterialEditorMainWindow::OnDocumentError(const AZ::Uuid& documentId)
-    {
-        Base::OnDocumentError(documentId);
-        m_documentInspector->SetDocumentId(documentId);
-    }
-
     void MaterialEditorMainWindow::ResizeViewportRenderTarget(uint32_t width, uint32_t height)
     {
         QSize requestedViewportSize = QSize(width, height) / devicePixelRatioF();

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.h
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.h
@@ -41,8 +41,6 @@ namespace MaterialEditor
 
         // AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler overrides...
         void OnDocumentOpened(const AZ::Uuid& documentId) override;
-        void OnDocumentCleared(const AZ::Uuid& documentId) override;
-        void OnDocumentError(const AZ::Uuid& documentId) override;
 
         // AtomToolsFramework::AtomToolsDocumentMainWindow overrides...
         AZStd::string GetHelpDialogText() const override;

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
@@ -37,19 +37,6 @@ namespace ShaderManagementConsole
         Base::OnDocumentOpened(documentId);
         m_documentInspector->SetDocumentId(documentId);
     }
-
-    void ShaderManagementConsoleWindow::OnDocumentCleared(const AZ::Uuid& documentId)
-    {
-        Base::OnDocumentCleared(documentId);
-        m_documentInspector->SetDocumentId(documentId);
-    }
-
-    void ShaderManagementConsoleWindow::OnDocumentError(const AZ::Uuid& documentId)
-    {
-        Base::OnDocumentError(documentId);
-        m_documentInspector->SetDocumentId(documentId);
-    }
-
 } // namespace ShaderManagementConsole
 
 #include <Window/moc_ShaderManagementConsoleWindow.cpp>

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
@@ -28,8 +28,6 @@ namespace ShaderManagementConsole
 
         // AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler overrides...
         void OnDocumentOpened(const AZ::Uuid& documentId) override;
-        void OnDocumentCleared(const AZ::Uuid& documentId) override;
-        void OnDocumentError(const AZ::Uuid& documentId) override;
 
     private:
         AtomToolsFramework::AtomToolsDocumentInspector* m_documentInspector = {};


### PR DESCRIPTION
## What does this PR do?

- Fix this problem in material editor, material canvas, shader management console causing inspector properties to disappear if multiple documents are open then closed. The properties would come back if reselecting the same document.
- Exposed a virtual function from the base main window class for tools to override if they want to override the file save workflow. By default, it opens a save dialog. Shader management console needs to restrict saving files to specific folders.
- Updated material canvas to export material input group names as material type property group display names and descriptions.
- Updated material editor to use a default group display name if one was not specified.

https://github.com/o3de/sig-graphics-audio/issues/51
https://github.com/o3de/o3de/issues/11380
https://github.com/o3de/o3de/issues/11342
Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Manually tested opening and closing multiple documents in all three tools.
Verified that properties appear for the currently open document.
Verified that files can still be opened and saved.
Verified that group display names and descriptions are being saved in material canvas generated material types.
verified that material editor will substitute the group name for the display name if one is not available.