### PR TITLE
Remove boilerplate args from multitest framework

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
@@ -51,7 +51,7 @@ class TestAutomation(EditorTestSuite):
         extra_cmdline_args = ["-rhi=dx12"]
 
         # Custom setup/teardown to remove old screenshots and establish paths to golden images
-        def setup(self, request, workspace, editor_test_results, launcher_platform):
+        def setup(self, request, workspace):
             self.screenshot_directory = os.path.join(workspace.paths.project(), DEFAULT_SUBFOLDER_PATH)
             self.screenshot_names = [
                 "AreaLight_1.ppm",
@@ -64,7 +64,7 @@ class TestAutomation(EditorTestSuite):
                 screenshot_directory=self.screenshot_directory,
                 screenshot_names=self.screenshot_names)
 
-        def wrap_run(self, request, workspace, editor_test_results, launcher_platform):
+        def wrap_run(self, request, workspace, editor_test_results):
             yield
             assert compare_screenshot_to_golden_image(self.screenshot_directory,
                                                       self.test_screenshots,
@@ -78,7 +78,7 @@ class TestAutomation(EditorTestSuite):
         extra_cmdline_args = ["-rhi=vulkan"]
 
         # Custom setup/teardown to remove old screenshots and establish paths to golden images
-        def setup(self, request, workspace, editor_test_results, launcher_platform):
+        def setup(self, request, workspace):
             self.screenshot_directory = os.path.join(workspace.paths.project(), DEFAULT_SUBFOLDER_PATH)
             self.screenshot_names = [
                 "AreaLight_1.ppm",
@@ -91,7 +91,7 @@ class TestAutomation(EditorTestSuite):
                 screenshot_directory=self.screenshot_directory,
                 screenshot_names=self.screenshot_names)
 
-        def wrap_run(self, request, workspace, editor_test_results, launcher_platform):
+        def wrap_run(self, request, workspace, editor_test_results):
             yield
             assert compare_screenshot_to_golden_image(self.screenshot_directory,
                                                       self.test_screenshots,
@@ -105,7 +105,7 @@ class TestAutomation(EditorTestSuite):
         extra_cmdline_args = ["-rhi=dx12"]
 
         # Custom setup/teardown to remove old screenshots and establish paths to golden images
-        def setup(self, request, workspace, editor_test_results, launcher_platform):
+        def setup(self, request, workspace):
             self.screenshot_directory = os.path.join(workspace.paths.project(), DEFAULT_SUBFOLDER_PATH)
             self.screenshot_names = [
                 "SpotLight_1.ppm",
@@ -119,7 +119,7 @@ class TestAutomation(EditorTestSuite):
                 screenshot_directory=self.screenshot_directory,
                 screenshot_names=self.screenshot_names)
 
-        def wrap_run(self, request, workspace, editor_test_results, launcher_platform):
+        def wrap_run(self, request, workspace, editor_test_results):
             yield
             assert compare_screenshot_to_golden_image(self.screenshot_directory,
                                                       self.test_screenshots,
@@ -133,7 +133,7 @@ class TestAutomation(EditorTestSuite):
         extra_cmdline_args = ["-rhi=vulkan"]
 
         # Custom setup/teardown to remove old screenshots and establish paths to golden images
-        def setup(self, request, workspace, editor_test_results, launcher_platform):
+        def setup(self, request, workspace):
             self.screenshot_directory = os.path.join(workspace.paths.project(), DEFAULT_SUBFOLDER_PATH)
             self.screenshot_names = [
                 "SpotLight_1.ppm",
@@ -147,7 +147,7 @@ class TestAutomation(EditorTestSuite):
                 screenshot_directory=self.screenshot_directory,
                 screenshot_names=self.screenshot_names)
 
-        def wrap_run(self, request, workspace, editor_test_results, launcher_platform):
+        def wrap_run(self, request, workspace, editor_test_results):
             yield
             assert compare_screenshot_to_golden_image(self.screenshot_directory,
                                                       self.test_screenshots,

--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Sandbox.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Sandbox.py
@@ -53,7 +53,7 @@ class EditorSingleTest_WithFileOverrides(EditorSingleTest):
     search_subdirs = True
 
     @classmethod
-    def wrap_run(cls, instance, request, workspace, editor_test_results, launcher_platform):
+    def wrap_run(cls, instance, request, workspace, editor_test_results):
         root_path = cls.base_dir
         if root_path is not None:
             root_path = os.path.join(workspace.paths.engine_root(), root_path)

--- a/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/TestSuite_Periodic.py
@@ -21,7 +21,7 @@ class TestAutomation(EditorTestSuite):
         from .tests import UserDefinedProperties_Works as test_module
 
         @classmethod
-        def setup(cls, instance, request, workspace, editor_test_results, launcher_platform):
+        def setup(cls, instance, request, workspace):
             # close out any previous O3DE active tool instances
             editor_test_utils.kill_all_ly_processes(include_asset_processor=True)
 
@@ -36,7 +36,7 @@ class TestAutomation(EditorTestSuite):
             workspace.asset_processor.batch_process(extra_params="--debugOutput")
 
         @classmethod
-        def teardown(cls, instance, request, workspace, editor_test_results, launcher_platform):
+        def teardown(cls, instance, request, workspace, editor_test_results):
             if os.path.exists(instance.default_mat_dst):
                 os.remove(instance.default_mat_dst)
 

--- a/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
@@ -35,10 +35,10 @@ class TestAutomationNoAutoTestMode(EditorTestSuite):
     class test_BasicEditorWorkflows_LevelEntityComponentCRUD(EditorSingleTest):
 
         # Custom setup and teardown to remove level created during test
-        def setup(self, request, workspace, editor_test_results, launcher_platform):
+        def setup(self, request, workspace):
             TestAutomationNoAutoTestMode.cleanup_test_level(self, workspace)
 
-        def teardown(self, request, workspace, editor_test_results, launcher_platform):
+        def teardown(self, request, workspace, editor_test_results):
             TestAutomationNoAutoTestMode.cleanup_test_level(self, workspace)
 
         from .EditorScripts import BasicEditorWorkflows_LevelEntityComponentCRUD as test_module
@@ -49,10 +49,10 @@ class TestAutomationNoAutoTestMode(EditorTestSuite):
         use_null_renderer = False
 
         # Custom teardown to remove level created during test
-        def setup(self, request, workspace, editor_test_results, launcher_platform):
+        def setup(self, request, workspace):
             TestAutomationNoAutoTestMode.cleanup_test_level(self, workspace)
 
-        def teardown(self, request, workspace, editor_test_results, launcher_platform):
+        def teardown(self, request, workspace, editor_test_results):
             TestAutomationNoAutoTestMode.cleanup_test_level(self, workspace)
 
         from .EditorScripts import BasicEditorWorkflows_LevelEntityComponentCRUD as test_module

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/TestSuite_Main.py
@@ -55,10 +55,10 @@ class TestAutomation(EditorTestSuite):
         from .EditorScripts import LayerBlender_E2E_Editor as test_module
 
         # Custom setup/teardown to remove test level created during test
-        def setup(self, request, workspace, editor_test_results, launcher_platform):
+        def setup(self, request, workspace):
             TestAutomation.cleanup_test_level(self, workspace)
 
-        def teardown(self, request, workspace, editor_test_results, launcher_platform):
+        def teardown(self, request, workspace, editor_test_results):
             TestAutomation.cleanup_test_level(self, workspace)
 
     class test_LayerBlocker_InstancesBlockedInConfiguredArea(EditorSharedTest):
@@ -103,20 +103,20 @@ class TestAutomation(EditorTestSuite):
         from .EditorScripts import PrefabInstanceSpawner_Embedded_E2E as test_module
 
         # Custom setup/teardown to remove test level created during test
-        def setup(self, request, workspace, editor_test_results, launcher_platform):
+        def setup(self, request, workspace):
             TestAutomation.cleanup_test_level(self, workspace)
 
-        def teardown(self, request, workspace, editor_test_results, launcher_platform):
+        def teardown(self, request, workspace, editor_test_results):
             TestAutomation.cleanup_test_level(self, workspace)
 
     class test_PrefabInstanceSpawner_External_E2E_Editor(EditorSingleTest):
         from .EditorScripts import PrefabInstanceSpawner_External_E2E as test_module
 
         # Custom setup/teardown to remove test level created during test
-        def setup(self, request, workspace, editor_test_results, launcher_platform):
+        def setup(self, request, workspace):
             TestAutomation.cleanup_test_level(self, workspace)
 
-        def teardown(self, request, workspace, editor_test_results, launcher_platform):
+        def teardown(self, request, workspace, editor_test_results):
             TestAutomation.cleanup_test_level(self, workspace)
 
     class test_RotationModifier_InstancesRotateWithinRange(EditorSharedTest):

--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -55,16 +55,12 @@ class EditorSingleTest(SingleTest):
     @staticmethod
     def setup(instance: EditorTestSuite.MultiTestCollector,
               request: _pytest.fixtures.FixtureRequest,
-              workspace: AbstractWorkspaceManager,
-              editor_test_results: EditorTestSuite.TestData,
-              launcher_platform: str) -> None:
+              workspace: AbstractWorkspaceManager) -> None:
         """
         User-overrideable setup function, which will run before the test.
         :param instance: Parent EditorTestSuite.MultiTestCollector instance executing the test
         :param request: PyTest request object
         :param workspace: LyTestTools workspace manager
-        :param editor_test_results: Currently recorded editor test results
-        :param launcher_platform: user-parameterized string for LyTestTools
         """
         pass
 
@@ -72,8 +68,7 @@ class EditorSingleTest(SingleTest):
     def wrap_run(instance: EditorTestSuite.MultiTestCollector,
                  request: _pytest.fixtures.FixtureRequest,
                  workspace: AbstractWorkspaceManager,
-                 editor_test_results: EditorTestSuite.TestData,
-                 launcher_platform: str) -> None:
+                 editor_test_results: EditorTestSuite.TestData) -> None:
         """
         User-overrideable wrapper function, which will run both before and after test.
         Any code before the 'yield' statement will run before the test. With code after yield run after the test.
@@ -81,8 +76,7 @@ class EditorSingleTest(SingleTest):
         :param instance: Parent EditorTestSuite.MultiTestCollector instance executing the test
         :param request: PyTest request object
         :param workspace: LyTestTools workspace manager
-        :param editor_test_results: Currently recorded EditorTest results
-        :param launcher_platform: user-parameterized string for LyTestTools
+        :param editor_test_results: results container, which will be updated after yield
         """
         yield
 
@@ -90,15 +84,13 @@ class EditorSingleTest(SingleTest):
     def teardown(instance: EditorTestSuite.MultiTestCollector,
                  request: _pytest.fixtures.FixtureRequest,
                  workspace: AbstractWorkspaceManager,
-                 editor_test_results: EditorTestSuite.TestData,
-                 launcher_platform: str) -> None:
+                 editor_test_results: EditorTestSuite.TestData) -> None:
         """
         User-overrideable teardown function, which will run after the test
         :param instance: Parent EditorTestSuite.MultiTestCollector instance executing the test
         :param request: PyTest request object
         :param workspace: LyTestTools workspace manager
-        :param editor_test_results: Currently recorded editor test results
-        :param launcher_platform: user-parameterized string for LyTestTools
+        :param editor_test_results: results from the test that executed
         """
         pass
 

--- a/Tools/LyTestTools/ly_test_tools/o3de/material_editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/material_editor_test.py
@@ -57,16 +57,12 @@ class MaterialEditorSingleTest(SingleTest):
     @staticmethod
     def setup(instance: MaterialEditorTestSuite.MultiTestCollector,
               request: _pytest.fixtures.FixtureRequest,
-              workspace: AbstractWorkspaceManager,
-              material_editor_test_results: MultiTestSuite.TestData,
-              launcher_platform: str) -> None:
+              workspace: AbstractWorkspaceManager) -> None:
         """
         User-overrideable setup function, which will run before the test.
         :param instance: Parent MaterialEditorTestSuite.MultiTestCollector instance executing the test
         :param request: PyTest request object
         :param workspace: LyTestTools workspace manager
-        :param material_editor_test_results: Currently recorded MaterialEditor test results
-        :param launcher_platform: user-parameterized string for LyTestTools
         """
         pass
 
