### PR TITLE
Add to AWSCore support for retrieving AWS creds from EC2 instance profile

### DIFF
--- a/Gems/AWSCore/Code/Source/AWSCoreInternalBus.h
+++ b/Gems/AWSCore/Code/Source/AWSCoreInternalBus.h
@@ -34,10 +34,11 @@ namespace AWSCore
         //! @return The path of AWS resource mapping config file
         virtual AZStd::string GetResourceMappingConfigFilePath() const = 0;
 
-        //! IsAllowedAWSMetadataQueries
-        //! Whether calls to AWS environmental endpoints, such as the Amazon EC2 instance metadata service (IMDS), are permitted
-        //! @return The AllowAWSMetadataQueries setting value
-        virtual bool IsAllowedAWSMetadataQueries() const = 0;
+        //! IsAllowedAWSMetadataCredentials
+        //! Whether retrieving credentials from AWS environmental endpoints,
+        //! such as the Amazon EC2 instance metadata service (IMDS), is permitted
+        //! @return The AllowAWSMetadataCredentials setting value
+        virtual bool IsAllowedAWSMetadataCredentials() const = 0;
 
         //! ReloadConfiguration
         //! Reload AWSCore configuration without restarting application

--- a/Gems/AWSCore/Code/Source/AWSCoreInternalBus.h
+++ b/Gems/AWSCore/Code/Source/AWSCoreInternalBus.h
@@ -34,6 +34,11 @@ namespace AWSCore
         //! @return The path of AWS resource mapping config file
         virtual AZStd::string GetResourceMappingConfigFilePath() const = 0;
 
+        //! IsAllowedAWSMetadataQueries
+        //! Whether calls to AWS environmental endpoints, such as the Amazon EC2 instance metadata service (IMDS), are permitted
+        //! @return The AllowAWSMetadataQueries setting value
+        virtual bool IsAllowedAWSMetadataQueries() const = 0;
+
         //! ReloadConfiguration
         //! Reload AWSCore configuration without restarting application
         virtual void ReloadConfiguration() = 0;

--- a/Gems/AWSCore/Code/Source/Configuration/AWSCoreConfiguration.cpp
+++ b/Gems/AWSCore/Code/Source/Configuration/AWSCoreConfiguration.cpp
@@ -20,6 +20,7 @@ namespace AWSCore
         : m_sourceProjectFolder("")
         , m_profileName(AWSCoreDefaultProfileName)
         , m_resourceMappingConfigFileName("")
+        , m_allowAWSMetadataQueries(false)
     {
     }
 
@@ -54,6 +55,11 @@ namespace AWSCore
             m_sourceProjectFolder.c_str(), AWSCoreResourceMappingConfigFolderName, m_resourceMappingConfigFileName.c_str());
         AzFramework::StringFunc::Path::Normalize(configFilePath);
         return configFilePath;
+    }
+
+    bool AWSCoreConfiguration::IsAllowedAWSMetadataQueries() const
+    {
+        return m_allowAWSMetadataQueries;
     }
 
     void AWSCoreConfiguration::InitConfig()
@@ -100,6 +106,14 @@ namespace AWSCore
             AZ_Warning(AWSCoreConfigurationName, false, ProfileNameNotFoundErrorMessage);
             m_profileName = AWSCoreDefaultProfileName;
         }
+
+        auto allowAWSMetadataPath = AZStd::string::format("%s%s",
+            AZ::SettingsRegistryMergeUtils::OrganizationRootKey, AWSCoreAllowAWSMetadataQueriesKey);
+        if (!settingsRegistry->Get(m_allowAWSMetadataQueries, allowAWSMetadataPath))
+        {
+            AZ_Warning(AWSCoreConfigurationName, false, AllowAWSMetadataQueriesNotFoundMessage);
+            m_allowAWSMetadataQueries = false;
+        }
     }
 
     void AWSCoreConfiguration::ResetSettingsRegistryData()
@@ -120,6 +134,11 @@ namespace AWSCore
             AZ::SettingsRegistryMergeUtils::OrganizationRootKey, AWSCoreResourceMappingConfigFileNameKey);
         settingsRegistry->Remove(resourceMappingConfigFileNamePath);
         m_resourceMappingConfigFileName.clear();
