### PR TITLE
Material Canvas: Initial support for creating and editing shader config and dynamic node config files plus other fixes

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsAnyDocument.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsAnyDocument.h
@@ -35,26 +35,32 @@ namespace AtomToolsFramework
         AtomToolsAnyDocument(
             const AZ::Crc32& toolId,
             const DocumentTypeInfo& documentTypeInfo,
-            const AZ::Uuid& contentTypeIdIfNotEmbedded = AZ::Uuid::CreateNull());
+            const AZStd::any& defaultValue,
+            const AZ::Uuid& contentTypeIdIfNotEmbedded);
         virtual ~AtomToolsAnyDocument();
 
-        // AtomToolsDocument overrides...
+        // Configure the document type name and supported extensions for this document class.
+        // @documentTypeName The display name for the document and registered extensions
+        // @documentTypeExtensions The set of extensions supported by this document type
+        // @contentTypeIdIfNotEmbedded The explicit type ID that should be used for documents that do not have the type info
+        // embedded in the JSON file. If this value is not null, then the document class will use an alternate path for loading and saving
+        // the JSON data that assumes no type info exists in the file.
         static DocumentTypeInfo BuildDocumentTypeInfo(
             const AZStd::string& documentTypeName,
             const AZStd::vector<AZStd::string>& documentTypeExtensions,
-            const AZ::Uuid& contentTypeIdIfNotEmbedded = AZ::Uuid::CreateNull());
+            const AZStd::any& defaultValue,
+            const AZ::Uuid& contentTypeIdIfNotEmbedded);
+
+        // AtomToolsDocument overrides...
         DocumentObjectInfoVector GetObjectInfo() const override;
         bool Open(const AZStd::string& loadPath) override;
         bool Save() override;
         bool SaveAsCopy(const AZStd::string& savePath) override;
         bool SaveAsChild(const AZStd::string& savePath) override;
-        bool IsOpen() const override;
         bool IsModified() const override;
         bool BeginEdit() override;
         bool EndEdit() override;
         void Clear() override;
-        bool ReopenRecordState() override;
-        bool ReopenRestoreState() override;
 
         // AtomToolsAnyDocumentRequestBus::Handler overrides...
         const AZStd::any& GetContent() const override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsAnyDocument.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsAnyDocument.h
@@ -25,7 +25,7 @@ namespace AtomToolsFramework
         , public AtomToolsAnyDocumentRequestBus::Handler
     {
     public:
-        AZ_RTTI(AtomToolsAnyDocument, "{7DD73C7D-06BB-4AF1-907A-0F87AFDA54AF}", AtomToolsDocument);
+        AZ_RTTI(AtomToolsAnyDocument, "{EB339BF7-CC6B-4BC5-BD6C-7B5CAAFEE012}", AtomToolsDocument);
         AZ_CLASS_ALLOCATOR(AtomToolsAnyDocument, AZ::SystemAllocator, 0);
         AZ_DISABLE_COPY_MOVE(AtomToolsAnyDocument);
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsAnyDocument.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsAnyDocument.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AtomToolsFramework/Document/AtomToolsAnyDocumentRequestBus.h>
+#include <AtomToolsFramework/Document/AtomToolsDocument.h>
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/RTTI/RTTI.h>
+
+namespace AtomToolsFramework
+{
+    //! AtomToolsAnyDocument is a bare bones document class for adapting arbitrary data types that use standard serialize and edit context
+    //! reflection into AtomToolsFramework document system and applications. Document data is wrapped by AZStd::any to load, save, and edit
+    //! content. Pre-existing JSON serialized data must include the outer type info object in order to be deserialized by this class. Many
+    //! Atom classes like shader source data, material types, and materials don't serialize the type info so the class needs to support two
+    //! paths for saving and loading based on a supply type id.
+    class AtomToolsAnyDocument
+        : public AtomToolsDocument
+        , public AtomToolsAnyDocumentRequestBus::Handler
+    {
+    public:
+        AZ_RTTI(AtomToolsAnyDocument, "{7DD73C7D-06BB-4AF1-907A-0F87AFDA54AF}", AtomToolsDocument);
+        AZ_CLASS_ALLOCATOR(AtomToolsAnyDocument, AZ::SystemAllocator, 0);
+        AZ_DISABLE_COPY_MOVE(AtomToolsAnyDocument);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        AtomToolsAnyDocument() = default;
+        AtomToolsAnyDocument(
+            const AZ::Crc32& toolId,
+            const DocumentTypeInfo& documentTypeInfo,
+            const AZ::Uuid& contentTypeIdIfNotEmbedded = AZ::Uuid::CreateNull());
+        virtual ~AtomToolsAnyDocument();
+
+        // AtomToolsDocument overrides...
+        static DocumentTypeInfo BuildDocumentTypeInfo(
+            const AZStd::string& documentTypeName,
+            const AZStd::vector<AZStd::string>& documentTypeExtensions,
+            const AZ::Uuid& contentTypeIdIfNotEmbedded = AZ::Uuid::CreateNull());
+        DocumentObjectInfoVector GetObjectInfo() const override;
+        bool Open(const AZStd::string& loadPath) override;
+        bool Save() override;
+        bool SaveAsCopy(const AZStd::string& savePath) override;
+        bool SaveAsChild(const AZStd::string& savePath) override;
+        bool IsOpen() const override;
+        bool IsModified() const override;
+        bool BeginEdit() override;
+        bool EndEdit() override;
+        void Clear() override;
+        bool ReopenRecordState() override;
+        bool ReopenRestoreState() override;
+
+        // AtomToolsAnyDocumentRequestBus::Handler overrides...
+        const AZStd::any& GetContent() const override;
+
+    private:
+        void RecordContentState();
+        void RestoreContentState(const AZStd::vector<AZ::u8>& contentState);
+        bool LoadAny();
+        bool SaveAny() const;
+
+        AZStd::any m_content;
+        AZ::Uuid m_contentTypeIdIfNotEmbedded = AZ::Uuid::CreateNull();
+        AZStd::vector<AZ::u8> m_contentStateForUndoRedo;
+        bool m_modified = {};
+    };
+} // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsAnyDocumentNotificationBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsAnyDocumentNotificationBus.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+
+namespace AtomToolsFramework
+{
+    class AtomToolsAnyDocumentNotifications : public AZ::EBusTraits
+    {
+    public:
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+        typedef AZ::Crc32 BusIdType;
+    };
+
+    using AtomToolsAnyDocumentNotificationBus = AZ::EBus<AtomToolsAnyDocumentNotifications>;
+} // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsAnyDocumentRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsAnyDocumentRequestBus.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/std/any.h>
+
+namespace AtomToolsFramework
+{
+    // AtomToolsAnyDocumentRequests declares an interface for a general purpose document class that can be used to serialize and edit
+    // objects using standard serialize and edit context reflection within atom tools.
+    class AtomToolsAnyDocumentRequests : public AZ::EBusTraits
+    {
+    public:
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+        typedef AZ::Uuid BusIdType;
+
+        // Get the object containing the content.
+        virtual const AZStd::any& GetContent() const = 0;
+    };
+
+    using AtomToolsAnyDocumentRequestBus = AZ::EBus<AtomToolsAnyDocumentRequests>;
+} // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
@@ -80,12 +80,6 @@ namespace AtomToolsFramework
         //! Select the target path where a document will be saved.
         virtual AZStd::string GetSaveDocumentParams(const AZStd::string& initialPath) const;
 
-        //! Requests source and target paths for creating a new document based on another
-        virtual bool GetCreateDocumentParams(AZStd::string& openPath, AZStd::string& savePath) const;
-
-        //! Prompts the user for a selection of documents to open
-        virtual AZStd::vector<AZStd::string> GetOpenDocumentParams() const;
-
         // AtomToolsMainWindowRequestBus::Handler overrides...
         void CreateMenus(QMenuBar* menuBar) override;
         void UpdateMenus(QMenuBar* menuBar) override;
@@ -93,6 +87,10 @@ namespace AtomToolsFramework
         AZStd::vector<AZStd::shared_ptr<DynamicPropertyGroup>> GetSettingsDialogGroups() const override;
 
     protected:
+        // Create menus and actions to open and create files for all registered document types 
+        void BuildCreateMenu(QAction* insertPostion);
+        void BuildOpenMenu(QAction* insertPostion);
+
         void AddDocumentTabBar();
         void UpdateRecentFileMenu();
 
@@ -118,8 +116,6 @@ namespace AtomToolsFramework
 
         QMenu* m_menuOpenRecent = {};
 
-        QAction* m_actionNew = {};
-        QAction* m_actionOpen = {};
         QAction* m_actionClose = {};
         QAction* m_actionCloseAll = {};
         QAction* m_actionCloseOthers = {};

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -204,5 +204,5 @@ namespace AtomToolsFramework
     // @param menu The menu where the actions will be inserted
     // @param registryKey The path to the registry setting where script categories are registered
     // @param arguments The list of arguments passed into the script when executed
-    void AddRegisteredScriptToMenu(QMenu* menu, const AZStd::string& registryKey, const AZStd::vector<AZStd::string_view>& arguments);
+    void AddRegisteredScriptToMenu(QMenu* menu, const AZStd::string& registryKey, const AZStd::vector<AZStd::string>& arguments);
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowserInteractions.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowserInteractions.cpp
@@ -100,8 +100,8 @@ namespace AtomToolsFramework
             });
 
         QMenu* scriptsMenu = menu->addMenu(QObject::tr("Python Scripts"));
