### PR TITLE
Fix Component mode border flicker - PR11585

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeCollection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeCollection.cpp
@@ -287,10 +287,6 @@ namespace AzToolsFramework
                 componentModeCommand.release();
             }
 
-            // remove the component mode viewport border
-            ViewportUi::ViewportUiRequestBus::Event(
-                ViewportUi::DefaultViewportId, &ViewportUi::ViewportUiRequestBus::Events::RemoveViewportBorder);
-
             // notify listeners the editor has left ComponentMode - listeners may
             // wish to modify state to indicate this (e.g. appearance, functionality etc.)
             m_viewportEditorModeTracker->DeactivateMode({ GetEntityContextId() }, ViewportEditorMode::Component);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
@@ -109,17 +109,6 @@ namespace AzToolsFramework::ComponentModeFramework
         auto* toolsApplicationRequests = AzToolsFramework::ToolsApplicationRequestBus::FindFirstHandler();
         const auto& selectedEntityIds = toolsApplicationRequests->GetSelectedEntities();
 
-        if (!newlyDeselectedEntityIds.empty())
-        {
-            // clear the switcher then add the components back if entities are still selected
-            ClearSwitcher();
-
-            if (!selectedEntityIds.empty())
-            {
-                UpdateSwitcherOnEntitySelectionChange(selectedEntityIds, EntityIdList{});
-            }
-        }
-
         if (!newlySelectedEntityIds.empty())
         {
             for (auto entityId : newlySelectedEntityIds)
@@ -132,7 +121,7 @@ namespace AzToolsFramework::ComponentModeFramework
                 {
                     // if two or more entities are selected, ensure the only components
                     // that remain on the switcher are common to all entities
-                    if (selectedEntityIds.size() > 1 && !m_addedComponents.empty())
+                    if (selectedEntityIds.size() > 1 && m_addedComponents.size() != 0)
                     {
                         RemoveNonCommonComponents(*entity);
                         // if components have been removed from the switcher and there is nothing left on the switcher
@@ -153,6 +142,16 @@ namespace AzToolsFramework::ComponentModeFramework
                         AddComponentButton(entityComponentIdPair);
                     }
                 }
+            }
+        }
+        else if (!newlyDeselectedEntityIds.empty())
+        {
+            // clear the switcher then add the components back if entities are still selected
+            ClearSwitcher();
+
+            if (selectedEntityIds.size() >= 1)
+            {
+                UpdateSwitcherOnEntitySelectionChange(selectedEntityIds, EntityIdList{});
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
@@ -109,6 +109,17 @@ namespace AzToolsFramework::ComponentModeFramework
         auto* toolsApplicationRequests = AzToolsFramework::ToolsApplicationRequestBus::FindFirstHandler();
         const auto& selectedEntityIds = toolsApplicationRequests->GetSelectedEntities();
 
+        if (!newlyDeselectedEntityIds.empty())
+        {
+            // clear the switcher then add the components back if entities are still selected
+            ClearSwitcher();
+
+            if (!selectedEntityIds.empty())
+            {
+                UpdateSwitcherOnEntitySelectionChange(selectedEntityIds, EntityIdList{});
+            }
+        }
+
         if (!newlySelectedEntityIds.empty())
         {
             for (auto entityId : newlySelectedEntityIds)
@@ -121,7 +132,7 @@ namespace AzToolsFramework::ComponentModeFramework
                 {
                     // if two or more entities are selected, ensure the only components
                     // that remain on the switcher are common to all entities
-                    if (selectedEntityIds.size() > 1 && m_addedComponents.size() != 0)
+                    if (selectedEntityIds.size() > 1 && !m_addedComponents.empty())
                     {
                         RemoveNonCommonComponents(*entity);
                         // if components have been removed from the switcher and there is nothing left on the switcher
@@ -142,16 +153,6 @@ namespace AzToolsFramework::ComponentModeFramework
                         AddComponentButton(entityComponentIdPair);
                     }
                 }
-            }
-        }
-        else if (!newlyDeselectedEntityIds.empty())
-        {
-            // clear the switcher then add the components back if entities are still selected
-            ClearSwitcher();
-
-            if (selectedEntityIds.size() >= 1)
-            {
-                UpdateSwitcherOnEntitySelectionChange(selectedEntityIds, EntityIdList{});
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
@@ -247,23 +247,28 @@ namespace AzToolsFramework::ComponentModeFramework
         {
             componentData = componentDataIt;
         }
+     
+        if (buttonId == m_transformButtonId)
+        {
+            AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::Broadcast(
+                &ComponentModeSystemRequests::EndComponentMode);
+
+            return;
+        }
 
         bool inComponentMode;
         AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::BroadcastResult(
             inComponentMode, &ComponentModeSystemRequests::InComponentMode);
 
-        // if already in component mode, end current mode and switch active button to the selected component
         if (inComponentMode)
         {
-            AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::Broadcast(
-                &ComponentModeSystemRequests::EndComponentMode);
-
             ViewportUi::ViewportUiRequestBus::Event(
                 ViewportUi::DefaultViewportId, &ViewportUi::ViewportUiRequestBus::Events::SetSwitcherActiveButton, m_switcherId, buttonId);
-        }
 
-        // if the newly active button is not the transform button (no component mode associated), emter component mode
-        if (buttonId != m_transformButtonId)
+            AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::Broadcast(
+                &ComponentModeSystemRequests::ChangeComponentMode, componentData->m_component->GetUnderlyingComponentType());
+        }
+        else
         {
             AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::Broadcast(
                 &ComponentModeSystemRequests::AddSelectedComponentModesOfType, componentData->m_component->GetUnderlyingComponentType());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
@@ -246,7 +246,10 @@ namespace AzToolsFramework::ComponentModeFramework
         {
             componentData = componentDataIt;
         }
-     
+
+        // the transform button does not have an associated component mode,
+        // if the user clicks the transform button they must already be in component mode
+        // so when they click it, leave component mode
         if (buttonId == m_transformButtonId)
         {
             AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::Broadcast(
@@ -255,7 +258,7 @@ namespace AzToolsFramework::ComponentModeFramework
             return;
         }
 
-        bool inComponentMode;
+        bool inComponentMode = false;
         AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::BroadcastResult(
             inComponentMode, &ComponentModeSystemRequests::InComponentMode);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
@@ -261,11 +261,11 @@ namespace AzToolsFramework::ComponentModeFramework
 
         if (inComponentMode)
         {
-            ViewportUi::ViewportUiRequestBus::Event(
-                ViewportUi::DefaultViewportId, &ViewportUi::ViewportUiRequestBus::Events::SetSwitcherActiveButton, m_switcherId, buttonId);
-
             AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::Broadcast(
                 &ComponentModeSystemRequests::ChangeComponentMode, componentData->m_component->GetUnderlyingComponentType());
+
+            ViewportUi::ViewportUiRequestBus::Event(
+                ViewportUi::DefaultViewportId, &ViewportUi::ViewportUiRequestBus::Events::SetSwitcherActiveButton, m_switcherId, buttonId);
         }
         else
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorBaseComponentMode.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorBaseComponentMode.cpp
@@ -53,13 +53,34 @@ namespace AzToolsFramework
             ComponentModeViewportUiRequestBus::Event(
                 GetComponentType(), &ComponentModeViewportUiRequestBus::Events::RegisterViewportElementGroup,
                 GetEntityComponentIdPair(), elementIdsToDisplay);
-            // create the component mode border with the specific name for this component mode
-            ViewportUi::ViewportUiRequestBus::Event(
-                ViewportUi::DefaultViewportId, &ViewportUi::ViewportUiRequestBus::Events::CreateViewportBorder, GetComponentModeName(),
-                []
-                {
-                    ComponentModeSystemRequestBus::Broadcast(&ComponentModeSystemRequests::EndComponentMode);
-                });
+
+            bool borderVisible;
+            ViewportUi::ViewportUiRequestBus::EventResult(
+                borderVisible,
+                ViewportUi::DefaultViewportId,
+                &ViewportUi::ViewportUiRequestBus::Events::ViewportBorderVisible);
+
+            // if the border is visible, change the border title
+            // else create the component mode border with the specific name for this component mode
+            if (borderVisible)
+            {
+                ViewportUi::ViewportUiRequestBus::Event(
+                    ViewportUi::DefaultViewportId,
+                    &ViewportUi::ViewportUiRequestBus::Events::ChangeViewportBorderText,
+                    GetComponentModeName());
+            }
+            else
+            {
+                ViewportUi::ViewportUiRequestBus::Event(
+                    ViewportUi::DefaultViewportId,
+                    &ViewportUi::ViewportUiRequestBus::Events::CreateViewportBorder,
+                    GetComponentModeName(),
+                    []
+                    {
+                        ComponentModeSystemRequestBus::Broadcast(&ComponentModeSystemRequests::EndComponentMode);
+                    });
+            }
+
             // set the EntityComponentId for this ComponentMode to active in the ComponentModeViewportUi system
             ComponentModeViewportUiRequestBus::Event(
                 GetComponentType(), &ComponentModeViewportUiRequestBus::Events::SetViewportUiActiveEntityComponentId,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorBaseComponentMode.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorBaseComponentMode.cpp
@@ -54,11 +54,11 @@ namespace AzToolsFramework
                 GetComponentType(), &ComponentModeViewportUiRequestBus::Events::RegisterViewportElementGroup,
                 GetEntityComponentIdPair(), elementIdsToDisplay);
 
-            bool borderVisible;
+            bool borderVisible = false;
             ViewportUi::ViewportUiRequestBus::EventResult(
                 borderVisible,
                 ViewportUi::DefaultViewportId,
-                &ViewportUi::ViewportUiRequestBus::Events::ViewportBorderVisible);
+                &ViewportUi::ViewportUiRequestBus::Events::GetViewportBorderVisible);
 
             // if the border is visible, change the border title
             // else create the component mode border with the specific name for this component mode

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorComponentModeBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorComponentModeBus.h
@@ -142,8 +142,8 @@ namespace AzToolsFramework
             /// has the same Component on it, move all Components into ComponentMode.
             virtual void AddSelectedComponentModesOfType(const AZ::Uuid& componentType) = 0;
 
-            // If the user changes component edit mode through the switcher, switch the 
-            // component edit modes seamlessly.
+            // If the user changes component mode through the switcher, switch the 
+            // component mode seamlessly.
             virtual void ChangeComponentMode(const AZ::Uuid& componentType) = 0;
 
             /// Move to the next active ComponentMode so the Actions for that mode

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorComponentModeBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorComponentModeBus.h
@@ -142,6 +142,10 @@ namespace AzToolsFramework
             /// has the same Component on it, move all Components into ComponentMode.
             virtual void AddSelectedComponentModesOfType(const AZ::Uuid& componentType) = 0;
 
+            // If the user changes component edit mode through the switcher, switch the 
+            // component edit modes seamlessly.
+            virtual void ChangeComponentMode(const AZ::Uuid& componentType) = 0;
+
             /// Move to the next active ComponentMode so the Actions for that mode
             /// become available (it is now 'selected').
             /// Return true if the mode actually changed - the mode will not change if

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorComponentModeBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorComponentModeBus.h
@@ -142,7 +142,7 @@ namespace AzToolsFramework
             /// has the same Component on it, move all Components into ComponentMode.
             virtual void AddSelectedComponentModesOfType(const AZ::Uuid& componentType) = 0;
 
-            // Switches to the ComponentMode of input component type immediately.
+            /// Switches to the ComponentMode of input component type immediately.
             virtual void ChangeComponentMode(const AZ::Uuid& componentType) = 0;
 
             /// Move to the next active ComponentMode so the Actions for that mode

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorComponentModeBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorComponentModeBus.h
@@ -142,8 +142,7 @@ namespace AzToolsFramework
             /// has the same Component on it, move all Components into ComponentMode.
             virtual void AddSelectedComponentModesOfType(const AZ::Uuid& componentType) = 0;
 
-            // If the user changes component mode through the switcher, switch the 
-            // component mode seamlessly.
+            // Switches to the ComponentMode of input component type immediately.
             virtual void ChangeComponentMode(const AZ::Uuid& componentType) = 0;
 
             /// Move to the next active ComponentMode so the Actions for that mode

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorDefaultSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorDefaultSelection.cpp
@@ -135,6 +135,9 @@ namespace AzToolsFramework
     void EditorDefaultSelection::EndComponentMode()
     {
         TransitionFromComponentMode();
+        // remove the component mode viewport border
+        ViewportUi::ViewportUiRequestBus::Event(
+            ViewportUi::DefaultViewportId, &ViewportUi::ViewportUiRequestBus::Events::RemoveViewportBorder);
     }
 
     void EditorDefaultSelection::Refresh(const AZ::EntityComponentIdPair& entityComponentIdPair)
@@ -149,6 +152,20 @@ namespace AzToolsFramework
 
     void EditorDefaultSelection::AddSelectedComponentModesOfType(const AZ::Uuid& componentType)
     {
+        ComponentModeFramework::ComponentModeDelegateRequestBus::EnumerateHandlers(
+            [componentType](ComponentModeFramework::ComponentModeDelegateRequestBus::InterfaceType* componentModeMouseRequests)
+            {
+                componentModeMouseRequests->AddComponentModeOfType(componentType);
+                return true;
+            });
+
+        TransitionToComponentMode();
+    }
+
+    void EditorDefaultSelection::ChangeComponentMode(const AZ::Uuid& componentType)
+    {
+        TransitionFromComponentMode();
+
         ComponentModeFramework::ComponentModeDelegateRequestBus::EnumerateHandlers(
             [componentType](ComponentModeFramework::ComponentModeDelegateRequestBus::InterfaceType* componentModeMouseRequests)
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorDefaultSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorDefaultSelection.h
@@ -67,6 +67,7 @@ namespace AzToolsFramework
         void Refresh(const AZ::EntityComponentIdPair& entityComponentIdPair) override;
         bool AddedToComponentMode(const AZ::EntityComponentIdPair& entityComponentIdPair, const AZ::Uuid& componentType) override;
         void AddSelectedComponentModesOfType(const AZ::Uuid& componentType) override;
+        void ChangeComponentMode(const AZ::Uuid& componentType) override;
         bool SelectNextActiveComponentMode() override;
         bool SelectPreviousActiveComponentMode() override;
         bool SelectActiveComponentMode(const AZ::Uuid& componentType) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
@@ -313,12 +313,10 @@ namespace AzToolsFramework::ViewportUi::Internal
         m_uiOverlayLayout.setContentsMargins(
             HighlightBorderSize + ViewportUiOverlayMargin, ViewportUiTopBorderSize + ViewportUiOverlayMargin,
             HighlightBorderSize + ViewportUiOverlayMargin, HighlightBorderSize + ViewportUiOverlayMargin);
-
-        m_viewportBorderText.setFixedWidth(m_uiOverlay.width());
         m_viewportBorderText.setAlignment(Qt::AlignCenter);
 
         m_viewportBorderText.show();
-        m_viewportBorderText.setText(borderTitle.c_str());
+        ChangeViewportBorderText(borderTitle.c_str());
 
         // only display the back button if a callback was provided
         m_viewportBorderBackButtonCallback = backButtonCallback;
@@ -326,10 +324,12 @@ namespace AzToolsFramework::ViewportUi::Internal
     }
 
     void ViewportUiDisplay::ChangeViewportBorderText(
-        const AZStd::string& borderTitle)
+        const char* borderTitle)
     {
+        // when the text changes if the width is different it will flicker as it changes,
+        // this sets the width to the entire overlay to avoid that
         m_viewportBorderText.setFixedWidth(m_uiOverlay.width());
-        m_viewportBorderText.setText(borderTitle.c_str());
+        m_viewportBorderText.setText(borderTitle);
     }
 
     void ViewportUiDisplay::RemoveViewportBorder()
@@ -341,6 +341,11 @@ namespace AzToolsFramework::ViewportUi::Internal
             ViewportUiOverlayMargin);
         m_viewportBorderBackButtonCallback.reset();
         m_viewportBorderBackButton.hide();
+    }
+
+    inline const bool ViewportUiDisplay::GetViewportBorderVisible() const
+    {
+        return m_viewportBorderText.isVisible();
     }
 
     void ViewportUiDisplay::PositionViewportUiElementFromWorldSpace(ViewportUiElementId elementId, const AZ::Vector3& pos)
@@ -460,7 +465,9 @@ namespace AzToolsFramework::ViewportUi::Internal
             region -= QRect(
                 QPoint(m_uiOverlay.rect().left() + HighlightBorderSize, m_uiOverlay.rect().top() + ViewportUiTopBorderSize),
                 QPoint(m_uiOverlay.rect().right() - HighlightBorderSize, m_uiOverlay.rect().bottom() - HighlightBorderSize));
-
+            
+            // if the user changes the size of their window, release the width of the border so the
+            // overlay can resize
             if (m_viewportBorderText.width() != m_renderOverlay->width())
             {
                 m_viewportBorderText.setMinimumWidth(0);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
@@ -313,13 +313,23 @@ namespace AzToolsFramework::ViewportUi::Internal
         m_uiOverlayLayout.setContentsMargins(
             HighlightBorderSize + ViewportUiOverlayMargin, ViewportUiTopBorderSize + ViewportUiOverlayMargin,
             HighlightBorderSize + ViewportUiOverlayMargin, HighlightBorderSize + ViewportUiOverlayMargin);
+
+        m_viewportBorderText.setFixedWidth(m_uiOverlay.width());
+        m_viewportBorderText.setAlignment(Qt::AlignCenter);
+
         m_viewportBorderText.show();
         m_viewportBorderText.setText(borderTitle.c_str());
-        UpdateUiOverlayGeometry();
 
         // only display the back button if a callback was provided
         m_viewportBorderBackButtonCallback = backButtonCallback;
         m_viewportBorderBackButton.setVisible(m_viewportBorderBackButtonCallback.has_value());
+    }
+
+    void ViewportUiDisplay::ChangeViewportBorderText(
+        const AZStd::string& borderTitle)
+    {
+        m_viewportBorderText.setFixedWidth(m_uiOverlay.width());
+        m_viewportBorderText.setText(borderTitle.c_str());
     }
 
     void ViewportUiDisplay::RemoveViewportBorder()
@@ -450,6 +460,12 @@ namespace AzToolsFramework::ViewportUi::Internal
             region -= QRect(
                 QPoint(m_uiOverlay.rect().left() + HighlightBorderSize, m_uiOverlay.rect().top() + ViewportUiTopBorderSize),
                 QPoint(m_uiOverlay.rect().right() - HighlightBorderSize, m_uiOverlay.rect().bottom() - HighlightBorderSize));
+
+            if (m_viewportBorderText.width() != m_renderOverlay->width())
+            {
+                m_viewportBorderText.setMinimumWidth(0);
+                m_viewportBorderText.setMaximumWidth(m_renderOverlay->width());
+            }
         }
 
         // add all children widget regions

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
@@ -343,7 +343,7 @@ namespace AzToolsFramework::ViewportUi::Internal
         m_viewportBorderBackButton.hide();
     }
 
