### PR TITLE
Motion Matching: Added standard scaler

### DIFF
--- a/Gems/MotionMatching/Code/Source/BlendTreeMotionMatchNode.cpp
+++ b/Gems/MotionMatching/Code/Source/BlendTreeMotionMatchNode.cpp
@@ -135,6 +135,7 @@ namespace EMotionFX::MotionMatching
         settings.m_minFramesPerKdTreeNode = animGraphNode->m_minFramesPerKdTreeNode;
         settings.m_motionList.reserve(animGraphNode->m_motionIds.size());
         settings.m_normalizeData = animGraphNode->m_normalizeData;
+        settings.m_featureScalerType = animGraphNode->m_featureScalerType;
         settings.m_featureTansformerSettings.m_featureMin = animGraphNode->m_featureMin;
         settings.m_featureTansformerSettings.m_featureMax = animGraphNode->m_featureMax;
         settings.m_featureTansformerSettings.m_clip = animGraphNode->m_clipFeatures;
@@ -324,9 +325,19 @@ namespace EMotionFX::MotionMatching
         return AZ::Edit::PropertyVisibility::Show;
     }
 
-    AZ::Crc32 BlendTreeMotionMatchNode::GetDataNormalizationSettingsVisibility() const
+    AZ::Crc32 BlendTreeMotionMatchNode::GetFeatureScalerTypeSettingsVisibility() const
     {
         if (m_normalizeData)
+        {
+            return AZ::Edit::PropertyVisibility::Show;
+        }
+
+        return AZ::Edit::PropertyVisibility::Hide;
+    }
+
+    AZ::Crc32 BlendTreeMotionMatchNode::GetMinMaxSettingsVisibility() const
+    {
+        if (m_normalizeData && m_featureScalerType == MotionMatchingData::MinMaxScalerType)
         {
             return AZ::Edit::PropertyVisibility::Show;
         }
@@ -371,7 +382,7 @@ namespace EMotionFX::MotionMatching
         }
 
         serializeContext->Class<BlendTreeMotionMatchNode, AnimGraphNode>()
-            ->Version(10)
+            ->Version(11)
             ->Field("lowestCostSearchFrequency", &BlendTreeMotionMatchNode::m_lowestCostSearchFrequency)
             ->Field("sampleRate", &BlendTreeMotionMatchNode::m_sampleRate)
             ->Field("controlSplineMode", &BlendTreeMotionMatchNode::m_trajectoryQueryMode)
@@ -386,6 +397,7 @@ namespace EMotionFX::MotionMatching
             ->Field("mirror", &BlendTreeMotionMatchNode::m_mirror)
             ->Field("featureSchema", &BlendTreeMotionMatchNode::m_featureSchema)
             ->Field("motionIds", &BlendTreeMotionMatchNode::m_motionIds)
+            ->Field("featureScalerType", &BlendTreeMotionMatchNode::m_featureScalerType)
             ;
 
         AZ::EditContext* editContext = serializeContext->GetEditContext();
@@ -425,15 +437,21 @@ namespace EMotionFX::MotionMatching
                 ->DataElement(AZ::Edit::UIHandlers::Default, &BlendTreeMotionMatchNode::m_normalizeData, "Normalize Data", "Normalize feature data for more intuitive control over weighting the cost factors.")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &BlendTreeMotionMatchNode::Reinit)
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                ->DataElement(AZ::Edit::UIHandlers::ComboBox, &BlendTreeMotionMatchNode::m_featureScalerType, "Type", "Feature scaler type to be used to normalize the data.")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &BlendTreeMotionMatchNode::Reinit)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &BlendTreeMotionMatchNode::GetFeatureScalerTypeSettingsVisibility)
+                    ->EnumAttribute(MotionMatchingData::StandardScalerType, "Standard Scaler")
+                    ->EnumAttribute(MotionMatchingData::MinMaxScalerType, "Min-max Scaler")
                 ->DataElement(AZ::Edit::UIHandlers::Default, &BlendTreeMotionMatchNode::m_featureMin, "Feature Minimum", "Minimum value after data transformation.")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &BlendTreeMotionMatchNode::Reinit)
