### PR TITLE
Hide the create new image option if paint feature isn't enabled

### DIFF
--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.cpp
@@ -121,7 +121,7 @@ namespace GradientSignal
                     // Either show the "Create" options or the "use image" options based on how this is set.
                     ->DataElement(AZ::Edit::UIHandlers::ComboBox, &EditorImageGradientComponent::m_creationSelectionChoice,
                         "Source Type", "Select whether to create a new image or use an existing image.")
-                        ->Attribute(AZ::Edit::Attributes::EnumValues, &SupportedImageOptions)
+                        ->Attribute(AZ::Edit::Attributes::EnumValues, &EditorImageGradientComponent::SupportedImageOptions)
                         ->Attribute(AZ::Edit::Attributes::ReadOnly, &EditorImageGradientComponent::InComponentMode)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorImageGradientComponent::RefreshCreationSelectionChoice)
 

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.cpp
@@ -121,8 +121,7 @@ namespace GradientSignal
                     // Either show the "Create" options or the "use image" options based on how this is set.
                     ->DataElement(AZ::Edit::UIHandlers::ComboBox, &EditorImageGradientComponent::m_creationSelectionChoice,
                         "Source Type", "Select whether to create a new image or use an existing image.")
-                        ->EnumAttribute(ImageCreationOrSelection::UseExistingImage, "Use Existing Image")
-                        ->EnumAttribute(ImageCreationOrSelection::CreateNewImage, "Create New Image")
+                        ->Attribute(AZ::Edit::Attributes::EnumValues, &SupportedImageOptions)
                         ->Attribute(AZ::Edit::Attributes::ReadOnly, &EditorImageGradientComponent::InComponentMode)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorImageGradientComponent::RefreshCreationSelectionChoice)
 
@@ -433,7 +432,7 @@ namespace GradientSignal
         return (m_creationSelectionChoice == ImageCreationOrSelection::CreateNewImage);
     }
 
-    AZ::Crc32 EditorImageGradientComponent::GetPaintModeVisibility() const
+    bool EditorImageGradientComponent::IsPaintFeatureEnabled() const
     {
         // temporary setting to disable this feature unless the registry key is set.
         if (AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get())
@@ -441,10 +440,19 @@ namespace GradientSignal
             constexpr AZStd::string_view ImageGradientPaintFeature = "/O3DE/Preferences/ImageGradient/PaintFeature";
             bool hasPaintFeature = false;
             settingsRegistry->Get(hasPaintFeature, ImageGradientPaintFeature);
-            if (!hasPaintFeature)
-            {
-                return AZ::Edit::PropertyVisibility::Hide;
-            }
+
+            return hasPaintFeature;
+        }
+
+        return false;
+    }
+
+    AZ::Crc32 EditorImageGradientComponent::GetPaintModeVisibility() const
+    {
+        // temporary setting to disable this feature unless the registry key is set.
+        if (!IsPaintFeatureEnabled())
+        {
+            return AZ::Edit::PropertyVisibility::Hide;
         }
 
         // Only show the image painting button while we're using an image, not while we're creating one.
@@ -584,6 +592,24 @@ namespace GradientSignal
         }
 
         return true;
+    }
+
+    AZStd::vector<AZ::Edit::EnumConstant<EditorImageGradientComponent::ImageCreationOrSelection>> EditorImageGradientComponent::
+        SupportedImageOptions() const
+    {
+        AZStd::vector<AZ::Edit::EnumConstant<EditorImageGradientComponent::ImageCreationOrSelection>> options;
+
+        options.push_back(
+            AZ::Edit::EnumConstant<ImageCreationOrSelection>(ImageCreationOrSelection::UseExistingImage, "Use Existing Image"));
+
+        // Temporarily don't show the Create New Image option if the Paint Feature isn't enabled
+        if (IsPaintFeatureEnabled())
+        {
+            options.push_back(
+                AZ::Edit::EnumConstant<ImageCreationOrSelection>(ImageCreationOrSelection::CreateNewImage, "Create New Image"));
+        }
+
+        return options;
     }
 
     void EditorImageGradientComponent::StartImageModification()

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.h
@@ -76,6 +76,9 @@ namespace GradientSignal
             CreateNewImage
         };
 
+        AZStd::vector<AZ::Edit::EnumConstant<ImageCreationOrSelection>> SupportedImageOptions() const;
+        bool IsPaintFeatureEnabled() const;
+
         // EditorImageGradientRequestBus overrides ...
         void StartImageModification() override;
         void EndImageModification() override;


### PR DESCRIPTION
## What does this PR do?

Fixes #11720 

This hides the `Create New Image` option in the `Image Gradient` if the `/O3DE/Preferences/ImageGradient/PaintFeature` feature isn't enabled. Without the paint feature, the user is unable to edit the newly created image, which makes the workflow confusing.

Once the paint feature is complete and enabled by default, this flag will be removed and the `Create New Image` option will be enabled by default as well.

## How was this PR tested?

Tested the `Image Gradient` component with the paint feature enabled and disabled and verified the `Create New Image` option is shown/hidden, respectively.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>