-    inline const bool ViewportUiDisplay::GetViewportBorderVisible() const
+    bool ViewportUiDisplay::GetViewportBorderVisible() const
     {
         return m_viewportBorderText.isVisible();
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.h
@@ -94,7 +94,7 @@ namespace AzToolsFramework::ViewportUi::Internal
         void CreateViewportBorder(const AZStd::string& borderTitle, AZStd::optional<ViewportUiBackButtonCallback> backButtonCallback);
         void ChangeViewportBorderText(const char* borderTitle);
         void RemoveViewportBorder();
-        const bool GetViewportBorderVisible() const;
+        bool GetViewportBorderVisible() const;
 
     private:
         void PrepareWidgetForViewportUi(QPointer<QWidget> widget);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.h
@@ -92,7 +92,12 @@ namespace AzToolsFramework::ViewportUi::Internal
         bool IsViewportUiElementVisible(ViewportUiElementId elementId);
 
         void CreateViewportBorder(const AZStd::string& borderTitle, AZStd::optional<ViewportUiBackButtonCallback> backButtonCallback);
+        void ChangeViewportBorderText(const AZStd::string& borderTitle);
         void RemoveViewportBorder();
+        const bool ViewportBorderVisible()
+        {
+            return m_viewportBorderText.isVisible();
+        }
 
     private:
         void PrepareWidgetForViewportUi(QPointer<QWidget> widget);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.h
@@ -92,12 +92,9 @@ namespace AzToolsFramework::ViewportUi::Internal
         bool IsViewportUiElementVisible(ViewportUiElementId elementId);
 
         void CreateViewportBorder(const AZStd::string& borderTitle, AZStd::optional<ViewportUiBackButtonCallback> backButtonCallback);
-        void ChangeViewportBorderText(const AZStd::string& borderTitle);
+        void ChangeViewportBorderText(const char* borderTitle);
         void RemoveViewportBorder();
-        const bool ViewportBorderVisible()
-        {
-            return m_viewportBorderText.isVisible();
-        }
+        const bool GetViewportBorderVisible() const;
 
     private:
         void PrepareWidgetForViewportUi(QPointer<QWidget> widget);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
@@ -271,7 +271,7 @@ namespace AzToolsFramework::ViewportUi
         return m_viewportUi->GetViewportBorderVisible();
     }
 
