### PR TITLE
AudioSystem Gem Shutdown Fixes

### DIFF
--- a/Code/Legacy/CryCommon/IAudioSystem.h
+++ b/Code/Legacy/CryCommon/IAudioSystem.h
@@ -478,7 +478,6 @@ namespace Audio
         virtual bool Initialize() = 0;
         virtual void Release() = 0;
         virtual void ExternalUpdate() = 0;
-        virtual bool IsInitialized() const { return false; }
 
         virtual void PushRequest(AudioRequestVariant&& request) = 0;
         virtual void PushRequests(AudioRequestsQueue& requests) = 0;
@@ -599,17 +598,11 @@ namespace Audio
             ///////////////////////////////////////////////////////////////////////////////////////////
         };
 
-        class SystemRequests : public SystemBusInterface
-        {
-        public:
-            virtual void RevertToNullAudio() = 0;
-        };
-
-        class EngineRequests : public SystemBusInterface {};
-
         // SystemRequestBus is used with AudioSystem Gem
+        class SystemRequests : public SystemBusInterface {};
         using SystemRequestBus = AZ::EBus<SystemRequests>;
         // EngineRequestBus is used with AudioEngine* Gem
+        class EngineRequests : public SystemBusInterface {};
         using EngineRequestBus = AZ::EBus<EngineRequests>;
 
     } // namespace Gem

--- a/Code/Legacy/CryCommon/IAudioSystem.h
+++ b/Code/Legacy/CryCommon/IAudioSystem.h
@@ -478,6 +478,7 @@ namespace Audio
         virtual bool Initialize() = 0;
         virtual void Release() = 0;
         virtual void ExternalUpdate() = 0;
+        virtual bool IsInitialized() const { return false; }
 
         virtual void PushRequest(AudioRequestVariant&& request) = 0;
         virtual void PushRequests(AudioRequestsQueue& requests) = 0;
@@ -578,43 +579,38 @@ namespace Audio
     namespace Gem
     {
         ///////////////////////////////////////////////////////////////////////////////////////////////
-        // Used for initializing and releasing the audio system (AudioSystem/ATL) code.
-        class AudioSystemGemRequests
+        // Audio initialization loads resources that may not be ready until after
+        // component application (and AP) is fully up, so it is delayed until CSystem::Init.
+        // Similarly, release is called in CSystem::ShutDown.
+        class SystemBusInterface
             : public AZ::EBusTraits
         {
         public:
+            virtual ~SystemBusInterface() = default;
+
             ///////////////////////////////////////////////////////////////////////////////////////////
             // EBusTraits overrides
             static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
             static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
             ///////////////////////////////////////////////////////////////////////////////////////////
-
-            // Interface methods
-            virtual bool Initialize(const SSystemInitParams* initParams) = 0;
-            virtual void Release() = 0;
-        };
-
-        using AudioSystemGemRequestBus = AZ::EBus<AudioSystemGemRequests>;
-
-
-        ///////////////////////////////////////////////////////////////////////////////////////////////
-        // Used for initializing and releasing the audio engine (middleware layer) code.
-        class AudioEngineGemRequests
-            : public AZ::EBusTraits
-        {
-        public:
-            ///////////////////////////////////////////////////////////////////////////////////////////
-            // EBusTraits overrides
-            static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
-            static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
-            ///////////////////////////////////////////////////////////////////////////////////////////
-
             // Interface methods
             virtual bool Initialize() = 0;
             virtual void Release() = 0;
+            ///////////////////////////////////////////////////////////////////////////////////////////
         };
 
-        using AudioEngineGemRequestBus = AZ::EBus<AudioEngineGemRequests>;
+        class SystemRequests : public SystemBusInterface
+        {
+        public:
+            virtual void RevertToNullAudio() = 0;
+        };
+
+        class EngineRequests : public SystemBusInterface {};
+
+        // SystemRequestBus is used with AudioSystem Gem
+        using SystemRequestBus = AZ::EBus<SystemRequests>;
+        // EngineRequestBus is used with AudioEngine* Gem
+        using EngineRequestBus = AZ::EBus<EngineRequests>;
 
     } // namespace Gem
 

--- a/Code/Legacy/CrySystem/System.cpp
+++ b/Code/Legacy/CrySystem/System.cpp
@@ -392,7 +392,7 @@ void CSystem::ShutDown()
 
     // Audio System Shutdown!
     // Shut down audio as late as possible but before the streaming system and console get released!
-    Audio::Gem::AudioSystemGemRequestBus::Broadcast(&Audio::Gem::AudioSystemGemRequestBus::Events::Release);
+    Audio::Gem::SystemRequestBus::Broadcast(&Audio::Gem::SystemRequestBus::Events::Release);
 
     // Shut down console as late as possible and after audio!
     SAFE_RELEASE(m_env.pConsole);

