### PR TITLE
Added back missing '.' character that was incorrectly removed

### DIFF
--- a/Code/Tools/AssetProcessor/native/InternalBuilders/SettingsRegistryBuilder.cpp
+++ b/Code/Tools/AssetProcessor/native/InternalBuilders/SettingsRegistryBuilder.cpp
@@ -167,7 +167,7 @@ namespace AssetProcessor
             }
         }
 
-        AZ::IO::Path outputPath = AZ::IO::Path(request.m_tempDirPath) / "bootstrap.game";
+        AZ::IO::Path outputPath = AZ::IO::Path(request.m_tempDirPath) / "bootstrap.game.";
         size_t extensionOffset = outputPath.Native().size();
 
         if (!platformCodes.empty())


### PR DESCRIPTION
The Settings Registry builder uses a filename prefix of
`bootstrap.game.` as a prefix for generating the launchers settings
registry file and the final '.' was incorrectly removed in this
[commit](https://github.com/o3de/o3de/commit/139e535cb8f494d43e6689a8b19ed1905db784f3#diff-8709932f0f3f12cb1ef4041a9245713e5ac46ba615a4b5f3d01b3b83abad7b58R170)

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