+
+        auto allowAWSMetadataPath =
+            AZStd::string::format("%s%s", AZ::SettingsRegistryMergeUtils::OrganizationRootKey, AWSCoreAllowAWSMetadataQueriesKey);
+        settingsRegistry->Remove(allowAWSMetadataPath);
+        m_allowAWSMetadataQueries = false;
 
         // Reload the AWSCore setting registry file from disk.
         if (m_sourceProjectFolder.empty())

--- a/Gems/AWSCore/Code/Source/Configuration/AWSCoreConfiguration.cpp
+++ b/Gems/AWSCore/Code/Source/Configuration/AWSCoreConfiguration.cpp
@@ -20,7 +20,7 @@ namespace AWSCore
         : m_sourceProjectFolder("")
         , m_profileName(AWSCoreDefaultProfileName)
         , m_resourceMappingConfigFileName("")
-        , m_allowAWSMetadataQueries(false)
+        , m_allowAWSMetadataCredentials(false)
     {
     }
 
@@ -57,9 +57,9 @@ namespace AWSCore
         return configFilePath;
     }
 
-    bool AWSCoreConfiguration::IsAllowedAWSMetadataQueries() const
+    bool AWSCoreConfiguration::IsAllowedAWSMetadataCredentials() const
     {
-        return m_allowAWSMetadataQueries;
+        return m_allowAWSMetadataCredentials;
     }
 
     void AWSCoreConfiguration::InitConfig()
@@ -108,11 +108,11 @@ namespace AWSCore
         }
 
         auto allowAWSMetadataPath = AZStd::string::format("%s%s",
-            AZ::SettingsRegistryMergeUtils::OrganizationRootKey, AWSCoreAllowAWSMetadataQueriesKey);
-        if (!settingsRegistry->Get(m_allowAWSMetadataQueries, allowAWSMetadataPath))
+            AZ::SettingsRegistryMergeUtils::OrganizationRootKey, AWSCoreAllowAWSMetadataCredentialsKey);
+        if (!settingsRegistry->Get(m_allowAWSMetadataCredentials, allowAWSMetadataPath))
         {
-            AZ_Warning(AWSCoreConfigurationName, false, AllowAWSMetadataQueriesNotFoundMessage);
-            m_allowAWSMetadataQueries = false;
+            AZ_Warning(AWSCoreConfigurationName, false, AllowAWSMetadataCredentialsNotFoundMessage);
+            m_allowAWSMetadataCredentials = false;
         }
     }
 
@@ -136,9 +136,9 @@ namespace AWSCore
         m_resourceMappingConfigFileName.clear();
 
         auto allowAWSMetadataPath =
-            AZStd::string::format("%s%s", AZ::SettingsRegistryMergeUtils::OrganizationRootKey, AWSCoreAllowAWSMetadataQueriesKey);
+            AZStd::string::format("%s%s", AZ::SettingsRegistryMergeUtils::OrganizationRootKey, AWSCoreAllowAWSMetadataCredentialsKey);
         settingsRegistry->Remove(allowAWSMetadataPath);
-        m_allowAWSMetadataQueries = false;
+        m_allowAWSMetadataCredentials = false;
 
         // Reload the AWSCore setting registry file from disk.
         if (m_sourceProjectFolder.empty())

--- a/Gems/AWSCore/Code/Source/Configuration/AWSCoreConfiguration.h
+++ b/Gems/AWSCore/Code/Source/Configuration/AWSCoreConfiguration.h
@@ -29,7 +29,7 @@ namespace AWSCore
         static constexpr const char AWSCoreDefaultProfileName[] = "default";
         static constexpr const char AWSCoreProfileNameKey[] = "/AWSCore/ProfileName";
 
-        static constexpr const char AWSCoreAllowAWSMetadataQueriesKey[] = "/AWSCore/AllowAWSMetadataQueries";
+        static constexpr const char AWSCoreAllowAWSMetadataCredentialsKey[] = "/AWSCore/AllowAWSMetadataCredentials";
 
         static constexpr const char ProjectSourceFolderNotFoundErrorMessage[] =
             "Failed to get project source folder path.";
@@ -41,8 +41,8 @@ namespace AWSCore
             "Failed to load AWSCore settings registry file.";
         static constexpr const char GlobalSettingsRegistryLoadFailureErrorMessage[] =
             "Failed to load AWSCore configurations from global settings registry.";
