### PR TITLE
Validate net property access

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
@@ -1,6 +1,18 @@
 {% import 'AutoComponent_Common.jinja' as AutoComponentMacros %}
 {% macro UpperFirst(text) %}{{ text[0] | upper}}{{ text[1:] }}{% endmacro %}
 {% macro LowerFirst(text) %}{{ text[0] | lower}}{{ text[1:] }}{% endmacro %}
+{#
+
+#}
+{% macro ValidateNetworkPropertyGet(ClassName, Property) %}
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyRead("{{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}", Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
+    }
+{% endmacro %}
+{#
+
+#}
 {% macro DefineNetworkPropertyGet(ClassName, Property, Prefix = '') %}
 {%     if Property.attrib['Container'] == 'Array' %}
 {%          if Property.attrib['IsRewindable']|booleanTrue %}
@@ -9,19 +21,13 @@ const Multiplayer::RewindableArray<{{ Property.attrib['Type'] }}, {{ Property.at
 const AZStd::array<{{ Property.attrib['Type'] }}, {{ Property.attrib['Count'] }}>& {{ ClassName }}::Get{{ UpperFirst(Property.attrib['Name']) }}Array() const
 {%          endif %}
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
-    }
+{{ ValidateNetworkPropertyGet(ClassName, Property) }}
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }};
 }
 
 const {{ Property.attrib['Type'] }}& {{ ClassName }}::Get{{ UpperFirst(Property.attrib['Name']) }}(int32_t index) const
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
-    }
+{{ ValidateNetworkPropertyGet(ClassName, Property) }}
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}[index];
 }
 
@@ -39,19 +45,13 @@ const RewindableFixedVector<{{ Property.attrib['Type'] }}, {{ Property.attrib['C
 const AZStd::fixed_vector<{{ Property.attrib['Type'] }}, {{ Property.attrib['Count'] }}>& {{ ClassName }}::Get{{ UpperFirst(Property.attrib['Name']) }}Vector() const
 {%          endif %}
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
-    }
+{{ ValidateNetworkPropertyGet(ClassName, Property) }}
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }};
 }
 
 const {{ Property.attrib['Type'] }}& {{ ClassName }}::Get{{ UpperFirst(Property.attrib['Name']) }}(int32_t index) const
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
-    }
+{{ ValidateNetworkPropertyGet(ClassName, Property) }}
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}[index];
 }
 
@@ -64,19 +64,13 @@ void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}AddEvent(AZ::Even
 {%          endif %}
 const {{ Property.attrib['Type'] }}& {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}GetBack() const
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
-    }
+{{ ValidateNetworkPropertyGet(ClassName, Property) }}
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}.back();
 }
 
 uint32_t {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}GetSize() const
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
-    }
+{{ ValidateNetworkPropertyGet(ClassName, Property) }}
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}.size();
 }
 
@@ -90,19 +84,13 @@ void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}SizeChangedAddEve
 {%     else %}
 const {{ Property.attrib['Type'] }}& {{ ClassName }}::Get{{ UpperFirst(Property.attrib['Name']) }}() const
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
-    }
+{{ ValidateNetworkPropertyGet(ClassName, Property) }}
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }};
 }
 {%          if Property.attrib['IsRewindable']|booleanTrue %}
 const {{ Property.attrib['Type'] }}& {{ ClassName }}::Get{{ UpperFirst(Property.attrib['Name']) }}Previous() const
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
-    }
+{{ ValidateNetworkPropertyGet(ClassName, Property) }}
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}.GetPrevious();
 }
 {%          endif %}
@@ -118,16 +106,21 @@ void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}AddEvent(AZ::Even
 {#
 
 #}
-{% macro DefineNetworkPropertySet(Component, ReplicateFrom, ReplicateTo, ClassName, Property) %}
+{% macro ValidateNetworkPropertySet(ClassName, Property) %}
 {% set IsPredictable = "true" if Property.attrib['IsPredictable']|booleanTrue else "false" %}
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyWrite("{{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}", Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
+    }
+{% endmacro %}
+{#
+
+#}
+{% macro DefineNetworkPropertySet(Component, ReplicateFrom, ReplicateTo, ClassName, Property) %}
 {%     if Property.attrib['Container'] == 'Array' %}
 void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index, const {{ Property.attrib['Type'] }}& value)
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
-    }
-
+{{ ValidateNetworkPropertySet(ClassName, Property) }}
     if (GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}[index] != value)
     {
         Modify{{ UpperFirst(Property.attrib['Name']) }}(index) = value;
@@ -136,11 +129,7 @@ void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index
 
 {{ Property.attrib['Type'] }}& {{ ClassName }}::Modify{{ UpperFirst(Property.attrib['Name']) }}(int32_t index)
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
-    }
-
+{{ ValidateNetworkPropertySet(ClassName, Property) }}
     int32_t bitIndex = index + static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property, 'Start') }});
     GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(bitIndex, true);
     GetParent().MarkDirty();
