### PR TITLE
More C++20 Range Improvements

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentExport.h
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentExport.h
@@ -12,6 +12,7 @@
 #include <AzCore/RTTI/TypeInfoSimple.h>
 
 #include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/function/function_fwd.h>
 
 namespace AZ
 {

--- a/Code/Framework/AzCore/AzCore/Console/ConsoleDataWrapper.inl
+++ b/Code/Framework/AzCore/AzCore/Console/ConsoleDataWrapper.inl
@@ -10,7 +10,7 @@
 
 #include <sstream>
 #include <AzCore/Console/ConsoleTypeHelpers.h>
-
+#include <AzCore/RTTI/TypeInfo.h>
 
 namespace AZ
 {

--- a/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.inl
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.inl
@@ -8,6 +8,10 @@
 
 #pragma once
 
+#include <AzCore/std/ranges/ranges_algorithm.h>
+#include <AzCore/std/ranges/as_rvalue_view.h>
+#include <AzCore/std/utility/as_const.h>
+
 namespace AZ::Dom
 {
     template<class T>
@@ -23,26 +27,30 @@ namespace AZ::Dom
     template<class Range, class>
     DomPrefixTree<T>::DomPrefixTree(Range&& range)
     {
-        for (auto&& [path, value] : AZStd::forward<Range>(range))
+        if constexpr (AZStd::is_lvalue_reference_v<Range>)
         {
-            SetValue(path, value);
+            auto AddPrefixes = [this](auto&& valuePair)
+            {
+                auto&& [path, value] = valuePair;
+                this->SetValue(path, value);
+            };
+            AZStd::ranges::for_each(range, AZStd::move(AddPrefixes));
+        }
+        else
+        {
+            auto AddPrefixes = [this](auto&& valuePair)
+            {
+                auto&& [path, value] = valuePair;
+                this->SetValue(path, AZStd::move(value));
+            };
+            AZStd::ranges::for_each(range | AZStd::views::as_rvalue, AZStd::move(AddPrefixes));
         }
     }
 
     template<class T>
     auto DomPrefixTree<T>::GetNodeForPath(const Path& path) -> Node*
     {
-        Node* node = &m_rootNode;
-        for (const auto& entry : path)
-        {
-            auto entryIt = node->m_values.find(entry);
-            if (entryIt == node->m_values.end())
-            {
-                return nullptr;
-            }
-            node = &entryIt->second;
-        }
-        return node;
+        return const_cast<Node*>(AZStd::as_const(*this).GetNodeForPath(path));
     }
 
     template<class T>

--- a/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
+++ b/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
@@ -263,4 +263,5 @@ set(FILES
     utility/as_const.h
     utility/declval.h
     utility/move.h
+    utility/to_underlying.h
 )

--- a/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
+++ b/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
@@ -33,17 +33,26 @@ set(FILES
     hash.h
     hash_table.h
     iterator/common_iterator.h
+    iterator/const_iterator.h
+    iterator/counted_iterator.h
+    iterator/move_sentinel.h
+    iterator/unreachable_sentinel.h
     iterator/iterator_primitives.h
     iterator.h
     limits.h
     numeric.h
     math.h
     optional.h
+    ranges/as_const_view.h
+    ranges/as_rvalue_view.h
     ranges/all_view.h
     ranges/common_view.h
+    ranges/counted_view.h
     ranges/elements_view.h
     ranges/empty_view.h
     ranges/filter_view.h
+    ranges/iota_internal.h
+    ranges/iota_view.h
     ranges/iter_move.h
     ranges/iter_swap.h
     ranges/join_view.h
@@ -55,6 +64,7 @@ set(FILES
     ranges/ranges_functional.h
     ranges/ranges_to.h
     ranges/ref_view.h
+    ranges/repeat_view.h
     ranges/reverse_view.h
     ranges/single_view.h
     ranges/subrange.h
@@ -247,6 +257,7 @@ set(FILES
     typetraits/conditional.h
     typetraits/has_member_function.h
     typetraits/void_t.h
+    typetraits/internal/is_complete.h
     typetraits/internal/type_sequence_traits.h
     typetraits/internal/is_template_copy_constructible.h
     utility/as_const.h

--- a/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
+++ b/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
@@ -35,6 +35,7 @@ set(FILES
     iterator/common_iterator.h
     iterator/const_iterator.h
     iterator/counted_iterator.h
+    iterator/move_iterator.h
     iterator/move_sentinel.h
     iterator/unreachable_sentinel.h
     iterator/iterator_primitives.h

--- a/Code/Framework/AzCore/AzCore/std/containers/deque.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/deque.h
@@ -12,6 +12,9 @@
 #include <AzCore/std/allocator_traits.h>
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/createdestroy.h>
+#include <AzCore/std/iterator/const_iterator.h>
+#include <AzCore/std/ranges/common_view.h>
+#include <AzCore/std/ranges/as_rvalue_view.h>
 #include <AzCore/std/typetraits/aligned_storage.h>
 #include <AzCore/std/typetraits/alignment_of.h>
 #include <AzCore/std/typetraits/is_integral.h>
@@ -30,6 +33,91 @@ namespace AZStd
         };
     };
 
+    // Forward declare deque for use in deque_iterator_impl
+    template <class T, class Allocator = AZStd::allocator, AZStd::size_t NumElementsPerBlock = AZStd::deque_block<sizeof(T)>::num_elements, AZStd::size_t MinMapSize = 8 >
+    class deque;
+
+    template <class T, class Allocator, AZStd::size_t NumElementsPerBlock, AZStd::size_t MinMapSize>
+    class deque_iterator_impl
+    {
+        enum
+        {
+            ITERATOR_VERSION = 1
+        };
+
+        typedef deque_iterator_impl                       this_type;
+        friend deque<T, Allocator, NumElementsPerBlock, MinMapSize>;
+        typedef deque<T, Allocator, NumElementsPerBlock, MinMapSize> container_type;
+    public:
+        typedef T                                   value_type;
+        typedef AZStd::ptrdiff_t                    difference_type;
+        using size_type = make_unsigned_t<difference_type>;
+        typedef T* pointer;
+        typedef T& reference;
+        typedef AZStd::random_access_iterator_tag   iterator_category;
+
+        AZ_FORCE_INLINE deque_iterator_impl()
+            : m_offset(0) {}
+        AZ_FORCE_INLINE deque_iterator_impl(size_type offset, const container_type* container)
+            : m_offset(offset)
+            , m_container(container)
+        {}
+
+        AZ_FORCE_INLINE reference operator*() const
+        {
+            size_type block = m_offset / NumElementsPerBlock;
+            size_type offset = m_offset & (NumElementsPerBlock - 1);
+            if (m_container->m_mapSize <= block)
+            {
+                block -= m_container->m_mapSize;
+            }
+            return m_container->m_map[block][offset];
+        }
+
+        AZ_FORCE_INLINE pointer operator->() const
+        {
+            size_type block = m_offset / NumElementsPerBlock;
+            size_type offset = m_offset & (NumElementsPerBlock - 1);
+            if (m_container->m_mapSize <= block)
+            {
+                block -= m_container->m_mapSize;
+            }
+            return &m_container->m_map[block][offset];
+        }
+
+        AZ_FORCE_INLINE this_type& operator++() { ++m_offset;   return *this; }
+        AZ_FORCE_INLINE this_type  operator++(int) { this_type tmp = *this; ++m_offset; return tmp; }
+        AZ_FORCE_INLINE this_type& operator--() { --m_offset;   return *this; }
+        AZ_FORCE_INLINE this_type  operator--(int) { this_type tmp = *this; --m_offset; return tmp; }
+        AZ_FORCE_INLINE this_type& operator+=(difference_type offset) { m_offset += offset; return *this; }
+        AZ_FORCE_INLINE this_type  operator+(difference_type offset) const { this_type tmp = *this; tmp += offset; return tmp; }
+        friend AZ_FORCE_INLINE this_type operator+(difference_type offset, const this_type& rhs) { this_type tmp = rhs; tmp += offset; return tmp; }
+        AZ_FORCE_INLINE this_type& operator-=(difference_type offset) { m_offset -= offset; return *this; }
+        AZ_FORCE_INLINE this_type  operator-(difference_type offset) const { this_type tmp = *this; tmp -= offset; return tmp; }
+        /// ???
+        AZ_FORCE_INLINE difference_type operator-(const this_type& rhs) const
+        {
+            return rhs.m_offset <= m_offset ? m_offset - rhs.m_offset : -(difference_type)(rhs.m_offset - m_offset);
+        }
+        AZ_FORCE_INLINE reference operator[](difference_type offset) const { this_type tmp = *this; tmp += offset; return *tmp; }
+        AZ_FORCE_INLINE bool operator==(const this_type& rhs) const { return m_offset == rhs.m_offset; }
+        AZ_FORCE_INLINE bool operator!=(const this_type& rhs) const { return m_offset != rhs.m_offset; }
+        AZ_FORCE_INLINE bool operator<(const this_type& rhs) const { return m_offset < rhs.m_offset; }
+        AZ_FORCE_INLINE bool operator>(const this_type& rhs) const { return m_offset > rhs.m_offset; }
+        AZ_FORCE_INLINE bool operator<=(const this_type& rhs) const { return m_offset <= rhs.m_offset; }
+        AZ_FORCE_INLINE bool operator>=(const this_type& rhs) const { return m_offset >= rhs.m_offset; }
+
+    protected:
+        size_type               m_offset;
+        const container_type* m_container;
+    };
+
+    // To allow incomplete types to be used with the const_iterator
+    // the list_iterator has specializations added for the basic_const_iterator
+    // constraints
+    template <class T, class Allocator, AZStd::size_t NumElementsPerBlock, AZStd::size_t MinMapSize>
+    inline constexpr bool input_or_output_iterator<deque_iterator_impl<T, Allocator, NumElementsPerBlock, MinMapSize>> = true;
+
     /**
      * The deque is complaint with \ref CStd (23.2.1). In addition we introduce the following \ref DequeExtensions "extensions".
      * \par
@@ -42,7 +130,7 @@ namespace AZStd
      * Check the deque \ref AZStdExamples.
      * \attention If you customize the block and map sizes make sure that NumElementsPerBlock and MinMapSize are >= 1.
      */
-    template <class T, class Allocator = AZStd::allocator, AZStd::size_t NumElementsPerBlock = AZStd::deque_block<sizeof(T)>::num_elements, AZStd::size_t MinMapSize = 8 >
+    template <class T, class Allocator, AZStd::size_t NumElementsPerBlock, AZStd::size_t MinMapSize>
     class deque
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
         : public Debug::checked_container_base
@@ -54,6 +142,7 @@ namespace AZStd
         };
 
         typedef deque<T, Allocator, NumElementsPerBlock, MinMapSize>   this_type;
+        friend deque_iterator_impl<T, Allocator, NumElementsPerBlock, MinMapSize>;
         // use this only for size reference
         struct block_node
         {
@@ -73,8 +162,6 @@ namespace AZStd
 
         typedef T&                                      reference;
         typedef const T&                                const_reference;
-        typedef typename Allocator::difference_type     difference_type;
-        typedef typename Allocator::size_type           size_type;
         typedef Allocator                               allocator_type;
 
         // AZSTD extension.
@@ -84,138 +171,16 @@ namespace AZStd
         typedef pointer                                 map_node_type;
         typedef map_node_type*                          map_node_ptr_type;
 
-        class const_iterator_impl
-        {
-            enum
-            {
-                ITERATOR_VERSION = 1
-            };
-
-            friend class deque;
-            typedef const_iterator_impl                 this_type;
-            typedef deque<T, Allocator, NumElementsPerBlock, MinMapSize> container_type;
-        public:
-            typedef T                                   value_type;
-            typedef AZStd::ptrdiff_t                    difference_type;
-            typedef const T*                            pointer;
-            typedef const T&                            reference;
-            typedef AZStd::random_access_iterator_tag   iterator_category;
-
-            AZ_FORCE_INLINE const_iterator_impl()
-                : m_offset(0) {}
-            AZ_FORCE_INLINE const_iterator_impl(size_type offset, const container_type* container)
-                : m_offset(offset)
-                , m_container(container)
-            {}
-
-            AZ_FORCE_INLINE reference operator*() const
-            {
-                size_type block = m_offset / NumElementsPerBlock;
-                size_type offset = m_offset & (NumElementsPerBlock - 1);
-                if (m_container->m_mapSize <= block)
-                {
-                    block -= m_container->m_mapSize;
-                }
-                return m_container->m_map[block][offset];
-            }
-
-            AZ_FORCE_INLINE pointer operator->() const
-            {
-                size_type block = m_offset / NumElementsPerBlock;
-                size_type offset = m_offset & (NumElementsPerBlock - 1);
-                if (m_container->m_mapSize <= block)
-                {
-                    block -= m_container->m_mapSize;
-                }
-                return &m_container->m_map[block][offset];
-            }
-
-            AZ_FORCE_INLINE this_type& operator++()     { ++m_offset;   return *this;   }
-            AZ_FORCE_INLINE this_type  operator++(int)  { this_type tmp = *this; ++m_offset; return tmp; }
-            AZ_FORCE_INLINE this_type& operator--()     { --m_offset;   return *this;   }
-            AZ_FORCE_INLINE this_type  operator--(int)  { this_type tmp = *this; --m_offset; return tmp; }
-            AZ_FORCE_INLINE this_type& operator+=(difference_type offset)   { m_offset += offset; return *this; }
-            AZ_FORCE_INLINE this_type  operator+(difference_type offset) const   { this_type tmp = *this; tmp += offset; return tmp; }
-            friend AZ_FORCE_INLINE this_type operator+(difference_type offset, const this_type& rhs) { this_type tmp = rhs; tmp += offset; return tmp; }
-            AZ_FORCE_INLINE this_type& operator-=(difference_type offset)   { m_offset -= offset; return *this; }
-            AZ_FORCE_INLINE this_type  operator-(difference_type offset) const  { this_type tmp = *this; tmp -= offset; return tmp; }
-            /// ???
-            AZ_FORCE_INLINE difference_type operator-(const this_type& rhs) const
-            {
-                return rhs.m_offset <= m_offset ? m_offset - rhs.m_offset : -(difference_type)(rhs.m_offset - m_offset);
-            }
-            AZ_FORCE_INLINE reference operator[](difference_type offset) const { this_type tmp = *this; tmp += offset; return *tmp; }
-            AZ_FORCE_INLINE bool operator==(const this_type& rhs) const { return m_offset == rhs.m_offset;  }
-            AZ_FORCE_INLINE bool operator!=(const this_type& rhs) const { return m_offset != rhs.m_offset;  }
-            AZ_FORCE_INLINE bool operator<(const this_type& rhs) const  { return m_offset < rhs.m_offset; }
-            AZ_FORCE_INLINE bool operator>(const this_type& rhs) const  { return m_offset > rhs.m_offset; }
-            AZ_FORCE_INLINE bool operator<=(const this_type& rhs) const { return m_offset <= rhs.m_offset; }
-            AZ_FORCE_INLINE bool operator>=(const this_type& rhs) const { return m_offset >= rhs.m_offset; }
-
-        protected:
-            size_type               m_offset;
-            const container_type*   m_container;
-        };
-
-        class iterator_impl
-            : public const_iterator_impl
-        {
-            typedef iterator_impl               this_type;
-            typedef const_iterator_impl         base_type;
-            typedef deque<T, Allocator, NumElementsPerBlock, MinMapSize> container_type;
-        public:
-            typedef T*                          pointer;
-            typedef T&                          reference;
-            typedef AZStd::ptrdiff_t            difference_type;
-
-            AZ_FORCE_INLINE iterator_impl() {}
-            AZ_FORCE_INLINE iterator_impl(size_type offset, const container_type* container)
-                : base_type(offset, container) {}
-            AZ_FORCE_INLINE reference operator*() const
-            {
-                size_type block = base_type::m_offset / NumElementsPerBlock;
-                size_type offset = base_type::m_offset & (NumElementsPerBlock - 1);
-                if (base_type::m_container->m_mapSize <= block)
-                {
-                    block -= base_type::m_container->m_mapSize;
-                }
-                return base_type::m_container->m_map[block][offset];
-            }
-
-            AZ_FORCE_INLINE pointer operator->() const
-            {
-                size_type block = base_type::m_offset / NumElementsPerBlock;
-                size_type offset = base_type::m_offset & (NumElementsPerBlock - 1);
-                if (base_type::m_container->m_mapSize <= block)
-                {
-                    block -= base_type::m_container->m_mapSize;
-                }
-                return &base_type::m_container->m_map[block][offset];
-            }
-
-            AZ_FORCE_INLINE this_type& operator++()     { ++base_type::m_offset;    return *this;   }
-            AZ_FORCE_INLINE this_type  operator++(int)  { this_type tmp = *this; ++base_type::m_offset; return tmp; }
-            AZ_FORCE_INLINE this_type& operator--()     { --base_type::m_offset;    return *this;   }
-            AZ_FORCE_INLINE this_type  operator--(int)  { this_type tmp = *this; --base_type::m_offset; return tmp; }
-            AZ_FORCE_INLINE this_type& operator+=(difference_type offset)   { base_type::m_offset += offset; return *this; }
-            AZ_FORCE_INLINE this_type  operator+(difference_type offset) const { this_type tmp = *this; tmp += offset; return tmp; }
-            friend AZ_FORCE_INLINE this_type  operator+(difference_type offset, const this_type& rhs) { this_type tmp = rhs; tmp += offset; return tmp; }
-            AZ_FORCE_INLINE this_type& operator-=(difference_type offset)   { base_type::m_offset -= offset; return *this; }
-            AZ_FORCE_INLINE this_type  operator-(difference_type offset) const { this_type tmp = *this; tmp -= offset; return tmp; }
-            AZ_FORCE_INLINE difference_type operator-(const this_type& rhs) const
-            {
-                return rhs.m_offset <= base_type::m_offset ? base_type::m_offset - rhs.m_offset : -(difference_type)(rhs.m_offset - base_type::m_offset);
-            }
-            AZ_FORCE_INLINE reference operator[](difference_type offset) const { this_type tmp = *this; tmp += offset; return *tmp; }
-        };
 
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
-        typedef Debug::checked_randomaccess_iterator<iterator_impl, this_type>           iterator;
-        typedef Debug::checked_randomaccess_iterator<const_iterator_impl, this_type> const_iterator;
+        using iterator = Debug::checked_randomaccess_iterator<deque_iterator_impl<T, Allocator, NumElementsPerBlock, MinMapSize>, this_type>;
+        using const_iterator = Debug::checked_randomaccess_iterator<basic_const_iterator<deque_iterator_impl<T, Allocator, NumElementsPerBlock, MinMapSize>>, this_type>;
 #else
-        typedef iterator_impl                           iterator;
-        typedef const_iterator_impl                     const_iterator;
+        using iterator = deque_iterator_impl<T, Allocator, NumElementsPerBlock, MinMapSize>;
+        using const_iterator = basic_const_iterator<iterator>;
 #endif
+        using difference_type = typename iterator::difference_type;
+        using size_type = make_unsigned_t<difference_type>;
 
         typedef AZStd::reverse_iterator<iterator>       reverse_iterator;
         typedef AZStd::reverse_iterator<const_iterator> const_reverse_iterator;
@@ -237,7 +202,7 @@ namespace AZStd
             , m_firstOffset(0)
             , m_size(0)
         {
-            insert(iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset, this)), numElements, value_type());
+            insert(iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset, this)), numElements, value_type());
         }
         AZ_FORCE_INLINE deque(size_type numElements, const value_type& value)
             : m_map(0)
@@ -245,7 +210,7 @@ namespace AZStd
             , m_firstOffset(0)
             , m_size(0)
         {
-            insert(iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset, this)), numElements, value);
+            insert(iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset, this)), numElements, value);
         }
         AZ_FORCE_INLINE deque(size_type numElements, const value_type& value, const Allocator& allocator)
             : m_map(0)
@@ -254,7 +219,7 @@ namespace AZStd
             , m_size(0)
             , m_allocator(allocator)
         {
-            insert(iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset, this)), numElements, value);
+            insert(iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset, this)), numElements, value);
         }
 
         AZ_FORCE_INLINE deque(const this_type& rhs)
@@ -266,7 +231,7 @@ namespace AZStd
         {
             if (!rhs.empty())
             {
-                insert(iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset, this)), rhs.begin(), rhs.end());
+                insert(iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset, this)), rhs.begin(), rhs.end());
             }
         }
 
@@ -320,19 +285,19 @@ namespace AZStd
             return *this;
         }
 
-        AZ_FORCE_INLINE iterator        begin() noexcept         { return iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset, this)); }
+        AZ_FORCE_INLINE iterator        begin() noexcept         { return iterator(m_firstOffset, this); }
         AZ_FORCE_INLINE const_iterator  begin() const noexcept   { return cbegin(); }
-        AZ_FORCE_INLINE const_iterator  cbegin() const noexcept  { return const_iterator(AZSTD_CHECKED_ITERATOR_2(const_iterator_impl, m_firstOffset, this)); }
-        AZ_FORCE_INLINE iterator        end() noexcept           { return iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset + m_size, this)); }
+        AZ_FORCE_INLINE const_iterator  cbegin() const noexcept  { return iterator(m_firstOffset, this); }
+        AZ_FORCE_INLINE iterator        end() noexcept           { return iterator(m_firstOffset + m_size, this); }
         AZ_FORCE_INLINE const_iterator  end() const noexcept     { return cend(); }
-        AZ_FORCE_INLINE const_iterator  cend() const noexcept    { return const_iterator(AZSTD_CHECKED_ITERATOR_2(const_iterator_impl, m_firstOffset + m_size, this)); }
+        AZ_FORCE_INLINE const_iterator  cend() const noexcept    { return iterator(m_firstOffset + m_size, this); }
 
-        AZ_FORCE_INLINE reverse_iterator        rbegin() noexcept        { return reverse_iterator(iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset + m_size, this))); }
+        AZ_FORCE_INLINE reverse_iterator        rbegin() noexcept        { return reverse_iterator(end()); }
         AZ_FORCE_INLINE const_reverse_iterator  rbegin() const noexcept  { return crbegin(); }
-        AZ_FORCE_INLINE const_reverse_iterator  crbegin() const noexcept { return const_reverse_iterator(const_iterator(AZSTD_CHECKED_ITERATOR_2(const_iterator_impl, m_firstOffset + m_size, this))); }
-        AZ_FORCE_INLINE reverse_iterator        rend() noexcept          { return reverse_iterator(iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset, this))); }
+        AZ_FORCE_INLINE const_reverse_iterator  crbegin() const noexcept { return const_reverse_iterator(cend()); }
+        AZ_FORCE_INLINE reverse_iterator        rend() noexcept          { return reverse_iterator(begin()); }
         AZ_FORCE_INLINE const_reverse_iterator  rend() const noexcept    { return crend(); }
-        AZ_FORCE_INLINE const_reverse_iterator  crend() const noexcept   { return const_reverse_iterator(const_iterator(AZSTD_CHECKED_ITERATOR_2(const_iterator_impl, m_firstOffset, this))); }
+        AZ_FORCE_INLINE const_reverse_iterator  crend() const noexcept   { return const_reverse_iterator(cbegin()); }
 
         AZ_FORCE_INLINE void resize(size_type newSize)              { resize(newSize, value_type()); }
         AZ_FORCE_INLINE void resize(size_type newSize, const value_type& value)
@@ -351,16 +316,16 @@ namespace AZStd
         AZ_FORCE_INLINE size_type max_size() const  { return AZStd::allocator_traits<allocator_type>::max_size(m_allocator) / sizeof(block_node_type); }
         AZ_FORCE_INLINE bool empty() const          { return m_size == 0; }
 
-        AZ_FORCE_INLINE const_reference at(size_type offset) const { return *const_iterator(AZSTD_CHECKED_ITERATOR_2(const_iterator_impl, m_firstOffset + offset, this)); }
-        AZ_FORCE_INLINE reference       at(size_type offset)       { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset + offset, this)); }
-        AZ_FORCE_INLINE const_reference operator[](size_type offset) const { return *const_iterator(AZSTD_CHECKED_ITERATOR_2(const_iterator_impl, m_firstOffset + offset, this)); }
-        AZ_FORCE_INLINE reference       operator[](size_type offset)       { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset + offset, this)); }
+        AZ_FORCE_INLINE const_reference at(size_type offset) const { return iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset + offset, this)); }
+        AZ_FORCE_INLINE reference       at(size_type offset)       { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset + offset, this)); }
+        AZ_FORCE_INLINE const_reference operator[](size_type offset) const { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset + offset, this)); }
+        AZ_FORCE_INLINE reference       operator[](size_type offset)       { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset + offset, this)); }
 
-        AZ_FORCE_INLINE const_reference front() const   { return *const_iterator(AZSTD_CHECKED_ITERATOR_2(const_iterator_impl, m_firstOffset, this)); }
-        AZ_FORCE_INLINE reference       front()         { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset, this)); }
+        AZ_FORCE_INLINE const_reference front() const   { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset, this)); }
+        AZ_FORCE_INLINE reference       front()         { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset, this)); }
 
-        AZ_FORCE_INLINE const_reference back() const    { return *const_iterator(AZSTD_CHECKED_ITERATOR_2(const_iterator_impl, m_firstOffset + m_size - 1, this)); }
-        AZ_FORCE_INLINE reference       back()          { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset + m_size - 1, this)); }
+        AZ_FORCE_INLINE const_reference back() const    { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset + m_size - 1, this)); }
+        AZ_FORCE_INLINE reference       back()          { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset + m_size - 1, this)); }
 
         inline void push_front(const value_type& value)
         {
@@ -482,11 +447,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                assign_iter(ranges::begin(rg), ranges::end(rg), false_type{});
+                auto rangeView = rg | views::common;
+                assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                assign_iter(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)), false_type{});
+                auto rangeView = rg | views::as_rvalue | views::common;
+                assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }
 
@@ -611,11 +578,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                return insert_iter(insertPos, ranges::begin(rg), ranges::end(rg), false_type{});
+                auto rangeView = rg | views::common;
+                return insert_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                return insert_iter(insertPos, make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)), false_type{});
+                auto rangeView = rg | views::as_rvalue | views::common;
+                return insert_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }
 
@@ -633,8 +602,8 @@ namespace AZStd
         {
             AZSTD_CONTAINER_ASSERT(constFirst <= constLast, "AZStd::deque::erase - first iterator should be before last iterator!");
 
-            iterator first = AZStd::Internal::ConstIteratorCast<iterator>(constFirst);
-            iterator last = AZStd::Internal::ConstIteratorCast<iterator>(constLast);
+            iterator first = constFirst.base();
+            iterator last = constLast.base();
 
             size_type offset = first - begin();
             size_type numElements = last - first;
@@ -941,11 +910,11 @@ namespace AZStd
         inline int      validate_iterator(const const_iterator& iter) const
         {
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
-            AZ_Assert(iter.m_container == this, "This iterator doesn't belong to this container");
-            size_type iterOffset = iter.m_iter.m_offset;
+            AZ_Assert(iter.base().m_container == this, "This iterator doesn't belong to this container");
+            size_type iterOffset = iter.base().m_iter.m_offset;
             //          AZ_Assert(iter.m_iter.m_container==this,"AZStd::deque::validate_iterator - this iter doesn't belong to this container!");
 #else
-            size_type iterOffset = iter.m_offset;
+            size_type iterOffset = iter.base().m_offset;
 #endif
             if (iterOffset < m_firstOffset || iterOffset > (m_firstOffset + m_size))
             {
@@ -979,13 +948,13 @@ namespace AZStd
         template <class InputIterator>
         AZ_FORCE_INLINE void    construct_iter(const InputIterator& first, const InputIterator& last, const true_type& /* is_integral<InputIterator> */)
         {
-            insert(iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset, this)), (size_type)first, (value_type)last);
+            insert(iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset, this)), (size_type)first, (value_type)last);
         }
 
         template <class InputIterator>
         AZ_FORCE_INLINE void    construct_iter(const InputIterator& first, const InputIterator& last, const false_type& /* !is_integral<InputIterator> */)
         {
-            insert(iterator(AZSTD_CHECKED_ITERATOR_2(iterator_impl, m_firstOffset, this)), first, last);
+            insert(iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset, this)), first, last);
         }
 
         AZ_FORCE_INLINE void    deallocate_memory(void* ptr, size_type size, size_type alignment, const true_type& /* allocator::allow_memory_leaks */)
@@ -1137,7 +1106,7 @@ namespace AZStd
             while (iter != 0)
             {
                 AZ_Assert(iter->m_container == static_cast<const checked_container_base*>(this), "AZStd::deque::orphan_range - iterator was corrupted!");
-                iterator_impl deqIter = static_cast<iterator*>(iter)->m_iter;
+                iterator deqIter = static_cast<iterator*>(iter)->m_iter;
                 if (deqIter.m_offset >= offset && deqIter.m_offset <= offset_end)
                 {
                     // orphan the iterator

--- a/Code/Framework/AzCore/AzCore/std/containers/deque.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/deque.h
@@ -447,12 +447,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }
@@ -578,12 +578,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 return insert_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 return insert_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }

--- a/Code/Framework/AzCore/AzCore/std/containers/fixed_vector.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/fixed_vector.h
@@ -11,7 +11,8 @@
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/containers/containers_concepts.h>
 #include <AzCore/std/createdestroy.h>
-#include <AzCore/std/ranges/ranges.h>
+#include <AzCore/std/ranges/common_view.h>
+#include <AzCore/std/ranges/as_rvalue_view.h>
 #include <AzCore/std/typetraits/typetraits.h>
 
 namespace AZStd::Internal
@@ -633,11 +634,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                assign(ranges::begin(rg), ranges::end(rg));
+                auto rangeView = rg | views::common;
+                assign(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                assign(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)));
+                auto rangeView = rg | views::as_rvalue | views::common;
+                assign(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
 
@@ -748,12 +751,14 @@ namespace AZStd
             AZSTD_CONTAINER_ASSERT(insertPos >= cbegin() && insertPos <= cend(), "insert position must be in range of container");
             if constexpr (is_lvalue_reference_v<R>)
             {
-                return insert_iter(insertPos, ranges::begin(rg), ranges::end(rg),
+                auto rangeView = rg | views::common;
+                return insert_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView),
                     typename iterator_traits<ranges::iterator_t<R>>::iterator_category());
             }
             else
             {
-                return insert_iter(insertPos, make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)),
+                auto rangeView = rg | views::as_rvalue | views::common;
+                return insert_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView),
                     typename iterator_traits<ranges::iterator_t<R>>::iterator_category());
             }
         };

--- a/Code/Framework/AzCore/AzCore/std/containers/fixed_vector.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/fixed_vector.h
@@ -634,12 +634,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 assign(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 assign(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
@@ -751,13 +751,13 @@ namespace AZStd
             AZSTD_CONTAINER_ASSERT(insertPos >= cbegin() && insertPos <= cend(), "insert position must be in range of container");
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 return insert_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView),
                     typename iterator_traits<ranges::iterator_t<R>>::iterator_category());
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 return insert_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView),
                     typename iterator_traits<ranges::iterator_t<R>>::iterator_category());
             }

--- a/Code/Framework/AzCore/AzCore/std/containers/forward_list.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/forward_list.h
@@ -13,6 +13,8 @@
 #include <AzCore/std/containers/containers_concepts.h>
 #include <AzCore/std/createdestroy.h>
 #include <AzCore/std/ranges/ranges_algorithm.h>
