### PR TITLE
Next set of core engine VR support work for a function AtomSampleViewer VR sample. 

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Components/CameraBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Components/CameraBus.h
@@ -111,6 +111,11 @@ namespace Camera
         //! The height is calculated automatically based on the aspect ratio.
         virtual void SetOrthographicHalfWidth(float halfWidth) = 0;
 
+        //! Sets the Quaternion related to a stereoscopic view for a camera with the provided view index related to your eye.
+        //! @params viewQuat Used to cache view orientation data from the XR device
+        //! @params xrViewIndex View index related to the pipeline associated with a specific eye
+        virtual void SetStereoscopicView(const AZ::Quaternion& viewQuat, uint32_t xrViewIndex) = 0;
+
         //! Makes the camera the active view
         virtual void MakeActiveView() = 0;
 

--- a/Code/Framework/AzFramework/AzFramework/Components/CameraBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Components/CameraBus.h
@@ -114,7 +114,7 @@ namespace Camera
         //! Sets the Quaternion related to a stereoscopic view for a camera with the provided view index related to your eye.
         //! @params viewQuat Used to cache view orientation data from the XR device
         //! @params xrViewIndex View index related to the pipeline associated with a specific eye
-        virtual void SetStereoscopicView(const AZ::Quaternion& viewQuat, uint32_t xrViewIndex) = 0;
+        virtual void SetXRViewQuaternion(const AZ::Quaternion& viewQuat, uint32_t xrViewIndex) = 0;
 
         //! Makes the camera the active view
         virtual void MakeActiveView() = 0;

--- a/Gems/Atom/Component/DebugCamera/Code/Include/Atom/Component/DebugCamera/CameraComponent.h
+++ b/Gems/Atom/Component/DebugCamera/Code/Include/Atom/Component/DebugCamera/CameraComponent.h
@@ -104,7 +104,7 @@ namespace AZ
             void SetFrustumHeight(float height) override;
             void SetOrthographic(bool orthographic) override;
             void SetOrthographicHalfWidth(float halfWidth) override;
-            void SetStereoscopicView(const AZ::Quaternion& viewQuat, uint32_t xrViewIndex) override;
+            void SetXRViewQuaternion(const AZ::Quaternion& viewQuat, uint32_t xrViewIndex) override;
 
             void MakeActiveView() override;
             bool IsActiveView() override;

--- a/Gems/Atom/Component/DebugCamera/Code/Include/Atom/Component/DebugCamera/CameraComponent.h
+++ b/Gems/Atom/Component/DebugCamera/Code/Include/Atom/Component/DebugCamera/CameraComponent.h
@@ -20,6 +20,7 @@
 #include <Atom/RPI.Public/View.h>
 #include <Atom/RPI.Public/WindowContext.h>
 #include <Atom/RPI.Public/WindowContextBus.h>
+#include <Atom/RPI.Public/XR/XRRenderingInterface.h>
 
 namespace AZ
 {
@@ -76,6 +77,7 @@ namespace AZ
 
             // RPI::ViewProviderBus::Handler overrides...
             RPI::ViewPtr GetView() const override;
+            RPI::ViewPtr GetStereoscopicView(uint32_t viewIndex) const override;
 
         private:
             // AZ::Component overrides...
@@ -102,25 +104,41 @@ namespace AZ
             void SetFrustumHeight(float height) override;
             void SetOrthographic(bool orthographic) override;
             void SetOrthographicHalfWidth(float halfWidth) override;
+            void SetStereoscopicView(const AZ::Quaternion& viewQuat, uint32_t xrViewIndex) override;
+
             void MakeActiveView() override;
             bool IsActiveView() override;
             AZ::Vector3 ScreenToWorld(const AZ::Vector2& screenPosition, float depth) override;
             AZ::Vector3 ScreenNdcToWorld(const AZ::Vector2& screenPosition, float depth) override;
             AZ::Vector2 WorldToScreen(const AZ::Vector3& worldPosition) override;
             AZ::Vector2 WorldToScreenNdc(const AZ::Vector3& worldPosition) override;
-
+            
             // RPI::WindowContextNotificationBus overrides...
             void OnViewportResized(uint32_t width, uint32_t height) override;
 
             void UpdateAspectRatio();
-
             void UpdateViewToClipMatrix();
 
-            RPI::ViewPtr m_view = nullptr;
-            
+            //! Enum to describe view type
+            enum class ViewType : uint32_t
+            {
+                Default = 0,
+                XrLeft,
+                XrRight,
+                Count
+            };
+            AZStd::vector<RPI::ViewPtr> m_cameraViews;
+
+            // Stereoscopic view related data
+            RPI::XRRenderingInterface* m_xrSystem = nullptr;
+            AZ::u32 m_numXrViews = 0;
+            AZStd::fixed_vector<AZ::Quaternion, AZ::RPI::XRNumControllers> m_stereoscopicViewQuats;
+            // Boolean used to indicate when the stereoscopic view was updated
+            bool m_stereoscopicViewUpdate = false;
+
             // Work around the EntityContext being detached before the camera component is deactivated.
             // Without EntityContext class can't get AuxGeomFeatureProcessor to clean up per view draw interface.
-            RPI::AuxGeomFeatureProcessorInterface* m_auxGeomFeatureProcessor = nullptr;
+            AZ::RPI::AuxGeomFeatureProcessorInterface* m_auxGeomFeatureProcessor = nullptr;
 
             CameraComponentConfig m_componentConfig;
             float m_aspectRatio = 1.0f;

--- a/Gems/Atom/Component/DebugCamera/Code/Include/Atom/Component/DebugCamera/CameraComponent.h
+++ b/Gems/Atom/Component/DebugCamera/Code/Include/Atom/Component/DebugCamera/CameraComponent.h
@@ -77,7 +77,7 @@ namespace AZ
 
             // RPI::ViewProviderBus::Handler overrides...
             RPI::ViewPtr GetView() const override;
-            RPI::ViewPtr GetStereoscopicView(uint32_t viewIndex) const override;
+            RPI::ViewPtr GetStereoscopicView(RPI::ViewType viewType) const override;
 
         private:
             // AZ::Component overrides...
@@ -119,20 +119,14 @@ namespace AZ
             void UpdateAspectRatio();
             void UpdateViewToClipMatrix();
 
-            //! Enum to describe view type
-            enum class ViewType : uint32_t
-            {
-                Default = 0,
-                XrLeft,
-                XrRight,
-                Count
-            };
+            // A vector to hold all the camera views. Stereoscopic and non-stereoscopic.
+            // This will allow us to render to PC window as well as a XR device at the same time 
             AZStd::vector<RPI::ViewPtr> m_cameraViews;
 
             // Stereoscopic view related data
             RPI::XRRenderingInterface* m_xrSystem = nullptr;
             AZ::u32 m_numXrViews = 0;
-            AZStd::fixed_vector<AZ::Quaternion, AZ::RPI::XRNumControllers> m_stereoscopicViewQuats;
+            AZStd::fixed_vector<AZ::Quaternion, AZ::RPI::XRMaxNumViews> m_stereoscopicViewQuats;
             // Boolean used to indicate when the stereoscopic view was updated
             bool m_stereoscopicViewUpdate = false;
 

--- a/Gems/Atom/Component/DebugCamera/Code/Include/Atom/Component/DebugCamera/NoClipControllerBus.h
+++ b/Gems/Atom/Component/DebugCamera/Code/Include/Atom/Component/DebugCamera/NoClipControllerBus.h
@@ -56,6 +56,13 @@ namespace AZ
             virtual void SetPitch(float pitch) = 0;
             virtual void SetFov(float fov) = 0;
 
+            virtual void SetCameraStateForward(float value) = 0;
+            virtual void SetCameraStateBack(float value) = 0;
+            virtual void SetCameraStateLeft(float value) = 0;
+            virtual void SetCameraStateRight(float value) = 0;
+            virtual void SetCameraStateUp(float value) = 0;
+            virtual void SetCameraStateDown(float value) = 0;
+
             virtual float GetMouseSensitivityX() = 0;
             virtual float GetMouseSensitivityY() = 0;
             virtual float GetMoveSpeed() = 0;

--- a/Gems/Atom/Component/DebugCamera/Code/Include/Atom/Component/DebugCamera/NoClipControllerComponent.h
+++ b/Gems/Atom/Component/DebugCamera/Code/Include/Atom/Component/DebugCamera/NoClipControllerComponent.h
@@ -61,6 +61,13 @@ namespace AZ
             void SetPitch(float pitch) override;
             void SetFov(float fov) override;
 
+            void SetCameraStateForward(float value) override;
+            void SetCameraStateBack(float value) override;
+            void SetCameraStateLeft(float value) override;
+            void SetCameraStateRight(float value) override;
+            void SetCameraStateUp(float value) override;
+            void SetCameraStateDown(float value) override;
+
             float GetMouseSensitivityX() override;
             float GetMouseSensitivityY() override;
             float GetMoveSpeed() override;

--- a/Gems/Atom/Component/DebugCamera/Code/Source/CameraComponent.cpp
+++ b/Gems/Atom/Component/DebugCamera/Code/Source/CameraComponent.cpp
@@ -270,7 +270,7 @@ namespace AZ
             return 0.0f;
         }
 
