### PR TITLE
Ensure entity is created at local (0, 0, 0) if created from the Entity Outliner

### DIFF
--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/ContextMenuHandlers.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/ContextMenuHandlers.cpp
@@ -8,6 +8,7 @@
 
 #include <ContextMenuHandlers.h>
 
+#include <AzFramework/Viewport/ScreenGeometry.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 
@@ -30,7 +31,7 @@ int ContextMenuBottomHandler::GetMenuPosition() const
 }
 
 void ContextMenuBottomHandler::PopulateEditorGlobalContextMenu(
-    QMenu* menu, [[maybe_unused]] const AZ::Vector2& point, [[maybe_unused]] int flags)
+    QMenu* menu, [[maybe_unused]] const AZStd::optional<AzFramework::ScreenPoint>& point, [[maybe_unused]] int flags)
 {
     AzToolsFramework::EntityIdList selected;
     AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/ContextMenuHandlers.h
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/ContextMenuHandlers.h
@@ -18,6 +18,6 @@ public:
 
 private:
     // EditorContextMenu overrides ...
-    void PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2& point, int flags) override;
+    void PopulateEditorGlobalContextMenu(QMenu* menu, const AZStd::optional<AzFramework::ScreenPoint>& point, int flags) override;
     int GetMenuPosition() const override;
 };

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -617,7 +617,8 @@ int SandboxIntegrationManager::GetMenuPosition() const
     return aznumeric_cast<int>(AzToolsFramework::EditorContextMenuOrdering::TOP);
 }
 
