### PR TITLE
Adding ScopeAttachmentUsage::Indirect to work.

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/AttachmentEnums.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/AttachmentEnums.cpp
@@ -83,6 +83,8 @@ namespace AZ
                 return "Resolve";
             case ScopeAttachmentUsage::Predication:
                 return "Predication";
+            case ScopeAttachmentUsage::Indirect:
+                return "Indirect";
             case ScopeAttachmentUsage::InputAssembly:
                 return "InputAssembly";
             case ScopeAttachmentUsage::Uninitialized:
@@ -148,6 +150,13 @@ namespace AZ
                 return access;
             case ScopeAttachmentUsage::Predication:
                 return access;
+
+            case ScopeAttachmentUsage::Indirect:
+                AZ_Error(
+                    "ScopeAttachment",
+                    !RHI::CheckBitsAll(access, ScopeAttachmentAccess::Write),
+                    "ScopeAttachmentAccess cannot be 'Write' when usage is 'Indirect'.");
+                return ScopeAttachmentAccess::Read;
 
             case ScopeAttachmentUsage::Uninitialized:
                 return access;


### PR DESCRIPTION
Added it to ToString and AdjustAccessBasedOnUsage to avoid the error
"Unkown ScopeAttachmentUsage: 7" when Indirect is used.

Signed-off-by: Joerg H. Mueller <joerg.mueller@huawei.com>

## What does this PR do?

Fixes above mentioned error.

## How was this PR tested?

Using a custom data driven pass/pipeline (i.e. json) that included a slot with `Indirect` as `ScopeAttachmentUsage`.