-        void CameraComponent::SetStereoscopicView(const AZ::Quaternion& viewQuat, uint32_t xrViewIndex)
+        void CameraComponent::SetXRViewQuaternion(const AZ::Quaternion& viewQuat, uint32_t xrViewIndex)
         {
             AZ_Assert(xrViewIndex < AZ::RPI::XRNumControllers, "Xr view index is out of range.");
             m_stereoscopicViewQuats[xrViewIndex] = viewQuat;
@@ -398,7 +398,7 @@ namespace AZ
                 m_componentConfig.m_depthNear,
                 m_componentConfig.m_depthFar,
                 reverseDepth);
-            m_cameraViews[static_cast<uint32_t>(ViewType::Default)]->SetViewToClipMatrix(viewToClipMatrix, reverseDepth);
+            m_cameraViews[static_cast<uint32_t>(ViewType::Default)]->SetViewToClipMatrix(viewToClipMatrix);
 
             //Update stereoscopic projection matrix
             if (m_xrSystem)

--- a/Gems/Atom/Component/DebugCamera/Code/Source/CameraComponent.cpp
+++ b/Gems/Atom/Component/DebugCamera/Code/Source/CameraComponent.cpp
@@ -73,11 +73,46 @@ namespace AZ
             AZ::Name viewName = GetEntity() ?
                 AZ::Name(AZStd::string::format("Camera View (entity: \"%s\")", GetEntity()->GetName().c_str())) :
                 AZ::Name("Camera view (unknown entity)");
-            m_view = RPI::View::CreateView(viewName, RPI::View::UsageCamera);
+            
+            uint32_t defaultViewIndex = static_cast<uint32_t>(ViewType::Default);
+            if (defaultViewIndex < m_cameraViews.size())
+            {
+                m_cameraViews[defaultViewIndex] = RPI::View::CreateView(viewName, RPI::View::UsageCamera);
+            }
+            else
+            {
+                m_cameraViews.insert(m_cameraViews.begin() + defaultViewIndex, RPI::View::CreateView(viewName, RPI::View::UsageCamera));
+            }
+
+            // Add XR pipelines if it is active
+            m_xrSystem = RPI::RPISystemInterface::Get()->GetXRSystem();
+            if (m_xrSystem)
+            {
+                m_numXrViews = m_xrSystem->GetNumViews();
+                AZ_Assert(m_numXrViews <= AZ::RPI::XRNumControllers, "Atom only supports two XR views");
+                for (AZ::u32 i = 0; i < m_numXrViews; i++)
+                {
+                    uint32_t xrViewIndex = i == 0 ? static_cast<uint32_t>(ViewType::XrLeft) : static_cast<uint32_t>(ViewType::XrRight);
+                    if (xrViewIndex < m_cameraViews.size())
+                    {
+                        m_cameraViews[xrViewIndex] = RPI::View::CreateView(viewName, RPI::View::UsageCamera | RPI::View::UsageXR);
+                    }
+                    else
+                    {
+                        m_cameraViews.insert(m_cameraViews.begin() + xrViewIndex, RPI::View::CreateView(viewName, RPI::View::UsageCamera| RPI::View::UsageXR));
+                    }
+                }
+            }
+
+            for (uint16_t i = 0; i < AZ::RPI::XRNumControllers; i++)
+            {
+                m_stereoscopicViewQuats.insert(m_stereoscopicViewQuats.begin() + i, AZ::Quaternion::CreateIdentity());
+            }
+
             m_auxGeomFeatureProcessor = RPI::Scene::GetFeatureProcessorForEntity<RPI::AuxGeomFeatureProcessorInterface>(GetEntityId());
             if (m_auxGeomFeatureProcessor)
             {
-                m_auxGeomFeatureProcessor->GetOrCreateDrawQueueForView(m_view.get());
+                m_auxGeomFeatureProcessor->GetOrCreateDrawQueueForView(m_cameraViews[defaultViewIndex].get());
             }
 
             //Get transform at start
@@ -102,15 +137,27 @@ namespace AZ
 
             if (m_auxGeomFeatureProcessor)
             {
-                m_auxGeomFeatureProcessor->ReleaseDrawQueueForView(m_view.get());
+                m_auxGeomFeatureProcessor->ReleaseDrawQueueForView(m_cameraViews[static_cast<uint32_t>(ViewType::Default)].get());
             }
-            m_view = nullptr;
+            
+            for (auto& cameraView : m_cameraViews)
+            {
+                cameraView = nullptr;
+            } 
             m_auxGeomFeatureProcessor = nullptr;
         }
 
         RPI::ViewPtr CameraComponent::GetView() const
         {
-            return m_view;
+            AZ_Assert(aznumeric_cast<uint32_t>(m_cameraViews.size()) > 0, "No views available");
+            return m_cameraViews[static_cast<uint32_t>(ViewType::Default)];
+        }
+
+        RPI::ViewPtr CameraComponent::GetStereoscopicView(uint32_t viewIndex) const
+        {
+            uint32_t xrViewIndex = viewIndex == 0 ? static_cast<uint32_t>(ViewType::XrLeft) : static_cast<uint32_t>(ViewType::XrRight);
+            AZ_Assert(xrViewIndex < aznumeric_cast<uint32_t>(m_cameraViews.size()), "View with index %i does not exist", viewIndex);    
+            return m_cameraViews[xrViewIndex];
         }
 
         bool CameraComponent::ReadInConfig(const AZ::ComponentConfig* baseConfig)
@@ -145,12 +192,40 @@ namespace AZ
             return false;
         }
 
-        void CameraComponent::OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world)
+        void CameraComponent::OnTransformChanged([[maybe_unused]] const AZ::Transform& local, const AZ::Transform& world)
         {
-            AZ_UNUSED(local);
+            //Apply transform to stereoscopic views
+            for (AZ::u32 i = 0; i < m_numXrViews; i++)
+            {
+                uint32_t xrViewIndex = i == 0 ? static_cast<uint32_t>(ViewType::XrLeft) : static_cast<uint32_t>(ViewType::XrRight);
 
+                if (m_stereoscopicViewUpdate)
+                {
+                    // Apply the stereoscopic view provided by the device
+                    AZ::Matrix3x4 worldTransform =
+                        AZ::Matrix3x4::CreateFromQuaternionAndTranslation(m_stereoscopicViewQuats[i], world.GetTranslation());
+                    m_cameraViews[xrViewIndex]->SetCameraTransform(worldTransform);
+                }
+                else
+                {
+                    // Apply the view using keyboard/mouse input
+                    m_cameraViews[xrViewIndex]->SetCameraTransform(AZ::Matrix3x4::CreateFromTransform(world));
+                }
+            }
 
-            m_view->SetCameraTransform(AZ::Matrix3x4::CreateFromTransform(world));
+            // Apply transform to normal views
+            if (m_stereoscopicViewUpdate)
+            {
+                //Handle the case when we have a PC window showing the view of the left eye
+                AZ::Matrix3x4 worldTransform = AZ::Matrix3x4::CreateFromQuaternionAndTranslation(
+                    m_stereoscopicViewQuats[static_cast<uint32_t>(ViewType::XrLeft)], world.GetTranslation());
+                m_cameraViews[static_cast<uint32_t>(ViewType::Default)]->SetCameraTransform(worldTransform);
+            }
+            else
+            {
+                m_cameraViews[static_cast<uint32_t>(ViewType::Default)]->SetCameraTransform(AZ::Matrix3x4::CreateFromTransform(world));
+            }
+            m_stereoscopicViewUpdate = false;
 
             UpdateViewToClipMatrix();
         }