-    void ViewportUiManager::ChangeViewportBorderText(const AZStd::string borderTitle)
+    void ViewportUiManager::ChangeViewportBorderText(const AZStd::string& borderTitle)
     {
         m_viewportUi->ChangeViewportBorderText(borderTitle.c_str());
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
@@ -266,7 +266,7 @@ namespace AzToolsFramework::ViewportUi
         m_viewportUi->CreateViewportBorder(borderTitle, backButtonCallback);
     }
 
-    const bool ViewportUiManager::GetViewportBorderVisible() const
+    bool ViewportUiManager::GetViewportBorderVisible() const
     {
         return m_viewportUi->GetViewportBorderVisible();
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
@@ -266,6 +266,16 @@ namespace AzToolsFramework::ViewportUi
         m_viewportUi->CreateViewportBorder(borderTitle, backButtonCallback);
     }
 
+    const bool ViewportUiManager::ViewportBorderVisible()
+    {
+        return m_viewportUi->ViewportBorderVisible();
+    }
+
+    void ViewportUiManager::ChangeViewportBorderText(AZStd::string borderTitle)
+    {
+        m_viewportUi->ChangeViewportBorderText(borderTitle);
+    }
+
     void ViewportUiManager::RemoveViewportBorder()
     {
         m_viewportUi->RemoveViewportBorder();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
@@ -266,14 +266,14 @@ namespace AzToolsFramework::ViewportUi
         m_viewportUi->CreateViewportBorder(borderTitle, backButtonCallback);
     }
 
