### PR TITLE
Adding unit tests for TagRegistry and a variant of TagRegistry for bit flags

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawFilterTagRegistry.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawFilterTagRegistry.h
@@ -9,11 +9,12 @@
 
 #include <Atom/RHI/DrawItem.h>
 #include <Atom/RHI/TagRegistry.h>
+#include <Atom/RHI.Reflect/Handle.h>
 
 namespace AZ
 {
     namespace RHI
     {
-        using DrawFilterTagRegistry = TagRegistry<DrawFilterTag, Limits::Pipeline::DrawFilterTagCountMax>;
+        using DrawFilterTagRegistry = TagRegistry<DrawFilterTag::IndexType, Limits::Pipeline::DrawFilterTagCountMax>;
     }
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawListTagRegistry.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawListTagRegistry.h
@@ -14,6 +14,6 @@ namespace AZ
 {
     namespace RHI
     {
-        using DrawListTagRegistry = TagRegistry<DrawListTag, Limits::Pipeline::DrawListTagCountMax>;
+        using DrawListTagRegistry = TagRegistry<DrawListTag::IndexType, Limits::Pipeline::DrawListTagCountMax>;
     }
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/TagBitRegistry.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/TagBitRegistry.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Math/MathIntrinsics.h>
+#include <AzCore/Name/Name.h>
+#include <AzCore/std/smart_ptr/intrusive_base.h>
+#include <AzCore/std/parallel/shared_mutex.h>
+#include <Atom/RHI/TagRegistry.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        //! 
+        //! Allocates and registers tags by name, allowing the user to acquire and find tags from names.
+        //! The class is designed to map user-friendly tag names defined through content or higher level code to
+        //! low-level tags, which are simple handles.
+        //! 
+        //! Some notes about usage and design:
+        //!   - TagType need to be a Handle<Integer> type.
+        //!   - Tags are reference counted, which means multiple calls to 'Acquire' with the same name will increment 
+        //!     the internal reference count on the tag. This allows shared ownership between systems, if necessary.
+        //!   - FindTag is provided to search for a tag reference without taking ownership.
+        //!   - Names are case sensitive.
+        //!
+        template<typename TagType>
+        class TagBitRegistry final
+            : public AZStd::intrusive_base
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(TagBitRegistry, AZ::SystemAllocator, 0);
+            AZ_DISABLE_COPY_MOVE(TagBitRegistry);
+
+            static Ptr<TagBitRegistry> Create();
+
+            //! Resets the registry back to an empty state. All references are released.
+            void Reset() { m_tagRegistry.Reset(); };
+
+            //! Acquires a tag from the provided name (case sensitive). If the tag already existed, it is ref-counted.
+            //! Returns a valid tag on success; returns a null tag if the registry is at full capacity. You must
+            //! call ReleaseTag() if successful.
+            TagType AcquireTag(const Name& tagName);
+
+            //! Releases a reference to a tag. Tags are ref-counted, so it's necessary to maintain ownership of the
+            //! tag and release when its no longer needed.
+            void ReleaseTag(TagType tagName);
+
+            //! Finds the tag associated with the provided name (case sensitive). If a tag exists with that name, the tag
+            //! is returned. The reference count is NOT incremented on success; ownership is not passed to the user. If
+            //! the tag does not exist, a null tag is returned.
+            TagType FindTag(const Name& tagName) const;
+
+            //! Returns the name of the given tag, or empty string if the tag is not registered.
+            Name GetName(TagType tag) const;
+
+            //! Returns the number of allocated tags in the registry.
+            size_t GetAllocatedTagCount() const { return m_tagRegistry.GetAllocatedTagCount(); };
+
+        private:
+            TagBitRegistry() = default;
+            static TagType ConvertToUnderlyingType(TagType tag);
+            TagRegistry<typename TagType, sizeof(TagType) * 8> m_tagRegistry;
+        };
+
+        template<typename TagType>
+        Ptr<TagBitRegistry<TagType>> TagBitRegistry<TagType>::Create()
+        {
+            return aznew TagBitRegistry<TagType>();
+        }
+
+        template<typename TagType>
+        TagType TagBitRegistry<TagType>::AcquireTag(const Name& tagName)
+        {
+            if (TagType bitPos = m_tagRegistry.AcquireTag(tagName); bitPos.IsValid())
+            {
+                return TagType(1 << bitPos.GetIndex());
+            }
+            return {};
+        }
+
+        template<typename TagType>
+        void TagBitRegistry<TagType>::ReleaseTag(TagType tag)
+        {
+            m_tagRegistry.ReleaseTag(ConvertToUnderlyingType(tag));
+        }
+
+        template<typename TagType>
+        TagType TagBitRegistry<TagType>::FindTag(const Name& tagName) const
+        {
+            if (TagType bitPos = m_tagRegistry.FindTag(tagName); bitPos.IsValid())
+            {
+                return TagType(1 << m_tagRegistry.FindTag(tagName).GetIndex());
+            }
+            return {};
+        }
+
+        template<typename TagType>
+        Name TagBitRegistry<TagType>::GetName(TagType tag) const
+        {
+            return m_tagRegistry.GetName(ConvertToUnderlyingType(tag));
+        }
+
+        template<typename TagType>
+        TagType TagBitRegistry<TagType>::ConvertToUnderlyingType(TagType tag)
+        {
+            return TagType(az_ctz_u64(tag.GetIndex()));
+        }
+    }
+}

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/TagRegistry.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/TagRegistry.h
@@ -35,7 +35,7 @@ namespace AZ
             AZ_CLASS_ALLOCATOR(TagRegistry, AZ::SystemAllocator, 0);
             AZ_DISABLE_COPY_MOVE(TagRegistry);
 
