### PR TITLE
feat(Python Console): add clear option to python console

### DIFF
--- a/Code/Editor/Controls/ConsoleSCB.cpp
+++ b/Code/Editor/Controls/ConsoleSCB.cpp
@@ -418,12 +418,10 @@ void CConsoleSCB::RefreshStyle()
         m_colorTable[6] = QColor(0xff, 0xaa, 0x22);     // Warning (Yellow)
     }
 
-    const bool uiAndDark = !GetIEditor()->IsInConsolewMode() && CConsoleSCB::GetCreatedInstance() && m_backgroundTheme == AzToolsFramework::ConsoleColorTheme::Dark;
-
     QColor bgColor;
     if (!GetIEditor()->IsInConsolewMode() && CConsoleSCB::GetCreatedInstance() && m_backgroundTheme == AzToolsFramework::ConsoleColorTheme::Dark)
     {
-        bgColor = Qt::black;
+        bgColor = QColor(0x22, 0x22, 0x22);
         AzQtComponents::ScrollBar::applyLightStyle(ui->textEdit);
     }
     else
@@ -436,8 +434,7 @@ void CConsoleSCB::RefreshStyle()
     m_colorTable[0] = textColor;
     m_colorTable[1] = textColor;
 
-    ui->textEdit->setBackgroundVisible(!uiAndDark);
-    ui->textEdit->setStyleSheet(uiAndDark ? QString() : QString("QPlainTextEdit{ background: %1 }").arg(bgColor.name(QColor::HexRgb)));
+    ui->textEdit->setStyleSheet(QString("background: %1").arg(bgColor.name(QColor::HexRgb)));
 
     // Clear out the console text when we change our background color since
     // some of the previous text colors may not be appropriate for the

--- a/Code/Editor/Controls/ConsoleSCB.cpp
+++ b/Code/Editor/Controls/ConsoleSCB.cpp
@@ -338,7 +338,7 @@ CConsoleSCB::CConsoleSCB(QWidget* parent)
 
     connect(ui->button, &QPushButton::clicked, this, &CConsoleSCB::showVariableEditor);
     connect(ui->findButton, &QPushButton::clicked, this, &CConsoleSCB::toggleConsoleSearch);