-    const bool ViewportUiManager::ViewportBorderVisible()
+    const bool ViewportUiManager::GetViewportBorderVisible() const
     {
-        return m_viewportUi->ViewportBorderVisible();
+        return m_viewportUi->GetViewportBorderVisible();
     }
 
-    void ViewportUiManager::ChangeViewportBorderText(AZStd::string borderTitle)
+    void ViewportUiManager::ChangeViewportBorderText(const AZStd::string borderTitle)
     {
-        m_viewportUi->ChangeViewportBorderText(borderTitle);
+        m_viewportUi->ChangeViewportBorderText(borderTitle.c_str());
     }
 
     void ViewportUiManager::RemoveViewportBorder()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
@@ -54,7 +54,9 @@ namespace AzToolsFramework::ViewportUi
         void SetTextFieldVisible(TextFieldId textFieldId, bool visible) override;
         void CreateViewportBorder(
             const AZStd::string& borderTitle, AZStd::optional<ViewportUiBackButtonCallback> backButtonCallback) override;
+        void ChangeViewportBorderText(AZStd::string borderTitle) override;
         void RemoveViewportBorder() override;
+        const bool ViewportBorderVisible() override;
         void PressButton(ClusterId clusterId, ButtonId buttonId) override;
         void PressButton(SwitcherId switcherId, ButtonId buttonId) override;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