-        AZStd::vector<AZStd::string_view> pythonArgs{ entry->GetFullPath() };
-        AddRegisteredScriptToMenu(scriptsMenu, "/O3DE/AtomToolsFramework/AssetBrowser/ContextMenuScripts", pythonArgs);
+        const AZStd::vector<AZStd::string> arguments{ entry->GetFullPath() };
+        AddRegisteredScriptToMenu(scriptsMenu, "/O3DE/AtomToolsFramework/AssetBrowser/ContextMenuScripts", arguments);
     }
 
     void AtomToolsAssetBrowserInteractions::AddContextMenuActionsForFolderEntries(

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsAnyDocument.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsAnyDocument.cpp
@@ -81,28 +81,22 @@ namespace AtomToolsFramework
 
     DocumentObjectInfoVector AtomToolsAnyDocument::GetObjectInfo() const
     {
-        if (!IsOpen())
+        DocumentObjectInfoVector objects = AtomToolsDocument::GetObjectInfo();
+
+        if (!m_content.empty())
         {
-            AZ_Error("AtomToolsAnyDocument", false, "Document is not open.");
-            return {};
+            // The reflected data stored within the document will be converted to a description of the object and its type info. This data
+            // will be used to populate the inspector.
+            DocumentObjectInfo objectInfo;
+            objectInfo.m_visible = true;
+            objectInfo.m_name = GetDocumentTypeInfo().m_documentTypeName;
+            objectInfo.m_displayName = GetDocumentTypeInfo().m_documentTypeName;
+            objectInfo.m_description = GetDocumentTypeInfo().m_documentTypeName;
+            objectInfo.m_objectType = m_content.type();
+            objectInfo.m_objectPtr = AZStd::any_cast<void>(const_cast<AZStd::any*>(&m_content));
+            objects.push_back(AZStd::move(objectInfo));
         }
 
-        if (m_content.empty())
-        {
-            return {};
-        }
-
-        // The reflected data stored within the document will be converted to a description of the object and its type info. This data will
-        // be used to populate the inspector and anything else concerned with RTTI.
-        DocumentObjectInfoVector objects;
-        DocumentObjectInfo objectInfo;
-        objectInfo.m_visible = true;
-        objectInfo.m_name = GetDocumentTypeInfo().m_documentTypeName;
-        objectInfo.m_displayName = GetDocumentTypeInfo().m_documentTypeName;
-        objectInfo.m_description = GetDocumentTypeInfo().m_documentTypeName;
-        objectInfo.m_objectType = m_content.type();
-        objectInfo.m_objectPtr = AZStd::any_cast<void>(const_cast<AZStd::any*>(&m_content));
-        objects.push_back(objectInfo);
         return objects;
     }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsAnyDocument.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsAnyDocument.cpp
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RPI.Edit/Common/AssetUtils.h>
+#include <Atom/RPI.Edit/Common/JsonUtils.h>
+#include <Atom/RPI.Reflect/System/AnyAsset.h>
+#include <AtomToolsFramework/Document/AtomToolsAnyDocument.h>
+#include <AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h>
+#include <AtomToolsFramework/Util/Util.h>
+#include <AzCore/IO/ByteContainerStream.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/ObjectStream.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/Utils.h>
+#include <AzCore/Utils/Utils.h>
+
+namespace AtomToolsFramework
+{
+    void AtomToolsAnyDocument::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<AtomToolsAnyDocument, AtomToolsDocument>()->Version(0);
+        }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<AtomToolsAnyDocumentRequestBus>("AtomToolsAnyDocumentRequestBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Category, "Editor")
+                ->Attribute(AZ::Script::Attributes::Module, "atomtools")
+                ->Event("GetContent", &AtomToolsAnyDocumentRequests::GetContent);
+        }
+    }
+
+    AtomToolsAnyDocument::AtomToolsAnyDocument(
+        const AZ::Crc32& toolId, const DocumentTypeInfo& documentTypeInfo, const AZ::Uuid& contentTypeIdIfNotEmbedded)
+        : AtomToolsDocument(toolId, documentTypeInfo)
+        , m_contentTypeIdIfNotEmbedded(contentTypeIdIfNotEmbedded)
+    {
+        AtomToolsAnyDocumentRequestBus::Handler::BusConnect(m_id);
+    }
+
+    AtomToolsAnyDocument::~AtomToolsAnyDocument()
+    {
+        AtomToolsAnyDocumentRequestBus::Handler::BusDisconnect();
+    }
+
+    DocumentTypeInfo AtomToolsAnyDocument::BuildDocumentTypeInfo(
+        const AZStd::string& documentTypeName,
+        const AZStd::vector<AZStd::string>& documentTypeExtensions,
+        const AZ::Uuid& contentTypeIdIfNotEmbedded)
+    {
+        DocumentTypeInfo documentType;
+        documentType.m_documentTypeName = documentTypeName;
+        documentType.m_documentFactoryCallback =
+            [contentTypeIdIfNotEmbedded](const AZ::Crc32& toolId, const DocumentTypeInfo& documentTypeInfo)
+        {
+            return aznew AtomToolsAnyDocument(toolId, documentTypeInfo, contentTypeIdIfNotEmbedded);
+        };
+
+        for (const auto& documentTypeExtension : documentTypeExtensions)
+        {
+            documentType.m_supportedExtensionsToOpen.push_back({ documentTypeName, documentTypeExtension });
+            documentType.m_supportedExtensionsToSave.push_back({ documentTypeName, documentTypeExtension });
+        }
+        return documentType;
+    }
+
+    DocumentObjectInfoVector AtomToolsAnyDocument::GetObjectInfo() const
+    {
+        if (!IsOpen())
+        {
+            AZ_Error("AtomToolsAnyDocument", false, "Document is not open.");
+            return {};
+        }
+
+        // Register the object info for the content so that it can be made available to the inspector for editing.
+        DocumentObjectInfoVector objects;
+        DocumentObjectInfo objectInfo;
+        objectInfo.m_visible = true;
+        objectInfo.m_name = GetDocumentTypeInfo().m_documentTypeName;
+        objectInfo.m_displayName = GetDocumentTypeInfo().m_documentTypeName;
+        objectInfo.m_description = GetDocumentTypeInfo().m_documentTypeName;
+        objectInfo.m_objectType = m_content.type();
+        objectInfo.m_objectPtr = AZStd::any_cast<void>(const_cast<AZStd::any*>(&m_content));
+        objects.push_back(objectInfo);
+
+        return objects;
+    }
+
+    bool AtomToolsAnyDocument::Open(const AZStd::string& loadPath)
+    {
+        if (!AtomToolsDocument::Open(loadPath))
+        {
+            return false;
+        }
+
+        if (!LoadAny())
+        {
+            return OpenFailed();
+        }
+
+        m_modified = false;
+        return OpenSucceeded();
+    }
+
+    bool AtomToolsAnyDocument::Save()
+    {
+        if (!AtomToolsDocument::Save())
+        {
+            // SaveFailed has already been called so just forward the result without additional notifications.
+            // TODO Replace bool return value with enum for open and save states.
+            return false;
+        }
+
+        if (!SaveAny())
+        {
+            return SaveFailed();
+        }
+
+        m_modified = false;
+        m_absolutePath = m_savePathNormalized;
+        return SaveSucceeded();
+    }
+
+    bool AtomToolsAnyDocument::SaveAsCopy(const AZStd::string& savePath)
+    {
+        if (!AtomToolsDocument::SaveAsCopy(savePath))
+        {
+            // SaveFailed has already been called so just forward the result without additional notifications.
+            // TODO Replace bool return value with enum for open and save states.
+            return false;
+        }
+
+
+        if (!SaveAny())
+        {
+            return SaveFailed();
+        }
+
+        m_modified = false;
+        m_absolutePath = m_savePathNormalized;
+        return SaveSucceeded();
+    }
+
+    bool AtomToolsAnyDocument::SaveAsChild(const AZStd::string& savePath)
+    {
+        if (!AtomToolsDocument::SaveAsChild(savePath))
+        {
+            // SaveFailed has already been called so just forward the result without additional notifications.
+            // TODO Replace bool return value with enum for open and save states.
+            return false;
+        }
+
+        if (!SaveAny())
+        {
+            return SaveFailed();
+        }
+
+        m_modified = false;
+        m_absolutePath = m_savePathNormalized;
+        return SaveSucceeded();
+    }
+
+    bool AtomToolsAnyDocument::IsOpen() const
+    {
+        return AtomToolsDocument::IsOpen() && !m_content.empty();
+    }
+
+    bool AtomToolsAnyDocument::IsModified() const
+    {
+        return m_modified;
+    }
+
+    bool AtomToolsAnyDocument::BeginEdit()
+    {
+        RecordContentState();
+        return true;
+    }
+
+    bool AtomToolsAnyDocument::EndEdit()
+    {
+        auto undoState = m_contentStateForUndoRedo;
+        RecordContentState();
+        auto redoState = m_contentStateForUndoRedo;
+
+        if (undoState != redoState)
+        {
+            AddUndoRedoHistory(
+                [this, undoState]() { RestoreContentState(undoState); },
+                [this, redoState]() { RestoreContentState(redoState); });
+
+            m_modified = true;
+            AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentModified, m_id);
+        }
+        return true;
+    }
+
+    void AtomToolsAnyDocument::Clear()
+    {
+        m_contentStateForUndoRedo.clear();
+        m_content.clear();
+        m_modified = false;
+
+        AtomToolsDocument::Clear();
+    }
+
+    bool AtomToolsAnyDocument::ReopenRecordState()
+    {
+        return AtomToolsDocument::ReopenRecordState();
+    }
+
+    bool AtomToolsAnyDocument::ReopenRestoreState()
+    {
+        return AtomToolsDocument::ReopenRestoreState();
+    }
+
+    const AZStd::any& AtomToolsAnyDocument::GetContent() const
+    {
+        return m_content;
+    }
+
+    void AtomToolsAnyDocument::RecordContentState()
+    {
+        // Serialize the current content to a byte stream so that it can be restored with undo redo operations.
+        m_contentStateForUndoRedo.clear();
+        AZ::IO::ByteContainerStream<decltype(m_contentStateForUndoRedo)> undoContentStateStream(&m_contentStateForUndoRedo);
+        AZ::Utils::SaveObjectToStream(undoContentStateStream, AZ::ObjectStream::ST_BINARY, &m_content);
+    }
+
+    void AtomToolsAnyDocument::RestoreContentState(const AZStd::vector<AZ::u8>& contentState)
+    {
+        // Restore a version of the content that was previously serialized to a byte stream
+        m_contentStateForUndoRedo = contentState;
+        AZ::IO::ByteContainerStream<decltype(m_contentStateForUndoRedo)> undoContentStateStream(&m_contentStateForUndoRedo);
+
+        m_content.clear();
+        AZ::Utils::LoadObjectFromStreamInPlace(undoContentStateStream, m_content);
+
+        m_modified = true;
+        AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentObjectInfoInvalidated, m_id);
+        AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentModified, m_id);
+    }
+
+    bool AtomToolsAnyDocument::LoadAny()
+    {
+        m_content.clear();
+
+        if (!m_contentTypeIdIfNotEmbedded.IsNull())
+        {
+            AZ::SerializeContext* serializeContext = {};
+            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
+            AZ_Assert(serializeContext, "Failed to acquire application serialize context.");
+
+            auto loadOutcome = AZ::JsonSerializationUtils::ReadJsonFile(m_absolutePath);
+            if (!loadOutcome.IsSuccess())
+            {
+                AZ_Error("AtomToolsAnyDocument", false, "%s", loadOutcome.GetError().c_str());
+                return false;
+            }
+
+            rapidjson::Document& document = loadOutcome.GetValue();
+
+            AZ::JsonDeserializerSettings jsonSettings;
+            AZ::RPI::JsonReportingHelper reportingHelper;
+            reportingHelper.Attach(jsonSettings);
+
+            m_content = serializeContext->CreateAny(m_contentTypeIdIfNotEmbedded);
+            AZ::JsonSerialization::Load(
+                AZStd::any_cast<void>(&m_content),
+                m_contentTypeIdIfNotEmbedded,
+                document,
+                jsonSettings);
+
+            if (reportingHelper.ErrorsReported())
+            {
+                AZ_Error("AtomToolsAnyDocument", false, "Failed to load object from JSON file: %s", m_absolutePath.c_str());
+                return false;
+            }
+        }
+        else
+        {
+            auto loadResult = AZ::JsonSerializationUtils::LoadAnyObjectFromFile(m_absolutePath);
+            if (!loadResult && !loadResult.GetValue().empty())
+            {
+                return false;
+            }
+            m_content = loadResult.GetValue();
+        }
+
+        return true;
+    }
+
+    bool AtomToolsAnyDocument::SaveAny() const
+    {
+        if (m_content.empty())
+        {
+            return false;
+        }
+
+        if (!m_contentTypeIdIfNotEmbedded.IsNull())
+        {
+            AZ::SerializeContext* serializeContext = {};
+            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
+            AZ_Assert(serializeContext, "Failed to acquire application serialize context.");
+            AZStd::any defaultContent = serializeContext->CreateAny(m_contentTypeIdIfNotEmbedded);
+
+            rapidjson::Document document;
+            document.SetObject();
+
+            AZ::JsonSerializerSettings settings;
+            AZ::RPI::JsonReportingHelper reportingHelper;
+            reportingHelper.Attach(settings);
+
+            AZ::JsonSerialization::Store(
+                document,
+                document.GetAllocator(),
+                AZStd::any_cast<void>(&m_content),
+                AZStd::any_cast<void>(&defaultContent),
+                m_contentTypeIdIfNotEmbedded,
+                settings);
+
+            if (reportingHelper.ErrorsReported())
+            {
+                AZ_Error("AtomToolsAnyDocument", false, "Failed to write object data to JSON document: %s", m_savePathNormalized.c_str());
+                return false;
+            }
+
+            AZ::JsonSerializationUtils::WriteJsonFile(document, m_savePathNormalized);
+            if (reportingHelper.ErrorsReported())
+            {
+                AZ_Error("AtomToolsAnyDocument", false, "Failed to write JSON document to file: %s", m_savePathNormalized.c_str());
+                return false;
+            }
+        }
+        else
+        {
+            if (!AZ::JsonSerializationUtils::SaveObjectToFileByType(
+                    AZStd::any_cast<void>(&m_content), m_content.type(), m_savePathNormalized))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+} // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocument.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocument.cpp
@@ -132,12 +132,6 @@ namespace AtomToolsFramework
 
     bool AtomToolsDocument::Save()
     {
-        if (!IsOpen())
-        {
-            AZ_Error("AtomToolsDocument", false, "Document is not open to be saved: '%s'.", m_absolutePath.c_str());
-            return SaveFailed();
-        }
-
         if (!CanSave())
         {
             AZ_Error("AtomToolsDocument", false, "Document type can not be saved: '%s'.", m_absolutePath.c_str());
@@ -162,12 +156,6 @@ namespace AtomToolsFramework
 
     bool AtomToolsDocument::SaveAsCopy(const AZStd::string& savePath)
     {
-        if (!IsOpen())
-        {
-            AZ_Error("AtomToolsDocument", false, "Document is not open to be saved: '%s'.", m_absolutePath.c_str());
-            return SaveFailed();
-        }
-
         if (!CanSave())
         {
             AZ_Error("AtomToolsDocument", false, "Document type can not be saved: '%s'.", m_absolutePath.c_str());
@@ -192,12 +180,6 @@ namespace AtomToolsFramework
 
     bool AtomToolsDocument::SaveAsChild(const AZStd::string& savePath)
     {
-        if (!IsOpen())
-        {
-            AZ_Error("AtomToolsDocument", false, "Document is not open to be saved: '%s'.", m_absolutePath.c_str());
-            return SaveFailed();
-        }
-
         m_savePathNormalized = savePath;
         if (!ValidateDocumentPath(m_savePathNormalized))
         {
@@ -222,14 +204,7 @@ namespace AtomToolsFramework
 
     bool AtomToolsDocument::Close()
     {
-        if (!IsOpen())
-        {
-            AZ_Error("AtomToolsDocument", false, "Document is not open.");
-            return false;
-        }
-
         AZ_TracePrintf("AtomToolsDocument", "Document closed: '%s'.\n", m_absolutePath.c_str());
-
         AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentClosed, m_id);
 
         // Clearing after notification so paths are still available
@@ -252,7 +227,7 @@ namespace AtomToolsFramework
 
     bool AtomToolsDocument::IsOpen() const
     {
-        return !m_id.IsNull() && !m_absolutePath.empty();
+        return !m_id.IsNull();
     }
 
     bool AtomToolsDocument::IsModified() const
@@ -262,19 +237,19 @@ namespace AtomToolsFramework
 
     bool AtomToolsDocument::CanSave() const
     {
-        return IsOpen() && GetDocumentTypeInfo().IsSupportedExtensionToSave(m_absolutePath);
+        return GetDocumentTypeInfo().IsSupportedExtensionToSave(m_absolutePath);
     }
 
     bool AtomToolsDocument::CanUndo() const
     {
         // Undo will only be allowed if something has been recorded and we're not at the beginning of history
-        return IsOpen() && !m_undoHistory.empty() && m_undoHistoryIndex > 0;
+        return !m_undoHistory.empty() && m_undoHistoryIndex > 0;
     }
 
     bool AtomToolsDocument::CanRedo() const
     {
         // Redo will only be allowed if something has been recorded and we're not at the end of history
-        return IsOpen() && !m_undoHistory.empty() && m_undoHistoryIndex < m_undoHistory.size();
+        return !m_undoHistory.empty() && m_undoHistoryIndex < m_undoHistory.size();
     }
 
     bool AtomToolsDocument::Undo()

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -306,11 +306,9 @@ namespace AtomToolsFramework
             const QString name = tr("New %1 Document...").arg(documentType.m_documentTypeName.c_str());
             CreateActionAtPosition(parentMenu, insertPostion, name, [documentType, toolId = m_toolId, this]() {
                 // Open the create document dialog with labels and filters configured from the document type info.
-                CreateDocumentDialog dialog(
-                    documentType,
-                    AZStd::string::format("%s/Assets", AZ::Utils::GetProjectPath().c_str()).c_str(),
-                    const_cast<AtomToolsDocumentMainWindow*>(this));
-                dialog.adjustSize();
+                    CreateDocumentDialog dialog(
+                        documentType, AZStd::string::format("%s/Assets", AZ::Utils::GetProjectPath().c_str()).c_str(), this);
+                    dialog.adjustSize();
 
                 if (dialog.exec() == QDialog::Accepted)
                 {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -573,8 +573,6 @@ namespace AtomToolsFramework
 
     void AtomToolsDocumentMainWindow::OnDocumentOpened(const AZ::Uuid& documentId)
     {
-        bool isOpen = false;
-        AtomToolsDocumentRequestBus::EventResult(isOpen, documentId, &AtomToolsDocumentRequestBus::Events::IsOpen);
         AZStd::string absolutePath;
         AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
 
@@ -585,7 +583,7 @@ namespace AtomToolsFramework
         // Whenever a document is opened or selected select the corresponding tab
         m_tabWidget->setCurrentIndex(GetDocumentTabIndex(documentId));
 
-        if (isOpen && !absolutePath.empty())
+        if (!absolutePath.empty())
         {
             // Find and select the file path in the asset browser
             m_assetBrowser->SelectEntries(absolutePath);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -41,6 +41,7 @@ namespace AtomToolsFramework
     {
         AddDocumentTabBar();
 
+        // Register a handler with the asset browser that attempts to open the first compatible document type for the selected path.
         m_assetBrowser->SetOpenHandler([this](const AZStd::string& absolutePath) {
             DocumentTypeInfoVector documentTypes;
             AtomToolsDocumentSystemRequestBus::EventResult(
@@ -55,9 +56,11 @@ namespace AtomToolsFramework
                 }
             }
 
+            // If there was no compatible document type I tend to open the file using standard OS file openers
             QDesktopServices::openUrl(QUrl::fromLocalFile(absolutePath.c_str()));
         });
 
+        // Enable dragging and dropping of files onto this window.
         setAcceptDrops(true);
 
         AtomToolsDocumentNotificationBus::Handler::BusConnect(m_toolId);
@@ -72,25 +75,11 @@ namespace AtomToolsFramework
     {
         Base::CreateMenus(menuBar);
 
+        // Generating the main menu manually because it's easier and we will have some dynamic or data driven entries
         QAction* insertPostion = !m_menuFile->actions().empty() ? m_menuFile->actions().front() : nullptr;
 
-        // Generating the main menu manually because it's easier and we will have some dynamic or data driven entries
-        m_actionNew = CreateActionAtPosition(m_menuFile, insertPostion, "&New...", [this]() {
-            AZStd::string openPath;
-            AZStd::string savePath;
-            if (GetCreateDocumentParams(openPath, savePath))
-            {
-                AtomToolsDocumentSystemRequestBus::Event(
-                    m_toolId, &AtomToolsDocumentSystemRequestBus::Events::CreateDocumentFromFilePath, openPath, savePath);
-            }
-        }, QKeySequence::New);
-
-        m_actionOpen = CreateActionAtPosition(m_menuFile, insertPostion, "&Open...", [this]() {
-            for (const auto& path : GetOpenDocumentParams())
-            {
-                AtomToolsDocumentSystemRequestBus::Event(m_toolId, &AtomToolsDocumentSystemRequestBus::Events::OpenDocument, path);
-            }
-        }, QKeySequence::Open);
+        BuildCreateMenu(insertPostion);
+        BuildOpenMenu(insertPostion);
 
         m_menuOpenRecent = new QMenu("Open Recent", this);
         connect(m_menuOpenRecent, &QMenu::aboutToShow, this, [this]() {
@@ -218,8 +207,6 @@ namespace AtomToolsFramework
         const bool hasTabs = m_tabWidget->count() > 0;
 
         // Update menu options
-        m_actionNew->setEnabled(true);
-        m_actionOpen->setEnabled(true);
         m_actionClose->setEnabled(hasTabs);
         m_actionCloseAll->setEnabled(hasTabs);
         m_actionCloseOthers->setEnabled(hasTabs);
@@ -275,6 +262,91 @@ namespace AtomToolsFramework
                     aznumeric_cast<AZ::s64>(250)),
             }));
         return groups;
+    }
+
+    void AtomToolsDocumentMainWindow::BuildCreateMenu(QAction* insertPostion)
+    {
+        DocumentTypeInfoVector documentTypes;
+        AtomToolsDocumentSystemRequestBus::EventResult(
+            documentTypes, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::GetRegisteredDocumentTypes);
+
+        // If there is more than one document type then we create a sub menu to insert all of the actions
+        auto parentMenu = m_menuFile;
+        if (documentTypes.size() > 1)
+        {
+            parentMenu = new QMenu("&New", this);
+            m_menuFile->insertMenu(insertPostion, parentMenu);
+        }
+
+        bool isFirstDocumentTypeAdded = true;
+        for (const auto& documentType : documentTypes)
+        {
+            const QString name = tr("New %1 Document...").arg(documentType.m_documentTypeName.c_str());
+            CreateActionAtPosition(parentMenu, insertPostion, name, [documentType, toolId = m_toolId, this]() {
+                // Open the create document dialog with labels and filters configured from the document type info.
+                CreateDocumentDialog dialog(
+                    documentType,
+                    AZStd::string::format("%s/Assets", AZ::Utils::GetProjectPath().c_str()).c_str(),
+                    const_cast<AtomToolsDocumentMainWindow*>(this));
+                dialog.adjustSize();
+
+                if (dialog.exec() == QDialog::Accepted)
+                {
+                    AtomToolsDocumentSystemRequestBus::Event(
+                        toolId,
+                        &AtomToolsDocumentSystemRequestBus::Events::CreateDocumentFromFilePath,
+                        dialog.m_sourcePath.toUtf8().constData(),
+                        dialog.m_targetPath.toUtf8().constData());
+                }
+            }, isFirstDocumentTypeAdded ? QKeySequence::New : QKeySequence());
+            isFirstDocumentTypeAdded = false;
+        }
+    }
+
+    void AtomToolsDocumentMainWindow::BuildOpenMenu(QAction* insertPostion)
+    {
+        DocumentTypeInfoVector documentTypes;
+        AtomToolsDocumentSystemRequestBus::EventResult(
+            documentTypes, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::GetRegisteredDocumentTypes);
+
+        // If there is more than one document type then we create a sub menu to insert all of the actions
+        auto parentMenu = m_menuFile;
+        if (documentTypes.size() > 1)
+        {
+            parentMenu = new QMenu("&Open", this);
+            m_menuFile->insertMenu(insertPostion, parentMenu);
+        }
+
+        bool isFirstDocumentTypeAdded = true;
+        for (const auto& documentType : documentTypes)
+        {
+            // Build a list of all extensions supported by this document type so they can be combined into a file dialog filter
+            QStringList extensionList;
+            for (const auto& extensionInfo : documentType.m_supportedExtensionsToOpen)
+            {
+                extensionList.append(extensionInfo.second.c_str());
+            }
+
+            if (!extensionList.empty())
+            {
+                // Generate a regular expression that combines all of the supported extensions to use as a filter for the asset picker
+                const QString expression = QString("[\\w\\-.]+\\.(%1)").arg(extensionList.join("|"));
+
+                // Create a menu action for each document type instead of one action for all document types to reduce the number of
+                // extensions displayed in the get open file path dialog
+                const QString name = tr("Open %1 Document...").arg(documentType.m_documentTypeName.c_str());
+                const QString title = tr("%1 Document").arg(documentType.m_documentTypeName.c_str());
+                CreateActionAtPosition(parentMenu, insertPostion, name, [expression, title, toolId = m_toolId]() {
+                    // Open all files selected in the get open file path dialog
+                    for (const auto& path : GetOpenFilePaths(QRegExp(expression, Qt::CaseInsensitive), title.toUtf8().constData()))
+                    {
+                        AtomToolsDocumentSystemRequestBus::Event(
+                            toolId, &AtomToolsDocumentSystemRequestBus::Events::OpenDocument, path);
+                    }
+                }, isFirstDocumentTypeAdded ? QKeySequence::Open : QKeySequence());
+                isFirstDocumentTypeAdded = false;
+            }
+        }
     }
 
     void AtomToolsDocumentMainWindow::AddDocumentTabBar()
@@ -499,84 +571,6 @@ namespace AtomToolsFramework
         return GetSaveFilePath(initialPath);
     }
 
-    bool AtomToolsDocumentMainWindow::GetCreateDocumentParams(AZStd::string& openPath, AZStd::string& savePath) const
-    {
-        DocumentTypeInfoVector documentTypes;
-        AtomToolsDocumentSystemRequestBus::EventResult(
-            documentTypes, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::GetRegisteredDocumentTypes);
-
-        if (documentTypes.empty())
-        {
-            return false;
-        }
-
-        int documentTypeIndex = 0;
-        if (documentTypes.size() > 1)
-        {
-            QStringList items;
-            for (const auto& documentType : documentTypes)
-            {
-                items.append(documentType.m_documentTypeName.c_str());
-            }
-
-            bool result = false;
-            QString item = QInputDialog::getItem(
-                const_cast<AtomToolsDocumentMainWindow*>(this),
-                tr("Select Document Type"),
-                tr("Select document type to create"),
-                items,
-                0,
-                false,
-                &result);
-            if (!result || item.isEmpty())
-            {
-                return false;
-            }
-
-            documentTypeIndex = items.indexOf(item);
-        }
-
-        const auto& documentType = documentTypes[documentTypeIndex];
-        CreateDocumentDialog dialog(
-            documentType,
-            AZStd::string::format("%s/Assets", AZ::Utils::GetProjectPath().c_str()).c_str(),
-            const_cast<AtomToolsDocumentMainWindow*>(this));
-        dialog.adjustSize();
-
-        if (dialog.exec() == QDialog::Accepted && !dialog.m_sourcePath.isEmpty() && !dialog.m_targetPath.isEmpty())
-        {
-            savePath = dialog.m_targetPath.toUtf8().constData();
-            openPath = dialog.m_sourcePath.toUtf8().constData();
-            return true;
-        }
-        return false;
-    }
-
-    AZStd::vector<AZStd::string> AtomToolsDocumentMainWindow::GetOpenDocumentParams() const
-    {
-        DocumentTypeInfoVector documentTypes;
-        AtomToolsDocumentSystemRequestBus::EventResult(
-            documentTypes, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::GetRegisteredDocumentTypes);
-
-        QStringList extensionList;
-        for (const auto& documentType : documentTypes)
-        {
-            for (const auto& extensionInfo : documentType.m_supportedExtensionsToOpen)
-            {
-                extensionList.append(extensionInfo.second.c_str());
-            }
-        }
-
-        if (!extensionList.empty())
-        {
-            // Generate a regular expression that combines all of the supported extensions to use as a filter for the asset picker
-            QString expression = QString("[\\w\\-.]+\\.(%1)").arg(extensionList.join("|"));
-            return GetOpenFilePaths(QRegExp(expression, Qt::CaseInsensitive));
-        }
-
-        return {};
-    }
-
     void AtomToolsDocumentMainWindow::OnDocumentOpened(const AZ::Uuid& documentId)
     {
         bool isOpen = false;
@@ -588,11 +582,11 @@ namespace AtomToolsFramework
         ActivateWindow();
         QueueUpdateMenus(true);
 
+        // Whenever a document is opened or selected select the corresponding tab
+        m_tabWidget->setCurrentIndex(GetDocumentTabIndex(documentId));
+
         if (isOpen && !absolutePath.empty())
         {
-            // Whenever a document is opened or selected select the corresponding tab
-            m_tabWidget->setCurrentIndex(GetDocumentTabIndex(documentId));
-
             // Find and select the file path in the asset browser
             m_assetBrowser->SelectEntries(absolutePath);
 
@@ -723,5 +717,3 @@ namespace AtomToolsFramework
         return action;
     }
 } // namespace AtomToolsFramework
-
-//#include <AtomToolsFramework/Document/moc_AtomToolsDocumentMainWindow.cpp>

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -90,40 +90,62 @@ namespace AtomToolsFramework
 
         m_actionSave = CreateActionAtPosition(m_menuFile, insertPostion, "&Save", [this]() {
             const AZ::Uuid documentId = GetCurrentDocumentId();
-            bool result = false;
-            AtomToolsDocumentSystemRequestBus::EventResult(
-                result, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::SaveDocument, documentId);
-            if (!result)
+            const QString documentPath = GetDocumentPath(documentId);
+
+            // If the file already has a path then it can be saved without user selecting a new one.
+            if (!documentPath.isEmpty())
             {
-                SetStatusError(tr("Document save failed: %1").arg(GetDocumentPath(documentId)));
+                bool result = false;
+                AtomToolsDocumentSystemRequestBus::EventResult(
+                    result, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::SaveDocument, documentId);
+                if (!result)
+                {
+                    SetStatusError(tr("Document save failed: %1").arg(documentPath));
+                }
+                return;
+            }
+
+            // If the file does not have a path, meaning it was not previously saved, then we have to do a save as operation.
+            if (const auto& savePath = GetSaveDocumentParams(documentPath.toUtf8().constData()); !savePath.empty())
+            {
+                bool result = false;
+                AtomToolsDocumentSystemRequestBus::EventResult(
+                    result, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsCopy, documentId, savePath);
+                if (!result)
+                {
+                    SetStatusError(tr("Document save failed: %1").arg(documentPath));
+                }
+                return;
             }
         }, QKeySequence::Save);
 
         m_actionSaveAsCopy = CreateActionAtPosition(m_menuFile, insertPostion, "Save &As...", [this]() {
             const AZ::Uuid documentId = GetCurrentDocumentId();
             const QString documentPath = GetDocumentPath(documentId);
-
-            bool result = false;
-            AtomToolsDocumentSystemRequestBus::EventResult(
-                result, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsCopy, documentId,
-                GetSaveDocumentParams(documentPath.toUtf8().constData()));
-            if (!result)
+            if (const auto& savePath = GetSaveDocumentParams(documentPath.toUtf8().constData()); !savePath.empty())
             {
-                SetStatusError(tr("Document save failed: %1").arg(documentPath));
+                bool result = false;
+                AtomToolsDocumentSystemRequestBus::EventResult(
+                    result, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsCopy, documentId, savePath);
+                if (!result)
+                {
+                    SetStatusError(tr("Document save failed: %1").arg(documentPath));
+                }
             }
         }, QKeySequence::SaveAs);
 
         m_actionSaveAsChild = CreateActionAtPosition(m_menuFile, insertPostion, "Save As &Child...", [this]() {
             const AZ::Uuid documentId = GetCurrentDocumentId();
             const QString documentPath = GetDocumentPath(documentId);
-
-            bool result = false;
-            AtomToolsDocumentSystemRequestBus::EventResult(
-                result, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsChild, documentId,
-                GetSaveDocumentParams(documentPath.toUtf8().constData()));
-            if (!result)
+            if (const auto& savePath = GetSaveDocumentParams(documentPath.toUtf8().constData()); !savePath.empty())
             {
-                SetStatusError(tr("Document save failed: %1").arg(documentPath));
+                bool result = false;
+                AtomToolsDocumentSystemRequestBus::EventResult(
+                    result, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsChild, documentId, savePath);
+                if (!result)
+                {
+                    SetStatusError(tr("Document save failed: %1").arg(documentPath));
+                }
             }
         });
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
@@ -160,10 +160,16 @@ namespace AtomToolsFramework
 
     AZ::Uuid AtomToolsDocumentSystem::CreateDocumentFromFilePath(const AZStd::string& sourcePath, const AZStd::string& targetPath)
     {
+        // This function attempts to create a new document in a couple of different ways.
+        // If a source path is specified then it will attempt to create a document using the source path extension and automatically open
+        // the source file. This mechanism supports creating new documents from pre-existing templates or using the source document as a
+        // parent. If no source file is specified, an attempt will be made to create the document using the target path extension to
+        // determine the document type. If a target path is specified then the new document will also automatically be saved to that
+        // location.
         TraceRecorder traceRecorder(m_maxMessageBoxLineCount);
 
         AZStd::string openPath = sourcePath;
-        if (!ValidateDocumentPath(openPath))
+        if (!openPath.empty() && !ValidateDocumentPath(openPath))
         {
             DisplayErrorMessage(
                 GetToolMainWindow(),
@@ -182,43 +188,51 @@ namespace AtomToolsFramework
             return AZ::Uuid::CreateNull();
         }
 
-        AZ::Uuid documentId = CreateDocumentFromFileType(openPath);
+        const AZStd::string& createPath = !openPath.empty() ? openPath : savePath;
+        AZ::Uuid documentId = CreateDocumentFromFileType(createPath);
         if (documentId.IsNull())
         {
             DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be created"),
-                QObject::tr("Failed to create document from file type: \n%1\n\n%2").arg(openPath.c_str()).arg(traceRecorder.GetDump().c_str()));
+                QObject::tr("Failed to create document from file type: \n%1\n\n%2").arg(createPath.c_str()).arg(traceRecorder.GetDump().c_str()));
             return AZ::Uuid::CreateNull();
         }
 
-        bool openResult = false;
-        AtomToolsDocumentRequestBus::EventResult(openResult, documentId, &AtomToolsDocumentRequestBus::Events::Open, openPath);
-        if (!openResult)
+        if (!openPath.empty())
         {
-            DisplayErrorMessage(
-                GetToolMainWindow(),
-                QObject::tr("Document could not be opened"),
-                QObject::tr("Failed to open: \n%1\n\n%2").arg(openPath.c_str()).arg(traceRecorder.GetDump().c_str()));
-            DestroyDocument(documentId);
-            return AZ::Uuid::CreateNull();
-        }
-
-        if (!savePath.empty())
-        {
-            if (!SaveDocumentAsChild(documentId, savePath))
+            bool openResult = false;
+            AtomToolsDocumentRequestBus::EventResult(openResult, documentId, &AtomToolsDocumentRequestBus::Events::Open, openPath);
+            if (!openResult)
             {
-                CloseDocument(documentId);
+                DisplayErrorMessage(
+                    GetToolMainWindow(),
+                    QObject::tr("Document could not be opened"),
+                    QObject::tr("Failed to open: \n%1\n\n%2").arg(openPath.c_str()).arg(traceRecorder.GetDump().c_str()));
+                DestroyDocument(documentId);
                 return AZ::Uuid::CreateNull();
             }
-
-            // Send document open notification after creating new one
-            AddRecentFilePath(savePath);
-            AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
         }
-        else
+
+        if (!documentId.IsNull())
         {
-            AddRecentFilePath(openPath);
+            if (!savePath.empty())
+            {
+                if (!SaveDocumentAsChild(documentId, savePath))
+                {
+                    CloseDocument(documentId);
+                    return AZ::Uuid::CreateNull();
+                }
+
+                // Send document open notification after creating new one
+                AddRecentFilePath(savePath);
+                AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
+            }
+            else
+            {
+                AddRecentFilePath(openPath);
+                AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
+            }
         }
 
         if (traceRecorder.GetWarningCount(true) > 0)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
@@ -283,20 +283,12 @@ namespace AtomToolsFramework
 
     bool AtomToolsDocumentSystem::CloseDocument(const AZ::Uuid& documentId)
     {
-        bool isOpen = false;
-        AtomToolsDocumentRequestBus::EventResult(isOpen, documentId, &AtomToolsDocumentRequestBus::Events::IsOpen);
-        if (!isOpen)
-        {
-            // immediately destroy unopened documents
-            DestroyDocument(documentId);
-            return true;
-        }
-
         AZStd::string documentPath;
         AtomToolsDocumentRequestBus::EventResult(documentPath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
 
         bool isModified = false;
         AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
+
         if (isModified)
         {
             auto selection = QMessageBox::question(

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
@@ -150,7 +150,7 @@ namespace AtomToolsFramework
     {
         for (const auto& documentType : m_documentTypes)
         {
-            if (documentType.IsSupportedExtensionToCreate(path))
+            if (documentType.IsSupportedExtensionToCreate(path) || documentType.IsSupportedExtensionToOpen(path))
             {
                 return CreateDocumentFromType(documentType);
             }
@@ -188,7 +188,7 @@ namespace AtomToolsFramework
             DisplayErrorMessage(
                 GetToolMainWindow(),
                 QObject::tr("Document could not be created"),
-                QObject::tr("Failed to create: \n%1\n\n%2").arg(openPath.c_str()).arg(traceRecorder.GetDump().c_str()));
+                QObject::tr("Failed to create document from file type: \n%1\n\n%2").arg(openPath.c_str()).arg(traceRecorder.GetDump().c_str()));
             return AZ::Uuid::CreateNull();
         }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/CreateDocumentDialog.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/CreateDocumentDialog.cpp
@@ -98,8 +98,8 @@ namespace AtomToolsFramework
     CreateDocumentDialog::CreateDocumentDialog(const DocumentTypeInfo& documentType, const QString& initialPath, QWidget* parent)
         : CreateDocumentDialog(
               tr("Create %1 Document").arg(documentType.m_documentTypeName.c_str()),
-              tr("Select Type"),
-              tr("Select %1 Path").arg(documentType.m_documentTypeName.c_str()),
+              tr("Select source file, type, or template to create %1 document").arg(documentType.m_documentTypeName.c_str()),
+              tr("Select target path to save %1 document").arg(documentType.m_documentTypeName.c_str()),
               initialPath,
               { documentType.GetDefaultExtensionToSave().c_str() },
               documentType.m_defaultAssetIdToCreate,

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/CreateDocumentDialog.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/CreateDocumentDialog.cpp
@@ -37,30 +37,41 @@ namespace AtomToolsFramework
         , m_initialPath(initialPath)
     {
         setModal(true);
-        resize(400, 128);
-        setMinimumSize(QSize(400, 128));
-        setMaximumSize(QSize(16777215, 128));
+        setMinimumWidth(600);
+        resize(500, 128);
         setWindowTitle(title);
 
-        auto sourceSelectionComboBoxLabel = new QLabel(this);
-        sourceSelectionComboBoxLabel->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred));
-        sourceSelectionComboBoxLabel->setText(sourceLabel);
+        // Create the layout for all the widgets to be stacked vertically.
+        auto verticalLayout = new QVBoxLayout();
+
+        // The source selection combo box is used to pick from a set of source files or templates that can be used as a starting point or
+        // parent for a new document. If there is no filter then no source selection widgets or connections will be made.
+        if (filterCallback)
+        {
+            auto sourceSelectionComboBoxLabel = new QLabel(this);
+            sourceSelectionComboBoxLabel->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed));
+            sourceSelectionComboBoxLabel->setText(sourceLabel);
+            verticalLayout->addWidget(sourceSelectionComboBoxLabel);
+
+            m_sourceSelectionComboBox = new AssetSelectionComboBox(filterCallback, this);
+            m_sourceSelectionComboBox->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed));
+            m_sourceSelectionComboBox->SelectAsset(defaultSourceAssetId);
+            m_sourcePath = m_sourceSelectionComboBox->GetSelectedAssetSourcePath().c_str();
+            QObject::connect(m_sourceSelectionComboBox, &AssetSelectionComboBox::AssetSelected, this, [this]() {
+                m_sourcePath = m_sourceSelectionComboBox->GetSelectedAssetSourcePath().c_str();
+            });
+            verticalLayout->addWidget(m_sourceSelectionComboBox);
+        }
 
         auto targetSelectionBrowserLabel = new QLabel(this);
-        targetSelectionBrowserLabel->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred));
+        targetSelectionBrowserLabel->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed));
         targetSelectionBrowserLabel->setText(targetLabel);
-
-        m_sourceSelectionComboBox = new AssetSelectionComboBox(filterCallback, this);
-        m_sourceSelectionComboBox->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred));
-        m_sourceSelectionComboBox->SelectAsset(defaultSourceAssetId);
-        m_sourcePath = m_sourceSelectionComboBox->GetSelectedAssetSourcePath().c_str();
-        QObject::connect(m_sourceSelectionComboBox, &AssetSelectionComboBox::AssetSelected, this, [this]() {
-            m_sourcePath = m_sourceSelectionComboBox->GetSelectedAssetSourcePath().c_str();
-        });
+        verticalLayout->addWidget(targetSelectionBrowserLabel);
 
         m_targetSelectionBrowser = new AzQtComponents::BrowseEdit(this);
-        m_targetSelectionBrowser->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred));
+        m_targetSelectionBrowser->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed));
         m_targetSelectionBrowser->setLineEditReadOnly(true);
