### PR TITLE
Atom Tools: Support for registering dedicated Python scripts with SMC, ME, MC

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -24,6 +24,7 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnin
 AZ_POP_DISABLE_WARNING
 
 class QImage;
+class QMenu;
 class QMimeData;
 class QWidget;
 
@@ -183,9 +184,15 @@ namespace AtomToolsFramework
     //! Helper function to convert a full path into one containing an alias
     AZStd::string GetPathWithAlias(const AZStd::string& path);
 
-    //! Collect a set of file paths contained within asset browser entry or URL mine data
+    //! Collect a set of file paths contained within asset browser entry or URL mime data
     AZStd::set<AZStd::string> GetPathsFromMimeData(const QMimeData* mimeData);
 
     //! Collect a set of file paths from all project safe folders matching a wild card
     AZStd::set<AZStd::string> GetPathsInSourceFoldersMatchingWildcard(const AZStd::string& wildcard);
+
+    // Add menu actions for scripts specified in the settings registry
+    // @param menu The menu where the actions will be inserted
+    // @param registryKey The path to the registry setting where script categories are registered
+    // @param arguments The list of arguments passed into the script when executed
+    void AddRegisteredScriptToMenu(QMenu* menu, const AZStd::string& registryKey, const AZStd::vector<AZStd::string_view>& arguments);
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
@@ -65,6 +65,7 @@ namespace AtomToolsFramework
 
         void BuildDockingMenu();
         void BuildLayoutsMenu();
+        void BuildScriptsMenu();
 
         virtual void SetupMetrics();
         virtual void UpdateMetrics();

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowserInteractions.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowserInteractions.cpp
@@ -99,18 +99,9 @@ namespace AtomToolsFramework
                 }
             });
 
-        menu->addAction("Run Python on File...", [caller, entry]()
-            {
-                const QString script = QFileDialog::getOpenFileName(
-                    caller, QObject::tr("Run Script"), QString(AZ::Utils::GetProjectPath().c_str()), QString("*.py"));
-                if (!script.isEmpty())
-                {
-                    AZStd::vector<AZStd::string_view> pythonArgs{ entry->GetFullPath() };
-                    AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(
-                        &AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilenameWithArgs, script.toUtf8().constData(),
-                        pythonArgs);
-                }
-            });
+        QMenu* scriptsMenu = menu->addMenu(QObject::tr("Python Scripts"));
+        AZStd::vector<AZStd::string_view> pythonArgs{ entry->GetFullPath() };
+        AddRegisteredScriptToMenu(scriptsMenu, "/O3DE/AtomToolsFramework/AssetBrowser/ContextMenuScripts", pythonArgs);
     }
 
     void AtomToolsAssetBrowserInteractions::AddContextMenuActionsForFolderEntries(

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AtomToolsFrameworkSystemComponent.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AtomToolsFrameworkSystemComponent.cpp
@@ -36,6 +36,7 @@ namespace AtomToolsFramework
         if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->RegisterGenericType<AZStd::unordered_map<AZStd::string, bool>>();
+            serialize->RegisterGenericType<AZStd::map<AZStd::string, AZStd::vector<AZStd::string>>>();
 
             serialize->Class<AtomToolsFrameworkSystemComponent, AZ::Component>()
                 ->Version(0)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -231,18 +231,7 @@ namespace AtomToolsFramework
         m_menuHelp = menuBar->addMenu("&Help");
         m_menuHelp->setObjectName("menuHelp");
 
-        m_menuFile->addAction(tr("Run &Python..."), [this]() {
-            const QString script = QFileDialog::getOpenFileName(
-                this, QObject::tr("Run Script"), QString(AZ::Utils::GetProjectPath().c_str()), QString("*.py"));
-            if (!script.isEmpty())
-            {
-                QTimer::singleShot(0, [script]() {
-                    AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(
-                        &AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilename, script.toUtf8().constData());
-                });
-            }
-        });
-
+        BuildScriptsMenu();
         m_menuFile->addSeparator();
 
         m_menuFile->addAction(tr("E&xit"), [this]() {
@@ -475,6 +464,15 @@ namespace AtomToolsFramework
                         m_advancedDockManager->restoreState(m_defaultWindowState);
                     });
             });
+    }
+
+    void AtomToolsMainWindow::BuildScriptsMenu()
+    {
+        QMenu* scriptsMenu = m_menuFile->addMenu(tr("Python Scripts"));
+        connect(scriptsMenu, &QMenu::aboutToShow, this, [scriptsMenu]() {
+            scriptsMenu->clear();
+            AddRegisteredScriptToMenu(scriptsMenu, "/O3DE/AtomToolsFramework/MainWindow/FileMenuScripts", {});
+        });
     }
 
     void AtomToolsMainWindow::SetupMetrics()

--- a/Gems/Atom/Tools/ShaderManagementConsole/Registry/scripts.shadermanagementconsole.setreg
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Registry/scripts.shadermanagementconsole.setreg
@@ -1,0 +1,11 @@
+{
+    "O3DE": {
+        "AtomToolsFramework": {
+            "AssetBrowser": {
+                "ContextMenuScripts": {
+                    "": [ "@gemroot:ShaderManagementConsole@/Scripts/GenerateShaderVariantListForMaterials.py" ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Shader management console requires a generic method for registering applications specific scripts with the file menu and asset browser context menu. This allows those scripts to be added using the settings registry. The settings can be registered in application specific settings registry files or at runtime, by specifying a category and a list of script paths. If the category name is empty, the script will be added to the top-level menu. When executed from the asset browser context menu, the first selected file is passed in as an argument.

https://github.com/o3de/o3de/issues/11380
Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Verified that the generate shader varian list script appears in the asset browser context menu and runs when collected. The script currently produces errors but that is being addressed in a separate PR.

![image](https://user-images.githubusercontent.com/82461473/186992963-02717ac5-d518-4014-9cfb-43042968ce15.png)