@@ -193,6 +268,13 @@ namespace AZ
         float CameraComponent::GetOrthographicHalfWidth()
         {
             return 0.0f;
+        }
+
+        void CameraComponent::SetStereoscopicView(const AZ::Quaternion& viewQuat, uint32_t xrViewIndex)
+        {
+            AZ_Assert(xrViewIndex < AZ::RPI::XRNumControllers, "Xr view index is out of range.");
+            m_stereoscopicViewQuats[xrViewIndex] = viewQuat;
+            m_stereoscopicViewUpdate = true;
         }
 
         void CameraComponent::SetFovDegrees(float fov)
@@ -305,15 +387,42 @@ namespace AZ
 
         void CameraComponent::UpdateViewToClipMatrix()
         {
-            // Note: This is projection assumes a setup for reversed depth
+            // O3de assumes a setup for reversed depth
+            bool reverseDepth = true;
+            
             AZ::Matrix4x4 viewToClipMatrix;
-            MakePerspectiveFovMatrixRH(viewToClipMatrix,
+            MakePerspectiveFovMatrixRH(
+                viewToClipMatrix,
                 m_componentConfig.m_fovY,
                 m_aspectRatio,
                 m_componentConfig.m_depthNear,
-                m_componentConfig.m_depthFar, true);
+                m_componentConfig.m_depthFar,
+                reverseDepth);
+            m_cameraViews[static_cast<uint32_t>(ViewType::Default)]->SetViewToClipMatrix(viewToClipMatrix, reverseDepth);
 
-            m_view->SetViewToClipMatrix(viewToClipMatrix);
+            //Update stereoscopic projection matrix
+            if (m_xrSystem)
+            {
+                AZ::Matrix4x4 projection = AZ::Matrix4x4::CreateIdentity();
+                for (AZ::u32 i = 0; i < m_numXrViews; i++)
+                {
+                    uint32_t xrViewIndex = i == 0 ? static_cast<uint32_t>(ViewType::XrLeft) : static_cast<uint32_t>(ViewType::XrRight);
+                    AZ::RPI::FovData fovData;
+                    AZ::RPI::PoseData poseData;
+                    [[maybe_unused]] AZ::RHI::ResultCode resultCode = m_xrSystem->GetViewFov(i, fovData);
+                    resultCode = m_xrSystem->GetViewPose(i, poseData);
+
+                    projection = m_xrSystem->CreateProjectionOffset(
+                        fovData.m_angleLeft,
+                        fovData.m_angleRight,
+                        fovData.m_angleDown,
+                        fovData.m_angleUp,
+                        m_componentConfig.m_depthNear,
+                        m_componentConfig.m_depthFar,
+                        reverseDepth);
+                    m_cameraViews[xrViewIndex]->SetStereoscopicViewToClipMatrix(projection, reverseDepth);
+                }
+            } 
         }
 
     } // namespace Debug

--- a/Gems/Atom/Component/DebugCamera/Code/Source/NoClipControllerComponent.cpp
+++ b/Gems/Atom/Component/DebugCamera/Code/Source/NoClipControllerComponent.cpp
@@ -27,6 +27,7 @@ namespace AZ
         static constexpr float MaxFov = 160.0f * Constants::Pi / 180.0f;
         static constexpr float MinFov = 1.0f * Constants::Pi / 180.0f;
         static constexpr float DefaultFov = Constants::QuarterPi;
+        static constexpr float deadZone = 0.07f;
 
         void NoClipControllerProperties::Reflect(AZ::ReflectContext* context)
         {
@@ -85,10 +86,8 @@ namespace AZ
             Camera::CameraRequestBus::Event(GetEntityId(), &Camera::CameraRequestBus::Events::SetFovRadians, DefaultFov);
         }
 
