### PR TITLE
Revert functionality in GenerateShaderVariantListForMaterials.py and …

### DIFF
--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
@@ -109,9 +109,7 @@ namespace ShaderManagementConsole
         documentType.m_documentTypeName = "Shader Variant List";
         documentType.m_documentFactoryCallback = [](const AZ::Crc32& toolId, const AtomToolsFramework::DocumentTypeInfo& documentTypeInfo) {
             return aznew ShaderManagementConsoleDocument(toolId, documentTypeInfo); };
-        documentType.m_supportedExtensionsToCreate.push_back({ "Shader", AZ::RPI::ShaderSourceData::Extension });
         documentType.m_supportedExtensionsToCreate.push_back({ "Shader Variant List", AZ::RPI::ShaderVariantListSourceData::Extension });
-        documentType.m_supportedExtensionsToOpen.push_back({ "Shader", AZ::RPI::ShaderSourceData::Extension });
         documentType.m_supportedExtensionsToOpen.push_back({ "Shader Variant List", AZ::RPI::ShaderVariantListSourceData::Extension });
         documentType.m_supportedExtensionsToSave.push_back({ "Shader Variant List", AZ::RPI::ShaderVariantListSourceData::Extension });
         documentType.m_supportedAssetTypesToCreate.insert(azrtti_typeid<AZ::RPI::ShaderAsset>());
@@ -278,83 +276,7 @@ namespace ShaderManagementConsole
 
     bool ShaderManagementConsoleDocument::LoadShaderSourceData()
     {
-        // Get info such as relative path of the file and asset id
-        bool result = false;
-        AZ::Data::AssetInfo shaderAssetInfo;
-        AZStd::string watchFolder;
-        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
-            result, &AzToolsFramework::AssetSystem::AssetSystemRequest::GetSourceInfoBySourcePath, m_absolutePath.c_str(), shaderAssetInfo,
-            watchFolder);
-
-        if (!result)
-        {
-            AZ_Error("ShaderManagementConsoleDocument", false, "Failed to get the asset info for the file: %s.", m_absolutePath.c_str());
-            return OpenFailed();
-        }
-
-        // retrieves a list of all material source files that use the shader. Note that materials inherit from materialtype files, which
-        // are actual files that refer to shader files.
-        const auto& materialAssetIds = FindMaterialAssetsUsingShader(shaderAssetInfo.m_relativePath);
-
-        // This loop collects all uniquely-identified shader items used by the materials based on its shader variant id.
-        AZStd::set<AZ::RPI::ShaderVariantId> shaderVariantIds;
-        AZStd::vector<AZ::RPI::ShaderOptionGroup> shaderVariantListShaderOptionGroups;
-        for (const auto& materialAssetId : materialAssetIds)
-        {
-            const auto& materialInstanceShaderItems = GetMaterialInstanceShaderItems(materialAssetId);
-            for (const auto& shaderItem : materialInstanceShaderItems)
-            {
-                const auto& shaderAssetId = shaderItem.GetShaderAsset().GetId();
-                if (shaderAssetInfo.m_assetId == shaderAssetId)
-                {
-                    const auto& shaderVariantId = shaderItem.GetShaderVariantId();
-                    if (!shaderVariantId.IsEmpty() && shaderVariantIds.insert(shaderVariantId).second)
-                    {
-                        shaderVariantListShaderOptionGroups.push_back(shaderItem.GetShaderOptionGroup());
-                    }
-                }
-            }
-        }
-
-        // Generate the shader variant list data by collecting shader option name-value pairs.s
-        AZ::RPI::ShaderVariantListSourceData shaderVariantListSourceData;
-        shaderVariantListSourceData.m_shaderFilePath = shaderAssetInfo.m_relativePath;
-        int stableId = 1;
-        for (const auto& shaderOptionGroup : shaderVariantListShaderOptionGroups)
-        {
-            AZ::RPI::ShaderVariantListSourceData::VariantInfo variantInfo;
-            variantInfo.m_stableId = stableId;
-
-            const auto& shaderOptionDescriptors = shaderOptionGroup.GetShaderOptionDescriptors();
-            for (const auto& shaderOptionDescriptor : shaderOptionDescriptors)
-            {
-                const auto& optionName = shaderOptionDescriptor.GetName();
-                const auto& optionValue = shaderOptionGroup.GetValue(optionName);
-                if (!optionValue.IsValid())
-                {
-                    continue;
-                }
-
-                const auto& valueName = shaderOptionDescriptor.GetValueName(optionValue);
-                variantInfo.m_options[optionName.GetStringView()] = valueName.GetStringView();
-            }
-
-            if (!variantInfo.m_options.empty())
-            {
-                shaderVariantListSourceData.m_shaderVariants.push_back(variantInfo);
-                stableId++;
-            }
-        }
-
-        // Even though the data originated from a different file source it has now been transformed into a shader variant list so update the
-        // extension to match. This will allow the document to be resaved immediately without doing a save as child or derived type when
-        // loaded from a shader source file.
-        AzFramework::StringFunc::Path::ReplaceExtension(m_absolutePath, AZ::RPI::ShaderVariantListSourceData::Extension);
-
-        SetShaderVariantListSourceData(shaderVariantListSourceData);
-        m_modified = {};
-
-        return IsOpen() ? OpenSucceeded() : OpenFailed();
+        return OpenFailed();
     }
 
     bool ShaderManagementConsoleDocument::LoadShaderVariantListSourceData()