@@ -54,9 +54,9 @@ namespace AzToolsFramework::ViewportUi
         void SetTextFieldVisible(TextFieldId textFieldId, bool visible) override;
         void CreateViewportBorder(
             const AZStd::string& borderTitle, AZStd::optional<ViewportUiBackButtonCallback> backButtonCallback) override;
-        void ChangeViewportBorderText(AZStd::string borderTitle) override;
+        void ChangeViewportBorderText(const AZStd::string borderTitle) override;
         void RemoveViewportBorder() override;
-        const bool ViewportBorderVisible() override;
+        const bool GetViewportBorderVisible() const override;
         void PressButton(ClusterId clusterId, ButtonId buttonId) override;
         void PressButton(SwitcherId switcherId, ButtonId buttonId) override;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
@@ -56,7 +56,7 @@ namespace AzToolsFramework::ViewportUi
             const AZStd::string& borderTitle, AZStd::optional<ViewportUiBackButtonCallback> backButtonCallback) override;
         void ChangeViewportBorderText(const AZStd::string borderTitle) override;
         void RemoveViewportBorder() override;
-        const bool GetViewportBorderVisible() const override;
+        bool GetViewportBorderVisible() const override;
         void PressButton(ClusterId clusterId, ButtonId buttonId) override;
         void PressButton(SwitcherId switcherId, ButtonId buttonId) override;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
