### PR TITLE
Fix hang when calling ElidingLabel::setText from other thread other t…

### DIFF
--- a/Code/Editor/Plugins/EditorAssetImporter/AssetImporterWindow.cpp
+++ b/Code/Editor/Plugins/EditorAssetImporter/AssetImporterWindow.cpp
@@ -256,9 +256,7 @@ void AssetImporterWindow::OpenFileInternal(const AZStd::string& filePath)
         {
             m_assetImporterDocument->LoadScene(filePath);
 
-            // Update the UI on the main thread.
-            QTimer::singleShot(0, [&]() { UpdateSceneDisplay({}); });
-            
+            UpdateSceneDisplay({}); 
         },
         [this]()
         {
@@ -612,9 +610,9 @@ void AssetImporterWindow::UpdateSceneDisplay(const AZStd::shared_ptr<AZ::SceneAP
             .append(")");
     }
 
-    if (scene)
+     if (scene)
     {
-        m_rootDisplay->SetSceneDisplay(sceneHeaderText, scene);
+         m_rootDisplay->SetSceneDisplay(sceneHeaderText, scene);
     }
     else
     {


### PR DESCRIPTION
…han main.

Signed-off-by: sphrose <82213493+sphrose@users.noreply.github.com>

## What does this PR do?

This PR fixes an issue where an eliding label has its setText method called from a thread. The subsequent call to FontMetrics::elidedText will cause a crash within Qt.

https://github.com/o3de/o3de/issues/11487

## How was this PR tested?

The case mentioned in the issue was used for testing. The Scene Setting tool was opened on an fbx file, with the call to setText removed from the QTimer::singleShot protection: no crash occurred. Without the fix to ElidingLabel.cpp included here, the crash was as described.