-        void NoClipControllerComponent::OnTick(float deltaTime, AZ::ScriptTimePoint time)
+        void NoClipControllerComponent::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
         {
-            AZ_UNUSED(time);
-
             static const float normalSpeed = 3.0f;
             static const float sprintSpeed = 10.0f;
 
@@ -246,7 +245,6 @@ namespace AZ
                 {
                     auto* positionData = inputChannel.GetCustomData<AzFramework::InputChannel::PositionData2D>();
                     AZ::Vector2 screenPos = positionData->m_normalizedPosition;
-                    const float deadZone = 0.07f;
                     if (inputChannelId == m_mouseLookTouch.m_channelId)
                     {
                         // modify yaw angle
@@ -402,6 +400,36 @@ namespace AZ
         {
             m_currentHeading = heading;
             m_currentHeading = NormalizeAngle(m_currentHeading);
+        }
+
+        void NoClipControllerComponent::SetCameraStateForward(float value)
+        {
+            m_inputStates[CameraKeys::Forward] = value < -deadZone ? false : true; 
+        }
+
+        void NoClipControllerComponent::SetCameraStateBack(float value)
+        {
+            m_inputStates[Back] = value > deadZone ? false : true;
+        }
+
+        void NoClipControllerComponent::SetCameraStateLeft(float value)
+        {
+            m_inputStates[Left] = value < -deadZone ? true : false; 
+        }
+
+        void NoClipControllerComponent::SetCameraStateRight(float value)
+        {
+            m_inputStates[Right] = value > deadZone ? true : false;
+        }
+
+        void NoClipControllerComponent::SetCameraStateUp(float value)
+        {
+            m_inputStates[Up] = value > deadZone ? true : false;
+        }
+
+        void NoClipControllerComponent::SetCameraStateDown(float value)
+        {
+            m_inputStates[Down] = value > deadZone ? true : false;
         }
 
         void NoClipControllerComponent::SetPitch(float pitch)

--- a/Gems/Atom/Feature/Common/Assets/Passes/LowEndPipelineXRLeft.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LowEndPipelineXRLeft.pass
@@ -1,0 +1,373 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "LowEndPipelineXRLeftTemplate",
+            "PassClass": "ParentPass",
+            "Slots": [
+                {
+                    "Name": "PipelineOutput",
+                    "SlotType": "InputOutput"
+                }
+            ],
+            "PassData": {
+                "$type": "PassData",
+                "PipelineGlobalConnections": [
+                    {
+                        "GlobalName": "PipelineOutput",
+                        "Slot": "PipelineOutput"
+                    }
+                ]
+            },
+            "PassRequests": [
+                {
+                    "Name": "MorphTargetPass",
+                    "TemplateName": "MorphTargetPassTemplate"
+                },
+                {
+                    "Name": "SkinningPass",
+                    "TemplateName": "SkinningPassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshOutputStream",
+                            "AttachmentRef": {
+                                "Pass": "MorphTargetPass",
+                                "Attachment": "MorphTargetDeltaOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "DepthPrePass",
+                    "TemplateName": "DepthParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshes",
+                            "AttachmentRef": {
+                                "Pass": "SkinningPass",
+                                "Attachment": "SkinnedMeshOutputStream"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "LightCullingPass",
+                    "TemplateName": "LightCullingParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshes",
+                            "AttachmentRef": {
+                                "Pass": "SkinningPass",
+                                "Attachment": "SkinnedMeshOutputStream"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthMSAA",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthMSAA"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "Shadows",
+                    "TemplateName": "ShadowParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshes",
+                            "AttachmentRef": {
+                                "Pass": "SkinningPass",
+                                "Attachment": "SkinnedMeshOutputStream"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Depth",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthMSAA"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "ForwardPass",
+                    "TemplateName": "LowEndForwardPassTemplate",
+                    "Connections": [
+                        // Inputs...
+                        {
+                            "LocalSlot": "DirectionalLightShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ExponentialShadowmapDirectional",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ExponentialShadowmapProjected",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "TileLightData",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "TileLightData"
+                            }
+                        },
+                        {
+                            "LocalSlot": "LightListRemapped",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "LightListRemapped"
+                            }
+                        },
+                        // Input/Outputs...
+                        {
+                            "LocalSlot": "DepthStencilInputOutput",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthMSAA"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "RasterPassData",
+                        "DrawListTag": "lowEndForward",
+                        "PipelineViewTag": "MainCamera",
+                        "PassSrgShaderAsset": {
+                            "FilePath": "Shaders/ForwardPassSrg.shader"
+                        }
+                    }
+                },
+                {
+                    "Name": "SkyBoxPass",
+                    "TemplateName": "SkyBoxTemplate",
+                    "Enabled": true,
+                    "Connections": [
+                        {
+                            "LocalSlot": "SpecularInputOutput",
+                            "AttachmentRef": {
+                                "Pass": "ForwardPass",
+                                "Attachment": "LightingOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "SkyBoxDepth",
+                            "AttachmentRef": {
+                                "Pass": "ForwardPass",
+                                "Attachment": "DepthStencilInputOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "MSAAResolvePass",
+                    "TemplateName": "MSAAResolveColorTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "SkyBoxPass",
+                                "Attachment": "SpecularInputOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TransparentPass",
+                    "TemplateName": "TransparentParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "DirectionalShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DirectionalESM",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedESM",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "TileLightData",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "TileLightData"
+                            }
+                        },
+                        {
+                            "LocalSlot": "LightListRemapped",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "LightListRemapped"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputLinearDepth",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthLinear"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthStencil",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "Depth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputOutput",
+                            "AttachmentRef": {
+                                "Pass": "MSAAResolvePass",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "LightAdaptation",
+                    "TemplateName": "LightAdaptationParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "LightingInput",
+                            "AttachmentRef": {
+                                "Pass": "TransparentPass",
+                                "Attachment": "InputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "AuxGeomPass",
+                    "TemplateName": "AuxGeomPassTemplate",
+                    "Enabled": true,
+                    "Connections": [
+                        {
+                            "LocalSlot": "ColorInputOutput",
+                            "AttachmentRef": {
+                                "Pass": "LightAdaptation",
+                                "Attachment": "Output"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthInputOutput",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "Depth"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "RasterPassData",
+                        "DrawListTag": "auxgeom",
+                        "PipelineViewTag": "MainCamera"
+                    }
+                },
+                {
+                    "Name": "UIPass",
+                    "TemplateName": "UIParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputOutput",
+                            "AttachmentRef": {
+                                "Pass": "AuxGeomPass",
+                                "Attachment": "ColorInputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthInputOutput",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "Depth"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "CopyToSwapChain",
+                    "TemplateName": "FullscreenCopyTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "UIPass",
+                                "Attachment": "InputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/LowEndPipelineXRRight.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LowEndPipelineXRRight.pass
@@ -1,0 +1,373 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "LowEndPipelineXRRightTemplate",
+            "PassClass": "ParentPass",
+            "Slots": [
+                {
+                    "Name": "PipelineOutput",
+                    "SlotType": "InputOutput"
+                }
+            ],
+            "PassData": {
+                "$type": "PassData",
+                "PipelineGlobalConnections": [
+                    {
+                        "GlobalName": "PipelineOutput",
+                        "Slot": "PipelineOutput"
+                    }
+                ]
+            },
+            "PassRequests": [
+                {
+                    "Name": "MorphTargetPass",
+                    "TemplateName": "MorphTargetPassTemplate"
+                },
+                {
+                    "Name": "SkinningPass",
+                    "TemplateName": "SkinningPassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshOutputStream",
+                            "AttachmentRef": {
+                                "Pass": "MorphTargetPass",
+                                "Attachment": "MorphTargetDeltaOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "DepthPrePass",
+                    "TemplateName": "DepthParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshes",
+                            "AttachmentRef": {
+                                "Pass": "SkinningPass",
+                                "Attachment": "SkinnedMeshOutputStream"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "LightCullingPass",
+                    "TemplateName": "LightCullingParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshes",
+                            "AttachmentRef": {
+                                "Pass": "SkinningPass",
+                                "Attachment": "SkinnedMeshOutputStream"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthMSAA",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthMSAA"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "Shadows",
+                    "TemplateName": "ShadowParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshes",
+                            "AttachmentRef": {
+                                "Pass": "SkinningPass",
+                                "Attachment": "SkinnedMeshOutputStream"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Depth",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthMSAA"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "ForwardPass",
+                    "TemplateName": "LowEndForwardPassTemplate",
+                    "Connections": [
+                        // Inputs...
+                        {
+                            "LocalSlot": "DirectionalLightShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ExponentialShadowmapDirectional",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ExponentialShadowmapProjected",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "TileLightData",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "TileLightData"
+                            }
+                        },
+                        {
+                            "LocalSlot": "LightListRemapped",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "LightListRemapped"
+                            }
+                        },
+                        // Input/Outputs...
+                        {
+                            "LocalSlot": "DepthStencilInputOutput",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthMSAA"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "RasterPassData",
+                        "DrawListTag": "lowEndForward",
+                        "PipelineViewTag": "MainCamera",
+                        "PassSrgShaderAsset": {
+                            "FilePath": "Shaders/ForwardPassSrg.shader"
+                        }
+                    }
+                },
+                {
+                    "Name": "SkyBoxPass",
+                    "TemplateName": "SkyBoxTemplate",
+                    "Enabled": true,
+                    "Connections": [
+                        {
+                            "LocalSlot": "SpecularInputOutput",
+                            "AttachmentRef": {
+                                "Pass": "ForwardPass",
+                                "Attachment": "LightingOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "SkyBoxDepth",
+                            "AttachmentRef": {
+                                "Pass": "ForwardPass",
+                                "Attachment": "DepthStencilInputOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "MSAAResolvePass",
+                    "TemplateName": "MSAAResolveColorTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "SkyBoxPass",
+                                "Attachment": "SpecularInputOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TransparentPass",
+                    "TemplateName": "TransparentParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "DirectionalShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DirectionalESM",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedESM",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "TileLightData",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "TileLightData"
+                            }
+                        },
+                        {
+                            "LocalSlot": "LightListRemapped",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "LightListRemapped"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputLinearDepth",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthLinear"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthStencil",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "Depth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputOutput",
+                            "AttachmentRef": {
+                                "Pass": "MSAAResolvePass",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "LightAdaptation",
+                    "TemplateName": "LightAdaptationParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "LightingInput",
+                            "AttachmentRef": {
+                                "Pass": "TransparentPass",
+                                "Attachment": "InputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "AuxGeomPass",
+                    "TemplateName": "AuxGeomPassTemplate",
+                    "Enabled": true,
+                    "Connections": [
+                        {
+                            "LocalSlot": "ColorInputOutput",
+                            "AttachmentRef": {
+                                "Pass": "LightAdaptation",
+                                "Attachment": "Output"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthInputOutput",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "Depth"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "RasterPassData",
+                        "DrawListTag": "auxgeom",
+                        "PipelineViewTag": "MainCamera"
+                    }
+                },
+                {
+                    "Name": "UIPass",
+                    "TemplateName": "UIParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputOutput",
+                            "AttachmentRef": {
+                                "Pass": "AuxGeomPass",
+                                "Attachment": "ColorInputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthInputOutput",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "Depth"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "CopyToSwapChain",
+                    "TemplateName": "FullscreenCopyTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "UIPass",
+                                "Attachment": "InputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
@@ -489,6 +489,14 @@
                 "Path": "Passes/LowEndPipeline.pass"
             },
             {
+                "Name": "LowEndPipelineXRLeftTemplate",
+                "Path": "Passes/LowEndPipelineXRLeft.pass"
+            },
+            {
+                "Name": "LowEndPipelineXRRightTemplate",
+                "Path": "Passes/LowEndPipelineXRRight.pass"
+            },
+            {
                 "Name": "KawaseShadowBlurTemplate",
                 "Path": "Passes/KawaseShadowBlur.pass"
             },

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrg.azsli
@@ -25,6 +25,7 @@ partial ShaderResourceGroup ViewSrg
     float3 m_worldPosition;
 
     float4 m_nearZ_farZ_farZTimesNearZ_farZMinusNearZ;
+    float4 m_linearizeDepthConstants;
 
     // Constants used to unproject depth values and reconstruct the view-space position (Z-forward & Y-up)
     // See the GetViewSpacePosition( ) function below
@@ -40,22 +41,22 @@ partial ShaderResourceGroup ViewSrg
 
     float GetNearZ()
     {
-        return ViewSrg::m_nearZ_farZ_farZTimesNearZ_farZMinusNearZ.x;
+        return m_linearizeDepthConstants.x;
     }
 
     float GetFarZ()
     {
-        return ViewSrg::m_nearZ_farZ_farZTimesNearZ_farZMinusNearZ.y;
+        return ViewSrg::m_linearizeDepthConstants.y;
     }
 
     float GetFarZTimesNearZ()
     {
-        return ViewSrg::m_nearZ_farZ_farZTimesNearZ_farZMinusNearZ.z;
+        return ViewSrg::m_linearizeDepthConstants.z;
     }
 
     float GetFarZMinusNearZ()
     {
-        return ViewSrg::m_nearZ_farZ_farZTimesNearZ_farZMinusNearZ.w;
+        return ViewSrg::m_linearizeDepthConstants.w;
     }
 
     // Uses linearDepth value at screenUV to reconstruct view-space position (Z-forward & Y-up)

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrg.azsli
@@ -24,7 +24,7 @@ partial ShaderResourceGroup ViewSrg
 
     float3 m_worldPosition;
 
-    float4 m_nearZ_farZ_farZTimesNearZ_farZMinusNearZ;
+    // Constants to help caluclate linear depth in an optimized manner
     float4 m_linearizeDepthConstants;
 
     // Constants used to unproject depth values and reconstruct the view-space position (Z-forward & Y-up)
@@ -46,23 +46,23 @@ partial ShaderResourceGroup ViewSrg
 
     float GetFarZ()
     {
-        return ViewSrg::m_linearizeDepthConstants.y;
+        return m_linearizeDepthConstants.y;
     }
 
     float GetFarZTimesNearZ()
     {
-        return ViewSrg::m_linearizeDepthConstants.z;
+        return m_linearizeDepthConstants.z;
     }
 
     float GetFarZMinusNearZ()
     {
-        return ViewSrg::m_linearizeDepthConstants.w;
+        return m_linearizeDepthConstants.w;
     }
 
     // Uses linearDepth value at screenUV to reconstruct view-space position (Z-forward & Y-up)
     float3 GetViewSpacePosition(float2 screenUV, float linearDepth)
     {
-        float2 screenRay = (screenUV * ViewSrg::m_unprojectionConstants.xy + ViewSrg::m_unprojectionConstants.zw);
+        float2 screenRay = (screenUV * m_unprojectionConstants.xy + m_unprojectionConstants.zw);
         return float3(screenRay * linearDepth, linearDepth);
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -208,6 +208,14 @@ namespace AZ
             // If, in the future, the need arises across other RHIs and platforms
             // We can revisit these hard coded parameters.
             auto dxcArguments = shaderBuildArguments.m_dxcArguments;
+
+            //Add debug symbols within spirv
+            const bool graphicsDevMode = RHI::IsGraphicsDevModeEnabled();
+            if (graphicsDevMode || BuildHasDebugInfo(shaderBuildArguments))
+            {
+                RHI::ShaderBuildArguments::AppendArguments(dxcArguments, { "-fspv-debug=line" });
+            }
+
             switch (shaderStageType)
             {
             case RHI::ShaderHardwareStage::Vertex:
@@ -244,7 +252,6 @@ namespace AZ
             args.m_destinationFolder = tempFolder.c_str();
 
             const auto dxcInputFile = RHI::PrependFile(args);  // Prepend header
-            const bool graphicsDevMode = RHI::IsGraphicsDevModeEnabled();
 
             if (graphicsDevMode || BuildHasDebugInfo(shaderBuildArguments))
             {

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
@@ -113,6 +113,10 @@ namespace AZ
             //! It's the same as SetPersistentView(GetMainViewTag(), view)
             void SetDefaultView(ViewPtr view);
 
+            //! Set a stereoscopic view to the default view tag.
+            //! It's the same as SetPersistentView(GetMainViewTag(), view)
+            void SetDefaultStereoscopicViewFromEntity(EntityId entityId, uint32_t viewIndex);
+
             //! Get the view for the default view tag. 
             //! It's the same as GetViews(GetMainViewTag()) and using first element.
             ViewPtr GetDefaultView();

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
@@ -18,6 +18,7 @@
 #include <Atom/RPI.Reflect/Pass/PassAsset.h>
 #include <Atom/RPI.Reflect/Pass/PassTemplate.h>
 #include <Atom/RPI.Reflect/System/RenderPipelineDescriptor.h>
+#include <Atom/RPI.Public/ViewProviderBus.h>
 #include <Atom/RPI.Public/WindowContext.h>
 
 #include <AzCore/std/containers/vector.h>
@@ -115,7 +116,7 @@ namespace AZ
 
             //! Set a stereoscopic view to the default view tag.
             //! It's the same as SetPersistentView(GetMainViewTag(), view)
-            void SetDefaultStereoscopicViewFromEntity(EntityId entityId, uint32_t viewIndex);
+            void SetDefaultStereoscopicViewFromEntity(EntityId entityId, RPI::ViewType viewType);
 
             //! Get the view for the default view tag. 
             //! It's the same as GetViews(GetMainViewTag()) and using first element.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -53,7 +53,8 @@ namespace AZ
                 UsageNone = 0u,
                 UsageCamera = (1u << 0),
                 UsageShadow = (1u << 1),
-                UsageReflectiveCubeMap = (1u << 2)
+                UsageReflectiveCubeMap = (1u << 2),
+                UsageXR = (1u << 3)
             };
             //! Only use this function to create a new view object. And force using smart pointer to manage view's life time
             static ViewPtr CreateView(const AZ::Name& name, UsageFlags usage);
@@ -85,7 +86,10 @@ namespace AZ
             void SetCameraTransform(const AZ::Matrix3x4& cameraTransform);
 
             //! Sets the viewToClip matrix and recalculates the other matrices
-            void SetViewToClipMatrix(const AZ::Matrix4x4& viewToClip);
+            void SetViewToClipMatrix(const AZ::Matrix4x4& viewToClip, bool reverseDepth = true);
+
+            //! Sets the viewToClip matrix and recalculates the other matrices for stereoscopic projection
+            void SetStereoscopicViewToClipMatrix(const AZ::Matrix4x4& viewToClip, bool reverseDepth = true);
 
             //! Sets a pixel offset on the view, usually used for jittering the camera for anti-aliasing techniques.
             void SetClipSpaceOffset(float xOffset, float yOffset);
@@ -173,7 +177,7 @@ namespace AZ
             RHI::ShaderInputNameIndex m_projectionMatrixInverseConstantIndex = "m_projectionMatrixInverse";
             RHI::ShaderInputNameIndex m_clipToWorldMatrixConstantIndex = "m_viewProjectionInverseMatrix";
             RHI::ShaderInputNameIndex m_worldToClipPrevMatrixConstantIndex = "m_viewProjectionPrevMatrix";
-            RHI::ShaderInputNameIndex m_zConstantsConstantIndex = "m_nearZ_farZ_farZTimesNearZ_farZMinusNearZ";
+            RHI::ShaderInputNameIndex m_zConstantsConstantIndex = "m_linearizeDepthConstants";
             RHI::ShaderInputNameIndex m_unprojectionConstantsIndex = "m_unprojectionConstants";
 
             // The context containing draw lists associated with the view.
@@ -183,13 +187,14 @@ namespace AZ
             Matrix4x4 m_worldToViewMatrix;
             Matrix4x4 m_viewToWorldMatrix;
             Matrix4x4 m_viewToClipMatrix;
+            Matrix4x4 m_clipToViewMatrix;
             Matrix4x4 m_clipToWorldMatrix;
 
             // View's position in world space
             Vector3 m_position;
 
             // Precached constants for linearZ process
-            Vector4 m_nearZ_farZ_farZTimesNearZ_farZMinusNearZ;
+            Vector4 m_linearizeDepthConstants;
 
             // Constants used to unproject depth values and reconstruct the view-space position (Z-forward & Y-up)
             Vector4 m_unprojectionConstants;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -86,7 +86,7 @@ namespace AZ
             void SetCameraTransform(const AZ::Matrix3x4& cameraTransform);
 
             //! Sets the viewToClip matrix and recalculates the other matrices
-            void SetViewToClipMatrix(const AZ::Matrix4x4& viewToClip, bool reverseDepth = true);
+            void SetViewToClipMatrix(const AZ::Matrix4x4& viewToClip);
 
             //! Sets the viewToClip matrix and recalculates the other matrices for stereoscopic projection
             void SetStereoscopicViewToClipMatrix(const AZ::Matrix4x4& viewToClip, bool reverseDepth = true);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewProviderBus.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewProviderBus.h
@@ -30,6 +30,7 @@ namespace AZ
             using BusIdType = AZ::EntityId;
 
             virtual ViewPtr GetView() const = 0;
+            virtual ViewPtr GetStereoscopicView(uint32_t viewIndex) const = 0;
         };
 
         using ViewProviderBus = AZ::EBus<ViewProvider>;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewProviderBus.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewProviderBus.h
@@ -19,6 +19,15 @@ namespace AZ
 {
     namespace RPI
     {
+        //! Enum to describe view type
+        enum class ViewType : uint32_t
+        {
+            Default = 0,
+            XrLeft,
+            XrRight,
+            Count
+        };
+
         //! Interface for component which may provide a RPI view. 
         class ViewProvider
             : public AZ::EBusTraits
@@ -30,7 +39,7 @@ namespace AZ
             using BusIdType = AZ::EntityId;
 
             virtual ViewPtr GetView() const = 0;
-            virtual ViewPtr GetStereoscopicView(uint32_t viewIndex) const = 0;
+            virtual ViewPtr GetStereoscopicView(RPI::ViewType viewType) const = 0;
         };
 
         using ViewProviderBus = AZ::EBus<ViewProvider>;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/XR/XRRenderingInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/XR/XRRenderingInterface.h
@@ -20,6 +20,8 @@ namespace AZ::RHI
 
 namespace AZ::RPI
 {
+    static const int XRNumControllers = 2;
+
     //! XR View specific Fov data (in radians).
     struct FovData
     {
@@ -36,8 +38,8 @@ namespace AZ::RPI
     //! XR pose specific data 
     struct PoseData
     {
-        AZ::Quaternion orientation;
-        AZ::Vector3 position;
+        AZ::Quaternion m_orientation = AZ::Quaternion::CreateIdentity();
+        AZ::Vector3 m_position = AZ::Vector3::CreateZero();
     };
 
     //! This class contains the interface related to XR but significant to RPI level functionality
@@ -54,7 +56,7 @@ namespace AZ::RPI
         virtual AZ::RHI::ResultCode InitInstance() = 0;
 
         //! This api is used to acquire swapchain image for the provided view index. 
-        virtual void AcquireSwapChainImage(AZ::u32 viewIndex) = 0;
+        virtual void AcquireSwapChainImage(const AZ::u32 viewIndex) = 0;
 
         //! Return the number of views associated with the device.
         virtual AZ::u32 GetNumViews() const  = 0;
@@ -63,35 +65,67 @@ namespace AZ::RPI
         virtual bool ShouldRender() const = 0;
 
         //! Return the swapChain width (in pixels) associated with the view index.
-        virtual AZ::u32 GetSwapChainWidth(AZ::u32 viewIndex) const = 0;
+        virtual AZ::u32 GetSwapChainWidth(const AZ::u32 viewIndex) const = 0;
 
         //! Return the swapChain height (in pixels) associated with the view index.
-        virtual AZ::u32 GetSwapChainHeight(AZ::u32 viewIndex) const = 0;
+        virtual AZ::u32 GetSwapChainHeight(const AZ::u32 viewIndex) const = 0;
 
         //! Return the swapChain format associated with the view index.
-        virtual AZ::RHI::Format GetSwapChainFormat(AZ::u32 viewIndex) const = 0;
+        virtual AZ::RHI::Format GetSwapChainFormat(const AZ::u32 viewIndex) const = 0;
 
         //! Return the Fov data (in radians) associated with provided view index.
-        virtual FovData GetViewFov(AZ::u32 viewIndex) const = 0;
+        virtual AZ::RHI::ResultCode GetViewFov(const AZ::u32 viewIndex, AZ::RPI::FovData& outFovData) const = 0;
 
         //! Return the Pose data associated with provided view index.
-        virtual PoseData GetViewPose(AZ::u32 viewIndex) const = 0;
+        virtual RHI::ResultCode GetViewPose(const AZ::u32 viewIndex, PoseData& outPoseData) const = 0;
 
         //! Return the controller Pose data associated with provided hand Index.
-        virtual PoseData GetControllerPose(AZ::u32 handIndex) const = 0;
+        virtual RHI::ResultCode GetControllerPose(const AZ::u32 handIndex, PoseData& outPoseData) const = 0;
 
         //! Return the Pose data associated with front view.
-        virtual PoseData GetViewFrontPose() const = 0;
+        virtual RHI::ResultCode GetViewFrontPose(PoseData& outPoseData) const = 0;
+
+        //! Return the Pose data associated with local view.
+        //! This pose tracks center Local space which is world-locked origin, gravity-aligned to exclude
+        //! pitch and roll, with +Y up, +X to the right, and -Z forward.
+        virtual RHI::ResultCode GetViewLocalPose(PoseData& outPoseData) const = 0;
+
+        //! Return the Pose data associated with local view translated and Rotated by 60 deg left or right based on handIndex
+        virtual RHI::ResultCode GetControllerStagePose(const AZ::u32 handIndex, PoseData& outPoseData) const = 0;
 
         //! Return the controller scale data associated with provided hand Index.
-        virtual float GetControllerScale(AZ::u32 handIndex) const = 0;
+        virtual float GetControllerScale(const AZ::u32 handIndex) const = 0;
 
-        //! Creates an off-center projection matrix suitable for VR. Angles are in radians and distance is in meters
+        //! Creates an off-center projection matrix suitable for VR. Angles are in radians and distance is in meters.
         virtual AZ::Matrix4x4 CreateProjectionOffset(
-            float angleLeft, float angleRight, float angleBottom, float angleTop, float nearDist, float farDist) = 0;
+            float angleLeft, float angleRight, float angleBottom, float angleTop, float nearDist, float farDist, bool reverseDepth) = 0;
 
         //! Returns the XR specific RHI rendering interface.
         virtual AZ::RHI::XRRenderingInterface* GetRHIXRRenderingInterface() = 0;
+
+        //! Return the X button state from the controller.
+        virtual float GetXButtonState() const = 0;
+
+        //! Return the Y button state from the controller.
+        virtual float GetYButtonState() const = 0;
+
+        //! Return the A button state from the controller.
+        virtual float GetAButtonState() const = 0;
+
+        //! Return the B button state from the controller.
+        virtual float GetBButtonState() const = 0;
+
+        //! Return the controller related joystick state for x-axis.
+        virtual float GetXJoyStickState(const AZ::u32 handIndex) const = 0;
+
+        //! Return the controller related joystick state for y-axis.
+        virtual float GetYJoyStickState(const AZ::u32 handIndex) const = 0;
+
+        //! Return the X button state from the controller.
+        virtual float GetSqueezeState(const AZ::u32 handIndex) const = 0;
+
+        //! Return the X button state from the controller.
+        virtual float GetTriggerState(const AZ::u32 handIndex) const = 0;
     };
 
     //! This class contains the interface that will be used to register the XR system with RPI and RHI.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/XR/XRRenderingInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/XR/XRRenderingInterface.h
@@ -20,7 +20,8 @@ namespace AZ::RHI
 
 namespace AZ::RPI
 {
-    static const int XRNumControllers = 2;
+    static const int XRMaxNumControllers = 2;
+    static const int XRMaxNumViews = 2;
 
     //! XR View specific Fov data (in radians).
     struct FovData

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -265,10 +265,10 @@ namespace AZ
             }
         }
 
-        void RenderPipeline::SetDefaultStereoscopicViewFromEntity(EntityId entityId, uint32_t viewIndex)
+        void RenderPipeline::SetDefaultStereoscopicViewFromEntity(EntityId entityId, RPI::ViewType viewType)
         {
             ViewPtr cameraView;
-            ViewProviderBus::EventResult(cameraView, entityId, &ViewProvider::GetStereoscopicView, viewIndex);
+            ViewProviderBus::EventResult(cameraView, entityId, &ViewProvider::GetStereoscopicView, viewType);
             if (cameraView)
             {
                 SetDefaultView(cameraView);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -265,6 +265,16 @@ namespace AZ
             }
         }
 
+        void RenderPipeline::SetDefaultStereoscopicViewFromEntity(EntityId entityId, uint32_t viewIndex)
+        {
+            ViewPtr cameraView;
+            ViewProviderBus::EventResult(cameraView, entityId, &ViewProvider::GetStereoscopicView, viewIndex);
+            if (cameraView)
+            {
+                SetDefaultView(cameraView);
+            }
+        }
+
         void RenderPipeline::AddTransientView(const PipelineViewTag& viewTag, ViewPtr view)
         {
             // If a view is registered for multiple viewTags, it gets only the PassesByDrawList of whatever

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -173,33 +173,111 @@ namespace AZ
             m_onWorldToClipMatrixChange.Signal(m_worldToClipMatrix);
         }        
 
-        void View::SetViewToClipMatrix(const AZ::Matrix4x4& viewToClip)
+        void View::SetViewToClipMatrix(const AZ::Matrix4x4& viewToClip, bool reverseDepth)
         {
             m_viewToClipMatrix = viewToClip;
-
+            m_clipToViewMatrix = m_viewToClipMatrix.GetInverseFull();
             m_worldToClipMatrix = m_viewToClipMatrix * m_worldToViewMatrix;
             m_clipToWorldMatrix = m_worldToClipMatrix.GetInverseFull();
 
             // Update z depth constant simultaneously
-            // zNear -> n, zFar -> f
-            // A = f / (n - f), B = nf / (n - f) 
-            // the formula of A and B should be the same as projection matrix's definition 
-            // currently defined in MakePerspectiveFovMatrixRH in MatrixUtil.cpp
-            double A = m_viewToClipMatrix.GetElement(2, 2);
-            double B = m_viewToClipMatrix.GetElement(2, 3);
+            if (reverseDepth)
+            {
+                // zNear -> n, zFar -> f
+                // A = n / (f - n), B = nf / (f - n) 
+                // the formula of A and B should be the same as projection matrix's definition 
+                // currently defined in MakePerspectiveFovMatrixRH in MatrixUtil.cpp
+                double A = m_viewToClipMatrix.GetElement(2, 2);
+                double B = m_viewToClipMatrix.GetElement(2, 3);
 
-            m_nearZ_farZ_farZTimesNearZ_farZMinusNearZ.SetX(float(B / A));
-            m_nearZ_farZ_farZTimesNearZ_farZMinusNearZ.SetY(float(B / (A + 1.0)));
-            m_nearZ_farZ_farZTimesNearZ_farZMinusNearZ.SetZ(float((B * B) / (A * (A + 1.0))));
-            m_nearZ_farZ_farZTimesNearZ_farZMinusNearZ.SetW(float(-B / (A * (A + 1.0))));
+                // Based on linearZ = 2fn / (depth*(f-n) - n)
+                m_linearizeDepthConstants.SetX(float(B / A));  //<----f
+                m_linearizeDepthConstants.SetY(float(B / (A + 1.0)));  //<----n
+                m_linearizeDepthConstants.SetZ(float((B * B) / (A * (A + 1.0))));  //<----nf
+                m_linearizeDepthConstants.SetW(float(-B / (A * (A + 1.0))));  //<-----f-n
+            }
+            else
+            {
+                // Update z depth constant simultaneously
+                // zNear -> n, zFar -> f
+                // A = f / (n - f), B = nf / (n - f)
+                double A = m_viewToClipMatrix.GetElement(2, 2);
+                double B = m_viewToClipMatrix.GetElement(2, 3);
 
-            double tanHalfFovX = 1.0 / m_viewToClipMatrix.GetElement(0, 0);
-            double tanHalfFovY = 1.0 / m_viewToClipMatrix.GetElement(1, 1);
+                // Based on linearZ = 2fn / (depth*(n-f) - f)
+                m_linearizeDepthConstants.SetX(float(B / A));  //<------------n
+                m_linearizeDepthConstants.SetY(float(B / (A + 1.0)));  //<---------f
+                m_linearizeDepthConstants.SetZ(float((B * B) / (A * (A + 1.0))));  //<-----nf
+                m_linearizeDepthConstants.SetW(float(-B / (A * (A + 1.0)))); //<------n - f
+            }
 
+            double tanHalfFovX = m_clipToViewMatrix.GetElement(0, 0);
+            double tanHalfFovY = m_clipToViewMatrix.GetElement(1, 1);
+
+            // The constants below try to remapping 0---1 to -1---+1 and multiplying with inverse of projection.
+            // Assuming that inverse of projection matrix only has value in the first column for first row
+            // x = (2u-1)*ProjInves[0][0]
+            // Assuming that inverse of projection matrix only has value in the second column for second row
+            // y = (1-2v)*ProjInves[1][1]
             m_unprojectionConstants.SetX(float(2.0 * tanHalfFovX));
             m_unprojectionConstants.SetY(float(-2.0 * tanHalfFovY));
             m_unprojectionConstants.SetZ(float(-tanHalfFovX));
             m_unprojectionConstants.SetW(float(tanHalfFovY));
+
+            m_onWorldToClipMatrixChange.Signal(m_worldToClipMatrix);
+        }
+
+        void View::SetStereoscopicViewToClipMatrix(const AZ::Matrix4x4& viewToClip, bool reverseDepth)
+        {
+            m_viewToClipMatrix = viewToClip;
+            m_clipToViewMatrix = m_viewToClipMatrix.GetInverseFull();
+            
+            m_worldToClipMatrix = m_viewToClipMatrix * m_worldToViewMatrix;
+            m_clipToWorldMatrix = m_worldToClipMatrix.GetInverseFull();
+
+            // Update z depth constant simultaneously
+            if(reverseDepth)
+            {       
+                // zNear -> n, zFar -> f
+                // A = 2n/(f-n), B = 2fn / (f - n)
+                // the formula of A and B should be the same as projection matrix's definition
+                // currently defined in CreateProjectionOffset in XRUtils.cpp
+                double A = m_viewToClipMatrix.GetElement(2, 2);
+                double B = m_viewToClipMatrix.GetElement(2, 3);
+
+                // Based on linearZ = 2fn / (depth*(f-n) - 2n)
+                m_linearizeDepthConstants.SetX(float(B / A)); //<----f
+                m_linearizeDepthConstants.SetY(float((2 * B) / (A + 2.0))); //<--- 2n
+                m_linearizeDepthConstants.SetZ(float((2 * B * B) / (A * (A + 2.0)))); //<-----2fn
+                m_linearizeDepthConstants.SetW(float((-2 * B) / (A * (A + 2.0)))); //<------f-n
+            }
+            else
+            {
+                // A = -(f+n)/(f-n), B = -2fn / (f - n)
+                double A = m_viewToClipMatrix.GetElement(2, 2);
+                double B = m_viewToClipMatrix.GetElement(2, 3);
+
+                //Based on linearZ = 2fn / (depth*(n-f) - (f+n))
+                m_linearizeDepthConstants.SetX(float(B / (A + 1.0))); //<----f
+                m_linearizeDepthConstants.SetY(float((2 * B * A)/ ((A + 1.0) * (A - 1.0)))); //<--- f+n
+                m_linearizeDepthConstants.SetZ(float((2 * B * B) / ((A - 1.0) * (A + 1.0)))); //<-----2fn
+                m_linearizeDepthConstants.SetW(float(B / ((A - 1.0) * (A + 1.0)))); //<------n-f
+            }     
+
+            // The constants below try to remap 0---1 to -1---+1 and multiply with inverse of projection.
+            // Assuming that inverse of projection matrix only has value in the first column for first row
+            // x = (2u-1)*ProjInves[0][0] + ProjInves[0][3]
+            // Assuming that inverse of projection matrix only has value in the second column for second row
+            // y = (1-2v)*ProjInves[1][1] + ProjInves[1][3]
+            float multiplierConstantX = 2.0f * m_clipToViewMatrix.GetElement(0, 0);
+            float multiplierConstantY = -2.0f * m_clipToViewMatrix.GetElement(1, 1);
+            float additionConstantX = m_clipToViewMatrix.GetElement(0, 3) - m_clipToViewMatrix.GetElement(0, 0);
+            float additionConstantY = m_clipToViewMatrix.GetElement(1, 1) + m_clipToViewMatrix.GetElement(1, 3);
+
+            m_unprojectionConstants.SetX(multiplierConstantX);
+            m_unprojectionConstants.SetY(multiplierConstantY);
+            m_unprojectionConstants.SetZ(additionConstantX);
+            m_unprojectionConstants.SetW(additionConstantY);
 
             m_onWorldToClipMatrixChange.Signal(m_worldToClipMatrix);
         }
@@ -440,7 +518,7 @@ namespace AZ
                     m_shaderResourceGroup->SetConstant(m_viewProjectionMatrixConstantIndex, m_worldToClipMatrix);
                     m_shaderResourceGroup->SetConstant(m_projectionMatrixConstantIndex, m_viewToClipMatrix);
                     m_shaderResourceGroup->SetConstant(m_clipToWorldMatrixConstantIndex, m_clipToWorldMatrix);
-                    m_shaderResourceGroup->SetConstant(m_projectionMatrixInverseConstantIndex, m_viewToClipMatrix.GetInverseFull());
+                    m_shaderResourceGroup->SetConstant(m_projectionMatrixInverseConstantIndex, m_clipToViewMatrix);
                 }
                 else
                 {
@@ -467,7 +545,7 @@ namespace AZ
                 m_shaderResourceGroup->SetConstant(m_worldPositionConstantIndex, m_position);
                 m_shaderResourceGroup->SetConstant(m_viewMatrixConstantIndex, m_worldToViewMatrix);
                 m_shaderResourceGroup->SetConstant(m_viewMatrixInverseConstantIndex, m_viewToWorldMatrix);
-                m_shaderResourceGroup->SetConstant(m_zConstantsConstantIndex, m_nearZ_farZ_farZTimesNearZ_farZMinusNearZ);
+                m_shaderResourceGroup->SetConstant(m_zConstantsConstantIndex, m_linearizeDepthConstants);
                 m_shaderResourceGroup->SetConstant(m_unprojectionConstantsIndex, m_unprojectionConstants);
 
                 m_shaderResourceGroup->Compile();

--- a/Gems/Camera/Code/Source/CameraComponent.cpp
+++ b/Gems/Camera/Code/Source/CameraComponent.cpp
@@ -106,6 +106,7 @@ namespace Camera
                 ->Event("SetOrthographic", &CameraRequestBus::Events::SetOrthographic)
                 ->Event("GetOrthographicHalfWidth", &CameraRequestBus::Events::GetOrthographicHalfWidth)
                 ->Event("SetOrthographicHalfWidth", &CameraRequestBus::Events::SetOrthographicHalfWidth)
+                ->Event("SetStereoscopicView", &CameraRequestBus::Events::SetStereoscopicView)
                 ->Event("ScreenToWorld", &CameraRequestBus::Events::ScreenToWorld)
                 ->Event("ScreenNdcToWorld", &CameraRequestBus::Events::ScreenNdcToWorld)
                 ->Event("WorldToScreen", &CameraRequestBus::Events::WorldToScreen)

--- a/Gems/Camera/Code/Source/CameraComponent.cpp
+++ b/Gems/Camera/Code/Source/CameraComponent.cpp
@@ -106,7 +106,7 @@ namespace Camera
                 ->Event("SetOrthographic", &CameraRequestBus::Events::SetOrthographic)
                 ->Event("GetOrthographicHalfWidth", &CameraRequestBus::Events::GetOrthographicHalfWidth)
                 ->Event("SetOrthographicHalfWidth", &CameraRequestBus::Events::SetOrthographicHalfWidth)
-                ->Event("SetStereoscopicView", &CameraRequestBus::Events::SetStereoscopicView)
+                ->Event("SetXRViewQuaternion", &CameraRequestBus::Events::SetXRViewQuaternion)
                 ->Event("ScreenToWorld", &CameraRequestBus::Events::ScreenToWorld)
                 ->Event("ScreenNdcToWorld", &CameraRequestBus::Events::ScreenNdcToWorld)
                 ->Event("WorldToScreen", &CameraRequestBus::Events::WorldToScreen)

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -390,6 +390,11 @@ namespace Camera
         UpdateCamera();
     }
 
+    void CameraComponentController::SetStereoscopicView([[maybe_unused]] const AZ::Quaternion& viewQuat, [[maybe_unused]] uint32_t xrViewIndex)
+    {
+        // todo:: Needs implementation
+    }
+
     void CameraComponentController::MakeActiveView()
     {
         if (IsActiveView())
@@ -506,6 +511,12 @@ namespace Camera
     AZ::RPI::ViewPtr CameraComponentController::GetView() const
     {
         return m_atomCamera;
+    }
+
+    AZ::RPI::ViewPtr CameraComponentController::GetStereoscopicView([[maybe_unused]] uint32_t viewIndex) const
+    {
+        //todo:: Needs implementation
+        return nullptr;
     }
 
     void CameraComponentController::UpdateCamera()

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -514,7 +514,7 @@ namespace Camera
         return m_atomCamera;
     }
 
-    AZ::RPI::ViewPtr CameraComponentController::GetStereoscopicView([[maybe_unused]] uint32_t viewIndex) const
+    AZ::RPI::ViewPtr CameraComponentController::GetStereoscopicView([[maybe_unused]] AZ::RPI::ViewType viewType) const
     {
         //todo:: Needs implementation
         AZ_Assert(false, "Not implemented");

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -390,8 +390,9 @@ namespace Camera
         UpdateCamera();
     }
 
-    void CameraComponentController::SetStereoscopicView([[maybe_unused]] const AZ::Quaternion& viewQuat, [[maybe_unused]] uint32_t xrViewIndex)
+    void CameraComponentController::SetXRViewQuaternion([[maybe_unused]] const AZ::Quaternion& viewQuat, [[maybe_unused]] uint32_t xrViewIndex)
     {
+        AZ_Assert(false, "Not implemented");
         // todo:: Needs implementation
     }
 
@@ -516,6 +517,7 @@ namespace Camera
     AZ::RPI::ViewPtr CameraComponentController::GetStereoscopicView([[maybe_unused]] uint32_t viewIndex) const
     {
         //todo:: Needs implementation
+        AZ_Assert(false, "Not implemented");
         return nullptr;
     }
 

--- a/Gems/Camera/Code/Source/CameraComponentController.h
+++ b/Gems/Camera/Code/Source/CameraComponentController.h
@@ -126,7 +126,7 @@ namespace Camera
 
         // AZ::RPI::ViewProviderBus::Handler interface
         AZ::RPI::ViewPtr GetView() const override;
-        AZ::RPI::ViewPtr GetStereoscopicView(uint32_t viewIndex) const override;
+        AZ::RPI::ViewPtr GetStereoscopicView(AZ::RPI::ViewType viewType) const override;
 
     private:
         AZ_DISABLE_COPY(CameraComponentController);

--- a/Gems/Camera/Code/Source/CameraComponentController.h
+++ b/Gems/Camera/Code/Source/CameraComponentController.h
@@ -107,7 +107,7 @@ namespace Camera
         void SetFrustumHeight(float height) override;
         void SetOrthographic(bool orthographic) override;
         void SetOrthographicHalfWidth(float halfWidth) override;
-        void SetStereoscopicView(const AZ::Quaternion& viewQuat, uint32_t xrViewIndex) override;
+        void SetXRViewQuaternion(const AZ::Quaternion& viewQuat, uint32_t xrViewIndex) override;
 
         void MakeActiveView() override;
         bool IsActiveView() override;

--- a/Gems/Camera/Code/Source/CameraComponentController.h
+++ b/Gems/Camera/Code/Source/CameraComponentController.h
@@ -107,6 +107,7 @@ namespace Camera
         void SetFrustumHeight(float height) override;
         void SetOrthographic(bool orthographic) override;
         void SetOrthographicHalfWidth(float halfWidth) override;
+        void SetStereoscopicView(const AZ::Quaternion& viewQuat, uint32_t xrViewIndex) override;
 
         void MakeActiveView() override;
         bool IsActiveView() override;
@@ -125,6 +126,7 @@ namespace Camera
 
         // AZ::RPI::ViewProviderBus::Handler interface
         AZ::RPI::ViewPtr GetView() const override;
+        AZ::RPI::ViewPtr GetStereoscopicView(uint32_t viewIndex) const override;
 
     private:
         AZ_DISABLE_COPY(CameraComponentController);


### PR DESCRIPTION
## What does this PR do?

 - Extend XR interface API to support XR device data related to controller, headset tracking. 
 - Views changes to help support Stereoscopic projections
 - Fixes for LinearDepth pass and Shadowmap pass to work with stereoscopic views
 - Camera changes to help support multiple views. In the case the ASV sample has 3 views - One for PC and 2 for XR
 - Enable debug shader symbols for spirv
 - Added a XR multi-view pipelines for left and the right eye. At the moment it supports Blendshapes, Skinning, DepthPrepass, LightCulling, Shadows, ForwardPass, SkyBox, TransparentPass, LightAdaptions, AuxGeom, UI, CopyToSwapChain. There is a lot of room for perf improvements like not doing ShadowPass twice or skipping DepthPrepass given that the device will be used tile deferred architecture but for now this work is left for later
 - Lots of Cleanup work
 - Please see PR description for other PRs linked to this one in order to get the full context of the work here

Linked PRS
New Features/OpenXR ASV sample PR - https://github.com/aws-lumberyard-dev/o3de-atom-sampleviewer/pull/7
XR/OpenXrVk gem changes related PR - https://github.com/o3de/o3de-extras/pull/22

![image](https://user-images.githubusercontent.com/47460854/187557977-f1b6f5e0-a6df-4906-af77-51e2c2b26e9b.png)
Signed-off-by: moudgils <47460854+moudgils@users.noreply.github.com>
## How was this PR tested?

Ran ASV full test suite using DX12 and Vk renderer