-            template<typename IndexType>
+            template<typename>
             friend class TagBitRegistry;
 
             using TagType = Handle<IndexType>;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/TagRegistry.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/TagRegistry.h
@@ -27,7 +27,7 @@ namespace AZ
         //!   - FindTag is provided to search for a tag reference without taking ownership.
         //!   - Names are case sensitive.
         //!
-        template<typename TagType, size_t MaxTagCount>
+        template<typename IndexType, size_t MaxTagCount>
         class TagRegistry final
             : public AZStd::intrusive_base
         {
@@ -35,8 +35,10 @@ namespace AZ
             AZ_CLASS_ALLOCATOR(TagRegistry, AZ::SystemAllocator, 0);
             AZ_DISABLE_COPY_MOVE(TagRegistry);
 
-            template<typename TagType>
+            template<typename IndexType>
             friend class TagBitRegistry;
+
+            using TagType = Handle<IndexType>;
 
             static Ptr<TagRegistry> Create();
 
@@ -77,22 +79,22 @@ namespace AZ
             size_t m_allocatedTagCount = 0;
         };
 
-        template<typename TagType, size_t MaxTagCount>
-        Ptr<TagRegistry<TagType, MaxTagCount>> TagRegistry<TagType, MaxTagCount>::Create()
+        template<typename IndexType, size_t MaxTagCount>
+        Ptr<TagRegistry<IndexType, MaxTagCount>> TagRegistry<IndexType, MaxTagCount>::Create()
         {
-            return aznew TagRegistry<TagType, MaxTagCount>();
+            return aznew TagRegistry<IndexType, MaxTagCount>();
         }
 
-        template<typename TagType, size_t MaxTagCount>
-        void TagRegistry<TagType, MaxTagCount>::Reset()
+        template<typename IndexType, size_t MaxTagCount>
+        void TagRegistry<IndexType, MaxTagCount>::Reset()
         {
             AZStd::unique_lock<AZStd::shared_mutex> lock(m_mutex);
             m_entriesByTag.fill({});
             m_allocatedTagCount = 0;
         }
 
