### PR TITLE
bugfix(Lua Editor): correctly handle marking when creating a new file

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
@@ -462,6 +462,7 @@ namespace LUAEditor
         //save new state
         m_Info = newInfo;
         m_gui->m_luaTextEdit->document()->setModified(modifiedValue);
+        UpdateModifyFlag();
     }
 
     void LUAViewWidget::OnPlainTextFocusChanged(bool hasFocus)
@@ -525,15 +526,17 @@ namespace LUAEditor
 
     void LUAViewWidget::modificationChanged(bool m)
     {
-        (void)m;
+        EBUS_EVENT(Context_DocumentManagement::Bus, NotifyDocumentModified, m_Info.m_assetId, m);
+        UpdateModifyFlag();
+    }
+
+    void LUAViewWidget::UpdateModifyFlag() {
         QString displayName = QString::fromUtf8(m_Info.m_displayName.c_str());
         if (m_gui->m_luaTextEdit->document()->isModified())
         {
             displayName += "*";
         }
         this->luaDockWidget()->setWindowTitle(displayName);
-
-        EBUS_EVENT(Context_DocumentManagement::Bus, NotifyDocumentModified, m_Info.m_assetId, m);
     }
 
     void LUAViewWidget::UpdateCurrentExecutingLine(int lineNumber)

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.hxx
@@ -153,6 +153,7 @@ namespace LUAEditor
         void RegainFocus();
         
     private:
+        void UpdateModifyFlag();
         void keyPressEvent(QKeyEvent *ev) override;
         int CalcDocPosition(int line, int column);
         template<typename Callable> //callabe must take a const QTextCursor& as a parameter


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/11586

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

this correctly handles marking the update state of the document. this is a visual change so this does not change how the lua editor works. 

## How was this PR tested?

when creating a new file the document shouldn't be marked with a '*'