--- a/Code/Legacy/CrySystem/System.h
+++ b/Code/Legacy/CrySystem/System.h
@@ -259,7 +259,7 @@ private:
     bool InitConsole();
     bool InitFileSystem();
     bool InitFileSystem_LoadEngineFolders(const SSystemInitParams& initParams);
-    bool InitAudioSystem(const SSystemInitParams& initParams);
+    bool InitAudioSystem();
 
     //@}
 

--- a/Code/Legacy/CrySystem/System.h
+++ b/Code/Legacy/CrySystem/System.h
@@ -267,7 +267,6 @@ private:
     // Helper functions.
     //////////////////////////////////////////////////////////////////////////
     void CreateSystemVars();
-    void CreateAudioVars();
 
     void QueryVersionInfo();
     void LogVersion();
@@ -366,8 +365,6 @@ private: // ------------------------------------------------------
 #define AZ_RESTRICTED_SECTION SYSTEM_H_SECTION_4
 #include AZ_RESTRICTED_FILE(System_h)
 #endif
-
-    ICVar* m_sys_audio_disable;
 
     ICVar* m_gpu_particle_physics;
 

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -352,39 +352,31 @@ bool CSystem::InitFileSystem_LoadEngineFolders(const SSystemInitParams&)
 //////////////////////////////////////////////////////////////////////////
 bool CSystem::InitAudioSystem(const SSystemInitParams& initParams)
 {
-    if (!Audio::Gem::AudioSystemGemRequestBus::HasHandlers())
+    if (!Audio::Gem::SystemRequestBus::HasHandlers())
     {
-        // AudioSystem Gem has not been enabled for this project.
+        // AudioSystem Gem has not been enabled for this project/configuration.
         // This should not generate an error, but calling scope will warn.
         return false;
     }
 
-    bool useRealAudioSystem = false;
-    if (!initParams.bPreview
-        && !m_bDedicatedServer
-        && m_sys_audio_disable->GetIVal() == 0)
-    {
-        useRealAudioSystem = true;
-    }
-
     bool result = false;
-    if (useRealAudioSystem)
-    {
-        Audio::Gem::AudioSystemGemRequestBus::BroadcastResult(result, &Audio::Gem::AudioSystemGemRequestBus::Events::Initialize, &initParams);
-    }
-    else
-    {
-        Audio::Gem::AudioSystemGemRequestBus::BroadcastResult(result, &Audio::Gem::AudioSystemGemRequestBus::Events::Initialize, nullptr);
-    }
 
-    if (result)
+    bool shouldInitializeAudioSystem = (!initParams.bPreview && !initParams.bUnattendedMode);
+    if (shouldInitializeAudioSystem)
     {
-        AZ_Assert(AZ::Interface<Audio::IAudioSystem>::Get() != nullptr,
-            "Initialization of the Audio System succeeded, but the IAudioSystem interface is not registered!\n");
+        Audio::Gem::SystemRequestBus::BroadcastResult(result, &Audio::Gem::SystemRequestBus::Events::Initialize);
+        if (result)
+        {
+            AZ_Printf(AZ_TRACE_SYSTEM_WINDOW, "Audio System is initialized and ready!\n");
+        }
+        else
+        {
+            AZ_Error(AZ_TRACE_SYSTEM_WINDOW, result, "The Audio System did not initialize correctly!\n");
+        }
     }
     else
     {
-        AZ_Error(AZ_TRACE_SYSTEM_WINDOW, result, "The Audio System did not initialize correctly!\n");
+        Audio::Gem::SystemRequestBus::Broadcast(&Audio::Gem::SystemRequestBus::Events::RevertToNullAudio);
     }
 
     return result;
@@ -892,9 +884,6 @@ AZ_POP_DISABLE_WARNING
             // Register system console variables.
             CreateSystemVars();
 
-            // Register Audio-related system CVars
-            CreateAudioVars();
-
             // Register any AZ CVar commands created above with the AZ Console system.
             AZ::ConsoleFunctorBase*& deferredHead = AZ::ConsoleFunctorBase::GetDeferredHead();
             AZ::Interface<AZ::IConsole>::Get()->LinkDeferredFunctors(deferredHead);
@@ -1356,20 +1345,6 @@ void CSystem::CreateSystemVars()
     // Since the UI Canvas Editor is incomplete, we have a variable to enable it.
     // By default it is now enabled. Modify system.cfg or game.cfg to disable it
     REGISTER_INT("sys_enableCanvasEditor", 1, VF_NULL, "Enables the UI Canvas Editor");
-}
-
-//////////////////////////////////////////////////////////////////////////
-void CSystem::CreateAudioVars()
-{
-    assert(gEnv);
-    assert(gEnv->pConsole);
-
-    m_sys_audio_disable = REGISTER_INT("sys_audio_disable", 0, VF_REQUIRE_APP_RESTART,
-            "Specifies whether to use the NULLAudioSystem in place of the regular AudioSystem\n"
-            "Usage: sys_audio_disable [0/1]\n"
-            "0: use regular AudioSystem.\n"
-            "1: use NullAudioSystem (disable all audio functionality).\n"
-            "Default: 0 (enable audio functionality)");
 }
 
 /////////////////////////////////////////////////////////////////////

