### PR TITLE
Fix the problem that create double actor instances when open workspaces

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Workspace.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Workspace.cpp
@@ -120,7 +120,6 @@ namespace EMStudio
 
     struct ActivationIndices
     {
-        int32 m_actorInstanceCommandIndex = -1;
         int32 m_animGraphCommandIndex = -1;
         int32 m_motionSetCommandIndex = -1;
     };
@@ -133,8 +132,7 @@ namespace EMStudio
         AZStd::string commands;
 
         // For each actor we are going to set a different activation command. We need to store the command indices
-        // that will produce the results for the actorInstanceIndex, animGraphIndex and motionSetIndex that are
-        // currently selected
+        // that will produce the results for animGraphIndex and motionSetIndex that are currently selected
         typedef AZStd::unordered_map<EMotionFX::ActorInstance*, ActivationIndices> ActivationIndicesByActorInstance;
         ActivationIndicesByActorInstance activationIndicesByActorInstance;
         int32 commandIndex = 0;
@@ -164,7 +162,7 @@ namespace EMStudio
                 AddFile(&commands, "ImportActor", actor->GetFileName());
                 ++commandIndex;
 
-                activationIndicesByActorInstance[actorInstance].m_actorInstanceCommandIndex = commandIndex;
+                activationIndicesByActorInstance.try_emplace(actorInstance, ActivationIndices());
             }
         }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Workspace.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Workspace.cpp
@@ -160,26 +160,11 @@ namespace EMStudio
                     continue;
                 }
 
-                const EMotionFX::Transform& transform = actorInstance->GetLocalSpaceTransform();
-                const AZ::Vector3&       pos     = transform.m_position;
-                const AZ::Quaternion&    rot     = transform.m_rotation;
-
-                #ifndef EMFX_SCALE_DISABLED
-                    const AZ::Vector3& scale = transform.m_scale;
-                #else
-                    const AZ::Vector3 scale = AZ::Vector3::CreateOne();
-                #endif
-
                 // We need to add it here because if we dont do the last result will be the id of the actor instance and then it won't work anymore.
                 AddFile(&commands, "ImportActor", actor->GetFileName());
                 ++commandIndex;
-                commandString = AZStd::string::format("CreateActorInstance -actorID %%LASTRESULT%% -xPos %f -yPos %f -zPos %f -xScale %f -yScale %f -zScale %f -rot %s\n",
-                        static_cast<float>(pos.GetX()), static_cast<float>(pos.GetY()), static_cast<float>(pos.GetZ()), static_cast<float>(scale.GetX()), static_cast<float>(scale.GetY()), static_cast<float>(scale.GetZ()),
-                        AZStd::to_string(rot).c_str());
-                commands += commandString;
 
                 activationIndicesByActorInstance[actorInstance].m_actorInstanceCommandIndex = commandIndex;
-                ++commandIndex;
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

Fix the problem that create double actor instance when loading workspace.

## How was this PR tested?

Manuel verified. 

This CL will stop saving the createActorInstance command in the workspace file. The actorInstance will be created in the actor component already, so createActorInstance command is not needed anymore.
