### PR TITLE
Support frustum shape in AuxGeom

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Frustum.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Frustum.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Math/Matrix4x4.h>
 #include <AzCore/Math/MathUtils.h>
 #include <AzCore/Math/MathScriptHelpers.h>
+#include <AzCore/Math/ShapeIntersection.h>
 
 namespace AZ
 {
@@ -235,5 +236,21 @@ namespace AZ
         viewFrustumAttributes.m_verticalFovRadians = 2.0f * std::atan(tanHalfFov);
 
         return viewFrustumAttributes;
+    }
+
+    bool Frustum::GetCorners(CornerVertexArray& corners) const
+    {
+        using namespace ShapeIntersection;
+
+        return
+            IntersectThreePlanes(GetPlane(Near), GetPlane(Top), GetPlane(Left), corners[NearTopLeft]) &&
+            IntersectThreePlanes(GetPlane(Near), GetPlane(Top), GetPlane(Right), corners[NearTopRight]) &&
+            IntersectThreePlanes(GetPlane(Near), GetPlane(Bottom), GetPlane(Left), corners[NearBottomLeft]) &&
+            IntersectThreePlanes(GetPlane(Near), GetPlane(Bottom), GetPlane(Right), corners[NearBottomRight]) &&
+            IntersectThreePlanes(GetPlane(Far), GetPlane(Top), GetPlane(Left), corners[FarTopLeft]) &&
+            IntersectThreePlanes(GetPlane(Far), GetPlane(Top), GetPlane(Right), corners[FarTopRight]) &&
+            IntersectThreePlanes(GetPlane(Far), GetPlane(Bottom), GetPlane(Left), corners[FarBottomLeft]) &&
+            IntersectThreePlanes(GetPlane(Far), GetPlane(Bottom), GetPlane(Right), corners[FarBottomRight])
+            ;
     }
 } // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Math/Frustum.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Frustum.cpp
@@ -240,7 +240,7 @@ namespace AZ
 
     bool Frustum::GetCorners(CornerVertexArray& corners) const
     {
-        using namespace ShapeIntersection;
+        using ShapeIntersection::IntersectThreePlanes;
 
         return
             IntersectThreePlanes(GetPlane(Near), GetPlane(Top), GetPlane(Left), corners[NearTopLeft]) &&

--- a/Code/Framework/AzCore/AzCore/Math/Frustum.h
+++ b/Code/Framework/AzCore/AzCore/Math/Frustum.h
@@ -70,7 +70,8 @@ namespace AZ
             False,
         };
 