+        verticalLayout->addWidget(m_targetSelectionBrowser);
 
         // Select a default location and unique name for the new document
         UpdateTargetPath(QFileInfo(GetUniqueFilePath(
@@ -73,17 +84,11 @@ namespace AtomToolsFramework
 
         // Connect ok and cancel buttons
         auto buttonBox = new QDialogButtonBox(this);
-        buttonBox->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred));
+        buttonBox->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed));
         buttonBox->setOrientation(Qt::Horizontal);
         buttonBox->setStandardButtons(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
         QObject::connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
         QObject::connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
-
-        auto verticalLayout = new QVBoxLayout();
-        verticalLayout->addWidget(sourceSelectionComboBoxLabel);
-        verticalLayout->addWidget(m_sourceSelectionComboBox);
-        verticalLayout->addWidget(targetSelectionBrowserLabel);
-        verticalLayout->addWidget(m_targetSelectionBrowser);
         verticalLayout->addWidget(buttonBox);
 
         auto gridLayout = new QGridLayout(this);
@@ -92,12 +97,14 @@ namespace AtomToolsFramework
 
     CreateDocumentDialog::CreateDocumentDialog(const DocumentTypeInfo& documentType, const QString& initialPath, QWidget* parent)
         : CreateDocumentDialog(
-              tr("Create %1").arg(documentType.m_documentTypeName.c_str()),
+              tr("Create %1 Document").arg(documentType.m_documentTypeName.c_str()),
               tr("Select Type"),
               tr("Select %1 Path").arg(documentType.m_documentTypeName.c_str()),
               initialPath,
               { documentType.GetDefaultExtensionToSave().c_str() },
               documentType.m_defaultAssetIdToCreate,
+              documentType.m_supportedExtensionsToCreate.empty() ?
+              AZStd::function<bool(const AZ::Data::AssetInfo&)>():
               [documentType](const AZ::Data::AssetInfo& assetInfo)
               {
                   // If any asset types are specified, do early rejection tests to avoid expensive string comparisons

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeConfig.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeConfig.cpp
@@ -42,6 +42,7 @@ namespace AtomToolsFramework
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_title, "Title", "Title that will appear at the top of the node UI in a graph.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_subTitle, "Sub Title", "Secondary title that will appear below the main title on the node UI in a graph.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_settings, "Settings", "Table of strings that can be used for any context specific or user defined data for each node.")
+                        ->ElementAttribute(AZ::Edit::Attributes::Handler, AZ::Edit::UIHandlers::MultiLineEdit)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_inputSlots, "Input Slots", "Container of dynamic node input slot configurations.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_outputSlots, "Output Slots", "Container of dynamic node output slot configurations.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_propertySlots, "Property Slots", "Container hub dynamic node property slot configurations.")

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeConfig.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeConfig.cpp
@@ -37,7 +37,7 @@ namespace AtomToolsFramework
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_id, "Id", "UUID for identifying this node configuration regardless of file location.")
-                        ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_category, "Category", "Name of the category where this node will appear in the node palette.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_title, "Title", "Title that will appear at the top of the node UI in a graph.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_subTitle, "Sub Title", "Secondary title that will appear below the main title on the node UI in a graph.")

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeSlotConfig.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeSlotConfig.cpp
@@ -24,8 +24,8 @@ namespace AtomToolsFramework
                 ->Field("name", &DynamicNodeSlotConfig::m_name)
                 ->Field("displayName", &DynamicNodeSlotConfig::m_displayName)
                 ->Field("description", &DynamicNodeSlotConfig::m_description)
