### PR TITLE
Fixed ImGui pass issue on pass hot reload

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -408,21 +408,8 @@ namespace AZ
         {
             if (m_requestedAsDefaultImguiPass)
             {
-                // Check to see if another default is already set.
-                ImGuiPass* currentDefaultPass = nullptr;
-                ImGuiSystemRequestBus::BroadcastResult(currentDefaultPass, &ImGuiSystemRequestBus::Events::GetDefaultImGuiPass);
-
-                if (currentDefaultPass != nullptr && currentDefaultPass->GetRenderPipeline() == GetRenderPipeline())
-                {
-                    // Only error when the pipelines match, meaning the default was set multiple times for the same pipeline. When the pipelines differ,
-                    // it's possible that multiple default ImGui passes are intentional, and only the first one to load should actually be set as default.
-                    AZ_Error("ImGuiPass", false, "Default ImGui pass is already set on this pipeline, ignoring request to set this pass as default. Only one ImGui pass should be marked as default in the pipeline.");
-                }
-                else
-                {
-                    m_isDefaultImGuiPass = true;
-                    ImGuiSystemRequestBus::Broadcast(&ImGuiSystemRequestBus::Events::PushDefaultImGuiPass, this);
-                }
+                m_isDefaultImGuiPass = true;
+                ImGuiSystemRequestBus::Broadcast(&ImGuiSystemRequestBus::Events::PushDefaultImGuiPass, this);
             }
 
             // This ImguiContextScope is just to ensure we set the imgui context to what it was previously at the end of this function


### PR DESCRIPTION
Code was checking for existing default pass with same pipeline
However during hot reload, we create new passes and initialize them to validate the hot reload
This creates a new ImGui pass, but it doesn't get assigned to default because it's the same pipeline as the current default
Then the reload succeeds, the old ImGui pass is removed and ImGui isn't pointing to any pass, so it doesn't render.
Upon inspection of the code, ImGui can have multiple pass pointers in it's stack of default passes (it already does for multiple pipelines) and these passes can be from the same pipeline, so the check preventing the addition of the new pass wasn't necessary. Tested and works after hot reload.