-        static constexpr const char AllowAWSMetadataQueriesNotFoundMessage[] =
-            "Failed to get AllowAWSMetadataQueries setting, will default to false.";
+        static constexpr const char AllowAWSMetadataCredentialsNotFoundMessage[] =
+            "Failed to get AllowAWSMetadataCredentials setting, will default to false.";
 
 
         AWSCoreConfiguration();
@@ -55,7 +55,7 @@ namespace AWSCore
         // AWSCoreInternalRequestBus interface implementation
         AZStd::string GetResourceMappingConfigFilePath() const override;
         AZStd::string GetProfileName() const override;
-        bool IsAllowedAWSMetadataQueries() const override;
+        bool IsAllowedAWSMetadataCredentials() const override;
         void ReloadConfiguration() override;
 
     private:
@@ -71,6 +71,6 @@ namespace AWSCore
         AZStd::string m_sourceProjectFolder;
         AZStd::string m_profileName;
         AZStd::string m_resourceMappingConfigFileName;
-        bool m_allowAWSMetadataQueries;
+        bool m_allowAWSMetadataCredentials;
     };
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Source/Configuration/AWSCoreConfiguration.h
+++ b/Gems/AWSCore/Code/Source/Configuration/AWSCoreConfiguration.h
@@ -29,6 +29,8 @@ namespace AWSCore
         static constexpr const char AWSCoreDefaultProfileName[] = "default";
         static constexpr const char AWSCoreProfileNameKey[] = "/AWSCore/ProfileName";
 
+        static constexpr const char AWSCoreAllowAWSMetadataQueriesKey[] = "/AWSCore/AllowAWSMetadataQueries";
+
         static constexpr const char ProjectSourceFolderNotFoundErrorMessage[] =
             "Failed to get project source folder path.";
         static constexpr const char ProfileNameNotFoundErrorMessage[] =
@@ -39,6 +41,8 @@ namespace AWSCore
             "Failed to load AWSCore settings registry file.";
         static constexpr const char GlobalSettingsRegistryLoadFailureErrorMessage[] =
             "Failed to load AWSCore configurations from global settings registry.";
+        static constexpr const char AllowAWSMetadataQueriesNotFoundMessage[] =
+            "Failed to get AllowAWSMetadataQueries setting, will default to false.";
 
 
         AWSCoreConfiguration();
@@ -51,6 +55,7 @@ namespace AWSCore
         // AWSCoreInternalRequestBus interface implementation
         AZStd::string GetResourceMappingConfigFilePath() const override;
         AZStd::string GetProfileName() const override;
+        bool IsAllowedAWSMetadataQueries() const override;
         void ReloadConfiguration() override;
 
     private:
@@ -66,5 +71,6 @@ namespace AWSCore
         AZStd::string m_sourceProjectFolder;
         AZStd::string m_profileName;
         AZStd::string m_resourceMappingConfigFileName;
