### PR TITLE
Prefab | Remove deprecated delete API in public interface

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -1060,13 +1060,6 @@ namespace AzToolsFramework
             return AZ::Success(m_prefabSystemComponentInterface->IsTemplateDirty(templateId));
         }
 
-        PrefabOperationResult PrefabPublicHandler::DeleteEntitiesInInstance(const EntityIdList& entityIds)
-        {
-            AZ_Warning(
-                "Prefab", false, "This function is marked for deprecation. Please use DeleteEntitiesAndAllDescendantsInInstance instead.");
-            return DeleteFromInstance(entityIds);
-        }
-
         PrefabOperationResult PrefabPublicHandler::DeleteEntitiesAndAllDescendantsInInstance(const EntityIdList& entityIds)
         {
             return DeleteFromInstance(entityIds);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -62,9 +62,6 @@ namespace AzToolsFramework
             AZ::IO::Path GetOwningInstancePrefabPath(AZ::EntityId entityId) const override;
             PrefabRequestResult HasUnsavedChanges(AZ::IO::Path prefabFilePath) const override;
 
-            //! [DEPRECATION]--This function is marked for deprecation. Please use DeleteEntitiesAndAllDescendantsInInstance instead.
-            PrefabOperationResult DeleteEntitiesInInstance(const EntityIdList& entityIds) override;
-
             PrefabOperationResult DeleteEntitiesAndAllDescendantsInInstance(const EntityIdList& entityIds) override;
             DuplicatePrefabResult DuplicateEntitiesInInstance(const EntityIdList& entityIds) override;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicInterface.h
@@ -159,14 +159,6 @@ namespace AzToolsFramework
             virtual PrefabRequestResult HasUnsavedChanges(AZ::IO::Path prefabFilePath) const = 0;
 
             /**
-             * [DEPRECATION]--This function is marked for deprecation. Please use DeleteEntitiesAndAllDescendantsInInstance instead.
-             * Deletes all entities from the owning instance. Bails if the entities don't all belong to the same instance.
-             * @param entities The entities to delete.
-             * @return An outcome object; on failure, it comes with an error message detailing the cause of the error.
-             */
-            virtual PrefabOperationResult DeleteEntitiesInInstance(const EntityIdList& entityIds) = 0;
-            
-            /**
              * Deletes all entities and their descendants from the owning instance. Bails if the entities don't all belong to the same
              * instance.
              * @param entities The entities to delete. Their descendants will be discovered by this function.

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteTests.cpp
@@ -18,7 +18,7 @@ namespace UnitTest
 {
     using PrefabDeleteTest = PrefabTestFixture;
 
-    TEST_F(PrefabDeleteTest, DeleteEntitiesInInstance_DeleteSingleEntitySucceeds)
+    TEST_F(PrefabDeleteTest, DeleteEntitiesAndAllDescendantsInInstance_DeleteSingleEntitySucceeds)
     {
         PrefabEntityResult createEntityResult = m_prefabPublicInterface->CreateEntity(AZ::EntityId(), AZ::Vector3());
 
@@ -35,7 +35,7 @@ namespace UnitTest
         EXPECT_TRUE(testEntity == nullptr);
     }
 
-    TEST_F(PrefabDeleteTest, DeleteEntitiesInInstance_DeleteSinglePrefabSucceeds)
+    TEST_F(PrefabDeleteTest, DeleteEntitiesAndAllDescendantsInInstance_DeleteSinglePrefabSucceeds)
     {
         PrefabEntityResult createEntityResult = m_prefabPublicInterface->CreateEntity(AZ::EntityId(), AZ::Vector3());
 


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

This PR removes the deprecated delete API in public prefab handler. The API was already marked as DEPRECATED since last release 2205.

## How was this PR tested?

All tests passed.
