### PR TITLE
Material Editor: Fixing access violation in EditorModeFeatureProcessor

### DIFF
--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.cpp
@@ -66,21 +66,41 @@ namespace AZ
 
         void EditorModeFeatureProcessor::OnRenderPipelineRemoved(RPI::RenderPipeline* pipeline)
         {
+            if (!m_editorStatePassSystem)
+            {
+                return;
+            }
+
             m_editorStatePassSystem->RemoveStatePassesForPipeline(pipeline);
         }
 
         void EditorModeFeatureProcessor::OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline)
         {
+            if (!m_editorStatePassSystem)
+            {
+                return;
+            }
+
             m_editorStatePassSystem->ConfigureStatePassesForPipeline(pipeline.get());
         }
 
         void EditorModeFeatureProcessor::OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline)
         {
+            if (!m_editorStatePassSystem)
+            {
+                return;
+            }
+
             m_editorStatePassSystem->ConfigureStatePassesForPipeline(renderPipeline);
         }
 
         void EditorModeFeatureProcessor::ApplyRenderPipelineChange(RPI::RenderPipeline* renderPipeline)
         {
+            if (!m_editorStatePassSystem)
+            {
+                return;
+            }
+
             m_editorStatePassSystem->AddPassesToRenderPipeline(renderPipeline);
 
             if(!m_maskRenderers.empty())
@@ -98,6 +118,11 @@ namespace AZ
 
         void EditorModeFeatureProcessor::Render([[maybe_unused]] const RenderPacket& packet)
         {
+            if (!m_editorStatePassSystem)
+            {
+                return;
+            }
+
             const auto entityMaskMap = m_editorStatePassSystem->GetEntitiesForEditorStates();
             for (const auto& [mask, entities] : entityMaskMap)
             {
@@ -111,6 +136,11 @@ namespace AZ
 
         void EditorModeFeatureProcessor::Simulate([[maybe_unused]] const SimulatePacket& packet)
         {
+            if (!m_editorStatePassSystem)
+            {
+                return;
+            }
+
             m_editorStatePassSystem->Update();
         }
     } // namespace Render


### PR DESCRIPTION
## What does this PR do?

This change adds early returns in EditorModeFeatureProcessor to stop a crash in the material editor. The crash is not happening on development for the automated testing project. It was happening on a game jam project, as described in this issue. 

https://github.com/o3de/o3de/issues/11382

These changes resolved the crash but there should be deeper investigation done in conjunction with owners of EditorModeFeatureProcessor.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Downloaded and set up the project that was having the issues.
Built and ran the editor and material editor with the project.
Debugged and verified that the crash was occurring in the feature processor.
Verified that crash was no longer occurring after adding guards into the code.