### PR TITLE
refactor: minor refactor or LUAViewWidget

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorBreakpointWidget.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorBreakpointWidget.cpp
@@ -62,9 +62,6 @@ namespace LUAEditor
     {
         ClearBreakpoints();
         m_textEdit = nullptr;
-        OnToggleBreakpoint.clear();
-        OnBreakpointLineMoved.clear();
-        OnBreakpointLineDeleted.clear();
     }
 
     void LUAEditorBreakpointWidget::paintEvent([[maybe_unused]] QPaintEvent* paintEvent)
@@ -194,20 +191,17 @@ namespace LUAEditor
 
     void LUAEditorBreakpointWidget::mouseReleaseEvent(QMouseEvent* event)
     {
-        if (OnToggleBreakpoint)
-        {
-            auto mousePos = event->localPos();
-
-            m_textEdit->ForEachVisibleBlock([&](const QTextBlock& block, const QRectF& blockRect)
+        auto mousePos = event->localPos();
+        m_textEdit->ForEachVisibleBlock(
+            [&](const QTextBlock& block, const QRectF& blockRect)
+            {
+                if (mousePos.y() >= blockRect.top() && mousePos.y() <= blockRect.bottom())
                 {
-                    if (mousePos.y() >= blockRect.top() && mousePos.y() <= blockRect.bottom())
-                    {
-                        OnToggleBreakpoint(block.blockNumber() + 1); // offset by one because line number starts from 1
-                    }
-                });
+                    emit toggleBreakpoint(block.blockNumber() + 1); // offset by one because line number starts from 1
+                }
+            });
 
-            event->accept();
-        }
+        event->accept();
     }
 
     void LUAEditorBreakpointWidget::OnBlockCountChange()
@@ -244,11 +238,11 @@ namespace LUAEditor
         }
         for (auto& moves : movedBreakpoints)
         {
-            OnBreakpointLineMoved(moves.first, moves.second);
+            emit breakpointLineMove(moves.first, moves.second);
         }
         for (auto& deletes : m_DeletedBreakpoints)
         {
-            OnBreakpointLineDeleted(deletes);
+            emit breakpointDelete(deletes);
         }
         m_DeletedBreakpoints.clear();
         UpdateSize();

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorBreakpointWidget.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorBreakpointWidget.hxx
@@ -46,12 +46,12 @@ namespace LUAEditor
         void RemoveBreakpoint(int lineNumber);
         void ClearBreakpoints();
 
-        AZStd::function<void(int lineNumber)> OnToggleBreakpoint;
-        //called if the line a breakpoint is on is moved. users should probably move the breakpoint in response to this.
-        AZStd::function<void(int fromLineNumber, int toLineNumber)> OnBreakpointLineMoved;
-        AZStd::function<void(int fromLineNumber)> OnBreakpointLineDeleted;
-
         void SetFont(QFont font);
+    signals:
+
+        void toggleBreakpoint(int lineNumber);
+        void breakpointLineMove(int fromLineNumber, int toLineNumber);
+        void breakpointDelete(int lineNumber);
 
     private:
         void paintEvent(QPaintEvent*) override;

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
@@ -84,7 +84,7 @@ namespace LUAEditor
     LUADockWidget::LUADockWidget(QWidget* parent, Qt::WindowFlags flags)
         : QDockWidget("LUADockWidget", parent, flags)
     {
-        connect(this, SIGNAL(dockLocationChanged(Qt::DockWidgetArea)), this, SLOT(OnDockLocationChanged(Qt::DockWidgetArea)));
+        connect(this, &LUADockWidget::dockLocationChanged, this, &LUADockWidget::OnDockLocationChanged);
     }
 
     void LUADockWidget::closeEvent(QCloseEvent* event)
@@ -117,6 +117,7 @@ namespace LUAEditor
 
     LUAViewWidget::LUAViewWidget(QWidget* pParent /*=NULL*/)
         : QWidget(pParent)
+        , m_gui(azcreate(Ui::LUAEditorView, ()))
         , m_pLUADockWidget(NULL)
         , m_pLoadingProgressShield(NULL)
         , m_pSavingProgressShield(NULL)
