### PR TITLE
bugfix(Script Canvas): use same icon for both normal and hover for preview color

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/ConstructMenuActions/ConstructPresetMenuActions.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/ConstructMenuActions/ConstructPresetMenuActions.cpp
@@ -52,8 +52,11 @@ namespace GraphCanvas
         QPixmap* pixmap = preset->GetDisplayIcon(contextMenu->GetEditorId());
 
         if (pixmap)
-        {
-            setIcon(QIcon((*pixmap)));
+        {     
+            QIcon icon;
+            icon.addPixmap(*pixmap, QIcon::Normal);
+            icon.addPixmap(*pixmap, QIcon::Active);
+            setIcon(icon);
         }
 
         m_isInToolbar = contextMenu->IsToolBarMenu();
@@ -124,7 +127,10 @@ namespace GraphCanvas
 
         if (pixmap)
         {
-            setIcon(QIcon((*pixmap)));
+            QIcon icon;
+            icon.addPixmap(*pixmap, QIcon::Normal);
+            icon.addPixmap(*pixmap, QIcon::Active);
+            setIcon(icon);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

use the same icon for both hover and normal state of color icon for script canvas.

https://user-images.githubusercontent.com/854359/188545833-7eb7adc9-305d-4bd2-8631-37d48f2e3c6b.mp4

## How was this PR tested?

follow steps listed in issue ticket

https://github.com/o3de/o3de/issues/11740