@@ -371,93 +293,5 @@ namespace ShaderManagementConsole
         m_modified = {};
 
         return IsOpen() ? OpenSucceeded() : OpenFailed();
-    }
-
-    AZStd::vector<AZ::Data::AssetId> ShaderManagementConsoleDocument::FindMaterialAssetsUsingShader(const AZStd::string& shaderFilePath)
-    {
-        AzToolsFramework::AssetDatabase::AssetDatabaseConnection assetDatabaseConnection;
-        assetDatabaseConnection.OpenDatabase();
-
-        // Find all material types that reference shaderFilePath
-        AZStd::list<AZStd::string> materialTypeSources;
-
-        assetDatabaseConnection.QuerySourceDependencyByDependsOnSource(
-            shaderFilePath.c_str(), nullptr, AzToolsFramework::AssetDatabase::SourceFileDependencyEntry::DEP_Any,
-            [&](AzToolsFramework::AssetDatabase::SourceFileDependencyEntry& sourceFileDependencyEntry)
-            {
-                if (AzFramework::StringFunc::Path::IsExtension(
-                        sourceFileDependencyEntry.m_source.c_str(), AZ::RPI::MaterialTypeSourceData::Extension))
-                {
-                    materialTypeSources.push_back(sourceFileDependencyEntry.m_source);
-                }
-                return true;
-            });
-
-        // Find all materials that reference any of the material types using this shader
-        AZStd::string watchFolder;
-        AZ::Data::AssetInfo materialTypeSourceAssetInfo;
-        AZStd::list<AzToolsFramework::AssetDatabase::ProductDatabaseEntry> productDependencies;
-        for (const auto& materialTypeSource : materialTypeSources)
-        {
-            bool result = false;
-            AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
-                result, &AzToolsFramework::AssetSystem::AssetSystemRequest::GetSourceInfoBySourcePath, materialTypeSource.c_str(),
-                materialTypeSourceAssetInfo, watchFolder);
-            if (result)
-            {
-                assetDatabaseConnection.QueryDirectReverseProductDependenciesBySourceGuidSubId(
-                    materialTypeSourceAssetInfo.m_assetId.m_guid, materialTypeSourceAssetInfo.m_assetId.m_subId,
-                    [&](AzToolsFramework::AssetDatabase::ProductDatabaseEntry& entry)
-                    {
-                        if (AzFramework::StringFunc::Path::IsExtension(entry.m_productName.c_str(), AZ::RPI::MaterialAsset::Extension))
-                        {
-                            productDependencies.push_back(entry);
-                        }
-                        return true;
-                    });
-            }
-        }
-
-        AZStd::vector<AZ::Data::AssetId> results;
-        results.reserve(productDependencies.size());
-        for (const auto& product : productDependencies)
-        {
-            assetDatabaseConnection.QueryCombinedByProductID(
-                product.m_productID,
-                [&](AzToolsFramework::AssetDatabase::CombinedDatabaseEntry& combined)
-                {
-                    results.push_back({ combined.m_sourceGuid, combined.m_subID });
-                    return false;
-                },
-                nullptr);
-        }
-
-        return results;
-    }
-
-    AZStd::vector<AZ::RPI::ShaderCollection::Item> ShaderManagementConsoleDocument::GetMaterialInstanceShaderItems(
-        const AZ::Data::AssetId& materialAssetId)
-    {
-        auto materialAsset =
-            AZ::RPI::AssetUtils::LoadAssetById<AZ::RPI::MaterialAsset>(materialAssetId, AZ::RPI::AssetUtils::TraceLevel::Error);
-        if (!materialAsset.IsReady())
-        {
-            AZ_Error(
-                "ShaderManagementConsoleDocument", false, "Failed to load material asset from asset id: %s",
-                materialAssetId.ToFixedString().c_str());
-            return AZStd::vector<AZ::RPI::ShaderCollection::Item>();
-        }
-
-        auto materialInstance = AZ::RPI::Material::Create(materialAsset);
-        if (!materialInstance)
-        {
-            AZ_Error(
-                "ShaderManagementConsoleDocument", false, "Failed to create material instance from asset: %s",
-                materialAsset.ToString<AZStd::string>().c_str());
-            return AZStd::vector<AZ::RPI::ShaderCollection::Item>();
-        }
-
-        return AZStd::vector<AZ::RPI::ShaderCollection::Item>(
-            materialInstance->GetShaderCollection().begin(), materialInstance->GetShaderCollection().end());
     }
 } // namespace ShaderManagementConsole

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
@@ -64,16 +64,21 @@ namespace ShaderManagementConsole
     {
         m_shaderVariantListSourceData = shaderVariantListSourceData;
         AZStd::string shaderPath = m_shaderVariantListSourceData.m_shaderFilePath;
-        AzFramework::StringFunc::Path::ReplaceExtension(shaderPath, AZ::RPI::ShaderAsset::Extension);
 
-        m_shaderAsset = AZ::RPI::AssetUtils::LoadAssetByProductPath<AZ::RPI::ShaderAsset>(shaderPath.c_str());
-        AZ_Error("ShaderManagementConsoleDocument", m_shaderAsset.IsReady(), "Could not load shader asset: %s.", shaderPath.c_str());
-
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
-            m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentObjectInfoInvalidated, m_id);
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
-            m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentModified, m_id);
-        m_modified = true;
+        auto shaderAssetResult = AZ::RPI::AssetUtils::LoadAsset<AZ::RPI::ShaderAsset>(m_absolutePath, shaderPath);
+        if (shaderAssetResult)
+        {
+            m_shaderAsset = shaderAssetResult.GetValue();
+            AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
+                m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentObjectInfoInvalidated, m_id);
+            AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
+                m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentModified, m_id);
+            m_modified = true;
+        }
+        else
+        {
+            AZ_Error("ShaderManagementConsoleDocument", false, "Could not load shader asset: %s.", shaderPath.c_str());
+        }
     }
 
     const AZ::RPI::ShaderVariantListSourceData& ShaderManagementConsoleDocument::GetShaderVariantListSourceData() const

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.h
@@ -66,12 +66,6 @@ namespace ShaderManagementConsole
         // Read shader source data from JSON then find all references to to populate the shader variant list and initialize the document
         bool LoadShaderVariantListSourceData();
 