+        bool m_allowAWSMetadataQueries;
     };
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Source/Credential/AWSDefaultCredentialHandler.cpp
+++ b/Gems/AWSCore/Code/Source/Credential/AWSDefaultCredentialHandler.cpp
@@ -70,7 +70,7 @@ namespace AWSCore
         {
             AZStd::lock_guard<AZStd::mutex> credentialsLock{ m_credentialMutex };
             bool allowAWSMetadata = false;
-            AWSCoreInternalRequestBus::BroadcastResult(allowAWSMetadata, &AWSCoreInternalRequests::IsAllowedAWSMetadataQueries);
+            AWSCoreInternalRequestBus::BroadcastResult(allowAWSMetadata, &AWSCoreInternalRequests::IsAllowedAWSMetadataCredentials);
             if (allowAWSMetadata)
             {
                 const auto ec2MetadataDisabled = Aws::Environment::GetEnv(AWS_EC2_METADATA_DISABLED);
@@ -117,7 +117,7 @@ namespace AWSCore
         }
 
         bool allowAWSMetadata = false;
-        AWSCoreInternalRequestBus::BroadcastResult(allowAWSMetadata, &AWSCoreInternalRequests::IsAllowedAWSMetadataQueries);
+        AWSCoreInternalRequestBus::BroadcastResult(allowAWSMetadata, &AWSCoreInternalRequests::IsAllowedAWSMetadataCredentials);
         if (allowAWSMetadata)
         {
             SetInstanceProfileCredentialProvider(

--- a/Gems/AWSCore/Code/Source/Credential/AWSDefaultCredentialHandler.cpp
+++ b/Gems/AWSCore/Code/Source/Credential/AWSDefaultCredentialHandler.cpp
@@ -73,20 +73,19 @@ namespace AWSCore
             AWSCoreInternalRequestBus::BroadcastResult(allowAWSMetadata, &AWSCoreInternalRequests::IsAllowedAWSMetadataQueries);
             if (allowAWSMetadata)
             {
-
-                if (!m_instanceProfileCredentailsProvider)
-                {
-                    SetInstanceProfileCredentialProvider(
-                        Aws::MakeShared<Aws::Auth::InstanceProfileCredentialsProvider>(AWSDEFAULTCREDENTIALHANDLER_ALLOC_TAG));
-                }
-
                 const auto ec2MetadataDisabled = Aws::Environment::GetEnv(AWS_EC2_METADATA_DISABLED);
                 if (Aws::Utils::StringUtils::ToLower(ec2MetadataDisabled.c_str()) != "true")
                 {
-                    auto credentials = m_instanceProfileCredentailsProvider->GetAWSCredentials();
+                    if (!m_instanceProfileCredentialsProvider)
+                    {
+                        SetInstanceProfileCredentialProvider(
+                            Aws::MakeShared<Aws::Auth::InstanceProfileCredentialsProvider>(AWSDEFAULTCREDENTIALHANDLER_ALLOC_TAG));
+                    }
+
+                    auto credentials = m_instanceProfileCredentialsProvider->GetAWSCredentials();
                     if (!credentials.IsEmpty())
                     {
-                        return m_instanceProfileCredentailsProvider;
+                        return m_instanceProfileCredentialsProvider;
                     }
                 }
             }
@@ -141,7 +140,7 @@ namespace AWSCore
     void AWSDefaultCredentialHandler::SetInstanceProfileCredentialProvider(
         std::shared_ptr<Aws::Auth::InstanceProfileCredentialsProvider> credentialsProvider)
     {
-        m_instanceProfileCredentailsProvider = credentialsProvider;
+        m_instanceProfileCredentialsProvider = credentialsProvider;
     }
 
     void AWSDefaultCredentialHandler::ResetCredentialsProviders()
@@ -150,9 +149,9 @@ namespace AWSCore
         AZStd::lock_guard<AZStd::mutex> credentialsLock{m_credentialMutex};
         m_environmentCredentialsProvider.reset();
         m_profileCredentialsProvider.reset();
-        if (m_instanceProfileCredentailsProvider)
+        if (m_instanceProfileCredentialsProvider)
         {
-            m_instanceProfileCredentailsProvider.reset();
+            m_instanceProfileCredentialsProvider.reset();
         }
     }
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Source/Credential/AWSDefaultCredentialHandler.h
+++ b/Gems/AWSCore/Code/Source/Credential/AWSDefaultCredentialHandler.h
@@ -40,6 +40,7 @@ namespace AWSCore
     protected:
         void SetEnvironmentCredentialsProvider(std::shared_ptr<Aws::Auth::EnvironmentAWSCredentialsProvider> credentialsProvider);
         void SetProfileCredentialsProvider(std::shared_ptr<Aws::Auth::ProfileConfigFileAWSCredentialsProvider> credentialsProvider);
+        void SetInstanceProfileCredentialProvider(std::shared_ptr<Aws::Auth::InstanceProfileCredentialsProvider> credentialsProvider);
 
     private:
         void InitCredentialsProviders();
@@ -49,5 +50,6 @@ namespace AWSCore
         std::shared_ptr<Aws::Auth::EnvironmentAWSCredentialsProvider> m_environmentCredentialsProvider;
         AZStd::string m_profileName;
         std::shared_ptr<Aws::Auth::ProfileConfigFileAWSCredentialsProvider> m_profileCredentialsProvider;
+        std::shared_ptr<Aws::Auth::InstanceProfileCredentialsProvider> m_instanceProfileCredentailsProvider;
     };
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Source/Credential/AWSDefaultCredentialHandler.h
+++ b/Gems/AWSCore/Code/Source/Credential/AWSDefaultCredentialHandler.h
@@ -50,6 +50,6 @@ namespace AWSCore
         std::shared_ptr<Aws::Auth::EnvironmentAWSCredentialsProvider> m_environmentCredentialsProvider;
         AZStd::string m_profileName;
         std::shared_ptr<Aws::Auth::ProfileConfigFileAWSCredentialsProvider> m_profileCredentialsProvider;
-        std::shared_ptr<Aws::Auth::InstanceProfileCredentialsProvider> m_instanceProfileCredentailsProvider;
+        std::shared_ptr<Aws::Auth::InstanceProfileCredentialsProvider> m_instanceProfileCredentialsProvider;
     };
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Tests/Configuration/AWSCoreConfigurationTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Configuration/AWSCoreConfigurationTest.cpp
@@ -21,7 +21,7 @@ R"({
         "AWSCore": {
             "ProfileName": "testprofile",
             "ResourceMappingConfigFileName": "test_aws_resource_mappings.json",
-            "AllowAWSMetadataQueries": true,
+            "AllowAWSMetadataCredentials": true,
         }
     }
 })";
