### PR TITLE
Show rotation feedback when editing PhysX collider

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/RotationManipulators.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/RotationManipulators.cpp
@@ -15,7 +15,7 @@ namespace AzToolsFramework
     RotationManipulators::RotationManipulators(const AZ::Transform& worldFromLocal)
         : m_viewAngularManipulator { AngularManipulator::MakeShared(worldFromLocal) }
     {
-        const auto saveMostRecentActionCb = [this](const AngularManipulator::Action& action)
+        const auto saveActionFn = [this](const AngularManipulator::Action& action)
         {
             m_angularManipulatorFeedback.m_mostRecentAction = action;
         };
@@ -23,21 +23,21 @@ namespace AzToolsFramework
         for (size_t manipulatorIndex = 0; manipulatorIndex < m_localAngularManipulators.size(); ++manipulatorIndex)
         {
             auto angularManipulator = AngularManipulator::MakeShared(worldFromLocal);
-            angularManipulator->InstallLeftMouseDownCallback(saveMostRecentActionCb);
-            angularManipulator->InstallLeftMouseUpCallback(saveMostRecentActionCb);
-            angularManipulator->InstallMouseMoveCallback(saveMostRecentActionCb);
+            angularManipulator->InstallLeftMouseDownCallback(saveActionFn);
+            angularManipulator->InstallLeftMouseUpCallback(saveActionFn);
+            angularManipulator->InstallMouseMoveCallback(saveActionFn);
             m_localAngularManipulators[manipulatorIndex] = angularManipulator;
         }
 
         m_manipulatorSpaceWithLocalTransform.SetSpace(worldFromLocal);
-        m_viewAngularManipulator->InstallLeftMouseDownCallback(saveMostRecentActionCb);
-        m_viewAngularManipulator->InstallLeftMouseUpCallback(saveMostRecentActionCb);
-        m_viewAngularManipulator->InstallMouseMoveCallback(saveMostRecentActionCb);
+        m_viewAngularManipulator->InstallLeftMouseDownCallback(saveActionFn);
+        m_viewAngularManipulator->InstallLeftMouseUpCallback(saveActionFn);
+        m_viewAngularManipulator->InstallMouseMoveCallback(saveActionFn);
     }
 
     void RotationManipulators::InstallLeftMouseDownCallback(const AngularManipulator::MouseActionCallback& onMouseDownCallback)
     {
-        const auto saveMostRecentActionHookCb = [this, onMouseDownCallback](const AngularManipulator::Action& action)
+        const auto saveActionAndCallOnMouseDownCallbackFn = [this, onMouseDownCallback](const AngularManipulator::Action& action)
         {
             m_angularManipulatorFeedback.m_mostRecentAction = action;
             onMouseDownCallback(action);
@@ -45,15 +45,15 @@ namespace AzToolsFramework
 
         for (AZStd::shared_ptr<AngularManipulator>& manipulator : m_localAngularManipulators)
         {
-            manipulator->InstallLeftMouseDownCallback(saveMostRecentActionHookCb);
+            manipulator->InstallLeftMouseDownCallback(saveActionAndCallOnMouseDownCallbackFn);
         }
 
-        m_viewAngularManipulator->InstallLeftMouseDownCallback(saveMostRecentActionHookCb);
+        m_viewAngularManipulator->InstallLeftMouseDownCallback(saveActionAndCallOnMouseDownCallbackFn);
     }
 
     void RotationManipulators::InstallMouseMoveCallback(const AngularManipulator::MouseActionCallback& onMouseMoveCallback)
     {
-        const auto saveMostRecentActionHookCb = [this, onMouseMoveCallback](const AngularManipulator::Action& action)
+        const auto saveActionAndCallOnMouseMoveCallbackFn = [this, onMouseMoveCallback](const AngularManipulator::Action& action)
         {
             m_angularManipulatorFeedback.m_mostRecentAction = action;
             onMouseMoveCallback(action);
@@ -61,15 +61,15 @@ namespace AzToolsFramework
 
         for (AZStd::shared_ptr<AngularManipulator>& manipulator : m_localAngularManipulators)
         {
-            manipulator->InstallMouseMoveCallback(saveMostRecentActionHookCb);
+            manipulator->InstallMouseMoveCallback(saveActionAndCallOnMouseMoveCallbackFn);
         }
 
-        m_viewAngularManipulator->InstallMouseMoveCallback(saveMostRecentActionHookCb);
+        m_viewAngularManipulator->InstallMouseMoveCallback(saveActionAndCallOnMouseMoveCallbackFn);
     }
 
     void RotationManipulators::InstallLeftMouseUpCallback(const AngularManipulator::MouseActionCallback& onMouseUpCallback)
     {
-        const auto saveMostRecentActionHookCb = [this, onMouseUpCallback](const AngularManipulator::Action& action)
+        const auto saveActionAndCallOnMouseUpCallbackFn = [this, onMouseUpCallback](const AngularManipulator::Action& action)
         {
             m_angularManipulatorFeedback.m_mostRecentAction = action;
             onMouseUpCallback(action);
@@ -77,10 +77,10 @@ namespace AzToolsFramework
 
         for (AZStd::shared_ptr<AngularManipulator>& manipulator : m_localAngularManipulators)
         {
-            manipulator->InstallLeftMouseUpCallback(saveMostRecentActionHookCb);
+            manipulator->InstallLeftMouseUpCallback(saveActionAndCallOnMouseUpCallbackFn);
         }
 
-        m_viewAngularManipulator->InstallLeftMouseUpCallback(saveMostRecentActionHookCb);
+        m_viewAngularManipulator->InstallLeftMouseUpCallback(saveActionAndCallOnMouseUpCallbackFn);
     }
 
     void RotationManipulators::SetLocalTransformImpl(const AZ::Transform& localTransform)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/RotationManipulators.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/RotationManipulators.h
@@ -55,13 +55,12 @@ namespace AzToolsFramework
 
         void ProcessManipulators(const ManipulatorVisitCallback&) override;
 
-        AZStd::shared_ptr<AngularManipulatorCircleViewFeedback> m_angularManipulatorFeedback;
-
     private:
         AZ_DISABLE_COPY_MOVE(RotationManipulators)
 
         AZStd::array<AZStd::shared_ptr<AngularManipulator>, 3> m_localAngularManipulators;
         AZStd::shared_ptr<AngularManipulator> m_viewAngularManipulator;
+        AngularManipulatorCircleViewFeedback m_angularManipulatorFeedback;
         float m_circleBoundWidth = 0.1f; //!< The default circle bound width for the angular manipulator torus.
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1423,10 +1423,6 @@ namespace AzToolsFramework
             RotationManipulatorRadius(), AzFramework::ViewportColors::XAxisColor, AzFramework::ViewportColors::YAxisColor,
             AzFramework::ViewportColors::ZAxisColor);
 
-        AZStd::shared_ptr<AngularManipulatorCircleViewFeedback> angularManipulatorCircleViewFeedback =
-            AZStd::make_shared<AngularManipulatorCircleViewFeedback>();
-        rotationManipulators->m_angularManipulatorFeedback = angularManipulatorCircleViewFeedback;
-
         struct SharedRotationState
         {
             AZ::Quaternion m_savedOrientation = AZ::Quaternion::CreateIdentity();
@@ -1438,11 +1434,9 @@ namespace AzToolsFramework
         AZStd::shared_ptr<SharedRotationState> sharedRotationState = AZStd::make_shared<SharedRotationState>();
 
         rotationManipulators->InstallLeftMouseDownCallback(
-            [this, sharedRotationState,
-             angularManipulatorCircleViewFeedback]([[maybe_unused]] const AngularManipulator::Action& action) mutable
+            [this, sharedRotationState](
+                [[maybe_unused]] const AngularManipulator::Action& action) mutable
             {
-                angularManipulatorCircleViewFeedback->m_mostRecentAction = action;
-
                 sharedRotationState->m_savedOrientation = AZ::Quaternion::CreateIdentity();
                 sharedRotationState->m_referenceFrameAtMouseDown = m_referenceFrame;
                 // important to sort entityIds based on hierarchy order when updating transforms
@@ -1458,11 +1452,8 @@ namespace AzToolsFramework
             });
 
         rotationManipulators->InstallMouseMoveCallback(
-            [this, prevModifiers = ViewportInteraction::KeyboardModifiers(), sharedRotationState,
-             angularManipulatorCircleViewFeedback](const AngularManipulator::Action& action) mutable
+            [this, prevModifiers = ViewportInteraction::KeyboardModifiers(), sharedRotationState](const AngularManipulator::Action& action) mutable
             {
-                angularManipulatorCircleViewFeedback->m_mostRecentAction = action;
-
                 const ReferenceFrame referenceFrame = m_spaceCluster.m_spaceLock.value_or(ReferenceFrameFromModifiers(action.m_modifiers));
                 const Influence influence = InfluenceFromModifiers(action.m_modifiers);
 
@@ -1554,10 +1545,8 @@ namespace AzToolsFramework
             });
 
         rotationManipulators->InstallLeftMouseUpCallback(
-            [this, sharedRotationState, angularManipulatorCircleViewFeedback]([[maybe_unused]] const AngularManipulator::Action& action)
+            [this, sharedRotationState]([[maybe_unused]] const AngularManipulator::Action& action)
             {
-                angularManipulatorCircleViewFeedback->m_mostRecentAction = action;
-
                 AzToolsFramework::EditorTransformChangeNotificationBus::Broadcast(
                     &AzToolsFramework::EditorTransformChangeNotificationBus::Events::OnEntityTransformChanged,
                     sharedRotationState->m_entityIds);

--- a/Gems/PhysX/Code/Editor/ColliderRotationMode.cpp
+++ b/Gems/PhysX/Code/Editor/ColliderRotationMode.cpp
@@ -100,5 +100,6 @@ namespace PhysX
     {
         const AzFramework::CameraState cameraState = AzToolsFramework::GetCameraState(viewportInfo.m_viewportId);
         m_rotationManipulators.RefreshView(cameraState.m_position);
+        m_rotationManipulators.DisplayFeedback(debugDisplay, cameraState);
     }
 } // namespace PhysX


### PR DESCRIPTION
Signed-off-by: guillaume-haerinck <guillaume.haerinck@outlook.com>

## What does this PR do?

When editing a PhysX collider, show the rotation feedback (as done when rotating object).
Suggested by @hultonha on https://github.com/o3de/o3de/pull/11550.

**Changes**

1. Call `DisplayFeedback` in the `ColliderRotationFeedback`
2. CircleViewFeedback is no longer a public member of `RotationManipulators`. Its updates are now handled inside the class by adding hook into the inputs callbacks
3. Subscribe to input callback in the `RotationManipulators` constructor, as when one is missing there can be visual glitches in the rotation feedback
4. Move `RotationManipulators::m_viewAngularManipulator` init in the class initialization list because we can

**In action**

Before :

https://user-images.githubusercontent.com/19243508/187020032-0840cf48-76e7-4564-b0d6-c7a29927e5fe.mp4

After :

https://user-images.githubusercontent.com/19243508/187020039-210e4ca4-4efc-47f3-9825-cec9aba987af.mp4

## How was this PR tested?

Rotate multiple physX collider types in subedit, and checked against object rotation to ensure that nothing broke.
