### PR TITLE
Add GetLinkDom and SetLinkDom benchmarks

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.cpp
@@ -10,8 +10,12 @@
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
 #include <Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.h>
 
-#define REGISTER_MULTIPLE_PATCHES_BENCHMARK(BaseClass, Method)                                                                              \
-    BENCHMARK_REGISTER_F(BaseClass, Method)->RangeMultiplier(10)->Range(100, 10000)->Unit(benchmark::kMillisecond);
+#define REGISTER_MULTIPLE_PATCHES_BENCHMARK(BaseClass, Method)                                                                             \
+    BENCHMARK_REGISTER_F(BaseClass, Method)                                                                                                \
+        ->RangeMultiplier(10)                                                                                                              \
+        ->Range(100, 10000)                                                                                                                \
+        ->ArgNames({ "PatchesCount" })                                                                                                     \
+        ->Unit(benchmark::kMillisecond);
 
 namespace Benchmark
 {
@@ -24,7 +28,10 @@ namespace Benchmark
         const unsigned int numEntities = static_cast<unsigned int>(state.range());
 
         AZStd::vector<AZ::Entity*> entities;
-        for (unsigned int i = 0; i < numEntities; i++)
+
+        // The patch array generated in this function on transform component has 2 elements. To keep the patch count match the range,
+        // we are only creating half the number of entities; (1 entity * 2 patches * n/2) = n patches, where n is the range.
+        for (unsigned int i = 0; i < numEntities / 2; i++)
         {
             entities.emplace_back(CreateEntity("Entity"));
         }
@@ -70,7 +77,6 @@ namespace Benchmark
 
         LinkReference link = m_prefabSystemComponent->FindLink(m_linkId);
         AZ_Assert(link.has_value(), "Link between prefabs is missing.");
-
         
         m_linkDomToSet->AddMember(
             rapidjson::StringRef(PrefabDomUtils::SourceName), rapidjson::StringRef(m_paths.front().c_str()), m_linkDomToSet->GetAllocator());

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#if defined(HAVE_BENCHMARK)
+
+#include <AzToolsFramework/Prefab/PrefabDomUtils.h>
+#include <Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.h>
+
+#define REGISTER_MULTIPLE_PATCHES_BENCHMARK(BaseClass, Method)                                                                              \
+    BENCHMARK_REGISTER_F(BaseClass, Method)->RangeMultiplier(10)->Range(100, 10000)->Unit(benchmark::kMillisecond);
+
+namespace Benchmark
+{
+    using namespace AzToolsFramework::Prefab;
+
+    void SingleInstanceMultiplePatchesBenchmarks::SetupHarness(const benchmark::State& state)
+    {
+        BM_Prefab::SetupHarness(state);
+        
+        const unsigned int numEntities = static_cast<unsigned int>(state.range());
+
+        AZStd::vector<AZ::Entity*> entities;
+        for (unsigned int i = 0; i < numEntities; i++)
+        {
+            entities.emplace_back(CreateEntity("Entity"));
+        }
+
+        CreateFakePaths(2);
+        AZStd::unique_ptr<AzToolsFramework::Prefab::Instance> nestedInstance =
+            m_prefabSystemComponent->CreatePrefab(entities, {}, m_paths.front());
+
+        m_parentInstance = m_prefabSystemComponent->CreatePrefab({}, MakeInstanceList(AZStd::move(nestedInstance)), m_paths.back());
+
+        m_linkDomToSet = AZStd::make_unique<PrefabDom>();
+        m_linkDomToSet->SetObject();
+        PrefabDomValue patchesArray;
+        patchesArray.SetArray();
+        m_parentInstance->GetNestedInstances(
+            [this, &patchesArray](AZStd::unique_ptr<Instance>& nestedInstance)
+            {
+                m_linkId = nestedInstance->GetLinkId();
+                nestedInstance->GetEntities(
+                    [this, &patchesArray](AZStd::unique_ptr<AZ::Entity>& entity)
+                    {
+                        PrefabDom entityDomBefore;
+                        InstanceToTemplateInterface* instanceToTemplateInterface = AZ::Interface<InstanceToTemplateInterface>::Get();
+                        AZ_Assert(instanceToTemplateInterface, "Could not retrieve instance of InstanceToTemplateInterface");
+                        instanceToTemplateInterface->GenerateDomForEntity(entityDomBefore, *(entity.get()));
+
+                        AZ::TransformBus::Event(entity->GetId(), &AZ::TransformBus::Events::SetWorldX, 10.0f);
+                        PrefabDom entityDomAfter;
+                        instanceToTemplateInterface->GenerateDomForEntity(entityDomAfter, *(entity.get()));
+
+                        PrefabDom patch;
+                        instanceToTemplateInterface->GeneratePatch(patch, entityDomBefore, entityDomAfter);
+                        instanceToTemplateInterface->AppendEntityAliasToPatchPaths(patch, entity->GetId());
+                        for (auto& entry : patch.GetArray())
+                        {
+                            PrefabDomValue patchEntryCopy;
+                            patchEntryCopy.CopyFrom(entry, m_linkDomToSet->GetAllocator());
+                            patchesArray.PushBack(patchEntryCopy.Move(), m_linkDomToSet->GetAllocator());
+                        }
+                        return true;
+                    });
+            });
+
+        LinkReference link = m_prefabSystemComponent->FindLink(m_linkId);
+        AZ_Assert(link.has_value(), "Link between prefabs is missing.");
+
+        
+        m_linkDomToSet->AddMember(
+            rapidjson::StringRef(PrefabDomUtils::SourceName), rapidjson::StringRef(m_paths.front().c_str()), m_linkDomToSet->GetAllocator());
+
+        m_linkDomToSet->AddMember(rapidjson::StringRef(PrefabDomUtils::PatchesName), patchesArray, m_linkDomToSet->GetAllocator());
+
+        link->get().SetLinkDom(*m_linkDomToSet);
+    }
+
+    void SingleInstanceMultiplePatchesBenchmarks::TeardownHarness(const benchmark::State& state)
+    {
+        m_linkDomToSet.reset();
+        m_parentInstance.reset();
+        BM_Prefab::TeardownHarness(state);
+    }
+
+    BENCHMARK_DEFINE_F(SingleInstanceMultiplePatchesBenchmarks, GetLinkDom)(benchmark::State& state)
+    {
+        for (auto _ : state)
+        {
+            LinkReference link = m_prefabSystemComponent->FindLink(m_linkId);
+            AZ_Assert(link.has_value(), "Link between prefabs is missing.");
+            link->get().GetLinkDom();
+        }
+    }
+    REGISTER_MULTIPLE_PATCHES_BENCHMARK(SingleInstanceMultiplePatchesBenchmarks, GetLinkDom);
+
+    BENCHMARK_DEFINE_F(SingleInstanceMultiplePatchesBenchmarks, SetLinkDom)(benchmark::State& state)
+    {
+        for (auto _ : state)
+        {
+            LinkReference link = m_prefabSystemComponent->FindLink(m_linkId);
+            AZ_Assert(link.has_value(), "Link between prefabs is missing.");
+            link->get().SetLinkDom(*m_linkDomToSet);
+        }
+    }
+    REGISTER_MULTIPLE_PATCHES_BENCHMARK(SingleInstanceMultiplePatchesBenchmarks, SetLinkDom);
+
+} // namespace Benchmark
+#endif

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#if defined(HAVE_BENCHMARK)
+
+#pragma once
+
+#include <Prefab/Benchmark/PrefabBenchmarkFixture.h>
+
+namespace Benchmark
+{
+    //! This class captures benchmarks around CRUD operations on patches to a single prefab instance with multiple entities that are side-by-side.
+    class SingleInstanceMultiplePatchesBenchmarks : public BM_Prefab
+    {
+    protected:
+        void SetupHarness(const benchmark::State& state) override;
+        void TeardownHarness(const benchmark::State& state) override;
+
+        AZStd::unique_ptr<PrefabDom> m_linkDomToSet;
+        AZStd::unique_ptr<Instance> m_parentInstance;
+        LinkId m_linkId;
+    };
+} // namespace Benchmark
+#endif

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -66,6 +66,8 @@ set(FILES
     ManipulatorViewTests.cpp
     PerforceComponentTests.cpp
     PlatformAddressedAssetCatalogTests.cpp
+    Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.cpp
+    Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.h
     Prefab/Benchmark/PrefabBenchmarkFixture.cpp
     Prefab/Benchmark/PrefabBenchmarkFixture.h
     Prefab/Benchmark/PrefabCreateBenchmarks.cpp


### PR DESCRIPTION
## What does this PR do?
This PR adds benchmarks for GetLinkDom and SetLinkDom functions in AzToolsFramework::Prefab::Link class. These benchmarks will be useful if and when the storage format or logic changes to get and set link doms.

## How was this PR tested?
Here are the benchmark numbers. The times taken are almost negligible because the current logic simply gets and sets a member variable in the object without doing any additional operations.
```
----------------------------------------------------------------------------------------------------------------
Benchmark                                                                      Time             CPU   Iterations
----------------------------------------------------------------------------------------------------------------
SingleInstanceMultiplePatchesBenchmarks/GetLinkDom/PatchesCount:100        0.000 ms        0.000 ms    213333333
SingleInstanceMultiplePatchesBenchmarks/GetLinkDom/PatchesCount:1000       0.000 ms        0.000 ms    213333333
SingleInstanceMultiplePatchesBenchmarks/GetLinkDom/PatchesCount:10000      0.000 ms        0.000 ms    203636364
SingleInstanceMultiplePatchesBenchmarks/SetLinkDom/PatchesCount:100        0.010 ms        0.010 ms        64000
SingleInstanceMultiplePatchesBenchmarks/SetLinkDom/PatchesCount:1000       0.104 ms        0.105 ms         7467
SingleInstanceMultiplePatchesBenchmarks/SetLinkDom/PatchesCount:10000       1.06 ms         1.05 ms          640
```