@@ -150,11 +139,7 @@ void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index
 {%     elif Property.attrib['Container'] == 'Vector' %}
 void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index, const {{ Property.attrib['Type'] }}& value)
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
-    }
-
+{{ ValidateNetworkPropertySet(ClassName, Property) }}
     if (GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}[index] != value)
     {
         Modify{{ UpperFirst(Property.attrib['Name']) }}(index) = value;
@@ -163,11 +148,7 @@ void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index
 
 {{ Property.attrib['Type'] }}& {{ ClassName }}::Modify{{ UpperFirst(Property.attrib['Name']) }}(int32_t index)
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
-    }
-
+{{ ValidateNetworkPropertySet(ClassName, Property) }}
     int32_t bitIndex = index + static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property, 'Start') }});
     GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(bitIndex, true);
     GetParent().MarkDirty();
@@ -176,11 +157,7 @@ void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index
 
 bool {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}PushBack(const {{ Property.attrib['Type'] }} &value)
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
-    }
-
+{{ ValidateNetworkPropertySet(ClassName, Property) }}
     int32_t indexToSet = GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.size();
     if (indexToSet < {{ Property.attrib['Count'] }})
     {
@@ -196,11 +173,7 @@ bool {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}PushBack(const {{
 
 bool {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}PopBack()
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
-    }
-
+{{ ValidateNetworkPropertySet(ClassName, Property) }}
     if (!GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.empty())
     {
         GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.pop_back();
@@ -213,11 +186,7 @@ bool {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}PopBack()
 
 void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}Clear()
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
-    }
-
+{{ ValidateNetworkPropertySet(ClassName, Property) }}
     GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(aznumeric_cast<uint32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property, 'Size') }}), true);
     GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.clear();
     GetParent().MarkDirty();
@@ -226,11 +195,7 @@ void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}Clear()
 {%     elif Property.attrib['Container'] == 'Object' %}
 void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(const {{ Property.attrib['Type'] }}& value)
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
-    }
-
+{{ ValidateNetworkPropertySet(ClassName, Property) }}
     if (GetParent().m_{{ LowerFirst(Property.attrib['Name']) }} != value)
     {
         Modify{{ UpperFirst(Property.attrib['Name']) }}() = value;
@@ -239,11 +204,7 @@ void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(const {{ Prop
 
 {{ Property.attrib['Type'] }}& {{ ClassName }}::Modify{{ UpperFirst(Property.attrib['Name']) }}()
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
-    }
-
+{{ ValidateNetworkPropertySet(ClassName, Property) }}
     GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property) }}), true);
     GetParent().MarkDirty();
     return static_cast<{{ Property.attrib['Type'] }}&>(GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}{% if Property.attrib['IsRewindable']|booleanTrue %}.Modify(){% endif %});
@@ -252,11 +213,7 @@ void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(const {{ Prop
 {%     else %}
 void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(const {{ Property.attrib['Type'] }}& value)
 {
-    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
-    {
-        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
-    }
-
+{{ ValidateNetworkPropertySet(ClassName, Property) }}
     if (GetParent().m_{{ LowerFirst(Property.attrib['Name']) }} != value)
     {
         GetParent().m_{{ LowerFirst(Property.attrib['Name']) }} = value;

--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
@@ -9,11 +9,19 @@ const Multiplayer::RewindableArray<{{ Property.attrib['Type'] }}, {{ Property.at
 const AZStd::array<{{ Property.attrib['Type'] }}, {{ Property.attrib['Count'] }}>& {{ ClassName }}::Get{{ UpperFirst(Property.attrib['Name']) }}Array() const
 {%          endif %}
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
+    }
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }};
 }
 
 const {{ Property.attrib['Type'] }}& {{ ClassName }}::Get{{ UpperFirst(Property.attrib['Name']) }}(int32_t index) const
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
+    }
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}[index];
 }
 