-        enum CornerIndices {
+        enum CornerIndices
+        {
             NearTopLeft, NearTopRight, NearBottomLeft, NearBottomRight,
             FarTopLeft, FarTopRight, FarBottomLeft, FarBottomRight,
             Count,

--- a/Code/Framework/AzCore/AzCore/Math/Frustum.h
+++ b/Code/Framework/AzCore/AzCore/Math/Frustum.h
@@ -55,20 +55,28 @@ namespace AZ
 
         enum PlaneId
         {
-            Near
-        ,   Far
-        ,   Left
-        ,   Right
-        ,   Top
-        ,   Bottom
-        ,   MAX
+            Near,
+            Far,
+            Left,
+            Right,
+            Top,
+            Bottom,
+            MAX,
         };
 
         enum class ReverseDepth
         {
-            True
-        ,   False
+            True,
+            False,
         };
+
+        enum CornerIndices {
+            NearTopLeft, NearTopRight, NearBottomLeft, NearBottomRight,
+            FarTopLeft, FarTopRight, FarBottomLeft, FarBottomRight,
+            Count,
+        };
+
+        using CornerVertexArray = AZStd::array<AZ::Vector3, CornerIndices::Count>;
 
         //! AzCore Reflection.
         //! @param context reflection context
@@ -145,6 +153,10 @@ namespace AZ
         //! Returns true if the current frustum and provided frustum are close to identical.
         //! @param rhs the frustum to compare against for closeness
         bool IsClose(const Frustum& rhs, float tolerance = Constants::Tolerance) const;
+
+        //! Fills an array with corner vertices and returns true for valid Frustums.
+        //! @param corners The array of corner vertices to fill.
+        bool GetCorners(CornerVertexArray& corners) const;
 
         //! Returns the corresponding view volume attributes for the frustum.
         ViewFrustumAttributes CalculateViewFrustumAttributes() const;

--- a/Code/Framework/AzCore/AzCore/Math/Frustum.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Frustum.inl
@@ -16,7 +16,6 @@ namespace AZ
         return planeId;
     }
 
-
     AZ_MATH_INLINE Frustum::Frustum()
     {
 #ifdef AZ_DEBUG_BUILD
@@ -27,12 +26,10 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Plane Frustum::GetPlane(PlaneId planeId) const
     {
         return Plane(m_planes[planeId]);
     }
-
 
     AZ_MATH_INLINE void Frustum::SetPlane(PlaneId planeId, const Plane& plane)
     {
@@ -44,7 +41,6 @@ namespace AZ
         const Vec4::FloatType length = Vec4::Sqrt(lengthSquared);
         m_planes[planeId] = Vec4::Div(plane.GetSimdValue(), length);
     }
-
 
     AZ_MATH_INLINE IntersectResult Frustum::IntersectSphere(const Vector3& center, float radius) const
     {
@@ -65,18 +61,15 @@ namespace AZ
         return intersect ? IntersectResult::Overlaps : IntersectResult::Interior;
     }
 
-
     AZ_MATH_INLINE IntersectResult Frustum::IntersectSphere(const Sphere& sphere) const
     {
         return IntersectSphere(sphere.GetCenter(), sphere.GetRadius());
     }
 
-
     AZ_MATH_INLINE IntersectResult Frustum::IntersectAabb(const Vector3& minimum, const Vector3& maximum) const
     {
         return IntersectAabb(Aabb::CreateFromMinMax(minimum, maximum));
     }
-
 
     AZ_MATH_INLINE IntersectResult Frustum::IntersectAabb(const Aabb& aabb) const
     {
@@ -109,7 +102,6 @@ namespace AZ
         return (numInterior < PlaneId::MAX) ? IntersectResult::Overlaps : IntersectResult::Interior;
     }
 
-
     AZ_MATH_INLINE bool Frustum::IsClose(const Frustum& rhs, float tolerance) const
     {
         return Vector4(m_planes[PlaneId::Near  ]).IsClose(Vector4(rhs.m_planes[PlaneId::Near  ]), tolerance)
@@ -119,4 +111,5 @@ namespace AZ
             && Vector4(m_planes[PlaneId::Top   ]).IsClose(Vector4(rhs.m_planes[PlaneId::Top   ]), tolerance)
             && Vector4(m_planes[PlaneId::Bottom]).IsClose(Vector4(rhs.m_planes[PlaneId::Bottom]), tolerance);
     }
+
 } // namespace AZ

--- a/Code/Framework/AzCore/Tests/Math/FrustumTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/FrustumTests.cpp
@@ -674,4 +674,47 @@ namespace UnitTest
         // the aabb is contained within the frustum
         EXPECT_TRUE(AZ::ShapeIntersection::Contains(viewFrustum, aabb));
     }
+
+    TEST(MATH_Frustum, FrustumCorners)
+    {
+        // position the frustum slightly along the x-axis looking down the negative x-axis
+        const AZ::Vector3 frustumOrigin = AZ::Vector3(5.0f, 0.0f, 0.0f);
+        const AZ::Quaternion frustumOrientation = AZ::Quaternion::CreateRotationZ(AZ::DegToRad(90.0f));
+        const AZ::Transform frustumTransform =
+            AZ::Transform::CreateFromQuaternionAndTranslation(frustumOrientation, frustumOrigin);
+
+        const AZ::Frustum viewFrustum = AZ::Frustum(
+            AZ::ViewFrustumAttributes(frustumTransform, 1920.0f / 1080.0f, AZ::DegToRad(60.0f), 0.1f, 100.0f));
+
+        AZ::Frustum::CornerVertexArray corners;
+        bool valid = viewFrustum.GetCorners(corners);
+
+        EXPECT_TRUE(valid);
+
+        // 8 unique positions all on 3 planes must be the 8 corners of the frustum.
+
+        // The various corners should all be unique
+        for (uint32_t i = 0; i < corners.size(); ++i)
+        {
+            for (uint32_t j = i + 1; j < corners.size(); ++j)
+            {
+                EXPECT_FALSE(corners.at(i).IsClose(corners.at(j)));
+            }
+        }
+
+        // The various corners should all lie on exactly 3 planes of the frustum
+        for (auto corner : corners)
+        {
+            uint32_t onPlaneCount = 0;
+            for (uint32_t planeId = 0; planeId < AZ::Frustum::PlaneId::MAX; ++planeId)
+            {
+                float distanceToPlane = viewFrustum.GetPlane(AZ::Frustum::PlaneId(planeId)).GetPointDist(corner);
+                if (abs(distanceToPlane) < 0.001f)
+                {
+                    ++onPlaneCount;
+                }
+            }
+            EXPECT_EQ(onPlaneCount, 3);
+        }
+    }
 } // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Math/FrustumTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/FrustumTests.cpp
