### PR TITLE
Benblac/maya materials conversion

### DIFF
--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/maya_menu_items/materials_helper.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/maya_menu_items/materials_helper.py
@@ -1,0 +1,385 @@
+import maya.cmds as mc
+from PySide2 import QtWidgets, QtCore, QtGui
+from azpy.o3de.renderer.materials import material_utilities
+from azpy.dcc.maya.helpers import maya_materials_conversion as material_utils
+from SDK.Python import general_utilities
+from maya import OpenMayaUI as omui
+from shiboken2 import wrapInstance
+from pathlib import Path
+import logging as _logging
+import os
+
+
+mayaMainWindowPtr = omui.MQtUtil.mainWindow()
+mayaMainWindow = wrapInstance(int(mayaMainWindowPtr), QtWidgets.QWidget)
+
+
+_LOGGER = _logging.getLogger('SDK.maya.scripts.Python.maya_menu.items')
+
+
+class MaterialsHelper(QtWidgets.QWidget):
+    def __init__(self, operation, parent=None):
+        super().__init__(parent)
+
+        self.setParent(mayaMainWindow)
+        self.setWindowFlags(QtCore.Qt.Window)
+        self.setGeometry(200, 200, 450, 600)
+        self.setObjectName('MaterialsHelper')
+        self.setWindowTitle('Materials Helper')
+        self.isTopLevel()
+        self.operation = operation
+        self.scope = 0
+        self.output_location = None
+        self.process_dictionary = None
+        self.source = None
+        self.desktop_location = os.path.join(os.environ['USERPROFILE'], 'Desktop')
+        self.bold_font = QtGui.QFont("Plastique", 8, QtGui.QFont.Bold)
+
+        self.main_container = QtWidgets.QVBoxLayout()
+        self.setLayout(self.main_container)
+        self.main_container.setAlignment(QtCore.Qt.AlignTop)
+
+        # Task Section
+        self.test_label = QtWidgets.QLabel('Task')
+        self.test_label.setFont(self.bold_font)
+        self.main_container.addWidget(self.test_label)
+        self.main_container.addSpacing(5)
+
+        self.task_button_container = QtWidgets.QHBoxLayout()
+        self.task_button_container.setAlignment(QtCore.Qt.AlignLeft)
+        self.main_container.addLayout(self.task_button_container)
+        self.task_button_group = QtWidgets.QButtonGroup()
+        self.task_button_group.idClicked.connect(self.task_radio_clicked)
+        self.task_radio_one = QtWidgets.QRadioButton('Query Material Attributes')
+        self.task_radio_one.setChecked(True)
+        self.task_button_container.addWidget(self.task_radio_one)
+        self.task_button_container.addSpacing(30)
+        self.task_button_group.addButton(self.task_radio_one, 0)
+        self.task_radio_two = QtWidgets.QRadioButton('Convert to O3DE Materials')
+        self.task_button_container.addWidget(self.task_radio_two)
+        self.task_button_group.addButton(self.task_radio_two, 1)
+        self.main_container.addLayout(self.create_spacer_line())
+
+        # Export Object Settings
+        self.object_settings_label = QtWidgets.QLabel('Export Object Settings')
+        self.object_settings_label.setFont(self.bold_font)
+        self.main_container.addWidget(self.object_settings_label)
+        self.main_container.addSpacing(5)
+        self.object_settings_layout = QtWidgets.QHBoxLayout()
+        self.object_settings_layout.setAlignment(QtCore.Qt.AlignLeft)
+        self.main_container.addLayout(self.object_settings_layout)
+        self.preserve_transforms_checkbox = QtWidgets.QCheckBox('Preserve Transform Values')
+        self.preserve_transforms_checkbox.setChecked(True)
+        self.object_settings_layout.addWidget(self.preserve_transforms_checkbox)
+        self.object_settings_layout.addSpacing(30)
+        self.preserve_grouped_checkbox = QtWidgets.QCheckBox('Preserve Grouped Objects')
+        self.object_settings_layout.addWidget(self.preserve_grouped_checkbox)
+        self.main_container.addLayout(self.create_spacer_line())
+
+        # Scope Section
+        self.scope_label = QtWidgets.QLabel('Scope')
+        self.scope_label.setFont(self.bold_font)
+        self.main_container.addWidget(self.scope_label)
+        self.main_container.addSpacing(5)
+        self.scope_button_container = QtWidgets.QHBoxLayout()
+        self.scope_button_container.setAlignment(QtCore.Qt.AlignLeft)
+        self.main_container.addLayout(self.scope_button_container)
+        self.main_container.addSpacing(5)
+        self.scope_button_group = QtWidgets.QButtonGroup()
+        self.scope_button_group.idClicked.connect(self.scope_radio_clicked)
+        self.scope_settings = ['Selected', 'By Name', 'Scene', 'Directory']
+        self.scope_values = [None] * len(self.scope_settings)
+        self.scope_radio_one = QtWidgets.QRadioButton(self.scope_settings[0])
+        self.scope_radio_one.setChecked(True)
+        self.scope_button_container.addWidget(self.scope_radio_one)
+        self.scope_button_container.addSpacing(30)
+        self.scope_button_group.addButton(self.scope_radio_one, 0)
+        self.scope_radio_two = QtWidgets.QRadioButton(self.scope_settings[1])
+        self.scope_button_container.addWidget(self.scope_radio_two)
+        self.scope_button_container.addSpacing(30)
+        self.scope_button_group.addButton(self.scope_radio_two, 1)
+        self.scope_radio_three = QtWidgets.QRadioButton(self.scope_settings[2])
+        self.scope_button_container.addWidget(self.scope_radio_three)
+        self.scope_button_container.addSpacing(30)
+        self.scope_button_group.addButton(self.scope_radio_three, 2)
+        self.scope_radio_four = QtWidgets.QRadioButton(self.scope_settings[3])
+        self.scope_button_container.addWidget(self.scope_radio_four)
+        self.scope_button_group.addButton(self.scope_radio_four, 3)
+        self.scope_target_layout = QtWidgets.QHBoxLayout()
+        self.main_container.addLayout(self.scope_target_layout)
+        self.scope_line_edit = QtWidgets.QLineEdit()
+        self.scope_line_edit.setFixedHeight(25)
+        self.scope_target_layout.addWidget(self.scope_line_edit)
+        self.scope_set_button = QtWidgets.QPushButton('Set')
+        self.scope_set_button.clicked.connect(self.set_scope_clicked)
+        self.scope_target_layout.addWidget(self.scope_set_button)
+        self.scope_set_button.setFixedSize(30, 25)
+        self.main_container.addLayout(self.create_spacer_line())
+
+        # Export Path
+        self.export_path_label = QtWidgets.QLabel('Export Path')
+        self.export_path_label.setFont(self.bold_font)
+        self.main_container.addWidget(self.export_path_label)
+        self.main_container.addSpacing(5)
+
+        self.export_path_layout = QtWidgets.QHBoxLayout()
+        self.main_container.addLayout(self.export_path_layout)
+        self.export_line_edit = QtWidgets.QLineEdit()
+        self.export_line_edit.setFixedHeight(25)
+        self.export_path_layout.addWidget(self.export_line_edit)
+        self.export_set_button = QtWidgets.QPushButton('Set')
+        self.export_set_button.clicked.connect(self.set_output_location)
+        self.export_path_layout.addWidget(self.export_set_button)
+        self.export_set_button.setFixedSize(30, 25)
+        self.main_container.addLayout(self.create_spacer_line())
+
+        # Output Window
+        self.output_label = QtWidgets.QLabel('Output')
+        self.output_label.setFont(self.bold_font)
+        self.main_container.addWidget(self.output_label)
+        self.main_container.addSpacing(5)
+        self.output_file_combobox = QtWidgets.QComboBox()
+        self.output_file_combobox.currentIndexChanged.connect(self.output_combobox_changed)
+        self.output_file_combobox.setFixedHeight(25)
+        self.main_container.addWidget(self.output_file_combobox)
+        self.output_window = QtWidgets.QTextEdit()
+        self.main_container.addWidget(self.output_window)
+
+        # Process Materials Button
+        self.process_materials_button = QtWidgets.QPushButton('Process Materials')
+        self.process_materials_button.clicked.connect(self.process_materials_clicked)
+        self.process_materials_button.setFixedHeight(50)
+        self.main_container.addWidget(self.process_materials_button)
+        self.set_window()
+
+    def process_materials(self):
+        _LOGGER.info('ProcessMaterialsClicked')
+        if self.validate_task():
+            # Include export options
+            export_options = []
+            for checkbox in [self.preserve_grouped_checkbox, self.preserve_transforms_checkbox]:
+                if checkbox.isChecked():
+                    export_options.append(checkbox.text())
+
+            self.process_dictionary = material_utilities.process_materials('Maya', self.operation, '_'.join(
+                self.scope_settings[self.scope].split(' ')).lower(), export_options, self.output_location, self.source)
+            self.set_output_combobox()
+            self.set_output_window()
+
+    def enable_scope_buttons(self, txt, btn):
+        self.scope_line_edit.setEnabled(txt)
+        self.scope_set_button.setEnabled(btn)
+
+    def validate_task(self):
+        self.source = self.get_source()
+        _LOGGER.info(f'Source: {self.source}  OutputLocation: {self.output_location}')
+        if self.source:
+            if self.operation == 'convert':
+                _LOGGER.info(f'Operation: {self.operation}')
+                if not self.output_location:
+                    self.set_error_window('export_path', 'missing')
+                    return False
+                elif not os.path.isdir(self.output_location):
+                    self.set_error_window('export_path', 'bad_path')
+                    return False
+            return True
+        return False
+
+    # +++++++++++++++++++++++++-->
+    # Getters/Setters +++++++++--->
+    # +++++++++++++++++++++++++-->
+
+    def set_error_window(self, error_location, error_type):
+        pass
+
+    def set_window(self):
+        if self.operation == 'convert':
+            self.task_radio_two.setChecked(True)
+        self.set_scope_widget()
+        self.show()
+
+    def set_scope_widget(self):
+        if self.scope == 0:
+            self.enable_scope_buttons(False, False)
+        elif self.scope == 1:
+            self.enable_scope_buttons(True, False)
+        else:
+            self.enable_scope_buttons(True, True)
+
+        scope_value = self.scope_values[self.scope]
+        scope_listing = scope_value if scope_value else ''
+        self.scope_line_edit.setText(scope_listing)
+
+    def set_output_combobox(self):
+        self.output_file_combobox.clear()
+        self.output_file_combobox.blockSignals(True)
+        output_keys = []
+        for key, values in self.process_dictionary.items():
+            for k, v in values.items():
+                output_keys.append(k)
+        self.output_file_combobox.addItems(output_keys)
+        self.output_file_combobox.blockSignals(False)
+
+    def set_output_window(self):
+        self.output_window.clear()
+        self.output_window.setText(self.get_formatted_output())
+
+        # Increase Line Spacing for better readability
+        block_format = QtGui.QTextBlockFormat()
+        block_format.setLineHeight(150, QtGui.QTextBlockFormat.ProportionalHeight)
+        txt_cursor = self.output_window.textCursor()
+        txt_cursor.clearSelection()
+        txt_cursor.select(QtGui.QTextCursor.Document)
+        txt_cursor.mergeBlockFormat(block_format)
+
+    def set_output_location(self):
+        directory = QtWidgets.QFileDialog.getExistingDirectory(self, 'Select Target Directory', self.desktop_location)
+        _LOGGER.info(f'Directory: {directory}')
+        if directory:
+            self.export_line_edit.setText(directory)
+            self.set_export_path()
+
+    def set_scope_location(self):
+        directory = QtWidgets.QFileDialog.getExistingDirectory(self, 'Select Target Directory', self.desktop_location)
+        if directory:
+            self.scope_values[self.scope] = directory
+            self.scope_line_edit.setText(directory)
+
+    def get_source(self):
+        source_list = []
+        scope_value = self.get_scope_value()
+        target_object = self.scope_line_edit.text()
+        if scope_value == 'Selected':
+            if material_utils.get_selected_objects():
+                for item in material_utils.get_selected_objects():
+                    source_list.append(item)
+        elif scope_value == 'By Name':
+            if material_utils.get_object_by_name(target_object):
+                source_list.append(target_object)
+        elif scope_value == 'Scene':
+            if self.scope_line_edit.text() == '':
+                source_list = material_utils.get_scene_objects()
+            else:
+                pass
+                # source_list.append(current_scene)
+        elif scope_value == 'Directory':
+            if os.path.isdir(target_object):
+                target_files = ['.ma', '.mb']
+                maya_files = self.get_files_by_type(target_object, target_files)
+                for file in maya_files:
+                    source_list.append(file)
+        if source_list:
+            return source_list
+        return None
+
+    def get_scope_value(self):
+        return self.scope_settings[self.scope]
+
+    def get_object_settings(self, object_name):
+        for key, values in self.process_dictionary.items():
+            for k, v in values.items():
+                if object_name in k:
+                    return {key: {k: v}}
+        return {}
+
+    def get_formatted_output(self):
+        current_selection = self.output_file_combobox.currentText()
+        output_dict = self.get_object_settings(current_selection)
+        output_string = ''
+        for target_file, object_list in output_dict.items():
+            output_string += f'\nPROCESSED FILE NAME:\n{target_file}\n'
+            try:
+                for object_name, object_properties in object_list.items():
+                    output_string += self.get_formatted_object_name(object_name)
+                    for material_name, material_properties in object_properties.items():
+                        _LOGGER.info(f'MaterialNameProcessing: {material_name}')
+                        output_string += '\n\n+---------\n'
+                        output_string += '+------------------\n+---------------------------------------------'
+                        output_string += f'\nMATERIAL NAME: {material_name}\n'
+                        output_string += f"MATERIAL TYPE: {material_properties['material_type']}\n"
+                        output_string += f'\nASSIGNED TEXTURES:\n'
+                        for texture_key, texture_values in material_properties['textures'].items():
+                            if texture_values:
+                                for k, v in texture_values.items():
+                                    if k == 'path':
+                                        output_string += f'--> {texture_key} ::: {v}\n'
+                        output_string += f'\nSETTINGS:\n'
+                        for property_name, property_value in material_properties['settings'].items():
+                            output_string += f'{property_name} ::: {property_value}\n'
+                        output_string += '+---------------------------------------------\n+------------------'
+                        output_string += '\n+---------'
+            except AttributeError as e:
+                _LOGGER.info(f'Error/Exception in get_formatted_output: {type(e)}   ::  {e}')
+            output_string += '\n\n'
+        return output_string
+
+    @staticmethod
+    def get_formatted_object_name(object_name):
+        separator = '#' * (len(object_name) + 6)
+        formatted_string = f'\n{separator}\nMESH: {object_name}\n{separator}'
+        return formatted_string
+
+    # +++++++++++++++++++++++++-->
+    # Button Actions ++++++++++--->
+    # +++++++++++++++++++++++++-->
+
+    def task_radio_clicked(self):
+        self.operation = 'query' if self.task_button_group.checkedId() == 0 else 'convert'
+
+    def scope_radio_clicked(self, id_):
+        self.scope = id_
+        self.set_scope_widget()
+
+    def set_scope_clicked(self):
+        self.set_scope_location()
+
+    def set_export_path(self):
+        target_path = self.export_line_edit.text()
+        self.output_location = target_path if Path(target_path).is_dir() else None
+        _LOGGER.info(f'-----> {self.output_location} -- {type(self.output_location)}')
+
+    def process_materials_clicked(self):
+        self.process_materials()
+
+    def output_combobox_changed(self):
+        self.set_output_window()
+
+    # +++++++++++++++++++++++++-->
+    # Static Methods ++++++++++--->
+    # +++++++++++++++++++++++++-->
+
+    @staticmethod
+    def create_spacer_line():
+        """! Convenience function for adding separation line to the UI. """
+        layout = QtWidgets.QHBoxLayout()
+        line = QtWidgets.QLabel()
+        line.setFrameStyle(QtWidgets.QFrame.HLine | QtWidgets.QFrame.Sunken)
+        line.setLineWidth(1)
+        line.setFixedHeight(10)
+        layout.addWidget(line)
+        layout.setContentsMargins(8, 0, 8, 0)
+        return layout
+
+    @staticmethod
+    def get_files_by_type(base_directory: Path, file_types: list) -> list:
+        file_list = []
+        for (root, dirs, files) in os.walk(base_directory, topdown=True):
+            root = Path(root)
+            for file in files:
+                if os.path.splitext(file)[-1] in file_types:
+                    file_list.append(root / file)
+        return file_list
+
+
+def delete_instances():
+    for obj in mayaMainWindow.children():
+        if str(type(obj)) == "<class 'SDK.Maya.Scripts.Python.maya_menu_items.materials_helper.MaterialsHelper'>":
+            if obj.__class__.__name__ == "MaterialsHelper":
+                obj.setParent(None)
+                obj.deleteLater()
+
+
+def show_ui(operation):
+    delete_instances()
+    ui = MaterialsHelper(operation, mayaMainWindow)
+    ui.show()

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Python/general_utilities.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Python/general_utilities.py
@@ -1,13 +1,15 @@
-# coding:utf-8
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# !/usr/bin/python
 #
