### PR TITLE
Add back newline append when writing to log files

### DIFF
--- a/Code/Legacy/CrySystem/Log.cpp
+++ b/Code/Legacy/CrySystem/Log.cpp
@@ -1338,6 +1338,11 @@ void CLog::LogStringToFile(AZStd::string_view message, ELogType logType, bool ap
                 m_logFileHandle.Write(timeStr.size(), timeStr.data());
             }
             m_logFileHandle.Write(message.size(), message.data());
+            if (!message.ends_with('\n'))
+            {
+                constexpr AZStd::string_view newline("\n");
+                m_logFileHandle.Write(newline.size(), newline.data());
+            }
 
 #if !defined(KEEP_LOG_FILE_OPEN)
             CloseLogFile();


### PR DESCRIPTION
Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Examined Editor.log to make sure newlines appeared between messages that didn't end with newline