### PR TITLE
{lyn13148} Updated logging for Object Stream

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
@@ -285,7 +285,7 @@ namespace AZ
                         "The class %s supports version %d. Found file class %s with version %d during deserializing, which is a newer version than the code supports. "
                         "First, check if you've built latest, your C++ code could be out of date. "
                         "It is possible that the class version has been reset. Please check if the team provides a conversion tool. "
-                        "To resolve you'll either need to get the proper new version of this class, or you'll need to roll back this change.",
+                        "To resolve you'll either need to get the latest version of this class, use any provided migration tools or resync to an early commit",
                         childClass->m_name,
                         childClass->m_version,
                         childNode.m_element.m_name,

--- a/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
@@ -248,7 +248,7 @@ namespace AZ
         //=========================================================================
         void ObjectStreamImpl::PreparseOldVersion(SerializeContext& sc, SerializeContext::DataElementNode& elementNode, IO::GenericStream& stream, const SerializeContext::ClassData* elementClass)
         {
-            // whenever tracing is availalble we make error logging available.
+            // whenever tracing is available we make error logging available.
 #if defined(AZ_ENABLE_TRACING) 
             {
                 SerializeContext::DbgStackEntry de;
@@ -281,7 +281,16 @@ namespace AZ
 
                 if (childClass)
                 {
-                    AZ_Assert(childNode.m_element.m_version <= childClass->m_version, "Serialize was parsing old version class and found newer version element! This should be impossible!");
+                    AZ_Error("Error", childNode.m_element.m_version <= childClass->m_version,
+                        "The class %s supports version %d. Found file class %s with version %d during deserializing, which is a newer version than the code supports. "
+                        "First, check if you've built latest, your C++ could be out of date. "
+                        "It is possible that the class version has been reset. Please check if the team provides a conversion tool. "
+                        "To resolve you'll either need to get the proper new version of this class, or you'll need to roll back this change.",
+                        childClass->m_name,
+                        childClass->m_version,
+                        childNode.m_element.m_name,
+                        childNode.m_element.m_version
+                    );
 
                     // Only proceed if:
                     // * the child node is out of date AND the class does not have a custom serializer
@@ -301,11 +310,6 @@ namespace AZ
                         }
                         continue;
                     }
-                }
-                else
-                {
-                    // output a warning
-                    //AZ_Warning("Serializer",false,"Element '%s' with class ID '%s' found while converting '%s' is not registered with the serializer! You will have to parse this data yourself!",childElement.m_name,childElement.m_id.ToString<AZStd::string>().c_str(), parent->m_name);
                 }
 
                 if (childNode.m_element.m_dataSize > 0) // if we have values to convert

--- a/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
@@ -282,13 +282,14 @@ namespace AZ
                 if (childClass)
                 {
                     AZ_Error("Error", childNode.m_element.m_version <= childClass->m_version,
-                        "The class %s supports version %d. Found file class %s with version %d during deserializing, which is a newer version than the code supports. "
+                        "The current class (%s) version is (%d). The field (%s) of class (%s) with version (%d) is a newer version than the code supports. "
                         "First, check if you've built latest, your C++ code could be out of date. "
                         "It is possible that the class version has been reset. Please check if the team provides a conversion tool. "
-                        "To resolve you'll either need to get the latest version of this class, use any provided migration tools or resync to an early commit",
+                        "To resolve you'll either need to get the latest version of this class, use any provided migration tools or re-sync to an early commit. ",
                         childClass->m_name,
                         childClass->m_version,
                         childNode.m_element.m_name,
+                        childClass->m_name,
                         childNode.m_element.m_version
                     );
 

--- a/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
@@ -283,7 +283,7 @@ namespace AZ
                 {
                     AZ_Error("Error", childNode.m_element.m_version <= childClass->m_version,
                         "The class %s supports version %d. Found file class %s with version %d during deserializing, which is a newer version than the code supports. "
-                        "First, check if you've built latest, your C++ could be out of date. "
+                        "First, check if you've built latest, your C++ code could be out of date. "
                         "It is possible that the class version has been reset. Please check if the team provides a conversion tool. "
                         "To resolve you'll either need to get the proper new version of this class, or you'll need to roll back this change.",
                         childClass->m_name,


### PR DESCRIPTION
## What does this PR do?

This cleans up the error log for the Object Stream when class version mismatches are encountered.

## How was this PR tested?

View the AP logs and output to see the new error log.