@@ -119,20 +119,20 @@ TEST_F(AWSCoreConfigurationTest, ReloadConfiguration_LoadValidSettingsRegistryAf
 
     auto actualConfigFilePath = m_awsCoreConfiguration->GetResourceMappingConfigFilePath();
     auto actualProfileName = m_awsCoreConfiguration->GetProfileName();
-    auto actualAllowAWSMetadataQueries = m_awsCoreConfiguration->IsAllowedAWSMetadataQueries();
+    auto actualAllowAWSMetadataCredentials = m_awsCoreConfiguration->IsAllowedAWSMetadataCredentials();
     EXPECT_TRUE(actualConfigFilePath.empty());
     EXPECT_TRUE(actualProfileName == AWSCoreConfiguration::AWSCoreDefaultProfileName);
-    EXPECT_FALSE(actualAllowAWSMetadataQueries);
+    EXPECT_FALSE(actualAllowAWSMetadataCredentials);
 
     CreateFile(m_setRegFilePath.Native(), TEST_VALID_RESOURCE_MAPPING_SETREG);
     m_awsCoreConfiguration->ReloadConfiguration();
 
     actualConfigFilePath = m_awsCoreConfiguration->GetResourceMappingConfigFilePath();
     actualProfileName = m_awsCoreConfiguration->GetProfileName();
-    actualAllowAWSMetadataQueries = m_awsCoreConfiguration->IsAllowedAWSMetadataQueries();
+    actualAllowAWSMetadataCredentials = m_awsCoreConfiguration->IsAllowedAWSMetadataCredentials();
     EXPECT_FALSE(actualConfigFilePath.empty());
     EXPECT_TRUE(actualProfileName != AWSCoreConfiguration::AWSCoreDefaultProfileName);
-    EXPECT_TRUE(actualAllowAWSMetadataQueries);
+    EXPECT_TRUE(actualAllowAWSMetadataCredentials);
 }
 
 TEST_F(AWSCoreConfigurationTest, ReloadConfiguration_LoadInvalidSettingsRegistryAfterValidOne_ReturnEmptyConfigFilePath)
@@ -142,18 +142,18 @@ TEST_F(AWSCoreConfigurationTest, ReloadConfiguration_LoadInvalidSettingsRegistry
 
     auto actualConfigFilePath = m_awsCoreConfiguration->GetResourceMappingConfigFilePath();
     auto actualProfileName = m_awsCoreConfiguration->GetProfileName();
-    auto actualAllowAWSMetadataQueries = m_awsCoreConfiguration->IsAllowedAWSMetadataQueries();
+    auto actualAllowAWSMetadataCredentials = m_awsCoreConfiguration->IsAllowedAWSMetadataCredentials();
     EXPECT_FALSE(actualConfigFilePath.empty());
     EXPECT_TRUE(actualProfileName != AWSCoreConfiguration::AWSCoreDefaultProfileName);
-    EXPECT_TRUE(actualAllowAWSMetadataQueries);
+    EXPECT_TRUE(actualAllowAWSMetadataCredentials);
 
     CreateFile(m_setRegFilePath.Native(), TEST_INVALID_RESOURCE_MAPPING_SETREG);
     m_awsCoreConfiguration->ReloadConfiguration();
 
     actualConfigFilePath = m_awsCoreConfiguration->GetResourceMappingConfigFilePath();
     actualProfileName = m_awsCoreConfiguration->GetProfileName();
-    actualAllowAWSMetadataQueries = m_awsCoreConfiguration->IsAllowedAWSMetadataQueries();
+    actualAllowAWSMetadataCredentials = m_awsCoreConfiguration->IsAllowedAWSMetadataCredentials();
     EXPECT_TRUE(actualConfigFilePath.empty());
     EXPECT_TRUE(actualProfileName == AWSCoreConfiguration::AWSCoreDefaultProfileName);
-    EXPECT_FALSE(actualAllowAWSMetadataQueries);
+    EXPECT_FALSE(actualAllowAWSMetadataCredentials);
 }