@@ -54,7 +54,7 @@ namespace AzToolsFramework::ViewportUi
         void SetTextFieldVisible(TextFieldId textFieldId, bool visible) override;
         void CreateViewportBorder(
             const AZStd::string& borderTitle, AZStd::optional<ViewportUiBackButtonCallback> backButtonCallback) override;
-        void ChangeViewportBorderText(const AZStd::string borderTitle) override;
+        void ChangeViewportBorderText(const AZStd::string& borderTitle) override;
         void RemoveViewportBorder() override;
         bool GetViewportBorderVisible() const override;
         void PressButton(ClusterId clusterId, ButtonId buttonId) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiRequestBus.h
@@ -105,7 +105,7 @@ namespace AzToolsFramework::ViewportUi
         //! Create the highlight border with optional back button to exit the given editor mode.
         virtual void CreateViewportBorder(const AZStd::string& borderTitle, AZStd::optional<ViewportUiBackButtonCallback> backButtonCallback) = 0;
         //! Retrns if the viewport border is visible.
-        virtual const bool GetViewportBorderVisible() const = 0;
+        virtual bool GetViewportBorderVisible() const = 0;
         //! Changes the text on the viewport border while in component mode.
         virtual void ChangeViewportBorderText(const AZStd::string borderTitle) = 0;
         //! Remove the viewport border.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiRequestBus.h
