### PR TITLE
Material Component: Renamed MaterialReceiver* to MaterialConsumer* plus comments

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
@@ -311,7 +311,7 @@ namespace AZ
             if (GetActiveAssetId().IsValid())
             {
                 AZStd::unordered_set<AZ::Name> modelUvNames;
-                MaterialReceiverRequestBus::EventResult(modelUvNames, m_entityId, &MaterialReceiverRequestBus::Events::GetModelUvNames);
+                MaterialConsumerRequestBus::EventResult(modelUvNames, m_entityId, &MaterialConsumerRequestBus::Events::GetModelUvNames);
 
                 RPI::MaterialModelUvOverrideMap matModUvOverrides;
                 MaterialComponentRequestBus::EventResult(

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -102,7 +102,7 @@ namespace AZ
 
         void MaterialComponentController::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
         {
-            required.push_back(AZ_CRC_CE("MaterialReceiverService"));
+            required.push_back(AZ_CRC_CE("MaterialConsumerService"));
         }
 
         MaterialComponentController::MaterialComponentController(const MaterialComponentConfig& config)
@@ -117,14 +117,14 @@ namespace AZ
             m_queuedMaterialUpdateNotification = false;
 
             MaterialComponentRequestBus::Handler::BusConnect(m_entityId);
-            MaterialReceiverNotificationBus::Handler::BusConnect(m_entityId);
+            MaterialConsumerNotificationBus::Handler::BusConnect(m_entityId);
             LoadMaterials();
         }
 
         void MaterialComponentController::Deactivate()
         {
             MaterialComponentRequestBus::Handler::BusDisconnect();
-            MaterialReceiverNotificationBus::Handler::BusDisconnect();
+            MaterialConsumerNotificationBus::Handler::BusDisconnect();
 
             ReleaseMaterials();
 
@@ -203,8 +203,8 @@ namespace AZ
             // Clear any previously loaded or queued material assets, instances, or notifications
             ReleaseMaterials();
 
-            MaterialReceiverRequestBus::EventResult(
-                m_defaultMaterialMap, m_entityId, &MaterialReceiverRequestBus::Events::GetDefautMaterialMap);
+            MaterialConsumerRequestBus::EventResult(
+                m_defaultMaterialMap, m_entityId, &MaterialConsumerRequestBus::Events::GetDefautMaterialMap);
 
             // Build tables of all referenced materials so that we can load and look up defaults
             for (const auto& [materialAssignmentId, materialAssignment] : m_defaultMaterialMap)
@@ -312,8 +312,8 @@ namespace AZ
             const MaterialAssignmentLodIndex lod, const AZStd::string& label) const
         {
             MaterialAssignmentId materialAssignmentId;
-            MaterialReceiverRequestBus::EventResult(
-                materialAssignmentId, m_entityId, &MaterialReceiverRequestBus::Events::FindMaterialAssignmentId, lod, label);
+            MaterialConsumerRequestBus::EventResult(
+                materialAssignmentId, m_entityId, &MaterialConsumerRequestBus::Events::FindMaterialAssignmentId, lod, label);
             return materialAssignmentId;
         }
 
@@ -326,7 +326,7 @@ namespace AZ
         AZStd::string MaterialComponentController::GetMaterialLabel(const MaterialAssignmentId& materialAssignmentId) const
         {
             MaterialAssignmentLabelMap labels;
-            MaterialReceiverRequestBus::EventResult(labels, m_entityId, &MaterialReceiverRequestBus::Events::GetMaterialLabels);
+            MaterialConsumerRequestBus::EventResult(labels, m_entityId, &MaterialConsumerRequestBus::Events::GetMaterialLabels);
 
             auto labelIt = labels.find(materialAssignmentId);
             return labelIt != labels.end() ? labelIt->second : "<unknown>";

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -22,7 +22,7 @@ namespace AZ
         //! to provide material overrides on a per-entity basis.
         class MaterialComponentController final
             : MaterialComponentRequestBus::Handler
-            , MaterialReceiverNotificationBus::Handler
+            , MaterialConsumerNotificationBus::Handler
             , Data::AssetBus::MultiHandler
             , SystemTickBus::Handler
         {
@@ -78,7 +78,7 @@ namespace AZ
                 const MaterialAssignmentId& materialAssignmentId, const AZ::RPI::MaterialModelUvOverrideMap& modelUvOverrides) override;
             AZ::RPI::MaterialModelUvOverrideMap GetModelUvOverrides(const MaterialAssignmentId& materialAssignmentId) const override;
 
-            //! MaterialReceiverNotificationBus::Handler overrides...
+            //! MaterialConsumerNotificationBus::Handler overrides...
             void OnMaterialAssignmentSlotsChanged() override;
 
         private:

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -56,7 +56,7 @@ namespace AZ
             {
                 if (classElement.GetVersion() < 2)
                 {
-                    RPI::Cullable::LodOverride lodOverride = aznumeric_cast<RPI::Cullable::LodOverride>(classElement.FindElement(AZ_CRC("LodOverride")));
+                    RPI::Cullable::LodOverride lodOverride = aznumeric_cast<RPI::Cullable::LodOverride>(classElement.FindElement(AZ_CRC_CE("LodOverride")));
                     static constexpr uint8_t old_NoLodOverride = AZStd::numeric_limits <RPI::Cullable::LodOverride>::max();
                     if (lodOverride == old_NoLodOverride)
                     {
@@ -207,20 +207,20 @@ namespace AZ
 
         void MeshComponentController::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
         {
-            dependent.push_back(AZ_CRC("TransformService", 0x8ee22c50));
+            dependent.push_back(AZ_CRC_CE("TransformService"));
             dependent.push_back(AZ_CRC_CE("NonUniformScaleService"));
         }
 
         void MeshComponentController::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
         {
-            provided.push_back(AZ_CRC("MaterialReceiverService", 0x0d1a6a74));
-            provided.push_back(AZ_CRC("MeshService", 0x71d8a455));
+            provided.push_back(AZ_CRC_CE("MaterialConsumerService"));
+            provided.push_back(AZ_CRC_CE("MeshService"));
         }
 
         void MeshComponentController::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
         {
-            incompatible.push_back(AZ_CRC("MaterialReceiverService", 0x0d1a6a74));
-            incompatible.push_back(AZ_CRC("MeshService", 0x71d8a455));
+            incompatible.push_back(AZ_CRC_CE("MaterialConsumerService"));
+            incompatible.push_back(AZ_CRC_CE("MeshService"));
         }
 
         MeshComponentController::MeshComponentController(const MeshComponentConfig& config)
@@ -258,7 +258,7 @@ namespace AZ
             MeshComponentRequestBus::Handler::BusConnect(entityId);
             MeshHandleStateRequestBus::Handler::BusConnect(entityId);
             TransformNotificationBus::Handler::BusConnect(entityId);
-            MaterialReceiverRequestBus::Handler::BusConnect(entityId);
+            MaterialConsumerRequestBus::Handler::BusConnect(entityId);
             MaterialComponentNotificationBus::Handler::BusConnect(entityId);
             AzFramework::BoundsRequestBus::Handler::BusConnect(entityId);
             AzFramework::RenderGeometry::IntersectionRequestBus::Handler::BusConnect({ entityId, entityContextId });
@@ -276,7 +276,7 @@ namespace AZ
             AzFramework::RenderGeometry::IntersectionRequestBus::Handler::BusDisconnect();
             AzFramework::BoundsRequestBus::Handler::BusDisconnect();
             MaterialComponentNotificationBus::Handler::BusDisconnect();
-            MaterialReceiverRequestBus::Handler::BusDisconnect();
+            MaterialConsumerRequestBus::Handler::BusDisconnect();
             TransformNotificationBus::Handler::BusDisconnect();
             MeshComponentRequestBus::Handler::BusDisconnect();
             MeshHandleStateRequestBus::Handler::BusDisconnect();
@@ -378,7 +378,7 @@ namespace AZ
                 const AZ::EntityId entityId = m_entityComponentIdPair.GetEntityId();
                 m_configuration.m_modelAsset = modelAsset;
                 MeshComponentNotificationBus::Event(entityId, &MeshComponentNotificationBus::Events::OnModelReady, m_configuration.m_modelAsset, model);
-                MaterialReceiverNotificationBus::Event(entityId, &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
+                MaterialConsumerNotificationBus::Event(entityId, &MaterialConsumerNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
                 AZ::Interface<AzFramework::IEntityBoundsUnion>::Get()->RefreshEntityLocalBoundsUnion(entityId);
                 AzFramework::RenderGeometry::IntersectionNotificationBus::Event(
                     m_intersectionNotificationBus, &AzFramework::RenderGeometry::IntersectionNotificationBus::Events::OnGeometryChanged,
@@ -422,8 +422,8 @@ namespace AZ
             else
             {
                 // If there is no model asset to be loaded then we need to invalidate the material slot configuration
-                MaterialReceiverNotificationBus::Event(
-                    m_entityComponentIdPair.GetEntityId(), &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
+                MaterialConsumerNotificationBus::Event(
+                    m_entityComponentIdPair.GetEntityId(), &MaterialConsumerNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
             }
         }
 
@@ -439,8 +439,8 @@ namespace AZ
                     m_entityComponentIdPair.GetEntityId(), &MeshHandleStateNotificationBus::Events::OnMeshHandleSet, &m_meshHandle);
 
                 // Model has been released which invalidates the material slot configuration
-                MaterialReceiverNotificationBus::Event(
-                    m_entityComponentIdPair.GetEntityId(), &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
+                MaterialConsumerNotificationBus::Event(
+                    m_entityComponentIdPair.GetEntityId(), &MaterialConsumerNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
             }
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -64,7 +64,7 @@ namespace AZ
             , public AzFramework::BoundsRequestBus::Handler
             , public AzFramework::RenderGeometry::IntersectionRequestBus::Handler
             , private TransformNotificationBus::Handler
-            , private MaterialReceiverRequestBus::Handler
+            , private MaterialConsumerRequestBus::Handler
             , private MaterialComponentNotificationBus::Handler
         {
         public:
@@ -134,7 +134,7 @@ namespace AZ
             // TransformNotificationBus::Handler overrides ...
             void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
 
-            // MaterialReceiverRequestBus::Handler overrides ...
+            // MaterialConsumerRequestBus::Handler overrides ...
             MaterialAssignmentId FindMaterialAssignmentId(
                 const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
             MaterialAssignmentLabelMap GetMaterialLabels() const override;

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -185,7 +185,7 @@ namespace AZ::Render
         AZ_Warning("AtomActorInstance", m_transformInterface, "Unable to attach to a TransformBus handler. This skinned mesh will always be rendered at the origin.");
 
         SkinnedMeshFeatureProcessorNotificationBus::Handler::BusConnect();
-        MaterialReceiverRequestBus::Handler::BusConnect(m_entityId);
+        MaterialConsumerRequestBus::Handler::BusConnect(m_entityId);
         LmbrCentral::SkeletalHierarchyRequestBus::Handler::BusConnect(m_entityId);
 
         Create();
@@ -195,7 +195,7 @@ namespace AZ::Render
     {
         SkinnedMeshOutputStreamNotificationBus::Handler::BusDisconnect();
         LmbrCentral::SkeletalHierarchyRequestBus::Handler::BusDisconnect();
-        MaterialReceiverRequestBus::Handler::BusDisconnect();
+        MaterialConsumerRequestBus::Handler::BusDisconnect();
         SkinnedMeshFeatureProcessorNotificationBus::Handler::BusDisconnect();
 
         Destroy();
@@ -673,7 +673,7 @@ namespace AZ::Render
         m_skinnedMeshInstance = m_skinnedMeshInputBuffers->CreateSkinnedMeshInstance();
         if (m_skinnedMeshInstance && m_skinnedMeshInstance->m_model)
         {
-            MaterialReceiverNotificationBus::Event(m_entityId, &MaterialReceiverNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
+            MaterialConsumerNotificationBus::Event(m_entityId, &MaterialConsumerNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
 
             RegisterActor();
         }

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
@@ -62,7 +62,7 @@ namespace AZ
         class AtomActorInstance
             : public EMotionFX::Integration::RenderActorInstance
             , public AZ::TransformNotificationBus::Handler
-            , public AZ::Render::MaterialReceiverRequestBus::Handler
+            , public AZ::Render::MaterialConsumerRequestBus::Handler
             , public AzFramework::BoundsRequestBus::Handler
             , public AZ::Render::MaterialComponentNotificationBus::Handler
             , public AZ::Render::MeshComponentRequestBus::Handler
@@ -123,7 +123,7 @@ namespace AZ
             void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
 
             /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-            // MaterialReceiverRequestBus::Handler overrides...
+            // MaterialConsumerRequestBus::Handler overrides...
             MaterialAssignmentId FindMaterialAssignmentId(
                 const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
             MaterialAssignmentLabelMap GetMaterialLabels() const override;

--- a/Gems/Blast/Code/Source/Editor/EditorBlastMeshDataComponent.cpp
+++ b/Gems/Blast/Code/Source/Editor/EditorBlastMeshDataComponent.cpp
@@ -169,8 +169,8 @@ namespace Blast
             AZ::Render::MeshComponentNotificationBus::Event(
                 GetEntityId(), &AZ::Render::MeshComponentNotificationBus::Events::OnModelReady, model->GetModelAsset(),
                 model);
-            AZ::Render::MaterialReceiverNotificationBus::Event(
-                GetEntityId(), &AZ::Render::MaterialReceiverNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
+            AZ::Render::MaterialConsumerNotificationBus::Event(
+                GetEntityId(), &AZ::Render::MaterialConsumerNotificationBus::Events::OnMaterialAssignmentSlotsChanged);
         }
     }
 

--- a/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
@@ -146,22 +146,22 @@ namespace EMotionFX
             //////////////////////////////////////////////////////////////////////////
             static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
             {
-                provided.push_back(AZ_CRC("EMotionFXActorService", 0xd6e8f48d));
-                provided.push_back(AZ_CRC("MeshService", 0x71d8a455));
-                provided.push_back(AZ_CRC("CharacterPhysicsDataService", 0x34757927));
-                provided.push_back(AZ_CRC("MaterialReceiverService", 0x0d1a6a74));
+                provided.push_back(AZ_CRC_CE("EMotionFXActorService"));
+                provided.push_back(AZ_CRC_CE("MeshService"));
+                provided.push_back(AZ_CRC_CE("CharacterPhysicsDataService"));
+                provided.push_back(AZ_CRC_CE("MaterialConsumerService"));
             }
 
             static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
             {
-                incompatible.push_back(AZ_CRC("EMotionFXActorService", 0xd6e8f48d));
-                incompatible.push_back(AZ_CRC("MeshService", 0x71d8a455));
+                incompatible.push_back(AZ_CRC_CE("EMotionFXActorService"));
+                incompatible.push_back(AZ_CRC_CE("MeshService"));
                 incompatible.push_back(AZ_CRC_CE("NonUniformScaleService"));
             }
 
             static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
             {
-                required.push_back(AZ_CRC("TransformService", 0x8ee22c50));
+                required.push_back(AZ_CRC_CE("TransformService"));
             }
 
             static void Reflect(AZ::ReflectContext* context);


### PR DESCRIPTION
## What does this PR do?

Renamed the material receiver related buses to material consumer and updated comments.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

This did not result in any behavioral changes