-        // Find all material assets that reference material types using shaderFilePath
-        AZStd::vector<AZ::Data::AssetId> FindMaterialAssetsUsingShader(const AZStd::string& shaderFilePath);
-
-        // Retrieve all of the shader collection items from a material instance created from materialAssetId
-        AZStd::vector<AZ::RPI::ShaderCollection::Item> GetMaterialInstanceShaderItems(const AZ::Data::AssetId& materialAssetId);
-
         // Source data for shader variant list
         AZ::RPI::ShaderVariantListSourceData m_shaderVariantListSourceData;
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/ShaderManagementConsoleApplication.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/ShaderManagementConsoleApplication.cpp
@@ -6,6 +6,10 @@
  *
  */
 
+#include <AssetDatabase/AssetDatabaseConnection.h>
+#include <Atom/RPI.Edit/Common/AssetUtils.h>
+#include <Atom/RPI.Edit/Material/MaterialTypeSourceData.h>
+#include <Atom/RPI.Public/Material/Material.h>
 #include <AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <ShaderManagementConsoleApplication.h>
@@ -42,11 +46,13 @@ namespace ShaderManagementConsole
         QApplication::setWindowIcon(QIcon(":/Icons/application.svg"));
 
         AzToolsFramework::EditorWindowRequestBus::Handler::BusConnect();
