### PR TITLE
Remote project fixes

### DIFF
--- a/Code/Tools/ProjectManager/Source/AddRemoteProjectDialog.cpp
+++ b/Code/Tools/ProjectManager/Source/AddRemoteProjectDialog.cpp
@@ -48,16 +48,30 @@ namespace O3DE::ProjectManager
 
         m_repoPath = new FormLineEditWidget(tr("Remote URL"), "", this);
         m_repoPath->setMinimumSize(QSize(600, 0));
+        m_repoPath->lineEdit()->setPlaceholderText("http://github.com/example.git");
         vLayout->addWidget(m_repoPath);
 
         vLayout->addSpacing(10);
+
+        QHBoxLayout* warningHLayout = new QHBoxLayout(this);
+
+        QLabel* warningIcon = new QLabel(this);
+        //warningIcon->setObjectName("projectWarningIconOverlay");
+        warningIcon->setPixmap(QIcon(":/Warning.svg").pixmap(32, 32));
+        warningIcon->setAlignment(Qt::AlignCenter);
+        warningIcon->setFixedSize(32, 32);
+        warningHLayout->addWidget(warningIcon);
+
+        warningHLayout->addSpacing(10);
 
         QLabel* warningLabel = new QLabel(tr("Online repositories may contain files that could potentially harm your computer,"
             " please ensure you understand the risks before downloading from third-party sources."), this);
         warningLabel->setObjectName("remoteProjectDialogWarningLabel");
         warningLabel->setWordWrap(true);
         warningLabel->setAlignment(Qt::AlignLeft);
-        vLayout->addWidget(warningLabel);
+        warningHLayout->addWidget(warningLabel);
+
+        vLayout->addLayout(warningHLayout);
 
         vLayout->addSpacing(10);
 
@@ -105,7 +119,7 @@ namespace O3DE::ProjectManager
         extraInfoGridLayout->setAlignment(Qt::AlignLeft);
         
 
-        m_requirementsTitleLabel = new QLabel(tr("Requirements"), this);
+        m_requirementsTitleLabel = new QLabel(tr("Project Requirements"), this);
         m_requirementsTitleLabel->setObjectName("remoteProjectDialogRequirementsTitleLabel");
         m_requirementsTitleLabel->setAlignment(Qt::AlignLeft);
 
@@ -211,7 +225,7 @@ namespace O3DE::ProjectManager
         if (addGemRepoResult.IsSuccess())
         {
             // Send download to project screen to initiate download
-            emit StartObjectDownload(m_currentProject.m_projectName);
+            emit StartObjectDownload(m_currentProject.m_projectName, GetInstallPath());
             emit QDialog::accept();
         }
         else

--- a/Code/Tools/ProjectManager/Source/AddRemoteProjectDialog.cpp
+++ b/Code/Tools/ProjectManager/Source/AddRemoteProjectDialog.cpp
@@ -48,15 +48,13 @@ namespace O3DE::ProjectManager
 
         m_repoPath = new FormLineEditWidget(tr("Remote URL"), "", this);
         m_repoPath->setMinimumSize(QSize(600, 0));
-        m_repoPath->lineEdit()->setPlaceholderText("http://github.com/example.git");
+        m_repoPath->lineEdit()->setPlaceholderText("http://github.com/o3de/example.git");
         vLayout->addWidget(m_repoPath);
 
         vLayout->addSpacing(10);
 
-        QHBoxLayout* warningHLayout = new QHBoxLayout(this);
-
-        QLabel* warningIcon = new QLabel(this);
-        //warningIcon->setObjectName("projectWarningIconOverlay");
+        QHBoxLayout* warningHLayout = new QHBoxLayout();
+        QLabel* warningIcon = new QLabel();
         warningIcon->setPixmap(QIcon(":/Warning.svg").pixmap(32, 32));
         warningIcon->setAlignment(Qt::AlignCenter);
         warningIcon->setFixedSize(32, 32);

--- a/Code/Tools/ProjectManager/Source/AddRemoteProjectDialog.h
+++ b/Code/Tools/ProjectManager/Source/AddRemoteProjectDialog.h
@@ -43,7 +43,7 @@ namespace O3DE::ProjectManager
         void SetDialogReady(bool isReady);
 
     signals:
-        void StartObjectDownload(const QString& objectName);
+        void StartObjectDownload(const QString& objectName, const QString& destinationPath);
 
     private slots:
         void ValidateURI();

--- a/Code/Tools/ProjectManager/Source/DownloadController.cpp
+++ b/Code/Tools/ProjectManager/Source/DownloadController.cpp
@@ -36,14 +36,14 @@ namespace O3DE::ProjectManager
         m_workerThread.wait();
     }
 
-    void DownloadController::AddObjectDownload(const QString& objectName, DownloadObjectType objectType)
+    void DownloadController::AddObjectDownload(const QString& objectName, const QString& destinationPath, DownloadObjectType objectType)
     {
-        m_objects.push_back({ objectName, objectType });
+        m_objects.push_back({ objectName, destinationPath, objectType });
         emit ObjectDownloadAdded(objectName, objectType);
 
         if (m_objects.size() == 1)
         {
-            m_worker->SetObjectToDownload(m_objects.front().m_objectName, objectType, false);
+            m_worker->SetObjectToDownload(m_objects.front().m_objectName, destinationPath, objectType, false);
             m_workerThread.start();
         }
     }
@@ -113,7 +113,7 @@ namespace O3DE::ProjectManager
         if (!m_objects.empty())
         {
             const DownloadableObject& nextObject = m_objects.front();
-            emit StartObjectDownload(nextObject.m_objectName, nextObject.m_objectType, true);
+            emit StartObjectDownload(nextObject.m_objectName, nextObject.m_destinationPath, nextObject.m_objectType, true);
         }
         else
         {

--- a/Code/Tools/ProjectManager/Source/DownloadController.h
+++ b/Code/Tools/ProjectManager/Source/DownloadController.h
@@ -34,13 +34,14 @@ namespace O3DE::ProjectManager
         struct DownloadableObject
         {
             QString m_objectName;
+            QString m_destinationPath;
             DownloadObjectType m_objectType;
         };
 
         explicit DownloadController(QWidget* parent = nullptr);
         ~DownloadController();
 
-        void AddObjectDownload(const QString& objectName, DownloadObjectType objectType);
+        void AddObjectDownload(const QString& objectName, const QString& destinationPath, DownloadObjectType objectType);
         void CancelObjectDownload(const QString& objectName, DownloadObjectType objectType);
 
         bool IsDownloadQueueEmpty()
@@ -70,7 +71,7 @@ namespace O3DE::ProjectManager
         void HandleResults(const QString& result, const QString& detailedError);
 
     signals:
-        void StartObjectDownload(const QString& objectName, DownloadObjectType objectType, bool downloadNow);
+        void StartObjectDownload(const QString& objectName, const QString& destinationPath, DownloadObjectType objectType, bool downloadNow);
         void Done(const QString& objectName, bool success = true);
         void ObjectDownloadAdded(const QString& objectName, DownloadObjectType objectType);
         void ObjectDownloadRemoved(const QString& objectName, DownloadObjectType objectType);

--- a/Code/Tools/ProjectManager/Source/DownloadWorker.cpp
+++ b/Code/Tools/ProjectManager/Source/DownloadWorker.cpp
@@ -27,15 +27,15 @@ namespace O3DE::ProjectManager
         IPythonBindings::DetailedOutcome objectInfoResult;
         if (m_downloadType == DownloadController::DownloadObjectType::Gem)
         {
-            objectInfoResult = PythonBindingsInterface::Get()->DownloadGem(m_objectName, objectDownloadProgress, /*force*/ true);
+            objectInfoResult = PythonBindingsInterface::Get()->DownloadGem(m_objectName, m_destinationPath , objectDownloadProgress, /*force*/ true);
         }
         else if (m_downloadType == DownloadController::DownloadObjectType::Project)
         {
-            objectInfoResult = PythonBindingsInterface::Get()->DownloadProject(m_objectName, objectDownloadProgress, /*force*/ true);
+            objectInfoResult = PythonBindingsInterface::Get()->DownloadProject(m_objectName, m_destinationPath, objectDownloadProgress, /*force*/ true);
         }
         else if (m_downloadType == DownloadController::DownloadObjectType::Template)
         {
-            objectInfoResult = PythonBindingsInterface::Get()->DownloadTemplate(m_objectName, objectDownloadProgress, /*force*/ true);
+            objectInfoResult = PythonBindingsInterface::Get()->DownloadTemplate(m_objectName, m_destinationPath, objectDownloadProgress, /*force*/ true);
         }
         else
         {
@@ -52,9 +52,10 @@ namespace O3DE::ProjectManager
         }
     }
 