@@ -31,11 +39,19 @@ const RewindableFixedVector<{{ Property.attrib['Type'] }}, {{ Property.attrib['C
 const AZStd::fixed_vector<{{ Property.attrib['Type'] }}, {{ Property.attrib['Count'] }}>& {{ ClassName }}::Get{{ UpperFirst(Property.attrib['Name']) }}Vector() const
 {%          endif %}
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
+    }
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }};
 }
 
 const {{ Property.attrib['Type'] }}& {{ ClassName }}::Get{{ UpperFirst(Property.attrib['Name']) }}(int32_t index) const
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
+    }
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}[index];
 }
 
@@ -48,11 +64,19 @@ void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}AddEvent(AZ::Even
 {%          endif %}
 const {{ Property.attrib['Type'] }}& {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}GetBack() const
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
+    }
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}.back();
 }
 
 uint32_t {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}GetSize() const
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
+    }
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}.size();
 }
 
@@ -66,11 +90,19 @@ void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}SizeChangedAddEve
 {%     else %}
 const {{ Property.attrib['Type'] }}& {{ ClassName }}::Get{{ UpperFirst(Property.attrib['Name']) }}() const
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
+    }
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }};
 }
 {%          if Property.attrib['IsRewindable']|booleanTrue %}
 const {{ Property.attrib['Type'] }}& {{ ClassName }}::Get{{ UpperFirst(Property.attrib['Name']) }}Previous() const
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyRead(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }});
+    }
     return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}.GetPrevious();
 }
 {%          endif %}
@@ -87,9 +119,15 @@ void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}AddEvent(AZ::Even
 
 #}
 {% macro DefineNetworkPropertySet(Component, ReplicateFrom, ReplicateTo, ClassName, Property) %}
+{% set IsPredictable = "true" if Property.attrib['IsPredictable']|booleanTrue else "false" %}
 {%     if Property.attrib['Container'] == 'Array' %}
 void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index, const {{ Property.attrib['Type'] }}& value)
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
+    }
+
     if (GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}[index] != value)
     {
         Modify{{ UpperFirst(Property.attrib['Name']) }}(index) = value;
@@ -98,107 +136,11 @@ void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index
 
 {{ Property.attrib['Type'] }}& {{ ClassName }}::Modify{{ UpperFirst(Property.attrib['Name']) }}(int32_t index)
 {
-    int32_t bitIndex = index + static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property, 'Start') }});
-    GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(bitIndex, true);
-    GetParent().MarkDirty();
-    return GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}[index];
-}
-
-{%     elif Property.attrib['Container'] == 'Vector' %}
-void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index, const {{ Property.attrib['Type'] }}& value)
-{
-    if (GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}[index] != value)
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
     {
-        Modify{{ UpperFirst(Property.attrib['Name']) }}(index) = value;
+        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
     }
-}
 
-{{ Property.attrib['Type'] }}& {{ ClassName }}::Modify{{ UpperFirst(Property.attrib['Name']) }}(int32_t index)
-{
-    int32_t bitIndex = index + static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property, 'Start') }});
-    GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(bitIndex, true);
-    GetParent().MarkDirty();
-    return GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}[index];
-}
-
-bool {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}PushBack(const {{ Property.attrib['Type'] }} &value)
-{
-    int32_t indexToSet = GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.size();
-    if (indexToSet < {{ Property.attrib['Count'] }})
-    {
-        GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.push_back(value);
-        int32_t bitIndex = indexToSet + static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property, 'Start') }});
-        GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(bitIndex, true);
-        GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(aznumeric_cast<uint32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property, 'Size') }}), true);
-        GetParent().MarkDirty();
-        return true;
-    }
-    return false;
-}
-
-bool {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}PopBack(const Multiplayer::NetworkInput&)
-{
-    if (!GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.empty())
-    {
-        GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.pop_back();
-        GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(aznumeric_cast<uint32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property, 'Size') }}), true);
-        GetParent().MarkDirty();
-        return true;
-    }
-    return false;
-}
-
-void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}Clear(const Multiplayer::NetworkInput&)
-{
-    GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property, 'Size') }}), true);
-    GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.clear();
-    GetParent().MarkDirty();
-}
-
-{%     elif Property.attrib['Container'] == 'Object' %}
-void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(const {{ Property.attrib['Type'] }}& value)
-{
-    if (GetParent().m_{{ LowerFirst(Property.attrib['Name']) }} != value)
-    {
-        Modify{{ UpperFirst(Property.attrib['Name']) }}() = value;
-    }
-}
-
-{{ Property.attrib['Type'] }}& {{ ClassName }}::Modify{{ UpperFirst(Property.attrib['Name']) }}()
-{
-    GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property) }}), true);
-    GetParent().MarkDirty();
-    return GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}{% if Property.attrib['IsRewindable']|booleanTrue %}.Modify(){% endif %};
-}
-
-{%     else %}
-void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(const {{ Property.attrib['Type'] }}& value)
-{
-    if (GetParent().m_{{ LowerFirst(Property.attrib['Name']) }} != value)
-    {
-        GetParent().m_{{ LowerFirst(Property.attrib['Name']) }} = value;
-        GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property) }}), true);
-        GetParent().MarkDirty();
-    }
-}
-
-{%     endif %}
-{% endmacro %}
-{#
-
-#}
-{% macro DefineNetworkPropertySet(Component, ReplicateFrom, ReplicateTo, ClassName, Property) %}
-{%     if Property.attrib['Container'] == 'Array' %}
-void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index, const {{ Property.attrib['Type'] }}& value)
-{
-    if (GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}[index] != value)
-    {
-        Modify{{ UpperFirst(Property.attrib['Name']) }}(index) = value;
-    }
-}
-
-{{ Property.attrib['Type'] }}& {{ ClassName }}::Modify{{ UpperFirst(Property.attrib['Name']) }}(int32_t index)
-{
     int32_t bitIndex = index + static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property, 'Start') }});
     GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(bitIndex, true);
     GetParent().MarkDirty();
