### PR TITLE
Enable PythonCoverage gem in automated testing

### DIFF
--- a/AutomatedTesting/Gem/Code/enabled_gems.cmake
+++ b/AutomatedTesting/Gem/Code/enabled_gems.cmake
@@ -65,4 +65,5 @@ set(ENABLED_GEMS
     RecastNavigation
     ScriptAutomation
     DiffuseProbeGrid
+    PythonCoverage
 )


### PR DESCRIPTION
Signed-off-by: Jack Curtis <jcurtisk@amazon.com>

## What does this PR do?

Enables the previously tested PythonCoverage gem in the AutomatedTesting project. This is necessary to enable TIAF to generate coverage of Python tests.

## How was this PR tested?

Manual testing.