-    void DownloadWorker::SetObjectToDownload(const QString& objectName, DownloadController::DownloadObjectType objectType, bool downloadNow)
+    void DownloadWorker::SetObjectToDownload(const QString& objectName, const QString& destinationPath, DownloadController::DownloadObjectType objectType, bool downloadNow)
     {
         m_objectName = objectName;
+        m_destinationPath = destinationPath;
         m_downloadType = objectType;
         if (downloadNow)
         {

--- a/Code/Tools/ProjectManager/Source/DownloadWorker.h
+++ b/Code/Tools/ProjectManager/Source/DownloadWorker.h
@@ -30,7 +30,8 @@ namespace O3DE::ProjectManager
 
     public slots:
         void StartDownload();
-        void SetObjectToDownload(const QString& objectName, DownloadController::DownloadObjectType objectType, bool downloadNow = true);
+        void SetObjectToDownload(
+            const QString& objectName, const QString& destinationPath, DownloadController::DownloadObjectType objectType, bool downloadNow = true);
 
     signals:
         void UpdateProgress(int bytesDownloaded, int totalBytes);
@@ -39,6 +40,7 @@ namespace O3DE::ProjectManager
     private:
 
         QString m_objectName;
+        QString m_destinationPath;
         DownloadController::DownloadObjectType m_downloadType;
     };
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -337,7 +337,7 @@ namespace O3DE::ProjectManager
                 if (added && (GemModel::GetDownloadStatus(modelIndex) == GemInfo::DownloadStatus::NotDownloaded) ||
                     (GemModel::GetDownloadStatus(modelIndex) == GemInfo::DownloadStatus::DownloadFailed))
                 {
-                    m_downloadController->AddObjectDownload(GemModel::GetName(modelIndex), DownloadController::DownloadObjectType::Gem);
+                    m_downloadController->AddObjectDownload(GemModel::GetName(modelIndex), "", DownloadController::DownloadObjectType::Gem);
                     GemModel::SetDownloadStatus(*m_gemModel, modelIndex, GemInfo::DownloadStatus::Downloading);
                 }
             }
@@ -367,7 +367,7 @@ namespace O3DE::ProjectManager
         if (added && (GemModel::GetDownloadStatus(modelIndex) == GemInfo::DownloadStatus::NotDownloaded) ||
             (GemModel::GetDownloadStatus(modelIndex) == GemInfo::DownloadStatus::DownloadFailed))
         {
-            m_downloadController->AddObjectDownload(GemModel::GetName(modelIndex), DownloadController::DownloadObjectType::Gem);
+            m_downloadController->AddObjectDownload(GemModel::GetName(modelIndex), "" , DownloadController::DownloadObjectType::Gem);
             GemModel::SetDownloadStatus(*m_gemModel, modelIndex, GemInfo::DownloadStatus::Downloading);
         }
     }
@@ -433,7 +433,7 @@ namespace O3DE::ProjectManager
         GemUpdateDialog* confirmUpdateDialog = new GemUpdateDialog(selectedGemName, updateAvaliable, this);
         if (confirmUpdateDialog->exec() == QDialog::Accepted)
         {
-            m_downloadController->AddObjectDownload(selectedGemName, DownloadController::DownloadObjectType::Gem);
+            m_downloadController->AddObjectDownload(selectedGemName, "" , DownloadController::DownloadObjectType::Gem);
         }
     }
 

--- a/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.cpp
@@ -341,10 +341,10 @@ namespace O3DE::ProjectManager
         return projectTemplateDetails;
     }
 