-                ->Field("supportedDataTypes", &DynamicNodeSlotConfig::m_supportedDataTypes)
                 ->Field("supportsEditingOnNode", &DynamicNodeSlotConfig::m_supportsEditingOnNode)
+                ->Field("supportedDataTypes", &DynamicNodeSlotConfig::m_supportedDataTypes)
                 ->Field("defaultValue", &DynamicNodeSlotConfig::m_defaultValue)
                 ->Field("settings", &DynamicNodeSlotConfig::m_settings)
                 ;
@@ -38,10 +38,12 @@ namespace AtomToolsFramework
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_name, "Name", "Unique name used to identify individual slots on a node.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_displayName, "Display Name", "User friendly title of the slot that will appear on the node UI.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_description, "Description", "Detailed description of the node, its purpose, and behavior that will appear in tooltips and other UI.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_defaultValue, "Default Value", "The initial value of an input or property slot that has no incoming connection.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_supportedDataTypes, "Supported Data Types", "Container of names of data types that can be assigned to this slot. Output and property slots will be created using the first recognized data type in the container.")
+                        ->Attribute(AZ::Edit::Attributes::Handler, AZ::Edit::UIHandlers::MultiLineEdit)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_supportsEditingOnNode, "Supports Editing On Node", "Enable this to allow editing the the slot value directly in the node UI.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_supportedDataTypes, "Supported Data Types", "Container of names of data types that can be assigned to this slot. Output and property slots will be created using the first recognized data type in the container.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_defaultValue, "Default Value", "The initial value of an input or property slot that has no incoming connection.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_settings, "Settings", "Table of strings that can be used for any context specific or user defined data for each slot.")
+                        ->ElementAttribute(AZ::Edit::Attributes::Handler, AZ::Edit::UIHandlers::MultiLineEdit)
                     ;
             }
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -442,7 +442,7 @@ namespace AtomToolsFramework
         return results;
     }
 