-    connect(ui->textEdit, &ConsoleTextEdit::searchBarRequested, this, [this]
+    connect(ui->textEdit, &AzToolsFramework::ConsoleTextEdit::searchBarRequested, this, [this]
     {
         this->ui->findBar->setVisible(true);
         this->ui->lineEditFind->setFocus();
@@ -657,96 +657,6 @@ static void OnConsoleVariableUpdated(IVariable* pVar)
     }
 }
 
-ConsoleTextEdit::ConsoleTextEdit(QWidget* parent)
-    : QPlainTextEdit(parent)
-    , m_contextMenu(new QMenu(this))
-{
-    setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(this, &QPlainTextEdit::customContextMenuRequested, this, &ConsoleTextEdit::showContextMenu);
-
-    // Make sure to add the actions to this widget, so that the ShortCutDispatcher picks them up properly
-
-    QAction* copyAction = m_contextMenu->addAction(tr("&Copy"));
-    copyAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-    copyAction->setShortcut(QKeySequence::Copy);
-    copyAction->setEnabled(false);
-    connect(copyAction, &QAction::triggered, this, &QPlainTextEdit::copy);
-    addAction(copyAction);
-
-    QAction* selectAllAction = m_contextMenu->addAction(tr("Select &All"));
-    selectAllAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-    selectAllAction->setShortcut(QKeySequence::SelectAll);
-    selectAllAction->setEnabled(false);
-    connect(selectAllAction, &QAction::triggered, this, &QPlainTextEdit::selectAll);
-    addAction(selectAllAction);
-
-    m_contextMenu->addSeparator();
-
-    QAction* deleteAction = m_contextMenu->addAction(tr("Delete"));
-    deleteAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-    deleteAction->setShortcut(QKeySequence::Delete);
-    deleteAction->setEnabled(false);
-    connect(deleteAction, &QAction::triggered, this, [=]() { textCursor().removeSelectedText(); } );
-    addAction(deleteAction);
-
-    QAction* clearAction = m_contextMenu->addAction(tr("Clear"));
-    clearAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-    clearAction->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_C);
-    clearAction->setEnabled(false);
-    connect(clearAction, &QAction::triggered, this, &QPlainTextEdit::clear);
-    addAction(clearAction);
-
-    QAction* findAction = m_contextMenu->addAction(tr("Find"));
-    findAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-    findAction->setShortcut(QKeySequence::Find);
-    findAction->setEnabled(true);
-    connect(findAction, &QAction::triggered, this, &ConsoleTextEdit::searchBarRequested);
-    addAction(findAction);
-
-    connect(this, &QPlainTextEdit::copyAvailable, copyAction, &QAction::setEnabled);
-    connect(this, &QPlainTextEdit::copyAvailable, deleteAction, &QAction::setEnabled);
-    connect(this, &QPlainTextEdit::textChanged, selectAllAction, [=]
-        {
-            if (document() && !document()->isEmpty())
-            {
-                clearAction->setEnabled(true);
-                selectAllAction->setEnabled(true);
-            }
-            else
-            {
-                clearAction->setEnabled(false);
-                selectAllAction->setEnabled(false);
-            }
-        });
-}
-
-bool ConsoleTextEdit::event(QEvent* theEvent)
-{
-    if (theEvent->type() == QEvent::ShortcutOverride)
-    {
-        // ignore several possible key combinations to prevent them bubbling up to the main editor
-        QKeyEvent* shortcutEvent = static_cast<QKeyEvent*>(theEvent);
-
-        QKeySequence::StandardKey ignoredKeys[] = { QKeySequence::Backspace };
-
-        for (auto& currKey : ignoredKeys)
-        {
-            if (shortcutEvent->matches(currKey))
-            {
-                // these shortcuts are ignored. Accept them and do nothing.
-                theEvent->accept();
-                return true;
-            }
-        }
-    }
-
-    return QPlainTextEdit::event(theEvent);
-}
-
-void ConsoleTextEdit::showContextMenu(const QPoint &pt)
-{
-    m_contextMenu->exec(mapToGlobal(pt));
-}
 
 ConsoleVariableItemDelegate::ConsoleVariableItemDelegate(QObject* parent)
     : QStyledItemDelegate(parent)

--- a/Code/Editor/Controls/ConsoleSCB.h
+++ b/Code/Editor/Controls/ConsoleSCB.h
@@ -45,7 +45,6 @@ struct ConsoleLine
 };
 typedef std::deque<ConsoleLine> Lines;
 
-
 class ConsoleLineEdit
     : public QLineEdit
 {
@@ -68,23 +67,6 @@ private:
     QStringList m_history;
     unsigned int m_historyIndex;
     bool m_bReusedHistory;
-};
-
-class ConsoleTextEdit
-    : public QPlainTextEdit
-{
-    Q_OBJECT
-public:
-    explicit ConsoleTextEdit(QWidget* parent = nullptr);
-    virtual bool event(QEvent* theEvent) override;
-
-signals:
-    void searchBarRequested();
-
-private:
-    void showContextMenu(const QPoint& pt);
-
-    QScopedPointer<QMenu> m_contextMenu;
 };
 
 class ConsoleVariableItemDelegate

--- a/Code/Editor/Controls/ConsoleSCB.ui
+++ b/Code/Editor/Controls/ConsoleSCB.ui
@@ -39,7 +39,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="ConsoleTextEdit" name="textEdit">
+    <widget class="AzToolsFramework::ConsoleTextEdit" name="textEdit">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
@@ -221,10 +221,10 @@
    <header>Controls/ConsoleSCB.h</header>
   </customwidget>
   <customwidget>