-        template<typename TagType, size_t MaxTagCount>
-        TagType TagRegistry<TagType, MaxTagCount>::AcquireTag(const Name& tagName)
+        template<typename IndexType, size_t MaxTagCount>
+        auto TagRegistry<IndexType, MaxTagCount>::AcquireTag(const Name& tagName) -> TagType
         {
             if (tagName.IsEmpty())
             {
@@ -132,8 +134,8 @@ namespace AZ
             return tag;
         }
 
-        template<typename TagType, size_t MaxTagCount>
-        void TagRegistry<TagType, MaxTagCount>::ReleaseTag(TagType tag)
+        template<typename IndexType, size_t MaxTagCount>
+        void TagRegistry<IndexType, MaxTagCount>::ReleaseTag(TagType tag)
         {
             if (tag.IsValid())
             {
@@ -151,8 +153,8 @@ namespace AZ
             }
         }
 
-        template<typename TagType, size_t MaxTagCount>
-        TagType TagRegistry<TagType, MaxTagCount>::FindTag(const Name& tagName) const
+        template<typename IndexType, size_t MaxTagCount>
+        auto TagRegistry<IndexType, MaxTagCount>::FindTag(const Name& tagName) const -> TagType
         {
             AZStd::shared_lock<AZStd::shared_mutex> lock(m_mutex);
             for (size_t i = 0; i < m_entriesByTag.size(); ++i)
@@ -165,8 +167,8 @@ namespace AZ
             return {};
         }
 
-        template<typename TagType, size_t MaxTagCount>
-        Name TagRegistry<TagType, MaxTagCount>::GetName(TagType tag) const
+        template<typename IndexType, size_t MaxTagCount>
+        Name TagRegistry<IndexType, MaxTagCount>::GetName(TagType tag) const
         {
             if (tag.GetIndex() < m_entriesByTag.size())
             {
@@ -178,8 +180,8 @@ namespace AZ
             }
         }
 
-        template<typename TagType, size_t MaxTagCount>
-        size_t TagRegistry<TagType, MaxTagCount>::GetAllocatedTagCount() const
+        template<typename IndexType, size_t MaxTagCount>
+        size_t TagRegistry<IndexType, MaxTagCount>::GetAllocatedTagCount() const
         {
             return m_allocatedTagCount;
         }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/TagRegistry.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/TagRegistry.h
@@ -35,6 +35,9 @@ namespace AZ
             AZ_CLASS_ALLOCATOR(TagRegistry, AZ::SystemAllocator, 0);
             AZ_DISABLE_COPY_MOVE(TagRegistry);
 
+            template<typename TagType>
+            friend class TagBitRegistry;
+
             static Ptr<TagRegistry> Create();
 
             //! Resets the registry back to an empty state. All references are released.

--- a/Gems/Atom/RHI/Code/Tests/TagRegistryTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/TagRegistryTests.cpp
@@ -69,7 +69,6 @@ namespace UnitTest
 
     TEST_F(TagRegistryTest, TagValues)
     {
-
         auto tagRegistry = RHI::TagRegistry<IndexType, Count>::Create();
 
         AZStd::array<Name, Count> names = { Name("A"), Name("B"), Name("C"), Name("D"), };

--- a/Gems/Atom/RHI/Code/Tests/TagRegistryTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/TagRegistryTests.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "RHITestFixture.h"
+#include <Atom/RHI/TagRegistry.h>
+#include <Atom/RHI/TagBitRegistry.h>
+#include <Atom/RHI.Reflect/Handle.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+
+    class TagRegistryTest
+        : public RHITestFixture
+    {
+    public:
+        TagRegistryTest()
+            : RHITestFixture()
+        {}
+    };
+
+
+    TEST_F(TagRegistryTest, ConstructResetTagRegistry)
+    {
+        auto tagRegistry = RHI::TagRegistry<RHI::Handle<uint16_t>, 32>::Create();
+        EXPECT_EQ(tagRegistry->GetAllocatedTagCount(), 0);
+        auto tagA = tagRegistry->AcquireTag(Name("A"));
+        EXPECT_EQ(tagRegistry->GetAllocatedTagCount(), 1);
+        tagRegistry->Reset();
+        EXPECT_EQ(tagRegistry->GetAllocatedTagCount(), 0);
+    }
+
+    TEST_F(TagRegistryTest, TagValues)
+    {
+        auto tagRegistry = RHI::TagRegistry<RHI::Handle<uint16_t>, 32>::Create();
+        auto tagA = tagRegistry->AcquireTag(Name("A"));
+        auto tagB = tagRegistry->AcquireTag(Name("B"));
+        auto tagC = tagRegistry->AcquireTag(Name("C"));
+        auto tagD = tagRegistry->AcquireTag(Name("D"));
+
+        // Make sure values increment
+        EXPECT_EQ(tagA.GetIndex(), 0);
+        EXPECT_EQ(tagB.GetIndex(), 1);
+        EXPECT_EQ(tagC.GetIndex(), 2);
+        EXPECT_EQ(tagD.GetIndex(), 3);
+
+        // Check to see if they can be retrieved after acquired
+        EXPECT_EQ(tagA, tagRegistry->FindTag(Name("A")));
+        EXPECT_EQ(tagB, tagRegistry->FindTag(Name("B")));
+        EXPECT_EQ(tagC, tagRegistry->FindTag(Name("C")));
+        EXPECT_EQ(tagD, tagRegistry->FindTag(Name("D")));
+
+        // Make sure getting names of the tags works correctly.
+        EXPECT_EQ(tagRegistry->GetName(tagA), Name("A"));
+        EXPECT_EQ(tagRegistry->GetName(tagB), Name("B"));
+        EXPECT_EQ(tagRegistry->GetName(tagC), Name("C"));
+        EXPECT_EQ(tagRegistry->GetName(tagD), Name("D"));
+
+        // Check to make sure releasing and acquiring fills a hole
+        tagRegistry->ReleaseTag(tagB);
+        EXPECT_EQ(tagRegistry->FindTag(Name("B")), AZ::RHI::Handle<uint16_t>::Null);
+        auto tagBNew = tagRegistry->AcquireTag(Name("B"));
+        EXPECT_EQ(tagB, tagBNew);
+
+        // Check the next after all holes are filled is the next valid integer.
+        auto tagE = tagRegistry->AcquireTag(Name("E"));
+        EXPECT_EQ(tagE.GetIndex(), 4);
+
+    }
+
+    TEST_F(TagRegistryTest, RefCounting)
+    {
+        auto tagRegistry = RHI::TagRegistry<RHI::Handle<uint16_t>, 32>::Create();
+
+        const uint32_t refCount = 4;
+        AZ::RHI::Handle<uint16_t> tagA;
+        AZ::RHI::Handle<uint16_t> tagB;
+
+        // acquire refs
+        for (uint32_t i = 0; i < refCount; ++i)
+        {
+            tagA = tagRegistry->AcquireTag(Name("A"));
+            tagB = tagRegistry->AcquireTag(Name("B"));
+        }
+
+        // release refs, but make sure they exist until all refs released
+        for (uint32_t i = 0; i < refCount; ++i)
+        {
+            EXPECT_EQ(tagA, tagRegistry->FindTag(Name("A")));
+            EXPECT_EQ(tagB, tagRegistry->FindTag(Name("B")));
+            tagRegistry->ReleaseTag(tagA);
+            tagRegistry->ReleaseTag(tagB);
+        }
+
+        // should no longer exist.
+        EXPECT_EQ(tagRegistry->FindTag(Name("A")), AZ::RHI::Handle<uint16_t>::Null);
+        EXPECT_EQ(tagRegistry->FindTag(Name("B")), AZ::RHI::Handle<uint16_t>::Null);
+    }
+
+    TEST_F(TagRegistryTest, ConstructResetTagBitRegistry)
+    {
+        auto tagBitRegistry = RHI::TagBitRegistry<RHI::Handle<uint16_t>>::Create();
+        EXPECT_EQ(tagBitRegistry->GetAllocatedTagCount(), 0);
+        auto tagA = tagBitRegistry->AcquireTag(Name("A"));
+        EXPECT_EQ(tagBitRegistry->GetAllocatedTagCount(), 1);
+        tagBitRegistry->Reset();
+        EXPECT_EQ(tagBitRegistry->GetAllocatedTagCount(), 0);
+    }
+
+    TEST_F(TagRegistryTest, TagBitValues)
+    {
+        auto tagBitRegistry = RHI::TagBitRegistry<RHI::Handle<uint16_t>>::Create();
+        auto tagA = tagBitRegistry->AcquireTag(Name("A"));
+        auto tagB = tagBitRegistry->AcquireTag(Name("B"));
+        auto tagC = tagBitRegistry->AcquireTag(Name("C"));
+        auto tagD = tagBitRegistry->AcquireTag(Name("D"));
+
+        // Make sure values increment bit positions
+        EXPECT_EQ(tagA.GetIndex(), 0b0001);
+        EXPECT_EQ(tagB.GetIndex(), 0b0010);
+        EXPECT_EQ(tagC.GetIndex(), 0b0100);
+        EXPECT_EQ(tagD.GetIndex(), 0b1000);
+
+        // Check to see if they can be retrieved after acquired
+        EXPECT_EQ(tagA, tagBitRegistry->FindTag(Name("A")));
+        EXPECT_EQ(tagB, tagBitRegistry->FindTag(Name("B")));
+        EXPECT_EQ(tagC, tagBitRegistry->FindTag(Name("C")));
+        EXPECT_EQ(tagD, tagBitRegistry->FindTag(Name("D")));
+
+        // Make sure getting names of the tags works correctly.
+        EXPECT_EQ(tagBitRegistry->GetName(tagA), Name("A"));
+        EXPECT_EQ(tagBitRegistry->GetName(tagB), Name("B"));
+        EXPECT_EQ(tagBitRegistry->GetName(tagC), Name("C"));
+        EXPECT_EQ(tagBitRegistry->GetName(tagD), Name("D"));
+
+        // Check to make sure releasing and acquiring fills a hole
+        tagBitRegistry->ReleaseTag(tagB);
+        EXPECT_EQ(tagBitRegistry->FindTag(Name("B")), AZ::RHI::Handle<uint16_t>::Null);
+        auto tagBNew = tagBitRegistry->AcquireTag(Name("B"));
+        EXPECT_EQ(tagB, tagBNew);
+
+        // Check the next after all holes are filled is the next valid integer.
+        auto tagE = tagBitRegistry->AcquireTag(Name("E"));
+        EXPECT_EQ(tagE.GetIndex(), 0b10000);
+    }
+}

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -199,6 +199,7 @@ set(FILES
     Include/Atom/RHI/interval_map.h
     Include/Atom/RHI/ImageProperty.h
     Include/Atom/RHI/BufferProperty.h
+    Include/Atom/RHI/TagBitRegistry.h
     Include/Atom/RHI/TagRegistry.h
     Include/Atom/RHI/XRRenderingInterface.h
 )

--- a/Gems/Atom/RHI/Code/atom_rhi_tests_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_tests_files.cmake
@@ -44,6 +44,7 @@ set(FILES
     Tests/Scope.cpp
     Tests/ShaderResourceGroup.h
     Tests/ShaderResourceGroup.cpp
+    Tests/TagRegistryTests.cpp
     Tests/TransientAttachmentPool.h
     Tests/TransientAttachmentPool.cpp
     Tests/ThreadTester.h


### PR DESCRIPTION
## What does this PR do?

- Adds unit tests for TagRegistry. 
- Enforces Handle usage in TagRegistry instead of just expect users to use a Handle template type.
- Adds a new variant of TagRegistry that allocates bit flags per tag, which is implemented as a thin wrapper of TagRegistry. This could be used to accelerate draw list mask usage in the future, or by other systems that want the ability to reserve bit flags dynamically, without needing to do bit shifting logic themselves.

## How was this PR tested?

This doesn't change any existing functionality. The new unit tests were run. ASV and the editor were also run to ensure there weren't any unexpected side effects from the change to the TagRegistry template type.