-    void AddRegisteredScriptToMenu(QMenu* menu, const AZStd::string& registryKey, const AZStd::vector<AZStd::string_view>& arguments)
+    void AddRegisteredScriptToMenu(QMenu* menu, const AZStd::string& registryKey, const AZStd::vector<AZStd::string>& arguments)
     {
         // Map containing vectors of script file paths organized by category
         using ScriptsSettingsMap = AZStd::map<AZStd::string, AZStd::vector<AZStd::string>>;
@@ -478,7 +478,7 @@ namespace AtomToolsFramework
                             AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(
                                 &AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilenameWithArgs,
                                 scriptPath,
-                                arguments);
+                                AZStd::vector<AZStd::string_view>(arguments.begin(), arguments.end()));
                             });
                     });
                 }
@@ -496,7 +496,7 @@ namespace AtomToolsFramework
                     AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(
                         &AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilenameWithArgs,
                         scriptPath.toUtf8().constData(),
-                        arguments);
+                        AZStd::vector<AZStd::string_view>(arguments.begin(), arguments.end()));
                 });
             }
         });

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -242,7 +242,7 @@ namespace AtomToolsFramework
         m_menuTools->addSeparator();
 
         BuildLayoutsMenu();
-        m_menuTools->addSeparator();
+        m_menuView->addSeparator();
 
         m_menuTools->addAction(tr("&Settings..."), [this]() {
             OpenSettingsDialog();
@@ -405,7 +405,7 @@ namespace AtomToolsFramework
 
     void AtomToolsMainWindow::BuildLayoutsMenu()
     {
-        QMenu* layoutSettingsMenu = m_menuTools->addMenu(tr("Layouts"));
+        QMenu* layoutSettingsMenu = m_menuView->addMenu(tr("Layouts"));
         connect(
             layoutSettingsMenu,
             &QMenu::aboutToShow,

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/atomtoolsframework_files.cmake
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/atomtoolsframework_files.cmake
@@ -34,6 +34,9 @@ set(FILES
     Include/AtomToolsFramework/Debug/TraceRecorder.h
     Source/Debug/TraceRecorder.cpp
 
+    Include/AtomToolsFramework/Document/AtomToolsAnyDocument.h
+    Include/AtomToolsFramework/Document/AtomToolsAnyDocumentNotificationBus.h
+    Include/AtomToolsFramework/Document/AtomToolsAnyDocumentRequestBus.h
     Include/AtomToolsFramework/Document/AtomToolsDocument.h
     Include/AtomToolsFramework/Document/AtomToolsDocumentApplication.h
     Include/AtomToolsFramework/Document/AtomToolsDocumentInspector.h
@@ -45,6 +48,7 @@ set(FILES
     Include/AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h
     Include/AtomToolsFramework/Document/AtomToolsDocumentTypeInfo.h
     Include/AtomToolsFramework/Document/CreateDocumentDialog.h
+    Source/Document/AtomToolsAnyDocument.cpp
     Source/Document/AtomToolsDocument.cpp
     Source/Document/AtomToolsDocumentApplication.cpp
     Source/Document/AtomToolsDocumentInspector.cpp

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Textures/sample_texture_2d.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Textures/sample_texture_2d.materialcanvasnode
@@ -11,14 +11,7 @@
                 "float4 NODEID_outColor = MaterialSrg::NODEINPUTID.Sample(MaterialSrg::NODEINPUTID_sampler, NODEID_inUV);"
             ],
             "materialInputs": [
-                "Texture2D NODEINPUTID;",
-                "Sampler NODEINPUTID_sampler",
-                "{",
-                "    MaxAnisotropy = 16;",
-                "    AddressU = Wrap;",
-                "    AddressV = Wrap;",
-                "    AddressW = Wrap;",
-                "};"
+                "Texture2D NODEINPUTID;\nSampler NODEINPUTID_sampler\n{\n    MaxAnisotropy = 16;\n    AddressU = Wrap;\n    AddressV = Wrap;\n    AddressW = Wrap;\n};\n"
             ]
         },
         "propertySlots": [

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -219,7 +219,7 @@ namespace MaterialCanvas
             return false;
         }
 
-        AZ_Error("MaterialCanvasDocument", m_graph, "Attempting to save invalid graph objeTt. ");
+        AZ_Error("MaterialCanvasDocument", m_graph, "Attempting to save invalid graph object.");
         if (!m_graph || !AZ::JsonSerializationUtils::SaveObjectToFile(m_graph.get(), m_savePathNormalized))
         {
             return SaveFailed();
@@ -240,7 +240,7 @@ namespace MaterialCanvas
             return false;
         }
 
-        AZ_Error("MaterialCanvasDocument", m_graph, "Attempting to save invalid graph objeTt. ");
+        AZ_Error("MaterialCanvasDocument", m_graph, "Attempting to save invalid graph object.");
         if (!m_graph || !AZ::JsonSerializationUtils::SaveObjectToFile(m_graph.get(), m_savePathNormalized))
         {
             return SaveFailed();

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -69,16 +69,22 @@ namespace MaterialCanvas
         : AtomToolsFramework::AtomToolsDocument(toolId, documentTypeInfo)
         , m_graphContext(graphContext)
     {
+        AZ_Assert(m_graphContext, "Graph context must be valid in order to create a graph document.");
+
         // Creating the scene entity and graph for this document. This may end up moving to the view if we can have the document only store
         // minimal material graph specific data that can be transformed into a graph canvas graph in the view and back. That abstraction
         // would help maintain a separation between the serialized data and the UI for rendering and interacting with the graph. This would
         // also help establish a mediator pattern for other node based tools that want to visualize their data or documents as a graph. My
         // understanding is that graph model will help with this.
         m_graph = AZStd::make_shared<GraphModel::Graph>(m_graphContext);
+        AZ_Assert(m_graph, "Failed to create graph object.");
 
         GraphModelIntegration::GraphManagerRequestBus::BroadcastResult(
             m_sceneEntity, &GraphModelIntegration::GraphManagerRequests::CreateScene, m_graph, m_toolId);
+        AZ_Assert(m_sceneEntity, "Failed to create graph scene entity.");
+
         m_graphId = m_sceneEntity->GetId();
+        AZ_Assert(m_graphId.IsValid(), "Graph scene entity ID is not valid.");
 
         RecordGraphState();
 
@@ -150,14 +156,8 @@ namespace MaterialCanvas
 
     AtomToolsFramework::DocumentObjectInfoVector MaterialCanvasDocument::GetObjectInfo() const
     {
-        if (!IsOpen())
-        {
-            AZ_Error("MaterialCanvasDocument", false, "Document is not open.");
-            return {};
-        }
-
-        AtomToolsFramework::DocumentObjectInfoVector objects;
-        objects.reserve(m_groups.size());
+        AtomToolsFramework::DocumentObjectInfoVector objects = AtomToolsDocument::GetObjectInfo();
+        objects.reserve(objects.size() + m_groups.size());
 
         for (const auto& group : m_groups)
         {
@@ -175,7 +175,7 @@ namespace MaterialCanvas
                     // There are currently no indicators for material canvas nodes.
                     return nullptr;
                 };
-                objects.push_back(objectInfo);
+                objects.push_back(AZStd::move(objectInfo));
             }
         }
 
@@ -219,7 +219,8 @@ namespace MaterialCanvas
             return false;
         }
 
-        if (!AZ::JsonSerializationUtils::SaveObjectToFile(m_graph.get(), m_savePathNormalized))
+        AZ_Error("MaterialCanvasDocument", m_graph, "Attempting to save invalid graph objeTt. ");
+        if (!m_graph || !AZ::JsonSerializationUtils::SaveObjectToFile(m_graph.get(), m_savePathNormalized))
         {
             return SaveFailed();
         }
@@ -239,7 +240,8 @@ namespace MaterialCanvas
             return false;
         }
 
-        if (!AZ::JsonSerializationUtils::SaveObjectToFile(m_graph.get(), m_savePathNormalized))
+        AZ_Error("MaterialCanvasDocument", m_graph, "Attempting to save invalid graph objeTt. ");
+        if (!m_graph || !AZ::JsonSerializationUtils::SaveObjectToFile(m_graph.get(), m_savePathNormalized))
         {
             return SaveFailed();
         }
@@ -259,7 +261,8 @@ namespace MaterialCanvas
             return false;
         }
 
-        if (!AZ::JsonSerializationUtils::SaveObjectToFile(m_graph.get(), m_savePathNormalized))
+        AZ_Error("MaterialCanvasDocument", m_graph, "Attempting to save invalid graph object. ");
+        if (!m_graph || !AZ::JsonSerializationUtils::SaveObjectToFile(m_graph.get(), m_savePathNormalized))
         {
             return SaveFailed();
         }
@@ -268,11 +271,6 @@ namespace MaterialCanvas
         m_absolutePath = m_savePathNormalized;
         QueueCompileGraph();
         return SaveSucceeded();
-    }
-
-    bool MaterialCanvasDocument::IsOpen() const
-    {
-        return AtomToolsDocument::IsOpen() && m_graph && m_graphId.IsValid();
     }
 
     bool MaterialCanvasDocument::IsModified() const
@@ -326,16 +324,6 @@ namespace MaterialCanvas
         m_modified = false;
 
         AtomToolsFramework::AtomToolsDocument::Clear();
-    }
-
-    bool MaterialCanvasDocument::ReopenRecordState()
-    {
-        return AtomToolsDocument::ReopenRecordState();
-    }
-
-    bool MaterialCanvasDocument::ReopenRestoreState()
-    {
-        return AtomToolsDocument::ReopenRestoreState();
     }
 
     void MaterialCanvasDocument::OnGraphModelRequestUndoPoint()