@@ -208,6 +150,11 @@ void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index
 {%     elif Property.attrib['Container'] == 'Vector' %}
 void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index, const {{ Property.attrib['Type'] }}& value)
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
+    }
+
     if (GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}[index] != value)
     {
         Modify{{ UpperFirst(Property.attrib['Name']) }}(index) = value;
@@ -216,6 +163,11 @@ void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index
 
 {{ Property.attrib['Type'] }}& {{ ClassName }}::Modify{{ UpperFirst(Property.attrib['Name']) }}(int32_t index)
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
+    }
+
     int32_t bitIndex = index + static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property, 'Start') }});
     GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(bitIndex, true);
     GetParent().MarkDirty();
@@ -224,6 +176,11 @@ void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index
 
 bool {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}PushBack(const {{ Property.attrib['Type'] }} &value)
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
+    }
+
     int32_t indexToSet = GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.size();
     if (indexToSet < {{ Property.attrib['Count'] }})
     {
@@ -239,6 +196,11 @@ bool {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}PushBack(const {{
 
 bool {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}PopBack()
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
+    }
+
     if (!GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.empty())
     {
         GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.pop_back();
@@ -251,6 +213,11 @@ bool {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}PopBack()
 
 void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}Clear()
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
+    }
+
     GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(aznumeric_cast<uint32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property, 'Size') }}), true);
     GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.clear();
     GetParent().MarkDirty();
@@ -259,6 +226,11 @@ void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}Clear()
 {%     elif Property.attrib['Container'] == 'Object' %}
 void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(const {{ Property.attrib['Type'] }}& value)
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
+    }
+
     if (GetParent().m_{{ LowerFirst(Property.attrib['Name']) }} != value)
     {
         Modify{{ UpperFirst(Property.attrib['Name']) }}() = value;
@@ -267,6 +239,11 @@ void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(const {{ Prop
 
 {{ Property.attrib['Type'] }}& {{ ClassName }}::Modify{{ UpperFirst(Property.attrib['Name']) }}()
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
+    }
+
     GetParent().m_currentRecord->m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.SetBit(static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property) }}), true);
     GetParent().MarkDirty();
     return static_cast<{{ Property.attrib['Type'] }}&>(GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}{% if Property.attrib['IsRewindable']|booleanTrue %}.Modify(){% endif %});