+#include <AzCore/std/ranges/common_view.h>
+#include <AzCore/std/ranges/as_rvalue_view.h>
 
 namespace AZStd
 {
@@ -36,7 +38,7 @@ namespace AZStd
      * Constant forward list iterator implementation. SCARY iterator implementation.
      */
     template<class T>
-    class forward_list_const_iterator
+    class forward_list_iterator
     {
         enum
         {
@@ -45,12 +47,12 @@ namespace AZStd
 
         template<class E, class A>
         friend class forward_list;
-        typedef forward_list_const_iterator         this_type;
+        typedef forward_list_iterator               this_type;
     public:
         typedef T                                   value_type;
         typedef AZStd::ptrdiff_t                    difference_type;
-        typedef const T*                            pointer;
-        typedef const T&                            reference;
+        typedef T*                                  pointer;
+        typedef T&                                  reference;
         typedef AZStd::forward_iterator_tag         iterator_category;
 
         typedef Internal::forward_list_node<T>      node_type;
@@ -58,9 +60,9 @@ namespace AZStd
         typedef Internal::forward_list_node_base    base_node_type;
         typedef base_node_type*                     base_node_ptr_type;
 
-        AZ_FORCE_INLINE forward_list_const_iterator()
+        AZ_FORCE_INLINE forward_list_iterator()
             : m_node(0) {}
-        AZ_FORCE_INLINE forward_list_const_iterator(base_node_ptr_type baseNode)
+        AZ_FORCE_INLINE explicit forward_list_iterator(base_node_ptr_type baseNode)
             : m_node(baseNode) {}
         AZ_FORCE_INLINE reference operator*() const { return static_cast<node_ptr_type>(m_node)->m_value; }
         AZ_FORCE_INLINE pointer operator->() const { return &static_cast<node_ptr_type>(m_node)->m_value; }
@@ -92,45 +94,11 @@ namespace AZStd
         base_node_ptr_type  m_node;
     };
 
-    /**
-     * Forward list iterator implementation. SCARY iterator implementation.
-     */
-    template<class T>
-    class forward_list_iterator
-        : public forward_list_const_iterator<T>
-    {
-        typedef forward_list_iterator           this_type;
-        typedef forward_list_const_iterator<T>  base_type;
-    public:
-        typedef T*                              pointer;
-        typedef T&                              reference;
-
-        typedef typename base_type::node_type           node_type;
-        typedef typename base_type::node_ptr_type       node_ptr_type;
-        typedef typename base_type::base_node_type      base_node_type;
-        typedef typename base_type::base_node_ptr_type  base_node_ptr_type;
-
-        AZ_FORCE_INLINE forward_list_iterator() {}
-        AZ_FORCE_INLINE forward_list_iterator(base_node_ptr_type baseNode)
-            : forward_list_const_iterator<T>(baseNode) {}
-        AZ_FORCE_INLINE reference operator*() const { return static_cast<node_ptr_type>(base_type::m_node)->m_value; }
-        AZ_FORCE_INLINE pointer operator->() const { return &(static_cast<node_ptr_type>(base_type::m_node)->m_value); }
-        AZ_FORCE_INLINE this_type& operator++()
-        {
-            AZSTD_CONTAINER_ASSERT(base_type::m_node != 0, "AZSTD::forward_list::iterator_impl invalid node!");
-            base_type::m_node = base_type::m_node->m_next;
-            return *this;
-        }
-
-        AZ_FORCE_INLINE this_type operator++(int)
-        {
-            AZSTD_CONTAINER_ASSERT(base_type::m_node != 0, "AZSTD::forward_list::iterator_impl invalid node!");
-            this_type temp = *this;
-            base_type::m_node = base_type::m_node->m_next;
-            return temp;
-        }
-    };
-
+    // To allow incomplete types to be used with the const_iterator
+    // the forward list iterator has specializations added for the basic_const_iterator
+    // constraints
+    template<class I>
+    inline constexpr bool input_or_output_iterator<forward_list_iterator<I>> = true;
 
     /**
     * The list container (single linked list) is complaint with \ref CStd (23.2.2). In addition we introduce the following \ref ListExtensions "extensions".
@@ -167,8 +135,6 @@ namespace AZStd
 
     public:
         using allocator_type = Allocator;
-        using difference_type = typename AZStd::allocator_traits<allocator_type>::difference_type;
-        using size_type = typename AZStd::allocator_traits<allocator_type>::size_type;
 
     private:
         // AZSTD extension.
@@ -176,8 +142,8 @@ namespace AZStd
         using base_node_type = Internal::forward_list_node_base;
         using base_node_ptr_type = base_node_type*;
 
-        using const_iterator_impl = forward_list_const_iterator<T>;
         using iterator_impl = forward_list_iterator<T>;
+        using const_iterator_impl = basic_const_iterator<iterator_impl>;
 
     public:
         // Non-extension type aliases
@@ -188,6 +154,8 @@ namespace AZStd
         using iterator = iterator_impl;
         using const_iterator = const_iterator_impl;
 #endif
+        using difference_type = iter_difference_t<iterator>;
+        using size_type = make_unsigned_t<difference_type>;
 
         AZ_FORCE_INLINE forward_list()
             : m_numElements(0)
@@ -306,11 +274,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                assign_iter(ranges::begin(rg), ranges::end(rg), false_type{});
+                auto rangeView = rg | views::common;
+                assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                assign_iter(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)), false_type{});
+                auto rangeView = rg | views::as_rvalue | views::common;
+                assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }
 
@@ -328,12 +298,12 @@ namespace AZStd
         AZ_FORCE_INLINE size_type   max_size() const { return AZStd::allocator_traits<allocator_type>::max_size(m_allocator) / sizeof(node_type); }
         [[nodiscard]] bool    empty() const { return (m_numElements == 0); }
 
-        AZ_FORCE_INLINE iterator begin() { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, m_head.m_next)); }
-        AZ_FORCE_INLINE const_iterator begin() const { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, m_head.m_next)); }
-        AZ_FORCE_INLINE iterator end() { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, &m_head)); }
-        AZ_FORCE_INLINE const_iterator end() const { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, const_cast<base_node_ptr_type>(&m_head))); }
-        AZ_FORCE_INLINE iterator before_begin() { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, &m_head)); }
-        AZ_FORCE_INLINE const_iterator before_begin() const { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, const_cast<base_node_ptr_type>(&m_head))); }
+        AZ_FORCE_INLINE iterator begin() { return iterator(m_head.m_next); }
+        AZ_FORCE_INLINE const_iterator begin() const { return const_iterator(iterator(m_head.m_next)); }
+        AZ_FORCE_INLINE iterator end() { return iterator(&m_head); }
+        AZ_FORCE_INLINE const_iterator end() const { return const_iterator(iterator(const_cast<base_node_ptr_type>(&m_head))); }
+        AZ_FORCE_INLINE iterator before_begin() { return iterator(&m_head); }
+        AZ_FORCE_INLINE const_iterator before_begin() const { return const_iterator(iterator(const_cast<base_node_ptr_type>(&m_head))); }
 
         // AZStd Extensions for tracking the last node within the forward_list
         // This isn't a fast function, as it involves traversing the list from the beginning
@@ -346,19 +316,19 @@ namespace AZStd
 #else
             base_node_ptr_type iNode = iter.m_node;
 #endif
-            return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, previous(iNode)));
+            return iterator(previous(iNode));
         }
         AZ_FORCE_INLINE const_iterator previous(const_iterator iter)
         {
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
-            base_node_ptr_type iNode = iter.get_iterator().m_node;
+            base_node_ptr_type iNode = iter.base().get_iterator().m_node;
 #else
-            base_node_ptr_type iNode = iter.m_node;
+            base_node_ptr_type iNode = iter.base().m_node;
 #endif
-            return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, previous(iNode)));
+            return const_iterator(iterator(previous(iNode)));
         }
-        AZ_FORCE_INLINE iterator before_end() { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, m_lastNode)); }
-        AZ_FORCE_INLINE const_iterator before_end() const { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, const_cast<base_node_ptr_type>(m_lastNode))); }
+        AZ_FORCE_INLINE iterator before_end() { return iterator(m_lastNode); }
+        AZ_FORCE_INLINE const_iterator before_end() const { return const_iterator(iterator(const_cast<base_node_ptr_type>(m_lastNode))); }
 
         inline void resize(size_type newNumElements, const_reference value = value_type())
         {
@@ -451,11 +421,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                return insert_after_iter(insertPos, ranges::begin(rg), ranges::end(rg), false_type{});
+                auto rangeView = rg | views::common;
+                return insert_after_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                return insert_after_iter(insertPos, make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)), false_type{});
+                auto rangeView = rg | views::as_rvalue | views::common;
+                return insert_after_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }
 
@@ -482,9 +454,9 @@ namespace AZStd
             construct_at(ptr, AZStd::forward<Args>(args)...);
 
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
-            base_node_ptr_type prevNode = insertPos.get_iterator().m_node;
+            base_node_ptr_type prevNode = insertPos.base().get_iterator().m_node;
 #else
-            base_node_ptr_type prevNode = insertPos.m_node;
+            base_node_ptr_type prevNode = insertPos.base().m_node;
 #endif
 
             ++m_numElements;
@@ -505,12 +477,12 @@ namespace AZStd
             m_numElements += numElements;
 
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
-            base_node_ptr_type prevNode = insertPos.get_iterator().m_node;
+            base_node_ptr_type prevNode = insertPos.base().get_iterator().m_node;
 #else
-            base_node_ptr_type prevNode = insertPos.m_node;
+            base_node_ptr_type prevNode = insertPos.base().m_node;
 #endif
             // Tracks the first insert node to return as the iterator value
-            iterator returnIter(insertPos.m_node);
+            iterator returnIter(insertPos.base().m_node);
             base_node_ptr_type insNode = prevNode->m_next;
 
             for (bool firstIteration = true; 0 < numElements; --numElements, firstIteration = false)
@@ -544,13 +516,13 @@ namespace AZStd
         inline iterator erase_after(const_iterator toEraseNext)
         {
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
-            base_node_ptr_type prevNode = toEraseNext.get_iterator().m_node;
+            base_node_ptr_type prevNode = toEraseNext.base().get_iterator().m_node;
             ++toEraseNext; // This will validate the operation.
-            base_node_ptr_type node = toEraseNext.get_iterator().m_node;
+            base_node_ptr_type node = toEraseNext.base().get_iterator().m_node;
             orphan_node(node);
 #else
-            AZSTD_CONTAINER_ASSERT(toEraseNext.m_node != 0, "AZStd::forward_list::erase_after - invalid node!");
-            base_node_ptr_type prevNode = toEraseNext.m_node;
+            AZSTD_CONTAINER_ASSERT(toEraseNext.base().m_node != 0, "AZStd::forward_list::erase_after - invalid node!");
+            base_node_ptr_type prevNode = toEraseNext.base().m_node;
             base_node_ptr_type node = prevNode->m_next;
 #endif
             pointer toDestroy = &static_cast<node_ptr_type>(node)->m_value;
@@ -570,8 +542,8 @@ namespace AZStd
 
         inline iterator erase_after(const_iterator constPrevFirst, const_iterator constLast)
         {
-            iterator prevFirst = AZStd::Internal::ConstIteratorCast<iterator>(constPrevFirst);
-            iterator last = AZStd::Internal::ConstIteratorCast<iterator>(constLast);
+            iterator prevFirst = constPrevFirst.base();
+            iterator last = constLast.base();
             iterator first = prevFirst;
             ++first; // to the first element to delete
             while (first != last)
@@ -764,7 +736,7 @@ namespace AZStd
         {
             AZSTD_CONTAINER_ASSERT(this != &rhs || splicePos != last, "AZSTD::forward_list::splice_after invalid iterators");
 
-            if (AZStd::next(beforeFirst) == last)
+            if (ranges::next(beforeFirst) == last)
             {
                 // There are no nodes after "beforeFirst" and before "last" that can be spliced
                 return;
@@ -773,23 +745,23 @@ namespace AZStd
             if (m_allocator == rhs.m_allocator)
             {
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
-                base_node_ptr_type beforeFirstNode = beforeFirst.get_iterator().m_node;
-                base_node_ptr_type lastNode = last.get_iterator().m_node;
-                base_node_ptr_type splicePosNode = splicePos.get_iterator().m_node;
+                base_node_ptr_type beforeFirstNode = beforeFirst.base().get_iterator().m_node;
+                base_node_ptr_type lastNode = last.base().get_iterator().m_node;
+                base_node_ptr_type splicePosNode = splicePos.base().get_iterator().m_node;
                 if (this != &rhs)  // only if we actually moving nodes, from different lists.
                 {
                     for (iterator next = beforeFirst; next != last; )
                     {
-                        base_node_ptr_type node = next.get_iterator().m_node;
+                        base_node_ptr_type node = next.base().get_iterator().m_node;
                         ++next;
                         rhs.orphan_node(node);
                     }
                 }
 #else
-                base_node_ptr_type beforeFirstNode = beforeFirst.m_node;
+                base_node_ptr_type beforeFirstNode = beforeFirst.base().m_node;
                 base_node_ptr_type firstNode = beforeFirstNode->m_next;
-                base_node_ptr_type lastNode = last.m_node;
-                base_node_ptr_type splicePosNode = splicePos.m_node;
+                base_node_ptr_type lastNode = last.base().m_node;
+                base_node_ptr_type splicePosNode = splicePos.base().m_node;
 #endif
 
                 base_node_ptr_type preLastNode = beforeFirstNode;
@@ -1127,9 +1099,9 @@ namespace AZStd
         {
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
             AZ_Assert(iter.m_container == this, "Iterator doesn't belong to this container");
-            base_node_ptr_type iterNode = iter.m_iter.m_node;
+            base_node_ptr_type iterNode = iter.base().m_iter.m_node;
 #else
-            base_node_ptr_type iterNode = iter.m_node;
+            base_node_ptr_type iterNode = iter.base().m_node;
 #endif
 
             if (iterNode == &m_head)
@@ -1213,7 +1185,7 @@ namespace AZStd
         template <class InputIterator>
         iterator insert_after_iter(const_iterator insertPos, InputIterator first, InputIterator last, const false_type& /* !is_integral<InputIterator> */)
         {
-            iterator returnIter(insertPos.m_node);
+            iterator returnIter(insertPos.base().m_node);
             for (bool firstIteration = true; first != last; ++first, ++insertPos, firstIteration = false)
             {
                 // The first iteration of the loop sets the iterator to the beginning of the inserted elements

--- a/Code/Framework/AzCore/AzCore/std/containers/forward_list.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/forward_list.h
@@ -274,12 +274,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }
@@ -421,12 +421,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 return insert_after_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 return insert_after_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }

--- a/Code/Framework/AzCore/AzCore/std/containers/list.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/list.h
@@ -275,12 +275,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }
@@ -469,12 +469,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 return insert_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 return insert_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }

--- a/Code/Framework/AzCore/AzCore/std/containers/list.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/list.h
@@ -12,6 +12,9 @@
 #include <AzCore/std/allocator_traits.h>
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/createdestroy.h>
+#include <AzCore/std/iterator/const_iterator.h>
+#include <AzCore/std/ranges/common_view.h>
+#include <AzCore/std/ranges/as_rvalue_view.h>
 #include <AzCore/std/typetraits/alignment_of.h>
 #include <AzCore/std/typetraits/is_constructible.h>
 #include <AzCore/std/typetraits/is_integral.h>
@@ -38,7 +41,7 @@ namespace AZStd
      * List constant iterator implementation. SCARY iterator implementation.
      */
     template< class T >
-    class list_const_iterator
+    class list_iterator
     {
         enum
         {
@@ -47,12 +50,12 @@ namespace AZStd
 
         template<class E, class A>
         friend class list;
-        typedef list_const_iterator                 this_type;
+        typedef list_iterator                       this_type;
     public:
         typedef T                                   value_type;
         typedef AZStd::ptrdiff_t                    difference_type;
-        typedef const T*                            pointer;
-        typedef const T&                            reference;
+        typedef T*                                  pointer;
+        typedef T&                                  reference;
         typedef AZStd::bidirectional_iterator_tag   iterator_category;
 
         typedef Internal::list_node<T>              node_type;
@@ -60,9 +63,9 @@ namespace AZStd
         typedef Internal::list_node_base            base_node_type;
         typedef base_node_type*                     base_node_ptr_type;
 
-        AZ_FORCE_INLINE list_const_iterator()
-            : m_node(0) {}
-        AZ_FORCE_INLINE list_const_iterator(base_node_ptr_type node)
+        AZ_FORCE_INLINE list_iterator() = default;
+
+        AZ_FORCE_INLINE explicit list_iterator(base_node_ptr_type node)
             : m_node(node) {}
         AZ_FORCE_INLINE reference operator*() const { return static_cast<node_ptr_type>(m_node)->m_value; }
         AZ_FORCE_INLINE pointer operator->() const { return &static_cast<node_ptr_type>(m_node)->m_value; }
@@ -105,63 +108,15 @@ namespace AZStd
             return (m_node != rhs.m_node);
         }
     protected:
-        base_node_ptr_type  m_node;
+        base_node_ptr_type m_node{};
     };
 
-    /**
-     * List iterator implementation. SCARY iterator implementation.
-     */
+
+    // To allow incomplete types to be used with the const_iterator
+    // the list_iterator has specializations added for the basic_const_iterator
+    // constraints
     template<class T>
-    class list_iterator
-        : public list_const_iterator<T>
-    {
-        typedef list_iterator                   this_type;
-        typedef list_const_iterator<T>          base_type;
-    public:
-        typedef T*                              pointer;
-        typedef T&                              reference;
-
-        typedef typename base_type::node_type           node_type;
-        typedef typename base_type::node_ptr_type       node_ptr_type;
-        typedef typename base_type::base_node_type      base_node_type;
-        typedef typename base_type::base_node_ptr_type  base_node_ptr_type;
-
-        AZ_FORCE_INLINE list_iterator() {}
-        AZ_FORCE_INLINE list_iterator(base_node_ptr_type node)
-            : list_const_iterator<T>(node)   {}
-        AZ_FORCE_INLINE this_type& operator++()
-        {
-            AZSTD_CONTAINER_ASSERT(base_type::m_node != 0, "AZSTD::list::iterator_impl invalid node!");
-            base_type::m_node = base_type::m_node->m_next;
-            return *this;
-        }
-
-        AZ_FORCE_INLINE reference operator*() const { return static_cast<node_ptr_type>(base_type::m_node)->m_value; }
-        AZ_FORCE_INLINE pointer operator->() const { return &(static_cast<node_ptr_type>(base_type::m_node)->m_value); }
-        AZ_FORCE_INLINE this_type operator++(int)
-        {
-            AZSTD_CONTAINER_ASSERT(base_type::m_node != 0, "AZSTD::list::iterator_impl invalid node!");
-            this_type temp = *this;
-            base_type::m_node = base_type::m_node->m_next;
-            return temp;
-        }
-
-        AZ_FORCE_INLINE this_type& operator--()
-        {
-            AZSTD_CONTAINER_ASSERT(base_type::m_node != 0, "AZSTD::list::const_iterator invalid node!");
-            base_type::m_node = base_type::m_node->m_prev;
-            return *this;
-        }
-
-        AZ_FORCE_INLINE this_type operator--(int)
-        {
-            AZSTD_CONTAINER_ASSERT(base_type::m_node != 0, "AZSTD::list::const_iterator invalid node!");
-            this_type temp = *this;
-            base_type::m_node = base_type::m_node->m_prev;
-            return temp;
-        }
-    };
-
+    inline constexpr bool input_or_output_iterator<list_iterator<T>> = true;
 
     /**
     * The list container (double linked list) is complaint with \ref CStd (23.2.2). In addition we introduce the following \ref ListExtensions "extensions".
@@ -194,8 +149,6 @@ namespace AZStd
 
         typedef T&                                      reference;
         typedef const T&                                const_reference;
-        typedef typename Allocator::difference_type     difference_type;
-        typedef typename Allocator::size_type           size_type;
         typedef Allocator                               allocator_type;
 
         // AZSTD extension.
@@ -205,15 +158,17 @@ namespace AZStd
         typedef Internal::list_node_base                base_node_type;
         typedef base_node_type*                         base_node_ptr_type;
 
-        typedef list_const_iterator<T>                  const_iterator_impl;
-        typedef list_iterator<T>                        iterator_impl;
+        using iterator_impl = list_iterator<T>;
+        using const_iterator_impl = basic_const_iterator<iterator_impl>;
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
-        typedef Debug::checked_bidirectional_iterator<iterator_impl, this_type>          iterator;
-        typedef Debug::checked_bidirectional_iterator<const_iterator_impl, this_type>    const_iterator;
+        using iterator = Debug::checked_bidirectional_iterator<iterator_impl, this_type>;
+        using const_iterator = Debug::checked_bidirectional_iterator<const_iterator_impl, this_type>;
 #else
-        typedef iterator_impl                           iterator;
-        typedef const_iterator_impl                     const_iterator;
+        using iterator = iterator_impl;
+        using const_iterator = const_iterator_impl;
 #endif
+        using difference_type = typename iterator::difference_type;
+        using size_type = make_unsigned_t<difference_type>;
 
         typedef AZStd::reverse_iterator<iterator>       reverse_iterator;
         typedef AZStd::reverse_iterator<const_iterator> const_reverse_iterator;
@@ -320,11 +275,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                assign_iter(ranges::begin(rg), ranges::end(rg), false_type{});
+                auto rangeView = rg | views::common;
+                assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                assign_iter(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)), false_type{});
+                auto rangeView = rg | views::as_rvalue | views::common;
+                assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }
 
@@ -333,19 +290,19 @@ namespace AZStd
             assign(iList.begin(), iList.end());
         }
 
-        AZ_FORCE_INLINE size_type   size() const            { return m_numElements; }
-        AZ_FORCE_INLINE size_type   max_size() const        { return AZStd::allocator_traits<allocator_type>::max_size(m_allocator) / sizeof(node_type); }
-        AZ_FORCE_INLINE bool    empty() const               { return (m_numElements == 0); }
+        AZ_FORCE_INLINE size_type   size() const { return m_numElements; }
+        AZ_FORCE_INLINE size_type   max_size() const { return AZStd::allocator_traits<allocator_type>::max_size(m_allocator) / sizeof(node_type); }
+        AZ_FORCE_INLINE bool    empty() const { return (m_numElements == 0); }
 
-        AZ_FORCE_INLINE iterator begin()                    { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, m_head.m_next)); }
-        AZ_FORCE_INLINE const_iterator begin() const        { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, m_head.m_next)); }
-        AZ_FORCE_INLINE iterator end()                      { return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, &m_head)); }
-        AZ_FORCE_INLINE const_iterator end() const          { return const_iterator(AZSTD_CHECKED_ITERATOR(const_iterator_impl, const_cast<base_node_ptr_type>(&m_head))); }
+        AZ_FORCE_INLINE iterator begin() { return iterator(m_head.m_next); }
+        AZ_FORCE_INLINE const_iterator begin() const { return const_iterator(iterator(m_head.m_next)); }
+        AZ_FORCE_INLINE iterator end() { return iterator(&m_head); }
+        AZ_FORCE_INLINE const_iterator end() const { return const_iterator(iterator(const_cast<base_node_ptr_type>(&m_head))); }
 
-        AZ_FORCE_INLINE reverse_iterator rbegin()           { return reverse_iterator(end()); }
-        AZ_FORCE_INLINE const_reverse_iterator rbegin() const{ return const_reverse_iterator(end()); }
-        AZ_FORCE_INLINE reverse_iterator rend()             { return reverse_iterator(begin()); }
-        AZ_FORCE_INLINE const_reverse_iterator rend() const { return const_reverse_iterator(begin());   }
+        AZ_FORCE_INLINE reverse_iterator rbegin() { return reverse_iterator(end()); }
+        AZ_FORCE_INLINE const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
+        AZ_FORCE_INLINE reverse_iterator rend() { return reverse_iterator(begin()); }
+        AZ_FORCE_INLINE const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
 
         AZ_FORCE_INLINE void resize(size_type newNumElements, const_reference value = value_type())
         {   // determine new length, padding with value elements as needed
@@ -362,28 +319,28 @@ namespace AZStd
             }
         }
 
-        AZ_FORCE_INLINE reference front()               { return (*begin()); }
-        AZ_FORCE_INLINE const_reference front() const   { return (*begin()); }
-        AZ_FORCE_INLINE reference back()                { return (*(--end())); }
-        AZ_FORCE_INLINE const_reference back() const    { return (*(--end())); }
+        AZ_FORCE_INLINE reference front() { return (*begin()); }
+        AZ_FORCE_INLINE const_reference front() const { return (*begin()); }
+        AZ_FORCE_INLINE reference back() { return (*(--end())); }
+        AZ_FORCE_INLINE const_reference back() const { return (*(--end())); }
 
         // 23.2.2.3 modifiers
-        AZ_FORCE_INLINE void push_front(const_reference value)  { insert(begin(), value); }
+        AZ_FORCE_INLINE void push_front(const_reference value) { insert(begin(), value); }
         template<class R>
         auto prepend_range(R&& rg) -> enable_if_t<Internal::container_compatible_range<R, T>>
         {
             insert_range(begin(), AZStd::forward<R>(rg));
         }
-        AZ_FORCE_INLINE void pop_front()                        { erase(begin()); }
-        AZ_FORCE_INLINE void push_back(const_reference value)   { insert(end(), value); }
+        AZ_FORCE_INLINE void pop_front() { erase(begin()); }
+        AZ_FORCE_INLINE void push_back(const_reference value) { insert(end(), value); }
         template<class R>
         auto append_range(R&& rg) -> enable_if_t<Internal::container_compatible_range<R, T>>
         {
             insert_range(end(), AZStd::forward<R>(rg));
         }
-        AZ_FORCE_INLINE void pop_back()                         { erase(--end()); }
+        AZ_FORCE_INLINE void pop_back() { erase(--end()); }
 
-        template <typename MyAllocator=allocator_type>
+        template <typename MyAllocator = allocator_type>
         list(this_type&& rhs, typename AZStd::enable_if_t<AZStd::is_default_constructible<MyAllocator>::value>* = nullptr)
             : m_numElements(0)
         {
@@ -440,7 +397,7 @@ namespace AZStd
         iterator emplace(const_iterator insertPos, ArgumentsInputs&& ... arguments)
         {
             insert_element(insertPos, AZStd::forward<ArgumentsInputs>(arguments) ...);
-            return iterator((--insertPos).m_node);
+            return iterator((--insertPos).base().m_node);
         }
 
         iterator insert(const_iterator insertPos, initializer_list<T> ilist)
@@ -457,9 +414,9 @@ namespace AZStd
             Internal::construct<pointer>::single(ptr, value);
 
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
-            base_node_ptr_type insNode = insertPos.get_iterator().m_node;
+            base_node_ptr_type insNode = insertPos.base().get_iterator().m_node;
 #else
-            base_node_ptr_type insNode = insertPos.m_node;
+            base_node_ptr_type insNode = insertPos.base().m_node;
 #endif
 
             ++m_numElements;
@@ -476,12 +433,12 @@ namespace AZStd
             m_numElements += numElements;
 
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
-            base_node_ptr_type insNode = insertPos.get_iterator().m_node;
+            base_node_ptr_type insNode = insertPos.base().get_iterator().m_node;
 #else
-            base_node_ptr_type insNode = insertPos.m_node;
+            base_node_ptr_type insNode = insertPos.base().m_node;
 #endif
 
-            for (; 0  < numElements; --numElements)
+            for (; 0 < numElements; --numElements)
             {
                 node_ptr_type newNode = reinterpret_cast<node_ptr_type>(m_allocator.allocate(sizeof(node_type), alignment_of<node_type>::value));
                 // copy construct
@@ -512,21 +469,23 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                return insert_iter(insertPos, ranges::begin(rg), ranges::end(rg), false_type{});
+                auto rangeView = rg | views::common;
+                return insert_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                return insert_iter(insertPos, make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)), false_type{});
+                auto rangeView = rg | views::as_rvalue | views::common;
+                return insert_iter(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }
 
         inline iterator erase(const_iterator toErase)
         {
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
-            node_ptr_type node = static_cast<node_ptr_type>(toErase.get_iterator().m_node);
+            node_ptr_type node = static_cast<node_ptr_type>(toErase.base().get_iterator().m_node);
             orphan_node(node);
 #else
-            node_ptr_type node = static_cast<node_ptr_type>(toErase.m_node);
+            node_ptr_type node = static_cast<node_ptr_type>(toErase.base().m_node);
 #endif
             base_node_ptr_type prevNode = node->m_prev;
             base_node_ptr_type nextNode = node->m_next;
@@ -547,7 +506,7 @@ namespace AZStd
                 erase(first++);
             }
 
-            return AZStd::Internal::ConstIteratorCast<iterator>(last);
+            return last.base();
         }
 
         AZ_FORCE_INLINE void clear()
@@ -1054,9 +1013,9 @@ namespace AZStd
         {
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
             AZ_Assert(iter.m_container == this, "This iterator doesn't belong to this container");
-            base_node_ptr_type iterNode = iter.m_iter.m_node;
+            base_node_ptr_type iterNode = iter.base().m_iter.m_node;
 #else
-            base_node_ptr_type iterNode = iter.m_node;
+            base_node_ptr_type iterNode = iter.base().m_node;
 #endif
 
             if (iterNode == &m_head)
@@ -1070,9 +1029,9 @@ namespace AZStd
         {
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
             AZ_Assert(iter.m_container == this, "This iterator doesn't belong to this container");
-            base_node_ptr_type iterNode = iter.m_iter.m_node;
+            base_node_ptr_type iterNode = iter.base().m_iter.m_node;
 #else
-            base_node_ptr_type iterNode = iter.m_node;
+            base_node_ptr_type iterNode = iter.base().m_node;
 #endif
             if (iterNode == &m_head)
             {
@@ -1182,7 +1141,7 @@ namespace AZStd
         //! This is used to implement a node handle construct in the unordered_map
         node_ptr_type unlink(const_iterator unlinkPos)
         {
-            node_ptr_type unlinkNode = static_cast<node_ptr_type>(unlinkPos.m_node);
+            node_ptr_type unlinkNode = static_cast<node_ptr_type>(unlinkPos.base().m_node);
 
             unlinkNode->m_prev->m_next = unlinkNode->m_next;
             unlinkNode->m_next->m_prev = unlinkNode->m_prev;
@@ -1197,7 +1156,7 @@ namespace AZStd
         //! Requirements: The list node must use the same allocator as the list being linked to
         iterator relink(const_iterator insertPos, const base_node_ptr_type nodeToLink)
         {
-            base_node_ptr_type insNode = insertPos.m_node;
+            base_node_ptr_type insNode = insertPos.base().m_node;
 
             ++m_numElements;
             nodeToLink->m_next = insNode;
@@ -1230,7 +1189,7 @@ namespace AZStd
             if (first == last)
             {
                 // If the list is empty, return a non-const iterator version of insertPos.
-                return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, insertPos.m_node));
+                return iterator(AZSTD_CHECKED_ITERATOR(iterator_impl, insertPos.base().m_node));
             }
 
             InputIterator iter(first);
@@ -1279,9 +1238,9 @@ namespace AZStd
             Internal::construct<pointer>::single(ptr, AZStd::forward<ArgumentsInputs>(arguments) ...);
 
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
-            base_node_ptr_type insNode = insertPos.get_iterator().m_node;
+            base_node_ptr_type insNode = insertPos.base().get_iterator().m_node;
 #else
-            base_node_ptr_type insNode = insertPos.m_node;
+            base_node_ptr_type insNode = insertPos.base().m_node;
 #endif
 
             ++m_numElements;

--- a/Code/Framework/AzCore/AzCore/std/containers/map.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/map.h
@@ -99,12 +99,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
@@ -190,12 +190,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
@@ -540,12 +540,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
@@ -613,12 +613,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }

--- a/Code/Framework/AzCore/AzCore/std/containers/map.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/map.h
@@ -12,6 +12,8 @@
 #include <AzCore/std/containers/node_handle.h>
 #include <AzCore/std/functional_basic.h>
 #include <AzCore/std/algorithm.h>
+#include <AzCore/std/ranges/common_view.h>
+#include <AzCore/std/ranges/as_rvalue_view.h>
 #include <AzCore/std/tuple.h>
 #include <AzCore/std/typetraits/type_identity.h>
 
@@ -97,23 +99,25 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                m_tree.insert_unique(ranges::begin(rg), ranges::end(rg));
+                auto rangeView = rg | views::common;
+                m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                m_tree.insert_unique(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)));
+                auto rangeView = rg | views::as_rvalue | views::common;
+                m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
 
         map(const map& rhs)
-            : m_tree(rhs.m_tree)  {}
+            : m_tree(rhs.m_tree) {}
         map(map&& rhs)
             : m_tree(AZStd::move(rhs.m_tree)) {}
 
         explicit map(const Allocator& alloc)
             : m_tree(alloc) {}
         map(const map& rhs, const type_identity_t<Allocator>& alloc)
-            : m_tree(rhs.m_tree, alloc)   {}
+            : m_tree(rhs.m_tree, alloc) {}
         map(map&& rhs, const type_identity_t<Allocator>& alloc)
             : m_tree(AZStd::move(rhs.m_tree), alloc) {}
 
@@ -139,20 +143,20 @@ namespace AZStd
 
         // Add move semantics...
         AZ_FORCE_INLINE this_type& operator=(const this_type& rhs) { m_tree = rhs.m_tree; return *this; }
-        AZ_FORCE_INLINE key_compare key_comp() const        { return m_tree.key_comp(); }
-        AZ_FORCE_INLINE value_compare value_comp() const    { return value_comp(m_tree.key_comp()); }
+        AZ_FORCE_INLINE key_compare key_comp() const { return m_tree.key_comp(); }
+        AZ_FORCE_INLINE value_compare value_comp() const { return value_comp(m_tree.key_comp()); }
 
-        AZ_FORCE_INLINE iterator begin()                    { return m_tree.begin(); }
-        AZ_FORCE_INLINE iterator end()                      { return m_tree.end(); }
-        AZ_FORCE_INLINE const_iterator begin() const        { return m_tree.begin(); }
-        AZ_FORCE_INLINE const_iterator end() const          { return m_tree.end(); }
-        AZ_FORCE_INLINE reverse_iterator rbegin()           { return m_tree.rbegin(); }
-        AZ_FORCE_INLINE reverse_iterator rend()             { return m_tree.rend(); }
+        AZ_FORCE_INLINE iterator begin() { return m_tree.begin(); }
+        AZ_FORCE_INLINE iterator end() { return m_tree.end(); }
+        AZ_FORCE_INLINE const_iterator begin() const { return m_tree.begin(); }
+        AZ_FORCE_INLINE const_iterator end() const { return m_tree.end(); }
+        AZ_FORCE_INLINE reverse_iterator rbegin() { return m_tree.rbegin(); }
+        AZ_FORCE_INLINE reverse_iterator rend() { return m_tree.rend(); }
         AZ_FORCE_INLINE const_reverse_iterator rbegin() const { return m_tree.rbegin(); }
         AZ_FORCE_INLINE const_reverse_iterator rend() const { return m_tree.rend(); }
-        AZ_FORCE_INLINE bool empty() const                  { return m_tree.empty(); }
-        AZ_FORCE_INLINE size_type size() const              { return m_tree.size(); }
-        AZ_FORCE_INLINE size_type max_size() const          { return m_tree.max_size(); }
+        AZ_FORCE_INLINE bool empty() const { return m_tree.empty(); }
+        AZ_FORCE_INLINE size_type size() const { return m_tree.size(); }
+        AZ_FORCE_INLINE size_type max_size() const { return m_tree.max_size(); }
         MappedType& operator[](const key_type& key)
         {
             iterator iter = m_tree.lower_bound(key);
@@ -171,11 +175,11 @@ namespace AZStd
             }
             return (*iter).second;
         }
-        AZ_FORCE_INLINE void swap(this_type& rhs)           { m_tree.swap(rhs.m_tree); }
+        AZ_FORCE_INLINE void swap(this_type& rhs) { m_tree.swap(rhs.m_tree); }
 
         // insert/erase
-        AZ_FORCE_INLINE pair<iterator, bool> insert(const value_type& value)             { return m_tree.insert_unique(value); }
-        AZ_FORCE_INLINE iterator insert(const_iterator insertPos, const value_type& value)    { return m_tree.insert_unique(insertPos, value); }
+        AZ_FORCE_INLINE pair<iterator, bool> insert(const value_type& value) { return m_tree.insert_unique(value); }
+        AZ_FORCE_INLINE iterator insert(const_iterator insertPos, const value_type& value) { return m_tree.insert_unique(insertPos, value); }
         template <class InputIterator>
         void insert(InputIterator first, InputIterator last)
         {
@@ -186,16 +190,18 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                m_tree.insert_unique(ranges::begin(rg), ranges::end(rg));
+                auto rangeView = rg | views::common;
+                m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                m_tree.insert_unique(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)));
+                auto rangeView = rg | views::as_rvalue | views::common;
+                m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
-        AZ_FORCE_INLINE iterator erase(const_iterator erasePos)                         { return m_tree.erase(erasePos); }
-        AZ_FORCE_INLINE size_type erase(const key_type& key)                            { return m_tree.erase_unique(key); }
-        AZ_FORCE_INLINE iterator erase(const_iterator first, const_iterator last)       { return m_tree.erase(first, last); }
+        AZ_FORCE_INLINE iterator erase(const_iterator erasePos) { return m_tree.erase(erasePos); }
+        AZ_FORCE_INLINE size_type erase(const key_type& key) { return m_tree.erase_unique(key); }
+        AZ_FORCE_INLINE iterator erase(const_iterator first, const_iterator last) { return m_tree.erase(first, last); }
         AZ_FORCE_INLINE void clear() { m_tree.clear(); }
 
         this_type& operator=(this_type&& rhs)
@@ -297,15 +303,15 @@ namespace AZStd
         }
 
         // set operations:
-        const_iterator find(const key_type& key) const          { return m_tree.find(key); }
-        iterator find(const key_type& key)                      { return m_tree.find(key); }
-        bool contains(const key_type& key) const                { return m_tree.contains(key); }
-        size_type count(const key_type& key) const              { return m_tree.find(key) == m_tree.end() ? 0 : 1; }
-        iterator lower_bound(const key_type& key)               { return m_tree.lower_bound(key); }
-        const_iterator lower_bound(const key_type& key) const   { return m_tree.lower_bound(key); }
-        iterator upper_bound(const key_type& key)               { return m_tree.upper_bound(key); }
-        const_iterator upper_bound(const key_type& key) const   { return m_tree.upper_bound(key); }
-        pair<iterator, iterator> equal_range(const key_type& key)                   { return m_tree.equal_range_unique(key); }
+        const_iterator find(const key_type& key) const { return m_tree.find(key); }
+        iterator find(const key_type& key) { return m_tree.find(key); }
+        bool contains(const key_type& key) const { return m_tree.contains(key); }
+        size_type count(const key_type& key) const { return m_tree.find(key) == m_tree.end() ? 0 : 1; }
+        iterator lower_bound(const key_type& key) { return m_tree.lower_bound(key); }
+        const_iterator lower_bound(const key_type& key) const { return m_tree.lower_bound(key); }
+        iterator upper_bound(const key_type& key) { return m_tree.upper_bound(key); }
+        const_iterator upper_bound(const key_type& key) const { return m_tree.upper_bound(key); }
+        pair<iterator, iterator> equal_range(const key_type& key) { return m_tree.equal_range_unique(key); }
         pair<const_iterator, const_iterator> equal_range(const key_type& key) const { return m_tree.equal_range_unique(key); }
 
         template<typename ComparableToKey>
@@ -325,7 +331,7 @@ namespace AZStd
         auto lower_bound(const ComparableToKey& key) const -> enable_if_t<Internal::is_transparent<key_compare, ComparableToKey>::value, const_iterator> { return m_tree.lower_bound(key); }
 
         template<typename ComparableToKey>
-        auto upper_bound(const ComparableToKey& key) -> enable_if_t<Internal::is_transparent<key_compare, ComparableToKey>::value, iterator>{ return m_tree.upper_bound(key); }
+        auto upper_bound(const ComparableToKey& key) -> enable_if_t<Internal::is_transparent<key_compare, ComparableToKey>::value, iterator> { return m_tree.upper_bound(key); }
         template<typename ComparableToKey>
         auto upper_bound(const ComparableToKey& key) const -> enable_if_t<Internal::is_transparent<key_compare, ComparableToKey>::value, const_iterator> { return m_tree.upper_bound(key); }
 
@@ -352,15 +358,15 @@ namespace AZStd
             return m_tree.insert_unique(value_type(key, MappedType() /* post pone the ctor to avoid any copy */));
         }
         // The only difference from the standard is that we return the allocator instance, not a copy.