@@ -411,14 +399,18 @@ namespace MaterialCanvas
     {
         DestroyGraph();
 
-        m_graph = graph;
-        m_graph->PostLoadSetup(m_graphContext);
-        BuildEditablePropertyGroups();
-        RecordGraphState();
+        if (graph)
+        {
+            m_graph = graph;
+            m_graph->PostLoadSetup(m_graphContext);
 
-        // The graph controller will create all of the scene items on construction.
-        GraphModelIntegration::GraphManagerRequestBus::Broadcast(
-            &GraphModelIntegration::GraphManagerRequests::CreateGraphController, m_graphId, m_graph);
+            BuildEditablePropertyGroups();
+            RecordGraphState();
+
+            // The graph controller will create all of the scene items on construction.
+            GraphModelIntegration::GraphManagerRequestBus::Broadcast(
+                &GraphModelIntegration::GraphManagerRequests::CreateGraphController, m_graphId, m_graph);
+        }
     }
 
     void MaterialCanvasDocument::DestroyGraph()
@@ -656,6 +648,8 @@ namespace MaterialCanvas
     AZStd::vector<GraphModel::ConstNodePtr> MaterialCanvasDocument::GetInstructionNodesInExecutionOrder(
         GraphModel::ConstNodePtr outputNode, const AZStd::vector<AZStd::string>& inputSlotNames) const
     {
+        AZ_Assert(m_graph, "Attempting to generate data from invalid graph object.");
+
         AZStd::vector<GraphModel::ConstNodePtr> sortedNodes;
         sortedNodes.reserve(m_graph->GetNodes().size());
 
@@ -772,6 +766,8 @@ namespace MaterialCanvas
 
     AZStd::vector<AZStd::string> MaterialCanvasDocument::GetMaterialInputsFromNodes() const
     {
+        AZ_Assert(m_graph, "Attempting to generate data from invalid graph object.");
+
         AZStd::vector<AZStd::string> materialInputs;
 
         for (const auto& inputNodePair : m_graph->GetNodes())
@@ -869,6 +865,9 @@ namespace MaterialCanvas
     bool MaterialCanvasDocument::BuildMaterialTypeFromTemplate(
         GraphModel::ConstNodePtr templateNode, const AZStd::string& templateInputPath, const AZStd::string& templateOutputPath) const
     {
+        AZ_Assert(m_graph, "Attempting to generate data from invalid graph object.");
+        AZ_Assert(templateNode, "Attempting to generate data from invalid template node.");
+
         // Load the material type template file, which is the same format as MaterialTypeSourceData with a different extension
         auto materialTypeOutcome = AZ::RPI::MaterialUtils::LoadMaterialTypeSourceData(templateInputPath);
         if (!materialTypeOutcome.IsSuccess())
@@ -969,7 +968,7 @@ namespace MaterialCanvas
         m_compileGraphQueued = false;
         m_generatedFiles.clear();
 
-        if (!IsOpen())
+        if (!m_graph)
         {
             return false;
         }
@@ -1127,7 +1126,7 @@ namespace MaterialCanvas
 
     void MaterialCanvasDocument::QueueCompileGraph() const
     {
-        if (IsOpen() && !m_compileGraphQueued)
+        if (m_graph && !m_compileGraphQueued)
         {
             m_compileGraphQueued = true;
             AZ::SystemTickBus::QueueFunction([id = m_id](){

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -17,27 +17,25 @@
 #include <AtomToolsFramework/DynamicNode/DynamicNodeUtil.h>
 #include <AtomToolsFramework/Util/MaterialPropertyUtil.h>
 #include <AtomToolsFramework/Util/Util.h>
-#include <AzCore/RTTI/BehaviorContext.h>
-#include <AzCore/Serialization/EditContext.h>
-#include <AzCore/Serialization/SerializeContext.h>
-#include <Document/MaterialCanvasDocument.h>
-#include <Document/MaterialCanvasDocumentNotificationBus.h>
-#include <GraphCanvas/Components/SceneBus.h>
-#include <GraphCanvas/GraphCanvasBus.h>
-#include <GraphModel/Model/Connection.h>
-
 #include <AzCore/IO/ByteContainerStream.h>
 #include <AzCore/Math/Color.h>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Vector4.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/ObjectStream.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/sort.h>
+#include <Document/MaterialCanvasDocument.h>
+#include <Document/MaterialCanvasDocumentNotificationBus.h>
+#include <GraphCanvas/Components/SceneBus.h>
+#include <GraphCanvas/GraphCanvasBus.h>
+#include <GraphModel/Model/Connection.h>
 
 namespace MaterialCanvas
 {
@@ -112,7 +110,7 @@ namespace MaterialCanvas
 
     AtomToolsFramework::DocumentTypeInfo MaterialCanvasDocument::BuildDocumentTypeInfo()
     {
-        // Setting up placeholder document type info and extensions. This is not representative of final data.
+        // Setting up placeholder document type info and extensions.
         AtomToolsFramework::DocumentTypeInfo documentType;
         documentType.m_documentTypeName = "Material Canvas";
         documentType.m_documentFactoryCallback = [](const AZ::Crc32& toolId, const AtomToolsFramework::DocumentTypeInfo& documentTypeInfo) {

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
@@ -31,7 +31,7 @@ namespace MaterialCanvas
         , public GraphCanvas::SceneNotificationBus::Handler
     {
     public:
-        AZ_RTTI(MaterialCanvasDocument, "{C60CA7B2-D9FA-4E20-AD7D-D8A661902A7D}", AtomToolsFramework::AtomToolsDocument);
+        AZ_RTTI(MaterialCanvasDocument, "{16A936E3-6510-4E8F-8229-6BD7366A8D4B}", AtomToolsFramework::AtomToolsDocument);
         AZ_CLASS_ALLOCATOR(MaterialCanvasDocument, AZ::SystemAllocator, 0);
         AZ_DISABLE_COPY_MOVE(MaterialCanvasDocument);
 

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
@@ -22,7 +22,8 @@
 
 namespace MaterialCanvas
 {
-    //! MaterialCanvasDocument
+    //! MaterialCanvasDocument implements support for creating, loading, saving, and manipulating graph model and canvas graphs that
+    //! represent and will be transformed into shader and material data.
     class MaterialCanvasDocument
         : public AtomToolsFramework::AtomToolsDocument
         , public MaterialCanvasDocumentRequestBus::Handler
@@ -30,7 +31,7 @@ namespace MaterialCanvas
         , public GraphCanvas::SceneNotificationBus::Handler
     {
     public:
-        AZ_RTTI(MaterialCanvasDocument, "{90299628-AD02-4FEB-9527-7278FA2817AD}", AtomToolsFramework::AtomToolsDocument);
+        AZ_RTTI(MaterialCanvasDocument, "{C60CA7B2-D9FA-4E20-AD7D-D8A661902A7D}", AtomToolsFramework::AtomToolsDocument);
         AZ_CLASS_ALLOCATOR(MaterialCanvasDocument, AZ::SystemAllocator, 0);
         AZ_DISABLE_COPY_MOVE(MaterialCanvasDocument);
 
@@ -50,7 +51,6 @@ namespace MaterialCanvas
         bool Save() override;
         bool SaveAsCopy(const AZStd::string& savePath) override;
         bool SaveAsChild(const AZStd::string& savePath) override;
-        bool IsOpen() const override;
         bool IsModified() const override;
         bool BeginEdit() override;
         bool EndEdit() override;
@@ -66,8 +66,6 @@ namespace MaterialCanvas
     private:
         // AtomToolsFramework::AtomToolsDocument overrides...
         void Clear() override;
-        bool ReopenRecordState() override;
-        bool ReopenRestoreState() override;
 
         // GraphModelIntegration::GraphControllerNotificationBus::Handler overrides...
         void OnGraphModelRequestUndoPoint() override;

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
@@ -6,7 +6,9 @@
  *
  */
 
+#include <Atom/RPI.Edit/Shader/ShaderSourceData.h>
 #include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
+#include <AtomToolsFramework/Document/AtomToolsAnyDocument.h>
 #include <AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h>
 #include <AzCore/Math/Color.h>
 #include <AzCore/Math/Vector2.h>
@@ -19,6 +21,8 @@
 #include <MaterialCanvasApplication.h>
 #include <Window/MaterialCanvasGraphView.h>
 #include <Window/MaterialCanvasMainWindow.h>
+
+#include <QLabel>
 
 void InitMaterialCanvasResources()
 {
@@ -120,7 +124,8 @@ namespace MaterialCanvas
         auto documentTypeInfo = MaterialCanvasDocument::BuildDocumentTypeInfo();
 
         // Overriding default document factory function to pass in a shared graph context
-        documentTypeInfo.m_documentFactoryCallback = [this](const AZ::Crc32& toolId, const AtomToolsFramework::DocumentTypeInfo& documentTypeInfo)
+        documentTypeInfo.m_documentFactoryCallback =
+            [this](const AZ::Crc32& toolId, const AtomToolsFramework::DocumentTypeInfo& documentTypeInfo)
         {
             return aznew MaterialCanvasDocument(toolId, documentTypeInfo, m_graphContext);
         };
@@ -131,6 +136,30 @@ namespace MaterialCanvas
             return m_window->AddDocumentTab(documentId, aznew MaterialCanvasGraphView(toolId, documentId, graphViewConfig));
         };
 
+        AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Event(
+            m_toolId, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Handler::RegisterDocumentType, documentTypeInfo);
+
+        // Register document type for editing material canvas node configurations. This document type does not have a central view widget
+        // and will show a label directing users to the inspector.
+        documentTypeInfo =
+            AtomToolsFramework::AtomToolsAnyDocument::BuildDocumentTypeInfo("Material Canvas Node Config", { "materialcanvasnode" });
+        documentTypeInfo.m_documentViewFactoryCallback = [this]([[maybe_unused]] const AZ::Crc32& toolId, const AZ::Uuid& documentId) {
+            auto viewWidget = new QLabel("Material Canvas Node properties can be edited in the inspector.", m_window.get());
+            viewWidget->setAlignment(Qt::AlignCenter);
+            return m_window->AddDocumentTab(documentId, viewWidget);
+        };
+        AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Event(
+            m_toolId, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Handler::RegisterDocumentType, documentTypeInfo);
+
+        // Register document type for editing shader source data and template files. This document type also does not have a central view
+        // and will display a label widget that directs users to the property inspector.
+        documentTypeInfo = AtomToolsFramework::AtomToolsAnyDocument::BuildDocumentTypeInfo(
+            "Shader Source Data", { "shader", "shader.template" }, AZ::RPI::ShaderSourceData::TYPEINFO_Uuid());
+        documentTypeInfo.m_documentViewFactoryCallback = [this]([[maybe_unused]] const AZ::Crc32& toolId, const AZ::Uuid& documentId) {
+            auto viewWidget = new QLabel("Shader Source Data properties can be edited in the inspector.", m_window.get());
+            viewWidget->setAlignment(Qt::AlignCenter);
+            return m_window->AddDocumentTab(documentId, viewWidget);
+        };
         AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Event(
             m_toolId, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Handler::RegisterDocumentType, documentTypeInfo);
 

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
@@ -141,10 +141,14 @@ namespace MaterialCanvas
 
         // Register document type for editing material canvas node configurations. This document type does not have a central view widget
         // and will show a label directing users to the inspector.
-        documentTypeInfo =
-            AtomToolsFramework::AtomToolsAnyDocument::BuildDocumentTypeInfo("Material Canvas Node Config", { "materialcanvasnode" });
+        documentTypeInfo = AtomToolsFramework::AtomToolsAnyDocument::BuildDocumentTypeInfo(
+            "Material Canvas Node Config",
+            { "materialcanvasnode" },
+            AZStd::any(AtomToolsFramework::DynamicNodeConfig()),
+            AZ::Uuid::CreateNull()); // Null ID because JSON file contains type info and can be loaded directly into AZStd::any
+
         documentTypeInfo.m_documentViewFactoryCallback = [this]([[maybe_unused]] const AZ::Crc32& toolId, const AZ::Uuid& documentId) {
-            auto viewWidget = new QLabel("Material Canvas Node properties can be edited in the inspector.", m_window.get());
+            auto viewWidget = new QLabel("Material Canvas Node Config properties can be edited in the inspector.", m_window.get());
             viewWidget->setAlignment(Qt::AlignCenter);
             return m_window->AddDocumentTab(documentId, viewWidget);
         };
@@ -154,7 +158,11 @@ namespace MaterialCanvas
         // Register document type for editing shader source data and template files. This document type also does not have a central view
         // and will display a label widget that directs users to the property inspector.
         documentTypeInfo = AtomToolsFramework::AtomToolsAnyDocument::BuildDocumentTypeInfo(
-            "Shader Source Data", { "shader", "shader.template" }, AZ::RPI::ShaderSourceData::TYPEINFO_Uuid());
+            "Shader Source Data",
+            { "shader", "shader.template" },
+            AZStd::any(AZ::RPI::ShaderSourceData()),
+            AZ::RPI::ShaderSourceData::TYPEINFO_Uuid()); // Supplying ID because it is not included in the JSON file
+
         documentTypeInfo.m_documentViewFactoryCallback = [this]([[maybe_unused]] const AZ::Crc32& toolId, const AZ::Uuid& documentId) {
             auto viewWidget = new QLabel("Shader Source Data properties can be edited in the inspector.", m_window.get());
             viewWidget->setAlignment(Qt::AlignCenter);

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.h
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.h
@@ -46,7 +46,6 @@ namespace MaterialEditor
         bool Save() override;
         bool SaveAsCopy(const AZStd::string& savePath) override;
         bool SaveAsChild(const AZStd::string& savePath) override;
-        bool IsOpen() const override;
         bool IsModified() const override;
         bool BeginEdit() override;
         bool EndEdit() override;

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
@@ -88,7 +88,7 @@ namespace ShaderManagementConsole
 
     size_t ShaderManagementConsoleDocument::GetShaderOptionDescriptorCount() const
     {
-        if (IsOpen())
+        if (m_shaderAsset.IsReady())
         {
             const auto& layout = m_shaderAsset->GetShaderOptionGroupLayout();
             const auto& shaderOptionDescriptors = layout->GetShaderOptions();
@@ -99,7 +99,7 @@ namespace ShaderManagementConsole
 
     const AZ::RPI::ShaderOptionDescriptor& ShaderManagementConsoleDocument::GetShaderOptionDescriptor(size_t index) const
     {
-        if (IsOpen())
+        if (m_shaderAsset.IsReady())
         {
             const auto& layout = m_shaderAsset->GetShaderOptionGroupLayout();
             const auto& shaderOptionDescriptors = layout->GetShaderOptions();
@@ -114,7 +114,6 @@ namespace ShaderManagementConsole
         documentType.m_documentTypeName = "Shader Variant List";
         documentType.m_documentFactoryCallback = [](const AZ::Crc32& toolId, const AtomToolsFramework::DocumentTypeInfo& documentTypeInfo) {
             return aznew ShaderManagementConsoleDocument(toolId, documentTypeInfo); };
-        documentType.m_supportedExtensionsToCreate.push_back({ "Shader Variant List", AZ::RPI::ShaderVariantListSourceData::Extension });
         documentType.m_supportedExtensionsToOpen.push_back({ "Shader Variant List", AZ::RPI::ShaderVariantListSourceData::Extension });
         documentType.m_supportedExtensionsToSave.push_back({ "Shader Variant List", AZ::RPI::ShaderVariantListSourceData::Extension });
         documentType.m_supportedAssetTypesToCreate.insert(azrtti_typeid<AZ::RPI::ShaderAsset>());
@@ -123,13 +122,7 @@ namespace ShaderManagementConsole
 
     AtomToolsFramework::DocumentObjectInfoVector ShaderManagementConsoleDocument::GetObjectInfo() const
     {
-        if (!IsOpen())
-        {
-            AZ_Error("ShaderManagementConsoleDocument", false, "Document is not open.");
-            return {};
-        }
-
-        AtomToolsFramework::DocumentObjectInfoVector objects;
+        AtomToolsFramework::DocumentObjectInfoVector objects = AtomToolsDocument::GetObjectInfo();
 
         AtomToolsFramework::DocumentObjectInfo objectInfo;
         objectInfo.m_visible = true;
@@ -200,11 +193,6 @@ namespace ShaderManagementConsole
         }
 
         return SaveSourceData();
-    }
-
-    bool ShaderManagementConsoleDocument::IsOpen() const
-    {
-        return AtomToolsDocument::IsOpen() && m_shaderAsset.IsReady();
     }
 
     bool ShaderManagementConsoleDocument::IsModified() const
@@ -297,6 +285,6 @@ namespace ShaderManagementConsole
         SetShaderVariantListSourceData(shaderVariantListSourceData);
         m_modified = {};
 
-        return IsOpen() ? OpenSucceeded() : OpenFailed();
+        return OpenSucceeded();
     }
 } // namespace ShaderManagementConsole

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.h
@@ -42,7 +42,6 @@ namespace ShaderManagementConsole
         bool Save() override;
         bool SaveAsCopy(const AZStd::string& savePath) override;
         bool SaveAsChild(const AZStd::string& savePath) override;
-        bool IsOpen() const override;
         bool IsModified() const override;
         bool BeginEdit() override;
         bool EndEdit() override;


### PR DESCRIPTION
## What does this PR do?

- Created AtomToolsAnyDocument to wrap any serialize and edit context reflected classes to the document system and expose them to the document inspector. 
- Used AtomToolsAnyDocument to register shader source data and dynamic node config as editable document types within material canvas.
- Updated class with construction parameters and different code paths to support loading and saving JSON objects with and without type info and class data because some atom types use nonstandard serializers that don’t include the class the class data.
- Fixed a bug with passing arguments from the asset browser into Python scripts using string views. Script execution was deferred which caused the string view arguments to be invalid by the time the script executed.
- Removed checks for open document state and made other changes to support creating editable documents without a source file or saving. Most document types should be creatable and editable without first opening a source type or template or saving immediately. A lot of this code was originally refactored from the material editor, which required the user to select the material type to create a material. The system and dialogs have been updated to handle creating documents without a source file. The dialog currently still requires saving first but that can be modified in a future PR after confirming that material editor no longer needs that requirement and material canvas has a default location for saving generated data.

https://github.com/o3de/sig-graphics-audio/issues/51

## How was this PR tested?

Manually verified that new document types can be created, opened, edited, saved, inspected, and that undo and redo work for them.
Manually verified that new and open menus populate with document types correctly.
Manually verified that create document dialog only shows the select source drop down if the document requires a source file.
Manually verified that new documents can be created from the menu and create dialog without a source.
Manually verified that the Python script fixes work for shader management console, launching the existing generation script from the asset browser context menu.
Automated testing should be coming soon now that the new test framework for material editor and material canvas is in place.

![image](https://user-images.githubusercontent.com/82461473/187547567-109dbd91-84c8-429d-87bc-41e7791416cc.png)
![image](https://user-images.githubusercontent.com/82461473/187547670-83f5e66f-1c81-44f8-9183-74bbcb315a21.png)
![image](https://user-images.githubusercontent.com/82461473/187547737-d78bb4d0-cbbe-42fb-9468-965677f8d7f4.png)
![image](https://user-images.githubusercontent.com/82461473/187547923-44aebe2d-0b38-4af5-9263-003fa641ceee.png)
![image](https://user-images.githubusercontent.com/82461473/187548228-11629245-6add-4453-822d-9ce136787380.png)
![image](https://user-images.githubusercontent.com/82461473/187548410-63799932-2248-43e9-9102-ef8108d87929.png)