--- a/Gems/AudioEngineWwise/Code/Source/AudioEngineWwiseGemSystemComponent.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/AudioEngineWwiseGemSystemComponent.cpp
@@ -86,7 +86,7 @@ namespace AudioEngineWwiseGem
 
     void AudioEngineWwiseGemSystemComponent::Activate()
     {
-        Audio::Gem::AudioEngineGemRequestBus::Handler::BusConnect();
+        Audio::Gem::EngineRequestBus::Handler::BusConnect();
 
     #if defined(AUDIO_ENGINE_WWISE_EDITOR)
         AudioControlsEditor::EditorImplPluginEventBus::Handler::BusConnect();
@@ -95,7 +95,7 @@ namespace AudioEngineWwiseGem
 
     void AudioEngineWwiseGemSystemComponent::Deactivate()
     {
-        Audio::Gem::AudioEngineGemRequestBus::Handler::BusDisconnect();
+        Audio::Gem::EngineRequestBus::Handler::BusDisconnect();
 
     #if defined(AUDIO_ENGINE_WWISE_EDITOR)
         AudioControlsEditor::EditorImplPluginEventBus::Handler::BusDisconnect();
@@ -145,7 +145,7 @@ namespace AudioEngineWwiseGem
         m_engineWwise = AZStd::make_unique<Audio::CAudioSystemImpl_wwise>(assetPlatform.c_str());
         if (m_engineWwise)
         {
-            AZLOG_INFO("AudioEngineWwise created!");
+            AZLOG_INFO("%s", "AudioEngineWwise created!");
 
             Audio::SystemRequest::Initialize initRequest;
             AZ::Interface<Audio::IAudioSystem>::Get()->PushRequestBlocking(AZStd::move(initRequest));
@@ -154,7 +154,7 @@ namespace AudioEngineWwiseGem
         }
         else
         {
-            AZLOG_ERROR("Could not create AudioEngineWwise!");
+            AZLOG_ERROR("%s", "Could not create AudioEngineWwise!");
         }
 
         return success;

--- a/Gems/AudioEngineWwise/Code/Source/AudioEngineWwiseGemSystemComponent.h
+++ b/Gems/AudioEngineWwise/Code/Source/AudioEngineWwiseGemSystemComponent.h
@@ -25,7 +25,7 @@ namespace AudioEngineWwiseGem
 {
     class AudioEngineWwiseGemSystemComponent
         : public AZ::Component
-        , protected Audio::Gem::AudioEngineGemRequestBus::Handler
+        , protected Audio::Gem::EngineRequestBus::Handler
     #if defined(AUDIO_ENGINE_WWISE_EDITOR)
         , protected AudioControlsEditor::EditorImplPluginEventBus::Handler
     #endif // AUDIO_ENGINE_WWISE_EDITOR
@@ -42,7 +42,7 @@ namespace AudioEngineWwiseGem
 
     protected:
         ////////////////////////////////////////////////////////////////////////
-        // Audio::Gem::AudioEngineGemRequestBus interface implementation
+        // Audio::Gem::EngineRequestBus interface implementation
         bool Initialize() override;
         void Release() override;
         ////////////////////////////////////////////////////////////////////////

--- a/Gems/AudioEngineWwise/Code/Source/Engine/AudioSystemImpl_wwise.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/Engine/AudioSystemImpl_wwise.cpp
@@ -260,7 +260,7 @@ namespace Audio
 
         // Set up memory categories for debug tracking, do this early before initializing Wwise so they are available
         // before the any allocations through hooks occur.
-        AZLOG_INFO("Memory Categories:");
+        AZLOG_INFO("%s", "Memory Categories:");
         m_debugMemoryInfo.reserve(AkMemID_NUM + 1);
 
         for (AZ::u32 memId = 0; memId < AkMemID_NUM; ++memId)
@@ -448,7 +448,7 @@ namespace Audio
 
         if (AK::StreamMgr::Create(akStreamSettings) == nullptr)
         {
-            AZLOG_ERROR("AK::StreamMrg::Create() failed!");
+            AZLOG_ERROR("%s", "AK::StreamMrg::Create() failed!");
             ShutDown();
             return EAudioRequestStatus::Failure;
         }
@@ -676,7 +676,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_WARN("RegisterAudioObject failed, audioObjectData was null");
+            AZLOG_WARN("%s", "RegisterAudioObject failed, audioObjectData was null");
             return EAudioRequestStatus::Failure;
         }
     }
@@ -701,7 +701,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_WARN("UnregisterAudioObject failed, audioObjectData was null");
+            AZLOG_WARN("%s", "UnregisterAudioObject failed, audioObjectData was null");
             return EAudioRequestStatus::Failure;
         }
     }
