### PR TITLE
Disable parenting an entity to another instance (#11659)

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -56,6 +56,7 @@ namespace AzToolsFramework
             bool IsOwnedByProceduralPrefabInstance(AZ::EntityId entityId) const override;
             bool IsInstanceContainerEntity(AZ::EntityId entityId) const override;
             bool IsLevelInstanceContainerEntity(AZ::EntityId entityId) const override;
+            bool EntitiesBelongToSameInstance(const EntityIdList& entityIds) const;
             AZ::EntityId GetInstanceContainerEntityId(AZ::EntityId entityId) const override;
             AZ::EntityId GetLevelInstanceContainerEntityId() const override;
             AZ::IO::Path GetOwningInstancePrefabPath(AZ::EntityId entityId) const override;
@@ -82,7 +83,6 @@ namespace AzToolsFramework
             EntityIdList SanitizeEntityIdList(const EntityIdList& entityIds) const;
 
             InstanceOptionalReference GetOwnerInstanceByEntityId(AZ::EntityId entityId) const;
-            bool EntitiesBelongToSameInstance(const EntityIdList& entityIds) const;
             void AddNewEntityToSortOrder(Instance& owningInstance, PrefabDom& domToAddEntityUnder,
                 const EntityAlias& parentEntityAlias, const EntityAlias& entityToAddAlias);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicInterface.h
@@ -122,7 +122,15 @@ namespace AzToolsFramework
              * @return True if the entity is the container entity for the level prefab instance, false otherwise.
              */
             virtual bool IsLevelInstanceContainerEntity(AZ::EntityId entityId) const = 0;
-            
+
+            /**
+             * Detects if a list of entities are under the same instance. The instance of
+             * a container entity is special cased to be the parent instance of its instance.
+             * @param entityIds The list of entities to query.
+             * @return True if all entities in the list have the same instance, false otherwise.
+             */
+            virtual bool EntitiesBelongToSameInstance(const EntityIdList& entityIds) const = 0;
+
             /**
              * Gets the entity id for the instance container of the owning instance.
              * @param entityId The id of the entity to query.


### PR DESCRIPTION
* Disable parenting an entity from one instance to a parent in another instance

Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

## What does this PR do?

Cherry-pick https://github.com/o3de/o3de/pull/11659 from development branch.

## How was this PR tested?

Manual testing.