-   <class>ConsoleTextEdit</class>
-   <extends>QPlainTextEdit</extends>
-   <header>Controls/ConsoleSCB.h</header>
-  </customwidget>
+    <class>AzToolsFramework::ConsoleTextEdit</class>
+    <extends>QPlainTextEdit</extends>
+    <header>AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx</header>
+   </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>lineEdit</tabstop>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PythonTerminal/ScriptTermDialog.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PythonTerminal/ScriptTermDialog.cpp
@@ -103,7 +103,7 @@ namespace AzToolsFramework
             bgColor = Qt::white;
             AzQtComponents::ScrollBar::applyDarkStyle(ui->SCRIPT_OUTPUT);
         }
-        ui->SCRIPT_OUTPUT->setStyleSheet(QString("QPlainTextEdit{ background: %1 }").arg(bgColor.name(QColor::HexRgb)));
+        ui->SCRIPT_OUTPUT->setStyleSheet(QString("background: %1 ").arg(bgColor.name(QColor::HexRgb)));
 
         // Clear out the console text when we change our background color since
         // some of the previous text colors may not be appropriate for the

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PythonTerminal/ScriptTermDialog.ui
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PythonTerminal/ScriptTermDialog.ui
@@ -27,9 +27,12 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QPlainTextEdit" name="SCRIPT_OUTPUT">
+    <widget class="AzToolsFramework::ConsoleTextEdit" name="SCRIPT_OUTPUT">
      <property name="readOnly">
       <bool>true</bool>
+     </property>
+     <property name="searchEnabled">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
@@ -83,6 +86,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AzToolsFramework::ConsoleTextEdit</class>
+   <extends>QPlainTextEdit</extends>
+   <header>AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx>
+#include <AzCore/Debug/Trace.h>
+#include <QMenu>
+
+namespace AzToolsFramework
+{
+    ConsoleTextEdit::ConsoleTextEdit(QWidget* parent)
+        : QPlainTextEdit(parent)
+        , m_contextMenu(new QMenu(this))
+    {
+        setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(this, &QPlainTextEdit::customContextMenuRequested, this, &ConsoleTextEdit::showContextMenu);
+
+        // Make sure to add the actions to this widget, so that the ShortCutDispatcher picks them up properly
+
+        QAction* copyAction = m_contextMenu->addAction(tr("&Copy"));
+        copyAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        copyAction->setShortcut(QKeySequence::Copy);
+        copyAction->setEnabled(false);
+        connect(copyAction, &QAction::triggered, this, &QPlainTextEdit::copy);
+        addAction(copyAction);
+
+        QAction* selectAllAction = m_contextMenu->addAction(tr("Select &All"));
+        selectAllAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        selectAllAction->setShortcut(QKeySequence::SelectAll);
+        selectAllAction->setEnabled(false);
+        connect(selectAllAction, &QAction::triggered, this, &QPlainTextEdit::selectAll);
+        addAction(selectAllAction);
+
+        m_contextMenu->addSeparator();
+
+        QAction* deleteAction = m_contextMenu->addAction(tr("Delete"));
+        deleteAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        deleteAction->setShortcut(QKeySequence::Delete);
+        deleteAction->setEnabled(false);
+        connect(deleteAction, &QAction::triggered, this, [=]() { textCursor().removeSelectedText(); } );
+        addAction(deleteAction);
+
+        QAction* clearAction = m_contextMenu->addAction(tr("Clear"));
+        clearAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        clearAction->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_C);
+        clearAction->setEnabled(false);
+        connect(clearAction, &QAction::triggered, this, &QPlainTextEdit::clear);
+        addAction(clearAction);
+
+        m_searchAction = m_contextMenu->addAction(tr("Find"));
+        m_searchAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        m_searchAction->setShortcut(QKeySequence::Find);
+        m_searchAction->setEnabled(true);
+        connect(m_searchAction, &QAction::triggered, this, &ConsoleTextEdit::searchBarRequested);
+        addAction(m_searchAction);
+
+        connect(this, &QPlainTextEdit::copyAvailable, copyAction, &QAction::setEnabled);
+        connect(this, &QPlainTextEdit::copyAvailable, deleteAction, &QAction::setEnabled);
+        connect(this, &QPlainTextEdit::textChanged, selectAllAction, [=]
+            {
+                if (document() && !document()->isEmpty())
+                {
+                    clearAction->setEnabled(true);
+                    selectAllAction->setEnabled(true);
+                }
+                else
+                {
+                    clearAction->setEnabled(false);
+                    selectAllAction->setEnabled(false);
+                }
+            });
+    }
+
+    bool ConsoleTextEdit::searchEnabled() 
+    {
+        AZ_Assert(m_searchAction, "Search action is missing.");
+        return m_searchAction->isVisible();
+    }
+
+    void ConsoleTextEdit::setSearchEnabled(bool enabled)
+    {
+        AZ_Assert(m_searchAction, "Search action is missing.");
+        return m_searchAction->setVisible(enabled);
+    }
+
+    bool ConsoleTextEdit::event(QEvent* theEvent)
+    {
+        if (theEvent->type() == QEvent::ShortcutOverride)
+        {
+            // ignore several possible key combinations to prevent them bubbling up to the main editor
+            QKeyEvent* shortcutEvent = static_cast<QKeyEvent*>(theEvent);
+
+            QKeySequence::StandardKey ignoredKeys[] = { QKeySequence::Backspace };
+
+            for (auto& currKey : ignoredKeys)
+            {
+                if (shortcutEvent->matches(currKey))
+                {
+                    // these shortcuts are ignored. Accept them and do nothing.
+                    theEvent->accept();
+                    return true;
+                }
+            }
+        }
+
+        return QPlainTextEdit::event(theEvent);
+    }
+
+    void ConsoleTextEdit::showContextMenu(const QPoint &pt)
+    {
+        m_contextMenu->exec(mapToGlobal(pt));
+    }
+}

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include <AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx>
 #include <AzCore/Debug/Trace.h>
