### PR TITLE
Exposed level requests to python

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -450,6 +450,8 @@ namespace AzToolsFramework
                 ->Event("RegisterCustomViewPane", &EditorRequests::RegisterCustomViewPane)
                 ->Event("UnregisterViewPane", &EditorRequests::UnregisterViewPane)
                 ->Event("GetComponentTypeEditorIcon", &EditorRequests::GetComponentTypeEditorIcon)
+                ->Event("IsLevelDocumentOpen", &EditorRequests::IsLevelDocumentOpen)
+                ->Event("GetLevelName", &EditorRequests::GetLevelName)
                 ;
 
             behaviorContext->EBus<EditorEventsBus>("EditorEventBus")


### PR DESCRIPTION
## What does this PR do?

Necessary to fix #10213

Exposed the `IsLevelDocumentOpen` and `GetLevelName` requests from the `EditorRequestsBus` to python.

## How was this PR tested?

Tested via the following script in python and verified the APIs work.

```
import azlmbr.bus as bus
import azlmbr.editor as editor

level_open = editor.EditorRequestBus(bus.Broadcast, 'IsLevelDocumentOpen')

level_name = editor.EditorRequestBus(bus.Broadcast, 'GetLevelName')
```

Signed-off-by: Chris Galvan <chgalvan@amazon.com>