-# Copyright (c) Contributors to the Open 3D Engine Project.
-# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
 #
-# SPDX-License-Identifier: Apache-2.0 OR MIT
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #
-#
-# -------------------------------------------------------------------------
 
 """! @brief This module contains several common utilities/operations for Python when creating tools for the DCCsi. """
 
@@ -31,6 +33,7 @@ import logging
 import json
 import re
 import os
+
 
 _LOGGER = logging.getLogger('SDK.DCC.Python.general_utilities')
 
@@ -107,6 +110,10 @@ def get_markdown_information(target_path: Path) -> dict:
     return markdown
 
 
+def get_clean_path(target_path) -> str:
+    return target_path.replace('\\', '/')
+
+
 def get_files_by_name(base_directory: Path, target_file: str) -> list:
     file_list = []
     for (root, dirs, files) in os.walk(base_directory, topdown=True):
@@ -118,7 +125,7 @@ def get_files_by_name(base_directory: Path, target_file: str) -> list:
 
 
 def set_json_data(target_path: Path, json_data: Box):
-    with open(target_path, 'w') as json_file:
+    with open(str(target_path), 'w') as json_file:
         json.dump(json_data, json_file, indent=4)
 
 

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/Maya/Scripts/set_menu.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/Maya/Scripts/set_menu.py
@@ -53,6 +53,35 @@ def menu_cmd_test():
     return
 # -------------------------------------------------------------------------
 
+
+# -------------------------------------------------------------------------
+def export_scene_materials(args):
+    # It is unclear why a False argument is being passed when called from the menu item below, but needed to add args
+    # for function to fire
+
+    _LOGGER.info('Exporting Scene Materials')
+    from importlib import reload
+    from azpy.dcc.maya.helpers import maya_materials_conversion
+    from azpy.o3de.renderer.materials import material_utilities
+    from azpy.o3de.renderer.materials import o3de_material_generator
+    from azpy.dcc.maya.helpers import convert_aiStandardSurface_material
+    from azpy.dcc.maya.helpers import convert_aiStandard_material
+    from azpy.dcc.maya.helpers import convert_stingray_material
+    from SDK.Python import general_utilities
+    from SDK.Maya.Scripts.Python.maya_menu_items import materials_helper
+
+    reload(maya_materials_conversion)
+    reload(material_utilities)
+    reload(o3de_material_generator)
+    reload(convert_aiStandardSurface_material)
+    reload(convert_aiStandard_material)
+    reload(convert_stingray_material)
+    reload(general_utilities)
+    reload(materials_helper)
+    materials_helper.MaterialsHelper('convert')
+# -------------------------------------------------------------------------
+
+
 # -------------------------------------------------------------------------
 def set_main_menu(obj_name=OBJ_DCCSI_MAINMENU, label=TAG_DCCSI_MAINMENU):
     _main_window = pm.language.melGlobals['gMainWindow']
@@ -70,14 +99,16 @@ def set_main_menu(obj_name=OBJ_DCCSI_MAINMENU, label=TAG_DCCSI_MAINMENU):
                                  parent=_main_window,
                                  tearOff=True)
 
