### PR TITLE
Treat duplicate MarkForRemoval as acceptable

### DIFF
--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
@@ -553,7 +553,7 @@ namespace Multiplayer
         {
             if (entityReplicator->IsMarkedForRemoval())
             {
-                AZ_Warning("NET_RepDeletes", false, "Got a replicator delete message that is a duplicate id %llu remote host %s", static_cast<AZ::u64>(updateMessage.GetEntityId()), GetRemoteHostId().GetString().c_str());
+                AZ_Warning("NET_RepDeletes", false, "Entity replicator for id %llu is already marked for deletion on remote host %s", static_cast<AZ::u64>(updateMessage.GetEntityId()), GetRemoteHostId().GetString().c_str());
                 return true;
             }
             else if (entityReplicator->OwnsReplicatorLifetime())

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
@@ -554,6 +554,7 @@ namespace Multiplayer
             if (entityReplicator->IsMarkedForRemoval())
             {
                 AZLOG(NET_RepDeletes, "Got a replicator delete message that is a duplicate id %llu remote host %s", static_cast<AZ::u64>(updateMessage.GetEntityId()), GetRemoteHostId().GetString().c_str());
+                return true;
             }
             else if (entityReplicator->OwnsReplicatorLifetime())
             {

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
@@ -553,7 +553,7 @@ namespace Multiplayer
         {
             if (entityReplicator->IsMarkedForRemoval())
             {
-                AZLOG(NET_RepDeletes, "Got a replicator delete message that is a duplicate id %llu remote host %s", static_cast<AZ::u64>(updateMessage.GetEntityId()), GetRemoteHostId().GetString().c_str());
+                AZ_Warning("NET_RepDeletes", false, "Got a replicator delete message that is a duplicate id %llu remote host %s", static_cast<AZ::u64>(updateMessage.GetEntityId()), GetRemoteHostId().GetString().c_str());
                 return true;
             }
             else if (entityReplicator->OwnsReplicatorLifetime())
@@ -567,6 +567,11 @@ namespace Multiplayer
                 entityReplicator->MarkForRemoval();
                 AZLOG(NET_RepDeletes, "Deleting replicater for entity id %llu remote host %s", static_cast<AZ::u64>(updateMessage.GetEntityId()), GetRemoteHostId().GetString().c_str());
             }
+        }
+        else
+        {
+            AZ_Warning("NET_RepDeletes", false, "Replicator for id %llu is null on remote host %s", static_cast<AZ::u64>(updateMessage.GetEntityId()), GetRemoteHostId().GetString().c_str());
+            return true;
         }
 
         // Handle entity cleanup

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
@@ -570,7 +570,7 @@ namespace Multiplayer
         }
         else
         {
-            AZ_Warning("NET_RepDeletes", false, "Replicator for id %llu is null on remote host %s", static_cast<AZ::u64>(updateMessage.GetEntityId()), GetRemoteHostId().GetString().c_str());
+            AZ_Warning("NET_RepDeletes", false, "Replicator for id %llu is null on remote host %s. It may have already been deleted.", static_cast<AZ::u64>(updateMessage.GetEntityId()), GetRemoteHostId().GetString().c_str());
             return true;
         }
 

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
@@ -397,9 +397,9 @@ namespace Multiplayer
                 // @NetworkEntityManager::CreateEntitiesImmediate
                 AzFramework::GameEntityContextRequestBus::Broadcast(
                     &AzFramework::GameEntityContextRequestBus::Events::DestroyGameEntity, netBindComponent->GetEntityId());
-            }
 
-            m_networkEntityTracker.erase(entityId);
+                m_networkEntityTracker.erase(entityId);
+            }
         }
     }
 


### PR DESCRIPTION
Signed-off-by: puvvadar <puvvadar@amazon.com>

## What does this PR do?

HandleEntityDeleteMessage treats a duplicate MarkForRemoval of an entity as a failure resulting in a disconnection. This change updates to treat this as a no-op non failure.

Addresses https://github.com/o3de/o3de/issues/11695. 

## How was this PR tested?

Ran units and tested in MultiplayerSample.