### PR TITLE
Added Landscape Canvas support for Terrain Macro Material and Surface Materials List nodes

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/TerrainExtenderNodes_ComponentEntitySync.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/TerrainExtenderNodes_ComponentEntitySync.py
@@ -89,10 +89,12 @@ def TerrainExtenderNodes_ComponentEntitySync():
     # The heightfield colliders are a special case where they add each-other to make
     # the workflow easier since they depend on each-other
     extenders = {
+        'TerrainMacroMaterialNode': ['Terrain Macro Material'],
         'PhysXHeightfieldColliderNode': ['PhysX Heightfield Collider', 'Terrain Physics Heightfield Collider'],
         'TerrainPhysicsHeightfieldColliderNode': ['Terrain Physics Heightfield Collider', 'PhysX Heightfield Collider'],
         'TerrainSurfaceGradientListNode': ['Terrain Surface Gradient List'],
         'TerrainHeightGradientListNode': ['Terrain Height Gradient List'],
+        'TerrainSurfaceMaterialsListNode': ['Terrain Surface Materials List'],
     }
 
     # Retrieve a mapping of the TypeIds for all the components

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/TerrainNodes_DependentComponentsAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/TerrainNodes_DependentComponentsAdded.py
@@ -85,10 +85,18 @@ def TerrainNodes_DependentComponentsAdded():
     # Terrain node mapping with the key being the node name and the value is the
     # expected Components that should be added to the Entity created for the node
     areas = {
+        'TerrainMacroMaterialNode': [
+            'Terrain Macro Material',
+            'Axis Aligned Box Shape'
+        ],
         'TerrainLayerSpawnerNode': [
             'Terrain Layer Spawner',
             'Axis Aligned Box Shape'
-        ]
+        ],
+        'TerrainSurfaceMaterialsListNode': [
+            'Terrain Surface Materials List',
+            'Axis Aligned Box Shape'
+        ],
     }
 
     # Retrieve a mapping of the TypeIds for all the components

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/TerrainNodes_EntityCreatedOnNodeAdd.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/TerrainNodes_EntityCreatedOnNodeAdd.py
@@ -82,7 +82,9 @@ def TerrainNodes_EntityCreatedOnNodeAdd():
     # Terrain node mapping with the key being the node name and the value is the
     # expected Component that should be added to the Entity created for the node
     areas = {
-        'TerrainLayerSpawnerNode': 'Terrain Layer Spawner'
+        'TerrainMacroMaterialNode': 'Terrain Macro Material',
+        'TerrainLayerSpawnerNode': 'Terrain Layer Spawner',
+        'TerrainSurfaceMaterialsListNode': 'Terrain Surface Materials List',
     }
 
     # Retrieve a mapping of the TypeIds for all the components

--- a/Gems/GraphModel/Code/Include/GraphModel/GraphModelBus.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/GraphModelBus.h
@@ -109,6 +109,9 @@ namespace GraphModelIntegration
         //! This results in a no-op if node isn't actually wrapped on the wrapperNode
         virtual void UnwrapNode(GraphModel::NodePtr wrapperNode, GraphModel::NodePtr node) = 0;
 
+        //! Return if the specified node is a wrapped node
+        virtual bool IsNodeWrapped(GraphModel::NodePtr node) const = 0;
+
         //! Set the action string for the specified node (used by wrapper nodes for
         //! setting the action widget label)
         virtual void SetWrapperNodeActionString(GraphModel::NodePtr node, const char* actionString) = 0;

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphController.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphController.h
@@ -62,6 +62,7 @@ namespace GraphModelIntegration
         void WrapNode(GraphModel::NodePtr wrapperNode, GraphModel::NodePtr node) override;
         void WrapNodeOrdered(GraphModel::NodePtr wrapperNode, GraphModel::NodePtr node, AZ::u32 layoutOrder) override;
         void UnwrapNode(GraphModel::NodePtr wrapperNode, GraphModel::NodePtr node) override;