--- a/Gems/AWSCore/Code/Tests/Configuration/AWSCoreConfigurationTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Configuration/AWSCoreConfigurationTest.cpp
@@ -20,7 +20,8 @@ R"({
     {
         "AWSCore": {
             "ProfileName": "testprofile",
-            "ResourceMappingConfigFileName": "test_aws_resource_mappings.json"
+            "ResourceMappingConfigFileName": "test_aws_resource_mappings.json",
+            "AllowAWSMetadataQueries": true,
         }
     }
 })";
@@ -118,16 +119,20 @@ TEST_F(AWSCoreConfigurationTest, ReloadConfiguration_LoadValidSettingsRegistryAf
 
     auto actualConfigFilePath = m_awsCoreConfiguration->GetResourceMappingConfigFilePath();
     auto actualProfileName = m_awsCoreConfiguration->GetProfileName();
+    auto actualAllowAWSMetadataQueries = m_awsCoreConfiguration->IsAllowedAWSMetadataQueries();
     EXPECT_TRUE(actualConfigFilePath.empty());
     EXPECT_TRUE(actualProfileName == AWSCoreConfiguration::AWSCoreDefaultProfileName);
+    EXPECT_FALSE(actualAllowAWSMetadataQueries);
 
     CreateFile(m_setRegFilePath.Native(), TEST_VALID_RESOURCE_MAPPING_SETREG);
     m_awsCoreConfiguration->ReloadConfiguration();
 
     actualConfigFilePath = m_awsCoreConfiguration->GetResourceMappingConfigFilePath();
     actualProfileName = m_awsCoreConfiguration->GetProfileName();
+    actualAllowAWSMetadataQueries = m_awsCoreConfiguration->IsAllowedAWSMetadataQueries();
     EXPECT_FALSE(actualConfigFilePath.empty());
     EXPECT_TRUE(actualProfileName != AWSCoreConfiguration::AWSCoreDefaultProfileName);
+    EXPECT_TRUE(actualAllowAWSMetadataQueries);
 }
 
 TEST_F(AWSCoreConfigurationTest, ReloadConfiguration_LoadInvalidSettingsRegistryAfterValidOne_ReturnEmptyConfigFilePath)
@@ -137,14 +142,18 @@ TEST_F(AWSCoreConfigurationTest, ReloadConfiguration_LoadInvalidSettingsRegistry
 
     auto actualConfigFilePath = m_awsCoreConfiguration->GetResourceMappingConfigFilePath();
     auto actualProfileName = m_awsCoreConfiguration->GetProfileName();
+    auto actualAllowAWSMetadataQueries = m_awsCoreConfiguration->IsAllowedAWSMetadataQueries();
     EXPECT_FALSE(actualConfigFilePath.empty());
     EXPECT_TRUE(actualProfileName != AWSCoreConfiguration::AWSCoreDefaultProfileName);
+    EXPECT_TRUE(actualAllowAWSMetadataQueries);
 
     CreateFile(m_setRegFilePath.Native(), TEST_INVALID_RESOURCE_MAPPING_SETREG);
     m_awsCoreConfiguration->ReloadConfiguration();
 
     actualConfigFilePath = m_awsCoreConfiguration->GetResourceMappingConfigFilePath();
     actualProfileName = m_awsCoreConfiguration->GetProfileName();
+    actualAllowAWSMetadataQueries = m_awsCoreConfiguration->IsAllowedAWSMetadataQueries();
     EXPECT_TRUE(actualConfigFilePath.empty());
     EXPECT_TRUE(actualProfileName == AWSCoreConfiguration::AWSCoreDefaultProfileName);
+    EXPECT_FALSE(actualAllowAWSMetadataQueries);
 }

