### PR TITLE
Optimize engine usage of RapidJSON

### DIFF
--- a/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
+++ b/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
@@ -50,12 +50,34 @@ namespace rapidjson_ly_internal
 #pragma clang diagnostic ignored "-Wunknown-warning-option"
 #endif
 
-#if defined(AZ_COMPILER_MSVC)
-// windows defines may or may not be present for unity builds, so ensure StrCmp resolves to StrCmpW to avoid conflicts
-#define StrCmp StrCmpW
+// Detect what is available in the compiler and enable those features in RapidJSON.
+// Note that RapidJSON will use the combination of any of these to determine its final
+// set of instructions to use, so its best to set all that are applicable:
+#if defined(__SSE4_2__)
+#define RAPIDJSON_SSE42
 #endif
 
-// Make you have available rapidjson/include folder. Currently 3rdParty\rapidjson\rapidjson-1.1.0\include
+#if defined(__SSE2__)
+#define RAPIDJSON_SSE2
+#endif
+
+#if defined(__ARM_NEON__) || defined(__ARM_NEON) // older compilers define __ARM_NEON
+#define RAPIDJSON_NEON
+#endif
+
+#if defined(AZ_COMPILER_MSVC)
+    // windows defines may or may not be present for unity builds, so ensure StrCmp resolves to StrCmpW to avoid conflicts
+    #define StrCmp StrCmpW
+
+    // MSVC compiler does not necessarily specify any of the above macros.
+    // if we're compiling for a X64 target we can target SSE2.x at the very least.
+    #if defined(_M_AMD64)
+        #define RAPIDJSON_SSE2
+    #endif
+#endif
+
+// Now that all of the above is declared, bring the RapidJSON headers in.
+// If you add additional definitions or configuration options, add them above.
 #include <rapidjson/rapidjson.h>
 
 #if AZ_TRAIT_JSON_CLANG_IGNORE_UNKNOWN_WARNING && defined(AZ_COMPILER_CLANG)

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/UnorderedSetSerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/UnorderedSetSerializer.cpp
@@ -6,9 +6,9 @@
  *
  */
 
-#include <algorithm>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/Serialization/Json/UnorderedSetSerializer.h>
+#include <AzCore/std/sort.h>
 #include <AzCore/Memory/SystemAllocator.h>
 
 namespace AZ
@@ -31,12 +31,11 @@ namespace AZ
         // Only sort if there's an array. If something went wrong or the set has been fully defaulted then the output won't be an array.
         if (outputValue.IsArray())
         {
-            // Using std::sort because AZStd::sort isn't implemented in terms of move operations.
             auto less = [](const rapidjson::Value& lhs, const rapidjson::Value& rhs) -> bool
             {
                 return JsonSerialization::Compare(lhs, rhs) == JsonSerializerCompareResult::Less;
             };
-            std::sort(outputValue.Begin(), outputValue.End(), less);
+            AZStd::sort(outputValue.Begin(), outputValue.End(), less);
         }
 
         return result;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -10,6 +10,7 @@
 
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Interface/Interface.h>
+#include <AzCore/Memory/AllocatorManager.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipInterface.h>
@@ -284,6 +285,10 @@ namespace AzToolsFramework
                     // Notify Propagation has ended, then update selection (which is frozen during propagation, so this order matters)
                     PrefabPublicNotificationBus::Broadcast(&PrefabPublicNotifications::OnPrefabInstancePropagationEnd);
                     ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetSelectedEntities, selectedEntityIds);
+
+                    // after an instance update operation finishes, garbage collect to reclaim memory.
+                    AZ::AllocatorManager::Instance().GarbageCollect();
+                    AZ_MALLOC_TRIM(0);
                 }
 
                 m_updatingTemplateInstancesInQueue = false;


### PR DESCRIPTION
Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>

## What does this PR do?
 * turns on SIMD where available
 * (Used to enable the map feature, but this is no longer the case).
 * Garbage collects after prefab operations so that memory stays
   flat.

RapidJSON has config options for using SIMD operations as well as for optimizing lookups using a map, which we were simply not using.

## How was this PR tested?
Benchmarks, manual testing, and unit tests.

Benchmarks show a slight improvement in loading RapidJSON from text due to SIMD operations in the text parser.
It also shows the garbage collection resulting in memory being freed after large operations.