+        bool IsNodeWrapped(GraphModel::NodePtr node) const override;
         void SetWrapperNodeActionString(GraphModel::NodePtr node, const char* actionString) override;
 
         GraphModel::ConnectionPtr AddConnection(GraphModel::SlotPtr sourceSlot, GraphModel::SlotPtr targetSlot) override;

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/Graph.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/Graph.h
@@ -113,6 +113,9 @@ namespace GraphModel
         //! Remove the wrapping from the specified node
         void UnwrapNode(ConstNodePtr node);
 
+        //! Return if the specified node is a wrapped node
+        bool IsNodeWrapped(NodePtr node) const;
+
         //! Return our full map of node wrappings
         const NodeWrappingMap& GetNodeWrappings();
 

--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -597,6 +597,11 @@ namespace GraphModelIntegration
             m_graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelNodeUnwrapped, wrapperNode, node);
     }
 
+    bool GraphController::IsNodeWrapped(GraphModel::NodePtr node) const
+    {
+        return m_graph->IsNodeWrapped(node);
+    }
+
     void GraphController::WrapNodeUi(GraphModel::NodePtr wrapperNode, GraphModel::NodePtr node, AZ::u32 layoutOrder)
     {
         AZ::EntityId wrapperNodeUiId = m_elementMap.Find(wrapperNode);

--- a/Gems/GraphModel/Code/Source/Model/Graph.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Graph.cpp
@@ -221,6 +221,12 @@ namespace GraphModel
         }
     }
 
+    bool Graph::IsNodeWrapped(NodePtr node) const
+    {
+        auto it = m_nodeWrappings.find(node->GetId());
+        return it != m_nodeWrappings.end();
+    }
+
 
     const Graph::NodeWrappingMap& Graph::GetNodeWrappings()
     {

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainMacroMaterialNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainMacroMaterialNode.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <QObject>
+
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+#include <GraphModel/Integration/Helpers.h>
+
+#include <Editor/Core/GraphContext.h>
+#include <Editor/Nodes/Terrain/TerrainMacroMaterialNode.h>
+
+namespace LandscapeCanvas
+{
+    void TerrainMacroMaterialNode::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<TerrainMacroMaterialNode, BaseNode>()
+                ->Version(0)
+                ;
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<TerrainMacroMaterialNode>("TerrainMacroMaterialNode", "")->
+                    ClassElement(AZ::Edit::ClassElements::EditorData, "")->
+                    Attribute(GraphModelIntegration::Attributes::TitlePaletteOverride, "TerrainNodeTitlePalette")
+                    ;
+            }
+        }
+    }
+
+    const QString TerrainMacroMaterialNode::TITLE = QObject::tr("Terrain Macro Material");
+
+    TerrainMacroMaterialNode::TerrainMacroMaterialNode(GraphModel::GraphPtr graph)
+        : BaseNode(graph)
+    {
+        RegisterSlots();
+        CreateSlotData();
+    }
+
+    const BaseNode::BaseNodeType TerrainMacroMaterialNode::GetBaseNodeType() const
+    {
+        return BaseNode::TerrainExtender;
+    }
+
+    const char* TerrainMacroMaterialNode::GetTitle() const
+    {
+        return TITLE.toUtf8().constData();
+    }
+
+    void TerrainMacroMaterialNode::RegisterSlots()
+    {
+        CreateEntityNameSlot();
+    }
+} // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainMacroMaterialNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainMacroMaterialNode.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <QString>
+
+#include <Editor/Core/Core.h>
+#include <Editor/Nodes/BaseNode.h>
+
+namespace AZ
+{
+    class ReflectContext;
+}
+
+namespace LandscapeCanvas
+{
+    class TerrainMacroMaterialNode
+        : public BaseNode
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(TerrainMacroMaterialNode, AZ::SystemAllocator, 0);
+        AZ_RTTI(TerrainMacroMaterialNode, "{E55E39AA-133C-40CE-8FDE-CF674D0E8BB2}", BaseNode);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        TerrainMacroMaterialNode() = default;
+        explicit TerrainMacroMaterialNode(GraphModel::GraphPtr graph);
+
+        const BaseNodeType GetBaseNodeType() const override;
+
+        static const QString TITLE;
+        const char* GetTitle() const override;
+
+    protected:
+        void RegisterSlots() override;
+    };
+}

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceMaterialsListNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceMaterialsListNode.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <QObject>
+
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+#include <GraphModel/Integration/Helpers.h>
+
+#include <Editor/Core/GraphContext.h>
+#include <Editor/Nodes/Terrain/TerrainSurfaceMaterialsListNode.h>
+
+namespace LandscapeCanvas
+{
+    void TerrainSurfaceMaterialsListNode::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<TerrainSurfaceMaterialsListNode, BaseNode>()
+                ->Version(0)
+                ;
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<TerrainSurfaceMaterialsListNode>("TerrainSurfaceMaterialsListNode", "")->
+                    ClassElement(AZ::Edit::ClassElements::EditorData, "")->
+                    Attribute(GraphModelIntegration::Attributes::TitlePaletteOverride, "TerrainNodeTitlePalette")
+                    ;
+            }
+        }
+    }
+
+    const QString TerrainSurfaceMaterialsListNode::TITLE = QObject::tr("Terrain Surface Materials List");
+
+    TerrainSurfaceMaterialsListNode::TerrainSurfaceMaterialsListNode(GraphModel::GraphPtr graph)
+        : BaseNode(graph)
+    {
+        RegisterSlots();
+        CreateSlotData();
+    }
+
+    const BaseNode::BaseNodeType TerrainSurfaceMaterialsListNode::GetBaseNodeType() const
+    {
+        return BaseNode::TerrainExtender;
+    }
+
+    const char* TerrainSurfaceMaterialsListNode::GetTitle() const
+    {
+        return TITLE.toUtf8().constData();
+    }
+
+    void TerrainSurfaceMaterialsListNode::RegisterSlots()
+    {
+        CreateEntityNameSlot();
+    }
+} // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceMaterialsListNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceMaterialsListNode.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <QString>
+
+#include <Editor/Core/Core.h>
+#include <Editor/Nodes/BaseNode.h>
+
+namespace AZ
+{
+    class ReflectContext;
+}
+
+namespace LandscapeCanvas
+{
+    class TerrainSurfaceMaterialsListNode
+        : public BaseNode
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(TerrainSurfaceMaterialsListNode, AZ::SystemAllocator, 0);
+        AZ_RTTI(TerrainSurfaceMaterialsListNode, "{41A168E4-6C30-40FA-889A-D2B58724A1D9}", BaseNode);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        TerrainSurfaceMaterialsListNode() = default;
+        explicit TerrainSurfaceMaterialsListNode(GraphModel::GraphPtr graph);
+
+        const BaseNodeType GetBaseNodeType() const override;
+
+        static const QString TITLE;
+        const char* GetTitle() const override;
+
+    protected:
+        void RegisterSlots() override;
+    };
+}