@@ -74,8 +70,7 @@ class MaterialEditorSingleTest(SingleTest):
     def wrap_run(instance: MaterialEditorTestSuite.MultiTestCollector,
                  request: _pytest.fixtures.FixtureRequest,
                  workspace: AbstractWorkspaceManager,
-                 material_editor_test_results: MultiTestSuite.TestData,
-                 launcher_platform: str) -> None:
+                 material_editor_test_results: MultiTestSuite.TestData) -> None:
         """
         User-overrideable wrapper function, which will run both before and after test.
         Any code before the 'yield' statement will run before the test. With code after yield run after the test.
@@ -84,7 +79,6 @@ class MaterialEditorSingleTest(SingleTest):
         :param request: PyTest request object
         :param workspace: LyTestTools workspace manager
         :param material_editor_test_results: Currently recorded MaterialEditor test results
-        :param launcher_platform: user-parameterized string for LyTestTools
         """
         yield
 
@@ -92,15 +86,13 @@ class MaterialEditorSingleTest(SingleTest):
     def teardown(instance: MaterialEditorTestSuite.MultiTestCollector,
                  request: _pytest.fixtures.FixtureRequest,
                  workspace: AbstractWorkspaceManager,
-                 material_editor_test_results: MultiTestSuite.TestData,
-                 launcher_platform: str) -> None:
+                 material_editor_test_results: MultiTestSuite.TestData) -> None:
         """
         User-overrideable teardown function, which will run after the test
         :param instance: Parent MaterialEditorTestSuite.MultiTestCollector instance executing the test
         :param request: PyTest request object
         :param workspace: LyTestTools workspace manager
         :param material_editor_test_results: Currently recorded MaterialEditor test results
-        :param launcher_platform: user-parameterized string for LyTestTools
         """
         pass
 