-                    ->Attribute(AZ::Edit::Attributes::Visibility, &BlendTreeMotionMatchNode::GetDataNormalizationSettingsVisibility)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &BlendTreeMotionMatchNode::GetMinMaxSettingsVisibility)
                 ->DataElement(AZ::Edit::UIHandlers::Default, &BlendTreeMotionMatchNode::m_featureMax, "Feature Maximum", "Maximum value after data transformation.")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &BlendTreeMotionMatchNode::Reinit)
-                    ->Attribute(AZ::Edit::Attributes::Visibility, &BlendTreeMotionMatchNode::GetDataNormalizationSettingsVisibility)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &BlendTreeMotionMatchNode::GetMinMaxSettingsVisibility)
                 ->DataElement(AZ::Edit::UIHandlers::Default, &BlendTreeMotionMatchNode::m_clipFeatures, "Clip Features", "Clip feature values for outliers to the above range.")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &BlendTreeMotionMatchNode::Reinit)
-                ->Attribute(AZ::Edit::Attributes::Visibility, &BlendTreeMotionMatchNode::GetDataNormalizationSettingsVisibility)
+                ->Attribute(AZ::Edit::Attributes::Visibility, &BlendTreeMotionMatchNode::GetMinMaxSettingsVisibility)
             ->ClassElement(AZ::Edit::ClassElements::Group, "Acceleration Structure")
                 ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
             ->DataElement(AZ::Edit::UIHandlers::Default, &BlendTreeMotionMatchNode::m_maxKdTreeDepth, "Max kd-tree depth", "The maximum number of hierarchy levels in the kdTree.")

--- a/Gems/MotionMatching/Code/Source/BlendTreeMotionMatchNode.h
+++ b/Gems/MotionMatching/Code/Source/BlendTreeMotionMatchNode.h
@@ -92,7 +92,8 @@ namespace EMotionFX::MotionMatching
         void PostUpdate(AnimGraphInstance* animGraphInstance, float timePassedInSeconds) override;
 
         AZ::Crc32 GetTrajectoryPathSettingsVisibility() const;
-        AZ::Crc32 GetDataNormalizationSettingsVisibility() const;
+        AZ::Crc32 GetFeatureScalerTypeSettingsVisibility() const;
+        AZ::Crc32 GetMinMaxSettingsVisibility() const;
         AZ::Crc32 OnVisualizeSchemaButtonClicked();
         AZStd::string OnVisualizeSchemaButtonText() const;
 
@@ -110,6 +111,7 @@ namespace EMotionFX::MotionMatching
 
         // Data normalization.
         bool m_normalizeData = false;
+        MotionMatchingData::FeatureScalerType m_featureScalerType = MotionMatchingData::StandardScalerType;
         float m_featureMin = 0.0f;
         float m_featureMax = 1.0f;
         bool m_clipFeatures = false;

