### PR TITLE
Multiplayer Blocks Level Loads Based on Multiplayer State

### DIFF
--- a/Code/Legacy/CryCommon/ILevelSystem.h
+++ b/Code/Legacy/CryCommon/ILevelSystem.h
@@ -37,6 +37,8 @@ struct ILevelInfo
 struct ILevelSystemListener
 {
     virtual ~ILevelSystemListener() = default;
+    //! Gives listeners the opportunity to block the loadlevel command. Return true to stop loading.
+    virtual bool BlockLoading([[maybe_unused]] const char* levelName) { return false; }
     //! Called when loading a level fails due to it not being found.
     virtual void OnLevelNotFound([[maybe_unused]] const char* levelName) {}
     //! Called after ILevelSystem::PrepareNextLevel() completes.

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -195,7 +195,7 @@ namespace LegacyLevelSystem
     {
         if (gEnv->IsEditor())
         {
-            AZ_TracePrintf("CrySystem::CLevelSystem", "LoadLevel for %s was called in the editor - not actually loading.\n", levelName);
+            AZ_TracePrintf("CrySystem::SpawnableLevelSystem", "LoadLevel for %s was called in the editor - not actually loading.\n", levelName);
             return false;
         }
 
@@ -233,6 +233,16 @@ namespace LegacyLevelSystem
         {
             OnLevelNotFound(levelName);
             return false;
+        }
+
+        // This is a valid level, find out if any systems need to stop level loading before proceeding
+        for (const auto& listener : m_listeners)
+        {
+            if (listener->BlockLoading(validLevelName.c_str()))
+            {
+                AZ_TracePrintf("CrySystem::SpawnableLevelSystem", "LoadLevel for %s was blocked.\n", validLevelName.c_str());
+                return false;
+            }
         }
 
         // If a level is currently loaded, unload it before loading the next one.

--- a/Gems/Multiplayer/Code/CMakeLists.txt
+++ b/Gems/Multiplayer/Code/CMakeLists.txt
@@ -26,6 +26,7 @@ ly_add_target(
             AZ::AzCore
             AZ::AzFramework
             AZ::AzNetworking
+            Legacy::CryCommon
         PRIVATE
             Gem::EMotionFXStaticLib
             Gem::PhysX.Static

--- a/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
@@ -149,8 +149,10 @@ namespace Multiplayer
             return;
         }
 
-        const AzPhysics::RigidBody* rigidBody = GetParent().m_physicsRigidBodyComponent->GetRigidBody();
-        SetLinearVelocity(rigidBody->GetLinearVelocity());
-        SetAngularVelocity(rigidBody->GetAngularVelocity());
+        if (const AzPhysics::RigidBody* rigidBody = GetParent().m_physicsRigidBodyComponent->GetRigidBody())
+        {
+            SetLinearVelocity(rigidBody->GetLinearVelocity());
+            SetAngularVelocity(rigidBody->GetAngularVelocity());
+        }
     }
 } // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
@@ -143,7 +143,13 @@ namespace Multiplayer
 
     void NetworkRigidBodyComponentController::OnTransformUpdate()
     {
-        AzPhysics::RigidBody* rigidBody = GetParent().m_physicsRigidBodyComponent->GetRigidBody();
+        // Even though this component requires a rigid body, OnTransformUpdate can get called while the entity is being destroyed and may already have its rigidbody removed
+        if (GetEntity()->GetState() == AZ::Entity::State::Destroying)
+        {
+            return;
+        }
+
+        const AzPhysics::RigidBody* rigidBody = GetParent().m_physicsRigidBodyComponent->GetRigidBody();
         SetLinearVelocity(rigidBody->GetLinearVelocity());
         SetAngularVelocity(rigidBody->GetAngularVelocity());
     }

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
@@ -94,12 +94,12 @@ namespace Multiplayer
         //! @{
         void OnStartPlayInEditorBegin() override;
         void OnStartPlayInEditor() override;
-        //! @
+        //! @}
 
         //! AzToolsFramework::Prefab::PrefabToInMemorySpawnableNotificationBus::Handler overrides
         //! @{
         void OnPreparingInMemorySpawnableFromPrefab(const AzFramework::Spawnable& spawnable, const AZStd::string& assetHint) override;
-        //! @
+        //! @}
         
         //! EditorEvents::Handler overrides
         //! @{

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+
 #include <Multiplayer/IMultiplayer.h>
 #include <Multiplayer/Session/ISessionHandlingRequests.h>
 #include <Multiplayer/Session/SessionNotifications.h>
@@ -22,6 +23,8 @@
 #include <AzCore/Threading/ThreadSafeDeque.h>
 #include <AzCore/std/string/string.h>
 #include <AzNetworking/ConnectionLayer/IConnectionListener.h>
+#include <CryCommon/CrySystemBus.h>
+#include <ILevelSystem.h>
 
 namespace AzFramework
 {
@@ -44,6 +47,8 @@ namespace Multiplayer
         , public AzNetworking::IConnectionListener
         , public IMultiplayer
         , AzFramework::RootSpawnableNotificationBus::Handler
+        , CrySystemEventBus::Handler
+        , ILevelSystemListener
     {
     public:
         AZ_COMPONENT(MultiplayerSystemComponent, "{7C99C4C1-1103-43F9-AD62-8B91CF7C1981}");
@@ -144,6 +149,17 @@ namespace Multiplayer
         void OnRootSpawnableReady(AZ::Data::Asset<AzFramework::Spawnable> rootSpawnable, uint32_t generation) override;
         //! @}
 
+        //! CrySystemEventBus::Handler overrides.
+        //! @{
+        void OnCrySystemInitialized(ISystem&, const SSystemInitParams&) override;
+        void OnCrySystemShutdown(ISystem&) override;
+        //! @}
+
+        //! ILevelSystemListener overrides.
+        //! @{
+        bool BlockLoading(const char* levelName) override;
+        //! @}
+
     private:
 
         void TickVisibleNetworkEntities(float deltaTime, float serverRateSeconds);
@@ -203,6 +219,8 @@ namespace Multiplayer
         };
 
         AZStd::vector<PlayerWaitingToBeSpawned> m_playersWaitingToBeSpawned;
+        bool m_blockClientLoadLevel = true;
+        ILevelSystem* m_levelSystem = nullptr;
 
 #if !defined(AZ_RELEASE_BUILD)
         MultiplayerEditorConnection m_editorConnectionListener;


### PR DESCRIPTION
## What does this PR do?
Multiplayer system will blocks level loads based on the multiplayer state
Adds an opportunity for ILevelSystemListeners to block the next level load before it happens.
This is used by Multiplayer System Component to:
1) Stop non-hosts from loading networked levels; only hosts can properly load and populate the network entities that come with a network level. Loading a network level with hosting is a user error and can lead to confusing situations.
2) Stops multiplayer clients from changing their level, unless instructed by the host. The only levelload currently happening for clients is when first connecting to the host, the host will inform the new player to load a specific level for the match.
3) Stops hosts from changing levels when clients are already connected (include client-server from changing the level after his own player has spawned). Changing levels would destroy the existing autonomous player entities, leading to bad behavior.

Initial steps for resolving #9666. Next step will be displaying this information in the viewport to clients so it more apparent that just debug logs.

## How was this PR tested?
Running non-host, hosting, and connecting as a client and seeing what happens when loadlevel is called.