-    # make a dummpy sub-menu
-    pm.menuItem(label='Menu Item Stub',
+    # Conversion Section (sub-menu)
+    _LOGGER.info('A')
+    pm.menuItem(label='Conversion Utilities',
                 subMenu=True,
                 parent=_custom_tools_menu,
                 tearOff=True)
-    
-    # make a dummy menu item to test
-    pm.menuItem(label='Test', command=pm.Callback(menu_cmd_test))
+
+    # Conversion Section Menu Items
+    pm.menuItem(label='Export Scene Materials', command=export_scene_materials)
+
     return _custom_tools_menu
 
 # ==========================================================================

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/dcc/blender/helpers/blender_materials_conversion.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/dcc/blender/helpers/blender_materials_conversion.py
@@ -1,15 +1,4 @@
-# coding:utf-8
-#!/usr/bin/python
-#
-# Copyright (c) Contributors to the Open 3D Engine Project.
-# For complete copyright and license terms please see the LICENSE at the root of this distribution.
-#
-# SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-#
-# -------------------------------------------------------------------------
-
-#from pathlib import Path
+from pathlib import Path
 import logging as _logging
 import bpy
 from azpy.dcc.blender.helpers import convert_bsdf_material as bsdf
@@ -20,6 +9,12 @@ _LOGGER = _logging.getLogger('azpy.dcc.blender.helpers.blender_materials')
 supported_material_types = [
     'Principled BSDF'
 ]
+
+
+def prepare_material_export(target_mesh, export_location):
+    mesh_materials = get_mesh_materials(target_mesh)
+    export_path = get_mesh_export_path(target_mesh, export_location) if export_location else ''
+    return export_path, mesh_materials
 
 
 def get_current_scene():
@@ -45,6 +40,10 @@ def get_material_type(target_material):
     for node in target_material.node_tree.nodes:
         if node.name in shader_types:
             return node.name
+
+
+def get_mesh_export_path(target_mesh, export_location):
+    return Path(export_location) / f'{target_mesh}.fbx'
 
 
 def get_shader_types():

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/dcc/maya/helpers/convert_aiStandardSurface_material.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/dcc/maya/helpers/convert_aiStandardSurface_material.py
@@ -1,0 +1,142 @@
+#!/usr/bin/python
+#
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
+#
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+"""! @brief This module assists with material operations involving Maya aiStandardSurface (Arnold) materials. """
+
+##
+# @file convert_aiStandardSurface_material.py
+#
+# @brief This module contains several common materials utilities/operations for extracting/converting material
+# information contained in Maya aiStandardSurface. This includes gathering file texture information, and input/output
+# connections, and other material property settings relevant for materials conversion to O3DE
+#
+# @section Maya Materials Notes
+# - Comments are Doxygen compatible
+
+from azpy.dcc.maya.helpers import maya_materials_conversion
+from SDK.Python import general_utilities as helpers
+import logging as _logging
+import maya.cmds as mc
+
+_LOGGER = _logging.getLogger('azpy.dcc.maya.helpers.convert_aiStandardSurface_material')
+
+
+def get_material_info(target_material: str):
+    material_textures = get_material_textures(target_material)
+    target_keys = get_transferable_properties()
+    material_settings = maya_materials_conversion.get_material_attributes(target_material, target_keys)
+    material_info = {
+        'material_type': 'aiStandardSurface',
+        'dcc_application': 'Maya',
+        'settings': material_settings,
+        'textures': material_textures
+    }
+    return material_info
+
+
+def get_material_textures(target_material: str):
+    arnold_file_connections = {
+        'metalness':         None,
+        'baseColor':         None,
+        'specularRoughness': None,
+        'emissionColor':     None,
+        'normal':           None,
+        'alpha':             None,
+        'subsurfaceColor':   None
+    }
+
+    nodes = mc.listConnections(target_material, source=True, destination=False, skipConversionNodes=True) or {}
+    for node in nodes:
+        if 'file' not in node.lower():
+            node = get_file_node(node)
+
+        node_connections = mc.listConnections(node, p=True)
+        if node_connections[0] == 'defaultColorMgtGlobals.cmEnabled':
+            texture_slot = get_texture_slot(node_connections)
+        else:
+            parent_node = mc.listConnections(node, p=True)[0]
+            texture_slot = parent_node.split('.')[-1]
+        texture_path = mc.getAttr(f'{node}.fileTextureName')
+        arnold_file_connections[texture_slot] = {'node': node, 'path': helpers.get_clean_path(texture_path)}
+
+    return arnold_file_connections
+
+
+def get_texture_slot(node_connections):
+    supported_connections = [
+        'subsurfaceColor',
+        'bumpValue'
+    ]
+    for connection in node_connections:
+        connection = connection.split('.')[-1]
+        if connection in supported_connections:
+            connection = 'normal' if connection == 'bumpValue' else connection
+            return connection
+
+
+def get_file_node(source_node):
+    file_node = mc.listConnections(source_node, type='file', c=True)[1]
+    return file_node
+
+
+def get_transferable_properties():
+    """! This is a listing of properties on an aiStandardSurface material that can be directly transferred to an
+    O3DE material. When parsing the material attributes in Maya these values will be extracted and added to scene
+    material information. "*" Indicates a texture slot- if textures don't exist this likely can be controlled with
+    RGB values. This should probably be moved to a constants file once we work out how we are set everything up
+    """
+
+    # Please note: I'm unsure about the differences in mapping between "roughness" and "specular roughness with the
+    # Arnold shader. I'm pretty sure standard "roughness" mapping is found under "Specular" in the material properties
+    # but this is then contends with specularF0 roughness... need to get an answer on this
+    target_properties = {
+        'base': 'baseColor.factor',                     # BASE - Weight
+        'baseColor': 'baseColor.textureMap',            # BASE - * Color
+        'diffuseRoughness': '',                         # BASE - Roughness
+        'metalness': 'metallic.textureMap',             # BASE - Metalness
+
+        'specular': 'roughness.factor',                 # SPECULAR - Weight
+        'specularColor': '',                            # SPECULAR - Color
+        'specularRoughness': 'roughness.textureMap',    # SPECULAR - * Roughness
+        'specularIOR': '',                              # SPECULAR - IOR
+        'specularAnisotropy': '',                       # SPECULAR - Anisotropy
+        'specularRotation': '',                         # SPECULAR - Rotation
+
+        'subsurface': '',                               # SUBSURFACE - Weight
+        'subsurfaceColor': '',                          # SUBSURFACE - * Subsurface Color
+        'subsurfaceRadius': '',                         # SUBSURFACE - Radius
+        'subsurfaceScale': '',                          # SUBSURFACE - Scale
+
+        'coat': 'clearCoat.factor',                     # COAT - Weight
+        'coatColor': 'clearCoat.influenceMap',          # COAT - Color
+        'coatRoughness': 'clearCoat.roughness',         # COAT - Roughness
+        'coatIOR': '',                                  # COAT - IOR
+        'coatAnisotropy': '',                           # COAT - Anisotropy
+        'coatRotation': '',                             # COAT - Rotation
+
+        'sheen': '',                                    # SHEEN - Weight
+        'sheenColor': '',                               # SHEEN - Color
+        'sheenRoughness': '',                           # SHEEN - Roughness
+
+        'emission': 'emissive.intensity',               # EMISSION - Weight
+        'emissionColor': 'emissive.textureMap',         # EMISSION - * Color
+
+        'opacity': 'opacity.textureMap',                # GEOMETRY - Opacity
+        'normalCamera': 'normal.textureMap',            # GEOMETRY - * Bump Mapping (Normal Map input)
+
+        'aiEnableMatte': '',                            # MATTE - * Enable Matte (Alpha)
+        'aiMatteColor': 'opacity.textureMap',           # MATTE - Matte Color
+        'aiMatteColorA': 'opacity.factor',              # MATTE - Matte Opacity
+    }
+    return target_properties
+
+

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/dcc/maya/helpers/convert_aiStandard_material.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/dcc/maya/helpers/convert_aiStandard_material.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python
+#
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
+#
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+"""! @brief This module assists with material operations involving Maya aiStandard (Arnold) materials. """
+
+##
+# @file convert_aiStandard_material.py
+#
+# @brief This module contains several common materials utilities/operations for extracting/converting material
+# information contained in Maya aiStandardSurface. This includes gathering file texture information, and input/output
+# connections, and other material property settings relevant for materials conversion to O3DE
+#
+# @section Maya Materials Notes
+# - Comments are Doxygen compatible
+
+from azpy.dcc.maya.helpers import maya_materials_conversion
+from SDK.Python import general_utilities as helpers
+from pathlib import Path
+import logging as _logging
+import maya.cmds as mc
+
+
+_LOGGER = _logging.getLogger('azpy.dcc.maya.helpers.convert_aiStandard_material')
+
+
+def get_material_info(target_material: str):
+    material_textures = get_material_textures(target_material)
+    target_keys = get_transferable_properties()
+    material_settings = maya_materials_conversion.get_material_attributes(target_material, target_keys)
+    material_info = {
+        'material_type': 'aiStandard',
+        'dcc_application': 'Maya',
+        'settings': material_settings,
+        'textures': material_textures
+    }
+    return material_info
+
+
+def get_material_textures(target_material: str):
+    arnold_file_connections = {
+        'metalness':            None,
+        'color':                None,
+        'specularRoughness':    None,
+        'emissionColor':        None,
+        'normal':               None,
+        'aiMatteColor':         None,
+        'KsssColor':            None
+    }
+
+    nodes = mc.listConnections(target_material, source=True, destination=False, skipConversionNodes=True) or {}
+    for node in nodes:
+        parent_node = mc.listConnections(node, p=True)[0]
+        texture_slot = parent_node.split('.')[-1]
+
+        if texture_slot == 'normal':
+            slot_name = mc.listConnections(parent_node)[0]
+            texture_path = mc.getAttr(f'{slot_name}.fileTextureName')
+        else:
+            texture_path = mc.getAttr(f'{node}.fileTextureName')
+        arnold_file_connections[texture_slot] = {'node': node, 'path': helpers.get_clean_path(texture_path)}
+
+    arnold_file_connections = get_unassigned_textures(arnold_file_connections)
+    return arnold_file_connections
+
+
+def get_unassigned_textures(textures_dict: dict):
+    """! This runs a second pass of the location of registered textures in the event that additional related texture
+    files may exist, but are either unassigned or the script has difficulty sourcing connections
+
+    @param textures_dict This dictionary is passed after a material has been parsed, just as a cleanup pass, so that
+    when migrating assets, no textures are left behind that might otherwise get lost in the transfer to a new location.
+    """
+    search_values = {}
+    found_entries = {}
+    # Get search info //------------------------------------------------>>
+    for texture_type, texture_values in textures_dict.items():
+        if texture_values:
+            if texture_values['path']:
+                found_entries[texture_type] = texture_values['path']
+                if not search_values:
+                    base_directory = Path(texture_values['path']).parent
+                    search_values['base_directory'] = base_directory
+                    base_texture_name = Path(texture_values['path']).stem
+                    texture_parts = base_texture_name.split('_')
+                    texture_prefix = '_'.join(texture_parts[:-1])
+                    search_values['prefix'] = texture_prefix
+
+    # Filter //---------------------------------------------------------->>
+    p = Path(search_values['base_directory']).glob('**/*')
+    target_files = [x for x in p if x.is_file()]
+    for index, file_path in enumerate(target_files):
+        if file_path.suffix in ['.jpg', '.png', '.tif', 'tga']:
+            file_name = file_path.stem
+            file_path = helpers.get_clean_path(str(file_path))
+            if file_name.startswith(search_values['prefix']):
+                texture_type = file_name.split('_')[-1]
+                if not [k for k, v in found_entries.items() if Path(v) == Path(file_path)]:
+                    textures_dict[get_texture_type(texture_type)] = {'path': file_path}
+    return textures_dict
+
+
+def get_file_node(source_node):
+    file_node = mc.listConnections(source_node, type='file', c=True)[1]
+    return file_node
+
+
+def get_texture_type(texture_type):
+    """! Eventually we are going to want to add suffix matching for texture types in a centralized constants file
+    location. For the purposes of converting the Intel Sponza scene, this will provide proper texture assignments
+
+    @param texture_type Found in file texture name after the final underscore (but before extension)
+    Example: file_<texture_type>.png
+    """
+    texture_types = get_transferable_properties()
+    for type in texture_types.keys():
+        if type.lower() == texture_type.lower():
+            return type
+    return texture_type
+
+
+def get_transferable_properties():
+    """! This is a listing of properties on an aiStandardSurface material that can be directly transferred to an
+    O3DE material. When parsing the material attributes in Maya these values will be extracted and added to scene
+    material information. "*" Indicates a texture slot- if textures don't exist this likely can be controlled with
+    RGB values. This should probably be moved to a constants file once we work out how we are set everything up
+    """
+    target_properties = {
+        'color': 'baseColor.textureMap',                # BASE - * Color
+        'metalness': 'metallic.textureMap',             # BASE - Metalness
+        'specularRoughness': 'roughness.textureMap',    # SPECULAR - * Roughness
+        'emissionColor': 'emissive.textureMap',         # EMISSION - * Color
+        'normal': 'normal.textureMap',                  # GEOMETRY - * Bump Mapping (Normal Map input)
+        'aiMatteColor': 'opacity.textureMap',           # MATTE - Matte Color
+    }
+    return target_properties
+
+

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/dcc/maya/helpers/convert_stingray_material.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/dcc/maya/helpers/convert_stingray_material.py
@@ -1,13 +1,15 @@
-# coding:utf-8
 #!/usr/bin/python
 #
-# Copyright (c) Contributors to the Open 3D Engine Project.
-# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
 #
-# SPDX-License-Identifier: Apache-2.0 OR MIT
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #
-#
-# -------------------------------------------------------------------------
+
 """! @brief This module assists with material operations involving Maya StingrayPBS materials. """
 
 ##
@@ -20,11 +22,15 @@
 # @section Maya Materials Notes
 # - Comments are Doxygen compatible
 
+from azpy.dcc.maya.helpers import maya_materials_conversion
+from SDK.Python import general_utilities as helpers
 import logging as _logging
 import maya.cmds as mc
 from pathlib import Path
 
+
 _LOGGER = _logging.getLogger('azpy.dcc.maya.helpers.convert_stingray_material')
+
 
 stingray_file_connections = [
     'TEX_ao_map',
@@ -36,9 +42,25 @@ stingray_file_connections = [
 ]
 
 
+def enable_stingray_textures(material_name: str):
+    mc.setAttr('{}.use_color_map'.format(material_name), 1)
+    mc.setAttr('{}.use_normal_map'.format(material_name), 1)
+    mc.setAttr('{}.use_metallic_map'.format(material_name), 1)
+    mc.setAttr('{}.use_roughness_map'.format(material_name), 1)
+    mc.setAttr('{}.use_emissive_map'.format(material_name), 1)
+
+
 def get_material_info(target_material: str):
     material_textures = get_material_textures(target_material)
-    return get_material_settings(material_textures)
+    target_keys = get_transferable_properties()
+    material_settings = maya_materials_conversion.get_material_attributes(target_material, target_keys)
+    material_info = {
+        'material_type': 'StingrayPBS',
+        'dcc_application': 'Maya',
+        'settings': material_settings,
+        'textures': material_textures
+    }
+    return material_info
 
 
 def get_material_textures(target_material: str):
@@ -49,13 +71,11 @@ def get_material_textures(target_material: str):
         if texture_path.suffix != 'dds':
             texture_key = get_texture_key(node, target_material)
             if texture_key:
-                material_textures_dict[texture_key] = {'node': node, 'path': texture_path}
-
+                material_textures_dict[texture_key] = {
+                    'node': node,
+                    'path': helpers.get_clean_path(texture_path.__str__())
+                }
     return material_textures_dict
-
-
-def get_material_settings(material_textures):
-    return material_textures
 
 
 def get_file_node(source_node):
@@ -65,7 +85,7 @@ def get_file_node(source_node):
 
 def get_texture_key(source_node, target_material):
     active_texture_slots = get_active_texture_slots(get_shader(target_material))
-    key = mc.listConnections(source_node, plugs=1, destination=1)[-1]
+    key = mc.listConnections(source_node, plugs=1, destination=1)[0]
     texture_slot_name = str(key).split('.')[-1]
     if texture_slot_name in active_texture_slots:
         texture_base_type = texture_slot_name.split('_')[1]
@@ -75,12 +95,10 @@ def get_texture_key(source_node, target_material):
 
 
 def get_shader(material_name):
-    """
-    Convenience function for obtaining the shader that the specified material (as an argument)
+    """! Convenience function for obtaining the shader that the specified material (as an argument)
     is attached to.
 
-    :param material_name: Takes the material name as an argument to get associated shader object
-    :return:
+    @param material_name Takes the material name as an argument to get associated shader object
     """
     connections = mc.listConnections(material_name, type='shadingEngine')[0]
     shader_name = '{}.surfaceShader'.format(connections)
@@ -92,8 +110,8 @@ def get_active_texture_slots(shader):
     """
     Helper function for checking which texture slots are enabled via 'use_<textureSlot>_map' attributes
 
-    :param shader: The target shader object to analyze
-    :return: Complete set (in the form of two dictionaries) of file connections and material attribute values
+    @param shader: The target shader object to analyze
+    @return Complete set (in the form of two dictionaries) of file connections and material attribute values
     """
     slot_list = [x[3:] for x in stingray_file_connections]
     active_slots = []
@@ -108,4 +126,78 @@ def get_active_texture_slots(shader):
             _LOGGER.error('MayaAttributeError: {}'.format(e))
 
     return active_slots
+
+
+def get_texture_type(plug_name):
+    texture_types = {
+        'TEX_ao_map': 'AmbientOcclusion',
+        'TEX_color_map': 'BaseColor',
+        'TEX_metallic_map': 'Metallic',
+        'TEX_normal_map': 'Normal',
+        'TEX_roughness_map': 'Roughness',
+        'TEX_emissive': 'Emissive'
+    }
+    plug = plug_name.split('.')[-1]
+    if plug in texture_types.keys():
+        return texture_types[plug]
+    return None
+
+
+def get_transferable_properties():
+    """! This is a listing of properties on an StingrayPBS material that can be directly transferred to an
+    O3DE material. When parsing the material attributes in Maya these values will be extracted and added to scene
+    material information. "*" Indicates a texture slot- if textures don't exist this likely can be controlled with
+    RGB values. This should probably be moved to a constants file once we work out how we are set everything up
+    """
+    target_properties = {
+
+        'TEX_color_map': 'baseColor.textureMap',        # Color Map
+        'use_color_map': 'baseColor.useTexture',        # Use Color Map
+        'base_color': 'baseColor.color',                # Base Color
+        'TEX_normal_map': 'normal.textureMap',          # Normal Map
+        'use_normal_map': 'normal.useTexture',          # Use Normal Map
+        'TEX_metallic_map': 'metallic.textureMap',      # Metallic Map
+        'use_metallic_map': 'metallic.useTexture',      # Use Metallic Map
+        'metallic': 'metallic.factor',                  # Metallic
+        'TEX_roughness_map': 'roughness.textureMap',    # Roughness Map
+        'use_roughness_map': 'roughness.useTexture',    # Use Roughness Map
+        'roughness': 'roughness.factor',                # Roughness
+        'TEX_emissive_map': 'emissive.textureMap',      # Emissive Map
+        'use_emissive_map': 'emissive.useTexture',      # Use Emissive Map
+        'emissive': 'emissive.color',                   # Emissive
+        'emissive_intensity': 'emissive.intensity',     # Emissive Intensity
+        'TEX_ao_map': 'occlusion.diffuseTextureMap',    # Ao Map
+        'use_ao_map': 'occlusion.diffuseUseTexture',    # Use Ao Map
+        'uv_offsetX': 'uv.offsetU',                     # UV Offset (first listing)
+        'uv_offsetY': 'uv.offsetV',                     # UV Offset (second listing)
+        'uv_scaleX': 'uv.scale'                         # Uv Scale (I'm just using scaleX value to control... O3DE
+                                                        # Has a single control, where Stingray has two)
+    }
+    return target_properties
+
+
+def set_stingray_materials(material_dict: dict):
+    for material_name, material_values in material_dict.items():
+        if 'textures' in material_values.keys():
+
+            sha, sg = get_material(material_name)
+            material_textures = material_values['textures']
+            material_assignments = material_values['assigned']
+            material_modifications = material_values['modifications']
+
+            _LOGGER.info('+++++++++++++++++++++++++++++')
+            _LOGGER.info('Converting material: {}'.format(material_name))
+            _LOGGER.info('Material Textures: {}'.format(material_textures))
+            _LOGGER.info('Material Assignments: {}'.format(material_assignments))
+
+            try:
+                set_material(material_name, sg, material_assignments)
+                set_textures(material_name, material_textures)
+                if material_modifications:
+                    _LOGGER.info('\n++++++++++++++\nMaterialMods: {}\n++++++++++++++'.format(material_modifications))
+            except Exception as e:
+                _LOGGER.info('Material Assignment failed: {}'.format(e))
+
+
+
 

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/dcc/maya/helpers/maya_materials_conversion.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/dcc/maya/helpers/maya_materials_conversion.py
@@ -1,0 +1,506 @@
+#!/usr/bin/python
+#
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
+#
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+"""! @brief This module contains several common material utilities/operations. """
+
+##
+# @file maya_materials_conversion.py
+#
+# @brief This module contains several common materials utilities/operations for use with Maya.
+#
+# @section Maya Utilities Description
+# Python module containing most of the commonly needed helper functions for working with Maya scenes in the DCCsi.
+# DCCsi (Digital Content Creation Scripting Interface)
+#
+# @section Maya Materials Notes
+# - Comments are Doxygen compatible
+
+
+import os
+import logging as _logging
+from pathlib import Path
+import maya.cmds as mc
+from azpy.dcc.maya.utils import pycharm_debugger
+from azpy.dcc.maya.helpers import convert_aiStandard_material as aiStandard
+from azpy.dcc.maya.helpers import convert_aiStandardSurface_material as aiStandardSurface
+from azpy.dcc.maya.helpers import convert_stingray_material as stingray
+
+
+_LOGGER = _logging.getLogger('azpy.dcc.maya.utils.maya_materials_conversion')
+
+
+# TODO - You need to provide for creating new files while Maya is already open
+# TODO - You could add this tool to the shelf and incorporate that as well
+
+supported_material_types = [
+    'StingrayPBS',
+    'aiStandardSurface',
+    'aiStandard'
+]
+
+# Activate FBX plugin
+if 'fbxmaya' not in mc.pluginInfo(query=True, listPlugins=True):
+    mc.loadPlugin("fbxmaya")
+
+
+def prepare_material_export(target_mesh, export_location):
+    mesh_materials = get_mesh_materials(target_mesh)
+    export_path = get_mesh_export_path(target_mesh, export_location) if export_location else ''
+    return export_path, mesh_materials
+
+
+def create_preview_files(target_files, database_values):
+    """! This function is run from the 'material_preview_builder' tool to build Maya preview files using fbx files,
+    recorded materials and attached texture files from legacy .mtl file information.
+
+    @param target_files List of fbx files to process
+    @param database_values Values extracted from legacy .mtl files that assist with material assignments
+    """
+    _LOGGER.info('Database values passed: {}'.format(database_values))
+    for file in target_files:
+        _LOGGER.info('Creating Maya preview file:::> {}'.format(file))
+        maya_file_path = get_maya_file_path(file)
+        mc.file(new=True, force=True)
+        mc.file(file, i=True, type="FBX")
+        set_scene_attributes()
+        set_stingray_materials(database_values)
+        mc.file(rename=maya_file_path)
+        mc.file(save=True, type='mayaAscii', force=True)
+
+
+def process_single_file(action: str, target_file: Path, data: list):
+    """! Provides mechanism for compound material actions to be performed in a scene.
+
+    @param action: Description of the task that needs to be performed
+    @param target_file: Target file to perform actions to
+    @param data: Information needed to perform the specified action
+    """
+    if action == 'stingray_texture_assignment':
+        mc.file(target_file, o=True, force=True)
+        material_info = get_scene_material_information()
+
+        for material in data['materials']:
+            try:
+                if material in material_info.keys():
+                    pass
+            except Exception as e:
+                _LOGGER.info('Material conversion failed [{}]-- Error: {}'.format(material, e))
+
+
+def refresh_stingray_attributes():
+    """! This function is called to initialize/import the Stingray material support that does not initialize
+    by default, but is needed to programmatically assign stingray materials.
+
+    @return Boolean Success of refresh attempt
+    """
+    scene_geo = mc.ls(v=True, geometry=True)
+
+    for target_mesh in scene_geo:
+        shading_groups = list(set(mc.listConnections(target_mesh, type='shadingEngine')))
+        for sg in shading_groups:
+            materials = mc.ls(mc.listConnections(sg), materials=True)
+            for material in materials:
+                material_name = str(material)
+                material_attributes = {}
+
+                # Get shader attributes
+                for material_attribute in mc.listAttr(material_name, s=True, iu=True):
+                    try:
+                        target_value = mc.getAttr('{}.{}'.format(material_name, material_attribute))
+                        material_attributes[material_attribute] = target_value
+                    except Exception:
+                        pass
+
+                for attr_name, attr_value in material_attributes.items():
+                    if attr_name == 'use_color_map':
+                        return True
+    return False
+
+
+def open_target_scene(scene_path):
+    if scene_path != get_current_scene():
+        _LOGGER.info('Scenes dont match- need to open new scene')
+    else:
+        _LOGGER.info('Same scene. Skipping...')
+        return scene_path
+
+
+def run_operation(process_dictionary, operation, output):
+    _LOGGER.info(f'\n\n:::::::::::::::::::\nRun operation fired\n:::::::::::::::::::\n\nOperation Type: {operation}\n')
+    if operation == 'convert':
+        _LOGGER.info('* Set up conversion here *')
+
+
+def get_object_hierarchy(target_object):
+    object_hierarchy = [[get_object_type(target_object), target_object]]
+    while True:
+        parent = mc.listRelatives(target_object, allParents=True)
+        if parent:
+            parent_type = get_object_type(parent[0])
+            if parent_type in ['mesh', 'locator']:
+                object_hierarchy.append([parent_type, parent[0]])
+                target_object = parent[0]
+            else:
+                return object_hierarchy
+        else:
+            return object_hierarchy
+
+
+def get_object_type(target_object):
+    mc.select(target_object, hi=True)
+    current_shape = mc.ls(sl=True, shapes=True)[0]
+    return mc.objectType(current_shape)
+
+
+def get_materials_in_scene():
+    """! Audits scene to gather all materials present in the Hypershade.
+
+    @return list
+    """
+    material_list = []
+    for shading_engine in mc.ls(type='shadingEngine'):
+        if mc.sets(shading_engine, q=True):
+            for material in mc.ls(mc.listConnections(shading_engine), materials=True):
+                material_list.append(material)
+    return material_list
+
+
+def get_material_assignments():
+    """! Gathers all materials in a scene and which mesh they are assigned to.
+
+    @return dict - material keys and assigned mesh values
+    """
+    assignments = {}
+    scene_geo = mc.ls(v=True, geometry=True)
+    for mesh in scene_geo:
+        mesh_materials = get_mesh_materials(mesh)
+        for material in mesh_materials:
+            if material not in assignments.keys():
+                assignments[material] = [mesh]
+            else:
+                assignments[material].append(mesh)
+    return assignments
+
+
+def get_materials(selected_object):
+    shader = mc.listConnections(selected_object, type='shadingEngine')
+    materials = mc.ls(mc.listConnections(shader), materials=True)
+    return materials
+
+
+def get_material_type(target_material):
+    return mc.nodeType(target_material)
+
+
+def get_material_attributes(target_material: str, target_keys: list):
+    attribute_dictionary = {}
+    attributes = mc.listAttr(target_material)
+    for target_key in attributes:
+        if target_key in target_keys:
+            try:
+                target_value = mc.getAttr(target_material + '.' + target_key)
+                attribute_dictionary[target_key] = target_value
+            except RuntimeError as e:
+                _LOGGER.info(f'GetMaterialAttributes error: {e}')
+    return attribute_dictionary
+
+
+def get_current_scene():
+    current_scene = mc.file(q=True, sceneName=True)
+    return Path(current_scene)
+
+
+def get_scene_material_information():
+    """! Gathers several points of information about materials in current Maya scene.
+
+    @return dict - Material Info: Material Name, Shading Group, Material Type, Textures, Assignments
+    """
+    material_information = {}
+    scene_materials = get_materials_in_scene()
+    material_assignments = get_material_assignments()
+    for material_name in scene_materials:
+        material_listing = {
+            'shading_group': get_shading_group(material_name),
+            'material_type': mc.nodeType(material_name),
+            'assigned_geo': material_assignments[material_name],
+            'material_textures': get_material_textures(mc.nodeType(material_name), {'shading_group':
+                                                                                    get_shading_group(material_name),
+                                                                                    'name': material_name})
+        }
+        material_information[material_name] = material_listing
+    return material_information
+
+
+def get_shading_group(material_name):
+    """! Convenience function for obtaining the shader that the specified material (as an argument) is attached to.
+
+    @param material_name Takes the material name as an argument to get associated shader object
+    @return Maya Shading group
+    """
+    return mc.listConnections(material_name, type='shadingEngine')[0]
+
+
+def get_mesh_export_path(target_mesh, export_location):
+    if os.path.isdir(export_location):
+        return Path(export_location) / target_mesh / f'{target_mesh}.fbx'
+    return ''
+
+
+def get_mesh_materials(target_mesh):
+    """! Gathers single materials attached to mesh passed as argument. This will not return additional materials
+    attached to parented objects
+
+    @param target_mesh The target mesh to pull attached material information from.
+    @return list - Attached material name.
+    """
+    material_list = []
+    mc.select(target_mesh, r=True)
+    children = mc.listRelatives(ad=1)
+    for child in children:
+        shader_groups = mc.listConnections(mc.listHistory(child))
+        if shader_groups is not None:
+            for material in mc.ls(mc.listConnections(shader_groups), materials=1):
+                material_list.append(material)
+    return list(set(material_list))
+
+
+def get_all_mesh_materials(target_mesh):
+    """! Gathers a list of all materials attached to each mesh's shader.
+
+    @param target_mesh The target mesh to pull attached material information from.
+    @return list - Unique material values attached to the mesh passed as an argument.
+    """
+    mc.select(target_mesh, r=True)
+    target_nodes = mc.ls(sl=True, dag=True, s=True)
+    shading_group = mc.listConnections(target_nodes, type='shadingEngine')
+    materials = mc.ls(mc.listConnections(shading_group), materials=1)
+    return list(set(materials))
+
+
+def get_maya_file_path(fbx_file_path):
+    """! Convenience function for creating a maya file path based on an existing FBX path.
+    @param fbx_file_path Path to the existing FBX file
+    @return str - File path
+    """
+    return os.path.splitext(fbx_file_path)[0] + '.ma'
+
+
+def get_material(material_name: str) -> list:
+    """! Gets material assignments and swaps legacy formatted materials with Stingray PBS materials. This will delete
+    non-Stingray materials and replace with Stingray. Currently Stingray material attributes can only be queried
+    and/or altered if user manually initiates them in an open Maya system first. Bug has been filed with Autodesk.
+
+    @param material_name Target material name
+    @return list - Material, Shading Group
+    """
+    _LOGGER.info('Shaders in scene: {}'.format(get_materials_in_scene()))
+    sha = None
+    sg = None
+    if material_name in get_materials_in_scene():
+        mc.delete(material_name)
+
+    try:
+        sha = mc.shadingNode('StingrayPBS', asShader=True, name=material_name)
+        sg = mc.sets(renderable=True, noSurfaceShader=True, empty=True)
+        mc.connectAttr(sha + '.outColor', sg + '.surfaceShader', force=True)
+        enable_stingray_textures(material_name)
+    except Exception as e:
+        _LOGGER.info('Shader creation failed: {}'.format(e))
+    return [sha, sg]
+
+
+def get_new_material(material_type: str, material_name: str, assignment_list: list):
+    _LOGGER.info(f'Getting new material[{material_name}] of type: {material_type}  ApplyTo: {assignment_list}')
+
+
+def get_material_info(target_material: str):
+    mc.select(target_material, r=True)
+    material_type = get_material_type(mc.ls(sl=True, long=True) or [])
+    if material_type == 'aiStandardSurface':
+        return aiStandardSurface.get_material_info(target_material)
+    elif material_type == 'aiStandard':
+        return aiStandard.get_material_info(target_material)
+    elif material_type == 'StingrayPBS':
+        return stingray.get_material_info(target_material)
+
+
+def get_default_material_settings(material_type):
+    """! This is important for helping to detect user changes to the default material attributes. It compares a
+    new instance of the target material type and generates a dictionary of default values to compare with the
+    target material being read/parsed in the system.
+    """
+    # TODO - combine this with get_material above
+    default_settings = None
+    if material_type in mc.listNodeTypes('shader'):
+        try:
+            mc.sphere(n='templateSphere')
+            sg = set_new_material(material_type, 'templateShader', ['templateSphere'])
+            default_settings = get_material_info('templateShader')
+            mc.delete('templateSphere', 'templateShader', sg)
+        except KeyError:
+            _LOGGER.info(f'KeyError... Unable to retrieve default material settings.')
+    return default_settings
+
+
+def get_scene_objects():
+    mesh_objects = mc.ls(type='mesh')
+    return mesh_objects
+
+
+def get_selected_objects():
+    """! Filters selection to just meshes in the event that other items exist in the current selection."""
+    return mc.filterExpand(sm=12)
+
+
+def get_object_by_name(target_object):
+    try:
+        mc.select(target_object)
+        object_exists = True
+    except ValueError:
+        object_exists = False
+    return object_exists
+
+
+def get_object_position(target_object):
+    object_position = []
+    for item in ['translateX', 'translateY', 'translateZ']:
+        object_position.append(mc.getAttr(f'{target_object}.{item}'))
+    return object_position
+
+
+def get_transferable_properties(material_type):
+    if material_type == 'aiStandardSurface':
+        return aiStandardSurface.get_transferable_properties()
+    elif material_type == 'aiStandard':
+        return aiStandard.get_transferable_properties()
+    elif material_type == 'StingrayPBS':
+        return stingray.get_transferable_properties()
+
+
+def set_new_material(material_type: str, material_name: str, mesh_assignment: list):
+    # Create material if it doesn't already exist
+    sg = None
+    try:
+        if not mc.objExists(material_name):
+            sha = mc.shadingNode(material_type, asShader=True, name=material_name)
+            sg = mc.sets(renderable=True, noSurfaceShader=True, empty=True)
+            mc.connectAttr(sha + '.outColor', sg + '.surfaceShader', force=True)
+
+        for mesh_target in mesh_assignment:
+            try:
+                mc.select(mesh_target, replace=True)
+                mc.hyperShade(assign=material_name)
+            except Exception as e:
+                _LOGGER.info(f'SetNewMaterialError [type(e)]: {e}')
+    except Exception as e:
+        _LOGGER.info(f'Set Material failed [{type(e)}]: {e}')
+    return sg
+
+
+def set_selected_objects(objects_list):
+    for element in objects_list:
+        mc.select(element, add=True)
+
+
+def set_scene_attributes():
+    """! Preps Maya scene for Stingray Materials preview. """
+    set_camera_attributes()
+    mc.currentUnit(linear='meter')
+    mc.grid(reset=True)
+
+
+def set_camera_attributes():
+    """! Corrects Near/Far Clip planes so visual display of objects aren't clipped if user scene units were set to
+    Maya default of centimeters. """
+    camera_list = mc.ls(type='camera')
+    attributes = {'nearClipPlane': 0.01, 'farClipPlane': 1000000}
+    for c in camera_list:
+        for attrName in attributes.keys():
+            mc.setAttr('{}.{}'.format(c, attrName), attributes[attrName])
+
+
+def set_material(material_name: str, shading_group: str, assignment_list: list):
+    """! Assigns specified material to specified mesh
+
+    @param material_name Material name
+    @param shading_group Shading Group
+    @param assignment_list List of geometry to assign shader to
+    """
+    assignment_list = list(set([x.replace('.', '|') for x in assignment_list]))
+    _LOGGER.info('\n_\nSET MATERIAL: {} {{{{{{{{{{{{{{{{{{{{{{'.format(material_name))
+    _LOGGER.info('Assignment list--> {}'.format(assignment_list))
+    for item in assignment_list:
+        try:
+            mc.sets(item, e=True, forceElement=shading_group)
+        except Exception as e:
+            _LOGGER.info('Material assignment failed: {}'.format(e))
+            pass
+
+
+def set_textures(material_name: str, texture_dict: dict):
+    """
+    Plugs texture files into texture slots in the shader for specified material name. Currently due to the
+    aforementioned bug this functionality does not work as intended, but it remains for when Autodesk supplies a fix
+    :param material_name:
+    :param texture_list:
+    :return:
+    """
+    shader_translation_keys = {
+        'BaseColor': 'color',
+        'Roughness': 'roughness',
+        'Metallic': 'metallic',
+        'Emissive': 'emissive',
+        'Normal': 'normal'
+    }
+
+    _LOGGER.info('\n_\nSET_TEXTURE_MAPS {{{{{{{{{{{{{{{{{{{{{{')
+    _LOGGER.info('Material--> {}'.format(material_name))
+    for texture_type, texture_path in texture_dict.items():
+        try:
+            file_count = len(mc.ls(type='file')) + 1
+            texture_file = 'file{}'.format(file_count)
+            mc.shadingNode('file', asTexture=True, name=texture_file)
+            mc.setAttr('{}.fileTextureName'.format(texture_file), texture_path, type="string")
+            mc.setAttr('{}.use_{}_map'.format(material_name, shader_translation_keys[texture_type]), 1)
+            mc.connectAttr('{}.outColor'.format(texture_file),
+                           '{}.TEX_{}_map'.format(material_name, shader_translation_keys[texture_type]), force=True)
+
+            _LOGGER.info('Texture type: {}   Texture path: {}'.format(texture_type, texture_path))
+            _LOGGER.info('TexturePath: {}'.format(texture_path))
+            _LOGGER.info('Attributes: {}'.format(mc.listAttr(material_name)))
+
+        except Exception as e:
+            _LOGGER.info('Conversion failed: {}'.format(e))
+
+
+def export_mesh(target_object, mesh_export_location, export_options):
+    _LOGGER.info(f'Export Mesh firing[{target_object}]: {mesh_export_location}')
+    object_position = get_object_position(target_object)
+    try:
+        if 'Preserve Transform Values' not in export_options:
+            mc.move(0, 0, 0, target_object, absolute=True)
+        mc.select(target_object, replace=True)
+        mc.file(str(mesh_export_location), force=True, type='FBX export', exportSelected=True)
+        mc.move(object_position[0], object_position[1], object_position[2], target_object, absolute=True)
+        return True
+    except Exception as e:
+        _LOGGER.info(f'ExportMesh failed [type(e)]: {e}')
+
+
+def export_grouped_meshes(mesh_list, mesh_export_location, export_options):
+    for mesh in mesh_list:
+        mc.select(mesh, add=True)
+    mc.file(str(mesh_export_location), force=True, type='FBX export', exportSelected=True)
+
+
+def cleanup(target_objects):
+    mc.select(target_objects, replace=True)

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/o3de/renderer/materials/material_utilities.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/o3de/renderer/materials/material_utilities.py
@@ -1,117 +1,197 @@
-# coding:utf-8
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# !/usr/bin/python
 #
-# Copyright (c) Contributors to the Open 3D Engine Project.
-# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
 #
-# SPDX-License-Identifier: Apache-2.0 OR MIT
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #
-#
-# -------------------------------------------------------------------------
-import os
-from pathlib import Path
-from box import Box
-import logging as _logging
-import azpy.config_utils
-from azpy.dcc.maya.helpers import maya_materials
-from azpy.dcc.blender.helpers import blender_materials
+
+"""! @brief Description here..."""
+
 from azpy.o3de.utils import o3de_utilities as o3de_helpers
+from azpy.o3de.renderer.materials import o3de_material_generator as exporter
 from azpy.constants import FRMT_LOG_LONG
 from SDK.Python import general_utilities as helpers
+import azpy.config_utils
+from PySide2 import QtWidgets
+from pathlib import Path
+import importlib
+from box import Box
+import logging as _logging
 import click
+import json
+import os
 
-"""
 
-convert_material.py
-
-Location:
-azpy/o3de/renderer/materials/
-
-Main functions:
-- Get all properties material info
-- Validate material
-- read atom material
-- write atom material
-- convert legacy material
-- convert spec/gloss to metal/rough
-
-"""
-
-_LOGGER = _logging.getLogger('azpy.dcc.maya.utils.maya_materials')
-
-dcc_controller = {
-    'Maya': maya_materials,
-    'Blender': blender_materials
-}
+_LOGGER = _logging.getLogger('azpy.o3de.renderer.materials.material_utilities')
 
 
 def run_cli():
     _LOGGER.info('Material Conversion called in CLI Mode')
 
 
-def process_materials(dcc_app: str, operation: str, scope: str, source=None, output=None):
+def process_materials(dcc_app: str, operation: str, scope: str, options: list, output_path=None, source=None) -> dict:
     """
     Entry point of the material operations process.
-    :param dcc_app: Source application where conversion files were created
-    :param operation: Specifies operation to perform - 'query', 'validate', 'modify', 'convert'
-    :param scope: What gets converted- 'selected', 'by_name', 'scene', 'directory'
-    :param source: Provides a slot for passing source value for "by_name", "scene" and directory scope
-    :param output: Specifies location of output (if applicable)
-    :return:
+
+    @param dcc_app Source application where conversion files were created
+    @param operation Specifies operation to perform - 'query', 'validate', 'modify', 'convert'
+    @param scope What gets converted- 'selected', 'by_name', 'scene', 'directory'
+    @param options Export options for object export activated in UI
+    @param output_path Specifies location of output (if applicable)
+    @param source Provides a slot for passing file location when handling directory and/or scene requests outside of
+    the currently open file
+    @return process_dictionary Data collected in the conversion
     """
-    controller = dcc_controller[dcc_app]
+    # Gather material information
+    controller = get_dcc_controller(dcc_app)
+    process_dictionary = {}
     if scope == 'selected' or scope == 'by_name':
-        material_info = process_object_materials(controller, operation, source, output)
+        process_dictionary = process_object_materials(controller, operation, output_path, source)
     elif scope == 'scene':
-        material_info = process_scene_materials(controller, operation, source, output)
+        if get_source_type(source[0]) == 'file':
+            process_dictionary = process_scene_materials(controller, operation, output_path, source)
     elif scope == 'directory':
-        pass
-    _LOGGER.info(f'\nProcessMaterialsFired:\nResults: {material_info}')
+        if get_source_type(source[0]) == 'directory':
+            process_dictionary = process_directory_materials(controller, operation, output_path, source)
+
+    # Export Material
+    if operation == 'convert':
+        master_paths = get_master_paths(process_dictionary)
+        exporter.export_standard_pbr_materials(process_dictionary, output_path, options, master_paths)
+    return process_dictionary
 
 
-def process_object_materials(controller, operation, source, output):
-    source_file = controller.get_current_scene()
-    process_dictionary = {source_file: {}}
+def process_object_materials(controller, operation, output_path, source):
+    source_file = helpers.get_clean_path(controller.get_current_scene().__str__())
+    process_dictionary = Box({source_file: {}})
     target_objects = source if source else controller.get_selected_objects()
-
     for target_object in target_objects:
-        temp_dict = {}
-        target_object = target_object[1:] if target_object.startswith('|') else target_object
-        target_materials = controller.get_mesh_materials(target_object)
-        for target_material in target_materials:
-            temp_dict[target_material] = controller.get_material_info(target_material)
-        process_dictionary[source_file].update({target_object: temp_dict})
-    controller.run_operation(process_dictionary, operation, output)
+        try:
+            _LOGGER.info(f'TargetObject: {target_object}')
+            temp_dict = {}
+            target_object = target_object[1:] if target_object.startswith('|') else target_object
+            object_export_path, object_materials = controller.prepare_material_export(target_object, output_path)
+            _LOGGER.info(f'ExportPath: {object_export_path}  Materials: {object_materials}')
+            for target_material in object_materials:
+                temp_dict[target_material] = controller.get_material_info(target_material)
+                temp_dict[target_material].update({'mesh_export_location': object_export_path})
+                temp_dict[target_material].update({'parent_hierarchy': controller.get_object_hierarchy(target_object)})
+            process_dictionary[source_file].update({target_object: temp_dict})
+            _LOGGER.info(f'TempDict: {temp_dict}')
+        except Exception as e:
+            _LOGGER.info(f'ProcessObjectMaterials Fail [{type(e)}]: {e}')
+
+    _LOGGER.info(f'ProcessDictionary: {process_dictionary}')
+    # controller.run_operation(process_dictionary, operation, output)
     controller.cleanup(target_objects)
 
     return process_dictionary if process_dictionary else []
 
 
-def process_scene_materials(controller, operation, source, output):
-    if source and controller.get_current_scene() != source:
-        # TODO - Open a dialog saying the operation will close current scene- give option to cancel
-        pass
-    scene_objects = controller.get_scene_objects()
-    process_dictionary = process_object_materials(controller, operation, scene_objects, output)
+def process_scene_materials(controller, operation, output_path, source):
+    if source:
+        _LOGGER.info('::::::: You will have to launch standalone instance here')
+    else:
+        source = controller.get_scene_objects()
+    process_dictionary = process_object_materials(controller, operation, output_path, source)
     return process_dictionary
 
 
-def process_directory_materials(controller, operation, source, output):
-    pass
+def process_directory_materials(controller, operation, output_path, source):
+    process_dictionary = None
+    return process_dictionary
 
 
-def get_o3de_material_properties(material_type: str) -> Box:
+def get_source_type(source):
+    if source:
+        if Path(source[0]).is_file():
+            return 'file'
+        elif Path(source[0]).is_dir():
+            return 'directory'
+        else:
+            return 'object'
+
+
+def get_master_paths(process_dictionary):
+    """! This collects all paths being used for texture assignments in a conversion. With this information, when
+    copying assets across to the destination folder, the system will filter duplicate copies to save on disk space,
+     also re-pathing all subsequent instances in other materials to this single asset."""
+    master_paths = {}
+    for scene_file, scene_values in process_dictionary.items():
+        for object_name, material_values in scene_values.items():
+            for material_name, material_attributes in material_values.items():
+                for texture_key, texture_values in material_attributes['textures'].items():
+                    if texture_values:
+                        if 'path' in texture_values.keys():
+                            target_path = texture_values['path']
+                            if target_path not in master_paths.keys():
+                                master_paths.update({target_path: {'source': scene_file, 'object': object_name}})
+    return master_paths
+
+
+def get_dcc_controller(target_application: str) -> str:
+    """! Because we don't ever know which Python distribution we will be using until a command is fired, this function
+    uses importlib to dynamically import needed modules, and will help us to avoid failed imports and errors.
+
+    @param target_application Which DCC application you want to extract materials from
     """
-    Get the autogenerated "all properties" template file for given material type for cross reference with DCC materials/
-    plugging material values into a new O3DE material (.material) definition
-    :param material_type: Destination material type for O3DE material output
-    :return:
+    target = None
+    if target_application == 'Maya':
+        target = 'azpy.dcc.maya.helpers.maya_materials_conversion'
+    elif target_application == 'Blender':
+        target = 'azpy.dcc.blender.helpers.blender_materials_conversion'
+    return importlib.import_module(target) if target else None
+
+
+def get_transferable_properties(target_application: str, material_type) -> dict:
+    controller = get_dcc_controller(target_application)
+    return controller.get_transferable_properties(material_type)
+
+
+def get_material_templates_location():
+    registry_bootstrap_file = Path(os.environ['USERPROFILE']) / '.o3de/Registry/bootstrap.setreg'
+    try:
+        with open(str(registry_bootstrap_file), 'r') as data:
+            contents = json.loads(data.read())
+            current_project_path = contents['Amazon']['AzCore']['Bootstrap']['project_path']
+            _LOGGER.info(Path(current_project_path) / 'Cache/pc/materials/types')
+            return Path(current_project_path) / 'Cache/pc/materials/types'
+    except FileNotFoundError:
+        return None
+
+
+def get_all_properties_description(material_type: str):
+    """! There are several available all properties material templates. They include: basepbr, enhancedpbr, eye,
+    skin, standardmultilayerpbr, and standardpbr. One of these should be passed as the "material_type" class
+    argument in order to retrieve the full listing of available values and begin mapping process.
     """
-    pass
+    description_location = get_material_templates_location()
+    if description_location:
+        for file in [x for x in description_location.glob('**/*') if x.is_file()]:
+            if file.name == f'{material_type.lower()}_allproperties.material':
+                with open(str(file), 'r') as data:
+                    return json.loads(data.read())
+    return None
+
+
+def get_default_material_settings(target_application: str, material_type):
+    controller = get_dcc_controller(target_application)
+    return controller.get_default_material_settings(material_type)
+
+
+def export_mesh(dcc_application, target, mesh_export_location, export_options):
+    controller = get_dcc_controller(dcc_application)
+    if isinstance(target, list):
+        controller.export_grouped_meshes(target, mesh_export_location, export_options)
+    else:
+        controller.export_mesh(target, mesh_export_location, export_options)
 
 
 if __name__ == '__main__':
     run_cli()
-
-
-

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/o3de/renderer/materials/o3de_material_generator.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/o3de/renderer/materials/o3de_material_generator.py
@@ -1,0 +1,390 @@
+# -*- coding: utf-8 -*-
+# !/usr/bin/python
+#
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
+#
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+"""! @brief Description here..."""
+from azpy.o3de.renderer.materials import material_utilities
+from SDK.Python import general_utilities as helpers
+import logging as _logging
+from pathlib import Path
+from box import Box
+import shutil
+import json
+import os
+
+
+_LOGGER = _logging.getLogger('azpy.o3de.renderer.materials.o3de_material_generator')
+
+
+class MaterialGenerator:
+    debug_mode = True
+
+    def __init__(self, input, output, mesh, attributes, base_path, options, master_paths):
+        self.input_material = input
+        self.output_material = output
+        self.mesh_name = mesh
+        self.material_attributes = attributes
+        self.output_base_path = base_path
+        self.export_options = options
+        self.master_paths = master_paths
+        self.asset_directory = None
+        self.textures_directory = None
+        self.dcc_application = None
+        self.dcc_material_name = None
+        self.dcc_material_settings = None
+        self.default_dcc_material_settings = None
+        self.texture_list = None
+        self.mesh_export_location = None
+        self.material_name = None
+        self.parent_hierarchy = None
+        self.material_properties_dict = material_utilities.get_all_properties_description(output)
+        self.material_definition = Box({})
+        self.parse_material_attributes()
+        self.transferable_properties = self.get_transferable_properties()
+
+    def generate_material(self):
+        """! This is the main entry point that is called in order to process a material. Currently, this is
+        only called as an override, based on DCC caller.
+        """
+        pass
+
+    def parse_material_attributes(self):
+        """! This organizes material attributes into a number of separate class attributes to make accessing the
+        respective information a little more easily.
+        """
+        for material_key, material_values in self.material_attributes.items():
+            self.dcc_material_name = material_key
+            _LOGGER.info('::: MaterialAttributes ::::::::::::::::::::::')
+            for k, v in material_values.items():
+                _LOGGER.info(f'=> Key: {k}  Values: {v}')
+                if k == 'dcc_application':
+                    self.dcc_application = v
+                    self.get_default_material_settings()
+                elif k == 'textures':
+                    self.texture_list = v
+                elif k == 'mesh_export_location':
+                    self.mesh_export_location = v
+                elif k == 'settings':
+                    self.dcc_material_settings = v
+                elif k == 'parent_hierarchy':
+                    self.parent_hierarchy = v
+        self.set_export_directory()
+
+    ###################
+    # Getters/Setters #
+    ###################
+
+    def get_transferable_properties(self):
+        """! Gets key/value pairs for the intended material type definition that are mappable across to O3DE
+        material values
+        """
+        if self.dcc_application:
+            return material_utilities.get_transferable_properties(self.dcc_application, self.input_material)
+        return None
+
+    def get_default_material_settings(self):
+        """! This gathers the default material settings for the assigned DCC material. The system compares these
+        values with the found material attribute values- a change in values indicates that the attribute should be
+        mapped across to the O3DE material definition if applicable
+        """
+        self.default_dcc_material_settings = material_utilities.get_default_material_settings(self.dcc_application,
+                                                                                              self.input_material)
+
+    def get_property_values(self, property_values):
+        """! Maps found properties in DCC materials to corresponding values in an O3DE material
+
+        @property_values All the material attributes gathered from the DCC package that could possibly be transferred
+        to the new O3DE material definition... applied textures as well as procedural settings
+        """
+        properties_dictionary = {}
+        _LOGGER.info(f'\n\n>>>>> PROPERTY VALUES: {property_values}')
+        for material_property, property_value in property_values.items():
+            _LOGGER.info(f'MaterialProperty: {material_property}   PropertyValue: {property_value}')
+            for key, value in self.transferable_properties.items():
+                if value == material_property:
+                    property_components = material_property.split('.')
+                    # Handle Textures ------------------------>>
+                    if property_components[1] == 'textureMap':
+                        key_match = self.get_matching_key([key, property_components[0]], self.texture_list)
+                        if key_match:
+                            try:
+                                target_path = self.texture_list[key_match]['path']
+                                _LOGGER.info(f'\n\n++++++++++++++ MaterialProperty: {material_property}')
+                                _LOGGER.info(f'--> {key_match} -- {target_path}')
+                                properties_dictionary[material_property] = target_path
+                            except TypeError:
+                                pass
+                            except KeyError:
+                                pass
+                    else:
+                        # Handle Procedural Settings --------->>
+                        # Please note- this section is meant to catch changes to default shader values. If a change
+                        # is found to the values, an attempt to carry over the value to a transferable O3DE material
+                        # property will be made. After much troubleshooting, I believe that the Stingray material
+                        # creation bug I found for creating new StingrayPBS materials in Standalone mode is also
+                        # present in IDE-driven Maya sessions. If you create an instance of this material
+                        # programmatically several key attributes needed to assign texture maps as well as procedural
+                        # settings are missing in the attributes. This passage should work for all other material types,
+                        # but will currently not work on StingrayPBS
+                        try:
+                            key_match = self.get_matching_key([key, property_components[0]],
+                                                              self.default_dcc_material_settings['settings'])
+                            target_value = self.get_default_value(key_match)
+                            if target_value != 'default':
+                                properties_dictionary[material_property] = target_value
+                        except KeyError:
+                            pass
+
+        # The line below formats material definitions for materialTypeVersion "4"... I am seeing 5 now, which does not
+        # need this reformatting of the dictionary that is created above. Check to see if this is a permanent change
+        # properties_dictionary = self.set_properties_formatting(properties_dictionary)
+        _LOGGER.info(f'++++++++ PropertiesDictionary: {properties_dictionary}')
+        return properties_dictionary
+
+    def get_default_value(self, key):
+        """! Cross-references default material attribute values with target scene materials of the same kind. If the
+        setting is different, it returns the value present and otherwise returns "default". Default values indicate
+        that the target property does not need to be translated to the O3DE material
+        """
+        if self.default_dcc_material_settings['settings'][key] != self.dcc_material_settings[key]:
+            return self.dcc_material_settings[key]
+        return 'default'
+
+    def get_material_name(self):
+        """! Format the material output name to conform to O3DE naming convention- the name of the fbx name and the
+        applied material name, separated by an underscore
+        """
+        # parent_directory = self.get_parent_directory()
+        object_name = self.parent_hierarchy[-1][1]
+        return f'{object_name}_{self.dcc_material_name}.material'
+
+    def get_material_output_path(self):
+        parent_directory = self.get_parent_directory()
+        return parent_directory / self.get_material_name()
+
+    def get_relative_path(self, asset_path):
+        """! O3DE material definitions use relative paths in the definitions- this will truncate paths so that the
+        asset processor finds assets based on this relative path requirement. Target index value will be offset by
+        one directory, depending on whether output is being sent to a O3DE Gem directory structure or not
+        """
+        path_list = Path(asset_path).parts
+        base_path_key = 'Assets' if 'Assets' in path_list else Path(self.output_base_path).name
+        for index, part in enumerate(path_list):
+            if part == base_path_key:
+                target_index = index + 1 if base_path_key == 'Assets' else index
+                return '/'.join(path_list[target_index:])
+
+    @staticmethod
+    def get_matching_key(search_list_items, target_dictionary):
+        """! Texture attributes generally have the same names for types, but not always. This adds a little additional
+        flexibility for finding the property texture key for DCC material values
+
+        @search_list_items
+        """
+        for element in target_dictionary.keys():
+            for key in search_list_items:
+                if key == element:
+                    return key
+        return False
+
+    def get_parent_directory(self):
+        for member in reversed(self.parent_hierarchy):
+            object_type = member[0]
+            object_name = member[1]
+            if 'Preserve Grouped Objects' in self.export_options:
+                return Path(self.output_base_path) / object_name
+            else:
+                if object_type != 'locator':
+                    return Path(self.output_base_path) / object_name
+
+    def set_export_directory(self):
+        """! The export directory location is offset from the base directory specified when running the export
+        materials tool. This formatting helps for organizing assets to be ready for use in the engine.
+
+        @object_name Each exported object from a DCC package will be contained in an asset directory matching the
+        object's name in the scene
+        """
+        self.textures_directory = self.get_parent_directory() / 'textures'
+        os.makedirs(os.path.dirname(str(self.textures_directory)), exist_ok=True)
+
+    @staticmethod
+    def set_properties_formatting(properties_dictionary):
+        formatted_dictionary = Box({})
+        for key, value in properties_dictionary.items():
+            attribute_parts = key.split('.')
+            if attribute_parts[0] not in formatted_dictionary.keys():
+                formatted_dictionary[attribute_parts[0]] = {attribute_parts[-1]: value}
+            else:
+                formatted_dictionary[attribute_parts[0]].update({attribute_parts[-1]: value})
+        return formatted_dictionary.to_dict()
+
+    ##########
+    # Export #
+    ##########
+
+    def export_json(self):
+        """! This is a convenience function for debugging. Both an "all properties" and "dcc material data" json file
+        will be output to the user desktop when debug mode class property is enabled.
+
+        """
+        # Material data from DCC package --------->>
+        results_data = Path(os.environ['USERPROFILE']) / 'Desktop/dcc_material_data.json'
+        helpers.set_json_data(results_data, self.material_attributes)
+        # "All properties" data for target material type ---------->>
+        all_properties_data = Path(os.environ['USERPROFILE']) / 'Desktop/all_properties_data.json'
+        helpers.set_json_data(all_properties_data, self.material_properties_dict)
+
+    def export_mesh(self):
+        if 'Preserve Grouped Objects' not in self.export_options:
+            material_utilities.export_mesh(self.dcc_application, self.mesh_name, self.mesh_export_location,
+                                           self.export_options)
+
+    def export_textures(self):
+        for texture_type, texture_info in self.texture_list.items():
+            if texture_info:
+                if texture_info.get('path'):
+                    src = Path(texture_info['path'])
+                    t = str(src).replace('\\', '/')
+                    dst = self.get_parent_directory() / 'textures' / src.name
+                    os.makedirs(os.path.dirname(str(dst)), exist_ok=True)
+
+                    if not dst.is_file():
+                        shutil.copy(str(src), str(dst))
+                    self.texture_list[texture_type]['path'] = self.get_relative_path(str(dst))
+        _LOGGER.info(f'TextureList: {self.texture_list}')
+
+    def export_material(self):
+        """! Takes constructed 'material_definition' dictionary with information gathered in the process and saves with
+        JSON formatting into a .material file
+        """
+        # if self.debug_mode:
+        #     self.export_json()
+
+        material_output_path = self.get_material_output_path()
+        _LOGGER.info(f'ExportingMaterial..... {material_output_path}')
+        helpers.set_json_data(material_output_path, self.material_definition)
+
+
+# ++++++++++++++++-------------------------------------------------->>
+# MAYA EXTENSION +------------------------------------------------------>>
+# ++++++++++++++++-------------------------------------------------->>
+
+class MayaMaterialGenerator(MaterialGenerator):
+    def __init__(self, input, output, mesh, attributes, base_path, options, master_paths):
+        super().__init__(input, output, mesh, attributes, base_path, options, master_paths)
+
+        _LOGGER.info('\n\n+++++++++++++++++++++++++++++++++++++\nMayaMaterialGenerator instance created\n'
+                     '+++++++++++++++++++++++++++++++++++++\n\n')
+
+    def generate_material(self):
+        self.export_mesh()
+        self.export_textures()
+        self.material_name = self.get_material_name()
+        _LOGGER.info(f'MaterialName: {self.material_name}')
+
+        for key, values in self.material_properties_dict.items():
+            self.material_definition[key] = values if key != 'propertyValues' else self.get_property_values(values)
+
+        try:
+            _LOGGER.info(f'\n\n/////////////////////////////////\nMaterialExport [{self.material_name}]:'
+                         f' {self.material_definition}\n/////////////////////////////////\n\n')
+            self.export_material()
+            return {self.mesh_export_location: {self.material_name: self.material_definition}}
+        except Exception as e:
+            _LOGGER.info(f'Exception [{type(e)}]: {e}')
+            return {}
+        return {}
+
+
+# +++++++++++++++++++----------------------------------------------->>
+# BLENDER EXTENSION +------------------------------------------------------>>
+# +++++++++++++++++++----------------------------------------------->>
+
+class BlenderMaterialGenerator(MaterialGenerator):
+    def __init__(self, input, output, mesh, attributes, base_path, options, master_paths):
+        super().__init__(input, output, mesh, attributes, base_path, options, master_paths)
+        _LOGGER.info('\n\n+++++++++++++++++++++++++++++++++++++\nBlenderMaterialGenerator instance created\n'
+                     '+++++++++++++++++++++++++++++++++++++\n\n')
+
+    def generate_material(self):
+        # Add exports here
+        return self.material_definition
+
+
+# ++++++++++++++++++++++++------------------------------------->>
+# TRANSLATION ASSIGNMENT +----------------------------------------->>
+# ++++++++++++++++++++++++------------------------------------->>
+
+
+def get_dcc_application(target_dictionary):
+    for scene_name, translation_values in target_dictionary.items():
+        for object_key, material_data in translation_values.items():
+            for material_name, material_values in material_data.items():
+                return material_values['dcc_application']
+
+
+def export_grouped_objects(material_info, output_path, dcc_application, export_options):
+    exported_groups = {}
+    for key, values in material_info.items():
+        parent_values = get_scene_export_hierarchy(values)[-1]
+        parent_type = parent_values[0]
+        parent_name = parent_values[1]
+        if parent_name not in exported_groups.keys():
+            exported_groups[parent_name] = {'type': parent_type, 'children': [key]}
+        else:
+            exported_groups[parent_name]['children'].append(key)
+    _LOGGER.info(f'Exported Groups: {exported_groups}')
+    for key, values in exported_groups.items():
+        output_path = Path(output_path) / key / f'{key}.fbx'
+        os.makedirs(os.path.dirname(str(output_path)), exist_ok=True)
+        if values['type'] == 'mesh':
+            values['children'].append(key)
+        material_utilities.export_mesh(dcc_application, values['children'], output_path, export_options)
+
+
+def get_scene_export_hierarchy(translation_values):
+    for material_name, material_values in translation_values.items():
+        return material_values['parent_hierarchy']
+
+
+def export_standard_pbr_materials(material_info, base_path, options, master_paths):
+    exported_materials = {}
+    dcc_application = get_dcc_application(material_info)
+    for scene_name, translation_values in material_info.items():
+        if 'Preserve Grouped Objects' in options:
+            export_grouped_objects(translation_values, base_path, dcc_application, options)
+
+        for object_key, material_data in translation_values.items():
+            _LOGGER.info(f'\n\n+++ >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>'
+                         f'\n+++ OBJECT NAME: {object_key} >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
+                         f'+++ >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n\n')
+            t = None
+            for material_name, material_values in material_data.items():
+                _LOGGER.info(f'\n\n##############\nMATERIAL_NAME: {material_name}\n# MaterialValues: {material_values}')
+                input = material_values['material_type']
+                mesh = object_key
+                attributes = {material_name: material_values}
+                _LOGGER.info(f'------------> InputMaterial: {input}')
+                _LOGGER.info(f'------------> MaterialAttributes: {attributes}')
+                _LOGGER.info(f'------------> OutputPath: {base_path}')
+                _LOGGER.info(f'------------> Export Options: {options}')
+                _LOGGER.info(f'------------> DccApplication: {dcc_application}')
+
+                if dcc_application == 'Maya':
+                    t = MayaMaterialGenerator(input, 'standardPBR', mesh, attributes, base_path, options, master_paths)
+                elif dcc_application == 'Blender':
+                    t = BlenderMaterialGenerator(input, 'standardPBR', mesh, attributes, base_path, options, master_paths)
+
+                material_definition = t.generate_material()
+                _LOGGER.info(f'MaterialDefinition: {material_definition}\n\n\n\n\n\n\n\n\n')
+                exported_materials.update(material_definition)
+    return exported_materials

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/o3de/renderer/materials/o3de_material_generator_cli.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/o3de/renderer/materials/o3de_material_generator_cli.py
@@ -1,0 +1,81 @@
+# coding:utf-8
+# !/usr/bin/python
+#
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
+#
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+# File Description:
+# This file contains Lumberyard specific file and helper functions for handling material conversion
+# -------------------------------------------------------------------------
+
+
+import click
+from pathlib import *
+import os
+
+# TODO- you are going to need to create a separate ticket to figure out environment variable bootstrapping without
+# the use of BAT files
+
+
+@click.command()
+@click.version_option('1.0.0')
+@click.argument('src', nargs=1, type=click.Path())
+@click.argument('dst', nargs=1, type=click.Path())
+@click.argument('dcc', default='Maya', help='Which DCC package to use for conversion. Conversion will fail running '
+                                            'this argument with the wrong file type for chosen dcc package. Currently '
+                                            'supported: [Maya, Blender]')
+@click.argument('operation', default='query', help='Operation to perform. Options: [query, validate, modify, convert]')
+@click.option('--options', default=['Preserve Transform Values'], help='Available options: Preserve Transform Values, '
+                                                                       'Preserve Grouped Objects')
+@click.option('--scope', default='Scene', help='Where is the content that needs to be converted. Options: '
+                                               '[Scene, Directory]')
+
+
+def run(src, dst, dcc, operation, options, scope):
+    """
+    This is the commmand line interface for the Legacy Asset Converter tool. The purpose of this tool is to convert
+    legacy Lumberyard material files (.mtl) and their associated textures to the current O3DE format (.material). The
+    current PBR workflow is Metallic/Roughness, so the script will do its best to convert Diffuse, DDNA, and Specular
+    maps from the legacy format into BaseColor, Roughness, Normal, and Metallic maps. Additional Maps (i.e. Alpha,
+    Emissive, etc.) present in the .mtl files, if compatible with the supported material types will carry over.
+    Additional functionality can be found by using the Standalone UI version of the tool.
+
+    # -- Conversion Arguments
+    # -- Input Path (file or directory):
+    This can be a path to a directory that contains one or more FBX files, or a single FBX file for conversion.
+
+    # -- Output Path (directory)
+    The destination directory to send asset files to once converted. If both source and destination paths are to
+    the same directory, an in-place conversion will be made. In-place conversions require an additional base directory
+    name from which to set relative texture paths in the .material files. This value is set using the "base" option.
+
+    NOTE: If both paths are identical, the conversion will be in-place
+
+    # -- Conversion Options:
+    # ---->> Create .material Files ::: Default setting = True
+    # ---->> Create Output Logs ::: Default setting = True
+    # ---->> Reprocess Existing Files ::: Default setting = False
+    """
+    options_dictionary = {
+        'src': src,
+        'dst': dst,
+        'dcc': dcc,
+        'operation': operation,
+        'options': options,
+        'scope': scope
+    }
+
+    print('Material Generation CLI firing...')
+    for key, value in options_dictionary.items():
+        print(f'--> Key: {key}  Option: {value}')
+
+
+if __name__ == '__main__':
+    run()
+


### PR DESCRIPTION
## What does this PR do?
This includes the files needed to run a Maya Materials conversion to O3DE. Users should be able to run the script by opening Maya using the BAT file launching system, and using the conversion tool entry in the DCCsi Main Toolbar menu.

## How was this PR tested?
Tested locally- performed conversions successfully for both Arnold and Stingray materials, export file packaging worked as expected