--- a/Gems/AWSCore/Code/Tests/Credential/AWSDefaultCredentialHandlerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Credential/AWSDefaultCredentialHandlerTest.cpp
@@ -81,7 +81,7 @@ public:
     {
         m_credentialHandler->DeactivateHandler();
         m_credentialHandler.reset();
-        m_allowAWSMetadataQueries = false;
+        m_allowAWSMetadataCredentials = false;
         m_profileCredentialsProviderMock.reset();
         m_environmentCredentialsProviderMock.reset();
         m_instanceProfileCredentialsProviderMock.reset();
@@ -93,7 +93,7 @@ public:
     // AWSCoreInternalRequestBus interface implementation
     AZStd::string GetProfileName() const override { return m_profileName; }
     AZStd::string GetResourceMappingConfigFilePath() const override { return ""; }
-    bool IsAllowedAWSMetadataQueries() const override { return m_allowAWSMetadataQueries; }
+    bool IsAllowedAWSMetadataCredentials() const override { return m_allowAWSMetadataCredentials; }
     void ReloadConfiguration() override {}
 
     std::shared_ptr<EnvironmentAWSCredentialsProviderMock> m_environmentCredentialsProviderMock;
@@ -101,7 +101,7 @@ public:
     std::shared_ptr<InstanceProfileCredentialsProviderMock> m_instanceProfileCredentialsProviderMock;
     AZStd::unique_ptr<AWSDefaultCredentialHandlerMock> m_credentialHandler;
     AZStd::string m_profileName;
-    bool m_allowAWSMetadataQueries;
+    bool m_allowAWSMetadataCredentials;
 };
 
 TEST_F(AWSDefaultCredentialHandlerTest, GetCredentialsProvider_EnvironmentCredentialProviderReturnsNonEmptyCredentials_GetExpectedCredentialProvider)