@@ -104,6 +104,10 @@ namespace AzToolsFramework::ViewportUi
         virtual void SetTextFieldVisible(TextFieldId textFieldId, bool visible) = 0;
         //! Create the highlight border with optional back button to exit the given editor mode.
         virtual void CreateViewportBorder(const AZStd::string& borderTitle, AZStd::optional<ViewportUiBackButtonCallback> backButtonCallback) = 0;
+        //! Check if the viewport border is visible.
+        virtual bool const ViewportBorderVisible() = 0;
+        //! Changes the text on the viewport border while in component mode.
+        virtual void ChangeViewportBorderText(AZStd::string borderTitle) = 0;
         //! Remove the highlight border.
         virtual void RemoveViewportBorder() = 0;
         //! Invoke a button press on a cluster.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiRequestBus.h
@@ -104,11 +104,11 @@ namespace AzToolsFramework::ViewportUi
         virtual void SetTextFieldVisible(TextFieldId textFieldId, bool visible) = 0;
         //! Create the highlight border with optional back button to exit the given editor mode.
         virtual void CreateViewportBorder(const AZStd::string& borderTitle, AZStd::optional<ViewportUiBackButtonCallback> backButtonCallback) = 0;
-        //! Check if the viewport border is visible.
-        virtual bool const ViewportBorderVisible() = 0;
+        //! Retrns if the viewport border is visible.
+        virtual const bool GetViewportBorderVisible() const = 0;
         //! Changes the text on the viewport border while in component mode.