-void SandboxIntegrationManager::PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2& point, int flags)
+void SandboxIntegrationManager::PopulateEditorGlobalContextMenu(
+    QMenu* menu, const AZStd::optional<AzFramework::ScreenPoint>& point, int flags)
 {
     if (!IsLevelDocumentOpen())
     {
@@ -626,18 +627,18 @@ void SandboxIntegrationManager::PopulateEditorGlobalContextMenu(QMenu* menu, con
 
     if (flags & AzToolsFramework::EditorEvents::eECMF_USE_VIEWPORT_CENTER)
     {
-        CViewport* view = GetIEditor()->GetViewManager()->GetGameViewport();
         int width = 0;
         int height = 0;
         // If there is no 3D Viewport active to aid in the positioning of context menu
         // operations, we don't need to store anything but default values here. Any code
         // using these numbers for placement should default to the origin when there's
         // no 3D viewport to raycast into.
-        if (view)
+        if (const CViewport* view = GetIEditor()->GetViewManager()->GetGameViewport())
         {
             view->GetDimensions(&width, &height);
         }
-        m_contextMenuViewPoint.Set(static_cast<float>(width / 2), static_cast<float>(height / 2));
+
+        m_contextMenuViewPoint = AzFramework::ScreenPoint{ width / 2, height / 2 };
     }
     else
     {
@@ -1420,10 +1421,11 @@ void SandboxIntegrationManager::ContextMenu_NewEntity()
 
     // If we don't have a viewport active to aid in placement, the object
     // will be created at the origin.
-    if (CViewport* view = GetIEditor()->GetViewManager()->GetGameViewport())
+    if (CViewport* view = GetIEditor()->GetViewManager()->GetGameViewport();
+        view && m_contextMenuViewPoint.has_value())
     {
         worldPosition = AzToolsFramework::FindClosestPickIntersection(
-            view->GetViewportId(), AzFramework::ScreenPointFromVector2(m_contextMenuViewPoint), AzToolsFramework::EditorPickRayLength,
+            view->GetViewportId(), m_contextMenuViewPoint.value(), AzToolsFramework::EditorPickRayLength,
             AzToolsFramework::GetDefaultEntityPlacementDistance());
     }
 
@@ -1608,12 +1610,12 @@ void SandboxIntegrationManager::InstantiateSliceFromAssetId(const AZ::Data::Asse
 {
     AZ::Transform sliceWorldTransform = AZ::Transform::CreateIdentity();
 
-    CViewport* view = GetIEditor()->GetViewManager()->GetGameViewport();
     // If we don't have a viewport active to aid in placement, the slice
     // will be instantiated at the origin.
-    if (view)
+    if (CViewport* view = GetIEditor()->GetViewManager()->GetGameViewport())
     {
-        const QPoint viewPoint(static_cast<int>(m_contextMenuViewPoint.GetX()), static_cast<int>(m_contextMenuViewPoint.GetY()));
+        const QPoint viewPoint =
+            AzToolsFramework::ViewportInteraction::QPointFromScreenPoint(m_contextMenuViewPoint.value_or(AzFramework::ScreenPoint{}));
         sliceWorldTransform = AZ::Transform::CreateTranslation(LYVec3ToAZVec3(view->SnapToGrid(view->ViewToWorld(viewPoint))));
     }
 

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
@@ -176,7 +176,7 @@ private:
 
     //////////////////////////////////////////////////////////////////////////
     // AzToolsFramework::EditorContextMenu::Bus::Handler overrides
-    void PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2& point, int flags) override;
+    void PopulateEditorGlobalContextMenu(QMenu* menu, const AZStd::optional<AzFramework::ScreenPoint>& point, int flags) override;
     int GetMenuPosition() const override;
     //////////////////////////////////////////////////////////////////////////
 
@@ -277,9 +277,11 @@ private:
 private:
     ContextMenuBottomHandler m_contextMenuBottomHandler;
 
-    AZ::Vector2 m_contextMenuViewPoint;
+    //! Position of the cursor when the context menu is opened inside the 3d viewport.
+    //! note: The optional will be empty if the context menu was opened outside the 3d viewport.
+    AZStd::optional<AzFramework::ScreenPoint> m_contextMenuViewPoint;
 
-    short m_startedUndoRecordingNestingLevel;   // used in OnBegin/EndUndo to ensure we only accept undo's we started recording
+    short m_startedUndoRecordingNestingLevel; //!< Used in OnBegin/EndUndo to ensure we only accept undos we started recording
 
     AzToolsFramework::SliceOverridesNotificationWindowManager* m_notificationWindowManager;
 

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerWidget.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerWidget.cpp
@@ -542,10 +542,11 @@ void OutlinerWidget::contextMenuEvent(QContextMenuEvent* event)
 
     // Populate global context menu.
 
-    AzToolsFramework::EditorContextMenuBus::Broadcast(&AzToolsFramework::EditorContextMenuEvents::PopulateEditorGlobalContextMenu,
+    AzToolsFramework::EditorContextMenuBus::Broadcast(
+        &AzToolsFramework::EditorContextMenuEvents::PopulateEditorGlobalContextMenu,
         contextMenu,
-        AZ::Vector2::CreateZero(),
-        AzToolsFramework::EditorEvents::eECMF_HIDE_ENTITY_CREATION | AzToolsFramework::EditorEvents::eECMF_USE_VIEWPORT_CENTER);
+        AZStd::nullopt,
+        AzToolsFramework::EditorEvents::eECMF_HIDE_ENTITY_CREATION);
 
     PrepareSelection();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/EditorContextMenuBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/EditorContextMenuBus.h
@@ -15,6 +15,11 @@
 
 class QMenu;
 
+namespace AzFramework
+{
+    struct ScreenPoint;
+}
+
 namespace AzToolsFramework
 {
     enum class EditorContextMenuOrdering
@@ -75,8 +80,12 @@ namespace AzToolsFramework
          * Appends menu items to the global editor context menu.
          * This is the menu that appears when right clicking the main editor window,
          * including the Entity Outliner and the Viewport.
+         * @param menu The QMenu to append menu items to.
+         * @param point An optional screen point indicating where the user clicked in the 3d viewport for entity placement.
+         *              note: AZStd::nullopt may be passed when the context menu is created outside of the 3d viewport.
+         * @param flags See EditorEvents::EditorContextMenuFlags for available flags to pass.
          */
-        virtual void PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2& point, int flags) = 0;
+        virtual void PopulateEditorGlobalContextMenu(QMenu* menu, const AZStd::optional<AzFramework::ScreenPoint>& point, int flags) = 0;
     };
 
     using EditorContextMenuBus = AZ::EBus<EditorContextMenuEvents>;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -581,10 +581,11 @@ namespace AzToolsFramework
         QMenu* contextMenu = new QMenu(this);
 
         // Populate global context menu.
-        AzToolsFramework::EditorContextMenuBus::Broadcast(&AzToolsFramework::EditorContextMenuEvents::PopulateEditorGlobalContextMenu,
+        AzToolsFramework::EditorContextMenuBus::Broadcast(
+            &AzToolsFramework::EditorContextMenuEvents::PopulateEditorGlobalContextMenu,
             contextMenu,
-            AZ::Vector2::CreateZero(),
-            EditorEvents::eECMF_HIDE_ENTITY_CREATION | EditorEvents::eECMF_USE_VIEWPORT_CENTER);
+            AZStd::nullopt,
+            EditorEvents::eECMF_HIDE_ENTITY_CREATION);
 
         PrepareSelection();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -233,7 +233,7 @@ namespace AzToolsFramework
         }
 
         void PrefabIntegrationManager::PopulateEditorGlobalContextMenu(
-            QMenu* menu, [[maybe_unused]] const AZ::Vector2& point, [[maybe_unused]] int flags)
+            QMenu* menu, [[maybe_unused]] const AZStd::optional<AzFramework::ScreenPoint>& point, [[maybe_unused]] int flags)
         {
             AzToolsFramework::EntityIdList selectedEntities;
             AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
@@ -54,7 +54,7 @@ namespace AzToolsFramework
             // EditorContextMenuBus overrides ...
             int GetMenuPosition() const override;
             AZStd::string GetMenuIdentifier() const override;
-            void PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2& point, int flags) override;
+            void PopulateEditorGlobalContextMenu(QMenu* menu, const AZStd::optional<AzFramework::ScreenPoint>& point, int flags) override;
 
             // EditorEventsBus overrides ...
             void OnEscape() override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
@@ -57,7 +57,7 @@ namespace AzToolsFramework
                 const int contextMenuFlag = 0;
                 AzToolsFramework::EditorContextMenuBus::Broadcast(
                     &AzToolsFramework::EditorContextMenuEvents::PopulateEditorGlobalContextMenu, contextMenu.m_menu.data(),
-                    AzFramework::Vector2FromScreenPoint(mouseInteraction.m_mouseInteraction.m_mousePick.m_screenCoordinates),
+                    mouseInteraction.m_mouseInteraction.m_mousePick.m_screenCoordinates,
                     contextMenuFlag);
 
                 if (!contextMenu.m_menu->isEmpty())

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -3872,7 +3872,7 @@ namespace AzToolsFramework
     }
 
     void EditorTransformComponentSelection::PopulateEditorGlobalContextMenu(
-        QMenu* menu, [[maybe_unused]] const AZ::Vector2& point, [[maybe_unused]] int flags)
+        QMenu* menu, [[maybe_unused]] const AZStd::optional<AzFramework::ScreenPoint>& point, [[maybe_unused]] int flags)
     {
         // Don't show the Toggle Pivot option if any read-only entities are in the current selection
         // We need to request the selected entities instead of just using the m_selectedEntities variable

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
@@ -260,7 +260,7 @@ namespace AzToolsFramework
         void UndoRedoEntityManipulatorCommand(AZ::u8 pivotOverride, const AZ::Transform& transform) override;
 
         // EditorContextMenuBus overrides ...
-        void PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2& point, int flags) override;
+        void PopulateEditorGlobalContextMenu(QMenu* menu, const AZStd::optional<AzFramework::ScreenPoint>& point, int flags) override;
         int GetMenuPosition() const override;
         AZStd::string GetMenuIdentifier() const override;
 