-    void NewProjectSettingsScreen::StartTemplateDownload(const QString& templateName)
+    void NewProjectSettingsScreen::StartTemplateDownload(const QString& templateName, const QString& destinationPath)
     {
         AZ_Assert(m_downloadController, "DownloadController must exist.");
-        m_downloadController->AddObjectDownload(templateName, DownloadController::DownloadObjectType::Template);
+        m_downloadController->AddObjectDownload(templateName, destinationPath, DownloadController::DownloadObjectType::Template);
         auto foundButton = AZStd::ranges::find_if(
             m_templateButtons,
             [&templateName](const QAbstractButton* value)
@@ -370,7 +370,7 @@ namespace O3DE::ProjectManager
                     DownloadRemoteTemplateDialog* downloadRemoteTemplateDialog = new DownloadRemoteTemplateDialog(templateInfo, this);
                     if (downloadRemoteTemplateDialog->exec() == QDialog::DialogCode::Accepted)
                     {
-                        StartTemplateDownload(templateInfo.m_name);
+                        StartTemplateDownload(templateInfo.m_name, downloadRemoteTemplateDialog->GetInstallPath());
                     }
                 });
     }

--- a/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.h
+++ b/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.h
@@ -45,7 +45,7 @@ namespace O3DE::ProjectManager
         void OnTemplateSelectionChanged(int oldIndex, int newIndex);
 
     public slots:
-        void StartTemplateDownload(const QString& templateName);
+        void StartTemplateDownload(const QString& templateName, const QString& destinationPath);
         void HandleDownloadResult(const QString& projectName, bool succeeded);
         void HandleDownloadProgress(const QString& projectName, DownloadController::DownloadObjectType objectType, int bytesDownloaded, int totalBytes);
 

--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
@@ -511,6 +511,7 @@ namespace O3DE::ProjectManager
     {
         m_projectImageLabel->GetCloudIcon()->setVisible(true);
         m_projectImageLabel->GetWarningSpacer()->changeSize(0, 0, QSizePolicy::Expanding, QSizePolicy::Fixed);
+        m_projectMenuButton->setVisible(false);
 
         SetLaunchingEnabled(false);
     }
