### PR TITLE
Improve error messaging when users need to update scripts to new spawnable APIs

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Assets/ScriptCanvasFileHandling.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Assets/ScriptCanvasFileHandling.cpp
@@ -269,6 +269,10 @@ namespace ScriptCanvas
         const auto& asString = fileStringOutcome.GetValue();
         result.m_deserializeResult = Deserialize(asString, makeEntityIdsUnique, loadReferencedAssets);
         result.m_isSuccess = result.m_deserializeResult;
+        if (!result.m_deserializeResult.m_isSuccessful)
+        {
+            result.m_fileReadErrors = "Script Canvas Graph Deserialization Failed.\n" + result.m_deserializeResult.m_errors + "\n";
+        }
 
         result.m_handle = SourceHandle::FromRelativePath(result.m_deserializeResult.m_graphDataPtr, path);
         return result;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphSerialization.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphSerialization.cpp
@@ -145,7 +145,9 @@ namespace ScriptCanvas
                 , AZ::ObjectStream::FilterDescriptor(nullptr, AZ::ObjectStream::FILTERFLAG_IGNORE_UNKNOWN_CLASSES)))
             {
                 result.m_isSuccessful = false;
-                result.m_errors = "JSON (and failsafe XML) deserialize attempt failed.";
+                result.m_errors = "JSON (and failsafe XML) deserialize attempt failed.\n";
+                result.m_errors += "The error might be caused by deprecated Spawnable Nodes in your target Script Canvas Graph.\n";
+                result.m_errors += "If so, please run UpdateSpawnableNodes python script on the scriptcanvas file to see if the error is resolved.";
                 return result;
             }
         }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphSerialization.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphSerialization.cpp
@@ -146,8 +146,8 @@ namespace ScriptCanvas
             {
                 result.m_isSuccessful = false;
                 result.m_errors = "JSON (and failsafe XML) deserialize attempt failed.\n";
-                result.m_errors += "The error might be caused by deprecated Spawnable Nodes in your target Script Canvas Graph.\n";
-                result.m_errors += "If so, please run UpdateSpawnableNodes python script on the scriptcanvas file to see if the error is resolved.";
+                result.m_errors += "The error might be caused by deprecated Spawnable Nodes in your target scriptcanvas file.\n";
+                result.m_errors += "If so, please run UpdateSpawnableNodes python script for the scriptcanvas file to see if the error is resolved.";
                 return result;
             }
         }


### PR DESCRIPTION
Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>

This PR is to add extra improved error messages while opening an old SC graph with old spawnable nodes in it.

Tested with the files: [OldSCdata.zip](https://github.com/o3de/o3de/files/9462753/OldSCdata.zip)
Test Result:
- Before the fix:
![Screenshot 2022-08-30 112705](https://user-images.githubusercontent.com/82238204/187716164-aa8f7a8f-0c84-4d83-8912-63f8cbda9382.png)
- After the fix:
![Screenshot 2022-08-31 081228](https://user-images.githubusercontent.com/82238204/187716166-6f78b358-6811-43b0-a35e-bc66ec656ee5.png)

