### PR TITLE
Compile fix for enabled AZ_RPI_ENABLE_PASS_DEBUGGING.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -110,7 +110,7 @@ namespace AZ
         void Pass::LogError(AZStd::string&& message)
         {
 #if AZ_RPI_ENABLE_PASS_DEBUGGING
-            AZ::Debug::Trace::Break();
+            AZ::Debug::Trace::Instance().Break();
 #endif
 
             if (PassValidation::IsEnabled())


### PR DESCRIPTION
Signed-off-by: Joerg H. Mueller <joerg.mueller@huawei.com>

## What does this PR do?

Atom does not compile without this fix when `AZ_RPI_ENABLE_PASS_DEBUGGING` is set to 1.

## How was this PR tested?

I set `AZ_RPI_ENABLE_PASS_DEBUGGING` to 1, compiled and ran a test project.