--- a/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.cpp
@@ -81,8 +81,10 @@
 #include <Editor/Nodes/Terrain/PhysXHeightfieldColliderNode.h>
 #include <Editor/Nodes/Terrain/TerrainHeightGradientListNode.h>
 #include <Editor/Nodes/Terrain/TerrainLayerSpawnerNode.h>
+#include <Editor/Nodes/Terrain/TerrainMacroMaterialNode.h>
 #include <Editor/Nodes/Terrain/TerrainPhysicsHeightfieldColliderNode.h>
 #include <Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.h>
+#include <Editor/Nodes/Terrain/TerrainSurfaceMaterialsListNode.h>
 
 namespace LandscapeCanvas
 {
@@ -99,8 +101,10 @@ namespace LandscapeCanvas
             static constexpr const char* EditorPhysXHeightfieldColliderComponentTypeId = "{C388C3DB-8D2E-4D26-96D3-198EDC799B77}";
             static constexpr const char* EditorTerrainHeightGradientListComponentTypeId = "{2D945B90-ADAB-4F9A-A113-39E714708068}";
             static constexpr const char* EditorTerrainLayerSpawnerComponentTypeId = "{9403FC94-FA38-4387-BEFD-A728C7D850C1}";
+            static constexpr const char* EditorTerrainMacroMaterialComponentTypeId = "{24D87D5F-6845-4F1F-81DC-05B4CEBA3EF4}";
             static constexpr const char* EditorTerrainPhysicsHeightfieldColliderComponentTypeId = "{C43FAB8F-3968-46A6-920E-E84AEDED3DF5}";
             static constexpr const char* EditorTerrainSurfaceGradientListComponentTypeId = "{49831E91-A11F-4EFF-A824-6D85C284B934}";
+            static constexpr const char* EditorTerrainSurfaceMaterialsListComponentTypeId = "{335CDED5-2E76-4342-8675-A60F66C471BF}";
         }
 
         // The Vegetation gem is optional, so we need to keep track of the component type IDs