@@ -275,6 +252,11 @@ void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(const {{ Prop
 {%     else %}
 void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(const {{ Property.attrib['Type'] }}& value)
 {
+    if (const Multiplayer::NetBindComponent* netBindComponent = GetNetBindComponent())
+    {
+        netBindComponent->ValidatePropertyWrite(Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateFrom'] }}, Multiplayer::NetEntityRole::{{ Property.attrib['ReplicateTo'] }}, {{ IsPredictable }});
+    }
+
     if (GetParent().m_{{ LowerFirst(Property.attrib['Name']) }} != value)
     {
         GetParent().m_{{ LowerFirst(Property.attrib['Name']) }} = value;

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetBindComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetBindComponent.h
@@ -87,22 +87,68 @@ namespace Multiplayer
         //! @return EntityMigration::Enabled if the entity is allowed to migrate, EntityMigration::Disabled otherwise
         EntityMigration GetAllowEntityMigration() const;
 
+        //! This is a helper that validates the owning entity is in the correct role to read from a network property that matches the relicateFrom and replicateTo parameters.
+        //! @param replicateFrom the network entity role that the property replicates from
+        //! @param replicateTo   the network entity role that the property replicates to
+        //! @return boolean true if the read is valid, false if nothing is replicated to the target and invalid data will be read
+        bool ValidatePropertyRead(NetEntityRole replicateFrom, NetEntityRole replicateTo) const;
+
+        //! This is a helper that validates the owning entity is in the correct role to write to a network property that matches the relicateFrom, replicateTo parameters, and isPredictable parameters.
+        //! @param replicateFrom the network entity role that the property replicates from
+        //! @param replicateTo   the network entity role that the property replicates to
+        //! @param isPredictable true if the property is predictable, false otherwise
+        //! @return boolean true if the write is valid, false if the write will desync the network property
+        bool ValidatePropertyWrite(NetEntityRole replicateFrom, NetEntityRole replicateTo, bool isPredictable) const;
+
+        //! Returns whether or not a controller exists for the bound network entity.
+        //! Warning, this function is dangerous to use in game code as it makes it easy to write logic that will function incorrectly within multihost environments. Use carefully.
+        //! @return boolean true if a controller exists, false otherwise
         bool HasController() const;
+
+        //! Returns the bound NetworkEntityId that represents this entity.
+        //! @return the bound NetworkEntityId that represents this entity
         NetEntityId GetNetEntityId() const;
+
+        //! Returns the PrefabEntityId that this entity was loaded from.
+        //! @return the PrefabEntityId that this entity was loaded from
         const PrefabEntityId& GetPrefabEntityId() const;
+
+        //! Sets the PrefabEntityId that this entity was loaded from.
+        //! @param prefabEntityId the PrefabEntityId to mark as bound to this entity
         void SetPrefabEntityId(const PrefabEntityId& prefabEntityId);
+
+        //! Returns the PrefabAssetId of the prefab this entity was loaded from.
+        //! @return the PrefabAssetId of the prefab this entity was loaded from
         const AZ::Data::AssetId& GetPrefabAssetId() const;
+
+        //! Sets the PrefabAssetId of the prefab that this entity was loaded from.
+        //! @param val the PrefabAssetId to mark as bound to this entity
         void SetPrefabAssetId(const AZ::Data::AssetId& val);
+
+        //! Returns a const network entity handle to this entity.
+        //! @return a const network entity handle to this entity
         ConstNetworkEntityHandle GetEntityHandle() const;
+
+        //! Returns a non-const network entity handle for this entity, this allows controller access so use it with great caution.
+        //! Warning, this function is dangerous to use in game code as it makes it easy to write logic that will function incorrectly within multihost environments. Use carefully.
+        //! @return a non-const network entity handle to this entity
         NetworkEntityHandle GetEntityHandle();
 
+        //! Sets the AzNetworking::ConnectionId that 'owns' this entity from a local prediction standpoint.
+        //! This is important for correct rewind operation during backward reconciliation, as we shouldn't rewind anything owned by the autonomous entity itself.
+        //! @param connectionId the AzNetworking::ConnectionId to mark as the owner of this entity
         void SetOwningConnectionId(AzNetworking::ConnectionId connectionId);
+
+        //! Returns the AzNetworking::ConnectionId of the connection that owns this entity form a local prediction standpoint.
+        //! @return the AzNetworking::ConnectionId of the connection that owns this entity form a local prediction standpoint
         AzNetworking::ConnectionId GetOwningConnectionId() const;
 
         //! Allows a player host to autonomously control their player entity, even though the entity is in an authority role.
         //! Note: If this entity is already activated this will reactivate all of the multiplayer component controllers in order for them to reactivate under autonomous control.
         void EnablePlayerHostAutonomy(bool enabled);
 
+        //! This allocates and returns an appropriate MultiplayerComponentInputVector for the components bound to this entity.
+        //! @return a MultiplayerComponentInputVector suitable for this entity
         MultiplayerComponentInputVector AllocateComponentInputs();
 
         //! Return true if we're currently processing inputs.

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetBindComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetBindComponent.h
@@ -88,17 +88,19 @@ namespace Multiplayer
         EntityMigration GetAllowEntityMigration() const;
 
         //! This is a helper that validates the owning entity is in the correct role to read from a network property that matches the relicateFrom and replicateTo parameters.
+        //! @oaram propertyName  the name of the property, for logging and debugging purposes
         //! @param replicateFrom the network entity role that the property replicates from
         //! @param replicateTo   the network entity role that the property replicates to
         //! @return boolean true if the read is valid, false if nothing is replicated to the target and invalid data will be read
-        bool ValidatePropertyRead(NetEntityRole replicateFrom, NetEntityRole replicateTo) const;
+        bool ValidatePropertyRead(const char* propertyName, NetEntityRole replicateFrom, NetEntityRole replicateTo) const;
 
         //! This is a helper that validates the owning entity is in the correct role to write to a network property that matches the relicateFrom, replicateTo parameters, and isPredictable parameters.
+        //! @oaram propertyName  the name of the property, for logging and debugging purposes
         //! @param replicateFrom the network entity role that the property replicates from
         //! @param replicateTo   the network entity role that the property replicates to
         //! @param isPredictable true if the property is predictable, false otherwise
         //! @return boolean true if the write is valid, false if the write will desync the network property
-        bool ValidatePropertyWrite(NetEntityRole replicateFrom, NetEntityRole replicateTo, bool isPredictable) const;
+        bool ValidatePropertyWrite(const char* propertyName, NetEntityRole replicateFrom, NetEntityRole replicateTo, bool isPredictable) const;
 
         //! Returns whether or not a controller exists for the bound network entity.
         //! Warning, this function is dangerous to use in game code as it makes it easy to write logic that will function incorrectly within multihost environments. Use carefully.

--- a/Gems/Multiplayer/Code/Tests/NetworkEntityTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/NetworkEntityTests.cpp
@@ -441,4 +441,112 @@ namespace Multiplayer
         netBindComponent->MarkDirty();
         m_networkEntityManager->NotifyEntitiesDirtied();
     }
+
+    TEST_F(MultiplayerNetworkEntityTests, TestNetBindPropertyValidateAuthority)
+    {
+        AZStd::unique_ptr<EntityInfo> testEntity = AZStd::make_unique<EntityInfo>(3, "root", NetEntityId{ 3 }, EntityInfo::Role::None);
+        PopulateNetworkEntity(*testEntity);
+        SetupEntity(testEntity->m_entity, testEntity->m_netId, NetEntityRole::Authority);
+        testEntity->m_entity->Activate();
+        ConstNetworkEntityHandle handle(testEntity->m_entity.get(), m_networkEntityManager->GetNetworkEntityTracker());
+        NetBindComponent* netBindComponent = handle.GetNetBindComponent();
+
+        EXPECT_TRUE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Authority, NetEntityRole::Server));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Authority, NetEntityRole::Autonomous));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Authority, NetEntityRole::Client));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Autonomous, NetEntityRole::Authority));
+
+        const bool predictable(true);
+        EXPECT_TRUE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Server, predictable));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Autonomous, predictable));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Client, predictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Autonomous, NetEntityRole::Authority, predictable));
+
+        const bool notPredictable(false);
+        EXPECT_TRUE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Server, notPredictable));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Autonomous, notPredictable));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Client, notPredictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Autonomous, NetEntityRole::Authority, notPredictable));
+    }
+
+    TEST_F(MultiplayerNetworkEntityTests, TestNetBindPropertyValidateServer)
+    {
+        AZStd::unique_ptr<EntityInfo> testEntity = AZStd::make_unique<EntityInfo>(4, "root", NetEntityId{ 4 }, EntityInfo::Role::None);
+        PopulateNetworkEntity(*testEntity);
+        SetupEntity(testEntity->m_entity, testEntity->m_netId, NetEntityRole::Server);
+        testEntity->m_entity->Activate();
+        ConstNetworkEntityHandle handle(testEntity->m_entity.get(), m_networkEntityManager->GetNetworkEntityTracker());
+        NetBindComponent* netBindComponent = handle.GetNetBindComponent();
+
+        EXPECT_TRUE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Authority, NetEntityRole::Server));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Authority, NetEntityRole::Autonomous));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Authority, NetEntityRole::Client));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Autonomous, NetEntityRole::Authority));
+
+        const bool predictable(true);
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Server, predictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Autonomous, predictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Client, predictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Autonomous, NetEntityRole::Authority, predictable));
+
+        const bool notPredictable(false);
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Server, notPredictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Autonomous, notPredictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Client, notPredictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Autonomous, NetEntityRole::Authority, notPredictable));
+    }
+
+    TEST_F(MultiplayerNetworkEntityTests, TestNetBindPropertyValidateAutonomous)
+    {
+        AZStd::unique_ptr<EntityInfo> testEntity = AZStd::make_unique<EntityInfo>(5, "root", NetEntityId{ 5 }, EntityInfo::Role::None);
+        PopulateNetworkEntity(*testEntity);
+        SetupEntity(testEntity->m_entity, testEntity->m_netId, NetEntityRole::Autonomous);
+        testEntity->m_entity->Activate();
+        ConstNetworkEntityHandle handle(testEntity->m_entity.get(), m_networkEntityManager->GetNetworkEntityTracker());
+        NetBindComponent* netBindComponent = handle.GetNetBindComponent();
+
+        EXPECT_FALSE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Authority, NetEntityRole::Server));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Authority, NetEntityRole::Autonomous));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Authority, NetEntityRole::Client));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Autonomous, NetEntityRole::Authority));
+
+        const bool predictable(true);
+        EXPECT_TRUE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Server, predictable));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Autonomous, predictable));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Client, predictable));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Autonomous, NetEntityRole::Authority, predictable));
+
+        const bool notPredictable(false);
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Server, notPredictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Autonomous, notPredictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Client, notPredictable));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Autonomous, NetEntityRole::Authority, notPredictable));
+    }
+
+    TEST_F(MultiplayerNetworkEntityTests, TestNetBindPropertyValidateClient)
+    {
+        AZStd::unique_ptr<EntityInfo> testEntity = AZStd::make_unique<EntityInfo>(6, "root", NetEntityId{ 6 }, EntityInfo::Role::None);
+        PopulateNetworkEntity(*testEntity);
+        SetupEntity(testEntity->m_entity, testEntity->m_netId, NetEntityRole::Client);
+        testEntity->m_entity->Activate();
+        ConstNetworkEntityHandle handle(testEntity->m_entity.get(), m_networkEntityManager->GetNetworkEntityTracker());
+        NetBindComponent* netBindComponent = handle.GetNetBindComponent();
+
+        EXPECT_FALSE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Authority, NetEntityRole::Server));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Authority, NetEntityRole::Autonomous));
+        EXPECT_TRUE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Authority, NetEntityRole::Client));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyRead("TestProperty", NetEntityRole::Autonomous, NetEntityRole::Authority));
+
+        const bool predictable(true);
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Server, predictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Autonomous, predictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Client, predictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Autonomous, NetEntityRole::Authority, predictable));
+
+        const bool notPredictable(false);
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Server, notPredictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Autonomous, notPredictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Authority, NetEntityRole::Client, notPredictable));
+        EXPECT_FALSE(netBindComponent->ValidatePropertyWrite("TestProperty", NetEntityRole::Autonomous, NetEntityRole::Authority, notPredictable));
+    }
 } // namespace Multiplayer


### PR DESCRIPTION
Adds a series of validation hooks around network property read/write ops, so that gameplay programmers know when they've accessed a network property in a manner that violates an entities network role. Also adds unit tests as the logic for property read/write access are a bit non-trivial.

`[ RUN      ] MultiplayerNetworkEntityTests.TestNetBindPropertyValidateAuthority
[       OK ] MultiplayerNetworkEntityTests.TestNetBindPropertyValidateAuthority (4 ms)
[ RUN      ] MultiplayerNetworkEntityTests.TestNetBindPropertyValidateServer
[       OK ] MultiplayerNetworkEntityTests.TestNetBindPropertyValidateServer (5 ms)
[ RUN      ] MultiplayerNetworkEntityTests.TestNetBindPropertyValidateAutonomous
[       OK ] MultiplayerNetworkEntityTests.TestNetBindPropertyValidateAutonomous (5 ms)
[ RUN      ] MultiplayerNetworkEntityTests.TestNetBindPropertyValidateClient
[       OK ] MultiplayerNetworkEntityTests.TestNetBindPropertyValidateClient (4 ms)`