@@ -720,7 +720,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_WARN("ResetAudioObject failed, audioObjectData was null");
+            AZLOG_WARN("%s", "ResetAudioObject failed, audioObjectData was null");
             return EAudioRequestStatus::Failure;
         }
     }
@@ -886,7 +886,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_ERROR("Invalid AudioObjectData, ATLTriggerData, or EventData passed to ActivateTrigger");
+            AZLOG_ERROR("%s", "Invalid AudioObjectData, ATLTriggerData, or EventData passed to ActivateTrigger");
         }
 
         return result;
@@ -913,14 +913,14 @@ namespace Audio
                 }
                 default:
                 {
-                    AZLOG_ERROR("Stopping an event in this state is not supported yet");
+                    AZLOG_ERROR("%s", "Stopping an event in this state is not supported yet");
                     break;
                 }
             }
         }
         else
         {
-            AZLOG_ERROR("Invalid EventData passed to StopEvent");
+            AZLOG_ERROR("%s", "Invalid EventData passed to StopEvent");
         }
 
         return result;
@@ -943,7 +943,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_ERROR("Invalid AudioObjectData passed to StopAllEvents");
+            AZLOG_ERROR("%s", "Invalid AudioObjectData passed to StopAllEvents");
         }
         return result;
     }
@@ -974,7 +974,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_ERROR("Invalid AudioObjectData passed to SetPosition");
+            AZLOG_ERROR("%s", "Invalid AudioObjectData passed to SetPosition");
         }
 
         return result;
@@ -1018,7 +1018,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_ERROR("Invalid AudioObjectData passed to SetMultiplePositions");
+            AZLOG_ERROR("%s", "Invalid AudioObjectData passed to SetMultiplePositions");
         }
 
         return result;
@@ -1083,7 +1083,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_ERROR("Invalid AudioObjectData or EnvironmentData passed to SetEnvironment");
+            AZLOG_ERROR("%s", "Invalid AudioObjectData or EnvironmentData passed to SetEnvironment");
         }
 
         return result;
@@ -1117,7 +1117,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_ERROR("Invalid AudioObjectData or RtpcData passed to SetRtpc");
+            AZLOG_ERROR("%s", "Invalid AudioObjectData or RtpcData passed to SetRtpc");
         }
 
         return result;
@@ -1204,7 +1204,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_ERROR("Invalid AudioObjectData or SwitchStateData passed to SetSwitchState");
+            AZLOG_ERROR("%s", "Invalid AudioObjectData or SwitchStateData passed to SetSwitchState");
         }
 
         return result;
@@ -1253,7 +1253,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_ERROR("Invalid AudioObjectData passed to SetObjectObstructionAndOcclusion");
+            AZLOG_ERROR("%s", "Invalid AudioObjectData passed to SetObjectObstructionAndOcclusion");
         }
 
         return result;
@@ -1286,7 +1286,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_ERROR("Invalid ListenerData passed to SetListenerPosition");
+            AZLOG_ERROR("%s", "Invalid ListenerData passed to SetListenerPosition");
         }
 
         return result;
@@ -1315,7 +1315,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_ERROR("Invalid AudioObjectData or RtpcData passed to ResetRtpc");
+            AZLOG_ERROR("%s", "Invalid AudioObjectData or RtpcData passed to ResetRtpc");
         }
 
         return result;
@@ -1352,7 +1352,7 @@ namespace Audio
             }
             else
             {
-                AZLOG_ERROR("Invalid AudioFileEntryData passed to RegisterInMemoryFile");
+                AZLOG_ERROR("%s", "Invalid AudioFileEntryData passed to RegisterInMemoryFile");
             }
         }
 
@@ -1383,7 +1383,7 @@ namespace Audio
             }
             else
             {
-                AZLOG_ERROR("Invalid AudioFileEntryData passed to UnregisterInMemoryFile");
+                AZLOG_ERROR("%s", "Invalid AudioFileEntryData passed to UnregisterInMemoryFile");
             }
         }
 
@@ -1910,7 +1910,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_ERROR("Invalid ATLTriggerData or EventData passed to PrepUnprepTriggerSync");
+            AZLOG_ERROR("%s", "Invalid ATLTriggerData or EventData passed to PrepUnprepTriggerSync");
         }
 
         return result;

--- a/Gems/AudioSystem/Code/Source/AudioSystemGemSystemComponent.cpp
+++ b/Gems/AudioSystem/Code/Source/AudioSystemGemSystemComponent.cpp
@@ -8,6 +8,7 @@
 
 #include <AudioSystemGemSystemComponent.h>
 
+#include <AzCore/Console/IConsole.h>
 #include <AzCore/Console/ILogger.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Memory/OSAllocator.h>