@@ -698,7 +698,7 @@ namespace UnitTest
         {
             for (uint32_t j = i + 1; j < corners.size(); ++j)
             {
-                EXPECT_FALSE(corners.at(i).IsClose(corners.at(j)));
+                EXPECT_THAT(corners.at(i), testing::Not(IsClose(corners.at(j))));
             }
         }
 
@@ -708,8 +708,8 @@ namespace UnitTest
             uint32_t onPlaneCount = 0;
             for (uint32_t planeId = 0; planeId < AZ::Frustum::PlaneId::MAX; ++planeId)
             {
-                float distanceToPlane = viewFrustum.GetPlane(AZ::Frustum::PlaneId(planeId)).GetPointDist(corner);
-                if (abs(distanceToPlane) < 0.001f)
+                const float distanceToPlane = viewFrustum.GetPlane(AZ::Frustum::PlaneId(planeId)).GetPointDist(corner);
+                if (AZStd::abs(distanceToPlane) < 0.001f)
                 {
                     ++onPlaneCount;
                 }

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.cpp
@@ -613,17 +613,18 @@ namespace AZ
                     FarBottomLeft = Frustum::CornerIndices::FarBottomLeft,
                     FarBottomRight = Frustum::CornerIndices::FarBottomRight,
                 };
-                
+
+                RPI::AuxGeomDraw::AuxGeomDynamicIndexedDrawArguments drawArgs;
+                drawArgs.m_verts = corners.data();
+                drawArgs.m_vertCount = 8;
+                drawArgs.m_colors = &color;
+                drawArgs.m_colorCount = 1;
+                drawArgs.m_depthTest = depthTest;
+                drawArgs.m_depthWrite = depthWrite;
+                drawArgs.m_viewProjectionOverrideIndex = viewProjOverrideIndex;
+
                 if (style == DrawStyle::Point)
                 {
-                    RPI::AuxGeomDraw::AuxGeomDynamicDrawArguments drawArgs;
-                    drawArgs.m_verts = corners.data();
-                    drawArgs.m_vertCount = 8;
-                    drawArgs.m_colors = &color;
-                    drawArgs.m_colorCount = 1;
-                    drawArgs.m_depthTest = depthTest;
-                    drawArgs.m_depthWrite = depthWrite;
-                    drawArgs.m_viewProjectionOverrideIndex = viewProjOverrideIndex;
                     DrawPoints(drawArgs);
                 }
                 else
@@ -649,16 +650,8 @@ namespace AZ
                         NearBottomRight, FarBottomRight,
                     };
 
-                    RPI::AuxGeomDraw::AuxGeomDynamicIndexedDrawArguments drawArgs;
-                    drawArgs.m_verts = corners.data();
-                    drawArgs.m_vertCount = 8;
                     drawArgs.m_indices = lineIndices;
                     drawArgs.m_indexCount = 24;
-                    drawArgs.m_colors = &color;
-                    drawArgs.m_colorCount = 1;
-                    drawArgs.m_depthTest = depthTest;
-                    drawArgs.m_depthWrite = depthWrite;
-                    drawArgs.m_viewProjectionOverrideIndex = viewProjOverrideIndex;
                     DrawLines(drawArgs);
 
                     if (style == DrawStyle::Solid || style == DrawStyle::Shaded)
@@ -696,7 +689,6 @@ namespace AZ
                         drawArgs.m_indices = triangleIndices;
                         drawArgs.m_indexCount = 36;
                         drawArgs.m_colors = &transparentColor;
-                        drawArgs.m_opacityType = OpacityType::Translucent;
                         DrawTriangles(drawArgs, faceCull);
                     }
                 }
@@ -745,7 +737,7 @@ namespace AZ
                     planeNormalLineArgs.m_vertCount = 12;
                     planeNormalLineArgs.m_colors = planeNormalColors;
                     planeNormalLineArgs.m_colorCount = planeNormalLineArgs.m_vertCount;
