### PR TITLE
TIF/ Explicit path ways for reports and Changelists

### DIFF
--- a/cmake/TestImpactFramework/ConsoleFrontendConfig.in
+++ b/cmake/TestImpactFramework/ConsoleFrontendConfig.in
@@ -54,7 +54,9 @@
         "root": "${native_temp_dir}",
         "run_artifact_dir": "${LY_TEST_IMPACT_NATIVE_TEST_RUN_DIR}",
         "coverage_artifact_dir": "${native_temp_dir}/Coverage",
-        "enumeration_cache_dir": "${native_temp_dir}/EnumerationCache"
+        "enumeration_cache_dir": "${native_temp_dir}/EnumerationCache",
+        "change_list" : "${native_temp_dir}/Changelists",
+        "reports" : "${native_temp_dir}/Reports"
       },
       "active": {
         "root": "${native_active_dir}",
@@ -103,7 +105,9 @@
         "root": "${python_temp_dir}",
         "run_artifact_dir": "${LY_TEST_IMPACT_PYTHON_TEST_RUN_DIR}",
         "coverage_artifact_dir": "${python_temp_dir}/Coverage",
-        "enumeration_cache_dir": "${python_temp_dir}/EnumerationCache"
+        "enumeration_cache_dir": "${python_temp_dir}/EnumerationCache",
+        "change_list" : "${python_temp_dir}/Changelists",
+        "reports" : "${python_temp_dir}/Reports"
       },
       "active": {
         "root": "${python_active_dir}",

--- a/scripts/build/TestImpactAnalysis/Testing/conftest.py
+++ b/scripts/build/TestImpactAnalysis/Testing/conftest.py
@@ -30,7 +30,7 @@ LAST_COMMIT_HASH_KEY = "last_commit_hash"
 COVERAGE_DATA_KEY = "coverage_data"
 PREVIOUS_TEST_RUNS_KEY = "previous_test_runs"
 HISTORIC_DATA_FILE_KEY = "data"
-
+REPORT_KEY = "reports"
 
 @pytest.fixture
 def test_data_file(build_directory):
@@ -74,7 +74,7 @@ def binary_path(config_data, runtime_type):
 
 @pytest.fixture()
 def report_path(runtime_type, config_data, mock_uuid):
-    return config_data[runtime_type][WORKSPACE_KEY][TEMP_KEY][ROOT_KEY]+"\\report."+mock_uuid.hex+".json"
+    return config_data[runtime_type][WORKSPACE_KEY][TEMP_KEY][REPORT_KEY]+"\\report."+mock_uuid.hex+".json"
 
 
 @pytest.fixture

--- a/scripts/build/TestImpactAnalysis/persistent_storage/tiaf_persistent_storage.py
+++ b/scripts/build/TestImpactAnalysis/persistent_storage/tiaf_persistent_storage.py
@@ -97,7 +97,7 @@ class PersistentStorage(ABC):
                 logger.info("No previous test run data found.")
 
             # Create the active workspace directory for the unpacked historic data files so they are accessible by the runtime
-            self._active_workspace.mkdir(exist_ok=True)
+            self._active_workspace.mkdir(exist_ok=True, parents=True)
 
             # Coverage file
             logger.info(f"Writing coverage data to '{self._unpacked_coverage_data_file}'.")

--- a/scripts/build/TestImpactAnalysis/test_impact/base_test_impact.py
+++ b/scripts/build/TestImpactAnalysis/test_impact/base_test_impact.py
@@ -128,7 +128,7 @@ class BaseTestImpact(ABC):
                         args[ARG_INTEGRATION_POLICY] = "continue"
         # Store sequence and report into args so that our argument enum can be used to apply all relevant arguments.
         args[ARG_SEQUENCE] = args.get(ARG_SEQUENCE_OVERRIDE) or sequence_type
-        self._report_file = PurePath(self._temp_workspace).joinpath(
+        self._report_file = PurePath(self._report_workspace).joinpath(
             f"report.{self._instance_id}.json")
         args[ARG_REPORT] = self._report_file
         self._parse_arguments_to_runtime(
@@ -248,6 +248,8 @@ class BaseTestImpact(ABC):
         RUNTIME_BIN_KEY = "runtime_bin"
         RUNTIME_ARTIFACT_DIR_KEY = "run_artifact_dir"
         RUNTIME_COVERAGE_DIR_KEY = "coverage_artifact_dir"
+        REPORT_KEY = "reports"
+        CHANGE_LIST_KEY = "change_list"
 
         logger.info(
             f"Attempting to parse configuration file '{config_file}'...")
@@ -273,6 +275,8 @@ class BaseTestImpact(ABC):
                 self._active_workspace = config[self.runtime_type][WORKSPACE_KEY][ACTIVE_KEY][ROOT_KEY]
                 self._historic_workspace = config[self.runtime_type][WORKSPACE_KEY][HISTORIC_KEY][ROOT_KEY]
                 self._temp_workspace = config[self.runtime_type][WORKSPACE_KEY][TEMP_KEY][ROOT_KEY]
+                self._report_workspace = config[self.runtime_type][WORKSPACE_KEY][TEMP_KEY][REPORT_KEY]
+                self._change_list_workspace = config[self.runtime_type][WORKSPACE_KEY][TEMP_KEY][CHANGE_LIST_KEY]
 
                 # Data file paths
                 self._unpacked_coverage_data_file = config[self.runtime_type][
@@ -326,7 +330,7 @@ class BaseTestImpact(ABC):
                 # Attempt to generate a diff between the src and dst commits
                 logger.info(
                     f"Source '{self._src_commit}' and destination '{self._dst_commit}' will be diff'd.")
-                diff_path = Path(PurePath(self._temp_workspace).joinpath(
+                diff_path = Path(PurePath(self._change_list_workspace).joinpath(
                     f"changelist.{self._instance_id}.diff"))
                 self._repo.create_diff_file(
                     self._src_commit, self._dst_commit, diff_path, multi_branch)


### PR DESCRIPTION
Signed-off-by: Jack Curtis <jcurtisk@amazon.com>

## What does this PR do?
Creates explicit path ways for Reports and Changelists, and updates tests to match. Also includes a bugfix where in some cases if a parent folder did not exist our coverage data would not get written.

## How was this PR tested?

Manual testing + suite of automated tests
