### PR TITLE
Fix combo box warning message while switching focus across graphs

### DIFF
--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/ComboBoxNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/ComboBoxNodePropertyDisplay.cpp
@@ -359,6 +359,7 @@ namespace GraphCanvas
 
             m_menuDisplayDirty = false;
 
+            ViewNotificationBus::Handler::BusDisconnect();
             GeometryNotificationBus::Handler::BusDisconnect(GetNodeId());
         }
     }


### PR DESCRIPTION
Signed-off-by: onecent1101 <liug@amazon.com>

## What does this PR do?
While testing, find out annoying warning message while switching focus of combo box across graphs.
The issue is related to ViewNotificationBus, as it doesn't support multi handler, so we should disconnect it from previous one

Warning message example
```
(System) - Connecting to a different id on this bus without disconnecting first! Please ensure you call BusDisconnect before calling BusConnect again, or if multiple connections are desired you must use a MultiHandler instead.
(System) - ------------------------------------------------
(System) - D:\Lumberyard\o3de\Gems\GraphCanvas\Code\Source\Components\NodePropertyDisplays\ComboBoxNodePropertyDisplay.cpp (346) : GraphCanvas::ComboBoxNodePropertyDisplay::SetupProxyWidget
(System) - D:\Lumberyard\o3de\Gems\GraphCanvas\Code\Source\Components\NodePropertyDisplays\ComboBoxNodePropertyDisplay.cpp (143) : GraphCanvas::ComboBoxNodePropertyDisplay::GetEditableGraphicsLayoutItem
(System) - D:\Lumberyard\o3de\Gems\GraphCanvas\Code\Source\Widgets\NodePropertyDisplayWidget.cpp (242) : `GraphCanvas::NodePropertyDisplayWidget::UpdateLayout'::`2'::<lambda_1>::operator()
```

## How was this PR tested?
Tested on Editor.