--- a/Gems/MotionMatching/Code/Source/FeatureMatrixStandardScaler.cpp
+++ b/Gems/MotionMatching/Code/Source/FeatureMatrixStandardScaler.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Allocators.h>
+#include <AzCore/IO/GenericStreams.h>
+#include <AzCore/IO/SystemFile.h>
+#include <AzCore/std/string/conversions.h>
+#include <FeatureMatrixStandardScaler.h>
+
+namespace EMotionFX::MotionMatching
+{
+    AZ_CLASS_ALLOCATOR_IMPL(StandardScaler, MotionMatchAllocator, 0);
+
+    bool StandardScaler::Fit(const FeatureMatrix& featureMatrix, [[maybe_unused]] const Settings& settings)
+    {
+        const FeatureMatrix::Index numRows = featureMatrix.rows();
+        const FeatureMatrix::Index numColumns = featureMatrix.cols();
+
+        m_means.clear();
+        m_means.resize(numColumns);
+        m_standardDeviations.clear();
+        m_standardDeviations.resize(numColumns);
+
+        for (FeatureMatrix::Index column = 0; column < numColumns; ++column)
+        {
+            // Calculate mean value
+            float accumulated = 0.0f;
+            for (FeatureMatrix::Index row = 0; row < numRows; ++row)
+            {
+                accumulated += featureMatrix(row, column);
+            }
+            const float mean = accumulated / numRows;
+            m_means[column] = mean;
+
+            // Calculate the standard deviation
+            float rss = 0.0f; // Residual sum of squares
+            for (FeatureMatrix::Index row = 0; row < numRows; ++row)
+            {
+                const float value = featureMatrix(row, column);
+                rss += (value - mean) * (value - mean);
+            }
+            const float variance = rss / numRows;
+            const float standardDeviation = sqrtf(variance);
+            m_standardDeviations[column] = standardDeviation;
+        }
+
+        return true;
+    }
+
+    //-------------------------------------------------------------------------
+
+    float StandardScaler::Transform(float value, FeatureMatrix::Index column) const
+    {
+        const float mean = m_means[column];
+        float standardDeviation = m_standardDeviations[column];
+
+        if (standardDeviation < s_epsilon)
+        {
+            standardDeviation = 1.0f;
+        }
+
+        // Subtract the mean and scale to unit variance
+        return (value - mean) / standardDeviation;
+    }
+
+    AZ::Vector2 StandardScaler::Transform(const AZ::Vector2& value, FeatureMatrix::Index column) const
+    {
+        return AZ::Vector2(Transform(value.GetX(), column + 0), Transform(value.GetY(), column + 1));
+    }
+
+    AZ::Vector3 StandardScaler::Transform(const AZ::Vector3& value, FeatureMatrix::Index column) const
+    {
+        return AZ::Vector3(Transform(value.GetX(), column + 0), Transform(value.GetY(), column + 1), Transform(value.GetZ(), column + 2));
+    }
+
+    void StandardScaler::Transform(AZStd::span<float> data) const
+    {
+        const size_t numValues = data.size();
+        AZ_Assert(numValues == m_means.size(), "Input data needs to have the same number of elements.");
+        for (size_t i = 0; i < numValues; ++i)
+        {
+            data[i] = Transform(data[i], i);
+        }
+    }
+
+    FeatureMatrix StandardScaler::Transform(const FeatureMatrix& featureMatrix) const
+    {
+        const FeatureMatrix::Index numRows = featureMatrix.rows();
+        const FeatureMatrix::Index numColumns = featureMatrix.cols();
+        FeatureMatrix result;
+        result.resize(numRows, numColumns);
+
+        for (FeatureMatrix::Index row = 0; row < numRows; ++row)
+        {
+            for (FeatureMatrix::Index column = 0; column < numColumns; ++column)
+            {
+                result(row, column) = Transform(featureMatrix(row, column), column);
+            }
+        }
+
+        return result;
+    }
+
+    //-------------------------------------------------------------------------
+
+    FeatureMatrix StandardScaler::InverseTransform(const FeatureMatrix& featureMatrix) const
+    {
+        const FeatureMatrix::Index numRows = featureMatrix.rows();
+        const FeatureMatrix::Index numColumns = featureMatrix.cols();
+        FeatureMatrix result;
+        result.resize(numRows, numColumns);
+
+        for (FeatureMatrix::Index row = 0; row < numRows; ++row)
+        {
+            for (FeatureMatrix::Index column = 0; column < numColumns; ++column)
+            {
+                result(row, column) = InverseTransform(featureMatrix(row, column), column);
+            }
+        }
+
+        return result;
+    }
+
+    AZ::Vector2 StandardScaler::InverseTransform(const AZ::Vector2& value, FeatureMatrix::Index column) const
+    {
+        return AZ::Vector2(InverseTransform(value.GetX(), column + 0), InverseTransform(value.GetY(), column + 1));
+    }
+
+    AZ::Vector3 StandardScaler::InverseTransform(const AZ::Vector3& value, FeatureMatrix::Index column) const
+    {
+        return AZ::Vector3(
+            InverseTransform(value.GetX(), column + 0),
+            InverseTransform(value.GetY(), column + 1),
+            InverseTransform(value.GetZ(), column + 2));
+    }
+
+    float StandardScaler::InverseTransform(float value, FeatureMatrix::Index column) const
+    {
+        float standardDeviation = m_standardDeviations[column];
+        if (standardDeviation < s_epsilon)
+        {
+            standardDeviation = 1.0f;
+        }
+
+        return value * standardDeviation + m_means[column];
+    }
+
+    void StandardScaler::SaveAsCsv(const char* filename, const AZStd::vector<AZStd::string>& columnNames)
+    {
+        AZStd::string data;
+
+        // Save column names in the first row
+        if (!columnNames.empty())
+        {
+            for (size_t i = 0; i < columnNames.size(); ++i)
+            {
+                if (i != 0)
+                {
+                    data += ",";
+                }
+
+                data += columnNames[i].c_str();
+            }
+            data += "\n";
+        }
+
+        for (size_t i = 0; i < m_means.size(); ++i)
+        {
+            if (i != 0)
+            {
+                data += ",";
+            }
+
+            data += AZStd::to_string(m_means[i]);
+        }
+
+        data += "\n";
+
+        for (size_t i = 0; i < m_standardDeviations.size(); ++i)
+        {
+            if (i != 0)
+            {
+                data += ",";
+            }
+
+            data += AZStd::to_string(m_standardDeviations[i]);
+        }
+
+        data += "\n";
+
+        AZ::IO::SystemFile file;
+        if (file.Open(
+                filename,
+                AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY))
+        {
+            file.Write(data.data(), data.size());
+            file.Close();
+        }
+    }
+} // namespace EMotionFX::MotionMatching