-        AZ_FORCE_INLINE allocator_type&         get_allocator()         { return m_tree.get_allocator(); }
-        AZ_FORCE_INLINE const allocator_type&   get_allocator() const   { return m_tree.get_allocator(); }
+        AZ_FORCE_INLINE allocator_type& get_allocator() { return m_tree.get_allocator(); }
+        AZ_FORCE_INLINE const allocator_type& get_allocator() const { return m_tree.get_allocator(); }
         /// Set the vector allocator. If different than then current all elements will be reallocated.
         AZ_FORCE_INLINE void                    set_allocator(const allocator_type& allocator) { m_tree.set_allocator(allocator); }
         // Validate container status.
-        AZ_INLINE bool      validate() const    { return m_tree.validate(); }
+        AZ_INLINE bool      validate() const { return m_tree.validate(); }
         /// Validates an iter iterator. Returns a combination of \ref iterator_status_flag.
         AZ_INLINE int       validate_iterator(const const_iterator& iter) const { return m_tree.validate_iterator(iter); }
-        AZ_INLINE int       validate_iterator(const iterator& iter) const       { return m_tree.validate_iterator(iter); }
+        AZ_INLINE int       validate_iterator(const iterator& iter) const { return m_tree.validate_iterator(iter); }
 
         /**
         * Resets the container without deallocating any memory or calling any destructor.
@@ -370,7 +376,7 @@ namespace AZStd
         * \note This function is added to the vector for consistency. In the vector case we have only one allocation, and if the allocator allows memory leaks
         * it can just leave deallocate function empty, which performance wise will be the same. For more complex containers this will make big difference.
         */
-        AZ_FORCE_INLINE void                        leak_and_reset()    { m_tree.leak_and_reset(); }
+        AZ_FORCE_INLINE void                        leak_and_reset() { m_tree.leak_and_reset(); }
         /// @}
     private:
         tree_type   m_tree;
@@ -386,7 +392,7 @@ namespace AZStd
     inline bool operator==(const map<Key, MappedType, Compare, Allocator>& left, const map<Key, MappedType, Compare, Allocator>& right)
     {
         return (left.size() == right.size()
-                && equal(left.begin(), left.end(), right.begin()));
+            && equal(left.begin(), left.end(), right.begin()));
     }
 
     template<class Key, class MappedType, class Compare, class Allocator>
@@ -443,7 +449,7 @@ namespace AZStd
     // deduction guides
     template<class InputIterator, class Compare = less<iter_key_type<InputIterator>>,
         class Allocator = allocator>
-        map(InputIterator, InputIterator, Compare = Compare(), Allocator = Allocator())
+    map(InputIterator, InputIterator, Compare = Compare(), Allocator = Allocator())
         ->map<iter_key_type<InputIterator>, iter_mapped_type<InputIterator>, Compare, Allocator>;
 
     template<class R, class Compare = less<range_key_type<R>>,
@@ -454,7 +460,7 @@ namespace AZStd
 
     template<class Key, class T, class Compare = less<Key>,
         class Allocator = allocator>
-        map(initializer_list<pair<Key, T>>, Compare = Compare(), Allocator = Allocator())
+    map(initializer_list<pair<Key, T>>, Compare = Compare(), Allocator = Allocator())
         ->map<Key, T, Compare, Allocator>;
 
     template<class InputIterator, class Allocator>
@@ -516,7 +522,7 @@ namespace AZStd
 
         using reverse_iterator = typename tree_type::reverse_iterator;
         using const_reverse_iterator = typename tree_type::const_reverse_iterator;
-        
+
         using node_type = map_node_handle<map_node_traits<key_type, mapped_type, allocator_type, typename tree_type::node_type, typename tree_type::node_deleter>>;
 
         multimap() = default;
@@ -534,11 +540,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                m_tree.insert_equal(ranges::begin(rg), ranges::end(rg));
+                auto rangeView = rg | views::common;
+                m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                m_tree.insert_equal(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)));
+                auto rangeView = rg | views::as_rvalue | views::common;
+                m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
 
@@ -576,25 +584,25 @@ namespace AZStd
 
         // Add move semantics...
         AZ_FORCE_INLINE this_type& operator=(const this_type& rhs) { m_tree = rhs.m_tree; return *this; }
-        AZ_FORCE_INLINE key_compare key_comp() const        { return m_tree.key_comp(); }
-        AZ_FORCE_INLINE value_compare value_comp() const    { return value_compare(m_tree.key_comp()); }
+        AZ_FORCE_INLINE key_compare key_comp() const { return m_tree.key_comp(); }
+        AZ_FORCE_INLINE value_compare value_comp() const { return value_compare(m_tree.key_comp()); }
 
-        AZ_FORCE_INLINE iterator begin()                    { return m_tree.begin(); }
-        AZ_FORCE_INLINE iterator end()                      { return m_tree.end(); }
-        AZ_FORCE_INLINE const_iterator begin() const        { return m_tree.begin(); }
-        AZ_FORCE_INLINE const_iterator end() const          { return m_tree.end(); }
-        AZ_FORCE_INLINE reverse_iterator rbegin()           { return m_tree.rbegin(); }
-        AZ_FORCE_INLINE reverse_iterator rend()             { return m_tree.rend(); }
+        AZ_FORCE_INLINE iterator begin() { return m_tree.begin(); }
+        AZ_FORCE_INLINE iterator end() { return m_tree.end(); }
+        AZ_FORCE_INLINE const_iterator begin() const { return m_tree.begin(); }
+        AZ_FORCE_INLINE const_iterator end() const { return m_tree.end(); }
+        AZ_FORCE_INLINE reverse_iterator rbegin() { return m_tree.rbegin(); }
+        AZ_FORCE_INLINE reverse_iterator rend() { return m_tree.rend(); }
         AZ_FORCE_INLINE const_reverse_iterator rbegin() const { return m_tree.rbegin(); }
         AZ_FORCE_INLINE const_reverse_iterator rend() const { return m_tree.rend(); }
-        AZ_FORCE_INLINE bool empty() const                  { return m_tree.empty(); }
-        AZ_FORCE_INLINE size_type size() const              { return m_tree.size(); }
-        AZ_FORCE_INLINE size_type max_size() const          { return m_tree.max_size(); }
-        AZ_FORCE_INLINE void swap(this_type& rhs)           { m_tree.swap(rhs.m_tree); }
+        AZ_FORCE_INLINE bool empty() const { return m_tree.empty(); }
+        AZ_FORCE_INLINE size_type size() const { return m_tree.size(); }
+        AZ_FORCE_INLINE size_type max_size() const { return m_tree.max_size(); }
+        AZ_FORCE_INLINE void swap(this_type& rhs) { m_tree.swap(rhs.m_tree); }
 
         // insert/erase
-        AZ_FORCE_INLINE pair<iterator, bool> insert(const value_type& value)             { return m_tree.insert_equal(value); }
-        AZ_FORCE_INLINE iterator insert(const_iterator insertPos, const value_type& value)    { return m_tree.insert_equal(insertPos, value); }
+        AZ_FORCE_INLINE pair<iterator, bool> insert(const value_type& value) { return m_tree.insert_equal(value); }
+        AZ_FORCE_INLINE iterator insert(const_iterator insertPos, const value_type& value) { return m_tree.insert_equal(insertPos, value); }
         template <class InputIterator>
         void insert(InputIterator first, InputIterator last)
         {
@@ -605,11 +613,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                m_tree.insert_equal(ranges::begin(rg), ranges::end(rg));
+                auto rangeView = rg | views::common;
+                m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                m_tree.insert_equal(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)));
+                auto rangeView = rg | views::as_rvalue | views::common;
+                m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
         AZ_FORCE_INLINE iterator erase(const_iterator erasePos)                         { return m_tree.erase(erasePos); }

--- a/Code/Framework/AzCore/AzCore/std/containers/set.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/set.h
@@ -12,6 +12,8 @@
 #include <AzCore/std/containers/node_handle.h>
 #include <AzCore/std/containers/rbtree.h>
 #include <AzCore/std/functional_basic.h>
+#include <AzCore/std/ranges/common_view.h>
+#include <AzCore/std/ranges/as_rvalue_view.h>
 #include <AzCore/std/typetraits/type_identity.h>
 
 namespace AZStd
@@ -87,11 +89,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                m_tree.insert_unique(ranges::begin(rg), ranges::end(rg));
+                auto rangeView = rg | views::common;
+                m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                m_tree.insert_unique(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)));
+                auto rangeView = rg | views::as_rvalue | views::common;
+                m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
         set(const set& rhs)
@@ -124,25 +128,25 @@ namespace AZStd
 
         // Add move semantics...
         AZ_FORCE_INLINE this_type& operator=(const this_type& rhs) { m_tree = rhs.m_tree; return *this; }
-        AZ_FORCE_INLINE key_compare key_comp() const        { return m_tree.key_comp(); }
-        AZ_FORCE_INLINE value_compare value_comp() const    { return m_tree.key_comp(); }
+        AZ_FORCE_INLINE key_compare key_comp() const { return m_tree.key_comp(); }
+        AZ_FORCE_INLINE value_compare value_comp() const { return m_tree.key_comp(); }
 
-        AZ_FORCE_INLINE iterator begin()                    { return m_tree.begin(); }
-        AZ_FORCE_INLINE iterator end()                      { return m_tree.end(); }
-        AZ_FORCE_INLINE const_iterator begin() const        { return m_tree.begin(); }
-        AZ_FORCE_INLINE const_iterator end() const          { return m_tree.end(); }
-        AZ_FORCE_INLINE reverse_iterator rbegin()           { return m_tree.rbegin(); }
-        AZ_FORCE_INLINE reverse_iterator rend()             { return m_tree.rend(); }
+        AZ_FORCE_INLINE iterator begin() { return m_tree.begin(); }
+        AZ_FORCE_INLINE iterator end() { return m_tree.end(); }
+        AZ_FORCE_INLINE const_iterator begin() const { return m_tree.begin(); }
+        AZ_FORCE_INLINE const_iterator end() const { return m_tree.end(); }
+        AZ_FORCE_INLINE reverse_iterator rbegin() { return m_tree.rbegin(); }
+        AZ_FORCE_INLINE reverse_iterator rend() { return m_tree.rend(); }
         AZ_FORCE_INLINE const_reverse_iterator rbegin() const { return m_tree.rbegin(); }
         AZ_FORCE_INLINE const_reverse_iterator rend() const { return m_tree.rend(); }
-        AZ_FORCE_INLINE bool empty() const                  { return m_tree.empty(); }
-        AZ_FORCE_INLINE size_type size() const              { return m_tree.size(); }
-        AZ_FORCE_INLINE size_type max_size() const          { return m_tree.max_size(); }
-        AZ_FORCE_INLINE void swap(this_type& rhs)           { m_tree.swap(rhs.m_tree); }
+        AZ_FORCE_INLINE bool empty() const { return m_tree.empty(); }
+        AZ_FORCE_INLINE size_type size() const { return m_tree.size(); }
+        AZ_FORCE_INLINE size_type max_size() const { return m_tree.max_size(); }
+        AZ_FORCE_INLINE void swap(this_type& rhs) { m_tree.swap(rhs.m_tree); }
 
         // insert/erase
-        AZ_FORCE_INLINE pair<iterator, bool> insert(const value_type& value)             { return m_tree.insert_unique(value); }
-        AZ_FORCE_INLINE iterator insert(iterator insertPos, const value_type& value)    { return m_tree.insert_unique(insertPos, value); }
+        AZ_FORCE_INLINE pair<iterator, bool> insert(const value_type& value) { return m_tree.insert_unique(value); }
+        AZ_FORCE_INLINE iterator insert(iterator insertPos, const value_type& value) { return m_tree.insert_unique(insertPos, value); }
         template <class InputIterator>
         void insert(InputIterator first, InputIterator last)
         {
@@ -153,11 +157,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                m_tree.insert_unique(ranges::begin(rg), ranges::end(rg));
+                auto rangeView = rg | views::common;
+                m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                m_tree.insert_unique(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)));
+                auto rangeView = rg | views::as_rvalue | views::common;
+                m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
 
@@ -210,21 +216,21 @@ namespace AZStd
             return m_tree.template node_handle_extract<node_type>(it);
         }
 
-        AZ_FORCE_INLINE iterator erase(const_iterator erasePos)                         { return m_tree.erase(erasePos); }
-        AZ_FORCE_INLINE size_type erase(const key_type& key)                            { return m_tree.erase_unique(key); }
-        AZ_FORCE_INLINE iterator erase(const_iterator first, const_iterator last)       { return m_tree.erase(first, last); }
+        AZ_FORCE_INLINE iterator erase(const_iterator erasePos) { return m_tree.erase(erasePos); }
+        AZ_FORCE_INLINE size_type erase(const key_type& key) { return m_tree.erase_unique(key); }
+        AZ_FORCE_INLINE iterator erase(const_iterator first, const_iterator last) { return m_tree.erase(first, last); }
         AZ_FORCE_INLINE void clear() { m_tree.clear(); }
 
         // set operations:
-        const_iterator find(const key_type& key) const          { return m_tree.find(key); }
-        iterator find(const key_type& key)                      { return m_tree.find(key); }
-        bool contains(const key_type& key) const                { return m_tree.contains(key); }
-        size_type count(const key_type& key) const              { return m_tree.find(key) == m_tree.end() ? 0 : 1; }
-        iterator lower_bound(const key_type& key)               { return m_tree.lower_bound(key); }
-        const_iterator lower_bound(const key_type& key) const   { return m_tree.lower_bound(key); }
-        iterator upper_bound(const key_type& key)               { return m_tree.upper_bound(key); }
-        const_iterator upper_bound(const key_type& key) const   { return m_tree.upper_bound(key); }
-        pair<iterator, iterator> equal_range(const key_type& key)                   { return m_tree.equal_range_unique(key); }
+        const_iterator find(const key_type& key) const { return m_tree.find(key); }
+        iterator find(const key_type& key) { return m_tree.find(key); }
+        bool contains(const key_type& key) const { return m_tree.contains(key); }
+        size_type count(const key_type& key) const { return m_tree.find(key) == m_tree.end() ? 0 : 1; }
+        iterator lower_bound(const key_type& key) { return m_tree.lower_bound(key); }
+        const_iterator lower_bound(const key_type& key) const { return m_tree.lower_bound(key); }
+        iterator upper_bound(const key_type& key) { return m_tree.upper_bound(key); }
+        const_iterator upper_bound(const key_type& key) const { return m_tree.upper_bound(key); }
+        pair<iterator, iterator> equal_range(const key_type& key) { return m_tree.equal_range_unique(key); }
         pair<const_iterator, const_iterator> equal_range(const key_type& key) const { return m_tree.equal_range_unique(key); }
 
         template<typename ComparableToKey>
@@ -259,15 +265,15 @@ namespace AZStd
         * @{
         */
         // The only difference from the standard is that we return the allocator instance, not a copy.
-        AZ_FORCE_INLINE allocator_type&         get_allocator()         { return m_tree.get_allocator(); }
-        AZ_FORCE_INLINE const allocator_type&   get_allocator() const   { return m_tree.get_allocator(); }
+        AZ_FORCE_INLINE allocator_type& get_allocator() { return m_tree.get_allocator(); }
+        AZ_FORCE_INLINE const allocator_type& get_allocator() const { return m_tree.get_allocator(); }
         /// Set the vector allocator. If different than then current all elements will be reallocated.
         AZ_FORCE_INLINE void                    set_allocator(const allocator_type& allocator) { m_tree.set_allocator(allocator); }
         // Validate container status.
-        AZ_INLINE bool      validate() const    { return m_tree.validate(); }
+        AZ_INLINE bool      validate() const { return m_tree.validate(); }
         /// Validates an iter iterator. Returns a combination of \ref iterator_status_flag.
         AZ_INLINE int       validate_iterator(const const_iterator& iter) const { return m_tree.validate_iterator(iter); }
-        AZ_INLINE int       validate_iterator(const iterator& iter) const       { return m_tree.validate_iterator(iter); }
+        AZ_INLINE int       validate_iterator(const iterator& iter) const { return m_tree.validate_iterator(iter); }
 
         /**
         * Resets the container without deallocating any memory or calling any destructor.
@@ -277,7 +283,7 @@ namespace AZStd
         * \note This function is added to the vector for consistency. In the vector case we have only one allocation, and if the allocator allows memory leaks
         * it can just leave deallocate function empty, which performance wise will be the same. For more complex containers this will make big difference.
         */
-        AZ_FORCE_INLINE void                        leak_and_reset()    { m_tree.leak_and_reset(); }
+        AZ_FORCE_INLINE void                        leak_and_reset() { m_tree.leak_and_reset(); }
         /// @}
     private:
         tree_type   m_tree;
@@ -293,7 +299,7 @@ namespace AZStd
     inline bool operator==(const set<Key, Compare, Allocator>& left, const set<Key, Compare, Allocator>& right)
     {
         return (left.size() == right.size()
-                && equal(left.begin(), left.end(), right.begin()));
+            && equal(left.begin(), left.end(), right.begin()));
     }
 
     template<class Key, class Compare, class Allocator>
@@ -351,7 +357,7 @@ namespace AZStd
         class Compare = less<iter_value_type<InputIterator>>,
         class Allocator = allocator>
     set(InputIterator, InputIterator,
-            Compare = Compare(), Allocator = Allocator())
+        Compare = Compare(), Allocator = Allocator())
         ->set<iter_value_type<InputIterator>, Compare, Allocator>;
 
     template<class R, class Compare = less<ranges::range_value_t<R>>,
@@ -414,7 +420,7 @@ namespace AZStd
 
         using reverse_iterator = typename tree_type::reverse_iterator;
         using const_reverse_iterator = typename tree_type::const_reverse_iterator;
-        
+
         using node_type = set_node_handle<set_node_traits<value_type, allocator_type, typename tree_type::node_type, typename tree_type::node_deleter>>;
 
         multiset() = default;
@@ -433,11 +439,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                m_tree.insert_equal(ranges::begin(rg), ranges::end(rg));
+                auto rangeView = rg | views::common;
+                m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                m_tree.insert_equal(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)));
+                auto rangeView = rg | views::as_rvalue | views::common;
+                m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
         multiset(const multiset& rhs)
@@ -499,11 +507,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                m_tree.insert_equal(ranges::begin(rg), ranges::end(rg));
+                auto rangeView = rg | views::common;
+                m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                m_tree.insert_equal(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)));
+                auto rangeView = rg | views::as_rvalue | views::common;
+                m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
         AZ_FORCE_INLINE iterator erase(const_iterator erasePos)                         { return m_tree.erase(erasePos); }

--- a/Code/Framework/AzCore/AzCore/std/containers/set.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/set.h
@@ -89,12 +89,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
@@ -157,12 +157,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 m_tree.insert_unique(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
@@ -439,12 +439,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
@@ -507,12 +507,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 m_tree.insert_equal(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }

--- a/Code/Framework/AzCore/AzCore/std/containers/vector.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/vector.h
@@ -11,6 +11,8 @@
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/allocator_traits.h>
 #include <AzCore/std/createdestroy.h>
+#include <AzCore/std/ranges/common_view.h>
+#include <AzCore/std/ranges/as_rvalue_view.h>
 #include <AzCore/std/typetraits/alignment_of.h>
 #include <AzCore/std/typetraits/is_integral.h>
 
@@ -45,8 +47,6 @@ namespace AZStd
 
         typedef T&                                      reference;
         typedef const T&                                const_reference;
-        typedef typename Allocator::difference_type     difference_type;
-        typedef typename Allocator::size_type           size_type;
 
         typedef pointer                                 iterator_impl;
         typedef const_pointer                           const_iterator_impl;
@@ -57,6 +57,8 @@ namespace AZStd
         typedef iterator_impl                           iterator;
         typedef const_iterator_impl                     const_iterator;
 #endif
+        using difference_type = iter_difference_t<iterator>;
+        using size_type = make_unsigned_t<difference_type>;
         typedef AZStd::reverse_iterator<iterator>       reverse_iterator;
         typedef AZStd::reverse_iterator<const_iterator> const_reverse_iterator;
         typedef T                                       value_type;
@@ -628,11 +630,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                assign_iter(ranges::begin(rg), ranges::end(rg), false_type{});
+                auto rangeView = rg | views::common;
+                assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                assign_iter(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)), false_type{});
+                auto rangeView = rg | views::as_rvalue | views::common;
+                assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }
 
@@ -834,11 +838,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                return insert_impl(insertPos, ranges::begin(rg), ranges::end(rg), false_type{});
+                auto rangeView = rg | views::common;
+                return insert_impl(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                return insert_impl(insertPos, make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)), false_type{});
+                auto rangeView = rg | views::as_rvalue | views::common;
+                return insert_impl(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }
 
@@ -1150,7 +1156,7 @@ namespace AZStd
                 pointer insertPosPtr = const_cast<pointer>(insertPos);
 #endif
 
-                size_type numElements = distance(first, last);
+                difference_type numElements = distance(first, last);
                 if (numElements == 0)
                 {
                     return AZStd::ranges::next(begin(), offset);
@@ -1215,13 +1221,13 @@ namespace AZStd
                     m_last = newLast;
                     m_end = m_start + capacity;
                 }
-                else if (size_type(m_last - insertPosPtr) < numElements)
+                else if (m_last - insertPosPtr < numElements)
                 {
                     // Copy the elements after insert position.
                     pointer newLast = AZStd::uninitialized_move(insertPosPtr, m_last, insertPosPtr + numElements);
 
                     // Number of elements we can assign.
-                    size_type numInitializedToFill = size_type(m_last - insertPosPtr);
+                    auto numInitializedToFill = static_cast<iter_difference_t<Iterator>>(m_last - insertPosPtr);
 
                     // get last iterator to fill
                     Iterator lastToAssign = first;

--- a/Code/Framework/AzCore/AzCore/std/containers/vector.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/vector.h
@@ -630,12 +630,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 assign_iter(ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }
@@ -838,12 +838,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 return insert_impl(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 return insert_impl(insertPos, ranges::begin(rangeView), ranges::end(rangeView), false_type{});
             }
         }