+#include <AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx>
 #include <QMenu>
 
 namespace AzToolsFramework
@@ -41,7 +41,14 @@ namespace AzToolsFramework
         deleteAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
         deleteAction->setShortcut(QKeySequence::Delete);
         deleteAction->setEnabled(false);
-        connect(deleteAction, &QAction::triggered, this, [=]() { textCursor().removeSelectedText(); } );
+        connect(
+            deleteAction,
+            &QAction::triggered,
+            this,
+            [=]()
+            {
+                textCursor().removeSelectedText();
+            });
         addAction(deleteAction);
 
         QAction* clearAction = m_contextMenu->addAction(tr("Clear"));
@@ -60,7 +67,11 @@ namespace AzToolsFramework
 
         connect(this, &QPlainTextEdit::copyAvailable, copyAction, &QAction::setEnabled);
         connect(this, &QPlainTextEdit::copyAvailable, deleteAction, &QAction::setEnabled);
-        connect(this, &QPlainTextEdit::textChanged, selectAllAction, [=]
+        connect(
+            this,
+            &QPlainTextEdit::textChanged,
+            selectAllAction,
+            [=]
             {
                 if (document() && !document()->isEmpty())
                 {
@@ -75,7 +86,7 @@ namespace AzToolsFramework
             });
     }
 
-    bool ConsoleTextEdit::searchEnabled() 
+    bool ConsoleTextEdit::searchEnabled()
     {
         AZ_Assert(m_searchAction, "Search action is missing.");
         return m_searchAction->isVisible();
@@ -110,8 +121,8 @@ namespace AzToolsFramework
         return QPlainTextEdit::event(theEvent);
     }
 
-    void ConsoleTextEdit::showContextMenu(const QPoint &pt)
+    void ConsoleTextEdit::showContextMenu(const QPoint& pt)
     {
         m_contextMenu->exec(mapToGlobal(pt));
     }
-}
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <QPlainTextEdit>
+#include <QScopedPointer>
+#include <QPointer>
+
+#endif
+
+class QMenu;
+
+namespace AzToolsFramework
+{
+class ConsoleTextEdit
+    : public QPlainTextEdit
+{
+    Q_OBJECT
+    Q_PROPERTY(bool searchEnabled READ searchEnabled WRITE setSearchEnabled)
+public:
+
+    explicit ConsoleTextEdit( QWidget* parent = nullptr);
+    virtual bool event(QEvent* theEvent) override;
+
+    bool searchEnabled();
+    void setSearchEnabled(bool enabled);
+Q_SIGNALS:
+    void searchBarRequested();
+
+private:
+    void showContextMenu(const QPoint& pt);
+    
+    QScopedPointer<QMenu> m_contextMenu;
+    QPointer<QAction> m_searchAction;
+};
+}

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx
@@ -10,8 +10,8 @@
 
 #if !defined(Q_MOC_RUN)
 #include <QPlainTextEdit>