--- a/Gems/MotionMatching/Code/Source/FeatureMatrixStandardScaler.h
+++ b/Gems/MotionMatching/Code/Source/FeatureMatrixStandardScaler.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <FeatureMatrix.h>
+#include <FeatureMatrixTransformer.h>
+
+namespace EMotionFX::MotionMatching
+{
+    //! The standard scaler can be used to normalize the feature matrix, the query vector and other data.
+    //! It standardizes features by subtracting the mean and scaling to the unit variance.
+    //! This implementation is mimicking the behavior of the standard scaler from scikit-learn (sklearn.preprocessing.StandardScaler).
+    //! As we use floats by default, our errors are bigger, especially if the variance is small as this leads to a division by a small
+    //! value. In case the calculated standard deviation for a given feature is smaller than the given s_epsilon value, the standard
+    //! deviation gets force-set to 1.0 to avoid divisions by infinity and preserve the value when doing the transform -> inverse-transform
+    //! roundtrip.
+    class StandardScaler : public FeatureMatrixTransformer
+    {
+    public:
+        AZ_RTTI(StandardScaler, "{A0C7F056-94B0-43A1-8D12-B1A7B67AB92A}", FeatureMatrixTransformer);
+        AZ_CLASS_ALLOCATOR_DECL;
+
+        StandardScaler() = default;
+
+        bool Fit(const FeatureMatrix& featureMatrix, const Settings& settings = {}) override;
+
+        // Normalize and scale the values.
+        float Transform(float value, FeatureMatrix::Index column) const override;
+        AZ::Vector2 Transform(const AZ::Vector2& value, FeatureMatrix::Index column) const override;
+        AZ::Vector3 Transform(const AZ::Vector3& value, FeatureMatrix::Index column) const override;
+        void Transform(AZStd::span<float> data) const override;
+        FeatureMatrix Transform(const FeatureMatrix& featureMatrix) const override;
+
+        // From normalized and scaled back to the original values.
+        FeatureMatrix InverseTransform(const FeatureMatrix& featureMatrix) const override;
+        AZ::Vector2 InverseTransform(const AZ::Vector2& value, FeatureMatrix::Index column) const override;
+        AZ::Vector3 InverseTransform(const AZ::Vector3& value, FeatureMatrix::Index column) const override;
+        float InverseTransform(float value, FeatureMatrix::Index column) const override;
+
+        const AZStd::vector<float>& GetMeans() const
+        {
+            return m_means;
+        }
+        const AZStd::vector<float>& GetStandardDeviations() const
+        {
+            return m_standardDeviations;
+        }
+
+        static constexpr float s_epsilon = AZ::Constants::FloatEpsilon;
+
+        void SaveAsCsv(const char* filename, const AZStd::vector<AZStd::string>& columnNames = {});
+
+    private:
+        AZStd::vector<float> m_means; //!< The mean value for each feature / column.
+        AZStd::vector<float> m_standardDeviations; //!< The standard deviation for each feature / column.
+    };
+} // namespace EMotionFX::MotionMatching