--- a/Code/Framework/AzCore/AzCore/std/hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/hash_table.h
@@ -621,12 +621,12 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                auto rangeView = rg | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
                 insert(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                auto rangeView = rg | views::as_rvalue | views::common;
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
                 insert(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }

--- a/Code/Framework/AzCore/AzCore/std/hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/hash_table.h
@@ -13,8 +13,9 @@
 #include <AzCore/std/containers/fixed_vector.h>
 #include <AzCore/std/containers/list.h>
 #include <AzCore/std/containers/fixed_list.h>
-
 #include <AzCore/std/hash.h>
+#include <AzCore/std/ranges/common_view.h>
+#include <AzCore/std/ranges/as_rvalue_view.h>
 #include <AzCore/std/tuple.h>
 #include <AzCore/std/utils.h>
 #include <AzCore/std/functional_basic.h>
@@ -24,6 +25,9 @@
 
 namespace AZStd
 {
+    template<class Traits>
+    class hash_table;
+
     namespace Internal
     {
         /**
@@ -285,7 +289,7 @@ namespace AZStd
         template<class Traits>
         class hash_table_storage<Traits, false>
         {
-            typedef hash_table_storage<Traits, false> this_type;
+            typedef hash_table_storage this_type;
 
         public:
             typedef typename Traits::allocator_type                                     allocator_type;
@@ -617,11 +621,13 @@ namespace AZStd
         {
             if constexpr (is_lvalue_reference_v<R>)
             {
-                insert(ranges::begin(rg), ranges::end(rg));
+                auto rangeView = rg | views::common;
+                insert(ranges::begin(rangeView), ranges::end(rangeView));
             }
             else
             {
-                insert(make_move_iterator(ranges::begin(rg)), make_move_iterator(ranges::end(rg)));
+                auto rangeView = rg | views::as_rvalue | views::common;
+                insert(ranges::begin(rangeView), ranges::end(rangeView));
             }
         }
 
@@ -720,7 +726,7 @@ namespace AZStd
                 {
                     first = erase(first);
                 }
-                return AZStd::Internal::ConstIteratorCast<iterator>(first);
+                return first.base();
             }
         }
 

--- a/Code/Framework/AzCore/AzCore/std/iterator.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator.h
@@ -89,7 +89,7 @@ namespace AZStd
     /**
      * Default iterator traits struct.
     */
-    template <class Iterator>
+    template <class Iterator, class>
     struct iterator_traits
         : Internal::iterator_traits_type_aliases<Iterator, Internal::has_iterator_type_aliases_v<Iterator>>
     {

--- a/Code/Framework/AzCore/AzCore/std/iterator.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator.h
@@ -119,10 +119,6 @@ namespace AZStd
     using std::reverse_iterator;
     using std::make_reverse_iterator;
 
-    // Alias the C++ standard move_iterator into the AZStd:: namespace
-    using std::move_iterator;
-    using std::make_move_iterator;
-
     // Alias the C++ standard insert iterators into the AZStd:: namespace
     using std::back_insert_iterator;
     using std::back_inserter;
@@ -132,7 +128,7 @@ namespace AZStd
     using std::inserter;
 
 #if !defined(__cpp_lib_concepts)
-    // In order for pre C++20 back_inserter_iterator, front_inseter_iterator and insert_iterator
+    // In order for pre C++20 back_inserter_iterator, front_inserter_iterator and insert_iterator
     // to work with the range algorithms which require a weakly_incrementable iterator
     // the difference_type type alias must not be void as it is in C++17
     // https://en.cppreference.com/w/cpp/iterator/back_insert_iterator
@@ -230,3 +226,5 @@ namespace AZStd
     }
 } // namespace AZStd
 
+// Include the AZStd::move_iterator implementation after alias in the std:: iterator names
+#include <AzCore/std/iterator/move_iterator.h>

--- a/Code/Framework/AzCore/AzCore/std/iterator/common_iterator.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator/common_iterator.h
@@ -15,10 +15,6 @@ namespace AZStd
 {
     // Bring in std utility functions into AZStd namespace
     using std::forward;
-
-    // forward declare iterator_traits to avoid iterator.h include
-    template <class I>
-    struct iterator_traits;
 }
 
 namespace AZStd::Internal

--- a/Code/Framework/AzCore/AzCore/std/iterator/common_iterator.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator/common_iterator.h
@@ -66,16 +66,18 @@ namespace AZStd
             : m_iterSentinel {
             [&]()
             {
+            #if __cpp_constexpr_dynamic_alloc >= 201907L
                 AZ_Assert(!other.m_iterSentinel.valueless_by_exception(), "common_iterator variant must have an alternative");
+            #endif
                 if (other.m_iterSentinel.index() == 0)
                 {
                     // Initialize from the iterator alternative of the other common iterator
-                    return variant<I, S>{ in_place_index<0>, AZStd::get<0>(other.m_iterSentinel) };
+                    return variant<I, S>{ in_place_index<0>, get<0>(other.m_iterSentinel) };
                 }
                 else
                 {
                     // Initialize from the sentinel alternative of the other common iterator
-                    return variant<I, S>{ in_place_index<1>, AZStd::get<1>(other.m_iterSentinel) };
+                    return variant<I, S>{ in_place_index<1>, get<1>(other.m_iterSentinel) };
                 }
             }() }
         {
@@ -95,22 +97,22 @@ namespace AZStd
             {
                 if (other.m_iterSentinel.index() == 0)
                 {
-                    AZStd::get<0>(m_iterSentinel) = AZStd::get<0>(other.m_iterSentinel);
+                    get<0>(m_iterSentinel) = get<0>(other.m_iterSentinel);
                 }
                 else
                 {
-                    AZStd::get<0>(m_iterSentinel) = AZStd::get<0>(other.m_iterSentinel);
+                    get<0>(m_iterSentinel) = get<0>(other.m_iterSentinel);
                 }
             }
             else
             {
                 if (other.m_iterSentinel.index() == 0)
                 {
-                    m_iterSentinel.template emplace<0>(AZStd::get<0>(other.m_iterSentinel));
+                    m_iterSentinel.template emplace<0>(get<0>(other.m_iterSentinel));
                 }
                 else
                 {
-                    m_iterSentinel.template emplace<1>(AZStd::get<0>(other.m_iterSentinel));
+                    m_iterSentinel.template emplace<1>(get<0>(other.m_iterSentinel));
                 }
             }
 
@@ -119,14 +121,14 @@ namespace AZStd
 
         constexpr decltype(auto) operator*()
         {
-            AZ_Assert(AZStd::holds_alternative<I>(m_iterSentinel), "Attempting to deference the sentinel value");
-            return *AZStd::get<0>(m_iterSentinel);
+            AZ_Assert(holds_alternative<I>(m_iterSentinel), "Attempting to deference the sentinel value");
+            return *get<0>(m_iterSentinel);
         }
         template<bool Enable = Internal::dereferenceable<const I>, class = enable_if_t<Enable>>
         constexpr decltype(auto) operator*() const
         {
-            AZ_Assert(AZStd::holds_alternative<I>(m_iterSentinel), "Attempting to deference the sentinel value");
-            return *AZStd::get<0>(m_iterSentinel);
+            AZ_Assert(holds_alternative<I>(m_iterSentinel), "Attempting to deference the sentinel value");
+            return *get<0>(m_iterSentinel);
         }
         template<bool Enable = conjunction_v<
             bool_constant<indirectly_readable<const I>>,
@@ -138,14 +140,15 @@ namespace AZStd
             >, class = enable_if_t<Enable>>
         constexpr decltype(auto) operator->() const
         {
-            AZ_Assert(AZStd::holds_alternative<I>(m_iterSentinel), "arrow operator cannot invoked on sentinel value");
+            AZ_Assert(holds_alternative<I>(m_iterSentinel), "arrow operator cannot invoked on sentinel value");
             if constexpr (AZStd::is_pointer_v<I> || Internal::has_operator_arrow<const I>)
             {
-                return AZStd::get<I>(m_iterSentinel);
+                return get<I>(m_iterSentinel);
             }
             else if constexpr (is_reference_v<iter_reference_t<I>>)
             {
-                return AZStd::addressof(*AZStd::get<I>(m_iterSentinel));
+                auto&& tmp = *get<I>(m_iterSentinel);
+                return AZStd::addressof(tmp);
             }
             else
             {
@@ -161,30 +164,30 @@ namespace AZStd
                     }
                 };
 
-                return proxy(*AZStd::get<I>(m_iterSentinel));
+                return proxy(*get<I>(m_iterSentinel));
             }
         }
 
 
         constexpr common_iterator& operator++()
         {
-            AZ_Assert(AZStd::holds_alternative<I>(m_iterSentinel), "pre-increment cannot be invoked on the sentinel value");
-            ++AZStd::get<I>(m_iterSentinel);
+            AZ_Assert(holds_alternative<I>(m_iterSentinel), "pre-increment cannot be invoked on the sentinel value");
+            ++get<I>(m_iterSentinel);
             return *this;
         }
         constexpr decltype(auto) operator++(int)
         {
-            AZ_Assert(AZStd::holds_alternative<I>(m_iterSentinel), "pre-increment cannot be invoked on the sentinel value");
+            AZ_Assert(holds_alternative<I>(m_iterSentinel), "pre-increment cannot be invoked on the sentinel value");
             if constexpr (forward_iterator<I>)
             {
                 auto oldThis = *this;
-                ++AZStd::get<I>(m_iterSentinel);
+                ++get<I>(m_iterSentinel);
                 return oldThis;
             }
             else if constexpr (Internal::can_reference_post_increment<I>
                 || !(indirectly_readable<I> && constructible_from<iter_value_t<I>, iter_reference_t<I>> && move_constructible<iter_value_t<I>>))
             {
-                return AZStd::get<I>(m_iterSentinel)++;
+                return get<I>(m_iterSentinel)++;
             }
             else
             {
@@ -214,8 +217,10 @@ namespace AZStd
             bool_constant<!equality_comparable_with<I, I2>>
         >, bool>
         {
+        #if __cpp_constexpr_dynamic_alloc >= 201907L
             AZ_Assert(!x.m_iterSentinel.valueless_by_exception() && !y.m_iterSentinel.valueless_by_exception(),
                 "common_iterator variant must have an alternative");
+        #endif
             if (x.m_iterSentinel.index() == y.m_iterSentinel.index())
             {
                 return true;
@@ -223,13 +228,12 @@ namespace AZStd
 
             if (x.m_iterSentinel.index() == 0)
             {
-                return AZStd::get<0>(x.m_iterSentinel) == AZStd::get<1>(y.m_iterSentinel);
+                return get<0>(x.m_iterSentinel) == get<1>(y.m_iterSentinel);
             }
             else
             {
-                return AZStd::get<1>(x.m_iterSentinel) == AZStd::get<0>(y.m_iterSentinel);
+                return get<1>(x.m_iterSentinel) == get<0>(y.m_iterSentinel);
             }
-
         }
         template<class I2, class S2>
         friend constexpr auto operator!=(const common_iterator& x, const common_iterator<I2, S2>& y)
@@ -250,8 +254,10 @@ namespace AZStd
             bool_constant<equality_comparable_with<I, I2>>
         >, bool>
         {
+        #if __cpp_constexpr_dynamic_alloc >= 201907L
             AZ_Assert(!x.m_iterSentinel.valueless_by_exception() && !y.m_iterSentinel.valueless_by_exception(),
                 "common_iterator variant must have an alternative");
+        #endif
 
             if (x.m_iterSentinel.index() == y.m_iterSentinel.index())
             {
@@ -262,17 +268,17 @@ namespace AZStd
                 }
                 else
                 {
-                    return AZStd::get<0>(x.m_iterSentinel) == AZStd::get<0>(y.m_iterSentinel);
+                    return get<0>(x.m_iterSentinel) == get<0>(y.m_iterSentinel);
                 }
             }
 
             if (x.m_iterSentinel.index() == 0)
             {
-                return AZStd::get<0>(x.m_iterSentinel) == AZStd::get<1>(y.m_iterSentinel);
+                return get<0>(x.m_iterSentinel) == get<1>(y.m_iterSentinel);
             }
             else
             {
-                return AZStd::get<1>(x.m_iterSentinel) == AZStd::get<0>(y.m_iterSentinel);
+                return get<1>(x.m_iterSentinel) == get<0>(y.m_iterSentinel);
             }
         }
         template<class I2, class S2>
@@ -294,8 +300,10 @@ namespace AZStd
             bool_constant<sized_sentinel_for<S, I2>>
         >, iter_difference_t<I2>>
         {
+        #if __cpp_constexpr_dynamic_alloc >= 201907L
             AZ_Assert(!x.m_iterSentinel.valueless_by_exception() && !y.m_iterSentinel.valueless_by_exception(),
                 "common_iterator variant must have an alternative");
+        #endif
             if (x.m_iterSentinel.index() == y.m_iterSentinel.index())
             {
                 if (x.m_iterSentinel.index() == 1)
@@ -305,17 +313,17 @@ namespace AZStd
                 }
                 else
                 {
-                    return AZStd::get<0>(x.m_iterSentinel) - AZStd::get<0>(y.m_iterSentinel);
+                    return get<0>(x.m_iterSentinel) - get<0>(y.m_iterSentinel);
                 }
             }
 
             if (x.m_iterSentinel.index() == 0)
             {
-                return AZStd::get<0>(x.m_iterSentinel) - AZStd::get<1>(y.m_iterSentinel);
+                return get<0>(x.m_iterSentinel) - get<1>(y.m_iterSentinel);
             }
             else
             {
-                return AZStd::get<1>(x.m_iterSentinel) - AZStd::get<0>(y.m_iterSentinel);
+                return get<1>(x.m_iterSentinel) - get<0>(y.m_iterSentinel);
             }
         }
 
@@ -323,21 +331,271 @@ namespace AZStd
             noexcept(noexcept(ranges::iter_move(declval<const I&>())))
             -> enable_if_t<input_iterator<I>, iter_rvalue_reference_t<I>>
         {
-            AZ_Assert(AZStd::holds_alternative<I>(i.m_iterSentinel), "iter_move cannot be invoked on sentinel value");
-            return ranges::iter_move(AZStd::get<I>(i.m_iterSentinel));
+            AZ_Assert(holds_alternative<I>(i.m_iterSentinel), "iter_move cannot be invoked on sentinel value");
+            return ranges::iter_move(get<I>(i.m_iterSentinel));
         }
 
         template<class I2, class S2, enable_if_t<indirectly_swappable<I2, I>>>
         friend constexpr void iter_swap(const common_iterator& x, const common_iterator<I2, S2>& y)
             noexcept(noexcept(ranges::iter_swap(declval<const I&>(), declval<const I2&>())))
         {
-            AZ_Assert(AZStd::holds_alternative<I>(x.m_iterSentinel) && AZStd::holds_alternative<I>(y.m_iterSentinel),
+            AZ_Assert(holds_alternative<I>(x.m_iterSentinel) && holds_alternative<I>(y.m_iterSentinel),
                 "iter_swap requires both common_iterators alternatives be set to a valid deferenceable iterator");
-            return ranges::iter_swap(AZStd::get<I>(x.m_iterSentinel), AZStd::get<I>(y.m_iterSentinel));
+            return ranges::iter_swap(get<I>(x.m_iterSentinel), get<I>(y.m_iterSentinel));
         }
 
     private:
+        //! Because AZStd::variant under the hood invokes AZStd::construct_at, which uses placement new
+        //! this makes the emplace calls in this class non-constexpr
+        //! fallback to use a struct in C++17 with a bool, since it is simple to deal with than a union
+#if __cpp_constexpr_dynamic_alloc >= 201907L
         variant<I, S> m_iterSentinel{};
+#else
+        template<class Iter, class Sen>
+        struct IterVariant
+        {
+            constexpr IterVariant() = default;
+
+            template<size_t Index, class... Args>
+            constexpr IterVariant(in_place_index_t<Index>, Args&&... args)
+            {
+                if constexpr (Index == 0 || Index == 1)
+                {
+                    emplace<Index>(AZStd::forward<Args>(args)...);
+                }
+
+                static_assert(Index < 2, "IterVariant can only be constructed with Index < 2");
+            }
+            template<class T, class... Args>
+            constexpr IterVariant(in_place_type_t<T>, Args&&... args)
+            {
+                if constexpr (AZStd::same_as<T, Iter>)
+                {
+                    emplace<0>(AZStd::forward<Args>(args)...);
+                }
+                else if constexpr (AZStd::same_as<T, Sen>)
+                {
+                    emplace<1>(AZStd::forward<Args>(args)...);
+                }
+
+                static_assert(AZStd::same_as<T, Iter> || AZStd::same_as<T, Sen>,
+                    "type must match either Iter or Sen");
+            }
+
+            constexpr bool operator==(const IterVariant& other) const
+            {
+                return m_elementIndex != other.m_elementIndex ? false
+                    : m_elementIndex == 0
+                    ? m_iter == other.m_iter
+                    : m_sentinel == other.m_sentinel;
+            }
+            constexpr bool operator!=(const IterVariant& other) const
+            {
+                return !operator==(other);
+            }
+
+            template<size_t Index, class... Args>
+            constexpr auto& emplace(Args&&... args)
+            {
+                m_elementIndex = Index;
+                if constexpr (Index == 0)
+                {
+                    m_iter = Iter(AZStd::forward<Args>(args)...);
+                    return m_iter;
+                }
+                else if constexpr (Index == 1)
+                {
+                    m_sentinel = Sen(AZStd::forward<Args>(args)...);
+                    return m_sentinel;
+                }
+
+                static_assert(Index < 2, "Attempting to emplace an Index out of range of the common_iterator variant");
+            }
+
+            constexpr size_t index() const
+            {
+                return m_elementIndex;
+            }
+
+            template<size_t Index>
+            constexpr auto& get() &
+            {
+                AZ_Assert(Index == index(), "Attempting to retrieve an inactive alternative");
+                if constexpr (Index == 0)
+                {
+                    return m_iter;
+                }
+                else
+                {
+                    return m_sentinel;
+                }
+            }
+            template<size_t Index>
+            constexpr const auto& get() const &
+            {
+                AZ_Assert(Index == index(), "Attempting to retrieve an inactive alternative");
+                if constexpr (Index == 0)
+                {
+                    return m_iter;
+                }
+                else
+                {
+                    return m_sentinel;
+                }
+            }
+            template<size_t Index>
+            constexpr auto&& get() &&
+            {
+                AZ_Assert(Index == index(), "Attempting to retrieve an inactive alternative");
+                if constexpr (Index == 0)
+                {
+                    return AZStd::move(m_iter);
+                }
+                else
+                {
+                    return AZStd::move(m_sentinel);
+                }
+            }
+            template<size_t Index>
+            constexpr const auto&& get() const &&
+            {
+                AZ_Assert(Index == index(), "Attempting to retrieve an inactive alternative");
+                if constexpr (Index == 0)
+                {
+                    return AZStd::move(m_iter);
+                }
+                else
+                {
+                    return AZStd::move(m_sentinel);
+                }
+            }
+
+            template<class T>
+            constexpr T& get() &
+            {
+                if constexpr (AZStd::same_as<T, Iter>)
+                {
+                    AZ_Assert(m_elementIndex == 0, "Attempting to retrieve an inactive alternative");
+                    return m_iter;
+                }
+                else if constexpr (AZStd::same_as<T, Sen>)
+                {
+                    AZ_Assert(m_elementIndex == 1, "Attempting to retrieve an inactive alternative");
+                    return m_sentinel;
+                }
+
+                static_assert(AZStd::same_as<T, Iter> || AZStd::same_as<T, Sen>,
+                    "type-based value accessor must either supply the Iter or Sen type");
+            }
+            template<class T>
+            constexpr const T& get() const&
+            {
+                if constexpr (AZStd::same_as<T, Iter>)
+                {
+                    AZ_Assert(m_elementIndex == 0, "Attempting to retrieve an inactive alternative");
+                    return m_iter;
+                }
+                else if constexpr (AZStd::same_as<T, Sen>)
+                {
+                    AZ_Assert(m_elementIndex == 1, "Attempting to retrieve an inactive alternative");
+                    return m_sentinel;
+                }
+
+                static_assert(AZStd::same_as<T, Iter> || AZStd::same_as<T, Sen>,
+                    "type-based value accessor must either supply the Iter or Sen type");
+            }
+            template<class T>
+            constexpr T&& get() &&
+            {
+                if constexpr (AZStd::same_as<T, Iter>)
+                {
+                    AZ_Assert(m_elementIndex == 0, "Attempting to retrieve an inactive alternative");
+                    return AZStd::move(m_iter);
+                }
+                else if constexpr (AZStd::same_as<T, Sen>)
+                {
+                    AZ_Assert(m_elementIndex == 1, "Attempting to retrieve an inactive alternative");
+                    return AZStd::move(m_sentinel);
+                }
+
+                static_assert(AZStd::same_as<T, Iter> || AZStd::same_as<T, Sen>,
+                    "type-based value accessor must either supply the Iter or Sen type");
+            }
+            template<class T>
+            constexpr const T&& get() const&&
+            {
+                if constexpr (AZStd::same_as<T, Iter>)
+                {
+                    AZ_Assert(m_elementIndex == 0, "Attempting to retrieve an inactive alternative");
+                    return AZStd::move(m_iter);
+                }
+                else if constexpr (AZStd::same_as<T, Sen>)
+                {
+                    AZ_Assert(m_elementIndex == 1, "Attempting to retrieve an inactive alternative");
+                    return AZStd::move(m_sentinel);
+                }
+
+                static_assert(AZStd::same_as<T, Iter> || AZStd::same_as<T, Sen>,
+                    "type-based value accessor must either supply the Iter or Sen type");
+            }
+
+        private:
+            Iter m_iter{};
+            Sen m_sentinel{};
+            uint8_t m_elementIndex{};
+        };
+
+        template<size_t Index, class Iter, class Sen>
+        static constexpr auto& get(IterVariant<Iter, Sen>& elementIter)
+        {
+            return elementIter.template get<Index>();
+        }
+        template<size_t Index, class Iter, class Sen>
+        static constexpr const auto& get(const IterVariant<Iter, Sen>& elementIter)
+        {
+            return elementIter.template get<Index>();
+        }
+        template<size_t Index, class Iter, class Sen>
+        static constexpr auto&& get(IterVariant<Iter, Sen>&& elementIter)
+        {
+            return AZStd::move(elementIter).template get<Index>();
+        }
+
+        template<class T, class Iter, class Sen>
+        static constexpr auto& get(IterVariant<Iter, Sen>& elementIter)
+        {
+            return elementIter.template get<T>();
+        }
+        template<class T, class Iter, class Sen>
+        static constexpr const auto& get(const IterVariant<Iter, Sen>& elementIter)
+        {
+            return elementIter.template get<T>();
+        }
+        template<class T, class Iter, class Sen>
+        static constexpr auto&& get(IterVariant<Iter, Sen>&& elementIter)
+        {
+            return AZStd::move(elementIter).template get<T>();
+        }
+
+        template<class T, class Iter, class Sen>
+        static constexpr bool holds_alternative(const IterVariant<Iter, Sen>& elementIter)
+        {
+            if constexpr (AZStd::same_as<T, Iter>)
+            {
+                return elementIter.index() == 0;
+            }
+            else if constexpr (AZStd::same_as<T, Sen>)
+            {
+                return elementIter.index() == 1;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        IterVariant<I, S> m_iterSentinel;
+#endif
     };
 
     template<class I, class S>

--- a/Code/Framework/AzCore/AzCore/std/iterator/const_iterator.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator/const_iterator.h
@@ -15,6 +15,7 @@ namespace AZStd
 {
     // Bring in std utility functions into AZStd namespace
     using std::forward;
+    using std::addressof;
 
     //! basic_const_iterator is an iterator adapter that behaves the same as the underlying iterator type
     //! except its indirection operator converts the value returned by the underlying iterators'

--- a/Code/Framework/AzCore/AzCore/std/iterator/const_iterator.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator/const_iterator.h
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/base.h>
+#include <AzCore/std/concepts/concepts.h>
+#include <AzCore/std/iterator/iterator_primitives.h>
+
+namespace AZStd
+{
+    // Bring in std utility functions into AZStd namespace
+    using std::forward;
+
+    //! basic_const_iterator is an iterator adapter that behaves the same as the underlying iterator type
+    //! except its indirection operator converts the value returned by the underlying iterators'
+    //! indirection operator to a type such that this iterator is a constant_iterator
+    template<class I>
+    class basic_const_iterator;
+}
+
+namespace AZStd::Internal
+{
+    template<class It, class = void>
+    /*concept*/ constexpr bool constant_iterator = false;
+    template<class It>
+    /*concept*/ constexpr bool constant_iterator<It, enable_if_t<input_iterator<It> &&
+        same_as<iter_const_reference_t<It>, iter_reference_t<It>> >> = true;
+
+    template<class I, class = void>
+    struct basic_const_iterator_iter_category {};
+
+    template<class I>
+    struct basic_const_iterator_iter_category<I, enable_if_t<forward_iterator<I>>>
+    {
+        using iterator_category = typename ITER_TRAITS<I>::iterator_category;
+    };
+}
+
+namespace AZStd
+{
+    template<class I>
+    using const_iterator = enable_if_t<input_iterator<I>, conditional_t<Internal::constant_iterator<I>, I, basic_const_iterator<I>>>;
+
+    template<class S>
+    using const_sentinel = conditional_t<input_iterator<S>, const_iterator<S>, S>;
+
+    // Not a const concept is false if the iterator is a specialization of the basic_const_iterator template
+    template<class It>
+    /*concept*/ constexpr bool not_a_const_iterator = true;
+    template<class It>
+    /*concept*/ constexpr bool not_a_const_iterator<basic_const_iterator<It>> = Internal::is_primary_template_v<basic_const_iterator<It>>;
+
+    template<class I>
+    class basic_const_iterator
+        : public enable_if_t<input_or_output_iterator<I>, Internal::basic_const_iterator_iter_category<I>>
+    {
+    public:
+        using _is_primary_template = basic_const_iterator;
+
+        using iterator_concept = conditional_t<contiguous_iterator<I>, contiguous_iterator_tag,
+            conditional_t<random_access_iterator<I>, random_access_iterator_tag,
+            conditional_t<bidirectional_iterator<I>, bidirectional_iterator_tag,
+            conditional_t<forward_iterator<I>, forward_iterator_tag, input_iterator_tag>
+            >
+            >
+        >;
+
+        using value_type = iter_value_t<I>;
+        using difference_type = iter_difference_t<I>;
+
+        //! reference type and pointer type is need to use with algorithms that use pre c++20 iterator_traits
+        using reference = iter_const_reference_t<I>;
+        using pointer = const value_type*;
+
+        template<bool Enable = default_initializable<I>, class = enable_if<Enable>>
+        constexpr basic_const_iterator() {}
+        constexpr basic_const_iterator(I i)
+            : m_current{ AZStd::move(i) }
+        {
+        }
+
+        template<class I2, class = enable_if_t<convertible_to<I2, I>>>
+        constexpr basic_const_iterator(basic_const_iterator<I2> other)
+            : m_current(AZStd::move(other.m_current))
+        {
+        }
+
+        template<class T, class = enable_if_t<Internal::different_from<T, basic_const_iterator> && convertible_to<T, I>>>
+        constexpr basic_const_iterator(T&& current)
+            : m_current(AZStd::forward<T>(current))
+        {
+        }
+
+        constexpr const I& base() const& noexcept
+        {
+            return m_current;
+        }
+        constexpr I base() &&
+        {
+            return AZStd::move(m_current);
+        }
+
+        constexpr reference operator*() const
+        {
+            return static_cast<reference>(*m_current);
+        }
+
+        template<bool Enable = is_lvalue_reference_v<iter_reference_t<I>> &&
+            same_as<remove_cvref_t<iter_reference_t<I>>, value_type>, class = enable_if_t<Enable>>
+        constexpr const value_type* operator->() const
+        {
+            if constexpr (contiguous_iterator<I>)
+            {
+                return to_address(m_current);
+            }
+            else
+            {
+                return addressof(*m_current);
+            }
+        }
+
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        constexpr reference operator[](difference_type n) const
+        {
+            return static_cast<reference>(m_current[n]);
+        }
+
+        // operations
+        constexpr basic_const_iterator& operator++()
+        {
+            ++m_current;
+            return *this;
+        }
+        constexpr decltype(auto) operator++(int)
+        {
+            if constexpr (forward_iterator<I>)
+            {
+                basic_const_iterator tmp = *this;
+                ++*this;
+                return tmp;
+            }
+            else
+            {
+                // return type is void in this case
+                ++m_current;
+            }
+        }
+
+        template<bool Enable = bidirectional_iterator<I>, class = enable_if_t<Enable>>
+        constexpr basic_const_iterator& operator--()
+        {
+            --m_current;
+            return *this;
+        }
+
+        template<bool Enable = bidirectional_iterator<I>, class = enable_if_t<Enable>>
+        constexpr basic_const_iterator operator--(int)
+        {
+            basic_const_iterator tmp = *this;
+            --* this;
+            return tmp;
+        }
+
+        // operator +=, -=
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        constexpr basic_const_iterator& operator+=(iter_difference_t<I> n)
+        {
+            m_current += n;
+            return *this;
+        }
+
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        constexpr basic_const_iterator& operator-=(iter_difference_t<I> n)
+        {
+            m_current -= n;
+            return *this;
+        }
+
+
+        // comparison operations
+        template<class S>
+        friend constexpr auto operator==(const basic_const_iterator& i, const S& s)
+            -> enable_if_t<sentinel_for<S, I>, bool>
+        {
+            return i.base() == s;
+        }
+
+        template<class S>
+        friend constexpr auto operator!=(const basic_const_iterator& i, const S& s)
+            -> enable_if_t<sentinel_for<S, I>, bool>
+        {
+            return !operator==(i, s);
+        }
+
+        // friend comparison functions
+        template<class S>
+        friend constexpr auto operator==(const S& s, const basic_const_iterator& i)
+            -> enable_if_t<sentinel_for<S, I> && Internal::different_from<S, basic_const_iterator>, bool>
+        {
+            return operator==(i, s);
+        }
+
+        template<class S>
+        friend constexpr auto operator!=(const S& s, const basic_const_iterator& i)
+            -> enable_if_t<sentinel_for<S, I> && Internal::different_from<S, basic_const_iterator>, bool>
+        {
+            return !operator==(i, s);
+        }
+
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        friend constexpr bool operator<(const basic_const_iterator& x, const basic_const_iterator& y)
+        {
+            return x.base() < y.base();
+        }
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        friend constexpr bool operator>(const basic_const_iterator& x, const basic_const_iterator& y)
+        {
+            return x.base() > y.base();
+        }
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        friend constexpr bool operator<=(const basic_const_iterator& x, const basic_const_iterator& y)
+        {
+            return x.base() <= y.base();
+        }
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        friend constexpr bool operator>=(const basic_const_iterator& x, const basic_const_iterator& y)
+        {
+            return x.base() >= y.base();
+        }
+
+        // comparison against iterators that are not the exact type of this class
+        template<class I2>
+        friend constexpr auto operator<(const basic_const_iterator& x, const I2& y)
+            -> enable_if_t<Internal::different_from<I2, basic_const_iterator> && random_access_iterator<I> && totally_ordered_with<I, I2>,
+            bool>
+        {
+            return x.base() < y;
+        }
+        template<class I2>
+        friend constexpr auto operator>(const basic_const_iterator& x, const I2& y)
+            -> enable_if_t<Internal::different_from<I2, basic_const_iterator> && random_access_iterator<I>&& totally_ordered_with<I, I2>,
+            bool>
+        {
+            return x.base() > y;
+        }
+        template<class I2>
+        friend constexpr auto operator<=(const basic_const_iterator& x, const I2& y)
+            -> enable_if_t<Internal::different_from<I2, basic_const_iterator> && random_access_iterator<I>&& totally_ordered_with<I, I2>,
+            bool>
+        {
+            return x.base() <= y;
+        }
+        template<class I2>
+        friend constexpr auto operator>=(const basic_const_iterator& x, const I2& y)
+            -> enable_if_t<Internal::different_from<I2, basic_const_iterator> && random_access_iterator<I>&& totally_ordered_with<I, I2>,
+            bool>
+        {
+            return x.base() >= y;
+        }
+
+        // compares a specialization of basic_const_iterator against this instance
+        template<class I2>
+        friend constexpr auto operator<(const I2&x, const basic_const_iterator& y)
+            -> enable_if_t<not_a_const_iterator<I2> && random_access_iterator<I>&& totally_ordered_with<I, I2>,
+            bool>
+        {
+            return x < y.base();
+        }
+        template<class I2>
+        friend constexpr auto operator>(const I2&x, const basic_const_iterator& y)
+            -> enable_if_t<not_a_const_iterator<I2> && random_access_iterator<I>&& totally_ordered_with<I, I2>,
+            bool>
+        {
+            return x > y.base();
+        }
+        template<class I2>
+        friend constexpr auto operator<=(const I2&x, const basic_const_iterator& y)
+            -> enable_if_t<not_a_const_iterator<I2> && random_access_iterator<I>&& totally_ordered_with<I, I2>,
+            bool>
+        {
+            return x <= y.base();
+        }
+        template<class I2>
+        friend constexpr auto operator>=(const I2&x, const basic_const_iterator& y)
+            -> enable_if_t<not_a_const_iterator<I2> && random_access_iterator<I>&& totally_ordered_with<I, I2>,
+            bool>
+        {
+            return x >= y.base();
+        }
+
+        // friend arithmetic operators
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        friend constexpr basic_const_iterator operator+(const basic_const_iterator& i, iter_difference_t<I> n)
+        {
+            return basic_const_iterator(i.base() + n);
+        }
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        friend constexpr basic_const_iterator operator+(iter_difference_t<I> n, const basic_const_iterator& i)
+        {
+            return i + n;
+        }
+
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        friend constexpr basic_const_iterator operator-(const basic_const_iterator& i, iter_difference_t<I> n)
+        {
+            return basic_const_iterator(i.base() - n);
+        }
+
+        // friend navigation operators
+        template<class S>
+        friend constexpr auto operator-(const basic_const_iterator& i, const S& s)
+            -> enable_if_t<sized_sentinel_for<S, I>, difference_type>
+        {
+            return i.base() - s;
+        }
+
+        template<class S>
+        friend constexpr auto operator-(const S& s, const basic_const_iterator& i)
+            -> enable_if_t<sized_sentinel_for<S, I> && Internal::different_from<S, basic_const_iterator>, difference_type>
+        {
+            return s - i.base();
+        }
+
+    private:
+        I m_current{};
+    };
+
+    template<class I>
+    constexpr auto make_const_iterator(I it)
+        -> enable_if_t<input_iterator<I>, const_iterator<I>>
+    {
+        return it;
+    }
+
+    template<class S>
+    constexpr const_sentinel<S> make_const_sentinel(S s)
+    {
+        return s;
+    }
+}
+
+namespace std
+{
+    // As AZStd aliases std::common_type, the specializations need to be put in the std namespace
+    template<class T, class U>
+    struct common_type<AZStd::basic_const_iterator<T>, U>
+    {
+        using type = AZStd::enable_if_t<AZStd::common_with<U, T>, AZStd::basic_const_iterator<common_type_t<T, U>>>;
+    };
+    template<class T, class U>
+    struct common_type<U, AZStd::basic_const_iterator<T>>
+    {
+        using type = AZStd::enable_if_t<AZStd::common_with<U, T>, AZStd::basic_const_iterator<common_type_t<T, U>>>;
+    };
+    template<class T, class U>
+    struct common_type<AZStd::basic_const_iterator<T>, AZStd::basic_const_iterator<U>>
+    {
+        using type = AZStd::enable_if_t<AZStd::common_with<U, T>, AZStd::basic_const_iterator<common_type_t<T, U>>>;
+    };
+}

--- a/Code/Framework/AzCore/AzCore/std/iterator/counted_iterator.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator/counted_iterator.h
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/base.h>
+#include <AzCore/std/iterator/iterator_primitives.h>
+
+namespace AZStd
+{
+    // Bring in std utility functions into AZStd namespace
+    using std::forward;
+}
+
+namespace AZStd::Internal
+{
+    template<class I, class = void>
+    struct counted_iterator_value_type {};
+
+    template<class I>
+    struct counted_iterator_value_type<I, enable_if_t<indirectly_readable<I>>>
+    {
+        using value_type = iter_value_t<I>;
+    };
+
+    template<class I, class = void>
+    struct counted_iterator_iter_concept {};
+
+    template<class I>
+    struct counted_iterator_iter_concept<I, void_t<typename ITER_TRAITS<I>::iterator_concept>>
+    {
+        using iterator_concept = typename ITER_TRAITS<I>::iterator_concept;
+    };
+
+    template<class I, class = void>
+    struct counted_iterator_iter_category {};
+
+    template<class I>
+    struct counted_iterator_iter_category<I, void_t<typename ITER_TRAITS<I>::iterator_category>>
+    {
+        using iterator_category = typename ITER_TRAITS<I>::iterator_category;
+    };
+
+    struct counted_iterator_requirements_fulfilled {};
+}
+
+namespace AZStd
+{
+    //! counted_iterator is an iterator adapter that behaves the same as the underlying iterator
+    //! except its keeps track of the distance to the end of the range
+
+    template<class I>
+    class counted_iterator
+        : public Internal::counted_iterator_value_type<I>
+        , public Internal::counted_iterator_iter_concept<I>
+        , public Internal::counted_iterator_iter_category<I>
+        , private enable_if_t<input_or_output_iterator<I>, Internal::counted_iterator_requirements_fulfilled>
+    {
+    public:
+        using iterator_type = I;
+        using difference_type = iter_difference_t<I>;
+
+        //! reference type and pointer type is need to use with algorithms that use pre c++20 iterator_traits
+        using reference = iter_reference_t<I>;
+        using pointer = conditional_t<contiguous_iterator<I>, decltype(to_address(declval<I>())), void>;
+
+        template<bool Enable = default_initializable<I>, class = enable_if<Enable>>
+        constexpr counted_iterator() {}
+        constexpr counted_iterator(I i, iter_difference_t<I> length)
+            : m_current{ AZStd::move(i) }
+            , m_length{ length }
+        {
+        }
+
+        template<class I2, class = enable_if_t<convertible_to<const I2&, I>>>
+        constexpr counted_iterator(const counted_iterator<I2>& other)
+            : m_current(other.m_current)
+            , m_length(other.m_length)
+        {
+        }
+
+        template<class I2, class = enable_if_t<assignable_from<I&, const I2&>>>
+        constexpr counted_iterator& operator=(const counted_iterator<I2>& other)
+        {
+            m_current = other.m_current;
+            m_length = other.m_length;
+            return *this;
+        }
+
+        constexpr const I& base() const& noexcept
+        {
+            return m_current;
+        }
+        constexpr I base() &&
+        {
+            return AZStd::move(m_current);
+        }
+
+        constexpr iter_difference_t<I> count() const noexcept
+        {
+            return m_length;
+        }
+
+        constexpr decltype(auto) operator*()
+        {
+            AZ_Assert(m_length > 0, "Attempting to dereference a counted_iterator with a negative count");
+            return *m_current;
+        }
+        template<bool Enable = Internal::dereferenceable<const I>, class = enable_if_t<Enable>>
+        constexpr decltype(auto) operator*() const
+        {
+            AZ_Assert(m_length > 0, "Attempting to dereference a counted_iterator with a negative count");
+            return *m_current;
+        }
+
+        template<bool Enable = contiguous_iterator<I>, class = enable_if_t<Enable>>
+        constexpr auto operator->() const noexcept
+        {
+            return to_address(m_current);
+        }
+
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        constexpr decltype(auto) operator[](iter_difference_t<I> n) const noexcept
+        {
+            AZ_Assert(n < m_length, "index %lld is out of range count %lld", static_cast<AZ::s64>(n), static_cast<AZ::s64>(m_length));
+            return m_current[n];
+        }
+
+        // navigation operators
+        constexpr counted_iterator& operator++()
+        {
+            AZ_Assert(m_length > 0, "counted_iterator count is 0, it can no longer be incremented");
+            ++m_current;
+            --m_length;
+            return *this;
+        }
+        constexpr decltype(auto) operator++(int)
+        {
+            AZ_Assert(m_length > 0, "counted_iterator count is 0, it can no longer be incremented");
+            if constexpr (forward_iterator<I>)
+            {
+                counted_iterator tmp = *this;
+                ++*this;
+                return tmp;
+            }
+            else
+            {
+                --m_length;
+                return m_current++;
+            }
+        }
+
+        template<bool Enable = bidirectional_iterator<I>, class = enable_if_t<Enable>>
+        constexpr counted_iterator& operator--()
+        {
+            --m_current;
+            ++m_length;
+            return *this;
+        }
+
+        template<bool Enable = bidirectional_iterator<I>, class = enable_if_t<Enable>>
+        constexpr counted_iterator operator--(int)
+        {
+            counted_iterator tmp = *this;
+            --*this;
+            return tmp;
+        }
+
+        // operator+, +=
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        constexpr counted_iterator operator+(iter_difference_t<I> n)
+        {
+            return counted_iterator(m_current + n, m_length - n);
+        }
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        constexpr counted_iterator& operator+=(iter_difference_t<I> n)
+        {
+            AZ_Assert(n <= m_length, "the input distance cannot advance the counted_iterator pass the end of the count");
+            m_current += n;
+            m_length -= n;
+            return *this;
+        }
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        friend constexpr counted_iterator operator+(iter_difference_t<I> n, const counted_iterator& x)
+        {
+            return x + n;
+        }
+
+        // operator-, -=
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        constexpr counted_iterator operator-(iter_difference_t<I> n)
+        {
+            return counted_iterator(m_current - n, m_length + n);
+        }
+        template<bool Enable = random_access_iterator<I>, class = enable_if_t<Enable>>
+        constexpr counted_iterator& operator-=(iter_difference_t<I> n)
+        {
+            AZ_Assert(-n <= m_length, "the input distance cannot advance the counted_iterator pass the end of the count");
+            m_current -= n;
+            m_length += n;
+            return *this;
+        }
+
+        // friend navigation operators
+        template<class I2>
+        friend constexpr auto operator-(const counted_iterator& x, const counted_iterator<I2>& y)
+            -> enable_if_t<common_with<I2, I>, iter_difference_t<I2>>
+        {
+            return y.count() - x.count();
+        }
+
+        friend constexpr iter_difference_t<I> operator-(const counted_iterator& x, default_sentinel_t)
+        {
+            return -x.count();
+        }
+
+        friend constexpr iter_difference_t<I> operator-(default_sentinel_t, const counted_iterator& y)
+        {
+            return y.count();
+        }
+
+        // comparison operations
+        template<class I2>
+        friend constexpr auto operator==(const counted_iterator& x, const counted_iterator<I2>& y)
+            -> enable_if_t<common_with<I2, I>, bool>
+        {
+            return x.count() == y.count();
+        }
+        template<class I2>
+        friend constexpr auto operator!=(const counted_iterator& x, const counted_iterator<I2>& y)
+            ->enable_if_t<common_with<I2, I>, bool>
+        {
+            return !operator==(x, y);
+        }
+
+        friend constexpr bool operator==(const counted_iterator& x, default_sentinel_t)
+        {
+            return x.count() == 0;
+        }
+        friend constexpr bool operator!=(const counted_iterator& x, default_sentinel_t)
+        {
+            return !operator==(x, default_sentinel);
+        }
+        friend constexpr bool operator==(default_sentinel_t, const counted_iterator& x)
+        {
+            return operator==(x, default_sentinel);
+        }
+        friend constexpr bool operator!=(default_sentinel_t, const counted_iterator& x)
+        {
+            return !operator==(x, default_sentinel);
+        }
+
+        template<class I2>
+        friend constexpr auto operator<(const counted_iterator& x, const counted_iterator<I2>& y)
+            ->enable_if_t<common_with<I2, I>, bool>
+        {
+            // Comparison is reversed, due to length being decremented as the counted_iterator advances
+            // therefore a counted_iterator referring to the same sequence is further
+            // along if it has a lesser count value
+            return y.count() < x.count();
+        }
+        template<class I2>
+        friend constexpr auto operator>(const counted_iterator& x, const counted_iterator<I2>& y)
+            ->enable_if_t<common_with<I2, I>, bool>
+        {
+            return operator<(y, x);
+        }
+        template<class I2>
+        friend constexpr auto operator<=(const counted_iterator& x, const counted_iterator<I2>& y)
+            ->enable_if_t<common_with<I2, I>, bool>
+        {
+            return !operator<(y, x);
+        }
+        template<class I2>
+        friend constexpr auto operator>=(const counted_iterator& x, const counted_iterator<I2>& y)
+            ->enable_if_t<common_with<I2, I>, bool>
+        {
+            return !operator<(x, y);
+        }
+
+        friend constexpr auto iter_move(const counted_iterator& i)
+            noexcept(noexcept(ranges::iter_move(declval<const I&>())))
+            -> enable_if_t<input_iterator<I>, iter_rvalue_reference_t<I>>
+        {
+            AZ_Assert(i.count() > 0, "count value must be greater than 0 in order for iter_move to safely dereference the iterator");
+            return ranges::iter_move(i.base());
+        }
+
+        template<class I2, enable_if_t<indirectly_swappable<I2, I>>>
+        friend constexpr void iter_swap(const counted_iterator& x, const counted_iterator<I2>& y)
+            noexcept(noexcept(ranges::iter_swap(declval<const I&>(), declval<const I2&>())))
+        {
+            AZ_Assert(x.count() > 0 && y.count(),
+                "both iterators count must be greater than 0 in order for iter_swap to safely dereference the iterators");
+            return ranges::iter_swap(x.base(), y.base());
+        }
+
+    private:
+        I m_current{};
+        iter_difference_t<I> m_length{};
+    };
+}
+
+namespace AZStd::Internal
+{
+    template<class I, class = void>
+    constexpr bool counted_iterator_trait_requirements = false;
+
+    template<class I>
+    constexpr bool counted_iterator_trait_requirements<I, enable_if_t<input_iterator<I>&&
+        same_as<Internal::ITER_TRAITS<I>, iterator_traits<I>>&&
+        Internal::sfinae_trigger_v<typename I::_is_primary_template>> > = true;
+}
+
+namespace AZStd
+{
+    template<class I>
+    struct iterator_traits<counted_iterator<I>, enable_if_t<Internal::counted_iterator_trait_requirements<I>>>
+        : iterator_traits<I>
+    {
+        using pointer = conditional_t<contiguous_iterator<I>, add_pointer_t<iter_reference_t<I>>, void>;
+
+    };
+}

--- a/Code/Framework/AzCore/AzCore/std/iterator/iterator_primitives.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator/iterator_primitives.h
@@ -35,8 +35,8 @@ namespace AZStd
     // Bring in std utility functions into AZStd namespace
     using std::forward;
 
-    // forward declare iterator_traits to avoid iterator.h include
-    template <class I>
+    // forward declare iterator_traits to avoid circular include with iterator.h
+    template <class I, class = void>
     struct iterator_traits;
 }
 
@@ -143,10 +143,10 @@ namespace AZStd::Internal
         using difference_type = typename T::difference_type;
     };
     template <typename T>
-    struct incrementable_requires<T, enable_if_t< conjunction_v<
+    struct incrementable_requires<T, enable_if_t<conjunction_v<
         bool_constant<is_primary_template_v<iterator_traits<T>>>,
         bool_constant<!has_difference_type_v<T>>,
-        bool_constant<integral<decltype(declval<T>() - declval<T>())>>> >>
+        bool_constant<integral<decltype(declval<const T&>() - declval<const T&>())>>> >>
     {
         using difference_type = make_signed_t<decltype(declval<T>() - declval<T>())>;
     };
@@ -206,6 +206,11 @@ namespace AZStd
     template <typename T>
     using iter_common_reference_t = enable_if_t<Internal::indirectly_readable_impl<T>,
         common_reference_t<iter_reference_t<T>, iter_value_t<T>&>>;
+
+    template<class It>
+    using iter_const_reference_t = enable_if_t<Internal::indirectly_readable_impl<It>,
+        common_reference_t<const iter_value_t<It>&&, iter_reference_t<It>>>;
+
 }
 
 namespace AZStd

--- a/Code/Framework/AzCore/AzCore/std/iterator/move_iterator.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator/move_iterator.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/base.h>
+#include <AzCore/std/concepts/concepts.h>
+#include <AzCore/std/iterator/iterator_primitives.h>
+
+namespace AZStd
+{
+    // Bring in std utility functions into AZStd namespace
+    using std::forward;
+}
+
+namespace AZStd::Internal
+{
+    template<class I, class = void>
+    struct move_iterator_iter_category {};
+
+    template<class I>
+    struct move_iterator_iter_category<I, void_t<typename ITER_TRAITS<I>::iterator_category>>
+    {
+        using iterator_category = conditional_t<
+            derived_from<typename ITER_TRAITS<I>::iterator_category, random_access_iterator_tag>,
+            random_access_iterator_tag,
+            typename ITER_TRAITS<I>::iterator_category
+        >;
+    };
+}
+
+namespace AZStd
+{
+    // C++20 compliant move_iterator implementation
+    // https://eel.is/c++draft/iterators#move.iterators
+    template<class I>
+    class move_iterator
+        : public Internal::move_iterator_iter_category<I>
+    {
+    public:
+        using iterator_type = I;
+        using iterator_concept = conditional_t<random_access_iterator<I>, random_access_iterator_tag,
+                conditional_t<bidirectional_iterator<I>, bidirectional_iterator_tag,
+                conditional_t<forward_iterator<I>, forward_iterator_tag, input_iterator_tag>
+            >
+        >;
+        using value_type = iter_value_t<I>;
+        using difference_type = iter_difference_t<I>;
+        using pointer = I;
+        using reference = iter_rvalue_reference_t<I>;
+
+        constexpr move_iterator() = default;
+        constexpr move_iterator(I i)
+            : m_current{ AZStd::move(i) }
+        {
+        }
+
+        template<class I2, class = enable_if_t<!same_as<I2, I> && convertible_to<const I2&, I>>>
+        constexpr move_iterator(const move_iterator<I2>& other)
+            : m_current{ other.m_current }
+        {
+        }
+
+        template<class I2, class = enable_if_t<!same_as<I2, I>&& convertible_to<const I2&, I>>>
+        constexpr move_iterator& operator=(const move_iterator<I2>& other)
+        {
+            m_current = other.m_current;
+            return *this;
+        }
+
+        constexpr const I& base() const& noexcept
+        {
+            return m_current;
+        }
+
+        constexpr I base() &&
+        {
+            return AZStd::move(m_current);
+        }
+
+        constexpr reference operator*() const
+        {
+            return ranges::iter_move(m_current);
+        }
+
+        constexpr reference operator[](difference_type n) const
+        {
+            return ranges::iter_move(m_current + n);
+        }
+
+        constexpr move_iterator& operator++()
+        {
+            ++m_current;
+            return *this;
+        }
+        constexpr auto operator++(int)
+        {
+            if constexpr (forward_iterator<I>)
+            {
+                auto tmp = *this;
+                ++m_current;
+                return tmp;
+            }
+            else
+            {
+                ++m_current;
+            }
+        }
+
+        constexpr move_iterator& operator--()
+        {
+            --m_current;
+            return *this;
+        }
+        constexpr move_iterator operator--(int)
+        {
+            auto tmp = *this;
+            --m_current;
+            return tmp;
+        }
+
+        constexpr move_iterator operator+(difference_type n) const
+        {
+            return move_iterator(m_current + n);
+        }
+        constexpr move_iterator& operator+=(difference_type n)
+        {
+            m_current += n;
+            return *this;
+        }
+
+        constexpr move_iterator operator-(difference_type n) const
+        {
+            return move_iterator(m_current - n);
+        }
+        constexpr move_iterator& operator-=(difference_type n)
+        {
+            m_current -= n;
+            return *this;
+        }
+
+        // comparison
+        template<class I2>
+        friend constexpr auto operator==(const move_iterator& x, const move_iterator<I2>& y)
+            -> enable_if_t<equality_comparable_with<I, I2>, bool>
+        {
+            return x.base() == y.base();
+
+        }
+        template<class I2>
+        friend constexpr auto operator!=(const move_iterator& x, const move_iterator<I2>& y)
+            -> enable_if_t<equality_comparable_with<I, I2>, bool>
+        {
+            return !operator==(x, y);
+        }
+
+        template<class I2>
+        friend constexpr auto operator<(const move_iterator& x, const move_iterator<I2>& y)
+            -> enable_if_t<convertible_to<decltype(declval<I>() < declval<I2>()), bool>, bool>
+        {
+            return x.base() < y.base();
+        }
+        template<class I2>
+        friend constexpr auto operator>(const move_iterator& x, const move_iterator<I2>& y)
+            ->enable_if_t<convertible_to<decltype(declval<I>() < declval<I2>()), bool>, bool>
+        {
+            return operator<(y, x);
+        }
+        template<class I2>
+        friend constexpr auto operator<=(const move_iterator& x, const move_iterator<I2>& y)
+            ->enable_if_t<convertible_to<decltype(declval<I>() < declval<I2>()), bool>, bool>
+        {
+            return !operator<(y, x);
+        }
+        template<class I2>
+        friend constexpr auto operator>=(const move_iterator& x, const move_iterator<I2>& y)
+            ->enable_if_t<convertible_to<decltype(declval<I>() < declval<I2>()), bool>, bool>
+        {
+            return !operator<(x, y);
+        }
+
+        template<class I2>
+        friend constexpr auto operator-(const move_iterator& x, const move_iterator<I2>& y)
+            -> decltype(declval<const I&>() - declval<const I2&>())
+        {
+            return x.base() - y.base();
+        }
+
+        friend constexpr reference iter_move(const move_iterator& i)
+            noexcept(noexcept(ranges::iter_move(declval<const I&>())))
+        {
+            return ranges::iter_move(i.base());
+        }
+
+        template<class I2, enable_if_t<indirectly_swappable<I2, I>>>
+        friend constexpr void iter_swap(const move_iterator& x, const move_iterator<I2>& y)
+            noexcept(noexcept(ranges::iter_swap(declval<const I&>(), declval<const I2&>())))
+        {
+            return ranges::iter_swap(x.base(), y.base());
+        }
+
+    private:
+        I m_current{};
+    };
+
+    template <class I>
+    constexpr move_iterator<I> make_move_iterator(I i)
+    {
+        return move_iterator<I>(i);
+    }
+}

--- a/Code/Framework/AzCore/AzCore/std/iterator/move_sentinel.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator/move_sentinel.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/base.h>
+#include <AzCore/std/concepts/concepts.h>
+
+
+namespace AZStd
+{
+    template<class S, class = void>
+    class move_sentinel;
+
+    template<class S>
+    class move_sentinel<S, enable_if_t<semiregular<S>>>
+    {
+    public:
+        template<bool Enable = default_initializable<S>, class = enable_if<Enable>>
+        constexpr move_sentinel()
+            : m_last{}
+        {
+        }
+        constexpr explicit move_sentinel(S s)
+            : m_last{ AZStd::move(s) }
+        {
+        }
+
+        template<class S2, class = enable_if_t<convertible_to<const S2&, S>>>
+        constexpr move_sentinel(const move_sentinel<S2>& other)
+            : m_last{ other.m_last }
+        {
+        }
+
+        template<class S2, class = enable_if_t<assignable_from<S&, const S2&>>>
+        constexpr move_sentinel& operator=(const move_sentinel<S2>& other)
+        {
+            m_last = other.m_last;
+            return *this;
+        }
+
+        constexpr S base() const
+        {
+            return m_last;
+        }
+
+        template<class I, class = enable_if_t<sentinel_for<S, I>>>
+        friend constexpr bool operator==(const move_iterator<I>& x, const move_sentinel& y)
+        {
+            return x.base() == y.base();
+        }
+        template<class I, class = enable_if_t<sentinel_for<S, I>>>
+        friend constexpr bool operator!=(const move_iterator<I>& x, const move_sentinel& y)
+        {
+            return !operator==(x, y);
+        }
+
+        // Swap the compare arguments
+        template<class I, class = enable_if_t<sentinel_for<S, I>>>
+        friend constexpr bool operator==(const move_sentinel& y, const move_iterator<I>& x)
+        {
+            return operator==(x, y);
+        }
+        template<class I, class = enable_if_t<sentinel_for<S, I>>>
+        friend constexpr bool operator!=(const move_sentinel& y, const move_iterator<I>& x)
+        {
+            return !operator==(x, y);
+        }
+
+        template<class I, class = enable_if_t<sized_sentinel_for<S, I>>>
+        friend constexpr iter_difference_t<I> operator-(const move_sentinel& x, const move_iterator<I>& y)
+        {
+            return x.base() - y.base();
+        }
+        template<class I, class = enable_if_t<sized_sentinel_for<S, I>>>
+        friend constexpr iter_difference_t<I> operator-(const move_iterator<I>& x, const move_sentinel& y)
+        {
+            return x.base() - y.base();
+        }
+
+    private:
+        S m_last;
+    };
+}

--- a/Code/Framework/AzCore/AzCore/std/iterator/move_sentinel.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator/move_sentinel.h
@@ -13,11 +13,8 @@
 
 namespace AZStd
 {
-    template<class S, class = void>
-    class move_sentinel;
-
-    template<class S>
-    class move_sentinel<S, enable_if_t<semiregular<S>>>
+    template<class S, class = enable_if_t<semiregular<S>>>
+    class move_sentinel
     {
     public:
         template<bool Enable = default_initializable<S>, class = enable_if<Enable>>

--- a/Code/Framework/AzCore/AzCore/std/iterator/unreachable_sentinel.h
+++ b/Code/Framework/AzCore/AzCore/std/iterator/unreachable_sentinel.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/base.h>
+#include <AzCore/std/concepts/concepts.h>
+
+
+namespace AZStd
+{
+    //! Represents the upper bound of an unbounded range
+    //! It is never equal to the iterator being compared against.
+    struct unreachable_sentinel_t
+    {
+        template<class I, class = enable_if_t<weakly_incrementable<I>>>
+        friend bool operator==(unreachable_sentinel_t, const I&) noexcept
+        {
+            return false;
+        }
+        template<class I, class = enable_if_t<weakly_incrementable<I>>>
+        friend bool operator!=(unreachable_sentinel_t, const I&) noexcept
+        {
+            return true;
+        }
+        template<class I, class = enable_if_t<weakly_incrementable<I>>>
+        friend bool operator==(const I&, unreachable_sentinel_t) noexcept
+        {
+            return false;
+        }
+        template<class I, class = enable_if_t<weakly_incrementable<I>>>
+        friend bool operator!=(const I&, unreachable_sentinel_t) noexcept
+        {
+            return true;
+        }
+    };
+
+    inline constexpr unreachable_sentinel_t unreachable_sentinel{};
+}

--- a/Code/Framework/AzCore/AzCore/std/ranges/all_view.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/all_view.h
@@ -55,13 +55,13 @@ namespace AZStd::ranges::views
     namespace Internal
     {
         template <class R, class = void>
-        struct all_t {};
+        struct all_view {};
         template <class R>
-        struct all_t<R, enable_if_t<ranges::viewable_range<R>>>
+        struct all_view<R, enable_if_t<ranges::viewable_range<R>>>
         {
             using type = decltype(views::all(declval<R>()));
         };
     }
     template<class R>
-    using all_t = typename Internal::all_t<R>::type;
+    using all_t = typename Internal::all_view<R>::type;
 }

--- a/Code/Framework/AzCore/AzCore/std/ranges/as_const_view.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/as_const_view.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/containers/span.h>
+#include <AzCore/std/ranges/all_view.h>
+#include <AzCore/std/ranges/ranges_adaptor.h>
+
+namespace AZStd::ranges
+{
+    //! presents a view of the underlying sequence as a constant.
+    //! Elements of const_view cannot be modified
+    template<class View>
+    class as_const_view;
+}
+
+// views::as_const customization point
+namespace AZStd::ranges::views
+{
+    namespace Internal
+    {
+        template<class V, class = void>
+        constexpr bool is_all_t_constant_range = false;
+        template<class V>
+        constexpr bool is_all_t_constant_range<V, enable_if_t<constant_range<all_t<V>>>> = true;
+
+        template<class V>
+        constexpr bool is_view_span = false;
+        template<class X, size_t Extent>
+        constexpr bool is_view_span<span<X, Extent>> = true;
+
+        template<class V, class = void>
+        constexpr bool is_lvalue_constant_range_not_view = false;
+        template<class V>
+        constexpr bool is_lvalue_constant_range_not_view<V, enable_if_t<
+            is_lvalue_reference_v<V>&&
+            constant_range<const remove_cvref_t<V>> &&
+            !view<remove_cvref_t<V>>
+            >> = true;
+
+        template<class V>
+        struct get_const_span_type {};
+        template<class X, size_t Extent>
+        struct get_const_span_type<span<X, Extent>>
+        {
+            using type = span<const X, Extent>;
+        };
+
+        struct as_const_fn
+            : Internal::range_adaptor_closure<as_const_fn>
+        {
+            template<class View>
+            constexpr decltype(auto) operator()(View&& view) const
+            {
+                if constexpr (is_all_t_constant_range<View>)
+                {
+                    return views::all(AZStd::forward<View>(view));
+                }
+                else if constexpr (is_view_span<remove_cvref_t<View>>)
+                {
+                    return typename get_const_span_type<View>::type(AZStd::forward<View>(view));
+                }
+                else if constexpr (is_lvalue_constant_range_not_view<View>)
+                {
+                    return ref_view(static_cast<const remove_cvref_t<View>&>(AZStd::forward<View>(view)));
+                }
+                else
+                {
+                    return as_const_view(AZStd::forward<View>(view));
+                }
+            }
+        };
+    }
+    inline namespace customization_point_object
+    {
+        constexpr Internal::as_const_fn as_const{};
+    }
+}
+
+namespace AZStd::ranges::Internal
+{
+    struct as_const_view_requirements_fulfilled {};
+}
+
+namespace AZStd::ranges
+{
+    template<class View>
+    class as_const_view
+        : public view_interface<as_const_view<View>>
+        , private enable_if_t<input_range<View> && view<View>, Internal::as_const_view_requirements_fulfilled>
+    {
+    public:
+        template <bool Enable = default_initializable<View>,
+            class = enable_if_t<Enable>>
+        constexpr as_const_view() {}
+
+        explicit constexpr as_const_view(View base)
+            : m_base(AZStd::move(base))
+        {
+        }
+
+        template <bool Enable = copy_constructible<View>, class = enable_if_t<Enable>>
+        constexpr View base() const&
+        {
+            return m_base;
+        }
+        constexpr View base() &&
+        {
+            return AZStd::move(m_base);
+        }
+
+        template<bool Enable = !Internal::simple_view<View>, class = enable_if_t<Enable>>
+        constexpr auto begin()
+        {
+            return ranges::cbegin(m_base);
+        }
+        template<bool Enable = range<const View>, class = enable_if_t<Enable>>
+        constexpr auto begin() const
+        {
+            return ranges::cbegin(m_base);
+        }
+
+        template<bool Enable = !Internal::simple_view<View>, class = enable_if_t<Enable>>
+        constexpr auto end()
+        {
+            return ranges::cend(m_base);
+        }
+        template<bool Enable = range<const View>, class = enable_if_t<Enable>>
+        constexpr auto end() const
+        {
+            return ranges::cend(m_base);
+        }
+
+        template<bool Enable = sized_range<View>, class = enable_if_t<Enable>>
+        constexpr auto size()
+        {
+            return ranges::size(m_base);
+        }
+
+        template<bool Enable = sized_range<const View>, class = enable_if_t<Enable>>
+        constexpr auto size() const
+        {
+            return ranges::size(m_base);
+        }
+
+    private:
+        View m_base{};
+    };
+
+    // deduction guides
+    template<class R>
+    as_const_view(R&&) -> as_const_view<views::all_t<R>>;
+
+    template<class T>
+    inline constexpr bool enable_borrowed_range<as_const_view<T>> = enable_borrowed_range<T>;
+}

--- a/Code/Framework/AzCore/AzCore/std/ranges/as_rvalue_view.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/as_rvalue_view.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/iterator/move_sentinel.h>
+#include <AzCore/std/ranges/all_view.h>
+#include <AzCore/std/ranges/ranges_adaptor.h>
+
+namespace AZStd::ranges
+{
+    //! view which provides the same behavior of the underlying sequenence, except
+    //! that its elements are rvalues
+    template<class View>
+    class as_rvalue_view;
+}
+
+// views::as_rvalue customization point
+namespace AZStd::ranges::views
+{
+    namespace Internal
+    {
+        struct as_rvalue_fn
+            : Internal::range_adaptor_closure<as_rvalue_fn>
+        {
+            template<class View>
+            constexpr auto operator()(View&& view) const
+            {
+                // If the rvalue refrence is the same as the reference type, then an rvalue view
+                // will not have an effect, so use use all to return a suitable view
+                if constexpr(same_as<range_rvalue_reference_t<View>, range_reference_t<View>>)
+                {
+                    return views::all(AZStd::forward<View>(view));
+                }
+                else
+                {
+                    return as_rvalue_view(AZStd::forward<View>(view));
+                }
+            }
+        };
+    }
+    inline namespace customization_point_object
+    {
+        constexpr Internal::as_rvalue_fn as_rvalue{};
+    }
+}
+
+namespace AZStd::ranges::Internal
+{
+    struct as_rvalue_view_requirements_fulfilled {};
+}
+
+namespace AZStd::ranges
+{
+    template<class View>
+    class as_rvalue_view
+        : public view_interface<as_rvalue_view<View>>
+        , private enable_if_t<input_range<View>, Internal::as_rvalue_view_requirements_fulfilled>
+    {
+    public:
+        template <bool Enable = default_initializable<View>,
+            class = enable_if_t<Enable>>
+        constexpr as_rvalue_view() {}
+
+        explicit constexpr as_rvalue_view(View base)
+            : m_base(AZStd::move(base))
+        {
+        }
+
+        template <bool Enable = copy_constructible<View>, class = enable_if_t<Enable>>
+        constexpr View base() const&
+        {
+            return m_base;
+        }
+        constexpr View base() &&
+        {
+            return AZStd::move(m_base);
+        }
+
+        template<bool Enable = !Internal::simple_view<View>, class = enable_if_t<Enable>>
+        constexpr auto begin()
+        {
+            return move_iterator{ ranges::begin(m_base) };
+        }
+
+        template<bool Enable = range<const View>, class = enable_if_t<Enable>>
+        constexpr auto begin() const
+        {
+            return move_iterator{ ranges::begin(m_base) };
+        }
+
+        template<bool Enable = !Internal::simple_view<View>, class = enable_if_t<Enable>>
+        constexpr auto end()
+        {
+            if constexpr (common_range<View>)
+            {
+                return move_iterator{ ranges::end(m_base) };
+            }
+            else
+            {
+                return move_sentinel{ ranges::end(m_base) };
+            }
+        }
+
+        template<bool Enable = range<const View>, class = enable_if_t<Enable>>
+        constexpr auto end() const
+        {
+            if constexpr (common_range<const View>)
+            {
+                return move_iterator{ ranges::end(m_base) };
+            }
+            else
+            {
+                return move_sentinel{ ranges::end(m_base) };
+            }
+        }
+
+
+        template<bool Enable = sized_range<View>, class = enable_if_t<Enable>>
+        constexpr auto size()
+        {
+            return ranges::size(m_base);
+        }
+
+        template<bool Enable = sized_range<const View>, class = enable_if_t<Enable>>
+        constexpr auto size() const
+        {
+            return ranges::size(m_base);
+        }
+
+    private:
+        View m_base{};
+    };
+
+    // deduction guides
+    template<class R>
+    as_rvalue_view(R&&) -> as_rvalue_view<views::all_t<R>>;
+}

--- a/Code/Framework/AzCore/AzCore/std/ranges/common_view.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/common_view.h
@@ -15,7 +15,7 @@ namespace AZStd::ranges
 {
     template<class View, class = enable_if_t<conjunction_v<
         bool_constant<!common_range<View>>,
-        bool_constant<copyable<View>>
+        bool_constant<copyable<iterator_t<View>>>
         >
         >>
     class common_view;

--- a/Code/Framework/AzCore/AzCore/std/ranges/counted_view.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/counted_view.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/containers/span.h>
+#include <AzCore/std/ranges/subrange.h>
+#include <AzCore/std/iterator/counted_iterator.h>
+
+namespace AZStd::ranges::views
+{
+    namespace Internal
+    {
+        template<class T, class CountType, class = void>
+        constexpr bool count_convertible_to_iter_difference_v = false;
+        template<class T, class CountType>
+        constexpr bool count_convertible_to_iter_difference_v<T, CountType,
+            enable_if_t<convertible_to<CountType, iter_difference_t<decay_t<T>>> >> = true;
+
+        struct counted_fn
+            : Internal::range_adaptor_closure<counted_fn>
+        {
+            template<class Iterator, class DifferenceType, class = enable_if_t<
+                count_convertible_to_iter_difference_v<Iterator, DifferenceType> >>
+            constexpr decltype(auto) operator()(Iterator&& i, DifferenceType&& count) const
+            {
+                using DecayIterator = decay_t<Iterator>;
+                using IteratorDiffType = iter_difference_t<DecayIterator>;
+                if constexpr (contiguous_iterator<DecayIterator>)
+                {
+                    return span(to_address(i), static_cast<size_t>(static_cast<IteratorDiffType>(count)));
+                }
+                else if constexpr (random_access_iterator<DecayIterator>)
+                {
+                    return subrange(AZStd::forward<Iterator>(i),
+                        AZStd::forward<Iterator>(i) + static_cast<IteratorDiffType>(AZStd::forward<DifferenceType>(count)));
+                }
+                else
+                {
+                    return subrange<counted_iterator<Iterator>, default_sentinel_t>(counted_iterator<Iterator>(AZStd::forward<Iterator>(i), AZStd::forward<DifferenceType>(count)),
+                        default_sentinel);
+                }
+            }
+        };
+    }
+
+    inline namespace customization_point_object
+    {
+        constexpr Internal::counted_fn counted{};
+    }
+}

--- a/Code/Framework/AzCore/AzCore/std/ranges/filter_view.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/filter_view.h
@@ -16,7 +16,6 @@ namespace AZStd::ranges
     template<class View, class Pred, class = enable_if_t<conjunction_v<
         bool_constant<input_range<View>>,
         bool_constant<view<View>>,
-        bool_constant<copy_constructible<Pred>>,
         is_object<Pred>,
         bool_constant<indirect_unary_predicate<Pred, iterator_t<View>>>
         >
@@ -112,7 +111,7 @@ namespace AZStd::ranges
 
     private:
         View m_base{};
-        Internal::copyable_box<Pred> m_func{};
+        Internal::movable_box<Pred> m_func{};
     };
 
     // deduction guides

--- a/Code/Framework/AzCore/AzCore/std/ranges/iota_internal.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/iota_internal.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/concepts/concepts.h>
+#include <AzCore/std/typetraits/type_identity.h>
+
+
+namespace AZStd::ranges::Internal
+{
+    // Take advantage of type_identity type to "store" a type alias
+    template<class IntType>
+    static constexpr auto get_wider_signed_integer_type()
+    {
+        if constexpr (sizeof(IntType) < sizeof(AZ::s16))
+        {
+            return type_identity<AZ::s16>{};
+        }
+        else if constexpr (sizeof(IntType) < sizeof(AZ::s32))
+        {
+            return type_identity<AZ::s32>{};
+        }
+        else
+        {
+            return type_identity<AZ::s64>{};
+        }
+
+        static_assert(!::AZStd::Internal::is_integer_like<IntType> || sizeof(IntType) <= sizeof(AZ::s64),
+            "integer type which is larger than the largest signed integer type has been found.");
+    }
+
+    template<class IntType>
+    using get_wider_signed_integer_type_t = typename decltype(get_wider_signed_integer_type<IntType>())::type;
+
+    template<class W>
+    using IOTA_DIFF_T = conditional_t<!::AZStd::Internal::is_integer_like<W> || (sizeof(iter_difference_t<W>) > sizeof(W)),
+        iter_difference_t<W>, get_wider_signed_integer_type_t<W>>;
+}

--- a/Code/Framework/AzCore/AzCore/std/ranges/iota_view.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/iota_view.h
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/iterator/unreachable_sentinel.h>
+#include <AzCore/std/ranges/iota_internal.h>
+#include <AzCore/std/ranges/ranges_adaptor.h>
+
+namespace AZStd::ranges
+{
+    //! Generates a sequence of elements by repeating incrementing an initial element W
+    //! up to Bound
+    template<class W, class Bound = unreachable_sentinel_t, class = enable_if_t<conjunction_v<
+        bool_constant<weakly_incrementable<W>>,
+        bool_constant<semiregular<Bound>>,
+        bool_constant<::AZStd::Internal::weakly_equality_comparable_with<W, Bound>>,
+        bool_constant<copyable<W>>
+    > >>
+    class iota_view;
+
+    template<class W, class Bound>
+    inline constexpr bool enable_borrowed_range<iota_view<W, Bound>> = true;
+}
+
+// views::iota customization point
+namespace AZStd::ranges::views
+{
+    namespace Internal
+    {
+        struct iota_fn
+            : Internal::range_adaptor_closure<iota_fn>
+        {
+            template<class W, class Bound>
+            constexpr auto operator()(W&& value, Bound&& bound) const
+            {
+                return iota_view(AZStd::forward<W>(value), AZStd::forward<Bound>(bound));
+            }
+
+            template<class W>
+            constexpr auto operator()(W&& value) const
+            {
+                return iota_view(AZStd::forward<W>(value));
+            }
+        };
+    }
+    inline namespace customization_point_object
+    {
+        constexpr Internal::iota_fn iota{};
+    }
+}
+
+namespace AZStd::ranges::Internal
+{
+    template<class I, class = void>
+    /*concept*/ constexpr bool decrementable = false;
+    template<class I>
+    /*concept*/ constexpr bool decrementable<I, enable_if_t<conjunction_v<
+        bool_constant<incrementable<I>>,
+        bool_constant<same_as<decltype(--declval<I&>()), I&>>,
+        bool_constant<same_as<decltype(declval<I&>()--), I>>
+    > >> = true;
+
+    template<class I, class = void>
+    /*concept*/ constexpr bool advanceable = false;
+    template<class I>
+    /*concept*/ constexpr bool advanceable<I, enable_if_t<conjunction_v<
+        bool_constant<decrementable<I>>,
+        bool_constant<totally_ordered<I>>,
+        bool_constant<same_as<decltype(declval<I&>() += declval<const IOTA_DIFF_T<I>>()), I&>>,
+        bool_constant<same_as<decltype(declval<I&>() -= declval<const IOTA_DIFF_T<I>>()), I&>>,
+        sfinae_trigger<decltype(I(declval<const I>() + declval<const IOTA_DIFF_T<I>>()))>,
+        sfinae_trigger<decltype(I(declval<const IOTA_DIFF_T<I>>() + declval<const I>()))>,
+        sfinae_trigger<decltype(I(declval<const I>() - declval<const IOTA_DIFF_T<I>>()))>,
+        bool_constant<convertible_to<decltype(declval<const I&>() - declval<const I&>()), IOTA_DIFF_T<I> > >
+        > >> = true;
+}
+
+namespace AZStd::ranges
+{
+    template<class W, class Bound, class>
+    class iota_view
+        : public view_interface<iota_view<W, Bound>>
+    {
+        struct iterator;
+        struct sentinel;
+
+    public:
+        template <bool Enable = default_initializable<W>,
+            class = enable_if_t<Enable>>
+        constexpr iota_view() {}
+
+        explicit constexpr iota_view(W value)
+            : m_value(AZStd::move(value))
+        {
+        }
+
+        constexpr iota_view(type_identity_t<W> value, type_identity_t<Bound> bound)
+            : m_value(value)
+            , m_bound(bound)
+        {
+            if constexpr (totally_ordered_with<W, Bound>)
+            {
+                AZ_Assert(value <= bound, "W and Bound are totally ordered with and value is greater than bound");
+            }
+        }
+
+        //! iterator and sentinel are not complete types at this point,
+        //! so these construtors are defined after those types are defined
+        template<bool Enable = same_as<W, Bound>, class = enable_if_t<Enable>>
+        constexpr iota_view(iterator first, iterator last);
+
+        template<bool Enable = same_as<Bound, unreachable_sentinel_t>, class = enable_if_t<Enable>>
+        constexpr iota_view(iterator first, Bound last);
+
+        template<bool Enable = !same_as<W, Bound> && !same_as<Bound, unreachable_sentinel_t>, class = enable_if_t<Enable>>
+        constexpr iota_view(iterator first, sentinel last);
+
+        constexpr auto begin() const
+        {
+            return iterator(m_value);
+        }
+
+        constexpr auto end() const
+        {
+            if constexpr (same_as<W, Bound>)
+            {
+                return iterator{ m_bound };
+            }
+            else if constexpr (!same_as<Bound, unreachable_sentinel_t>)
+            {
+                return sentinel{ m_bound };
+            }
+            else
+            {
+                return unreachable_sentinel;
+            }
+        }
+
+        template<bool Enable = (same_as<W, Bound> && Internal::advanceable<W>)
+            || (::AZStd::Internal::is_integer_like<W> && ::AZStd::Internal::is_integer_like<Bound>)
+            || sized_sentinel_for<Bound, W>,
+            class = enable_if_t<Enable>>
+        constexpr auto size() const
+        {
+            if constexpr (::AZStd::Internal::is_integer_like<W> && ::AZStd::Internal::is_integer_like<Bound>)
+            {
+                return (m_value < 0) ? ((m_bound < 0)
+                    ? Internal::to_unsigned_like(-m_value) - Internal::to_unsigned_like(-m_bound)
+                    : Internal::to_unsigned_like(m_bound) + Internal::to_unsigned_like(m_value))
+                    : Internal::to_unsigned_like(m_bound) - Internal::to_unsigned_like(m_value);
+            }
+            else
+            {
+                return Internal::to_unsigned_like(m_bound - m_value);
+            }
+        }
+
+    private:
+        W m_value{};
+        Bound m_bound{};
+    };
+
+    // deduction guides
+    template<class W, class Bound, class = enable_if_t<disjunction_v<
+        bool_constant<!::AZStd::Internal::is_integer_like<W>>,
+        bool_constant<!::AZStd::Internal::is_integer_like<Bound>>,
+        bool_constant<::AZStd::Internal::is_signed_integer_like<W> == ::AZStd::Internal::is_signed_integer_like<Bound>>
+        >>>
+    iota_view(W, Bound) -> iota_view<W, Bound>;
+}
+
+namespace AZStd::ranges::Internal
+{
+    // Use for base class type in enable_if_t checks in iterator and sentinel
+    struct iota_view_requirements_fulfilled {};
+}
+
+namespace AZStd::ranges
+{
+    // iota iterator
+    template<class W, class Bound, class ViewEnable>
+    struct iota_view<W, Bound, ViewEnable>::iterator
+        : enable_if_t<conjunction_v<
+        bool_constant<weakly_incrementable<W>>,
+        bool_constant<semiregular<Bound>>,
+        bool_constant<::AZStd::Internal::weakly_equality_comparable_with<W, Bound>>,
+        bool_constant<copyable<W>>
+        >, Internal::iota_view_requirements_fulfilled>
+    {
+    private:
+        friend class iota_view;
+        friend struct sentinel;
+
+    public:
+
+        using iterator_concept = conditional_t<Internal::advanceable<W>, random_access_iterator_tag,
+            conditional_t<Internal::decrementable<W>, bidirectional_iterator_tag,
+            conditional_t<incrementable<W>, forward_iterator_tag, input_iterator_tag>
+            >>;
+
+        using iterator_category = input_iterator_tag;
+
+        using value_type = W;
+        using difference_type = Internal::IOTA_DIFF_T<W>;
+
+        // libstdc++ std::reverse_iterator use pre C++ concept when the concept feature is off
+        // which requires that the iterator type has the aliases
+        // of difference_type, value_type, pointer, reference, iterator_category,
+        // With C++20, the iterator concept support is used to deduce the traits
+        // needed, therefore alleviating the need to special std::iterator_traits
+        // The following code allows std::reverse_iterator(which is aliased into AZStd namespace)
+        // to work with the AZStd range views
+#if !__cpp_lib_concepts
+        using pointer = void;
+        using reference = W;
+#endif
+
+        template<bool Enable = default_initializable<W>,
+            class = enable_if_t<Enable>>
+        constexpr iterator() {}
+
+        constexpr explicit iterator(W value)
+            : m_value(value)
+        {
+        }
+
+        constexpr W operator*() const noexcept(is_nothrow_copy_constructible_v<W>)
+        {
+            return m_value;
+        }
+
+        constexpr iterator& operator++()
+        {
+            ++m_value;
+            return *this;
+        }
+
+        constexpr auto operator++(int)
+        {
+            if constexpr (incrementable<W>)
+            {
+                auto tmp = *this;
+                ++m_value;
+                return tmp;
+            }
+            else
+            {
+                ++m_value;
+            }
+        }
+
+        template<bool Enable = Internal::decrementable<W>, class = enable_if_t<Enable>>
+        constexpr iterator& operator--()
+        {
+            --m_value;
+            return *this;
+        }
+
+        template<bool Enable = Internal::decrementable<W>, class = enable_if_t<Enable>>
+        constexpr iterator operator--(int)
+        {
+            auto tmp = *this;
+            --m_value;
+            return tmp;
+        }
+
+        template<bool Enable = Internal::advanceable<W>, class = enable_if_t<Enable>>
+        constexpr iterator& operator+=(difference_type n)
+        {
+            m_value += n;
+            return *this;
+        }
+
+        template<bool Enable = Internal::advanceable<W>, class = enable_if_t<Enable>>
+        constexpr iterator& operator-=(difference_type n)
+        {
+            m_value -= n;
+            return *this;
+        }
+
+        template<bool Enable = Internal::advanceable<W>, class = enable_if_t<Enable>>
+        constexpr W operator[](difference_type n) const
+        {
+            return m_value + n;
+        }
+
+        template<bool Enable = equality_comparable<W>, class = enable_if_t<Enable>>
+        friend constexpr bool operator==(const iterator& x, const iterator& y)
+        {
+            return x.m_value == y.m_value;
+        }
+        template<bool Enable = equality_comparable<W>, class = enable_if_t<Enable>>
+        friend constexpr bool operator!=(const iterator& x, const iterator& y)
+        {
+            return !operator==(x, y);
+        }
+
+        template<bool Enable = totally_ordered<W>, class = enable_if_t<Enable>>
+        friend constexpr bool operator<(const iterator& x, const iterator& y)
+        {
+            return x.m_value < y.m_value;
+        }
+        template<bool Enable = totally_ordered<W>, class = enable_if_t<Enable>>
+        friend constexpr bool operator>(const iterator& x, const iterator& y)
+        {
+            return operator<(y, x);
+        }
+        template<bool Enable = totally_ordered<W>, class = enable_if_t<Enable>>
+        friend constexpr bool operator<=(const iterator& x, const iterator& y)
+        {
+            return !operator<(y, x);
+        }
+        template<bool Enable = totally_ordered<W>, class = enable_if_t<Enable>>
+        friend constexpr bool operator>=(const iterator& x, const iterator& y)
+        {
+            return !operator<(x, y);
+        }
+
+        template<bool Enable = Internal::advanceable<W>, class = enable_if_t<Enable>>
+        friend constexpr iterator operator+(iterator i, difference_type n)
+        {
+            i += n;
+            return i;
+        }
+        template<bool Enable = Internal::advanceable<W>, class = enable_if_t<Enable>>
+        friend constexpr iterator operator+(difference_type n, iterator i)
+        {
+            i += n;
+            return i;
+        }
+
+        template<bool Enable = Internal::advanceable<W>, class = enable_if_t<Enable>>
+        friend constexpr iterator operator-(iterator i, difference_type n)
+        {
+            i -= n;
+            return i;
+        }
+
+        template<bool Enable = Internal::advanceable<W>, class = enable_if_t<Enable>>
+        friend constexpr difference_type operator-(const iterator& x, const iterator& y)
+        {
+            if constexpr (::AZStd::Internal::is_integer_like<W>)
+            {
+                if constexpr (::AZStd::Internal::is_signed_integer_like<W>)
+                {
+                    return static_cast<difference_type>(difference_type(x.m_value) - difference_type(y.m_value));
+                }
+                else
+                {
+                    return y.m_value > x._value ? static_cast<difference_type>(-difference_type(y.m_value - x.m_value))
+                        : static_cast<difference_type>(x.m_value - y.m_value);
+                }
+            }
+            else
+            {
+                return x.m_value - y.m_value;
+            }
+        }
+
+    private:
+        //! current value
+        W m_value{};
+    };
+
+    // sentinel type for iota
+    template<class W, class Bound, class ViewEnable>
+    struct iota_view<W, Bound, ViewEnable>::sentinel
+        : enable_if_t<conjunction_v<
+        bool_constant<weakly_incrementable<W>>,
+        bool_constant<semiregular<Bound>>,
+        bool_constant<::AZStd::Internal::weakly_equality_comparable_with<W, Bound>>,
+        bool_constant<copyable<W>>
+        >, Internal::iota_view_requirements_fulfilled>
+    {
+    private:
+        friend class iota_view;
+
+    public:
+        sentinel() = default;
+        constexpr explicit sentinel(Bound bound)
+            : m_boundSentinel(bound)
+        {}
+
+        // comparison operators
+        friend constexpr bool operator==(const iterator& x, const sentinel& y)
+        {
+            return iterator_accessor(x) == y.m_end;
+        }
+        friend constexpr bool operator==(const sentinel& y, const iterator& x)
+        {
+            return operator==(x, y);
+        }
+        friend constexpr bool operator!=(const iterator& x, const sentinel& y)
+        {
+            return !operator==(x, y);
+        }
+        friend constexpr bool operator!=(const sentinel& y, const iterator& x)
+        {
+            return !operator==(x, y);
+        }
+
+        template<bool Enable = sized_sentinel_for<Bound, W>, class = enable_if_t<Enable>>
+        friend constexpr iter_difference_t<W> operator-(const iterator& x, const sentinel& y)
+        {
+            return iterator_accessor(x) - y.m_bound;
+        }
+
+        template<bool Enable = sized_sentinel_for<Bound, W>, class = enable_if_t<Enable>>
+        friend constexpr iter_difference_t<W> operator-(const sentinel& x, const iterator& y)
+        {
+            return -(y - x);
+        }
+
+    private:
+        // On MSVC The friend functions are can only access the sentinel struct members
+        // The iterator struct which is a friend of the sentinel struct is NOT a friend
+        // of the friend functions
+        // So a shim is added to provide access to the iterator m_current member
+        static constexpr auto iterator_accessor(const iterator& i)
+        {
+            return i.m_value;
+        }
+
+        Bound m_boundSentinel{};
+    };
+
+    //! iota_view iterator and sentinel constructor definitions
+    template<class W, class Bound, class ViewEnable>
+    template<bool, class>
+    constexpr iota_view<W, Bound, ViewEnable>::iota_view(iterator first, iterator last)
+        : m_value(AZStd::move(first.m_value))
+        , m_bound(AZStd::move(last.m_value))
+    {}
+
+    template<class W, class Bound, class ViewEnable>
+    template<bool, class>
+    constexpr iota_view<W, Bound, ViewEnable>::iota_view(iterator first, Bound last)
+        : m_value(AZStd::move(first.m_value))
+        , m_bound(unreachable_sentinel)
+    {}
+
+    template<class W, class Bound, class ViewEnable>
+    template<bool, class>
+    constexpr iota_view<W, Bound, ViewEnable>::iota_view(iterator first, sentinel last)
+        : m_value(AZStd::move(first.m_value))
+        , m_bound(AZStd::move(last.m_boundSentinel))
+    {}
+}

--- a/Code/Framework/AzCore/AzCore/std/ranges/join_with_view.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/join_with_view.h
@@ -301,11 +301,11 @@ namespace AZStd::ranges
         {
             if (i.m_innerIter.index() == 0)
             {
-                m_innerIter.template emplace<0>(AZStd::get<0>(AZStd::move(i.m_innerIter)));
+                m_innerIter.template emplace<0>(get<0>(AZStd::move(i.m_innerIter)));
             }
             else
             {
-                m_innerIter.template emplace<1>(AZStd::get<1>(AZStd::move(i.m_innerIter)));
+                m_innerIter.template emplace<1>(get<1>(AZStd::move(i.m_innerIter)));
             }
         }
 
@@ -313,13 +313,13 @@ namespace AZStd::ranges
         {
             using reference = common_reference_t<iter_reference_t<InnerIter>, iter_reference_t<PatternIter>>;
             auto get_reference = [](auto& it) -> reference { return *it; };
-            return AZStd::visit(AZStd::move(get_reference), m_innerIter);
+            return visit(AZStd::move(get_reference), m_innerIter);
         }
 
         constexpr iterator& operator++()
         {
             auto increment = [](auto& it) { ++it; };
-            AZStd::visit(increment, m_innerIter);
+            visit(increment, m_innerIter);
             satisfy();
             return *this;
         }
@@ -355,7 +355,7 @@ namespace AZStd::ranges
                 if (m_innerIter.index() == 0)
                 {
                     // The current iterator is pointing within the pattern
-                    auto& it = AZStd::get<0>(m_innerIter);
+                    auto& it = get<0>(m_innerIter);
                     if (it == ranges::begin(m_parent->m_pattern))
                     {
                         // swap iterator to point at the end of the input value
@@ -370,7 +370,7 @@ namespace AZStd::ranges
                 else
                 {
                     // The current iterator is pointing within an input value
-                    auto& it = AZStd::get<1>(m_innerIter);
+                    auto& it = get<1>(m_innerIter);
                     auto&& inner = *m_outerIter;
                     if (it == ranges::begin(inner))
                     {
@@ -386,7 +386,7 @@ namespace AZStd::ranges
 
             // Move inner iterator backwards to the previous element of the value being viewed
             auto decrement = [](auto& it) { --it; };
-            AZStd::visit(decrement, m_innerIter);
+            visit(decrement, m_innerIter);
             return *this;
         }
 
@@ -422,13 +422,13 @@ namespace AZStd::ranges
             using rvalue_reference = common_reference_t<
                 iter_rvalue_reference_t<InnerIter>,
                 iter_rvalue_reference_t<PatternIter>>;
-            return AZStd::visit<rvalue_reference>(ranges::iter_move, x.m_innerIter);
+            return visit<rvalue_reference>(ranges::iter_move, x.m_innerIter);
         }
 
 
         friend constexpr void iter_swap(iterator& x, iterator& y)
         {
-            return AZStd::visit(ranges::iter_swap, x.m_innerIter, y.m_innerIter);
+            visit(ranges::iter_swap, x.m_innerIter, y.m_innerIter);
         }
 
     private:
@@ -496,7 +496,7 @@ namespace AZStd::ranges
                 if (m_innerIter.index() == 0)
                 {
                     // If Currently iterating over the pattern break out the for loop
-                    if (AZStd::get<0>(m_innerIter) != ranges::end(m_parent->m_pattern))
+                    if (get<0>(m_innerIter) != ranges::end(m_parent->m_pattern))
                     {
                         break;
                     }
@@ -509,7 +509,7 @@ namespace AZStd::ranges
                 else
                 {
                     auto&& inner = get_inner(m_outerIter);
-                    if (AZStd::get<1>(m_innerIter) != ranges::end(inner))
+                    if (get<1>(m_innerIter) != ranges::end(inner))
                     {
                         break;
                     }
@@ -534,9 +534,159 @@ namespace AZStd::ranges
 
         //! iterator to the outer view element of the view wrapped by the join_with_view
         OuterIter m_outerIter{};
-        //! iterator to the range element which is wrapped by the view
-        //! or the pattern
+        //! iterator to the range element which is wrapped by the view or the pattern
+        //! placement new and destructor calls aren't constexpr until C++20
+        //! Because AZStd::variant under the hood invokes AZStd::construct_at, which uses placement new
+        //! this makes the emplace calls in this class non-constexpr
+        //! fallback to use a struct in C++17 with a bool, since it is simple to deal with than a union
+#if __cpp_constexpr_dynamic_alloc >= 201907L
         variant<PatternIter, InnerIter> m_innerIter{};
+#else
+        struct ElementIter
+        {
+            constexpr bool operator==(const ElementIter& other) const
+            {
+                return m_elementIndex != other.m_elementIndex ? false
+                    : m_elementIndex == 0
+                    ? m_pattern == other.m_pattern
+                    : m_inner == other.m_inner;
+            }
+            constexpr bool operator!=(const ElementIter& other) const
+            {
+                return !operator==(other);
+            }
+            template<size_t Index, class... Args>
+            constexpr auto& emplace(Args&&... args)
+            {
+                m_elementIndex = Index;
+                if constexpr (Index == 0)
+                {
+                    m_pattern = PatternIter(AZStd::forward<Args>(args)...);
+                    return m_pattern;
+                }
+                else
+                {
+                    m_inner = InnerIter(AZStd::forward<Args>(args)...);
+                    return m_inner;
+                }
+            }
+
+            constexpr size_t index() const
+            {
+                return m_elementIndex;
+            }
+
+            PatternIter m_pattern{};
+            InnerIter m_inner{};
+            uint8_t m_elementIndex{};
+        } m_innerIter;
+
+        template<size_t Index>
+        static constexpr auto& get(ElementIter& elementIter)
+        {
+            if constexpr (Index == 0)
+            {
+                return elementIter.m_pattern;
+            }
+            else
+            {
+                return elementIter.m_inner;
+            }
+        }
+        template<size_t Index>
+        static constexpr const auto& get(const ElementIter& elementIter)
+        {
+            if constexpr (Index == 0)
+            {
+                return elementIter.m_pattern;
+            }
+            else
+            {
+                return elementIter.m_inner;
+            }
+        }
+        template<size_t Index>
+        static constexpr auto&& get(ElementIter&& elementIter)
+        {
+            if constexpr (Index == 0)
+            {
+                return AZStd::move(elementIter.m_pattern);
+            }
+            else
+            {
+                return AZStd::move(elementIter.m_inner);
+            }
+        }
+        template<size_t Index>
+        static constexpr const auto&& get(const ElementIter&& elementIter)
+        {
+            if constexpr (Index == 0)
+            {
+                return AZStd::move(elementIter.m_pattern);
+            }
+            else
+            {
+                return AZStd::move(elementIter.m_inner);
+            }
+        }
+
+        template<class Fn, class ElementIter1>
+        static constexpr decltype(auto) visit(Fn&& fn, ElementIter1&& elementIter1)
+        {
+            if (elementIter1.m_elementIndex == 0)
+            {
+                return AZStd::forward<Fn>(fn)(AZStd::forward<ElementIter1>(elementIter1).m_pattern);
+            }
+            else
+            {
+                return AZStd::forward<Fn>(fn)(AZStd::forward<ElementIter1>(elementIter1).m_inner);
+            }
+        }
+
+        template<class R, class Fn, class ElementIter1>
+        static constexpr R visit(Fn&& fn, ElementIter1&& elementIter1)
+        {
+            if (elementIter1.m_elementIndex == 0)
+            {
+                return R(AZStd::forward<Fn>(fn)(AZStd::forward<ElementIter1>(elementIter1).m_pattern));
+            }
+            else
+            {
+                return R(AZStd::forward<Fn>(fn)(AZStd::forward<ElementIter1>(elementIter1).m_inner));
+            }
+        }
+
+        template<class Fn, class ElementIter1, class ElementIter2>
+        constexpr decltype(auto) visit(Fn&& fn, ElementIter1&& elementIter1, ElementIter2&& elementIter2)
+        {
+            if (elementIter1.m_elementIndex == 0)
+            {
+                if (elementIter2.m_elementIndex == 0)
+                {
+                    return AZStd::forward<Fn>(fn)(AZStd::forward<ElementIter1>(elementIter1).m_pattern,
+                        AZStd::forward<ElementIter2>(elementIter2).m_pattern);
+                }
+                else
+                {
+                    return AZStd::forward<Fn>(fn)(AZStd::forward<ElementIter1>(elementIter1).m_pattern,
+                        AZStd::forward<ElementIter2>(elementIter2).m_inner);
+                }
+            }
+            else
+            {
+                if (elementIter2.m_elementIndex == 0)
+                {
+                    return AZStd::forward<Fn>(fn)(AZStd::forward<ElementIter1>(elementIter1).m_inner,
+                        AZStd::forward<ElementIter2>(elementIter2).m_pattern);
+                }
+                else
+                {
+                    return AZStd::forward<Fn>(fn)(AZStd::forward<ElementIter1>(elementIter1).m_inner,
+                        AZStd::forward<ElementIter2>(elementIter2).m_inner);
+                }
+            }
+        }
+#endif
         //! reference to parent join_with_view
         Parent* m_parent{};
     };

--- a/Code/Framework/AzCore/AzCore/std/ranges/ranges_adaptor.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/ranges_adaptor.h
@@ -83,7 +83,7 @@ namespace AZStd::ranges::views::Internal
             convertible_to<UAdaptor, Adaptor>
             && convertible_to<tuple<UArgs...>, tuple<Args...>>
             >>
-        range_adaptor_argument_forwarder(UAdaptor adaptor, UArgs&&... args)
+        constexpr explicit range_adaptor_argument_forwarder(UAdaptor adaptor, UArgs&&... args)
             : m_adaptor{ AZStd::forward<UAdaptor>(adaptor) }
             , m_forwardArgs{ AZStd::forward<UArgs>(args)... }
         {}

--- a/Code/Framework/AzCore/AzCore/std/ranges/ranges_adaptor.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/ranges_adaptor.h
@@ -175,50 +175,54 @@ namespace AZStd::ranges::views::Internal
 
 namespace AZStd::ranges::Internal
 {
-    // Copyable Wrapper - https://eel.is/c++draft/ranges#range.copy.wrap
-    // Used to wrap a class that copy constructible, but not necessarily copy assignable
-    // and implements a copy assignment operator using the optional emplace function
+    // Movable Wrapper - https://eel.is/c++draft/ranges#range.copy.wrap
+    // Used to wrap a class that is copy constructible/move constructible,
+    // but not necessarily copy assignable/move assignable
+    // and implements the assignment operator using the optional emplace function
     // to construct in place
     template<class T, class = void>
-    class copyable_box;
+    class movable_box;
+
 
     template<class T>
-    class copyable_box<T, enable_if_t<is_copy_constructible_v<T>&& is_object_v<T>>>
+    class movable_box<T, enable_if_t<move_constructible<T>&& is_object_v<T>>>
     {
     public:
         template<class U = T, class = enable_if_t<default_initializable<U>>>
-        constexpr copyable_box() noexcept(is_nothrow_constructible_v<T>)
-            : copyable_box{ in_place }
+        constexpr movable_box() noexcept(is_nothrow_constructible_v<T>)
+            : movable_box{ in_place }
         {}
 
         template<class... Args>
-        explicit constexpr copyable_box(in_place_t, Args&&... args) noexcept(is_nothrow_constructible_v<T>)
-            : m_copyable_wrapper{ in_place, AZStd::forward<Args>(args)... }
+        explicit constexpr movable_box(in_place_t, Args&&... args) noexcept(is_nothrow_constructible_v<T>)
+            : m_value{ in_place, AZStd::forward<Args>(args)... }
         {}
 
-        explicit constexpr copyable_box(const T& rawValue) noexcept(is_nothrow_copy_constructible_v<T>)
-            : m_copyable_wrapper{ rawValue }
+        explicit constexpr movable_box(const T& rawValue) noexcept(is_nothrow_copy_constructible_v<T>)
+            : m_value{ rawValue }
         {}
-        explicit constexpr copyable_box(T&& rawValue) noexcept(is_nothrow_copy_constructible_v<T>)
-            : m_copyable_wrapper{ AZStd::move(rawValue) }
+        explicit constexpr movable_box(T&& rawValue) noexcept(is_nothrow_copy_constructible_v<T>)
+            : m_value{ AZStd::move(rawValue) }
         {}
 
-        constexpr copyable_box(const copyable_box&) = default;
-        constexpr copyable_box(copyable_box&&) = default;
+        constexpr movable_box(const movable_box&) = default;
+        constexpr movable_box(movable_box&&) = default;
 
-        constexpr copyable_box& operator=(const copyable_box& other) noexcept(is_nothrow_copy_constructible_v<T>)
+        // requires that the T is copy_constructible to implement copy assignment
+        constexpr auto operator=(const movable_box& other) noexcept(is_nothrow_copy_constructible_v<T>)
+            -> enable_if_t<copy_constructible<T>, movable_box&>
         {
-            if (this != &other)
+            if (this != addressof(other))
             {
                 if constexpr (copyable<T>)
                 {
-                    m_copyable_wrapper = other.m_copyable_wrapper;
+                    m_value = other.m_value;
                 }
                 else
                 {
                     if (other)
                     {
-                        emplace(other.m_copyable_wrapper);
+                        emplace(other.m_value);
                     }
                     else
                     {
@@ -230,19 +234,19 @@ namespace AZStd::ranges::Internal
             return *this;
         }
 
-        constexpr copyable_box& operator=(copyable_box&& other) noexcept(is_nothrow_move_constructible_v<T>)
+        constexpr movable_box& operator=(movable_box&& other) noexcept(is_nothrow_move_constructible_v<T>)
         {
-            if (this != &other)
+            if (this != addressof(other))
             {
                 if constexpr (movable<T>)
                 {
-                    m_copyable_wrapper = AZStd::move(other.m_copyable_wrapper);
+                    m_value = AZStd::move(other.m_value);
                 }
                 else
                 {
                     if (other)
                     {
-                        emplace(AZStd::move(other.m_copyable_wrapper));
+                        emplace(AZStd::move(other.m_value));
                     }
                     else
                     {
@@ -255,47 +259,47 @@ namespace AZStd::ranges::Internal
         }
         constexpr T& operator*() & noexcept
         {
-            return *m_copyable_wrapper;
+            return *m_value;
         }
         constexpr const T& operator*() const& noexcept
         {
-            return *m_copyable_wrapper;
+            return *m_value;
         }
         constexpr T&& operator*() && noexcept
         {
-            return AZStd::move(*m_copyable_wrapper);
+            return AZStd::move(*m_value);
         }
         constexpr const T&& operator*() const&& noexcept
         {
-            return AZStd::move(*m_copyable_wrapper);
+            return AZStd::move(*m_value);
         }
 
         constexpr T* operator->() noexcept
         {
-            return m_copyable_wrapper.operator->();
+            return m_value.operator->();
         }
         constexpr const T* operator->() const noexcept
         {
-            return m_copyable_wrapper.operator->();
+            return m_value.operator->();
         }
 
         constexpr explicit operator bool()
         {
-            return m_copyable_wrapper.has_value();
+            return m_value.has_value();
         }
 
         template<class... Args>
         constexpr T& emplace(Args&&... args)
         {
-            return m_copyable_wrapper.emplace(AZStd::forward<Args>(args)...);
+            return m_value.emplace(AZStd::forward<Args>(args)...);
         }
 
         constexpr void reset() noexcept
         {
-            m_copyable_wrapper.reset();
+            m_value.reset();
         }
     private:
-        optional<T> m_copyable_wrapper;
+        optional<T> m_value;
     };
 
     // Non-propagating cache - https://eel.is/c++draft/ranges#range.nonprop.cache

--- a/Code/Framework/AzCore/AzCore/std/ranges/repeat_view.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/repeat_view.h
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/iterator/unreachable_sentinel.h>
+#include <AzCore/std/ranges/iota_internal.h>
+#include <AzCore/std/ranges/ranges_adaptor.h>
+
+namespace AZStd::ranges
+{
+    //! Generates a sequence of elements by repeating incrementing an initial element W
+    //! up to Bound
+    template<class W, class Bound = unreachable_sentinel_t, class = enable_if_t<conjunction_v<
+        bool_constant<move_constructible<W>>,
+        bool_constant<semiregular<Bound>>,
+        is_object<W>,
+        bool_constant<same_as<W, remove_cv_t<W>>>,
+        disjunction<bool_constant<::AZStd::Internal::is_integer_like<Bound>>,
+            bool_constant<same_as<Bound, unreachable_sentinel_t>>
+            >
+    > >>
+    class repeat_view;
+}
+
+// views::repeat customization point
+namespace AZStd::ranges::views
+{
+    namespace Internal
+    {
+        struct repeat_fn
+            : Internal::range_adaptor_closure<repeat_fn>
+        {
+            template<class W, class Bound>
+            constexpr auto operator()(W&& value, Bound&& bound) const
+            {
+                return repeat_view(AZStd::forward<W>(value), AZStd::forward<Bound>(bound));
+            }
+
+            template<class W>
+            constexpr auto operator()(W&& value) const
+            {
+                return repeat_view(AZStd::forward<W>(value));
+            }
+        };
+    }
+    inline namespace customization_point_object
+    {
+        constexpr Internal::repeat_fn repeat{};
+    }
+}
+
+namespace AZStd::ranges
+{
+    template<class W, class Bound, class>
+    class repeat_view
+        : public view_interface<repeat_view<W, Bound>>
+    {
+        struct iterator;
+
+    public:
+        template <bool Enable = default_initializable<W>,
+            class = enable_if_t<Enable>>
+        constexpr repeat_view() {}
+
+        template<bool Enable = copy_constructible<W>, class = enable_if_t<Enable>>
+        constexpr explicit repeat_view(const W& value, Bound bound = {})
+            : m_value(value)
+            , m_bound(bound)
+        {
+        }
+
+        constexpr explicit repeat_view(W&& value, Bound bound = {})
+            : m_value(AZStd::move(value))
+            , m_bound(bound)
+        {
+        }
+
+        template<class... WArgs, class... BoundArgs,
+            bool Enable = constructible_from<W, WArgs...>&& constructible_from<Bound, BoundArgs...>,
+            class = enable_if_t<Enable>>
+        constexpr explicit repeat_view(piecewise_construct_t, tuple<WArgs...> valueArgs, tuple<BoundArgs...> boundArgs = {})
+            : repeat_view(piecewise_construct, AZStd::move(valueArgs), AZStd::move(boundArgs),
+                make_index_sequence<sizeof...(WArgs)>{}, make_index_sequence<sizeof...(BoundArgs)>{})
+        {}
+
+        constexpr auto begin() const
+        {
+            return iterator(addressof(*m_value));
+        }
+
+        constexpr auto end() const noexcept
+        {
+            if constexpr (!same_as<Bound, unreachable_sentinel_t>)
+            {
+                return iterator{ addressof(*m_value), m_bound };
+            }
+            else
+            {
+                return unreachable_sentinel;
+            }
+        }
+
+        template<bool Enable = !same_as<Bound, unreachable_sentinel_t>, class = enable_if_t<Enable>>
+        constexpr auto size() const
+        {
+            return Internal::to_unsigned_like(m_bound);
+        }
+
+    private:
+
+        // piecewise construct value and bound by forwarding arguments from each tuple
+        template<class... WArgs, class... BoundArgs, size_t... WIndices, size_t... BoundIndices>
+        constexpr repeat_view(piecewise_construct_t, tuple<WArgs...> valueArgs, tuple<BoundArgs...> boundArgs,
+            AZStd::index_sequence<WIndices...>, AZStd::index_sequence<BoundIndices...>)
+            : m_value{ in_place, AZStd::forward<WArgs>(AZStd::get<BoundArgs>(valueArgs))... }
+            , m_bound(AZStd::forward<BoundArgs>(AZStd::get<BoundIndices>(boundArgs))...)
+        {}
+
+        Internal::movable_box<W> m_value;
+        Bound m_bound{};
+    };
+
+    // deduction guides
+    template<class W, class Bound>
+    repeat_view(W, Bound) -> repeat_view<W, Bound>;
+}
+
+namespace AZStd::ranges::Internal
+{
+    struct repeat_view_requirements_fulfilled {};
+}
+
+namespace AZStd::ranges
+{
+    // repeat iterator
+    template<class W, class Bound, class ViewEnable>
+    struct repeat_view<W, Bound, ViewEnable>::iterator
+        : enable_if_t<conjunction_v<
+        bool_constant<move_constructible<W>>,
+        bool_constant<semiregular<Bound>>,
+        is_object<W>,
+        bool_constant<same_as<W, remove_cv_t<W>>>,
+        disjunction<bool_constant<::AZStd::Internal::is_integer_like<Bound>>,
+            bool_constant<same_as<Bound, unreachable_sentinel_t>>
+            >
+        >, Internal::repeat_view_requirements_fulfilled>
+    {
+    private:
+        friend class repeat_view;
+
+        using index_type = conditional_t<same_as<Bound, unreachable_sentinel_t>, ptrdiff_t, Bound>;
+
+    public:
+
+        using iterator_concept = random_access_iterator_tag;
+        using iterator_category = random_access_iterator_tag;
+
+        using value_type = W;
+        using difference_type = conditional_t<::AZStd::Internal::is_signed_integer_like<index_type>,
+            index_type, Internal::IOTA_DIFF_T<W>>;
+
+        // libstdc++ std::reverse_iterator use pre C++ concept when the concept feature is off
+        // which requires that the iterator type has the aliases
+        // of difference_type, value_type, pointer, reference, iterator_category,
+        // With C++20, the iterator concept support is used to deduce the traits
+        // needed, therefore alleviating the need to special std::iterator_traits
+        // The following code allows std::reverse_iterator(which is aliased into AZStd namespace)
+        // to work with the AZStd range views
+#if !__cpp_lib_concepts
+        using pointer = void;
+        using reference = const W&;
+#endif
+
+        template<bool Enable = default_initializable<W>,
+            class = enable_if_t<Enable>>
+        constexpr iterator() {}
+
+        constexpr explicit iterator(const W* value, index_type b = {})
+            : m_value(value)
+            , m_current{ b }
+        {
+        }
+
+        constexpr const W& operator*() const noexcept
+        {
+            return *m_value;
+        }
+
+        constexpr iterator& operator++()
+        {
+            ++m_current;
+            return *this;
+        }
+
+        constexpr iterator& operator++(int)
+        {
+            auto tmp = *this;
+            ++m_current;
+            return tmp;
+        }
+
+        constexpr iterator& operator--()
+        {
+            --m_current;
+            return *this;
+        }
+
+        constexpr iterator operator--(int)
+        {
+            auto tmp = *this;
+            --m_current;
+            return tmp;
+        }
+
+        constexpr iterator& operator+=(difference_type n)
+        {
+            m_current += n;
+            return *this;
+        }
+
+        constexpr iterator& operator-=(difference_type n)
+        {
+            m_current -= n;
+            return *this;
+        }
+
+        constexpr const W& operator[](difference_type n) const
+        {
+            return *(*this + n);
+        }
+
+        friend constexpr bool operator==(const iterator& x, const iterator& y)
+        {
+            return x.m_current == y.m_current;
+        }
+        friend constexpr bool operator!=(const iterator& x, const iterator& y)
+        {
+            return !operator==(x, y);
+        }
+
+        friend constexpr bool operator<(const iterator& x, const iterator& y)
+        {
+            return x.m_current < y.m_current;
+        }
+        friend constexpr bool operator>(const iterator& x, const iterator& y)
+        {
+            return operator<(y, x);
+        }
+        friend constexpr bool operator<=(const iterator& x, const iterator& y)
+        {
+            return !operator<(y, x);
+        }
+        friend constexpr bool operator>=(const iterator& x, const iterator& y)
+        {
+            return !operator<(x, y);
+        }
+
+        friend constexpr iterator operator+(iterator i, difference_type n)
+        {
+            i += n;
+            return i;
+        }
+        friend constexpr iterator operator+(difference_type n, iterator i)
+        {
+            i += n;
+            return i;
+        }
+
+        friend constexpr iterator operator-(iterator i, difference_type n)
+        {
+            i -= n;
+            return i;
+        }
+
+        friend constexpr difference_type operator-(const iterator& x, const iterator& y)
+        {
+            return static_cast<difference_type>(x.m_current) - static_cast<difference_type>(y.m_current);
+        }
+
+    private:
+        const W* m_value{};
+        index_type m_current{};
+    };
+}

--- a/Code/Framework/AzCore/AzCore/std/ranges/single_view.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/single_view.h
@@ -35,7 +35,7 @@ namespace AZStd::ranges
 
     template<class T>
     class single_view
-        : public enable_if_t<copy_constructible<T> && is_object_v<T>, view_interface<single_view<T>>>
+        : public enable_if_t<move_constructible<T> && is_object_v<T>, view_interface<single_view<T>>>
     {
     public:
 
@@ -81,7 +81,7 @@ namespace AZStd::ranges
             return m_value.operator->();
         }
     private:
-        Internal::copyable_box<T> m_value;
+        Internal::movable_box<T> m_value;
     };
 
     template<class T>

--- a/Code/Framework/AzCore/AzCore/std/ranges/transform_view.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/transform_view.h
@@ -15,7 +15,7 @@ namespace AZStd::ranges
     template<class View, class Func, class = enable_if_t<conjunction_v<
         bool_constant<input_range<View>>,
         bool_constant<view<View>>,
-        bool_constant<copy_constructible<Func>>,
+        bool_constant<move_constructible<Func>>,
         is_object<Func>,
         bool_constant<regular_invocable<Func&, range_reference_t<View>>>,
         bool_constant<AZStd::Internal::can_reference<invoke_result_t<Func&, range_reference_t<View>>>>
@@ -142,7 +142,7 @@ namespace AZStd::ranges
 
     private:
         View m_base{};
-        Internal::copyable_box<Func> m_func{};
+        Internal::movable_box<Func> m_func{};
     };
 
     // deduction guides

--- a/Code/Framework/AzCore/AzCore/std/string/fixed_string.h
+++ b/Code/Framework/AzCore/AzCore/std/string/fixed_string.h
@@ -269,6 +269,8 @@ namespace AZStd
         constexpr auto resize(size_type newSize) -> void;
         constexpr auto resize(size_type newSize, Element ch) -> void;
         constexpr auto resize_no_construct(size_type newSize) -> void;
+        template<class Operation>
+        constexpr auto resize_and_overwrite(size_type n, Operation op) -> void;
 
         constexpr auto reserve(size_type newCapacity = 0) -> void;
 

--- a/Code/Framework/AzCore/AzCore/std/string/fixed_string.inl
+++ b/Code/Framework/AzCore/AzCore/std/string/fixed_string.inl
@@ -13,7 +13,7 @@
 
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/ranges/common_view.h>
-
+#include <AzCore/std/ranges/as_rvalue_view.h>
 #include <AzCore/std/string/fixed_string_Platform.inl>
 
 namespace AZStd
@@ -523,8 +523,16 @@ namespace AZStd
     inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::assign_range(R&& rg)
         -> enable_if_t<Internal::container_compatible_range<R, value_type>, basic_fixed_string&>
     {
-        auto rangeView = rg | views::common;
-        return assign(ranges::begin(rangeView), ranges::end(rangeView));
+        if constexpr (is_lvalue_reference_v<R>)
+        {
+            auto rangeView = AZStd::forward<R>(rg) | views::common;
+            return assign(ranges::begin(rangeView), ranges::end(rangeView));
+        }
+        else
+        {
+            auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
+            return assign(ranges::begin(rangeView), ranges::end(rangeView));
+        }
     }
 
     template<class Element, size_t MaxElementCount, class Traits>

--- a/Code/Framework/AzCore/AzCore/std/string/fixed_string.inl
+++ b/Code/Framework/AzCore/AzCore/std/string/fixed_string.inl
@@ -12,6 +12,7 @@
 #include <cstring>
 
 #include <AzCore/std/algorithm.h>
+#include <AzCore/std/ranges/common_view.h>
 
 #include <AzCore/std/string/fixed_string_Platform.inl>
 
@@ -338,13 +339,13 @@ namespace AZStd
         if constexpr (contiguous_iterator<InputIt>
             && is_same_v<iter_value_t<InputIt>, value_type>)
         {
-            return append(AZStd::to_address(first), AZStd::distance(first, last));
+            return append(AZStd::to_address(first), ranges::distance(first, last));
         }
         else if constexpr (forward_iterator<InputIt>)
         {
             // Input Iterator pointer type doesn't match the const_pointer type
             // So the elements need to be appended one by one into the buffer
-            size_type newSize = m_size + AZStd::distance(first, last);
+            size_type newSize = m_size + ranges::distance(first, last);
             if (fits_in_capacity(newSize))
             {
                 for (size_t updateIndex = m_size; first != last; ++first, ++updateIndex)
@@ -359,7 +360,7 @@ namespace AZStd
         else
         {
             // input iterator that aren't forward iterators can only be used in a single pass
-            // algorithm. Therefore AZStd::distance can't be used
+            // algorithm. Therefore ranges::distance can't be used
             // So the input is copied into a local string and then delegated
             // to use the (const_pointer, size_type) overload
             basic_fixed_string inputCopy;
@@ -483,13 +484,13 @@ namespace AZStd
         if constexpr (contiguous_iterator<InputIt>
             && is_same_v<iter_value_t<InputIt>, value_type>)
         {
-            return assign(AZStd::to_address(first), AZStd::distance(first, last));
+            return assign(AZStd::to_address(first), ranges::distance(first, last));
         }
         else if constexpr (forward_iterator<InputIt>)
         {
             // Input Iterator pointer type doesn't match the const_pointer type
             // So the elements need to be assigned one by one into the buffer
-            size_type newSize = AZStd::distance(first, last);
+            size_type newSize = ranges::distance(first, last);
             if (fits_in_capacity(newSize))
             {
                 for (size_t updateIndex = 0; first != last; ++first, ++updateIndex)
@@ -504,7 +505,7 @@ namespace AZStd
         else
         {
             // input iterator that aren't forward iterators can only be used in a single pass
-            // algorithm. Therefore AZStd::distance can't be used
+            // algorithm. Therefore ranges::distance can't be used
             // So the input is copied into a local string and then delegated
             // to use the (const_pointer, size_type) overload
             basic_fixed_string inputCopy;
@@ -522,7 +523,8 @@ namespace AZStd
     inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::assign_range(R&& rg)
         -> enable_if_t<Internal::container_compatible_range<R, value_type>, basic_fixed_string&>
     {
-        return assign(ranges::begin(rg), ranges::end(rg));
+        auto rangeView = rg | views::common;
+        return assign(ranges::begin(rangeView), ranges::end(rangeView));
     }
 
     template<class Element, size_t MaxElementCount, class Traits>
@@ -655,17 +657,17 @@ namespace AZStd
     inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::insert(const_iterator insertPos,
         InputIt first, InputIt last)-> enable_if_t<input_iterator<InputIt> && !is_convertible_v<InputIt, size_type>, iterator>
     {   // insert [_First, _Last) at _Where
-        size_type insertOffset = AZStd::distance(cbegin(), insertPos);
+        size_type insertOffset = ranges::distance(cbegin(), insertPos);
         if constexpr (contiguous_iterator<InputIt>
             && is_same_v<iter_value_t<InputIt>, value_type>)
         {
-            insert(insertOffset, AZStd::to_address(first), AZStd::distance(first, last));
+            insert(insertOffset, AZStd::to_address(first), ranges::distance(first, last));
         }
         else if constexpr (forward_iterator<InputIt>)
         {
             // Input Iterator pointer type doesn't match the const_pointer type
             // So the elements need to be inserted one by one into the buffer
-            size_type count = AZStd::distance(first, last);
+            size_type count = ranges::distance(first, last);
             size_type newSize = m_size + count;
             if (fits_in_capacity(newSize))
             {
@@ -681,7 +683,7 @@ namespace AZStd
         else
         {
             // input iterator that aren't forward iterators can only be used in a single pass
-            // algorithm. Therefore AZStd::distance can't be used
+            // algorithm. Therefore ranges::distance can't be used
             // So the input is copied into a local string and then delegated
             // to use the (const_pointer, size_type) overload
             basic_fixed_string inputCopy;
@@ -923,21 +925,21 @@ namespace AZStd
     inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::replace(const_iterator first, const_iterator last,
         const basic_fixed_string& rhs) -> basic_fixed_string&
     {
-        return replace(AZStd::distance(cbegin(), first), AZStd::distance(first, last), rhs);
+        return replace(ranges::distance(cbegin(), first), ranges::distance(first, last), rhs);
     }
 
     template<class Element, size_t MaxElementCount, class Traits>
     inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::replace(const_iterator first, const_iterator last,
         const_pointer ptr, size_type count) -> basic_fixed_string&
     {   // replace [first, last) with [ptr, ptr + count)
-        return replace(AZStd::distance(cbegin(), first), AZStd::distance(first, last), ptr, count);
+        return replace(ranges::distance(cbegin(), first), ranges::distance(first, last), ptr, count);
     }
 
     template<class Element, size_t MaxElementCount, class Traits>
     inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::replace(const_iterator first, const_iterator last,
         const_pointer ptr) -> basic_fixed_string&
     {   // replace [first, last) with [ptr, <null>)
-        return replace(AZStd::distance(cbegin(), first), AZStd::distance(first, last), ptr);
+        return replace(ranges::distance(cbegin(), first), ranges::distance(first, last), ptr);
     }
     template<class Element, size_t MaxElementCount, class Traits>
     template<typename T>
@@ -968,17 +970,17 @@ namespace AZStd
         if constexpr (contiguous_iterator<InputIt>
             && is_same_v<iter_value_t<InputIt>, value_type>)
         {
-            return replace(first, last, AZStd::to_address(replaceFirst), AZStd::distance(replaceFirst, replaceLast));
+            return replace(first, last, AZStd::to_address(replaceFirst), ranges::distance(replaceFirst, replaceLast));
         }
         else if constexpr (forward_iterator<InputIt>)
         {
             // Input Iterator pointer type doesn't match the const_pointer type
             // So the elements need to be appended one by one into the buffer
 
-            size_type insertOffset = AZStd::distance(cbegin(), first);
-            size_type postInsertOffset = AZStd::distance(cbegin(), last);
-            size_type count = AZStd::distance(replaceFirst, replaceLast);
-            size_type newSize = m_size + count - AZStd::distance(first, last);
+            size_type insertOffset = ranges::distance(cbegin(), first);
+            size_type postInsertOffset = ranges::distance(cbegin(), last);
+            size_type count = ranges::distance(replaceFirst, replaceLast);
+            size_type newSize = m_size + count - ranges::distance(first, last);
             if (fits_in_capacity(newSize))
             {
                 Traits::move(first + count, last, m_size - postInsertOffset); // empty out hole
@@ -994,7 +996,7 @@ namespace AZStd
         else
         {
             // input iterator that aren't forward iterators can only be used in a single pass
-            // algorithm. Therefore AZStd::distance can't be used
+            // algorithm. Therefore ranges::distance can't be used
             // So the input is copied into a local string and then delegated
             // to use the (const_pointer, size_type) overload
             basic_fixed_string inputCopy;
@@ -1164,6 +1166,17 @@ namespace AZStd
             m_size = static_cast<internal_size_type>(newSize);
             Traits::assign(data[m_size], Element());  // terminate
         }
+    }
+
+    template<class Element, size_t MaxElementCount, class Traits>
+    template<class Operation>
+    inline constexpr auto basic_fixed_string<Element, MaxElementCount, Traits>::resize_and_overwrite(size_type n, Operation op) -> void
+    {
+        resize_no_construct(n);
+        const auto newSize = AZStd::move(op)(data(), n);
+        AZSTD_CONTAINER_ASSERT(newSize >= 0 && newSize <= n,
+            "resize_and_operation operation returned a new size that is outside the bounds of [0, %zu]", n);
+        resize_no_construct(newSize);
     }
 
     template<class Element, size_t MaxElementCount, class Traits>
@@ -1798,7 +1811,7 @@ namespace AZStd
         -> typename basic_fixed_string<Element, MaxElementCount, Traits>::size_type
     {
         auto iter = AZStd::remove(container.begin(), container.end(), element);
-        auto removedCount = AZStd::distance(iter, container.end());
+        auto removedCount = ranges::distance(iter, container.end());
         container.erase(iter, container.end());
         return removedCount;
     }
@@ -1808,7 +1821,7 @@ namespace AZStd
         -> typename basic_fixed_string<Element, MaxElementCount, Traits>::size_type
     {
         auto iter = AZStd::remove_if(container.begin(), container.end(), predicate);
-        auto removedCount = AZStd::distance(iter, container.end());
+        auto removedCount = ranges::distance(iter, container.end());
         container.erase(iter, container.end());
         return removedCount;
     }

--- a/Code/Framework/AzCore/AzCore/std/string/string.h
+++ b/Code/Framework/AzCore/AzCore/std/string/string.h
@@ -17,6 +17,7 @@
 #include <AzCore/std/base.h>
 #include <AzCore/std/iterator.h>
 #include <AzCore/std/ranges/common_view.h>
+#include <AzCore/std/ranges/as_rvalue_view.h>
 #include <AzCore/std/allocator.h>
 #include <AzCore/std/allocator_traits.h>
 #include <AzCore/std/algorithm.h>
@@ -463,8 +464,16 @@ namespace AZStd
         template<class R>
         auto assign_range(R&& rg) -> enable_if_t<Internal::container_compatible_range<R, value_type>, basic_string&>
         {
-            auto rangeView = rg | views::common;
-            return assign(ranges::begin(rangeView), ranges::end(rangeView));
+            if constexpr (is_lvalue_reference_v<R>)
+            {
+                auto rangeView = AZStd::forward<R>(rg) | views::common;
+                return assign(ranges::begin(rangeView), ranges::end(rangeView));
+            }
+            else
+            {
+                auto rangeView = AZStd::forward<R>(rg) | views::as_rvalue | views::common;
+                return assign(ranges::begin(rangeView), ranges::end(rangeView));
+            }
         }
 
         basic_string& assign(initializer_list<Element> iList)

--- a/Code/Framework/AzCore/AzCore/std/string/string.h
+++ b/Code/Framework/AzCore/AzCore/std/string/string.h
@@ -16,6 +16,7 @@
 #include <AzCore/std/containers/containers_concepts.h>
 #include <AzCore/std/base.h>
 #include <AzCore/std/iterator.h>
+#include <AzCore/std/ranges/common_view.h>
 #include <AzCore/std/allocator.h>
 #include <AzCore/std/allocator_traits.h>
 #include <AzCore/std/algorithm.h>
@@ -65,8 +66,6 @@ namespace AZStd
 
         using reference = Element&;
         using const_reference = const Element&;
-        using difference_type = typename Allocator::difference_type;
-        using size_type = typename Allocator::size_type;
 
         using iterator_impl = pointer;
         using const_iterator_impl = const_pointer;
@@ -77,6 +76,8 @@ namespace AZStd
         using iterator = iterator_impl;
         using const_iterator = const_iterator_impl;
 #endif
+        using difference_type = iter_difference_t<iterator>;
+        using size_type = make_unsigned_t<difference_type>;
         using reverse_iterator = AZStd::reverse_iterator<iterator>;
         using const_reverse_iterator = AZStd::reverse_iterator<const_iterator>;
         using value_type = Element;
@@ -270,14 +271,14 @@ namespace AZStd
             if constexpr (contiguous_iterator<InputIt>
                 && is_same_v<iter_value_t<InputIt>, value_type>)
             {
-                return append(AZStd::to_address(first), AZStd::distance(first, last));
+                return append(AZStd::to_address(first), ranges::distance(first, last));
             }
             else if constexpr (forward_iterator<InputIt>)
             {
                 // Input Iterator pointer type doesn't match the const_pointer type
                 // So the elements need to be appended one by one into the buffer
                 size_type oldSize = size();
-                size_type newSize = oldSize + AZStd::distance(first, last);
+                size_type newSize = oldSize + ranges::distance(first, last);
                 if (grow(newSize))
                 {
                     pointer buffer = data();
@@ -293,7 +294,7 @@ namespace AZStd
             else
             {
                 // input iterator that aren't forward iterators can only be used in a single pass
-                // algorithm. Therefore AZStd::distance can't be used
+                // algorithm. Therefore ranges::distance can't be used
                 // So the input is copied into a local string and then delegated
                 // to use the (const_pointer, size_type) overload
                 basic_string inputCopy;
@@ -425,13 +426,13 @@ namespace AZStd
             if constexpr (contiguous_iterator<InputIt>
                 && is_same_v<iter_value_t<InputIt>, value_type>)
             {
-                return assign(AZStd::to_address(first), AZStd::distance(first, last));
+                return assign(AZStd::to_address(first), ranges::distance(first, last));
             }
             else if constexpr (forward_iterator<InputIt>)
             {
                 // forward iterator pointer type doesn't match the const_pointer type
                 // So the elements need to be assigned one by one into the buffer
-                size_type newSize = AZStd::distance(first, last);
+                size_type newSize = ranges::distance(first, last);
                 if (grow(newSize))
                 {
                     pointer buffer = data();
@@ -447,7 +448,7 @@ namespace AZStd
             else
             {
                 // input iterator that aren't forward iterators can only be used in a single pass
-                // algorithm. Therefore AZStd::distance can't be used
+                // algorithm. Therefore ranges::distance can't be used
                 // So the input is copied into a local string and then delegated
                 // to use the (const_pointer, size_type) overload
                 basic_string inputCopy;
@@ -462,7 +463,8 @@ namespace AZStd
         template<class R>
         auto assign_range(R&& rg) -> enable_if_t<Internal::container_compatible_range<R, value_type>, basic_string&>
         {
-            return assign(ranges::begin(rg), ranges::end(rg));
+            auto rangeView = rg | views::common;
+            return assign(ranges::begin(rangeView), ranges::end(rangeView));
         }
 
         basic_string& assign(initializer_list<Element> iList)
@@ -577,17 +579,17 @@ namespace AZStd
         auto insert(const_iterator insertPos, InputIt first, InputIt last)
             -> enable_if_t<input_iterator<InputIt> && !is_convertible_v<InputIt, size_type>, iterator>
         {   // insert [_First, _Last) at _Where
-            size_type insertOffset = AZStd::distance(cbegin(), insertPos);
+            size_type insertOffset = ranges::distance(cbegin(), insertPos);
             if constexpr (contiguous_iterator<InputIt>
                 && is_same_v<iter_value_t<InputIt>, value_type>)
             {
-                insert(insertOffset, AZStd::to_address(first), AZStd::distance(first, last));
+                insert(insertOffset, AZStd::to_address(first), ranges::distance(first, last));
             }
             else if constexpr (forward_iterator<InputIt>)
             {
                 // Input Iterator pointer type doesn't match the const_pointer type
                 // So the elements need to be inserted one by one into the buffer
-                size_type count = AZStd::distance(first, last);
+                size_type count = ranges::distance(first, last);
                 size_type oldSize = size();
                 size_type newSize = oldSize + count;
                 if (grow(newSize))
@@ -605,7 +607,7 @@ namespace AZStd
             else
             {
                 // input iterator that aren't forward iterators can only be used in a single pass
-                // algorithm. Therefore AZStd::distance can't be used
+                // algorithm. Therefore ranges::distance can't be used
                 // So the input is copied into a local string and then delegated
                 // to use the (const_pointer, size_type) overload
                 basic_string inputCopy;
@@ -888,18 +890,18 @@ namespace AZStd
             if constexpr (contiguous_iterator<InputIt>
                 && is_same_v<iter_value_t<InputIt>, value_type>)
             {
-                return replace(first, last, AZStd::to_address(replaceFirst), AZStd::distance(replaceFirst, replaceLast));
+                return replace(first, last, AZStd::to_address(replaceFirst), ranges::distance(replaceFirst, replaceLast));
             }
             else if constexpr (forward_iterator<InputIt>)
             {
                 // Input Iterator pointer type doesn't match the const_pointer type
                 // So the elements need to be appended one by one into the buffer
 
-                size_type insertOffset = AZStd::distance(cbegin(), first);
-                size_type postInsertOffset = AZStd::distance(cbegin(), last);
-                size_type count = AZStd::distance(replaceFirst, replaceLast);
+                size_type insertOffset = ranges::distance(cbegin(), first);
+                size_type postInsertOffset = ranges::distance(cbegin(), last);
+                size_type count = ranges::distance(replaceFirst, replaceLast);
                 size_type oldSize = size();
-                size_type newSize = oldSize + count - AZStd::distance(first, last);
+                size_type newSize = oldSize + count - ranges::distance(first, last);
                 if (grow(newSize))
                 {
                     pointer buffer = data();
@@ -916,7 +918,7 @@ namespace AZStd
             else
             {
                 // input iterator that aren't forward iterators can only be used in a single pass
-                // algorithm. Therefore AZStd::distance can't be used
+                // algorithm. Therefore ranges::distance can't be used
                 // So the input is copied into a local string and then delegated
                 // to use the (const_pointer, size_type) overload
                 basic_string inputCopy;
@@ -1036,6 +1038,16 @@ namespace AZStd
                 m_storage.first().SetSize(newSize);
                 Traits::assign(data[newSize], Element());  // terminate
             }
+        }
+
+        template<class Operation>
+        void resize_and_overwrite(size_type n, Operation op)
+        {
+            resize_no_construct(n);
+            const auto newSize = AZStd::move(op)(data(), n);
+            AZSTD_CONTAINER_ASSERT(newSize >= 0 && newSize <= n,
+                "resize_and_operation operation returned a new size that is outside the bounds of [0, %zu]", n);
+            resize_no_construct(newSize);
         }
 
         inline void resize(size_type newSize, Element ch)
@@ -2102,7 +2114,7 @@ namespace AZStd
     decltype(auto) erase(basic_string<Element, Traits, Allocator>& container, const U& element)
     {
         auto iter = AZStd::remove(container.begin(), container.end(), element);
-        auto removedCount = AZStd::distance(iter, container.end());
+        auto removedCount = ranges::distance(iter, container.end());
         container.erase(iter, container.end());
         return removedCount;
     }
@@ -2111,7 +2123,7 @@ namespace AZStd
     decltype(auto) erase_if(basic_string<Element, Traits, Allocator>& container, Predicate predicate)
     {
         auto iter = AZStd::remove_if(container.begin(), container.end(), predicate);
-        auto removedCount = AZStd::distance(iter, container.end());
+        auto removedCount = ranges::distance(iter, container.end());
         container.erase(iter, container.end());
         return removedCount;
     }

--- a/Code/Framework/AzCore/AzCore/std/tuple.h
+++ b/Code/Framework/AzCore/AzCore/std/tuple.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <AzCore/RTTI/TypeInfo.h>
 #include <AzCore/std/containers/array.h>
 #include <AzCore/std/function/invoke.h>
+#include <AzCore/std/hash.h>
 #include <AzCore/std/utils.h>
 #include <AzCore/std/typetraits/is_same.h>
 #include <AzCore/std/typetraits/void_t.h>
@@ -33,8 +33,6 @@ namespace AZStd
     using std::forward_as_tuple;
     using std::tuple_cat;
     using std::get;
-
-
     //! Creates an hash specialization for tuple types using the hash_combine function
     //! The std::tuple implementation does not have this support. This is an extension
     template <typename... Types>
@@ -55,31 +53,6 @@ namespace AZStd
             return ElementHasher(value, AZStd::make_index_sequence<sizeof...(Types)>{});
         }
     };
-}
-
-namespace AZ
-{
-    // Specialize the AzDeprcatedTypeNameVisitor for tuple to make sure their
-    // is a mapping of the old type name to current type id
-    inline namespace DeprecatedTypeNames
-    {
-        template<typename... Types>
-        struct AzDeprecatedTypeNameVisitor<AZStd::tuple<Types...>>
-        {
-            template<class Functor>
-            constexpr void operator()(Functor&& visitCallback) const
-            {
-                // AZStd::tuple previous name was place into a buffer of size 128
-                AZStd::array<char, 128> deprecatedName{};
-
-                AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), "tuple<");
-                (AggregateTypeNameOld<Types>(deprecatedName.data(), deprecatedName.size()), ...);
-                AZ::Internal::AzTypeInfoSafeCat(deprecatedName.data(), deprecatedName.size(), ">");
-
-                AZStd::invoke(AZStd::forward<Functor>(visitCallback), deprecatedName.data());
-            }
-        };
-    }
 }
 
 namespace AZStd
@@ -365,11 +338,4 @@ namespace std
         using type = T;
     };
     AZ_POP_DISABLE_WARNING
-}
-
-
-// Adds typeinfo specialization for tuple type
-namespace AZ
-{
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZED_TEMPLATE_PREFIX_UUID(AZStd::tuple, "AZStd::tuple", "{F99F9308-DC3E-4384-9341-89CBF1ABD51E}", AZ_TYPE_INFO_INTERNAL_TYPENAME_VARARGS);
 }

--- a/Code/Framework/AzCore/AzCore/std/typetraits/internal/is_complete.h
+++ b/Code/Framework/AzCore/AzCore/std/typetraits/internal/is_complete.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/typetraits/disjunction.h>
+#include <AzCore/std/typetraits/is_array.h>
+#include <AzCore/std/typetraits/is_function.h>
+#include <AzCore/std/typetraits/is_reference.h>
+#include <AzCore/std/typetraits/is_void.h>
+#include <AzCore/std/typetraits/type_identity.h>
+
+namespace AZStd::Internal
+{
+    // Extension to implement a type trait that returns false_type
+    // for an incomplete class, union or bounded array of incomplete class or union type
+    // An incomplete class of unbounded array is not one definition used and doesn't need to be checked
+    template<class T, size_t = sizeof(T)>
+    constexpr true_type is_complete_or_unbounded_impl(type_identity<T>);
+
+    template<class TypeIdentity, class NestedType = typename TypeIdentity::type>
+    constexpr auto is_complete_or_unbounded_impl(TypeIdentity)
+        -> disjunction<
+        is_reference<NestedType>,
+        is_function<NestedType>,
+        is_void<NestedType>,
+        is_unbounded_array<NestedType>
+        >;
+
+    template<class T>
+    using is_complete_or_unbounded = decltype(is_complete_or_unbounded_impl(type_identity<T>{}));
+
+    template<class T>
+    constexpr bool is_complete_or_unbounded_v = is_complete_or_unbounded<T>();
+}

--- a/Code/Framework/AzCore/AzCore/std/typetraits/is_array.h
+++ b/Code/Framework/AzCore/AzCore/std/typetraits/is_array.h
@@ -8,9 +8,29 @@
 #pragma once
 
 #include <AzCore/std/typetraits/config.h>
+#include <AzCore/std/typetraits/integral_constant.h>
 
 namespace AZStd
 {
     using std::is_array;
     using std::is_array_v;
+
+    // C++20 is_bounded_array and is_unbounded_array
+    template<class T>
+    struct is_bounded_array : false_type {};
+
+    template<class T, size_t N>
+    struct is_bounded_array<T[N]> : true_type {};
+
+    template<class T>
+    constexpr bool is_bounded_array_v = is_bounded_array<T>::value;
+
+    template<class T>
+    struct is_unbounded_array : false_type {};
+
+    template<class T>
+    struct is_unbounded_array<T[]> : true_type {};
+
+    template<class T>
+    constexpr bool is_unbounded_array_v = is_unbounded_array<T>::value;
 }

--- a/Code/Framework/AzCore/AzCore/std/utility/to_underlying.h
+++ b/Code/Framework/AzCore/AzCore/std/utility/to_underlying.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/typetraits/underlying_type.h>
+
+namespace AZStd
+{
+    template<class Enum>
+    constexpr AZStd::underlying_type_t<Enum> to_underlying(Enum value) noexcept
+    {
+        return static_cast<AZStd::underlying_type_t<Enum>>(value);
+    }
+}

--- a/Code/Framework/AzCore/Tests/AZStd/Iterators.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Iterators.cpp
@@ -9,6 +9,10 @@
 #include <AzCore/std/concepts/concepts.h>
 #include <AzCore/std/iterator.h>
 #include <AzCore/std/iterator/common_iterator.h>
+#include <AzCore/std/iterator/const_iterator.h>
+#include <AzCore/std/iterator/counted_iterator.h>
+#include <AzCore/std/iterator/move_sentinel.h>
+#include <AzCore/std/iterator/unreachable_sentinel.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/containers/array.h>
 #include <AzCore/std/containers/list.h>
@@ -332,5 +336,114 @@ namespace UnitTest
         using CommonTestIterator = AZStd::common_iterator<IteratorInternal::TestIterator, IteratorInternal::TestSentinel>;
         CommonTestIterator testIter{ IteratorInternal::TestIterator{} };
         EXPECT_FALSE(testIter.operator->()->m_boolValue);
+    }
+
+    TEST_F(Iterators, UnreachableSentinel_DoesNotCompareEqualToAnyIterator)
+    {
+        char testString[] = "123";
+        EXPECT_NE(AZStd::unreachable_sentinel, AZStd::ranges::begin(testString));
+        EXPECT_NE(AZStd::unreachable_sentinel, AZStd::ranges::end(testString));
+        EXPECT_NE(AZStd::ranges::begin(testString), AZStd::unreachable_sentinel);
+        EXPECT_NE(AZStd::ranges::end(testString), AZStd::unreachable_sentinel);
+    }
+
+    TEST_F(Iterators, MoveSentinel_ComparableToMoveIterator_Succeeds)
+    {
+        AZStd::array testStringArray{ AZStd::string("Hello"), AZStd::string("World") };
+        auto moveIterator = AZStd::make_move_iterator(testStringArray.begin());
+        auto moveSentinel = AZStd::move_sentinel<decltype(testStringArray)::iterator>(testStringArray.end());
+
+        AZStd::array<AZStd::string, 2> movedStringArray{};
+        for (size_t i = 0; moveIterator != moveSentinel; ++moveIterator, ++i)
+        {
+            movedStringArray[i] = *moveIterator;
+        }
+
+        EXPECT_EQ(moveSentinel, moveIterator);
+        EXPECT_EQ(moveIterator, moveSentinel);
+        EXPECT_THAT(movedStringArray, ::testing::ElementsAre(AZStd::string_view("Hello"), AZStd::string_view("World")));
+        EXPECT_THAT(testStringArray, ::testing::ElementsAre(AZStd::string_view(), AZStd::string_view()));
+    }
+
+    TEST_F(Iterators, ConstIterator_ProvidesOnlyConstantReferencesToValueType_Succeeds)
+    {
+        AZStd::string testString("Hello World");
+        using ConstIterator = AZStd::const_iterator<typename decltype(testString)::iterator>;
+        using ConstSentinel = AZStd::const_sentinel<typename decltype(testString)::iterator>;
+        ConstIterator iter = testString.begin();
+        ConstSentinel sen = testString.end();
+
+        static_assert(AZStd::is_const_v<AZStd::remove_reference_t<decltype(*iter)>>);
+        AZStd::string result;
+        for (; iter != sen; ++iter)
+        {
+            result += *iter;
+        }
+
+        EXPECT_EQ(testString, result);
+    }
+
+    TEST_F(Iterators, ConstIterator_SupportsCpp17IteratorTraits_Compiles)
+    {
+        // Indicates whether the iterator type can be used with C++17 style iterator traits
+        // when using algorithms from std namespace
+        using ConstIterator = AZStd::const_iterator<typename AZStd::string::iterator>;
+        using ConstIteratorTraits = AZStd::iterator_traits<ConstIterator>;
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename ConstIteratorTraits::value_type>);
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename ConstIteratorTraits::difference_type>);
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename ConstIteratorTraits::iterator_category>);
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename ConstIteratorTraits::pointer>);
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename ConstIteratorTraits::reference>);
+    }
+
+    TEST_F(Iterators, CountedIterator_CanIterate_UntilDefaultSentinel)
+    {
+        AZStd::string testString("Hello World");
+        AZStd::counted_iterator<typename decltype(testString)::iterator> testCountedIter(testString.begin(), 5);
+
+        AZStd::string result;
+        for (; testCountedIter != AZStd::default_sentinel; ++testCountedIter)
+        {
+            result += *testCountedIter;
+        }
+
+        EXPECT_EQ("Hello", result);
+        EXPECT_EQ(AZStd::default_sentinel, testCountedIter);
+        ASSERT_EQ(testString.begin() + 5, testCountedIter.base());
+        EXPECT_EQ(0, testCountedIter.count());
+
+        auto copyIter = testCountedIter - 5;
+        copyIter[3] = 'j';
+        EXPECT_EQ('H', *copyIter);
+        EXPECT_EQ('j', *(copyIter + 3));
+    }
+
+    TEST_F(Iterators, CountedIterator_CompareableAgainstOtherCountedIterator)
+    {
+        AZStd::string_view testString("Hello World");
+        AZStd::counted_iterator<typename decltype(testString)::iterator> testCountedIter(testString.begin(), 5);
+        AZStd::counted_iterator<typename decltype(testString)::iterator> testCountedIter2(testString.begin(), 5);
+
+        EXPECT_EQ(testCountedIter, testCountedIter2);
+        ++testCountedIter;
+        EXPECT_NE(testCountedIter, testCountedIter2);
+        EXPECT_LT(testCountedIter2, testCountedIter);
+        EXPECT_GT(testCountedIter, testCountedIter2);
+        EXPECT_LE(testCountedIter2, testCountedIter);
+        EXPECT_GE(testCountedIter, testCountedIter2);
+        EXPECT_EQ(4, testCountedIter.count());
+    }
+
+    TEST_F(Iterators, CountedIterator_SupportsCpp17IteratorTraits_Compiles)
+    {
+        // Indicates whether the iterator type can be used with C++17 style iterator traits
+        // when using algorithms from std namespace
+        using CountedIterator = AZStd::counted_iterator<typename AZStd::string::iterator>;
+        using CountedIteratorTraits = AZStd::iterator_traits<CountedIterator>;
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename CountedIteratorTraits::value_type>);
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename CountedIteratorTraits::difference_type>);
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename CountedIteratorTraits::iterator_category>);
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename CountedIteratorTraits::pointer>);
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename CountedIteratorTraits::reference>);
     }
 }

--- a/Code/Framework/AzCore/Tests/AZStd/Iterators.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Iterators.cpp
@@ -347,6 +347,17 @@ namespace UnitTest
         EXPECT_NE(AZStd::ranges::end(testString), AZStd::unreachable_sentinel);
     }
 
+    TEST_F(Iterators, MoveIterator_SupportsCpp17IteratorTraits_Compiles)
+    {
+        using MoveIterator = AZStd::move_iterator<int*>;
+        using MoveIteratorTraits = AZStd::iterator_traits<MoveIterator>;
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename MoveIteratorTraits::value_type>);
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename MoveIteratorTraits::difference_type>);
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename MoveIteratorTraits::iterator_category>);
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename MoveIteratorTraits::pointer>);
+        static_assert(AZStd::Internal::sfinae_trigger_v<typename MoveIteratorTraits::reference>);
+    }
+
     TEST_F(Iterators, MoveSentinel_ComparableToMoveIterator_Succeeds)
     {
         AZStd::array testStringArray{ AZStd::string("Hello"), AZStd::string("World") };

--- a/Code/Framework/AzCore/Tests/AZStd/RangesAlgorithmTests.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/RangesAlgorithmTests.cpp
@@ -279,7 +279,7 @@ namespace UnitTest
         EXPECT_FALSE(AZStd::ranges::any_of(numbers, [](int i) { return i == 6; })) << "No number should equal 6";
     }
 
-    TEST_F(RangesAlgorithmTestFixture, RangesAnyOf_ReturnsTrueForNoMatchingViews)
+    TEST_F(RangesAlgorithmTestFixture, RangesNoneOf_ReturnsTrueForNoMatchingViews)
     {
         constexpr AZStd::array numbers{ 0, 1, 2, 3, 4, 5 };
         EXPECT_TRUE(AZStd::ranges::none_of(numbers, [](int i) { return i == 10; })) << "No number should equal 10";

--- a/Code/Framework/AzCore/Tests/AZStd/RangesAlgorithmTests.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/RangesAlgorithmTests.cpp
@@ -164,6 +164,23 @@ namespace UnitTest
         EXPECT_EQ(testVector.end(), foundIt);
     }
 
+    TEST_F(RangesAlgorithmTestFixture, RangesFindLast_LocatesLastMatchInContainer_Succeeds)
+    {
+        AZStd::vector testVector{ 5, 1, 22, 47, -8, -5, 1000, 687, 22, -8, 1000, 45 };
+
+        auto foundSubrange = AZStd::ranges::find_last(testVector, 22);
+        ASSERT_NE(testVector.begin() + 7, foundSubrange.begin());
+        EXPECT_EQ(22, *foundSubrange.begin());
+
+        foundSubrange = AZStd::ranges::find_last_if(testVector, [](int value) { return value < 0; });
+        ASSERT_NE(testVector.begin() + 8, foundSubrange.begin());
+        EXPECT_EQ(-8, *foundSubrange.begin());
+
+        foundSubrange = AZStd::ranges::find_last_if_not(testVector, [](int value) { return value < 1000; });
+        ASSERT_NE(testVector.begin() + 9, foundSubrange.begin());
+        EXPECT_EQ(1000, *foundSubrange.begin());
+    }
+
     TEST_F(RangesAlgorithmTestFixture, RangesSearch_LocatesElementInContainer_Succeeds)
     {
         AZStd::vector testVector{ 5, 1, 22, 47, -8, -5, 1000, 687, 22, -8, -8, 1000, 45 };
@@ -248,18 +265,25 @@ namespace UnitTest
         }
     }
 
-    TEST_F(RangesAlgorithmTestFixture, RangesAllOfReturnsTrueForMatchingViews)
+    TEST_F(RangesAlgorithmTestFixture, RangesAllOf_ReturnsTrueForMatchingViews)
     {
         constexpr AZStd::array numbers {0, 1, 2, 3, 4, 5};
         EXPECT_TRUE(AZStd::ranges::all_of(numbers, [](int i) { return i < 6; })) << "All numbers should be less than 6";
         EXPECT_FALSE(AZStd::ranges::all_of(numbers, [](int i) { return i < 5; })) << "At least one number should be greater than or equal to 5";
     }
 
-    TEST_F(RangesAlgorithmTestFixture, RangesAnyOfReturnsTrueForMatchingViews)
+    TEST_F(RangesAlgorithmTestFixture, RangesAnyOf_ReturnsTrueForMatchingViews)
     {
         constexpr AZStd::array numbers {0, 1, 2, 3, 4, 5};
         EXPECT_TRUE(AZStd::ranges::any_of(numbers, [](int i) { return i == 3; })) << "At least one number should equal 3";
         EXPECT_FALSE(AZStd::ranges::any_of(numbers, [](int i) { return i == 6; })) << "No number should equal 6";
+    }
+
+    TEST_F(RangesAlgorithmTestFixture, RangesAnyOf_ReturnsTrueForNoMatchingViews)
+    {
+        constexpr AZStd::array numbers{ 0, 1, 2, 3, 4, 5 };
+        EXPECT_TRUE(AZStd::ranges::none_of(numbers, [](int i) { return i == 10; })) << "No number should equal 10";
+        EXPECT_FALSE(AZStd::ranges::none_of(numbers, [](int i) { return i == 4; })) << "At least one number should equal 4";
     }
 
     TEST_F(RangesAlgorithmTestFixture, RangesForEach_LoopsOverElements_Success)
@@ -415,5 +439,65 @@ namespace UnitTest
         AZStd::ranges::move_backward(testString.begin(), testString.end(), charVector.end());
         EXPECT_THAT(charVector, ::testing::ElementsAre('H', 'e', 'l', 'l', 'o', 'W', 'o', 'r', 'l', 'd'));
         EXPECT_THAT(testString, ::testing::ElementsAre('\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0'));
+    }
+
+    TEST_F(RangesAlgorithmTestFixture, RangesContains_LocatesElementInContainer_Succeeds)
+    {
+        AZStd::vector testVector{ 5, 1, 22, 47, -8, -5, 1000, 687, 22, -8, 1000, 45 };
+
+        EXPECT_TRUE(AZStd::ranges::contains(testVector, 22));
+        EXPECT_TRUE(AZStd::ranges::contains(testVector.begin(), testVector.end(), 1000));
+        EXPECT_FALSE(AZStd::ranges::contains(testVector, -19));
+    }
+
+    TEST_F(RangesAlgorithmTestFixture, RangesContains_LocatesSubrangeInContainer_Succeeds)
+    {
+        AZStd::vector testVector{ 5, 1, 22, 47, -8, -5, 1000, 687, 22, -8, 1000, 45 };
+
+        constexpr AZStd::array searchRange{ 687, 22 };
+        EXPECT_TRUE(AZStd::ranges::contains_subrange(testVector, searchRange));
+        EXPECT_TRUE(AZStd::ranges::contains_subrange(testVector.begin(), testVector.end(),
+            searchRange.begin(), searchRange.end()));
+        EXPECT_FALSE(AZStd::ranges::contains_subrange(testVector, AZStd::array{735, 32}));
+        constexpr AZStd::array<int, 0> emptyRange{};
+        EXPECT_FALSE(AZStd::ranges::contains_subrange(testVector, emptyRange));
+    }
+
+    TEST_F(RangesAlgorithmTestFixture, RangesStartsWith_FindsSubrangeAtStart)
+    {
+        AZStd::vector testVector{ 5, 1, 22, 47, -8, -5, 1000, 687, 22, -8, -8, 1000, 45 };
+        AZStd::vector longerVector{ 5, 1, 22, 47, -8, -5, 1000, 687, 22, -8, -8, 1000, 45, 929 };
+        AZStd::vector shorterVector{ 5, 1, 22, 47, -8, -5, 1000, 687, 22, -8, -8, 1000 };
+        AZStd::vector unequalVector{ 5, 1, 22, 47, -8, -5, 1000, 14, 22, -8, -8, 1000, 25 };
+        AZStd::vector<int> emptyVector;
+
+        EXPECT_TRUE(AZStd::ranges::starts_with(testVector, emptyVector));
+        EXPECT_TRUE(AZStd::ranges::starts_with(emptyVector, emptyVector));
+
+        EXPECT_TRUE(AZStd::ranges::starts_with(testVector, testVector));
+        EXPECT_FALSE(AZStd::ranges::starts_with(testVector, longerVector));
+        EXPECT_TRUE(AZStd::ranges::starts_with(longerVector, testVector));
+
+        EXPECT_TRUE(AZStd::ranges::starts_with(testVector, shorterVector));
+        EXPECT_FALSE(AZStd::ranges::starts_with(shorterVector, testVector));
+        EXPECT_FALSE(AZStd::ranges::starts_with(testVector, unequalVector));
+    }
+
+    TEST_F(RangesAlgorithmTestFixture, RangesEndsWith_FindsSubrangeAtEnd)
+    {
+        AZStd::vector testVector{ 4, 5, 6, 7, 8, 9 };
+        AZStd::vector longerVector{ 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        AZStd::vector shorterVector{ 7, 8, 9 };
+        AZStd::vector<int> emptyVector;
+
+        EXPECT_TRUE(AZStd::ranges::ends_with(testVector, emptyVector));
+        EXPECT_TRUE(AZStd::ranges::ends_with(emptyVector, emptyVector));
+
+        EXPECT_TRUE(AZStd::ranges::ends_with(testVector, testVector));
+        EXPECT_FALSE(AZStd::ranges::ends_with(testVector, longerVector));
+        EXPECT_TRUE(AZStd::ranges::ends_with(longerVector, testVector));
+
+        EXPECT_TRUE(AZStd::ranges::ends_with(testVector, shorterVector));
+        EXPECT_FALSE(AZStd::ranges::ends_with(shorterVector, testVector));
     }
 }

--- a/Code/Framework/AzCore/Tests/AZStd/RangesTests.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/RangesTests.cpp
@@ -26,11 +26,11 @@ namespace UnitTest
     {
         return &rangeLike;
     }
-    const RangeLikeCustomizationPoint* cbegin(const RangeLikeCustomizationPoint& rangeLike)
+    const RangeLikeCustomizationPoint* begin(const RangeLikeCustomizationPoint& rangeLike)
     {
         return &rangeLike;
     }
-    const RangeLikeCustomizationPoint* cend(const RangeLikeCustomizationPoint& rangeLike)
+    const RangeLikeCustomizationPoint* end(const RangeLikeCustomizationPoint& rangeLike)
     {
         return &rangeLike;
     }
@@ -42,11 +42,11 @@ namespace UnitTest
     {
         return &rangeLike;
     }
-    const RangeLikeCustomizationPoint* crbegin(const RangeLikeCustomizationPoint& rangeLike)
+    const RangeLikeCustomizationPoint* rbegin(const RangeLikeCustomizationPoint& rangeLike)
     {
         return &rangeLike;
     }
-    const RangeLikeCustomizationPoint* crend(const RangeLikeCustomizationPoint& rangeLike)
+    const RangeLikeCustomizationPoint* rend(const RangeLikeCustomizationPoint& rangeLike)
     {
         return &rangeLike;
     }

--- a/Code/Framework/AzCore/Tests/AZStd/RangesViewTests.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/RangesViewTests.cpp
@@ -522,6 +522,15 @@ namespace UnitTest
         EXPECT_EQ(expectedString, accumString);
     }
 
+    TEST_F(RangesViewTestFixture, JoinWithView_IsConstexpr_Succeeds)
+    {
+        constexpr AZStd::string_view expectedString = "Hello, World, Moon, Sun";
+        constexpr AZStd::array<AZStd::string_view, 4> rope{ "Hello", "World", "Moon", "Sun" };
+        using namespace AZStd::literals::string_view_literals;
+        constexpr AZStd::fixed_string<128> accumString(AZStd::from_range, rope | AZStd::views::join_with(", "_sv));
+        static_assert(accumString == expectedString);
+    }
+
     // elements_view
     TEST_F(RangesViewTestFixture, ElementsView_CanIterateVectorOfTuple_Succeeds)
     {

--- a/Code/Framework/AzCore/Tests/AZStd/RangesViewTests.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/RangesViewTests.cpp
@@ -11,13 +11,18 @@
 #include <AzCore/std/containers/map.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/ranges/all_view.h>
+#include <AzCore/std/ranges/as_const_view.h>
+#include <AzCore/std/ranges/as_rvalue_view.h>
 #include <AzCore/std/ranges/common_view.h>
+#include <AzCore/std/ranges/counted_view.h>
 #include <AzCore/std/ranges/elements_view.h>
 #include <AzCore/std/ranges/empty_view.h>
 #include <AzCore/std/ranges/filter_view.h>
+#include <AzCore/std/ranges/iota_view.h>
 #include <AzCore/std/ranges/join_view.h>
 #include <AzCore/std/ranges/join_with_view.h>
 #include <AzCore/std/ranges/ranges_adaptor.h>
+#include <AzCore/std/ranges/repeat_view.h>
 #include <AzCore/std/ranges/reverse_view.h>
 #include <AzCore/std/ranges/single_view.h>
 #include <AzCore/std/ranges/split_view.h>
@@ -727,5 +732,160 @@ namespace UnitTest
         auto testSubrangeOfReverseReverse = testSubrangeOfReverse | AZStd::views::reverse;
         static_assert(AZStd::same_as<decltype(testSubrange), decltype(testSubrangeOfReverseReverse)>);
         EXPECT_TRUE(AZStd::ranges::equal(testSubrangeOfReverseReverse, "World"_sv));
+    }
+
+    TEST_F(RangesViewTestFixture, CountedView_CanCreateSubrange_FromIteratorAndCounted)
+    {
+        using namespace AZStd::literals::string_view_literals;
+
+        constexpr AZStd::string_view testString = "Hello,World,Moon,Sun";
+        constexpr auto testView = AZStd::views::counted(testString.begin() + 6, 5);
+        EXPECT_TRUE(AZStd::ranges::equal(testView, "World"_sv));
+    }
+
+    TEST_F(RangesViewTestFixture, CountedView_CanCreateSubrange_FromNonContiguousIterator)
+    {
+        using namespace AZStd::literals::string_view_literals;
+
+        AZStd::list<int> testContainer{ 1, 2, 3, 4, 5 };
+        auto testView = AZStd::views::counted(testContainer.begin(), 3);
+        constexpr auto expectedResult = AZStd::to_array<int>({ 1, 2, 3 });
+        EXPECT_TRUE(AZStd::ranges::equal(testView, expectedResult));
+    }
+
+    TEST_F(RangesViewTestFixture, AsRvalueView_MovesContainerElements_Succeeds)
+    {
+        using namespace AZStd::literals::string_view_literals;
+
+        AZStd::vector testStringContainer{ AZStd::string("Hello"), AZStd::string("World") };
+        AZStd::list movedStringContainer{ AZStd::from_range, testStringContainer | AZStd::views::as_rvalue };
+
+        EXPECT_THAT(movedStringContainer, ::testing::ElementsAre(AZStd::string_view("Hello"), AZStd::string_view("World")));
+        EXPECT_THAT(testStringContainer, ::testing::ElementsAre(AZStd::string_view(), AZStd::string_view()));
+    }
+
+    namespace RangesViewTestInternal
+    {
+        struct ConstMutableContainer
+        {
+            struct iterator
+            {
+                using value_type = int;
+                using iterator_concept = AZStd::bidirectional_iterator_tag;
+                using iterator_category = AZStd::bidirectional_iterator_tag;
+
+                const int& operator*() const { return m_charElement; }
+                int& operator*() { return m_intElement; }
+                const int* operator->() const { return &m_charElement; }
+                int* operator->() { return &m_intElement; }
+                iterator& operator++() { ++m_intElement; return *this; }
+                iterator operator++(int) { iterator tmp(*this); ++m_intElement; return tmp; }
+                iterator& operator--() { --m_intElement; return *this; }
+                iterator operator--(int) { iterator tmp(*this); --m_intElement; return tmp; }
+                bool operator==(const iterator& y) const { return m_intElement == y.m_intElement; }
+                bool operator!=(const iterator& y) const { return !operator==(y); }
+                ptrdiff_t operator-(const iterator& y) const { return m_intElement - y.m_intElement; }
+
+                int m_charElement = 'A';
+                int m_intElement = 55;
+            };
+
+            using iterator = iterator;
+            using const_iterator = const iterator;
+
+            iterator begin() { return iterator{}; }
+            iterator begin() const { return iterator{}; }
+            iterator end() { return iterator{ 'A', 60 }; }
+            iterator end() const { return iterator{ 'A', 60 }; }
+        };
+    }
+
+    TEST_F(RangesViewTestFixture, AsConstView_ActAsConstantViewOfContainerSucceeds)
+    {
+        RangesViewTestInternal::ConstMutableContainer testContainer;
+        AZStd::ranges::iterator_t<RangesViewTestInternal::ConstMutableContainer> foundIter = testContainer.begin();
+        EXPECT_EQ(55, *foundIter);
+
+        auto constView = testContainer | AZStd::views::as_const;
+        ASSERT_NE(constView.end(), constView.begin());
+        for (auto elem : constView)
+        {
+            EXPECT_EQ('A', elem);
+        }
+
+        AZStd::string_view testString;
+        [[maybe_unused]] auto constStringView = testString | AZStd::views::as_const;
+        static_assert(AZStd::same_as<decltype(testString), decltype(constStringView)>);
+    }
+
+    TEST_F(RangesViewTestFixture, IotaView_CanGenerateRangeUpToBound)
+    {
+        constexpr AZStd::array expectedValues{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        AZStd::vector testValue(AZStd::from_range, AZStd::views::iota(0, 10));
+        EXPECT_THAT(testValue, ::testing::ElementsAreArray(expectedValues));
+    }
+
+    TEST_F(RangesViewTestFixture, IotaView_CanGenerateUnboundedValues)
+    {
+        constexpr AZStd::array expectedValues{ -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+
+        constexpr int breakValue = 11;
+        AZStd::vector<int> resultValues;
+        for (int i : AZStd::views::iota(-3))
+        {
+            resultValues.push_back(i);
+            if (i >= breakValue)
+            {
+                break;
+            }
+        }
+        EXPECT_THAT(resultValues, ::testing::ElementsAreArray(expectedValues));
+    }
+
+    TEST_F(RangesViewTestFixture, IotaView_WithReverseView_CanGenerateDecrementingValues)
+    {
+        constexpr AZStd::array expectedValues{ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+        EXPECT_THAT(AZStd::vector(AZStd::from_range, AZStd::views::iota(0, 10) | AZStd::views::reverse), ::testing::ElementsAreArray(expectedValues));
+    }
+
+    TEST_F(RangesViewTestFixture, IotaView_WithZipView_CanGenerateIndexForEveryElementOfOtherView)
+    {
+        const AZStd::map expectedValues{ AZStd::pair{0, 'H'}, {1, 'e'}, { 2, 'l'}, { 3, 'l'}, {4, 'o'} };
+        constexpr AZStd::string_view testString = "Hello";
+
+        AZStd::map<int, char> resultValues;
+        for (auto [i, elem] : AZStd::views::zip(AZStd::views::iota(0), testString))
+        {
+            resultValues[static_cast<int>(i)] = elem;
+        }
+
+        EXPECT_THAT(resultValues, ::testing::ElementsAreArray(expectedValues));
+    }
+
+    TEST_F(RangesViewTestFixture, RepeatView_CanGenerateRangeUpToBound)
+    {
+        using namespace AZStd::literals::string_view_literals;
+        constexpr AZStd::array expectedValues{ "Hello"_sv, "Hello"_sv, "Hello"_sv };
+        AZStd::vector testValue(AZStd::from_range, AZStd::views::repeat("Hello"_sv, 3));
+        EXPECT_THAT(testValue, ::testing::ElementsAreArray(expectedValues));
+    }
+
+    TEST_F(RangesViewTestFixture, RepeatView_CanGenerateUnboundedValues)
+    {
+        using namespace AZStd::literals::string_view_literals;
+        constexpr int maxIterations = 4;
+        constexpr AZStd::array<AZStd::string_view, maxIterations> expectedValues{ "Hello"_sv, "Hello"_sv, "Hello"_sv, "Hello"_sv };
+
+        AZStd::vector<AZStd::string_view> resultValues;
+        int i = 0;
+        for (AZStd::string_view testView : AZStd::views::repeat("Hello"_sv))
+        {
+            if (i++ >= maxIterations)
+            {
+                break;
+            }
+            resultValues.push_back(testView);
+        }
+        EXPECT_THAT(resultValues, ::testing::ElementsAreArray(expectedValues));
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -582,12 +582,8 @@ namespace AzToolsFramework
                         linkId, templateId, templateToDelete.GetFilePath().c_str());
                 }
 
-                result = m_templateToLinkIdsMap.erase(templateToLinkIterator) != nullptr;
-                AZ_Assert(result,
-                    "Prefab - PrefabSystemComponent::RemoveTemplate - "
-                    "Failed to remove Template with Id '%llu' on file path '%s' "
-                    "from TemplateToLinkIdsMap.",
-                    templateId, templateToDelete.GetFilePath().c_str());
+                // erase with a valid iterator always succeeds
+                m_templateToLinkIdsMap.erase(templateToLinkIterator);
             }
 
             //Remove this Template from the rest of the maps.

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/PostProcessingShaderOptionBase.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/PostProcessingShaderOptionBase.cpp
@@ -74,7 +74,7 @@ namespace AZ
         const PostProcessingShaderOptionBase::ShaderVariantInformation* PostProcessingShaderOptionBase::GetShaderVariant(AZ::u64 key) const
         {
             auto result = m_shaderVariantTable.find(key);
-            return result != nullptr ? &result->second : nullptr;
+            return result != m_shaderVariantTable.end() ? &result->second : nullptr;
         }
 
     }   // namespace Render

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderReloadDebugTracker.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderReloadDebugTracker.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Atom/RPI.Public/Shader/ShaderReloadDebugTracker.h>
+#include <AzCore/Math/Crc.h>
 #include <AzCore/Module/Environment.h>
 
 namespace AZ

--- a/Gems/EMotionFX/Code/Source/Integration/Rendering/RenderFlag.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Rendering/RenderFlag.h
@@ -8,11 +8,12 @@
 #pragma once
 
 #include <AzCore/Preprocessor/Enum.h>
+#include <AzCore/RTTI/TypeInfo.h>
 #include <Atom/RHI.Reflect/Bits.h>
 
 namespace EMotionFX
 {
-    // The index of the render flag which is 0, 1, 2, 3.. based. 
+    // The index of the render flag which is 0, 1, 2, 3.. based.
     // Do not confuse this with the actual ActorRenderFlags::Type which is 1, 2, 4, 8.. based.
     enum ActorRenderFlagIndex : AZ::u8
     {
@@ -77,7 +78,7 @@ namespace EMotionFX
 
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(ActorRenderFlags);
 
-    static constexpr ActorRenderFlags s_requireUpdateTransforms = 
+    static constexpr ActorRenderFlags s_requireUpdateTransforms =
         ActorRenderFlags::Solid | ActorRenderFlags::Wireframe | ActorRenderFlags::AABB |
         ActorRenderFlags::FaceNormals |ActorRenderFlags::VertexNormals | ActorRenderFlags::Tangents |
         ActorRenderFlags::Skeleton | ActorRenderFlags::LineSkeleton | ActorRenderFlags::NodeOrientation | ActorRenderFlags::NodeNames |

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
@@ -295,9 +295,9 @@ namespace ScriptCanvas
                     continue;
                 }
 
-                if (slotIter->second == nullptr)
+                if (slotIter->second == slots.end())
                 {
-                    AZ_Error("ScriptCanvas", false, "Null Slot in slotIde map when attempting to version a node");
+                    AZ_Error("ScriptCanvas", false, "Null Slot in slotId map when attempting to version a node");
                     return false;
                 }
 
@@ -321,7 +321,7 @@ namespace ScriptCanvas
                         continue;
                     }
 
-                    if (datumIter->second == nullptr)
+                    if (datumIter->second == varDatums.end())
                     {
                         AZ_Error("ScriptCanvas", false, "Variable datum not found when attempting to version node");
                         return false;
@@ -337,12 +337,6 @@ namespace ScriptCanvas
 
                     for (auto offsetSlotIter = slots.begin(); offsetSlotIter != slotIter->second; ++offsetSlotIter)
                     {
-                        if (offsetSlotIter == nullptr)
-                        {
-                            AZ_Error("ScriptCanvas", false, "Offset slot iter was nullptr when trying to version a node");
-                            return false;
-                        }
-
                         if (offsetSlotIter->IsData() && offsetSlotIter->IsInput())
                         {
                             ++copyIterator;


### PR DESCRIPTION
Fixed the AZStd containers range constructors and (insert,append,prepend,assign,replace)_range functions to work with ranges that have a different iterator sentinel type(such a join_view) by using a common_iterator interally

Implemented the C++23 [as_rvalue_view](https://eel.is/c++draft/ranges#range.as.rvalue)
For treating a range underlying sequence as rvalues

Implemented the C++23 [as_const_view](https://eel.is/c++draft/ranges#range.as.const)
For treating a range underlying as constants

Implemented the C++20 [counted_view](https://eel.is/c++draft/ranges#range.counted)
Adapter which prevents a view counted range using an iterator and a count

Implemented the C++20 [iota_view](https://eel.is/c++draft/ranges#range.iota)
For generating a sequence of elements by repeating increating an initial value

Implemented the C++23 [repeat_view](https://eel.is/c++draft/ranges#range.repeat)
For generating a sequence of elements that repeatly produce the same value

Implemented the C++23 [basic_const_iterator](https://eel.is/c++draft/iterators#const.iterators)
Iterator adaptor that has the same behavior of the underlying iterator except that the indirection operators implciity convert the value returned by the underlying iterators' indirection operator to a type such that the adapted iterator is a constant iterator.
This is used to implement `as_const_view`

Implemented the C++20 [counted_iterator](https://eel.is/c++draft/iterators#counted)
Iterator adaptor with the same behavior as the underlying iteratgor except it keeps track of the distance to the end of the range. It can be used with a default_sentinel in generic algorithms to operator on a range of elements without needing to know the end position.
This is used to implement `counted_view`

Added the C++20 [unreachable_sentinel](https://eel.is/c++draft/iterators#unreachable.sentinel)
Sentinel type that can be used with any type that models the weakly_incrementable concept to denote an upper bound of an unbounded interval.
Pretty much it doesn't compare equal to any iterator and therefore allows iteration in generic algorithm until a condition is met.
Ex.
```c++
// Iterate until null-terminator character is found
size_t strlen(const char* p)
{
    return AZStd::ranges::find(p, unreachable_sentinel, '\0') - p;
}
```

Added the C++20 [move_sentinel](https://eel.is/c++draft/iterators#move.sentinel)
Sentinel adaptor that can be used with move_iterator to denote the end of a rvalue range.
This is used to implement `as_rvalue_view`

Updated deque, forward_list and list to use the `basic_const_iterator` adaptor to removed the duplicate const iterator implementation.

Added the C++20 is_unbounded_array and [is_bounded_array](https://eel.is/c++draft/tab:meta.unary.prop) type traits

Implemented the C++23 [resize_and_overwrite](https://eel.is/c++draft/strings#string.capacity-7) for the string class which provides a safer alternative to initializing a string buffer than the `resize_no_construct` extension.
After the call the string wouldn't be in an indeterminate state with regards to whether adde elements were initialized.

Implemented the C++ 23 [ranges::starts_with](https://eel.is/c++draft/algorithms#alg.starts.with) and [ranges::ends_with]
(https://eel.is/c++draft/algorithms#alg.starts.with)

Implemented the C++23 [ranges::contains](https://eel.is/c++draft/algorithms#alg.contains) and contains_subrange

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Wrote Unit Test for all the new features.
Verified existing Unit Test passes.