+        ShaderManagementConsoleRequestBus::Handler::BusConnect();
     }
 
     ShaderManagementConsoleApplication::~ShaderManagementConsoleApplication()
     {
         AzToolsFramework::EditorWindowRequestBus::Handler::BusDisconnect();
+        ShaderManagementConsoleRequestBus::Handler::BusDisconnect();
         m_window.reset();
     }
 
@@ -54,6 +60,17 @@ namespace ShaderManagementConsole
     {
         Base::Reflect(context);
         ShaderManagementConsoleDocument::Reflect(context);
+
+        if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<ShaderManagementConsoleRequestBus>("ShaderManagementConsoleRequestBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Category, "Editor")
+                ->Attribute(AZ::Script::Attributes::Module, "shadermanagementconsole")
+                ->Event("GetSourceAssetInfo", &ShaderManagementConsoleRequestBus::Events::GetSourceAssetInfo)
+                ->Event("FindMaterialAssetsUsingShader", &ShaderManagementConsoleRequestBus::Events::FindMaterialAssetsUsingShader)
+                ->Event("GetMaterialInstanceShaderItems", &ShaderManagementConsoleRequestBus::Events::GetMaterialInstanceShaderItems);
+        }
     }
 
     const char* ShaderManagementConsoleApplication::GetCurrentConfigurationName() const