--- a/Gems/MotionMatching/Code/Source/FeatureMatrixTransformer.h
+++ b/Gems/MotionMatching/Code/Source/FeatureMatrixTransformer.h
@@ -25,7 +25,7 @@ namespace EMotionFX::MotionMatching
 
         struct Settings
         {
-            float m_featureMin = 0.0f; //!< Minimum value after the transformation.
+            float m_featureMin = -1.0f; //!< Minimum value after the transformation.
             float m_featureMax = 1.0f; //!< Maximum value after the transformation.
 
             //! Depending on the transformer to be used there might be some outliers from range [m_featureMin, m_featureMax].

--- a/Gems/MotionMatching/Code/Source/MotionMatchingData.cpp
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingData.cpp
@@ -22,6 +22,7 @@
 #include <Allocators.h>
 #include <Feature.h>
 #include <FeatureMatrixMinMaxScaler.h>
+#include <FeatureMatrixStandardScaler.h>
 #include <FeatureSchemaDefault.h>
 #include <FeatureTrajectory.h>
 #include <FrameDatabase.h>
@@ -228,8 +229,25 @@ namespace EMotionFX::MotionMatching
             AZ::Debug::Timer transformFeatureTimer;
             transformFeatureTimer.Stamp();
 
-            MinMaxScaler* minMaxScaler = aznew MinMaxScaler();
-            m_featureTransformer.reset(minMaxScaler);
+            switch (settings.m_featureScalerType)
+            {
+            case FeatureScalerType::StandardScalerType:
+                {
+                    m_featureTransformer.reset(aznew StandardScaler());
+                    break;
+                }
+            case FeatureScalerType::MinMaxScalerType:
+                {
+                    m_featureTransformer.reset(aznew MinMaxScaler());
+                    break;
+                }
+            default:
+                {
+                    m_featureTransformer.reset();
+                    AZ_Error("Motion Matching", false, "Unknown feature scaler type.")
+                }
+            }
+
             m_featureTransformer->Fit(m_featureMatrix, settings.m_featureTansformerSettings);
             m_featureMatrix = m_featureTransformer->Transform(m_featureMatrix);
 

--- a/Gems/MotionMatching/Code/Source/MotionMatchingData.h
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingData.h
@@ -41,6 +41,12 @@ namespace EMotionFX::MotionMatching
         MotionMatchingData(const FeatureSchema& featureSchema);
         virtual ~MotionMatchingData();
 
+        enum FeatureScalerType
+        {
+            StandardScalerType = 0,
+            MinMaxScalerType = 1
+        };
+
         struct EMFX_API InitSettings
         {
             ActorInstance* m_actorInstance = nullptr;
@@ -51,6 +57,7 @@ namespace EMotionFX::MotionMatching
             bool m_importMirrored = false;
 
             bool m_normalizeData = false;
+            FeatureScalerType m_featureScalerType = StandardScalerType;
             FeatureMatrixTransformer::Settings m_featureTansformerSettings = {};
         };
         bool Init(const InitSettings& settings);

--- a/Gems/MotionMatching/Code/Tests/MinMaxScalerTests.cpp
+++ b/Gems/MotionMatching/Code/Tests/MinMaxScalerTests.cpp
@@ -67,7 +67,7 @@ namespace EMotionFX::MotionMatching
         m(2,0) = 1.0f;    m(2,1) = 0.5f;    m(2,2) =-5.0f;     m(2, 3) = 3.0f;
 
         MinMaxScaler minMaxScaler;
-        EXPECT_TRUE(minMaxScaler.Fit(m)); // default to normalization (feature range = [0, 1]
+        EXPECT_TRUE(minMaxScaler.Fit(m, {/*featureMin=*/0.0f, /*featureMax=*/1.0f, /*clip=*/false }));
         FeatureMatrix t = minMaxScaler.Transform(m);
 
         EXPECT_NEAR(t(0,0), 0.0f, s_testEpsilon); EXPECT_NEAR(t(0, 1), 0.0f, s_testEpsilon); EXPECT_NEAR(t(0, 2), 1.0f, s_testEpsilon); EXPECT_NEAR(t(0, 3), 3.0f, s_testEpsilon);
@@ -83,7 +83,7 @@ namespace EMotionFX::MotionMatching
         m(1, 0) = 2.0f; // range = 4.0
 
         MinMaxScaler minMaxScaler;
-        EXPECT_TRUE(minMaxScaler.Fit(m));
+        EXPECT_TRUE(minMaxScaler.Fit(m, {/*featureMin=*/0.0f, /*featureMax=*/1.0f, /*clip=*/false }));
 
         EXPECT_NEAR(minMaxScaler.Transform(-6.0f, 0), -1.0f, s_testEpsilon);
         EXPECT_NEAR(minMaxScaler.Transform(4.0f, 0), 1.5f, s_testEpsilon);

--- a/Gems/MotionMatching/Code/Tests/StandardScalerTests.cpp
+++ b/Gems/MotionMatching/Code/Tests/StandardScalerTests.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <FeatureMatrixStandardScaler.h>
+#include <Fixture.h>
+
+namespace EMotionFX::MotionMatching
+{
+    /*
+        # ground truth test data generated in python using the StandardScaler from scikit-learn
+
+        from sklearn.preprocessing import StandardScaler
+        import numpy as np
+
+        data = [[0, -1],
+                [0, -1],
+                [1, 1],
+                [1, 1]]
+        print("data")
+        print(data)
+
+        scaler = StandardScaler()
+        print(scaler.fit(data))
+
+        print("means")
+        print(scaler.mean_)
+        print("standard deviations")
+        print(np.sqrt(scaler.var_))
+
+        print("transformed data")
+        print(scaler.transform(data))
+
+        print("transform -> inverse_transform roundtrip")
+        print(scaler.inverse_transform(scaler.transform(data)))
+
+        print("transformed test sample")
+        print(scaler.transform([[2, 2]]))
+    */
+
+    class StandardScalerFixture : public Fixture
+    {
+    public:
+        static constexpr float s_testEpsilon = 1e-6f;
+
+        // First transforms and then inverse-transforms the data and compares the roundtrip to the original data.
+        void RoundtripTest(const FeatureMatrix& data, const FeatureMatrixTransformer& scaler, float epsilon = s_testEpsilon)
+        {
+            FeatureMatrix roundTrip = scaler.InverseTransform(scaler.Transform(data));
+
+            const FeatureMatrix::Index numRows = data.rows();
+            const FeatureMatrix::Index numColumns = data.cols();
+            for (FeatureMatrix::Index column = 0; column < numColumns; ++column)
+            {
+                for (FeatureMatrix::Index row = 0; row < numRows; ++row)
+                {
+                    EXPECT_NEAR(data(row, column), roundTrip(row, column), epsilon)
+                        << "Value at (" << row << ", " << column << ") does not match roundtrip value.";
+                }
+            }
+        }
+    };
+
+    TEST_F(StandardScalerFixture, BasicTransform1)
+    {
+        FeatureMatrix m;
+        m.resize(4, 2);
+        m(0, 0) = 0.0f;
+        m(0, 1) = -1.0f;
+        m(1, 0) = 0.0f;
+        m(1, 1) = -1.0f;
+        m(2, 0) = 1.0f;
+        m(2, 1) = 1.0f;
+        m(3, 0) = 1.0f;
+        m(3, 1) = 1.0f;
+
+        StandardScaler scaler;
+        EXPECT_TRUE(scaler.Fit(m));
+
+        // Test mean and standard deviations
+        const AZStd::vector<float>& means = scaler.GetMeans();
+        const AZStd::vector<float>& standardDeviations = scaler.GetStandardDeviations();
+        EXPECT_NEAR(means[0], 0.5f, s_testEpsilon);
+        EXPECT_NEAR(means[1], 0.0f, s_testEpsilon);
+        EXPECT_NEAR(standardDeviations[0], 0.5f, s_testEpsilon);
+        EXPECT_NEAR(standardDeviations[1], 1.0f, s_testEpsilon);
+
+        // Test transform
+        EXPECT_NEAR(scaler.Transform(2.0f, 0), 3.0f, s_testEpsilon);
+        EXPECT_NEAR(scaler.Transform(2.0f, 1), 2.0f, s_testEpsilon);
+
+        RoundtripTest(m, scaler);
+    }
+
+    TEST_F(StandardScalerFixture, BasicTransform2)
+    {
+        FeatureMatrix m;
+        m.resize(4, 2);
+        m(0, 0) = 1.0f;
+        m(0, 1) = -1.0f;
+        m(1, 0) = 2.0f;
+        m(1, 1) = -4.0f;
+        m(2, 0) = 3.0f;
+        m(2, 1) = 2.0f;
+        m(3, 0) = 4.0f;
+        m(3, 1) = 0.5f;
+
+        StandardScaler scaler;
+        EXPECT_TRUE(scaler.Fit(m));
+
+        // Test mean and standard deviations
+        const AZStd::vector<float>& means = scaler.GetMeans();
+        const AZStd::vector<float>& standardDeviations = scaler.GetStandardDeviations();
+        EXPECT_NEAR(means[0], 2.5f, s_testEpsilon);
+        EXPECT_NEAR(means[1], -0.625f, s_testEpsilon);
+        EXPECT_NEAR(standardDeviations[0], 1.11803399f, s_testEpsilon);
+        EXPECT_NEAR(standardDeviations[1], 2.21852992f, s_testEpsilon);
+
+        // Test transform
+        EXPECT_NEAR(scaler.Transform(2.0f, 0), -0.4472136f, s_testEpsilon);
+        EXPECT_NEAR(scaler.Transform(2.0f, 1), 1.18321596f, s_testEpsilon);
+
+        RoundtripTest(m, scaler);
+    }
+
+    TEST_F(StandardScalerFixture, LargeValues)
+    {
+        const float largeValueTestEpsilon = 0.001f;
+
+        FeatureMatrix m;
+        m.resize(4, 2);
+        m(0, 0) = 10000.0f;
+        m(0, 1) = 4242.0f;
+        m(1, 0) = -10000.0f;
+        m(1, 1) = -4242.0f;
+        m(2, 0) = 300.0f;
+        m(2, 1) = 4242.0f;
+        m(3, 0) = -250.0f;
+        m(3, 1) = 4242.0f;
+
+        StandardScaler scaler;
+        EXPECT_TRUE(scaler.Fit(m));
+
+        // Test mean and standard deviations
+        const AZStd::vector<float>& means = scaler.GetMeans();
+        const AZStd::vector<float>& standardDeviations = scaler.GetStandardDeviations();
+        EXPECT_NEAR(means[0], 12.5f, largeValueTestEpsilon);
+        EXPECT_NEAR(means[1], 2121.0f, largeValueTestEpsilon);
+        EXPECT_NEAR(standardDeviations[0], 7073.75209843f, largeValueTestEpsilon);
+        EXPECT_NEAR(standardDeviations[1], 3673.67976285f, largeValueTestEpsilon);
+
+        // Test transform
+        EXPECT_NEAR(scaler.Transform(2.0f, 0), -0.00148436f, s_testEpsilon);
+        EXPECT_NEAR(scaler.Transform(2.0f, 1), -0.57680586, s_testEpsilon);
+
+        RoundtripTest(m, scaler, largeValueTestEpsilon);
+    }
+
+    TEST_F(StandardScalerFixture, ClosebyValues1)
+    {
+        const float closebyValueTestEpsilon = 0.001f;
+
+        FeatureMatrix m;
+        m.resize(4, 2);
+        m(0, 0) = 1.0f;
+        m(0, 1) = 1.01f;
+        m(1, 0) = 1.0f;
+        m(1, 1) = 1.0f;
+        m(2, 0) = 1.0f;
+        m(2, 1) = 1.0f;
+        m(3, 0) = 1.0f;
+        m(3, 1) = 1.0f;
+
+        StandardScaler scaler;
+        EXPECT_TRUE(scaler.Fit(m));
+
+        // Test mean and standard deviations
+        const AZStd::vector<float>& means = scaler.GetMeans();
+        const AZStd::vector<float>& standardDeviations = scaler.GetStandardDeviations();
+        EXPECT_NEAR(means[0], 1.0f, s_testEpsilon);
+        EXPECT_NEAR(means[1], 1.0025f, s_testEpsilon);
+        EXPECT_NEAR(standardDeviations[0], 0.0f, s_testEpsilon);
+        EXPECT_NEAR(standardDeviations[1], 0.00433013f, s_testEpsilon);
+
+        // Test transform
+        EXPECT_NEAR(scaler.Transform(2.0f, 0), 1.0, s_testEpsilon);
+        EXPECT_NEAR(scaler.Transform(2.0f, 1), 230.36275741f, closebyValueTestEpsilon);
+
+        RoundtripTest(m, scaler, closebyValueTestEpsilon);
+    }
+
+    TEST_F(StandardScalerFixture, ClosebyValues2)
+    {
+        const float closebyValueTestEpsilon = 0.001f;
+
+        FeatureMatrix m;
+        m.resize(4, 2);
+        m(0, 0) = 100000.0f;
+        m(0, 1) = 1.001f;
+        m(1, 0) = 100000.0f;
+        m(1, 1) = 1.0f;
+        m(2, 0) = 100000.0f;
+        m(2, 1) = 1.0f;
+        m(3, 0) = 100000.0f;
+        m(3, 1) = 1.0f;
+
+        StandardScaler scaler;
+        EXPECT_TRUE(scaler.Fit(m));
+
+        // Test mean and standard deviations
+        const AZStd::vector<float>& means = scaler.GetMeans();
+        const AZStd::vector<float>& standardDeviations = scaler.GetStandardDeviations();
+        EXPECT_NEAR(means[0], 1.00000e+05f, s_testEpsilon);
+        EXPECT_NEAR(means[1], 1.00025e+00f, s_testEpsilon);
+        EXPECT_NEAR(standardDeviations[0], 0.0f, s_testEpsilon);
+        EXPECT_NEAR(standardDeviations[1], 0.00043301f, s_testEpsilon);
+
+        // Test transform
+        const float floatPrecisionErrorEpsilon = 0.2f;
+        EXPECT_NEAR(scaler.Transform(2.0f, 0), -99998.0f, floatPrecisionErrorEpsilon);
+        EXPECT_NEAR(scaler.Transform(2.0f, 1), 2308.82372649f, floatPrecisionErrorEpsilon);
+
+        RoundtripTest(m, scaler, closebyValueTestEpsilon);
+    }
+} // namespace EMotionFX::MotionMatching

--- a/Gems/MotionMatching/Code/motionmatching_files.cmake
+++ b/Gems/MotionMatching/Code/motionmatching_files.cmake
@@ -26,6 +26,8 @@ set(FILES
     Source/FeatureMatrix.h
     Source/FeatureMatrixMinMaxScaler.cpp
     Source/FeatureMatrixMinMaxScaler.h
+    Source/FeatureMatrixStandardScaler.cpp
+    Source/FeatureMatrixStandardScaler.h
     Source/FeatureMatrixTransformer.h
     Source/FeatureAngularVelocity.cpp
     Source/FeatureAngularVelocity.h

--- a/Gems/MotionMatching/Code/motionmatching_tests_files.cmake
+++ b/Gems/MotionMatching/Code/motionmatching_tests_files.cmake
@@ -12,4 +12,5 @@ set(FILES
     Tests/FeatureSchemaTests.cpp
     Tests/MinMaxScalerTests.cpp
     Tests/MotionMatchingTest.cpp
+    Tests/StandardScalerTests.cpp
 )


### PR DESCRIPTION
The standard scaler can be used to normalize the feature matrix, the query vector and other data. It standardizes features by removing the mean and scaling to the unit variance. This implementation is mimicing the behavior of the standard scaler from scikit-learn (sklearn.preprocessing.StandardScaler). As we use floats by default, our errors are a bigger, especially if the variance is small as this leads to a division by a small value. In case the calculated standard deviation for a given feature is smaller than the given s_epsilon value, the standard deviation gets force-set to 1.0 to avoid divisions by infinity and preserve the value when doing the transform -> inverse-transform roundtrip.

If the standard deviation is small and basically a feature hardly changes (but does change a little bit more than our s_epsilon), the scaling is reaching floating point accuracy limits pretty quickly and the results differ from sklearn's StandardScaller as that internally seems to use double precision.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>