@@ -87,6 +88,7 @@ namespace AudioSystemGem
     AudioSystemGemSystemComponent::AudioSystemGemSystemComponent()
     {
         Audio::Platform::InitializeAudioAllocators();
+        CreateAudioSystem();
     }
 
     AudioSystemGemSystemComponent::~AudioSystemGemSystemComponent()
@@ -119,7 +121,7 @@ namespace AudioSystemGem
 
     void AudioSystemGemSystemComponent::Activate()
     {
-        Audio::Gem::AudioSystemGemRequestBus::Handler::BusConnect();
+        Audio::Gem::SystemRequestBus::Handler::BusConnect();
         AzFramework::ApplicationLifecycleEvents::Bus::Handler::BusConnect();
 
     #if defined(AUDIO_SYSTEM_EDITOR)
@@ -133,7 +135,7 @@ namespace AudioSystemGem
 
     void AudioSystemGemSystemComponent::Deactivate()
     {
-        Audio::Gem::AudioSystemGemRequestBus::Handler::BusDisconnect();
+        Audio::Gem::SystemRequestBus::Handler::BusDisconnect();
         AzFramework::ApplicationLifecycleEvents::Bus::Handler::BusDisconnect();
 
     #if defined(AUDIO_SYSTEM_EDITOR)
@@ -144,25 +146,16 @@ namespace AudioSystemGem
     #endif // AUDIO_SYSTEM_EDITOR
     }
 
-    bool AudioSystemGemSystemComponent::Initialize(const SSystemInitParams* initParams)
+    bool AudioSystemGemSystemComponent::Initialize()
     {
         using namespace Audio;
 
-        // When nullptr is passed, create a NullAudioSystem instead of the real thing.
-        if (!initParams)
+        bool success = AZ::Interface<Audio::IAudioSystem>::Get()->Initialize();
+        if (success)
         {
-            return CreateNullAudioSystem();
-        }
-
-        bool success = false;
-
-        if (CreateAudioSystem())
-        {
-            AZLOG_INFO("AudioSystem created!");
-
             // Initialize the implementation module...
             bool initImplSuccess = false;
-            Gem::AudioEngineGemRequestBus::BroadcastResult(initImplSuccess, &Gem::AudioEngineGemRequestBus::Events::Initialize);
+            Gem::EngineRequestBus::BroadcastResult(initImplSuccess, &Gem::EngineRequestBus::Events::Initialize);
 
             if (initImplSuccess)
             {
@@ -172,13 +165,13 @@ namespace AudioSystemGem
             }
             else
             {
-                if (Gem::AudioEngineGemRequestBus::HasHandlers())
+                if (Gem::EngineRequestBus::HasHandlers())
                 {
-                    AZLOG_ERROR("The Audio Engine did not initialize correctly!");
+                    AZLOG_ERROR("%s", "The Audio Engine did not initialize correctly!");
                 }
                 else
                 {
-                    AZLOG_NOTICE("Running without any Audio Engine!");
+                    AZLOG_NOTICE("%s", "Running without any Audio Engine!");
                 }
             }
 
@@ -188,27 +181,26 @@ namespace AudioSystemGem
         return success;
     }
 
-    bool AudioSystemGemSystemComponent::CreateNullAudioSystem()
-    {
-        AZ_Assert(!AZ::Interface<Audio::IAudioSystem>::Get(), "The IAudioSystem interface is already registered!");
-
-        m_audioSystem = AZStd::make_unique<Audio::NullAudioSystem>();
-
-        return (m_audioSystem != nullptr);
-    }
-
     void AudioSystemGemSystemComponent::Release()
     {
         AZ_Assert(AZ::Interface<Audio::IAudioSystem>::Get() != nullptr, "The IAudioSystem interface has already been unregistered!");
         AZ::Interface<Audio::IAudioSystem>::Get()->Release();
 
-        Audio::Gem::AudioEngineGemRequestBus::Broadcast(&Audio::Gem::AudioEngineGemRequestBus::Events::Release);
-
-        // Delete the Audio System
-        // It should be the last object that is freed from the audio system memory pool before the allocator is destroyed.
-        m_audioSystem.reset();
+        Audio::Gem::EngineRequestBus::Broadcast(&Audio::Gem::EngineRequestBus::Events::Release);
 
         GetISystem()->GetISystemEventDispatcher()->RemoveListener(this);
+    }
+
+    void AudioSystemGemSystemComponent::RevertToNullAudio()
+    {
+        AZ_Assert(m_audioSystem != nullptr, "Expected IAudioSystem interface to be registered!");
+        // Only do this when the audio system has been constructed but Initialize() hasn't been called yet.
+        // See CSystem::InitAudioSystem
+        if (!m_audioSystem->IsInitialized())
+        {
+            m_audioSystem.reset();
+            m_audioSystem = AZStd::make_unique<Audio::NullAudioSystem>();
+        }
     }
 
     void AudioSystemGemSystemComponent::OnSystemEvent(ESystemEvent event, [[maybe_unused]] UINT_PTR wparam, [[maybe_unused]] UINT_PTR lparam)
@@ -278,28 +270,31 @@ namespace AudioSystemGem
     }
 #endif // AUDIO_SYSTEM_EDITOR
 
-    bool AudioSystemGemSystemComponent::CreateAudioSystem()
+    void AudioSystemGemSystemComponent::CreateAudioSystem()
     {
-        AZ_Assert(!AZ::Interface<Audio::IAudioSystem>::Get(), "CreateAudioSystem - The IAudioSystem interface is already registered!");
-
-        bool success = false;
-        m_audioSystem = AZStd::make_unique<Audio::CAudioSystem>();
-        if (m_audioSystem)
+        int audioIsDisabled = 0;
+        if (auto console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
         {
-            success = AZ::Interface<Audio::IAudioSystem>::Get()->Initialize();
+            [[maybe_unused]] auto result = console->GetCvarValue("sys_audio_disable", audioIsDisabled);
+            AZ_Warning("AudioSystem", result == AZ::GetValueResult::Success,
+                "Failed to get the 's_AudioDisable' Cvar, result is %d\n", static_cast<int>(result));
+        }
+
+        if (audioIsDisabled)
+        {
+            m_audioSystem = AZStd::make_unique<Audio::NullAudioSystem>();
+            AZLOG_INFO("%s", "Null AudioSystem created!");
         }
         else
         {
-            AZLOG_ERROR("Could not create AudioSystem!");
+            m_audioSystem = AZStd::make_unique<Audio::CAudioSystem>();
+            AZLOG_INFO("%s", "AudioSystem created!");
         }
-
-        return success;
     }
 
     void AudioSystemGemSystemComponent::PrepareAudioSystem()
     {
         using namespace Audio;
-
         if (auto audioSystem = AZ::Interface<IAudioSystem>::Get(); audioSystem != nullptr)
         {
             // This is called when a new audio implementation has been set,

--- a/Gems/AudioSystem/Code/Source/AudioSystemGemSystemComponent.cpp
+++ b/Gems/AudioSystem/Code/Source/AudioSystemGemSystemComponent.cpp
@@ -191,18 +191,6 @@ namespace AudioSystemGem
         GetISystem()->GetISystemEventDispatcher()->RemoveListener(this);
     }
 
-    void AudioSystemGemSystemComponent::RevertToNullAudio()
-    {
-        AZ_Assert(m_audioSystem != nullptr, "Expected IAudioSystem interface to be registered!");
-        // Only do this when the audio system has been constructed but Initialize() hasn't been called yet.
-        // See CSystem::InitAudioSystem
-        if (!m_audioSystem->IsInitialized())
-        {
-            m_audioSystem.reset();
-            m_audioSystem = AZStd::make_unique<Audio::NullAudioSystem>();
-        }
-    }
-
     void AudioSystemGemSystemComponent::OnSystemEvent(ESystemEvent event, [[maybe_unused]] UINT_PTR wparam, [[maybe_unused]] UINT_PTR lparam)
     {
         switch (event)

--- a/Gems/AudioSystem/Code/Source/AudioSystemGemSystemComponent.h
+++ b/Gems/AudioSystem/Code/Source/AudioSystemGemSystemComponent.h
@@ -58,7 +58,6 @@ namespace AudioSystemGem
         // Audio::Gem::SystemRequestBus interface implementation
         bool Initialize() override;
         void Release() override;
-        void RevertToNullAudio() override;
         ////////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////

--- a/Gems/AudioSystem/Code/Source/AudioSystemGemSystemComponent.h
+++ b/Gems/AudioSystem/Code/Source/AudioSystemGemSystemComponent.h
@@ -28,7 +28,7 @@ namespace AudioSystemGem
         : public AZ::Component
         , public ISystemEventListener
         , public AzFramework::ApplicationLifecycleEvents::Bus::Handler
-        , protected Audio::Gem::AudioSystemGemRequestBus::Handler
+        , protected Audio::Gem::SystemRequestBus::Handler
     #if defined(AUDIO_SYSTEM_EDITOR)
         , private AzToolsFramework::EditorEvents::Bus::Handler
         , public AZ::RPI::ViewportContextNotificationBus::Handler
@@ -55,9 +55,10 @@ namespace AudioSystemGem
         ////////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////
-        // Audio::Gem::AudioSystemGemRequestBus interface implementation
-        bool Initialize(const SSystemInitParams* initParams) override;
+        // Audio::Gem::SystemRequestBus interface implementation
+        bool Initialize() override;
         void Release() override;
+        void RevertToNullAudio() override;
         ////////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////
@@ -86,8 +87,7 @@ namespace AudioSystemGem
 
     private:
         ////////////////////////////////////////////////////////////////////////
-        bool CreateAudioSystem();
-        bool CreateNullAudioSystem();
+        void CreateAudioSystem();
         void PrepareAudioSystem();
 
         /// This is here to express ownership

--- a/Gems/AudioSystem/Code/Source/Engine/ATL.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/ATL.cpp
@@ -817,17 +817,17 @@ namespace Audio
 
         m_implSubPath.clear();
 
-        EAudioRequestStatus eResult = EAudioRequestStatus::Failure;
-        AudioSystemImplementationRequestBus::BroadcastResult(eResult, &AudioSystemImplementationRequestBus::Events::ShutDown);
+        if (AudioSystemImplementationRequestBus::HasHandlers())
+        {
+            EAudioRequestStatus result = EAudioRequestStatus::Failure;
+            AudioSystemImplementationRequestBus::BroadcastResult(result, &AudioSystemImplementationRequestBus::Events::ShutDown);
+            AZ_Error("ATL", result == EAudioRequestStatus::Success,
+                "ATL ReleaseImplComponent - Shutting down the audio implementation failed!");
 
-        // If we allow developers to change the audio implementation module at run-time, these should be at Warning level.
-        // If we ever revoke that functionality, these should be promoted to Asserts.
-        AZ_Warning("ATL", eResult == EAudioRequestStatus::Success,
-            "ATL ReleaseImplComponent - Shutting down the audio implementation failed!");
-
-        AudioSystemImplementationRequestBus::BroadcastResult(eResult, &AudioSystemImplementationRequestBus::Events::Release);
-        AZ_Warning("ATL", eResult == EAudioRequestStatus::Success,
-            "ATL ReleaseImplComponent - Releasing the audio implementation failed!");
+            AudioSystemImplementationRequestBus::BroadcastResult(result, &AudioSystemImplementationRequestBus::Events::Release);
+            AZ_Error("ATL", result == EAudioRequestStatus::Success,
+                "ATL ReleaseImplComponent - Releasing the audio implementation failed!");
+        }
 
         m_nFlags &= ~eAIS_AUDIO_MIDDLEWARE_SHUTTING_DOWN;
     }

--- a/Gems/AudioSystem/Code/Source/Engine/ATLComponents.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/ATLComponents.cpp
@@ -71,7 +71,6 @@ namespace Audio
     ///////////////////////////////////////////////////////////////////////////////////////////////////
     CAudioEventManager::~CAudioEventManager()
     {
-        Release();
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -213,7 +212,7 @@ namespace Audio
 
             if (!pEvent)
             {
-                AZLOG_ERROR("Failed to get a new instance of an ATLEvent from the implementation.");
+                AZLOG_ERROR("%s", "Failed to get a new instance of an ATLEvent from the implementation.");
             }
         }
 
@@ -467,7 +466,7 @@ namespace Audio
 
             if (!pObject)
             {
-                AZLOG_ERROR("Failed to get a new instance of an AudioObject from the implementation. "
+                AZLOG_ERROR("%s", "Failed to get a new instance of an AudioObject from the implementation. "
                     "If this limit was reached from legitimate content creation and not a scripting error, "
                     "try increasing the Capacity of Audio::AudioSystemAllocator.");
                 //failed to get a new instance from the implementation
@@ -689,7 +688,6 @@ namespace Audio
     ///////////////////////////////////////////////////////////////////////////////////////////////////
     CAudioListenerManager::~CAudioListenerManager()
     {
-        Release();
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -722,21 +720,27 @@ namespace Audio
         {
             m_cActiveListeners.erase(m_nDefaultListenerID);
 
-            AudioSystemImplementationRequestBus::Broadcast(&AudioSystemImplementationRequestBus::Events::DeleteAudioListenerObjectData, m_pDefaultListenerObject->m_pImplData);
+            AudioSystemImplementationRequestBus::Broadcast(
+                &AudioSystemImplementationRequestBus::Events::DeleteAudioListenerObjectData, m_pDefaultListenerObject->m_pImplData);
             azdestroy(m_pDefaultListenerObject, Audio::AudioSystemAllocator);
             m_pDefaultListenerObject = nullptr;
         }
 
-        // Release any remaining active audio listeners back to the listener pool
-        for (auto listener : m_cActiveListeners)
+        // Release any remaining active audio listeners
+        for (auto listenerPair : m_cActiveListeners)
         {
-            ReleaseID(listener.first);
+            AudioSystemImplementationRequestBus::Broadcast(
+                &AudioSystemImplementationRequestBus::Events::DeleteAudioListenerObjectData, listenerPair.second->m_pImplData);
+            azdestroy(listenerPair.second, Audio::AudioSystemAllocator);
         }
 
-        // Delete all from the audio listener pool
+        m_cActiveListeners.clear();
+
+        // Delete all remaining listeners from the audio listener pool
         for (auto listener : m_cListenerPool)
         {
-            AudioSystemImplementationRequestBus::Broadcast(&AudioSystemImplementationRequestBus::Events::DeleteAudioListenerObjectData, listener->m_pImplData);
+            AudioSystemImplementationRequestBus::Broadcast(
+                &AudioSystemImplementationRequestBus::Events::DeleteAudioListenerObjectData, listener->m_pImplData);
             azdestroy(listener, Audio::AudioSystemAllocator);
         }
 
@@ -761,7 +765,7 @@ namespace Audio
         }
         else
         {
-            AZLOG_WARN("CAudioListenerManager::ReserveID - Reserved pool of pre-allocated Audio Listeners has been exhausted!");
+            AZLOG_WARN("%s", "CAudioListenerManager::ReserveID - Reserved pool of pre-allocated Audio Listeners has been exhausted!");
         }
 
         return bSuccess;

--- a/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
@@ -300,6 +300,12 @@ namespace Audio
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////
+    bool CAudioSystem::IsInitialized() const
+    {
+        return m_bSystemInitialized;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
     TAudioControlID CAudioSystem::GetAudioTriggerID(const char* const sAudioTriggerName) const
     {
         return m_oATL.GetAudioTriggerID(sAudioTriggerName);

--- a/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
@@ -300,12 +300,6 @@ namespace Audio
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////
-    bool CAudioSystem::IsInitialized() const
-    {
-        return m_bSystemInitialized;
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////////////////////////
     TAudioControlID CAudioSystem::GetAudioTriggerID(const char* const sAudioTriggerName) const
     {
         return m_oATL.GetAudioTriggerID(sAudioTriggerName);

--- a/Gems/AudioSystem/Code/Source/Engine/AudioSystem.h
+++ b/Gems/AudioSystem/Code/Source/Engine/AudioSystem.h
@@ -73,7 +73,6 @@ namespace Audio
         bool Initialize() override;
         void Release() override;
         void ExternalUpdate() override;
-        bool IsInitialized() const override;
 
         void PushRequest(AudioRequestVariant&& request) override;
         void PushRequests(AudioRequestsQueue& requests) override;

--- a/Gems/AudioSystem/Code/Source/Engine/AudioSystem.h
+++ b/Gems/AudioSystem/Code/Source/Engine/AudioSystem.h
@@ -72,13 +72,13 @@ namespace Audio
 
         bool Initialize() override;
         void Release() override;
+        void ExternalUpdate() override;
+        bool IsInitialized() const override;
 
         void PushRequest(AudioRequestVariant&& request) override;
         void PushRequests(AudioRequestsQueue& requests) override;
         void PushRequestBlocking(AudioRequestVariant&& request) override;
         void PushCallback(AudioRequestVariant&& callback) override;
-
-        void ExternalUpdate() override;
 
         TAudioControlID GetAudioTriggerID(const char* const sAudioTriggerName) const override;
         TAudioControlID GetAudioRtpcID(const char* const sAudioRtpcName) const override;

--- a/Gems/AudioSystem/Code/Source/Engine/SoundCVars.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/SoundCVars.cpp
@@ -20,6 +20,13 @@
 
 namespace Audio::CVars
 {
+    // Keep the name of this the same as it was in legacy CSystem.
+    AZ_CVAR(AZ::u32, sys_audio_disable, 0,
+        nullptr,
+        AZ::ConsoleFunctorFlags::Null,
+        "Globally enable/disable the audio system, 0 (default) = Audio is Enabled, 1 = Audio is Disabled\n"
+        "It is advised to put this setting under \"/O3DE/Autoexec/ConsoleCommands/\" in Settings Registry.");
+
     // CVar: s_EnableRaycasts
     // Usage: s_EnableRaycasts=true (false)
     AZ_CVAR(bool, s_EnableRaycasts, true,

--- a/Gems/AudioSystem/Code/Source/Engine/SoundCVars.h
+++ b/Gems/AudioSystem/Code/Source/Engine/SoundCVars.h
@@ -14,6 +14,8 @@
 
 namespace Audio::CVars
 {
+    AZ_CVAR_EXTERNED(AZ::u32, sys_audio_disable);
+
     AZ_CVAR_EXTERNED(AZ::u64, s_ATLMemorySize);
     AZ_CVAR_EXTERNED(AZ::u64, s_FileCacheManagerMemorySize);
     AZ_CVAR_EXTERNED(AZ::u64, s_AudioObjectPoolSize);


### PR DESCRIPTION
## What does this PR do?

This addresses a couple instances of shutdown crashes in GameLauncher related to audio Gems.
One fixes how a container of objects was being destructed.
The other changes the lifetime of the `IAudioSystem` interface, so that it's constructed earlier and destructed later. This prevents nullptr dereference.

fixes #11554 
fixes #11557

## How was this PR tested?

Run GameLaunchers for projects with and without audio setups.
Quit from levels with and without audio playing.
Ran Editor and exit.