@@ -97,5 +114,109 @@ namespace ShaderManagementConsole
     QWidget* ShaderManagementConsoleApplication::GetAppMainWindow()
     {
         return m_window.get();
+    }
+
+    AZ::Data::AssetInfo ShaderManagementConsoleApplication::GetSourceAssetInfo(const AZStd::string& sourceAssetFileName)
+    {
+        bool result = false;
+        AZ::Data::AssetInfo assetInfo;
+        AZStd::string watchFolder;
+        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+            result,
+            &AzToolsFramework::AssetSystem::AssetSystemRequest::GetSourceInfoBySourcePath,
+            sourceAssetFileName.c_str(),
+            assetInfo,
+            watchFolder);
+        AZ_Error(nullptr, result, "Failed to get the asset info for the file: %s.", sourceAssetFileName.c_str());
+
+        return assetInfo;
+    }
+
+    AZStd::vector<AZ::Data::AssetId> ShaderManagementConsoleApplication::FindMaterialAssetsUsingShader(const AZStd::string& shaderFilePath)
+    {
+        AzToolsFramework::AssetDatabase::AssetDatabaseConnection assetDatabaseConnection;
+        assetDatabaseConnection.OpenDatabase();
+
+        // Find all material types that reference shaderFilePath
+        AZStd::list<AZStd::string> materialTypeSources;
+
+        assetDatabaseConnection.QuerySourceDependencyByDependsOnSource(
+            shaderFilePath.c_str(), nullptr, AzToolsFramework::AssetDatabase::SourceFileDependencyEntry::DEP_Any,
+            [&](AzToolsFramework::AssetDatabase::SourceFileDependencyEntry& sourceFileDependencyEntry)
+            {
+                if (AzFramework::StringFunc::Path::IsExtension(
+                        sourceFileDependencyEntry.m_source.c_str(), AZ::RPI::MaterialTypeSourceData::Extension))
+                {
+                    materialTypeSources.push_back(sourceFileDependencyEntry.m_source);
+                }
+                return true;
+            });
+
+        // Find all materials that reference any of the material types using this shader
+        AZStd::string watchFolder;
+        AZ::Data::AssetInfo materialTypeSourceAssetInfo;
+        AZStd::list<AzToolsFramework::AssetDatabase::ProductDatabaseEntry> productDependencies;
+        for (const auto& materialTypeSource : materialTypeSources)
+        {
+            bool result = false;
+            AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+                result, &AzToolsFramework::AssetSystem::AssetSystemRequest::GetSourceInfoBySourcePath, materialTypeSource.c_str(),
+                materialTypeSourceAssetInfo, watchFolder);
+            if (result)
+            {
+                assetDatabaseConnection.QueryDirectReverseProductDependenciesBySourceGuidSubId(
+                    materialTypeSourceAssetInfo.m_assetId.m_guid, materialTypeSourceAssetInfo.m_assetId.m_subId,
+                    [&](AzToolsFramework::AssetDatabase::ProductDatabaseEntry& entry)
+                    {
+                        if (AzFramework::StringFunc::Path::IsExtension(entry.m_productName.c_str(), AZ::RPI::MaterialAsset::Extension))
+                        {
+                            productDependencies.push_back(entry);
+                        }
+                        return true;
+                    });
+            }
+        }
+
+        AZStd::vector<AZ::Data::AssetId> results;
+        results.reserve(productDependencies.size());
+        for (const auto& product : productDependencies)
+        {
+            assetDatabaseConnection.QueryCombinedByProductID(
+                product.m_productID,
+                [&](AzToolsFramework::AssetDatabase::CombinedDatabaseEntry& combined)
+                {
+                    results.push_back({ combined.m_sourceGuid, combined.m_subID });
+                    return false;
+                },
+                nullptr);
+        }
+
+        return results;
+    }
+
+    AZStd::vector<AZ::RPI::ShaderCollection::Item> ShaderManagementConsoleApplication::GetMaterialInstanceShaderItems(
+        const AZ::Data::AssetId& materialAssetId)
+    {
+        auto materialAsset =
+            AZ::RPI::AssetUtils::LoadAssetById<AZ::RPI::MaterialAsset>(materialAssetId, AZ::RPI::AssetUtils::TraceLevel::Error);
+        if (!materialAsset.IsReady())
+        {
+            AZ_Error(
+                "ShaderManagementConsole", false, "Failed to load material asset from asset id: %s",
+                materialAssetId.ToFixedString().c_str());
+            return AZStd::vector<AZ::RPI::ShaderCollection::Item>();
+        }
+
+        auto materialInstance = AZ::RPI::Material::Create(materialAsset);
+        if (!materialInstance)
+        {
+            AZ_Error(
+                "ShaderManagementConsole", false, "Failed to create material instance from asset: %s",
+                materialAsset.ToString<AZStd::string>().c_str());
+            return AZStd::vector<AZ::RPI::ShaderCollection::Item>();
+        }
+
+        return AZStd::vector<AZ::RPI::ShaderCollection::Item>(
+            materialInstance->GetShaderCollection().begin(), materialInstance->GetShaderCollection().end());
     }
 } // namespace ShaderManagementConsole

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/ShaderManagementConsoleApplication.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/ShaderManagementConsoleApplication.h
@@ -11,12 +11,14 @@
 #include <Atom/RPI.Reflect/Material/MaterialAsset.h>
 #include <AtomToolsFramework/Document/AtomToolsDocumentApplication.h>
 #include <AzToolsFramework/API/EditorWindowRequestBus.h>
