### PR TITLE
bugfix: remove drop shadow border on about dialog

### DIFF
--- a/Code/Editor/StartupLogoDialog.cpp
+++ b/Code/Editor/StartupLogoDialog.cpp
@@ -46,7 +46,7 @@ CStartupLogoDialog::CStartupLogoDialog(
     switch (m_dialogType)
     {
     case Loading:
-        setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
+        setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint);
         m_ui->m_pages->setCurrentIndex(0);
         setWindowTitle(tr("Starting Open 3D Engine Editor"));
         m_ui->m_TransparentConfidential->setObjectName("copyrightNotice");
@@ -58,7 +58,7 @@ CStartupLogoDialog::CStartupLogoDialog(
 
         break;
     case About:
-        setWindowFlags(Qt::FramelessWindowHint | Qt::Popup);
+        setWindowFlags(Qt::FramelessWindowHint | Qt::Popup | Qt::NoDropShadowWindowHint);
         m_ui->m_pages->setCurrentIndex(1);
         m_ui->m_transparentAllRightReserved->setObjectName("copyrightNotice");
         m_ui->m_transparentAllRightReserved->setTextFormat(Qt::RichText);


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/11684

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

disable drop shadow border for about dialog

## How was this PR tested?

follow steps in referenced PR. 
