### PR TITLE
Material Editor: Change asset browser duplicate action to save in the same folder

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowserInteractions.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowserInteractions.cpp
@@ -83,19 +83,16 @@ namespace AtomToolsFramework
     void AtomToolsAssetBrowserInteractions::AddContextMenuActionsForSourceEntries(
         [[maybe_unused]] QWidget* caller, QMenu* menu, const AzToolsFramework::AssetBrowser::AssetBrowserEntry* entry)
     {
-        menu->addAction("Duplicate...", [entry]()
+        menu->addAction("Duplicate", [entry]()
             {
-                const auto& duplicateFilePath = GetUniqueDuplicateFilePath(entry->GetFullPath());
-                if (!duplicateFilePath.empty())
+                const auto& duplicateFilePath = GetUniqueFilePath(entry->GetFullPath());
+                if (QFile::copy(entry->GetFullPath().c_str(), duplicateFilePath.c_str()))
                 {
-                    if (QFile::copy(entry->GetFullPath().c_str(), duplicateFilePath.c_str()))
-                    {
-                        QFile::setPermissions(duplicateFilePath.c_str(), QFile::ReadOther | QFile::WriteOther);
+                    QFile::setPermissions(duplicateFilePath.c_str(), QFile::ReadOther | QFile::WriteOther);
 
-                        // Auto add file to source control
-                        AzToolsFramework::SourceControlCommandBus::Broadcast(&AzToolsFramework::SourceControlCommandBus::Events::RequestEdit,
-                            duplicateFilePath.c_str(), true, [](bool, const AzToolsFramework::SourceControlFileInfo&) {});
-                    }
+                    // Auto add file to source control
+                    AzToolsFramework::SourceControlCommandBus::Broadcast(&AzToolsFramework::SourceControlCommandBus::Events::RequestEdit,
+                        duplicateFilePath.c_str(), true, [](bool, const AzToolsFramework::SourceControlFileInfo&) {});
                 }
             });
 


### PR DESCRIPTION
## What does this PR do?

https://github.com/o3de/o3de/issues/10944 reported that duplicating materials from the asset browser could not be opened or used. The duplicate action allowed the user to select a new file name and location before copying the file. Moving material files can break file associations that prevent the material from opening.

This change removes the save dialog and just duplicates in the same folder with a unique numeric suffix. The user can then take explicit action to rename or move the file and update any references.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Manually verified duplicated file is automatically added to the same folder with a unique numeric suffix and no user prompt