--- a/Gems/Camera/Code/Source/CameraEditorSystemComponent.cpp
+++ b/Gems/Camera/Code/Source/CameraEditorSystemComponent.cpp
@@ -67,7 +67,8 @@ namespace Camera
         AzToolsFramework::EditorContextMenuBus::Handler::BusDisconnect();
     }
 
-    void CameraEditorSystemComponent::PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2&, int flags)
+    void CameraEditorSystemComponent::PopulateEditorGlobalContextMenu(
+        QMenu* menu, [[maybe_unused]] const AZStd::optional<AzFramework::ScreenPoint>& point, int flags)
     {
         if (!(flags & AzToolsFramework::EditorEvents::eECMF_HIDE_ENTITY_CREATION))
         {

--- a/Gems/Camera/Code/Source/CameraEditorSystemComponent.h
+++ b/Gems/Camera/Code/Source/CameraEditorSystemComponent.h
@@ -40,7 +40,7 @@ namespace Camera
     private:
         //////////////////////////////////////////////////////////////////////////
         // AzToolsFramework::EditorContextMenuBus
-        void PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2& point, int flags) override;
+        void PopulateEditorGlobalContextMenu(QMenu* menu, const AZStd::optional<AzFramework::ScreenPoint>& point, int flags) override;
         //////////////////////////////////////////////////////////////////////////
 
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
@@ -152,9 +152,9 @@ namespace PhysX
         }
     }
 
-    void EditorSystemComponent::PopulateEditorGlobalContextMenu([[maybe_unused]] QMenu* menu, [[maybe_unused]] const AZ::Vector2& point, [[maybe_unused]] int flags)
+    void EditorSystemComponent::PopulateEditorGlobalContextMenu(
+        [[maybe_unused]] QMenu* menu, [[maybe_unused]] const AZStd::optional<AzFramework::ScreenPoint>& point, [[maybe_unused]] int flags)
     {
-
     }
 
     void EditorSystemComponent::NotifyRegisterViews()

--- a/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.h
+++ b/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.h
@@ -62,7 +62,7 @@ namespace PhysX
         void OnStopPlayInEditor() override;
 
         // AztoolsFramework::EditorContextMenuBus overrides...
-        void PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2& point, int flags) override;
+        void PopulateEditorGlobalContextMenu(QMenu* menu, const AZStd::optional<AzFramework::ScreenPoint>& point, int flags) override;
 
         // AztoolsFramework::EditorEvents overrides...
         void NotifyRegisterViews() override;


### PR DESCRIPTION
Signed-off-by: Tom Hulton-Harrop <82228511+hultonha@users.noreply.github.com>

## What does this PR do?

When creating an entity from the Entity Inspector, the entity is no longer created in the center of the viewport, instead the entity will be created at the origin (0, 0, 0), or if created as a child of another entity, have a local translation of (0, 0, 0) and exist at the same world space position as the parent.

Resolves #9754 

## How was this PR tested?

Currently this test has just been tested manually in the viewport. I would love to add tests for this and am inclined to create a follow-up task to do this as I know this fix is important to get in to the stabilization branch for the 22.10 release.

## Additional context

### Before

https://user-images.githubusercontent.com/82228511/189088219-c3544e06-da89-4f89-9d3c-8099b89953e7.mp4

### After

https://user-images.githubusercontent.com/82228511/189088262-21c83d44-d6a4-4d0d-8209-398ce986b7f0.mp4