-#include <QScopedPointer>
 #include <QPointer>
+#include <QScopedPointer>
 
 #endif
 
@@ -19,25 +19,23 @@ class QMenu;
 
 namespace AzToolsFramework
 {
-class ConsoleTextEdit
-    : public QPlainTextEdit
-{
-    Q_OBJECT
-    Q_PROPERTY(bool searchEnabled READ searchEnabled WRITE setSearchEnabled)
-public:
+    class ConsoleTextEdit : public QPlainTextEdit
+    {
+        Q_OBJECT
+        Q_PROPERTY(bool searchEnabled READ searchEnabled WRITE setSearchEnabled)
+    public:
+        explicit ConsoleTextEdit(QWidget* parent = nullptr);
+        virtual bool event(QEvent* theEvent) override;
 
-    explicit ConsoleTextEdit( QWidget* parent = nullptr);
-    virtual bool event(QEvent* theEvent) override;
+        bool searchEnabled();
+        void setSearchEnabled(bool enabled);
+    Q_SIGNALS:
+        void searchBarRequested();
 
-    bool searchEnabled();
-    void setSearchEnabled(bool enabled);
-Q_SIGNALS:
-    void searchBarRequested();
+    private:
+        void showContextMenu(const QPoint& pt);
 
-private:
-    void showContextMenu(const QPoint& pt);
-    
-    QScopedPointer<QMenu> m_contextMenu;
-    QPointer<QAction> m_searchAction;
-};
-}
+        QScopedPointer<QMenu> m_contextMenu;
+        QPointer<QAction> m_searchAction;
+    };
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -505,6 +505,8 @@ set(FILES
     UI/UICore/AspectRatioAwarePixmapWidget.cpp
     UI/UICore/ClickableLabel.hxx
     UI/UICore/ClickableLabel.cpp
+    UI/UICore/ConsoleTextEdit.hxx
+    UI/UICore/ConsoleTextEdit.cpp
     UI/UICore/IconButton.hxx
     UI/UICore/IconButton.cpp
     UI/UICore/PlainTextEdit.hxx


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/11478

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

This reuses the ConsoleTextEdit for default console and the python console. having the option to delete lines from the console is kind of a strange option? don't think I've seen that in anything I've used recently?

The styling could do with some tweaks since the color of the console seems to be coming from the same setting but through different means. python console is using an EBus and the standard console is getting set through the same global variable. Setting.cpp from my understanding is suppose to be replaced. I think I would like to explore this separately then add this to the current PR. 

## How was this PR tested?

verified with both console and python console.

https://user-images.githubusercontent.com/854359/188065193-ed3d5665-663c-4fb3-85cf-2c71cc3c71d9.mp4