@@ -519,6 +520,7 @@ namespace O3DE::ProjectManager
     {
         m_projectImageLabel->GetCloudIcon()->setVisible(true);
         m_projectImageLabel->GetWarningSpacer()->changeSize(0, 0, QSizePolicy::Expanding, QSizePolicy::Fixed);
+        m_projectMenuButton->setVisible(false);
 
         m_projectImageLabel->GetDownloadMessageLabel()->setVisible(true);
         m_projectImageLabel->GetProgressPercentage()->setVisible(true);

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.h
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.h
@@ -63,7 +63,7 @@ namespace O3DE::ProjectManager
         void QueueBuildProject(const ProjectInfo& projectInfo);
         void UnqueueBuildProject(const ProjectInfo& projectInfo);
 
-        void StartProjectDownload(const QString& projectName);
+        void StartProjectDownload(const QString& projectName, const QString& destinationPath);
         void HandleDownloadProgress(const QString& projectName, DownloadController::DownloadObjectType objectType, int bytesDownloaded, int totalBytes);
         void HandleDownloadResult(const QString& projectName, bool succeeded);
 

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -1547,7 +1547,7 @@ namespace O3DE::ProjectManager
     }
 
     IPythonBindings::DetailedOutcome  PythonBindings::DownloadGem(
-        const QString& gemName, std::function<void(int, int)> gemProgressCallback, bool force)
+        const QString& gemName, const QString& path, std::function<void(int, int)> gemProgressCallback, bool force)
     {
         // This process is currently limited to download a single object at a time.
         bool downloadSucceeded = false;
@@ -1558,7 +1558,7 @@ namespace O3DE::ProjectManager
             {
                 auto downloadResult = m_download.attr("download_gem")(
                     QString_To_Py_String(gemName), // gem name
-                    pybind11::none(), // destination path
+                    QString_To_Py_Path(path), // destination path
                     false, // skip auto register
                     force, // force overwrite
                     pybind11::cpp_function(
@@ -1587,7 +1587,7 @@ namespace O3DE::ProjectManager
     }
 
     IPythonBindings::DetailedOutcome PythonBindings::DownloadProject(
-        const QString& projectName, std::function<void(int, int)> projectProgressCallback, bool force)
+        const QString& projectName, const QString& path, std::function<void(int, int)> projectProgressCallback, bool force)
     {
         // This process is currently limited to download a single object at a time.
         bool downloadSucceeded = false;
@@ -1598,7 +1598,7 @@ namespace O3DE::ProjectManager
             {
                 auto downloadResult = m_download.attr("download_project")(
                     QString_To_Py_String(projectName), // gem name
-                    pybind11::none(), // destination path
+                    QString_To_Py_Path(path), // destination path
                     false, // skip auto register
                     force, // force overwrite
                     pybind11::cpp_function(
@@ -1626,7 +1626,7 @@ namespace O3DE::ProjectManager
     }
 
     IPythonBindings::DetailedOutcome PythonBindings::DownloadTemplate(
-        const QString& templateName, std::function<void(int, int)> templateProgressCallback, bool force)
+        const QString& templateName, const QString& path, std::function<void(int, int)> templateProgressCallback, bool force)
     {
         // This process is currently limited to download a single object at a time.
         bool downloadSucceeded = false;
@@ -1637,7 +1637,7 @@ namespace O3DE::ProjectManager
             {
                 auto downloadResult = m_download.attr("download_template")(
                     QString_To_Py_String(templateName), // gem name
-                    pybind11::none(), // destination path
+                    QString_To_Py_Path(path), // destination path
                     false, // skip auto register
                     force, // force overwrite
                     pybind11::cpp_function(

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -1558,7 +1558,7 @@ namespace O3DE::ProjectManager
             {
                 auto downloadResult = m_download.attr("download_gem")(
                     QString_To_Py_String(gemName), // gem name
-                    QString_To_Py_Path(path), // destination path
+                    path.isEmpty() ? pybind11::none() : QString_To_Py_Path(path), // destination path
                     false, // skip auto register
                     force, // force overwrite
                     pybind11::cpp_function(
@@ -1598,7 +1598,7 @@ namespace O3DE::ProjectManager
             {
                 auto downloadResult = m_download.attr("download_project")(
                     QString_To_Py_String(projectName), // gem name
-                    QString_To_Py_Path(path), // destination path
+                    path.isEmpty() ? pybind11::none() : QString_To_Py_Path(path), // destination path
                     false, // skip auto register
                     force, // force overwrite
                     pybind11::cpp_function(
@@ -1637,7 +1637,7 @@ namespace O3DE::ProjectManager
             {
                 auto downloadResult = m_download.attr("download_template")(
                     QString_To_Py_String(templateName), // gem name
-                    QString_To_Py_Path(path), // destination path
+                    path.isEmpty() ? pybind11::none() : QString_To_Py_Path(path), // destination path
                     false, // skip auto register
                     force, // force overwrite
                     pybind11::cpp_function(

--- a/Code/Tools/ProjectManager/Source/PythonBindings.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.h
@@ -74,11 +74,11 @@ namespace O3DE::ProjectManager
         AZ::Outcome<QVector<GemInfo>, AZStd::string> GetGemInfosForRepo(const QString& repoUri) override;
         AZ::Outcome<QVector<GemInfo>, AZStd::string> GetGemInfosForAllRepos() override;
         DetailedOutcome DownloadGem(
-            const QString& gemName, std::function<void(int, int)> gemProgressCallback, bool force = false) override;
+            const QString& gemName, const QString& path, std::function<void(int, int)> gemProgressCallback, bool force = false) override;
         DetailedOutcome DownloadProject(
-            const QString& projectName, std::function<void(int, int)> projectProgressCallback, bool force = false) override;
+            const QString& projectName, const QString& path, std::function<void(int, int)> projectProgressCallback, bool force = false) override;
         DetailedOutcome DownloadTemplate(
-            const QString& templateName, std::function<void(int, int)> templateProgressCallback, bool force = false) override;
+            const QString& templateName, const QString& path, std::function<void(int, int)> templateProgressCallback, bool force = false) override;
         void CancelDownload() override;
         bool IsGemUpdateAvaliable(const QString& gemName, const QString& lastUpdated) override;
 

--- a/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
@@ -310,7 +310,7 @@ namespace O3DE::ProjectManager
          * @return an outcome with a pair of string error and detailed messages on failure.
          */
         virtual DetailedOutcome DownloadGem(
-            const QString& gemName, std::function<void(int, int)> gemProgressCallback, bool force = false) = 0;
+            const QString& gemName, const QString& path, std::function<void(int, int)> gemProgressCallback, bool force = false) = 0;
 
         /**
          * Downloads and registers a project.
@@ -320,7 +320,7 @@ namespace O3DE::ProjectManager
          * @return an outcome with a pair of string error and detailed messages on failure.
          */
         virtual DetailedOutcome DownloadProject(
-            const QString& projectName, std::function<void(int, int)> projectProgressCallback, bool force = false) = 0;
+            const QString& projectName, const QString& path, std::function<void(int, int)> projectProgressCallback, bool force = false) = 0;
 
         /**
          * Downloads and registers a template.
@@ -330,7 +330,7 @@ namespace O3DE::ProjectManager
          * @return an outcome with a pair of string error and detailed messages on failure.
          */
         virtual DetailedOutcome DownloadTemplate(
-            const QString& templateName, std::function<void(int, int)> templateProgressCallback, bool force = false) = 0;
+            const QString& templateName, const QString& path, std::function<void(int, int)> templateProgressCallback, bool force = false) = 0;
 
         /**
          * Cancels the current download.

--- a/Code/Tools/ProjectManager/tests/MockPythonBindings.h
+++ b/Code/Tools/ProjectManager/tests/MockPythonBindings.h
@@ -56,7 +56,7 @@ namespace O3DE::ProjectManager
         MOCK_METHOD0(GetAllGemRepoInfos, AZ::Outcome<QVector<GemRepoInfo>, AZStd::string>());
         MOCK_METHOD1(GetGemInfosForRepo, AZ::Outcome<QVector<GemInfo>, AZStd::string>(const QString&));
         MOCK_METHOD0(GetGemInfosForAllRepos, AZ::Outcome<QVector<GemInfo>, AZStd::string>());
-        MOCK_METHOD3(DownloadGem, DetailedOutcome(const QString&, std::function<void(int, int)>, bool));
+        MOCK_METHOD3(DownloadGem, DetailedOutcome(const QString&, const QString&, std::function<void(int, int)>, bool));
         MOCK_METHOD0(CancelDownload, void());
         MOCK_METHOD2(IsGemUpdateAvaliable, bool(const QString&, const QString&));
 

--- a/Code/Tools/ProjectManager/tests/MockPythonBindings.h
+++ b/Code/Tools/ProjectManager/tests/MockPythonBindings.h
@@ -56,7 +56,7 @@ namespace O3DE::ProjectManager
         MOCK_METHOD0(GetAllGemRepoInfos, AZ::Outcome<QVector<GemRepoInfo>, AZStd::string>());
         MOCK_METHOD1(GetGemInfosForRepo, AZ::Outcome<QVector<GemInfo>, AZStd::string>(const QString&));
         MOCK_METHOD0(GetGemInfosForAllRepos, AZ::Outcome<QVector<GemInfo>, AZStd::string>());
-        MOCK_METHOD3(DownloadGem, DetailedOutcome(const QString&, const QString&, std::function<void(int, int)>, bool));
+        MOCK_METHOD4(DownloadGem, DetailedOutcome(const QString&, const QString&, std::function<void(int, int)>, bool));
         MOCK_METHOD0(CancelDownload, void());
         MOCK_METHOD2(IsGemUpdateAvaliable, bool(const QString&, const QString&));
 

--- a/scripts/o3de/o3de/github_utils.py
+++ b/scripts/o3de/o3de/github_utils.py
@@ -10,12 +10,18 @@ This file contains utility functions for using GitHub
 """
 
 import json
+import logging
 import pathlib
 import urllib.parse
 import urllib.request
 import subprocess
 
 from o3de import gitproviderinterface
+
+LOG_FORMAT = '[%(levelname)s] %(name)s: %(message)s'
+
+logger = logging.getLogger('o3de.github_utils')
+logging.basicConfig(format=LOG_FORMAT)
 
 class GitHubProvider(gitproviderinterface.GitProviderInterface):
     def get_specific_file_uri(parsed_uri):


### PR DESCRIPTION
Fix objects not being downloaded to the chosen path.
Fix remote projects not being shown if there are no local projects.
Adding placeholder text and warning icon in add remote project dialog, 
Fix exception using logger in github_utils.py

Signed-off-by: AMZN-Phil <pconroy@amazon.com>