-                    planeNormalLineArgs.m_depthTest = RPI::AuxGeomDraw::DepthTest::Off;
+                    planeNormalLineArgs.m_depthTest = depthTest;
                     DrawLines(planeNormalLineArgs);
                 }
             }

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.cpp
@@ -11,10 +11,11 @@
 
 #include <Atom/RPI.Public/Scene.h>
 
+#include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/Math/Obb.h>
 #include <AzCore/Math/Matrix4x4.h>
+#include <AzCore/Math/ShapeIntersection.h>
 #include <AzCore/std/functional.h>
-#include <AzCore/Casting/numeric_cast.h>
 
 namespace AZ
 {
@@ -582,6 +583,176 @@ namespace AZ
             box.m_viewProjOverrideIndex = viewProjOverrideIndex;
 
             AddBox(style, box);
+        }
+
+        void AuxGeomDrawQueue::DrawFrustum(
+            const Frustum& frustum,
+            const Color& color,
+            bool drawNormals,
+            DrawStyle style,
+            DepthTest depthTest,
+            DepthWrite depthWrite,
+            FaceCullMode faceCull,
+            int32_t viewProjOverrideIndex)
+        {
+
+            Frustum::CornerVertexArray corners;
+            bool validFrustum = frustum.GetCorners(corners);
+
+            if (validFrustum)
+            {
+                // This helps cut down on clutter below. Replace with a using-enum-declaration when c++20 support is required.
+                enum CornerIndices
+                {
+                    NearTopLeft = Frustum::CornerIndices::NearTopLeft,
+                    NearTopRight = Frustum::CornerIndices::NearTopRight,
+                    NearBottomLeft = Frustum::CornerIndices::NearBottomLeft,
+                    NearBottomRight = Frustum::CornerIndices::NearBottomRight,
+                    FarTopLeft = Frustum::CornerIndices::FarTopLeft,
+                    FarTopRight = Frustum::CornerIndices::FarTopRight,
+                    FarBottomLeft = Frustum::CornerIndices::FarBottomLeft,
+                    FarBottomRight = Frustum::CornerIndices::FarBottomRight,
+                };
+                
+                if (style == DrawStyle::Point)
+                {
+                    RPI::AuxGeomDraw::AuxGeomDynamicDrawArguments drawArgs;
+                    drawArgs.m_verts = corners.data();
+                    drawArgs.m_vertCount = 8;
+                    drawArgs.m_colors = &color;
+                    drawArgs.m_colorCount = 1;
+                    drawArgs.m_depthTest = depthTest;
+                    drawArgs.m_depthWrite = depthWrite;
+                    drawArgs.m_viewProjectionOverrideIndex = viewProjOverrideIndex;
+                    DrawPoints(drawArgs);
+                }
+                else
+                {
+                    // Always draw lines if draw style isn't Point.
+                    uint32_t lineIndices[24]{
+                        //near plane
+                        NearTopLeft, NearTopRight,
+                        NearTopRight, NearBottomRight,
+                        NearBottomRight, NearBottomLeft,
+                        NearBottomLeft, NearTopLeft,
+
+                        //Far plane
+                        FarTopLeft, FarTopRight,
+                        FarTopRight, FarBottomRight,
+                        FarBottomRight, FarBottomLeft,
+                        FarBottomLeft, FarTopLeft,
+
+                        //Near-to-Far connecting lines
+                        NearTopLeft, FarTopLeft,
+                        NearTopRight, FarTopRight,
+                        NearBottomLeft, FarBottomLeft,
+                        NearBottomRight, FarBottomRight,
+                    };
+
+                    RPI::AuxGeomDraw::AuxGeomDynamicIndexedDrawArguments drawArgs;
+                    drawArgs.m_verts = corners.data();
+                    drawArgs.m_vertCount = 8;
+                    drawArgs.m_indices = lineIndices;
+                    drawArgs.m_indexCount = 24;
+                    drawArgs.m_colors = &color;
+                    drawArgs.m_colorCount = 1;
+                    drawArgs.m_depthTest = depthTest;
+                    drawArgs.m_depthWrite = depthWrite;
+                    drawArgs.m_viewProjectionOverrideIndex = viewProjOverrideIndex;
+                    DrawLines(drawArgs);
+
+                    if (style == DrawStyle::Solid || style == DrawStyle::Shaded)
+                    {
+                        // DrawTriangles doesn't support shaded drawing, so we can't support it here either.
+                        AZ_WarningOnce("AuxGeomDrawQueue", style != DrawStyle::Shaded, "Cannot draw frustum with Shaded DrawStyle, using Solid instead.");
+
+                        uint32_t triangleIndices[36]{
+                            //near
+                            NearBottomLeft, NearTopLeft, NearTopRight,
+                            NearBottomLeft, NearTopRight, NearBottomRight,
+
+                            //far
+                            FarBottomRight, FarTopRight, FarTopLeft,
+                            FarBottomRight, FarTopLeft, FarBottomLeft,
+
+                            //left
+                            NearTopLeft, NearBottomLeft, FarBottomLeft,
+                            NearTopLeft, FarBottomLeft, FarTopLeft,
+
+                            //right
+                            NearBottomRight, NearTopRight, FarTopRight,
+                            NearBottomRight, FarTopRight, FarBottomRight,
+
+                            //bottom
+                            FarBottomLeft, NearBottomLeft, NearBottomRight,
+                            FarBottomLeft, NearBottomRight, FarBottomRight,
+
+                            //top
+                            NearTopLeft, FarTopLeft, FarTopRight,
+                            NearTopLeft, FarTopRight, NearTopRight,
+                        };
+
+                        Color transparentColor(color.GetR(), color.GetG(), color.GetB(), color.GetA() * 0.3f);
+                        drawArgs.m_indices = triangleIndices;
+                        drawArgs.m_indexCount = 36;
+                        drawArgs.m_colors = &transparentColor;
+                        drawArgs.m_opacityType = OpacityType::Translucent;
+                        DrawTriangles(drawArgs, faceCull);
+                    }
+                }
+
+                if (drawNormals)
+                {
+                    Vector3 planeNormals[] =
+                    {
+                        //near
+                        0.25f * (corners[NearBottomLeft] + corners[NearBottomRight] + corners[NearTopLeft] + corners[NearTopRight]),
+                        0.25f * (corners[NearBottomLeft] + corners[NearBottomRight] + corners[NearTopLeft] + corners[NearTopRight]) + frustum.GetPlane(Frustum::PlaneId::Near).GetNormal(),
+
+                        //far
+                        0.25f * (corners[FarBottomLeft] + corners[FarBottomRight] + corners[FarTopLeft] + corners[FarTopRight]),
+                        0.25f * (corners[FarBottomLeft] + corners[FarBottomRight] + corners[FarTopLeft] + corners[FarTopRight]) + frustum.GetPlane(Frustum::PlaneId::Far).GetNormal(),
+
+                        //left
+                        0.5f * (corners[NearBottomLeft] + corners[NearTopLeft]),
+                        0.5f * (corners[NearBottomLeft] + corners[NearTopLeft]) + frustum.GetPlane(Frustum::PlaneId::Left).GetNormal(),
+
+                        //right
+                        0.5f * (corners[NearBottomRight] + corners[NearTopRight]),
+                        0.5f * (corners[NearBottomRight] + corners[NearTopRight]) + frustum.GetPlane(Frustum::PlaneId::Right).GetNormal(),
+
+                        //bottom
+                        0.5f * (corners[NearBottomLeft] + corners[NearBottomRight]),
+                        0.5f * (corners[NearBottomLeft] + corners[NearBottomRight]) + frustum.GetPlane(Frustum::PlaneId::Bottom).GetNormal(),
+
+                        //top
+                        0.5f * (corners[NearTopLeft] + corners[NearTopRight]),
+                        0.5f * (corners[NearTopLeft] + corners[NearTopRight]) + frustum.GetPlane(Frustum::PlaneId::Top).GetNormal(),
+                    };
+
+                    Color planeNormalColors[] =
+                    {
+                        Colors::Red, Colors::Red,       //near
+                        Colors::Green, Colors::Green,   //far
+                        Colors::Blue, Colors::Blue,     //left
+                        Colors::Orange, Colors::Orange, //right
+                        Colors::Pink, Colors::Pink,     //bottom
+                        Colors::MediumPurple, Colors::MediumPurple, //top
+                    };
+
+                    RPI::AuxGeomDraw::AuxGeomDynamicDrawArguments planeNormalLineArgs;
+                    planeNormalLineArgs.m_verts = planeNormals;
+                    planeNormalLineArgs.m_vertCount = 12;
+                    planeNormalLineArgs.m_colors = planeNormalColors;
+                    planeNormalLineArgs.m_colorCount = planeNormalLineArgs.m_vertCount;
+                    planeNormalLineArgs.m_depthTest = RPI::AuxGeomDraw::DepthTest::Off;
+                    DrawLines(planeNormalLineArgs);
+                }
+            }
+            else
+            {
+                AZ_Assert(false, "invalid frustum, cannot draw");
+            }
         }
 
         AuxGeomBufferData* AuxGeomDrawQueue::Commit()

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.h
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.h
@@ -70,6 +70,7 @@ namespace AZ
             void DrawAabb(const AZ::Aabb& aabb, const AZ::Matrix3x4& transform, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
             void DrawObb(const AZ::Obb& obb, const AZ::Vector3& position, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
             void DrawObb(const AZ::Obb& obb, const AZ::Matrix3x4& transform, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
+            void DrawFrustum(const AZ::Frustum& frustum, const AZ::Color& color, bool drawNormals, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
 
             //! Switch clients of AuxGeom to using a different buffer and return the filled buffer for processing
             AuxGeomBufferData* Commit();

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/AuxGeom/AuxGeomDraw.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/AuxGeom/AuxGeomDraw.h
@@ -7,10 +7,11 @@
  */
 #pragma once
 
-#include <AzCore/Math/Vector3.h>
-#include <AzCore/Math/Color.h>
 #include <AzCore/Math/Aabb.h>
+#include <AzCore/Math/Color.h>
+#include <AzCore/Math/Frustum.h>
 #include <AzCore/Math/Matrix3x4.h>
+#include <AzCore/Math/Vector3.h>
 
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 
@@ -256,6 +257,17 @@ namespace AZ
             //! @param faceCull      Which (if any) facing triangles should be culled
             //! @param viewProjOverrideIndex Which view projection override entry to use, -1 if unused
             virtual void DrawObb(const AZ::Obb& obb, const AZ::Matrix3x4& transform, const AZ::Color& color, DrawStyle style = DrawStyle::Shaded, DepthTest depthTest = DepthTest::On, DepthWrite depthWrite = DepthWrite::On, FaceCullMode faceCull = FaceCullMode::Back, int32_t viewProjOverrideIndex = -1) = 0;
+
+            //! Draw a frustum.
+            //! @param frustum       The frustum
+            //! @param color         The color to draw the frustum
+            //! @param drawNormals   If true, frustum plane normals will be drawn as lines
+            //! @param style         The draw style (point, wireframe, solid, shaded etc)
+            //! @param depthTest     If depth testing should be enabled
+            //! @param depthWrite    If depth writing should be enabled
+            //! @param faceCull      Which (if any) facing triangles should be culled
+            //! @param viewProjOverrideIndex Which view projection override entry to use, -1 if unused
+            virtual void DrawFrustum(const AZ::Frustum& frustum, const AZ::Color& color, bool drawNormals = true, DrawStyle style = DrawStyle::Shaded, DepthTest depthTest = DepthTest::On, DepthWrite depthWrite = DepthWrite::On, FaceCullMode faceCull = FaceCullMode::Back, int32_t viewProjOverrideIndex = -1) = 0;
         };
 
     } // namespace RPI

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/AuxGeom/AuxGeomDraw.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/AuxGeom/AuxGeomDraw.h
@@ -262,7 +262,7 @@ namespace AZ
             //! @param frustum       The frustum
             //! @param color         The color to draw the frustum
             //! @param drawNormals   If true, frustum plane normals will be drawn as lines
-            //! @param style         The draw style (point, wireframe, solid, shaded etc)
+            //! @param style         The draw style (point, wireframe, solid) Shaded not currently supported.
             //! @param depthTest     If depth testing should be enabled
             //! @param depthWrite    If depth writing should be enabled
             //! @param faceCull      Which (if any) facing triangles should be culled


### PR DESCRIPTION
## What does this PR do?

This PR adds support for AZ::Frustum in AuxGeom using code originally written for culling. The original code has been cleaned up an corrected a little but remains largely the same.

As part of this work, the ability to retrieve the corners of a frustum was moved into the AZ::Frustum class itself, along with unit tests to validate the new functionality.

## How was this PR tested?

Core math tests were run to ensure new unit test passed. Tested culling debugging in ASV to ensure the frustum draws correctly using the new function.