-        virtual void ChangeViewportBorderText(AZStd::string borderTitle) = 0;
-        //! Remove the highlight border.
+        virtual void ChangeViewportBorderText(const AZStd::string borderTitle) = 0;
+        //! Remove the viewport border.
         virtual void RemoveViewportBorder() = 0;
         //! Invoke a button press on a cluster.
         virtual void PressButton(ClusterId clusterId, ButtonId buttonId) = 0;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiRequestBus.h
@@ -104,7 +104,7 @@ namespace AzToolsFramework::ViewportUi
         virtual void SetTextFieldVisible(TextFieldId textFieldId, bool visible) = 0;
         //! Create the highlight border with optional back button to exit the given editor mode.
         virtual void CreateViewportBorder(const AZStd::string& borderTitle, AZStd::optional<ViewportUiBackButtonCallback> backButtonCallback) = 0;
-        //! Retrns if the viewport border is visible.
+        //! Returns if the viewport border is visible.
         virtual bool GetViewportBorderVisible() const = 0;
         //! Changes the text on the viewport border while in component mode.
         virtual void ChangeViewportBorderText(const AZStd::string borderTitle) = 0;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiRequestBus.h
@@ -107,7 +107,7 @@ namespace AzToolsFramework::ViewportUi
         //! Returns if the viewport border is visible.
         virtual bool GetViewportBorderVisible() const = 0;
         //! Changes the text on the viewport border while in component mode.
-        virtual void ChangeViewportBorderText(const AZStd::string borderTitle) = 0;
+        virtual void ChangeViewportBorderText(const AZStd::string& borderTitle) = 0;
         //! Remove the viewport border.
         virtual void RemoveViewportBorder() = 0;
         //! Invoke a button press on a cluster.


### PR DESCRIPTION
## What does this PR do?

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

When the user changes component mode via the switcher, the border flickered on the change, with this PR, the border no longer flickers.

This PR has been approved (https://github.com/o3de/o3de/pull/11436) and merged into development.

Before:
https://user-images.githubusercontent.com/105638312/185807369-bb841254-eb94-4722-9d7f-f134c99814e0.mp4

After:
https://user-images.githubusercontent.com/105638312/185807390-3c4b0670-fc34-4632-8ba2-5925c6724bf3.mp4
