### PR TITLE
Sandbox 3 flaky AssetManager tests

### DIFF
--- a/Code/Framework/AzCore/CMakeLists.txt
+++ b/Code/Framework/AzCore/CMakeLists.txt
@@ -80,7 +80,7 @@ endif()
 # Tests
 ################################################################################
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
-    
+
     ly_add_target(
         NAME AzCoreTestCommon STATIC
         NAMESPACE AZ
@@ -151,6 +151,10 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     )
     ly_add_googletest(
         NAME AZ::AzCore.Tests
+    )
+    ly_add_googletest(
+        NAME AZ::AzCore.Tests
+        TEST_SUITE sandbox
     )
     ly_add_googlebenchmark(
         NAME AZ::AzCore.Benchmarks

--- a/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
@@ -3195,7 +3195,7 @@ namespace UnitTest
         EXPECT_TRUE(nestedDependentAsset.IsReady());
     }
 
-    TEST_F(AssetManagerClearAssetReferenceTests, ReloadTest)
+    TEST_F(AssetManagerClearAssetReferenceTests, ReloadTest_SUITE_sandbox)
     {
         // Regression test - there was a bug where rapid reloads could get stuck due to the owning container being invalidated
         // Note that for this bug to occur, the loaded asset needs to have dependencies
@@ -3307,7 +3307,7 @@ namespace UnitTest
         AssetManager::Instance().DispatchEvents();
     }
 
-    TEST_F(AssetManagerClearAssetReferenceTests, ReleaseOldReferenceWhileLoadingNewReference_DoesNotDeleteContainer)
+    TEST_F(AssetManagerClearAssetReferenceTests, ReleaseOldReferenceWhileLoadingNewReference_DoesNotDeleteContainer_SUITE_sandbox)
     {
         // Regression test very similar to the above test but this time it occurs when releasing an old asset reference while *loading* (not reloading) the same asset
         // Order of events to reproduce:
@@ -3502,7 +3502,7 @@ namespace UnitTest
         SignallingAssetManager* m_assetManager{};
     };
 
-    TEST_F(AssetManagerEbusSafety, OnAssetReady_GetAsset_DoesNotDeadlock)
+    TEST_F(AssetManagerEbusSafety, OnAssetReady_GetAsset_DoesNotDeadlock_SUITE_sandbox)
     {
         // Regression test
         // Steps to repro:


### PR DESCRIPTION
## What does this PR do?

Sandbox 3 flaky AssetManager tests

## How was this PR tested?

Ran CTEST command locally:

```
# ctest --test-dir build -C profile -L (SUITE_sandbox) --no-tests=error -T Test --verbose -R (AzCore.Tests)

3: Note: Google Test filter = *SUITE_sandbox*
3: [==========] Running 3 tests from 2 test cases.
3: [----------] Global test environment set-up.
3: [----------] 2 tests from AssetManagerClearAssetReferenceTests
3: [ RUN      ] AssetManagerClearAssetReferenceTests.ReloadTest_SUITE_sandbox
3: Waiting for initial asset load to complete
3: Starting reload of asset
3: Waiting for reload to complete
3: Starting another reload of asset
3: Waiting for 2nd reload to complete
3: Test conditions complete, beginning shutdown
3: [       OK ] AssetManagerClearAssetReferenceTests.ReloadTest_SUITE_sandbox (5 ms)
3: [ RUN      ] AssetManagerClearAssetReferenceTests.ReleaseOldReferenceWhileLoadingNewReference_DoesNotDeleteContainer_SUITE_sandbox
3: Waiting for initial asset load to complete
3: Starting reload of asset
3: Waiting for reload of asset to complete
3: Starting another load of asset
3: Waiting for 2nd reload to complete
3: Test conditions complete, beginning shutdown
3: [       OK ] AssetManagerClearAssetReferenceTests.ReleaseOldReferenceWhileLoadingNewReference_DoesNotDeleteContainer_SUITE_sandbox (3 ms)
3: [----------] 2 tests from AssetManagerClearAssetReferenceTests (8 ms total)
3:
3: [----------] 1 test from AssetManagerEbusSafety
3: [ RUN      ] AssetManagerEbusSafety.OnAssetReady_GetAsset_DoesNotDeadlock_SUITE_sandbox
3: ThreadA: OnAssetReady called
3: ThreadB: Starting
3: ThreadA: Resumed
3: ThreadB: Got asset
3: ThreadB: Asset loaded
3: ThreadA: Got asset
3: ThreadA: Asset loaded
3: [       OK ] AssetManagerEbusSafety.OnAssetReady_GetAsset_DoesNotDeadlock_SUITE_sandbox (3 ms)
3: [----------] 1 test from AssetManagerEbusSafety (3 ms total)
3:
3: [----------] Global test environment tear-down
3: [==========] 3 tests from 2 test cases ran. (11 ms total)
3: [  PASSED  ] 3 tests.
3: OKAY AzRunUnitTests() returned 0
3: Returning code: 0
1/1 Test #3: AZ::AzCore.Tests.sandbox::TEST_RUN ...   Passed    0.12 sec
```