@@ -124,7 +125,6 @@ namespace LUAEditor
         , m_PullRequestQueued(false)
         , m_AutoCompletionEnabled(true)
     {
-        m_gui = azcreate(Ui::LUAEditorView, ());
         m_gui->setupUi(this);
 
         setAcceptDrops(true);
@@ -143,28 +143,29 @@ namespace LUAEditor
 
         UpdateFont();
 
-        connect(m_gui->m_luaTextEdit, SIGNAL(modificationChanged(bool)), this, SLOT(modificationChanged(bool)));
-        connect(this, SIGNAL(RegainFocus()), this, SLOT(RegainFocusFinal()), Qt::QueuedConnection);
-        connect(m_gui->m_luaTextEdit, SIGNAL(cursorPositionChanged()), this, SLOT(UpdateBraceHighlight()));
-        connect(m_gui->m_luaTextEdit, SIGNAL(cursorPositionChanged()), m_gui->m_folding, SLOT(update()));
-        connect(m_gui->m_luaTextEdit, SIGNAL(cursorPositionChanged()), m_gui->m_breakpoints, SLOT(update()));
-        connect(m_gui->m_luaTextEdit, SIGNAL(Scrolled()), m_gui->m_breakpoints, SLOT(update()));
-        connect(m_gui->m_luaTextEdit, SIGNAL(Scrolled()), m_gui->m_folding, SLOT(update()));
-        connect(m_gui->m_luaTextEdit, SIGNAL(blockCountChanged(int)), m_gui->m_breakpoints, SLOT(OnBlockCountChange()));
-        connect(m_gui->m_luaTextEdit->document(), SIGNAL(contentsChange(int, int, int)), m_gui->m_breakpoints, SLOT(OnCharsRemoved(int, int)));
+        connect(m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::modificationChanged, this, &LUAViewWidget::modificationChanged);
+        connect(m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::cursorPositionChanged, this, &LUAViewWidget::UpdateBraceHighlight);
+        connect(m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::Scrolled, m_gui->m_folding, static_cast<void(FoldingWidget::*)()>(&FoldingWidget::update));
+        connect(m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::blockCountChanged, m_gui->m_breakpoints, &LUAEditorBreakpointWidget::OnBlockCountChange);
+        connect(m_gui->m_luaTextEdit->document(), &QTextDocument::contentsChange, m_gui->m_breakpoints, &LUAEditorBreakpointWidget::OnCharsRemoved);
         connect(m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::FocusChanged, this, &LUAViewWidget::OnPlainTextFocusChanged);
-        connect(m_gui->m_folding, &FoldingWidget::TextBlockFoldingChanged, this, [&]() {m_gui->m_breakpoints->update(); });
-        connect(m_gui->m_folding, &FoldingWidget::TextBlockFoldingChanged, this, [&]() {m_gui->m_luaTextEdit->update(); });
         connect(m_gui->m_luaTextEdit->document(), &QTextDocument::contentsChange, m_gui->m_folding, &FoldingWidget::OnContentChanged);
         connect(m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::ZoomIn, this, &LUAViewWidget::OnZoomIn);
         connect(m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::ZoomOut, this, &LUAViewWidget::OnZoomOut);
-        connect(m_Highlighter, &LUASyntaxHighlighter::LUANamesInScopeChanged, m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::OnScopeNamesUpdated);
-        connect(m_gui->m_folding, &FoldingWidget::destroyed, this, [&]() {m_gui->m_folding = nullptr; });
-        connect(m_gui->m_breakpoints, &LUAEditorBreakpointWidget::destroyed, this, [&]() {m_gui->m_breakpoints = nullptr; });
+        connect(m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::cursorPositionChanged, m_gui->m_folding, static_cast<void(FoldingWidget::*)()>(&FoldingWidget::update));
+        connect(m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::cursorPositionChanged, m_gui->m_breakpoints, static_cast<void(LUAEditorBreakpointWidget::*)()>(&LUAEditorBreakpointWidget::update));
+        connect(m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::Scrolled, m_gui->m_breakpoints, static_cast<void(LUAEditorBreakpointWidget::*)()>(&LUAEditorBreakpointWidget::update));
 
-        m_gui->m_breakpoints->OnToggleBreakpoint = AZStd::bind(&LUAViewWidget::BreakpointToggle, this, AZStd::placeholders::_1);
-        m_gui->m_breakpoints->OnBreakpointLineMoved = AZStd::bind(&LUAViewWidget::OnBreakpointLineMoved, this, AZStd::placeholders::_1, AZStd::placeholders::_2);
-        m_gui->m_breakpoints->OnBreakpointLineDeleted = AZStd::bind(&LUAViewWidget::OnBreakpointLineDeleted, this, AZStd::placeholders::_1);
+        connect(this, &LUAViewWidget::RegainFocus, this, &LUAViewWidget::RegainFocusFinal, Qt::QueuedConnection);
+    
+        connect(m_gui->m_folding, &FoldingWidget::TextBlockFoldingChanged, m_gui->m_breakpoints, static_cast<void(LUAEditorBreakpointWidget::*)()>(&LUAEditorBreakpointWidget::update));
+        connect(m_gui->m_folding, &FoldingWidget::TextBlockFoldingChanged, m_gui->m_luaTextEdit, static_cast<void(LUAEditorPlainTextEdit::*)()>(&LUAEditorPlainTextEdit::update));
+
+        connect(m_Highlighter, &LUASyntaxHighlighter::LUANamesInScopeChanged, m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::OnScopeNamesUpdated);
+
+        connect(m_gui->m_breakpoints, &LUAEditorBreakpointWidget::toggleBreakpoint, this, &LUAViewWidget::BreakpointToggle);
+        connect(m_gui->m_breakpoints, &LUAEditorBreakpointWidget::breakpointLineMove, this, &LUAViewWidget::OnBreakpointLineMoved);
+        connect(m_gui->m_breakpoints, &LUAEditorBreakpointWidget::breakpointDelete, this, &LUAViewWidget::OnBreakpointLineDeleted);
 
         CreateStyleSheet();
 
@@ -577,7 +578,7 @@ namespace LUAEditor
 
         if (!m_PullRequestQueued)
         {
-            QTimer::singleShot(1, this, SLOT(PullFreshBreakpoints()));
+            QTimer::singleShot(1, this, &LUAViewWidget::PullFreshBreakpoints);
             m_PullRequestQueued = true;
             return;
         }

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.hxx
@@ -12,6 +12,7 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/base.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
 
 #include <QtWidgets/QDockWidget>
 
@@ -86,8 +87,6 @@ namespace LUAEditor
         void BreakpointsUpdate(const LUAEditor::BreakpointMap& uniqueBreakpoints) override;
         void BreakpointHit(const LUAEditor::Breakpoint& breakpoint) override;
         void BreakpointResume() override;
-
-        void BreakpointToggle(int line);
         
         bool IsReadOnly() const;
         bool IsModified() const;
@@ -162,8 +161,6 @@ namespace LUAEditor
         template<typename Callable> //callabe sig (QString&, QTextBlock&)
         void CommentHelper(Callable callable);
         void SetReadonly(bool readonly);
-        void OnBreakpointLineMoved(int fromLineNumber, int toLineNumber);
-        void OnBreakpointLineDeleted(int removedLineNumber);
         //will call callable with 2 ints(start and end brace). if no matching braces currently, then callable is not called.
         //if currently on a bracket, but its not matched then callable will still get called, but with -1 for end brace
         template<typename Callable>
@@ -203,6 +200,10 @@ namespace LUAEditor
 
         AZStd::mutex m_extraHighlightingMutex;
 
+    private slots: 
+        void OnBreakpointLineMoved(int fromLineNumber, int toLineNumber);
+        void OnBreakpointLineDeleted(int removedLineNumber);
+
     public slots:
         void modificationChanged(bool m);
         void PullFreshBreakpoints();
@@ -211,6 +212,7 @@ namespace LUAEditor
         void OnVisibilityChanged(bool vc);
         void OnZoomIn();
         void OnZoomOut();
+        void BreakpointToggle(int line);
     };
 
     class LUAViewMessages : public AZ::EBusTraits


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

this is a refactor of the LuaEditorView and replaces the SIGNAL SLOT with method pointers. I also replaced OnToggleBreakpoint, 
OnBreakpointLineMoved, and OnBreakpointLineDeleted with signals from LUAEditorBreakpointWidget.


## How was this PR tested?

opened a lua document verified that breakpoints can be set and closing and opening documents works correctly. 