### PR TITLE
Fix ubuntu 20.04 installation issues related to duplicate 3rdParty::OpenSSL duplication

### DIFF
--- a/cmake/Platform/Linux/PAL_linux.cmake
+++ b/cmake/Platform/Linux/PAL_linux.cmake
@@ -51,16 +51,6 @@ set_property(CACHE PAL_TRAIT_LINUX_WINDOW_MANAGER PROPERTY STRINGS xcb wayland)
 # Use system default OpenSSL library instead of maintaining an O3DE version for Linux
 include(${CMAKE_CURRENT_LIST_DIR}/OpenSSL_linux.cmake)
 
-cmake_path(RELATIVE_PATH CMAKE_CURRENT_LIST_DIR BASE_DIRECTORY ${LY_ROOT_FOLDER} OUTPUT_VARIABLE openssl_install_code)
-
-set(openssl_install_code "
-# Use system default OpenSSL library instead of maintaining an O3DE version for Linux
-include(${openssl_cmake_rel_directory}/OpenSSL_linux.cmake)
-")
-
-# Inject custom logic to include the OpenSSL_linux.cmake into the generated BuiltInPackages_linux.cmake
-set_property(GLOBAL APPEND_STRING PROPERTY O3DE_BUILTIN_PACKAGES_INSTALL_CODE "${openssl_install_code}")
-
 if ("${OPENSSL_VERSION}" STREQUAL "")
     message(FATAL_ERROR "OpenSSL not detected. The OpenSSL dev package is required for O3DE")
 endif()

--- a/cmake/Platform/Linux/Packaging/prerm.in
+++ b/cmake/Platform/Linux/Packaging/prerm.in
@@ -10,12 +10,6 @@
 set -o errexit # exit on the first failure encountered
 
 {
-    # We dont remove this symlink that we potentially created because the user could have
-    # installed themselves. 
-    #if [[ -L "/usr/lib/x86_64-linux-gnu/libffi.so.6" ]]; then
-    #    sudo rm /usr/lib/x86_64-linux-gnu/libffi.so.6
-    #fi
-
     pushd @CPACK_PACKAGING_INSTALL_PREFIX@
     # delete python downloads
     rm -rf python/downloaded_packages python/runtime


### PR DESCRIPTION
## What does this PR do?
Fixes an issue with the installation debian package where the ```OpenSSL_linux.cmake``` file was included multiple times.

The root cause was the original logic to use the system openssl was in BuiltinPackages.cmake, which is not copied from the source installation but rather generated, so there was logic to append the openssl include. But with commit [d3760da](https://github.com/o3de/o3de/commit/d3760da0ab375a21d67a3be5ecefbedad2440d27) the include was moved to the PAL_Linux system cmake which always gets included. The ```O3DE_BUILTIN_PACKAGES_INSTALL_CODE``` string no longer needs this custom code to be injected.

Fixes https://github.com/o3de/o3de/issues/11743 

## How was this PR tested?

Built the installer on Ubuntu 20.04 and followed the repro steps