+#include <ShaderManagementConsoleRequestBus.h>
 #include <Window/ShaderManagementConsoleWindow.h>
 
 namespace ShaderManagementConsole
 {
     class ShaderManagementConsoleApplication
         : public AtomToolsFramework::AtomToolsDocumentApplication
+        , private ShaderManagementConsoleRequestBus::Handler
         , private AzToolsFramework::EditorWindowRequestBus::Handler
     {
     public:
@@ -38,6 +40,11 @@ namespace ShaderManagementConsole
 
         // AzToolsFramework::EditorWindowRequests::Bus::Handler
         QWidget* GetAppMainWindow() override;
+
+        // ShaderManagementConsoleRequestBus::Handler overrides...
+        AZ::Data::AssetInfo GetSourceAssetInfo(const AZStd::string& sourceAssetFileName) override;
+        AZStd::vector<AZ::Data::AssetId> FindMaterialAssetsUsingShader(const AZStd::string& shaderFilePath) override;
+        AZStd::vector<AZ::RPI::ShaderCollection::Item> GetMaterialInstanceShaderItems(const AZ::Data::AssetId& assetId) override;
 
     private:
         AZStd::unique_ptr<ShaderManagementConsoleWindow> m_window;

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/ShaderManagementConsoleRequestBus.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/ShaderManagementConsoleRequestBus.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Asset/AssetCommon.h>
+#include <Atom/RPI.Edit/Shader/ShaderVariantListSourceData.h>
+#include <Atom/RPI.Reflect/Material/ShaderCollection.h>
+
+namespace ShaderManagementConsole
+{
+    //! ShaderManagementConsoleRequestBus provides
+    class ShaderManagementConsoleRequests
+        : public AZ::EBusTraits
+    {
+    public:
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+
+        //! Returns a shader file's asset id and relative filepath
+        virtual AZ::Data::AssetInfo GetSourceAssetInfo(const AZStd::string& sourceAssetFileName) = 0;
+
+        // [GFX TODO][ATOM-14857] Generalize this API 
+        //! Returns a list of material AssetIds that use the shader file.
+        virtual AZStd::vector<AZ::Data::AssetId> FindMaterialAssetsUsingShader (const AZStd::string& shaderFilePath) = 0;
+
+        //! Returns a list of shader items contained within an instantiated material source's shader collection.
+        virtual AZStd::vector<AZ::RPI::ShaderCollection::Item> GetMaterialInstanceShaderItems(const AZ::Data::AssetId& assetId) = 0;
+    };
+    using ShaderManagementConsoleRequestBus = AZ::EBus<ShaderManagementConsoleRequests>;
+} // namespace ShaderManagementConsole

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/ShaderManagementConsoleRequestBus.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/ShaderManagementConsoleRequestBus.h
@@ -27,7 +27,6 @@ namespace ShaderManagementConsole
         //! Returns a shader file's asset id and relative filepath
         virtual AZ::Data::AssetInfo GetSourceAssetInfo(const AZStd::string& sourceAssetFileName) = 0;
 
-        // [GFX TODO][ATOM-14857] Generalize this API 
         //! Returns a list of material AssetIds that use the shader file.
         virtual AZStd::vector<AZ::Data::AssetId> FindMaterialAssetsUsingShader (const AZStd::string& shaderFilePath) = 0;
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/shadermanagementconsole_files.cmake
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/shadermanagementconsole_files.cmake
@@ -20,5 +20,6 @@ set(FILES
     Source/main.cpp
     Source/ShaderManagementConsoleApplication.cpp
     Source/ShaderManagementConsoleApplication.h
+    Source/ShaderManagementConsoleRequestBus.h
     ../Scripts/GenerateShaderVariantListForMaterials.py
 )


### PR DESCRIPTION
…ShaderManagementConsoleRequestBus.h

Signed-off-by: ethan <ethanchen1227@gmail.com>

This is a recreated PR for #11596 

## What does this PR do?

Moving the generate shader variant list function back to python
Bring back ShaderManagementConsoleRequestBus
LoadShaderSourceData() doing nothing for now

#11380

## How was this PR tested?

Running SMC and confirmed the following steps working correctly

1. Right click on a .shader file, "Run Python on File...", select GenerateShaderVariantListForMaterials.py
2. Shader variant list is generated in python
3. The default path of the .shadervariantlist file is used to open a Document
4. The Document will be update with the generated shader variant list, without auto saving or any windows popup