@@ -152,21 +152,21 @@ TEST_F(AWSDefaultCredentialHandlerTest, GetCredentialHandlerOrder_Call_AlwaysGet
 }
 
 TEST_F(AWSDefaultCredentialHandlerTest,
-    GetCredentialsProvider_AllowAWSMetadataQueries_InstanceProfileReturnsNonEmptyCredentials_GetExpectedCredentialProvider)
+    GetCredentialsProvider_AllowAWSMetadataCredentials_InstanceProfileReturnsNonEmptyCredentials_GetExpectedCredentialProvider)
 {
     Aws::Auth::AWSCredentials emptyCredential;
     Aws::Auth::AWSCredentials nonEmptyCredential(AWS_ACCESS_KEY, AWS_SECRET_KEY);
     EXPECT_CALL(*m_environmentCredentialsProviderMock, GetAWSCredentials()).Times(1).WillOnce(::testing::Return(emptyCredential));
     EXPECT_CALL(*m_profileCredentialsProviderMock, GetAWSCredentials()).Times(1).WillOnce(::testing::Return(emptyCredential));
     EXPECT_CALL(*m_instanceProfileCredentialsProviderMock, GetAWSCredentials()).Times(1).WillOnce(::testing::Return(nonEmptyCredential));
-    m_allowAWSMetadataQueries = true;
+    m_allowAWSMetadataCredentials = true;
     auto credentialProvider = m_credentialHandler->GetCredentialsProvider();
     EXPECT_TRUE(credentialProvider == m_instanceProfileCredentialsProviderMock);
 }
 
 TEST_F(
     AWSDefaultCredentialHandlerTest,
-    GetCredentialsProvider_AllowAWSMetadataQueries_InstanceMetadataNonTrueValue_GetExpectedCredentialProvider)
+    GetCredentialsProvider_AllowAWSMetadataCredentials_InstanceMetadataNonTrueValue_GetExpectedCredentialProvider)
 {
     // save current value so we can restore it after the test
     const auto currentEc2MetadataDisabledValue = Aws::Environment::GetEnv(AWS_EC2_METADATA_DISABLED);
@@ -179,7 +179,7 @@ TEST_F(
     EXPECT_CALL(*m_environmentCredentialsProviderMock, GetAWSCredentials()).Times(1).WillOnce(::testing::Return(emptyCredential));
     EXPECT_CALL(*m_profileCredentialsProviderMock, GetAWSCredentials()).Times(1).WillOnce(::testing::Return(emptyCredential));
     EXPECT_CALL(*m_instanceProfileCredentialsProviderMock, GetAWSCredentials()).Times(1).WillOnce(::testing::Return(nonEmptyCredential));
-    m_allowAWSMetadataQueries = true;
+    m_allowAWSMetadataCredentials = true;
     auto credentialProvider = m_credentialHandler->GetCredentialsProvider();
     EXPECT_TRUE(credentialProvider == m_instanceProfileCredentialsProviderMock);
     // restore previous value
@@ -188,7 +188,7 @@ TEST_F(
 
 TEST_F(
     AWSDefaultCredentialHandlerTest,
-    GetCredentialsProvider_AllowAWSMetadataQueries_InstanceMetadataDisabled_GetDifferentCredentialProvider)
+    GetCredentialsProvider_AllowAWSMetadataCredentials_InstanceMetadataDisabled_GetDifferentCredentialProvider)
 {
     // save current value so we can restore it after the test
     const auto currentEc2MetadataDisabledValue = Aws::Environment::GetEnv(AWS_EC2_METADATA_DISABLED);
@@ -200,20 +200,20 @@ TEST_F(
     EXPECT_CALL(*m_environmentCredentialsProviderMock, GetAWSCredentials()).Times(1).WillOnce(::testing::Return(emptyCredential));
     EXPECT_CALL(*m_profileCredentialsProviderMock, GetAWSCredentials()).Times(1).WillOnce(::testing::Return(emptyCredential));
     EXPECT_CALL(*m_instanceProfileCredentialsProviderMock, GetAWSCredentials()).Times(0);
-    m_allowAWSMetadataQueries = true;
+    m_allowAWSMetadataCredentials = true;
     auto credentialProvider = m_credentialHandler->GetCredentialsProvider();
     EXPECT_TRUE(credentialProvider != m_instanceProfileCredentialsProviderMock);
     // restore previous value
     AZ::Utils::SetEnv(AWS_EC2_METADATA_DISABLED, currentEc2MetadataDisabledValue.c_str(), 1);
 }
 
-TEST_F(AWSDefaultCredentialHandlerTest, GetCredentialsProvider_AllowAWSMetadataQueries_NoCredentialFoundInChain_GetNullPointer)
+TEST_F(AWSDefaultCredentialHandlerTest, GetCredentialsProvider_AllowAWSMetadataCredentials_NoCredentialFoundInChain_GetNullPointer)
 {
     Aws::Auth::AWSCredentials emptyCredential;
     EXPECT_CALL(*m_environmentCredentialsProviderMock, GetAWSCredentials()).Times(1).WillOnce(::testing::Return(emptyCredential));
     EXPECT_CALL(*m_profileCredentialsProviderMock, GetAWSCredentials()).Times(1).WillOnce(::testing::Return(emptyCredential));
     EXPECT_CALL(*m_instanceProfileCredentialsProviderMock, GetAWSCredentials()).Times(1).WillOnce(::testing::Return(emptyCredential));
-    m_allowAWSMetadataQueries = true;
+    m_allowAWSMetadataCredentials = true;
     auto credentialProvider = m_credentialHandler->GetCredentialsProvider();
     EXPECT_FALSE(credentialProvider);
 }

--- a/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp
@@ -137,6 +137,7 @@ public:
     // AWSCoreInternalRequestBus interface implementation
     AZStd::string GetProfileName() const override { return ""; }
     AZStd::string GetResourceMappingConfigFilePath() const override { return m_configFilePath.Native(); }
+    bool IsAllowedAWSMetadataQueries() const override { return false; }
     void ReloadConfiguration() override { m_reloadConfigurationCounter++; }
 
     AZStd::unique_ptr<AWSCore::AWSResourceMappingManager> m_resourceMappingManager;

--- a/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp
@@ -137,7 +137,7 @@ public:
     // AWSCoreInternalRequestBus interface implementation
     AZStd::string GetProfileName() const override { return ""; }
     AZStd::string GetResourceMappingConfigFilePath() const override { return m_configFilePath.Native(); }
-    bool IsAllowedAWSMetadataQueries() const override { return false; }
+    bool IsAllowedAWSMetadataCredentials() const override { return false; }
     void ReloadConfiguration() override { m_reloadConfigurationCounter++; }
 
     AZStd::unique_ptr<AWSCore::AWSResourceMappingManager> m_resourceMappingManager;


### PR DESCRIPTION
## What does this PR do?

Implements https://github.com/o3de/o3de/issues/10452 

## How was this PR tested?

- [x] target builds
- [x] unit tests pass
- [x] able to launch & run O3DE project which uses EC2 instance creds to submit metrics
- [x] ensure use of instance creds not possible when `AWS_EC2_METADATA_DISABLED` is set to `true` (is covered by unit test)
