### PR TITLE
added user query for keys when adding to an associative container

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomPath.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPath.h
@@ -68,6 +68,8 @@ namespace AZ::Dom
     class Path final
     {
     public:
+        AZ_TYPE_INFO(Path, "{C0081C45-F15D-4F46-9680-19535D33C312}")
+
         using ContainerType = AZStd::vector<PathEntry>;
         static constexpr char PathSeparator = '/';
         static constexpr char EscapeCharacter = '~';

--- a/Code/Framework/AzCore/AzCore/DOM/DomPath.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPath.h
@@ -68,7 +68,7 @@ namespace AZ::Dom
     class Path final
     {
     public:
-        AZ_TYPE_INFO(Path, "{C0081C45-F15D-4F46-9680-19535D33C312}")
+        AZ_TYPE_INFO(AZ::Dom::Path, "{C0081C45-F15D-4F46-9680-19535D33C312}")
 
         using ContainerType = AZStd::vector<PathEntry>;
         static constexpr char PathSeparator = '/';

--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -797,7 +797,7 @@ namespace AZ
             {
                 (void)classElement;
                 T* containerPtr = reinterpret_cast<T*>(instance);
-                return new(containerPtr->get_allocator().allocate(sizeof(ValueType), AZStd::alignment_of<ValueType>::value))ValueType;
+                return new (containerPtr->get_allocator().allocate(sizeof(ValueType), AZStd::alignment_of<ValueType>::value)) ValueType{};
             }
 
         protected:

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -44,6 +44,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr AZStd::string_view Name = "Adapter";
         static constexpr auto QueryKey = CallbackAttributeDefinition<void(DocumentAdapterPtr*, AZ::Dom::Path)>("QueryKey");
         static constexpr auto AddContainerKey = CallbackAttributeDefinition<void(DocumentAdapterPtr*, AZ::Dom::Path)>("AddContainerKey");
+        static constexpr auto RejectContainerKey = CallbackAttributeDefinition<void(DocumentAdapterPtr*, AZ::Dom::Path)>("RejectContainerKey");
 
         static bool CanAddToParentNode(const Dom::Value& parentNode);
         static bool CanBeParentToValue(const Dom::Value& value);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -42,6 +42,9 @@ namespace AZ::DocumentPropertyEditor::Nodes
     struct Adapter : NodeWithVisiblityControl
     {
         static constexpr AZStd::string_view Name = "Adapter";
+        static constexpr auto QueryKey = CallbackAttributeDefinition<void(DocumentAdapterPtr*, AZ::Dom::Path)>("QueryKey");
+        static constexpr auto AddContainerKey = CallbackAttributeDefinition<void(DocumentAdapterPtr*, AZ::Dom::Path)>("AddContainerKey");
+
         static bool CanAddToParentNode(const Dom::Value& parentNode);
         static bool CanBeParentToValue(const Dom::Value& value);
     };

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -92,7 +92,28 @@ namespace AZ::DocumentPropertyEditor
 
                 const AZ::SerializeContext::ClassElement* containerClassElement =
                     m_container->GetElement(m_container->GetDefaultElementNameCrc());
+
+                // dataAddress is allocated instance of key type. Get the key type and send it with the dataAddress in the
+                // message, then skip the store element below until we get an AddContainerKey message back from the DPE UI
                 void* dataAddress = m_container->ReserveElement(m_instance, containerClassElement);
+
+                auto associativeContainer = m_container->GetAssociativeContainerInterface();
+                if (associativeContainer)
+                {
+                    auto keyTypeAttribute = containerClassElement->FindAttribute(AZ_CRC("KeyType"));
+                    if (keyTypeAttribute)
+                    {
+                        auto* keyTypeData = azdynamic_cast<const AZ::Edit::AttributeData<AZ::Uuid>*>(keyTypeAttribute);
+                        if (keyTypeData)
+                        {
+                            auto keyType = keyTypeData->Get(nullptr);
+                            DocumentAdapterPtr reflectionAdapter = AZStd::make_shared<ReflectionAdapter>(dataAddress, keyType);
+                            Nodes::Adapter::QueryKey.InvokeOnDomNode(impl->m_adapter->GetContents(), &reflectionAdapter, path);
+                            return; // key queried; don't store the actual entry until the DPE handles the QueryKey message
+                        }
+                    }
+                }
+
                 m_container->StoreElement(m_instance, dataAddress);
 
                 auto containerNode = GetContainerNode(impl, path);
@@ -219,7 +240,9 @@ namespace AZ::DocumentPropertyEditor
         void VisitPrimitive(T& value, const Reflection::IAttributes& attributes)
         {
             VisitValue(
-                Dom::Utils::ValueFromType(value), &value, attributes,
+                Dom::Utils::ValueFromType(value),
+                &value,
+                attributes,
                 [&value](const Dom::Value& newValue)
                 {
                     AZStd::optional<T> extractedValue = Dom::Utils::ValueToType<T>(newValue);
@@ -345,7 +368,9 @@ namespace AZ::DocumentPropertyEditor
                 ExtractLabel(attributes);
                 AZStd::string& value = *reinterpret_cast<AZStd::string*>(access.Get());
                 VisitValue(
-                    Dom::Utils::ValueFromType(value), &value, attributes,
+                    Dom::Utils::ValueFromType(value),
+                    &value,
+                    attributes,
                     [&value](const Dom::Value& newValue)
                     {
                         value = newValue.GetString();
@@ -529,6 +554,8 @@ namespace AZ::DocumentPropertyEditor
     Dom::Value ReflectionAdapter::GenerateContents()
     {
         m_impl->m_builder.BeginAdapter();
+        m_impl->m_builder.AddMessageHandler(this, Nodes::Adapter::QueryKey);
+        m_impl->m_builder.AddMessageHandler(this, Nodes::Adapter::AddContainerKey);
         m_impl->m_onChangedCallbacks.Clear();
         m_impl->m_containers.Clear();
         if (m_instance != nullptr)
@@ -541,8 +568,7 @@ namespace AZ::DocumentPropertyEditor
 
     Dom::Value ReflectionAdapter::HandleMessage(const AdapterMessage& message)
     {
-        auto handlePropertyEditorChanged =
-            [&](const Dom::Value& valueFromEditor, Nodes::ValueChangeType changeType)
+        auto handlePropertyEditorChanged = [&](const Dom::Value& valueFromEditor, Nodes::ValueChangeType changeType)
         {
             auto changeHandler = m_impl->m_onChangedCallbacks.ValueAtPath(message.m_messageOrigin, AZ::Dom::PrefixTreeMatch::ExactPath);
             if (changeHandler != nullptr)
@@ -583,6 +609,18 @@ namespace AZ::DocumentPropertyEditor
                 }
             }
         };
+        auto addKeyToContainer = [&](AZ::DocumentPropertyEditor::DocumentAdapterPtr* adapter, AZ::Dom::Path containerPath)
+        {
+            ReflectionAdapter* actualAdapter = static_cast<ReflectionAdapter*>(adapter->get());
+            auto containerEntry = m_impl->m_containers.ValueAtPath(containerPath, AZ::Dom::PrefixTreeMatch::ParentsOnly);
+            void* keyInstance = actualAdapter->GetInstance();
+
+            containerEntry->m_container->StoreElement(containerEntry->m_instance, keyInstance);
+            auto containerNode = containerEntry->GetContainerNode(m_impl.get(), containerPath);
+            Nodes::PropertyEditor::AddNotify.InvokeOnDomNode(containerNode);
+            Nodes::PropertyEditor::ChangeNotify.InvokeOnDomNode(containerNode);
+            NotifyResetDocument();
+        };
 
         auto handleTreeUpdate = [&](Nodes::PropertyRefreshLevel)
         {
@@ -594,6 +632,7 @@ namespace AZ::DocumentPropertyEditor
         return message.Match(
             Nodes::PropertyEditor::OnChanged, handlePropertyEditorChanged,
             Nodes::ContainerActionButton::OnActivate, handleContainerOperation,
-            Nodes::PropertyEditor::RequestTreeUpdate, handleTreeUpdate);
+            Nodes::PropertyEditor::RequestTreeUpdate, handleTreeUpdate,
+            Nodes::Adapter::AddContainerKey, addKeyToContainer);
     }
 } // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.h
@@ -60,6 +60,9 @@ namespace AZ::DocumentPropertyEditor
         //! property editor instances has altered its value.
         void NotifyPropertyChanged(const PropertyChangeInfo& changeInfo);
 
+        void* GetInstance() { return m_instance; }
+        AZ::TypeId GetTypeId() { return m_typeId; }
+
     protected:
         Dom::Value GenerateContents() override;
         Dom::Value HandleMessage(const AdapterMessage& message) override;

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.h
@@ -61,7 +61,8 @@ namespace AZ::DocumentPropertyEditor
         void NotifyPropertyChanged(const PropertyChangeInfo& changeInfo);
 
         void* GetInstance() { return m_instance; }
-        AZ::TypeId GetTypeId() { return m_typeId; }
+        const void* GetInstance() const { return m_instance; }
+        AZ::TypeId GetTypeId() const { return m_typeId; }
 
     protected:
         Dom::Value GenerateContents() override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -9,6 +9,7 @@
 
 #include <AzQtComponents/Components/Widgets/ElidingLabel.h>
 #include <QCheckBox>
+#include <QDialog>
 #include <QLineEdit>
 #include <QTimer>
 #include <QVBoxLayout>
@@ -18,9 +19,10 @@
 #include <AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h>
 #include <AzFramework/DocumentPropertyEditor/PropertyEditorSystem.h>
 #include <AzQtComponents/Components/Widgets/CheckBox.h>
-#include <AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystemInterface.h>
 #include <AzToolsFramework/UI/DPEDebugViewer/DPEDebugModel.h>
 #include <AzToolsFramework/UI/DPEDebugViewer/DPEDebugWindow.h>
+#include <AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.h>
+#include <AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystemInterface.h>
 
 AZ_CVAR(
     bool,
@@ -32,7 +34,6 @@ AZ_CVAR(
 
 namespace AzToolsFramework
 {
-
     DPELayout::DPELayout(int depth, QWidget* parentWidget)
         : QHBoxLayout(parentWidget)
         , m_depth(depth)
@@ -121,7 +122,6 @@ namespace AzToolsFramework
         {
             return m_cachedMinLayoutSize;
         }
-
 
         int cumulativeWidth = 0;
         int minimumHeight = 0;
@@ -244,7 +244,8 @@ namespace AzToolsFramework
             DocumentPropertyEditor* dpe = GetDPE();
             // propertyHandlers own their widgets, so don't destroy them here. Set them free!
             for (auto propertyWidgetIter = m_widgetToPropertyHandler.begin(), endIter = m_widgetToPropertyHandler.end();
-                 propertyWidgetIter != endIter; ++propertyWidgetIter)
+                 propertyWidgetIter != endIter;
+                 ++propertyWidgetIter)
             {
                 QWidget* propertyWidget = propertyWidgetIter->first;
                 auto toRemove = AZStd::remove(m_domOrderedChildren.begin(), m_domOrderedChildren.end(), propertyWidget);
@@ -721,6 +722,13 @@ namespace AzToolsFramework
             });
         m_adapter->ConnectChangedHandler(m_changedHandler);
 
+        m_domMessageHandler = AZ::DocumentPropertyEditor::DocumentAdapter::MessageEvent::Handler(
+            [this](const AZ::DocumentPropertyEditor::AdapterMessage& message, AZ::Dom::Value& value)
+            {
+                this->HandleDomMessage(message, value);
+            });
+        m_adapter->ConnectMessageHandler(m_domMessageHandler);
+
         // populate the view from the full adapter contents, just like a reset
         HandleReset();
     }
@@ -902,7 +910,7 @@ namespace AzToolsFramework
         const bool indexInRange = (rowIndex <= m_domOrderedRows.size());
         AZ_Assert(indexInRange, "rowIndex cannot be more than one past the existing end!")
 
-        if (indexInRange)
+            if (indexInRange)
         {
             auto newRow = new DPERowWidget(0, nullptr);
 
@@ -1021,6 +1029,24 @@ namespace AzToolsFramework
                 rowWidget->HandleOperationAtPath(*operationIterator, pathDepth);
             }
         }
+    }
+
+    void DocumentPropertyEditor::HandleDomMessage(
+        const AZ::DocumentPropertyEditor::AdapterMessage& message, [[maybe_unused]] AZ::Dom::Value& value)
+    {
+        // message match for QueryKey
+        auto showKeyQueryDialog = [&](AZ::DocumentPropertyEditor::DocumentAdapterPtr* adapter, AZ::Dom::Path containerPath)
+        {
+            QDialog keyQueryDialog;
+            KeyQueryDPE keyQueryUi(adapter);
+            if (keyQueryUi.exec() == QDialog::Accepted)
+            {
+                AZ::DocumentPropertyEditor::Nodes::Adapter::AddContainerKey.InvokeOnDomNode(
+                    m_adapter->GetContents(), adapter, containerPath);
+            }
+        };
+
+        message.Match(AZ::DocumentPropertyEditor::Nodes::Adapter::QueryKey, showKeyQueryDialog);
     }
 
     void DocumentPropertyEditor::CleanupReleasedHandlers()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1059,7 +1059,7 @@ namespace AzToolsFramework
         const bool indexInRange = (rowIndex <= m_domOrderedRows.size());
         AZ_Assert(indexInRange, "rowIndex cannot be more than one past the existing end!")
 
-            if (indexInRange)
+        if (indexInRange)
         {
             auto newRow = new DPERowWidget(0, nullptr);
 
@@ -1186,11 +1186,15 @@ namespace AzToolsFramework
         // message match for QueryKey
         auto showKeyQueryDialog = [&](AZ::DocumentPropertyEditor::DocumentAdapterPtr* adapter, AZ::Dom::Path containerPath)
         {
-            QDialog keyQueryDialog;
             KeyQueryDPE keyQueryUi(adapter);
             if (keyQueryUi.exec() == QDialog::Accepted)
             {
                 AZ::DocumentPropertyEditor::Nodes::Adapter::AddContainerKey.InvokeOnDomNode(
+                    m_adapter->GetContents(), adapter, containerPath);
+            }
+            else
+            {
+                AZ::DocumentPropertyEditor::Nodes::Adapter::RejectContainerKey.InvokeOnDomNode(
                     m_adapter->GetContents(), adapter, containerPath);
             }
         };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -161,11 +161,14 @@ namespace AzToolsFramework
 
         void HandleReset();
         void HandleDomChange(const AZ::Dom::Patch& patch);
+        void HandleDomMessage(const AZ::DocumentPropertyEditor::AdapterMessage& message, AZ::Dom::Value& value);
         void CleanupReleasedHandlers();
 
         AZ::DocumentPropertyEditor::DocumentAdapterPtr m_adapter;
         AZ::DocumentPropertyEditor::DocumentAdapter::ResetEvent::Handler m_resetHandler;
         AZ::DocumentPropertyEditor::DocumentAdapter::ChangedEvent::Handler m_changedHandler;
+        AZ::DocumentPropertyEditor::DocumentAdapter::MessageEvent::Handler m_domMessageHandler;
+
         QVBoxLayout* m_layout = nullptr;
 
         bool m_spawnDebugView = false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "KeyQueryDPE.h"
+#include "AzToolsFramework/UI/DocumentPropertyEditor/ui_KeyQueryDPE.h"
+
+namespace AzToolsFramework
+{
+    KeyQueryDPE::KeyQueryDPE(AZ::DocumentPropertyEditor::DocumentAdapterPtr* keyQueryAdatper, QWidget* parentWidget)
+        : QDialog(parentWidget)
+    {
+        setupUi(this);
+        dpe->SetAdapter(*keyQueryAdatper);
+    }
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "AzToolsFramework/UI/DocumentPropertyEditor/ui_KeyQueryDPE.h"
+#include <QDialog>
+
+namespace AzToolsFramework
+{
+    class KeyQueryDPE
+        : public QDialog
+        , Ui::KeyQueryDPE
+    {
+    public:
+        KeyQueryDPE(AZ::DocumentPropertyEditor::DocumentAdapterPtr* keyQueryAdatper, QWidget* parentWidget = nullptr);
+    };
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.ui
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.ui
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>KeyQueryDPE</class>
+ <widget class="QDialog" name="KeyQueryDPE">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>418</width>
+    <height>147</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Enter key</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="AzToolsFramework::DocumentPropertyEditor" name="dpe">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AzToolsFramework::DocumentPropertyEditor</class>
+   <extends>QScrollArea</extends>
+   <header>DocumentPropertyEditor.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>KeyQueryDPE</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>KeyQueryDPE</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.ui
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.ui
@@ -37,7 +37,7 @@
   <customwidget>
    <class>AzToolsFramework::DocumentPropertyEditor</class>
    <extends>QScrollArea</extends>
-   <header>DocumentPropertyEditor.h</header>
+   <header location="global">AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -372,6 +372,9 @@ set(FILES
     UI/DocumentPropertyEditor/PropertyHandlerWidget.h
     UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
     UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+    UI/DocumentPropertyEditor/KeyQueryDPE.cpp
+    UI/DocumentPropertyEditor/KeyQueryDPE.h
+    UI/DocumentPropertyEditor/KeyQueryDPE.ui
     UI/DPEDebugViewer/DPEDebugModel.cpp
     UI/DPEDebugViewer/DPEDebugModel.h
     UI/DPEDebugViewer/DPEDebugTextView.cpp


### PR DESCRIPTION
Signed-off-by: Alex Montgomery <alexmont@amazon.com>

## What does this PR do?
Adds a mechanism for the DPE to query keys from the user, whenever a new entry is added to an associative container

Note: Although this is functional, it has some rough edges to address in a future PR, possibly by someone other than me:
1) Adapter shows a superfluous root node in the DPE embedded in the key query dialog. This should be suppressed using the same mechanism as AZ::Edit::PropertyVisibility::ShowChildrenOnly.
2) When creating integral types (likesay, an integer) the container does not zero construct the key, so the key query dialog will suggest something like, "-2556236", which isn't a great experience.
3) When triggering the key query, the container reserves a new entry before passing it via the adapter to the DPE. If the user cancels out of the key query, that entry is allocated but never stored. I'm honestly not sure if that's a leak or if that's okay as-is.

## How was this PR tested?
locally in DPEStandAlone

![image](https://user-images.githubusercontent.com/85521892/187137484-a48dbef2-f0f4-4e86-81cb-03bfb046f0db.png)
