### PR TITLE
Skipped screenshot gpu tests currently failing.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
@@ -45,6 +45,7 @@ class TestAutomation(EditorTestSuite):
         return test_screenshots, golden_images
 
     @pytest.mark.test_case_id("C34525095")
+    @pytest.mark.skip(reason="Remnant of AtomTest tests which are deprecated and currently failing, but keeping for reference.")
     class AtomGPU_LightComponent_AreaLightScreenshotsMatchGoldenImages_DX12(EditorSingleTest):
         from Atom.tests import hydra_AtomGPU_AreaLightScreenshotTest as test_module
 
@@ -72,6 +73,7 @@ class TestAutomation(EditorTestSuite):
                                                       similarity_threshold=0.96) is True
 
     @pytest.mark.test_case_id("C34525095")
+    @pytest.mark.skip(reason="Remnant of AtomTest tests which are deprecated and currently failing, but keeping for reference.")
     class AtomGPU_LightComponent_AreaLightScreenshotsMatchGoldenImages_Vulkan(EditorSingleTest):
         from Atom.tests import hydra_AtomGPU_AreaLightScreenshotTest as test_module
 
@@ -99,6 +101,7 @@ class TestAutomation(EditorTestSuite):
                                                       similarity_threshold=0.96) is True
 
     @pytest.mark.test_case_id("C34525110")
+    @pytest.mark.skip(reason="Remnant of AtomTest tests which are deprecated and currently failing, but keeping for reference.")
     class AtomGPU_LightComponent_SpotLightScreenshotsMatchGoldenImages_DX12(EditorSingleTest):
         from Atom.tests import hydra_AtomGPU_SpotLightScreenshotTest as test_module
 
@@ -127,6 +130,7 @@ class TestAutomation(EditorTestSuite):
                                                       similarity_threshold=0.96) is True
 
     @pytest.mark.test_case_id("C34525110")
+    @pytest.mark.skip(reason="Remnant of AtomTest tests which are deprecated and currently failing, but keeping for reference.")
     class AtomGPU_LightComponent_SpotLightScreenshotsMatchGoldenImages_Vulkan(EditorSingleTest):
         from Atom.tests import hydra_AtomGPU_SpotLightScreenshotTest as test_module
 


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

Skipping gpu tests that fail in nightly build. They are remnants of AtomTest tests which are deprecated. Kept for reference.