@@ -164,8 +168,10 @@ namespace LandscapeCanvas
     VISITOR_FUNCTION<PhysXHeightfieldColliderNode>(Internal::Terrain::EditorPhysXHeightfieldColliderComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<TerrainHeightGradientListNode>(Internal::Terrain::EditorTerrainHeightGradientListComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<TerrainLayerSpawnerNode>(Internal::Terrain::EditorTerrainLayerSpawnerComponentTypeId, ##__VA_ARGS__);     \
+    VISITOR_FUNCTION<TerrainMacroMaterialNode>(Internal::Terrain::EditorTerrainMacroMaterialComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<TerrainPhysicsHeightfieldColliderNode>(Internal::Terrain::EditorTerrainPhysicsHeightfieldColliderComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<TerrainSurfaceGradientListNode>(Internal::Terrain::EditorTerrainSurfaceGradientListComponentTypeId, ##__VA_ARGS__);     \
+    VISITOR_FUNCTION<TerrainSurfaceMaterialsListNode>(Internal::Terrain::EditorTerrainSurfaceMaterialsListComponentTypeId, ##__VA_ARGS__);     \
     /* Gradient generator nodes */    \
     VISITOR_FUNCTION<FastNoiseGradientNode>(Internal::EditorFastNoiseGradientComponentTypeId, ##__VA_ARGS__);     \
     VISITOR_FUNCTION<PerlinNoiseGradientNode>(GradientSignal::EditorPerlinGradientComponentTypeId, ##__VA_ARGS__);     \

--- a/Gems/LandscapeCanvas/Code/landscapecanvas_editor_static_files.cmake
+++ b/Gems/LandscapeCanvas/Code/landscapecanvas_editor_static_files.cmake
@@ -128,10 +128,14 @@ set(FILES
     Source/Editor/Nodes/Terrain/TerrainHeightGradientListNode.h
     Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.cpp
     Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.h
+    Source/Editor/Nodes/Terrain/TerrainMacroMaterialNode.cpp
+    Source/Editor/Nodes/Terrain/TerrainMacroMaterialNode.h
     Source/Editor/Nodes/Terrain/TerrainPhysicsHeightfieldColliderNode.cpp
     Source/Editor/Nodes/Terrain/TerrainPhysicsHeightfieldColliderNode.h
     Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.cpp
     Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.h
+    Source/Editor/Nodes/Terrain/TerrainSurfaceMaterialsListNode.cpp
+    Source/Editor/Nodes/Terrain/TerrainSurfaceMaterialsListNode.h
     Source/Editor/Nodes/UI/GradientPreviewThumbnailItem.cpp
     Source/Editor/Nodes/UI/GradientPreviewThumbnailItem.h
 )


### PR DESCRIPTION
## What does this PR do?

Added Landscape Canvas support for Terrain Macro Material and Surface Materials List nodes. These are the first nodes that can be either wrapped (on a Terrain Layer Spawner) or can be standalone on their own Entity, so Landscape Canvas needed some minor changes to be able to handle both cases (previously assumptions were made that a node could only ever be wrapped or not). Also made sure we never show the Entity Name property on wrapped nodes since it's already shown on the wrapper node.

![MacroMaterialAndSurfaceMaterialsListNodes](https://user-images.githubusercontent.com/7519264/187960679-38285c7b-6177-4002-81b1-d7b2326b0909.gif)

## How was this PR tested?

Updated the automated tests with the new nodes and verified all automated tests still pass. Also did manual testing creating nodes from node palette, wrapper action, right-click menu, and by manually adding components from the Entity Inspector.
