### PR TITLE
Prefab | Fix prefab instance reference conversion issue

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.cpp
@@ -54,7 +54,7 @@ namespace AzToolsFramework
                 return false;
             }
 
-            InstanceOptionalConstReference focusedInstance = prefabFocusInterface->GetFocusedPrefabInstance(s_editorEntityContextId);
+            InstanceOptionalReference focusedInstance = prefabFocusInterface->GetFocusedPrefabInstance(s_editorEntityContextId);
             if (!focusedInstance.has_value())
             {
                 AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateInstanceDom - "

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -375,12 +375,12 @@ namespace AzToolsFramework::Prefab
         }
 
         // Grab the owning instance.
-        InstanceOptionalConstReference owningInstance = m_instanceEntityMapperInterface->FindOwningInstance(entityId);
+        InstanceOptionalReference owningInstance = m_instanceEntityMapperInterface->FindOwningInstance(entityId);
         AZ_Assert(owningInstance.has_value(), "PrefabFocusHandler::AppendPathFromFocusedInstanceToPatchPaths - "
             "The owning instance of the given entity id is null.");
 
         // Retrieve the path from the focused prefab instance to the owningInstance of the given entity id.
-        InstanceOptionalConstReference focusedInstance = GetInstanceReference(m_rootAliasFocusPath);
+        InstanceOptionalReference focusedInstance = GetInstanceReference(m_rootAliasFocusPath);
         AZ_Assert(focusedInstance.has_value(), "PrefabFocusHandler::AppendPathFromFocusedInstanceToPatchPaths - "
             "The focused instance is null.");
         const Instance* focusedInstancePtr = &(focusedInstance->get());
@@ -405,12 +405,11 @@ namespace AzToolsFramework::Prefab
             for (auto instanceIter = startInstanceIter; instanceIter != climbUpResult.m_climbedInstances.rend(); ++instanceIter)
             {
                 prefix.append(PrefabDomUtils::PathStartingWithInstances);
-                const Instance& instance = (*instanceIter)->get();
-                prefix.append(instance.GetInstanceAlias());
+                prefix.append((*instanceIter)->GetInstanceAlias());
             }
 
             m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(providedPatch, entityId, AZStd::move(prefix));
-            return climbUpResult.m_climbedInstances.back()->get().GetLinkId();
+            return climbUpResult.m_climbedInstances.back()->GetLinkId();
         }
         else
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabInstanceUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabInstanceUtils.cpp
@@ -27,7 +27,7 @@ namespace AzToolsFramework
                 {
                     while (instancePtr != targetInstance && instancePtr->HasParentInstance())
                     {
-                        result.m_climbedInstances.emplace_back(*instancePtr);
+                        result.m_climbedInstances.emplace_back(instancePtr);
                         instancePtr = &(instancePtr->GetParentInstance()->get());
                     }
                 }
@@ -36,7 +36,7 @@ namespace AzToolsFramework
                     // Returns the root.
                     while (instancePtr->HasParentInstance())
                     {
-                        result.m_climbedInstances.emplace_back(*instancePtr);
+                        result.m_climbedInstances.emplace_back(instancePtr);
                         instancePtr = &(instancePtr->GetParentInstance()->get());
                     }
                 }
@@ -48,12 +48,12 @@ namespace AzToolsFramework
             AZStd::string GetRelativePathBetweenInstances(const Instance& parentInstance, const Instance& childInstance)
             {
                 const Instance* instancePtr = &childInstance;
-                AZStd::vector<InstanceOptionalConstReference> climbedInstances;
+                AZStd::vector<const Instance*> climbedInstances;
 
                 // Climbs up the instance hierarchy from the child instance until it hits the parent instance.
                 while (instancePtr != &parentInstance && instancePtr->HasParentInstance())
                 {
-                    climbedInstances.emplace_back(*instancePtr);
+                    climbedInstances.emplace_back(instancePtr);
                     instancePtr = &(instancePtr->GetParentInstance()->get());
                 }
 
@@ -67,15 +67,14 @@ namespace AzToolsFramework
                 return GetRelativePathFromClimbedInstances(climbedInstances);
             }
 
-            AZStd::string GetRelativePathFromClimbedInstances(const AZStd::vector<InstanceOptionalConstReference>& climbedInstances)
+            AZStd::string GetRelativePathFromClimbedInstances(const AZStd::vector<const Instance*>& climbedInstances)
             {
                 AZStd::string relativePath = "";
 
                 for (auto instanceIter = climbedInstances.rbegin(); instanceIter != climbedInstances.rend(); ++instanceIter)
                 {
                     relativePath.append(PrefabDomUtils::PathStartingWithInstances);
-                    const Instance& instance = (*instanceIter)->get();
-                    relativePath.append(instance.GetInstanceAlias());
+                    relativePath.append((*instanceIter)->GetInstanceAlias());
                 }
 
                 return relativePath;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabInstanceUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabInstanceUtils.h
@@ -24,7 +24,7 @@ namespace AzToolsFramework
             const Instance* m_reachedInstance = nullptr;
             //! Instance list that contains instances that are climbed up from bottom to top.
             //! The list does not include the reached instance.
-            AZStd::vector<InstanceOptionalConstReference> m_climbedInstances;
+            AZStd::vector<const Instance*> m_climbedInstances;
         };
 
         namespace PrefabInstanceUtils
@@ -45,7 +45,7 @@ namespace AzToolsFramework
             //! Generates a relative path from a list of climbed instances.
             //! @param climbedInstances The list of climbed instances from bottom to top.
             //! @return The relative path string.
-            AZStd::string GetRelativePathFromClimbedInstances(const AZStd::vector<InstanceOptionalConstReference>& climbedInstances);
+            AZStd::string GetRelativePathFromClimbedInstances(const AZStd::vector<const Instance*>& climbedInstances);
 
             //! Checks if the child instance is a descendant of the parent instance.
             //! @param childInstance The given child instance.


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

This PR fixes the issue of implicit conversion from `InstanceOptionalReference` to `InstanceOptionalConstReference`. It was reported that on macOS the conversion yields error.

```
/o3de/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp:378:40: 
No viable conversion from ‘optional<reference_wrapper<AzToolsFramework::Prefab::Instance>>’ to ‘optional<reference_wrapper<const AzToolsFramework::Prefab::Instance>>’
```

Fix:
- Use `InstanceOptionalReference` explicitly as what the code in other places is doing.

Minor Changes:
- Use `const Instance*` instead of `InstanceOptionalConstReference` in m_climbedInstances.

Reference:
- Might be related to this: https://stackoverflow.com/questions/65992868/cannot-convert-stdreferencet-to-stdreferenceconst-t-on-clang
- Tried compiling the code on mac intel and m1. Only m1 produces the error.

```cpp
#include <optional>
int main()
{
    int a = 10;
    std::optional<std::reference_wrapper<int>> optRef = a;
    std::optional<std::reference_wrapper<const int>> optConstRef = optRef;
    return 0;
}
```

## How was this PR tested?

- [x] Tests passed
- [x] Windows/Linux ARs
- [ ] Mac AR