### PR TITLE
Procedural Prefabs | Disable the ability to create a camera entity inside read-only procedural prefab instance

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -100,6 +100,13 @@ namespace AzToolsFramework::Prefab
             "Focus Mode Interface could not be found. "
             "Check that it is being correctly initialized.");
 
+        m_readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get();
+        AZ_Assert(
+            m_readOnlyEntityPublicInterface,
+            "Prefab - PrefabFocusHandler - "
+            "ReadOnly Entity Public Interface could not be found. "
+            "Check that it is being correctly initialized.");
+
         m_readOnlyEntityQueryInterface = AZ::Interface<ReadOnlyEntityQueryInterface>::Get();
         AZ_Assert(
             m_readOnlyEntityQueryInterface,
@@ -363,6 +370,18 @@ namespace AzToolsFramework::Prefab
         [[maybe_unused]] AzFramework::EntityContextId entityContextId) const
     {
         return GetInstanceReference(m_rootAliasFocusPath);
+    }
+
+    bool PrefabFocusHandler::IsFocusedPrefabInstanceReadOnly([[maybe_unused]] AzFramework::EntityContextId entityContextId) const
+    {
+        InstanceOptionalReference instance = GetInstanceReference(m_rootAliasFocusPath);
+
+        if (instance.has_value())
+        {
+            return m_readOnlyEntityPublicInterface->IsReadOnly(instance->get().GetContainerEntityId());
+        }
+
+        return false;
     }
 
     LinkId PrefabFocusHandler::AppendPathFromFocusedInstanceToPatchPaths(PrefabDom& providedPatch, AZ::EntityId entityId) const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
@@ -23,6 +23,7 @@ namespace AzToolsFramework
 {
     class ContainerEntityInterface;
     class FocusModeInterface;
+    class ReadOnlyEntityPublicInterface;
     class ReadOnlyEntityQueryInterface;
 }
 
@@ -55,6 +56,7 @@ namespace AzToolsFramework::Prefab
         PrefabFocusOperationResult FocusOnPrefabInstanceOwningEntityId(AZ::EntityId entityId) override;
         TemplateId GetFocusedPrefabTemplateId(AzFramework::EntityContextId entityContextId) const override;
         InstanceOptionalReference GetFocusedPrefabInstance(AzFramework::EntityContextId entityContextId) const override;
+        bool IsFocusedPrefabInstanceReadOnly(AzFramework::EntityContextId entityContextId) const override;
         LinkId AppendPathFromFocusedInstanceToPatchPaths(PrefabDom& providedPatch, AZ::EntityId entityId) const override;
 
         // PrefabFocusPublicInterface and PrefabFocusPublicRequestBus overrides ...
@@ -105,6 +107,7 @@ namespace AzToolsFramework::Prefab
 
         ContainerEntityInterface* m_containerEntityInterface = nullptr;
         FocusModeInterface* m_focusModeInterface = nullptr;
+        ReadOnlyEntityPublicInterface* m_readOnlyEntityPublicInterface = nullptr;
         ReadOnlyEntityQueryInterface* m_readOnlyEntityQueryInterface = nullptr;
     };
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusInterface.h
@@ -47,6 +47,11 @@ namespace AzToolsFramework::Prefab
         //! @return The focused instance.
         virtual InstanceOptionalReference GetFocusedPrefabInstance(AzFramework::EntityContextId entityContextId) const = 0;
 
+        //! Returns whether the currently focused prefab instance is read-only.
+        //! @param EntityContextId The entity context id.
+        //! @return True if the currently focused prefab instance is read-only, false otherwise.
+        virtual bool IsFocusedPrefabInstanceReadOnly(AzFramework::EntityContextId entityContextId) const = 0;
+
         //! Appends the path from the focused instance to entity id into the provided patch array.
         //! @param providedPatch The provided path array to be appended to.
         //! @return LinkId stored in the instance closest to the focused instance in hierarchy.

--- a/Gems/Camera/Code/Source/CameraEditorSystemComponent.cpp
+++ b/Gems/Camera/Code/Source/CameraEditorSystemComponent.cpp
@@ -21,6 +21,7 @@
 #include <AzToolsFramework/API/EntityCompositionRequestBus.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipInterface.h>
+#include <AzToolsFramework/Prefab/PrefabFocusInterface.h>
 
 #include <AzToolsFramework/API/EditorCameraBus.h>
 #include "ViewportCameraSelectorWindow.h"
@@ -71,25 +72,53 @@ namespace Camera
         if (!(flags & AzToolsFramework::EditorEvents::eECMF_HIDE_ENTITY_CREATION))
         {
             QAction* action = menu->addAction(QObject::tr("Create camera entity from view"));
-            const auto prefabEditorEntityOwnershipInterface = AZ::Interface<AzToolsFramework::PrefabEditorEntityOwnershipInterface>::Get();
-            if (prefabEditorEntityOwnershipInterface && !prefabEditorEntityOwnershipInterface->IsRootPrefabAssigned())
+            bool showAction = true;
+
+            if (const auto prefabEditorEntityOwnershipInterface = AZ::Interface<AzToolsFramework::PrefabEditorEntityOwnershipInterface>::Get();
+                prefabEditorEntityOwnershipInterface && !prefabEditorEntityOwnershipInterface->IsRootPrefabAssigned())
             {
-                action->setEnabled(false);
+                showAction = false;
             }
-            else
+
+            auto entityContextId = AzFramework::EntityContextId::CreateNull();
+            AzToolsFramework::EditorEntityContextRequestBus::BroadcastResult(
+                entityContextId, &AzToolsFramework::EditorEntityContextRequests::GetEditorEntityContextId);
+
+            if (const auto prefabFocusInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabFocusInterface>::Get();
+                prefabFocusInterface && prefabFocusInterface->IsFocusedPrefabInstanceReadOnly(entityContextId))
+            {
+                showAction = false;
+            }
+
+            if (showAction)
             {
                 QObject::connect(
                     action, &QAction::triggered,
                     [this]()
                     {
                         CreateCameraEntityFromViewport();
-                    });
+                    }
+                );
+            }
+            else
+            {
+                action->setEnabled(false);
             }
         }
     }
 
     void CameraEditorSystemComponent::CreateCameraEntityFromViewport()
     {
+        auto entityContextId = AzFramework::EntityContextId::CreateNull();
+        AzToolsFramework::EditorEntityContextRequestBus::BroadcastResult(
+            entityContextId, &AzToolsFramework::EditorEntityContextRequests::GetEditorEntityContextId);
+
+        if (const auto prefabFocusInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabFocusInterface>::Get();
+            prefabFocusInterface && prefabFocusInterface->IsFocusedPrefabInstanceReadOnly(entityContextId))
+        {
+            return;
+        }
+
         AzFramework::CameraState cameraState{};
         AZ::EBusReduceResult<bool, AZStd::logical_or<bool>> aggregator;
         Camera::EditorCameraRequestBus::BroadcastResult(


### PR DESCRIPTION
## What does this PR do?

Introduces checks to prevent the creation of camera entities inside a procedural prefab.

![DisableCameraCreationOnReadOnly](https://user-images.githubusercontent.com/82231674/188769075-88375e42-2496-4396-a0ab-34a5023abbb5.gif)

## How was this PR tested?

Manual testing
