### PR TITLE
bugfix(Script Canvas): Unable to edit Tag in property field

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Crc.h
+++ b/Code/Framework/AzCore/AzCore/Math/Crc.h
@@ -10,6 +10,7 @@
 #include <AzCore/base.h>
 #include <AzCore/std/hash.h>
 #include <AzCore/std/string/string_view.h>
+#include <AzCore/RTTI/TypeInfoSimple.h>
 
 //////////////////////////////////////////////////////////////////////////
 // Macros for pre-processor Crc32 conversion
@@ -57,6 +58,8 @@ namespace AZ
     class Crc32
     {
     public:
+        AZ_TYPE_INFO(Crc32, "{88345436-06F2-4DA9-B687-9F821A4FA115}")
+
         /**
          * Initializes to 0.
          */

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCRCCtrl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCRCCtrl.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
+#include <AzCore/Math/Crc.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <QtWidgets/QWidget>
 
@@ -56,24 +57,41 @@ namespace AzToolsFramework
         
     };
 
-    // note:  QT Objects cannot themselves be templates, else I would templatize creategui as well.
-    class U32CRCHandler  
-        : public QObject
-        , public PropertyHandler<AZ::u32, PropertyCRCCtrl>
+    template<class ValueType>
+    class CRC32HandlerCommon : public PropertyHandler<ValueType, PropertyCRCCtrl>
     {
-    Q_OBJECT
+    public:
+        AZ::u32 GetHandlerName(void) const override { return AZ::Edit::UIHandlers::Crc; }
+        bool IsDefaultHandler() const override { return true; }
+        QWidget* GetFirstInTabOrder(PropertyCRCCtrl* widget) override { return widget->GetFirstInTabOrder(); }
+        QWidget* GetLastInTabOrder(PropertyCRCCtrl* widget) override { return widget->GetLastInTabOrder(); }
+        void UpdateWidgetInternalTabbing(PropertyCRCCtrl* widget) override { widget->UpdateTabOrder(); }
+    };
+
+    class U32CRCHandler
+        : public QObject
+        , public CRC32HandlerCommon<AZ::u32>
+    {
     public:
         AZ_CLASS_ALLOCATOR(U32CRCHandler, AZ::SystemAllocator, 0);
-
-        AZ::u32 GetHandlerName(void) const override;
-        QWidget* GetFirstInTabOrder(PropertyCRCCtrl* widget) override;
-        QWidget* GetLastInTabOrder(PropertyCRCCtrl* widget) override;
-        void UpdateWidgetInternalTabbing(PropertyCRCCtrl* widget) override;
 
         QWidget* CreateGUI(QWidget* pParent) override;
         void ConsumeAttribute(PropertyCRCCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
         void WriteGUIValuesIntoProperty(size_t index, PropertyCRCCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
-        bool ReadValuesIntoGUI(size_t index, PropertyCRCCtrl* GUI, const property_t& instance, InstanceDataNode* node)  override;
+        bool ReadValuesIntoGUI(size_t index, PropertyCRCCtrl* GUI, const property_t& instance, InstanceDataNode* node) override;
+    };
+
+    class CRC32Handler
+        : public QObject
+        , public CRC32HandlerCommon<AZ::Crc32>
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(CRC32Handler, AZ::SystemAllocator, 0);
+
+        QWidget* CreateGUI(QWidget* pParent) override;
+        void ConsumeAttribute(PropertyCRCCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
+        void WriteGUIValuesIntoProperty(size_t index, PropertyCRCCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
+        bool ReadValuesIntoGUI(size_t index, PropertyCRCCtrl* GUI, const property_t& instance, InstanceDataNode* node) override;
     };
 
     void RegisterCrcHandler();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCRCCtrl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCRCCtrl.h
@@ -40,6 +40,7 @@ namespace AzToolsFramework
 
     Q_SIGNALS:
         void valueChanged(AZ::u32 newValue);
+        void finishedEditing(AZ::u32 newValue);
 
     public Q_SLOTS:
         void setValue(AZ::u32 val);
@@ -51,9 +52,6 @@ namespace AzToolsFramework
 
         void UpdateValueText();
         AZ::u32 TextToValue();
-
-    protected:
-        void FocusChangedEdit(bool hasFocus);
         
     };
 
@@ -62,7 +60,6 @@ namespace AzToolsFramework
     {
     public:
         AZ::u32 GetHandlerName(void) const override { return AZ::Edit::UIHandlers::Crc; }
-        bool IsDefaultHandler() const override { return true; }
         QWidget* GetFirstInTabOrder(PropertyCRCCtrl* widget) override { return widget->GetFirstInTabOrder(); }
         QWidget* GetLastInTabOrder(PropertyCRCCtrl* widget) override { return widget->GetLastInTabOrder(); }
         void UpdateWidgetInternalTabbing(PropertyCRCCtrl* widget) override { widget->UpdateTabOrder(); }
@@ -76,6 +73,7 @@ namespace AzToolsFramework
         AZ_CLASS_ALLOCATOR(U32CRCHandler, AZ::SystemAllocator, 0);
 
         QWidget* CreateGUI(QWidget* pParent) override;
+        bool IsDefaultHandler() const override { return false; }
         void ConsumeAttribute(PropertyCRCCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
         void WriteGUIValuesIntoProperty(size_t index, PropertyCRCCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
         bool ReadValuesIntoGUI(size_t index, PropertyCRCCtrl* GUI, const property_t& instance, InstanceDataNode* node) override;
@@ -89,6 +87,7 @@ namespace AzToolsFramework
         AZ_CLASS_ALLOCATOR(CRC32Handler, AZ::SystemAllocator, 0);
 
         QWidget* CreateGUI(QWidget* pParent) override;
+        bool IsDefaultHandler() const override { return true; }
         void ConsumeAttribute(PropertyCRCCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
         void WriteGUIValuesIntoProperty(size_t index, PropertyCRCCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
         bool ReadValuesIntoGUI(size_t index, PropertyCRCCtrl* GUI, const property_t& instance, InstanceDataNode* node) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h
@@ -289,6 +289,8 @@ namespace AzToolsFramework
         virtual PropertyHandlerBase* ResolvePropertyHandler(AZ::u32 handlerName, const AZ::Uuid& handlerType) = 0;
     };
 
+    using PropertyTypeRegistrationMessageBus = AZ::EBus<PropertyTypeRegistrationMessages>;
+
     /**
      * Events/bus for listening externally for property changes on a specific entity.
      */

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h
@@ -144,6 +144,8 @@ namespace AzToolsFramework
         virtual void OnEditingFinished([[maybe_unused]] QWidget* editorGUI) {}
     }; 
 
+    using PropertyEditorGUIMessagesBus = AZ::EBus<PropertyEditorGUIMessages>;
+
     // A GenericPropertyHandler may be used to register a widget for a property handler ID that is always used, regardless of the underlying
     // type This is useful for UI elements that don't have any specific underlying storage, like buttons
     template<class WidgetType>


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/9823

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

Fixes configure setting the tag property in the property window for script canvas. Couple of notes with this widget.

- Its very hard to set a value the cursor is reset so you have to set a single value one by one
- CRC tags are associated with strings would be convenient to let the user pass in a string to set the crc value. not sure how this would work maybe ux would have an opinion. 


https://user-images.githubusercontent.com/854359/188374443-22ffd8b7-d5f5-4853-9509-a430c53d863f.mp4

## How was this PR tested?

follow steps in the linked issue ticket.