--- a/Tools/LyTestTools/ly_test_tools/o3de/multi_test_framework.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/multi_test_framework.py
@@ -424,19 +424,19 @@ class MultiTestSuite(object):
                         if is_single_test:
                             # Setup step for wrap_run
                             wrap = inner_test_spec.wrap_run(
-                                self, request, workspace, collected_test_data, launcher_platform)
+                                self, request, workspace, collected_test_data)
                             assert isinstance(wrap, types.GeneratorType), (
                                 "wrap_run must return a generator, did you forget 'yield'?")
                             next(wrap, None)
                             # Setup step
                             inner_test_spec.setup(
-                                self, request, workspace, collected_test_data, launcher_platform)
+                                self, request, workspace)
                         # Run
                         self._run_single_test(request, workspace, collected_test_data, inner_test_spec)
                         if is_single_test:
                             # Teardown
                             inner_test_spec.teardown(
-                                self, request, workspace, collected_test_data, launcher_platform)
+                                self, request, workspace, collected_test_data)
                             # Teardown step for wrap_run
                             next(wrap, None)
 


### PR DESCRIPTION
Signed-off-by: sweeneys <sweeneys@amazon.com>

## What does this PR do?

Simplifies writing integration tests which use EditorSingleTest and MaterialEditorSingleTest by removing unused boilerplate from their overridable callbacks:
- launcher_platform is already user-parameterized, and tests should not need to access it
- Setup should never need to interact with results

Removes usage from existing tests, which demonstrate the boilerplate-ness of these args.

## How was this PR tested?

Tested locally on Windows by executing `ctest -C profile -L "(SUITE_smoke|SUITE_main)" --output-on-failure -j 6`
