### PR TITLE
Move validation step to GtiHub actions

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -1,0 +1,16 @@
+name: Validation
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Run Validation
+        run: |
+          python -u scripts/commit_validation/validate_file_or_folder.py

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -31,8 +31,6 @@ DEFAULT_BUILD_SNAPSHOT = BUILD_SNAPSHOTS_WITH_EMPTY.get(0)
 // Branches with build snapshots as comma separated value string
 env.BUILD_SNAPSHOTS = BUILD_SNAPSHOTS.join(",")
 
-VALIDATION_PIPELINE = /validation_pipe/
-
 def pipelineProperties = []
 
 def pipelineParameters = [
@@ -700,7 +698,7 @@ def CreateSingleNode(Map pipelineConfig, def platform, def build_job, Map envVar
                         if (params && params.containsKey('TEST_RESULTS') && params.TEST_RESULTS == 'True') {
                             CreateExportTestResultsStage(pipelineConfig, platform.key, build_job_name, envVars, params).call()
                         }
-                        if (!(build_job.key ==~ "${VALIDATION_PIPELINE}") && fileExists(GetCrashArtifactDir())) {
+                        if (fileExists(GetCrashArtifactDir())) {
                             CreateUploadCrashArtifactStage(build_job_name, platform.key).call()
                         }
                         if (params && params.containsKey('TEST_SCREENSHOTS') && params.TEST_SCREENSHOTS == 'True' && currentResult == 'FAILURE') {
@@ -924,7 +922,6 @@ try {
 
         // Build and Post-Build Testing Stage
         def buildConfigs = [:]
-        def validateConfig = [:] 
 
         // Platform Builds run on EC2
         pipelineConfig.platforms.each { platform ->
@@ -934,26 +931,12 @@ try {
                     envVars['JENKINS_JOB_NAME'] = env.JOB_NAME // Save original Jenkins job name to JENKINS_JOB_NAME
                     envVars['JOB_NAME'] = "${branchName}_${platform.key}_${build_job.key}" // backwards compatibility, some scripts rely on this
                     someBuildHappened = true
-                    if ("${build_job.key}" ==~ "${VALIDATION_PIPELINE}") {
-                        validateConfig["${platform.key} [${build_job.key}]"] = CreateBuildJobs(pipelineConfig, platform, build_job, envVars, branchName, pipelineName, repositoryName, projectName)
-                    }
-                    else {
-                        buildConfigs["${platform.key} [${build_job.key}]"] = CreateBuildJobs(pipelineConfig, platform, build_job, envVars, branchName, pipelineName, repositoryName, projectName)
-                    }
+                    buildConfigs["${platform.key} [${build_job.key}]"] = CreateBuildJobs(pipelineConfig, platform, build_job, envVars, branchName, pipelineName, repositoryName, projectName)
                 }
             }
         }
 
         timestamps {
-            stage('Validate') {
-                try {
-                    parallel validateConfig
-                }
-                catch (Exception e) {
-                    echo "Exception block: ${e}"
-                }
-            }
-
             stage('Build') {
                 if (params.FAIL_FAST) {
                     echo "Fail fast option enabled"

--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -30,7 +30,6 @@
   },
   "validation_pipe": {
     "TAGS": [
-      "default",
       "snapshot"
     ],
     "steps": [


### PR DESCRIPTION
## What does this PR do?

This PR adds a GitHub action workflow to run the validation step and removes the step from the Jenkins AR Pipeline. Validation will still be required to pass in order merge the PR. Also there is no increase in the runtime for the validation workflow (3-4min).

- Maintainers will have visibility into whether validation passes or fails prior to running AR. Checks will run when the PR is created and updated with new commits.
- This will reduce costs a bit since GitHub action usage is free for public repos.
- Validation can still be executed in branch builds by adding `validation` as an override.

This is how the check will appear on a PR:

<img width="588" alt="Screen Shot 2022-08-30 at 1 26 38 PM" src="https://user-images.githubusercontent.com/19914798/187536599-8927eedf-a9d2-463a-891d-c0d5692091f2.png">




## How was this PR tested?

Tested the new workflow on our fork and created a test PR here: https://github.com/aws-lumberyard-dev/o3de/pull/451  
