### PR TITLE
Final Python 3.7 -> 3.10 updates

### DIFF
--- a/Gems/AWSMetrics/cdk/README.md
+++ b/Gems/AWSMetrics/cdk/README.md
@@ -13,7 +13,7 @@ process also creates a virtualenv within this project, stored under the .env
 directory.  To create the virtualenv it assumes that there is a `python3`
 (or `python` for Windows) executable in your path with access to the `venv`
 package. If for any reason the automatic creation of the virtualenv fails,
-you can create the virtualenv manually. Please note that Python version 3.7.10 or higher is required to deploy this CDK application.
+you can create the virtualenv manually. Please note that Python version 3.10.5 or higher is required to deploy this CDK application.
 
 To manually create a virtualenv on MacOS and Linux:
 

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/Substance/readme.md
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/DCC/Substance/readme.md
@@ -82,7 +82,7 @@ Many DCC applications such as Substance Designer also come with a managed python
 
 - O3DE doesn't use a user or system installed python interpreter, nor do most DCC apps we are aware of.
 
-- The DCC apps python version may be different then O3DE e.g. python 3.7.12 vs 3.9.9.
+- The DCC apps python version may be different then O3DE e.g. python 3.10.5 vs 3.9.9.
 
 - O3DE and most DCC apps we are aware of don't make use of virtual environments, which is a common way to manage package dependencies for different versions of python.
 

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/Dev/Windows/DCC/Launch_Maya_2022.bat
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/Dev/Windows/DCC/Launch_Maya_2022.bat
@@ -49,7 +49,7 @@ SET PATH=%MAYA_BIN_PATH%;%DCCSI_PY_IDE%;%DCCSI_PY_DEFAULT%;%PATH%
 set "PATH_DCCSI_PYTHON=%PATH_DCCSIG%\3rdParty\Python"
 echo     PATH_DCCSI_PYTHON = %PATH_DCCSI_PYTHON%
 
-:: add access to a Lib location that matches the py version (example: 3.7.x)
+:: add access to a Lib location that matches the py version (example: 3.10.x)
 :: switch this for other python versions like maya (2.7.x)
 IF "%PATH_DCCSI_PYTHON_LIB%"=="" (set "PATH_DCCSI_PYTHON_LIB=%PATH_DCCSI_PYTHON%\Lib\%DCCSI_PY_VERSION_MAJOR%.x\%DCCSI_PY_VERSION_MAJOR%.%DCCSI_PY_VERSION_MINOR%.x\site-packages")
 echo     PATH_DCCSI_PYTHON_LIB = %PATH_DCCSI_PYTHON_LIB%

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/Dev/Windows/Env_O3DE_Python.bat
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/Dev/Windows/Env_O3DE_Python.bat
@@ -43,13 +43,13 @@ echo     DCCSI_PY_VERSION_MINOR = %DCCSI_PY_VERSION_MINOR%
 IF "%DCCSI_PY_VERSION_RELEASE%"=="" (set DCCSI_PY_VERSION_RELEASE=10)
 echo     DCCSI_PY_VERSION_RELEASE = %DCCSI_PY_VERSION_RELEASE%
 
-:: shared location for 64bit python 3.7 DEV location
+:: shared location for 64bit python 3.10 DEV location
 :: this defines a DCCsi sandbox for lib site-packages by version
 :: <O3DE>\Gems\AtomLyIntegration\TechnicalArt\DccScriptingInterface\3rdParty\Python\Lib
 set "PATH_DCCSI_PYTHON=%PATH_DCCSIG%\3rdParty\Python"
 echo     PATH_DCCSI_PYTHON = %PATH_DCCSI_PYTHON%
 
-:: add access to a Lib location that matches the py version (example: 3.7.x)
+:: add access to a Lib location that matches the py version (example: 3.10.x)
 :: switch this for other python versions like maya (2.7.x)
 IF "%PATH_DCCSI_PYTHON_LIB%"=="" (set "PATH_DCCSI_PYTHON_LIB=%PATH_DCCSI_PYTHON%\Lib\%DCCSI_PY_VERSION_MAJOR%.x\%DCCSI_PY_VERSION_MAJOR%.%DCCSI_PY_VERSION_MINOR%.x\site-packages")
 echo     PATH_DCCSI_PYTHON_LIB = %PATH_DCCSI_PYTHON_LIB%

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/Dev/Windows/Solutions/.idea/DccScriptingInterface.iml
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/Dev/Windows/Solutions/.idea/DccScriptingInterface.iml
@@ -16,7 +16,7 @@
       <sourceFolder url="file://$MODULE_DIR$/../../../.." isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/Tools/Dev/Solutions/.idea/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.7" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.10" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/IDE/Wing/readme.md
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Tools/IDE/Wing/readme.md
@@ -116,7 +116,7 @@ In the root of the DCCsi, one of the files will start O3DE python, you can start
 
 The actual interpreter that runs is somewhere like
 
-    `o3de\python\runtime\python-3.7.12-rev2-windows\python\python.exe`
+    `o3de\python\runtime\python-3.10.5-rev1-windows\python\python.exe`
 
 The folder for Wing developers is here:
 

--- a/scripts/build/build_node/Platform/Linux/install-ubuntu-build-tools.sh
+++ b/scripts/build/build_node/Platform/Linux/install-ubuntu-build-tools.sh
@@ -46,44 +46,6 @@ then
 fi
 
 #
-# If the linux distro is 20.04 (focal), we need libffi.so.6, which is not part of the focal distro. We 
-# will install it from the bionic distro manually into focal. This is needed since Ubuntu 20.04 supports
-# python 3.8 out of the box, but we are using 3.7
-#
-LIBFFI6_COUNT=$(apt list --installed 2>/dev/null | grep libffi6 | wc -l)
-if [ "$UBUNTU_DISTRO" == "focal" ] && [ $LIBFFI6_COUNT -eq 0 ]
-then
-    echo "Installing libffi for Ubuntu 20.04"
-
-    pushd /tmp >/dev/null
-
-    LIBFFI_PACKAGE_NAME=libffi6_3.2.1-8_amd64.deb
-    LIBFFI_PACKAGE_URL=http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/
-
-    curl --location $LIBFFI_PACKAGE_URL/$LIBFFI_PACKAGE_NAME -o $LIBFFI_PACKAGE_NAME
-    if [ $? -ne 0 ]
-    then
-        echo Unable to download $LIBFFI_PACKAGE_URL/$LIBFFI_PACKAGE_NAME
-        popd
-        exit 1
-    fi
-
-    apt install ./$LIBFFI_PACKAGE_NAME -y
-    if [ $? -ne 0 ]
-    then
-        echo Unable to install $LIBFFI_PACKAGE_NAME
-        rm -f ./$LIBFFI_PACKAGE_NAME
-        popd
-        exit 1
-    fi
-
-    rm -f ./$LIBFFI_PACKAGE_NAME
-    popd
-    echo "libffi.so.6 installed"
-fi
-
-
-#
 # Add the kitware repository for cmake if necessary
 #
 

--- a/scripts/build/build_node/Platform/Windows/install_python.ps1
+++ b/scripts/build/build_node/Platform/Windows/install_python.ps1
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 #>
 
 choco install -y python2 --version=2.7.15
-choco install -y python3 --version=3.7.5
+choco install -y python3 --version=3.10.5
 
 # Ensure Python paths are set
 [Environment]::SetEnvironmentVariable(

--- a/scripts/build/build_node/Platform/Windows/install_python.ps1
+++ b/scripts/build/build_node/Platform/Windows/install_python.ps1
@@ -5,15 +5,13 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 #>
 
-choco install -y python2 --version=2.7.15
 choco install -y python3 --version=3.10.5
 
 # Ensure Python paths are set
 [Environment]::SetEnvironmentVariable(
     "Path",
-    [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine) + ";C:\Python27;C:\Python27\Scripts",
+    [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine) + ";C:\Python310;C:\Python310\Scripts",
     [EnvironmentVariableTarget]::Machine)
 
 Write-Host "Installing packages" # requirements.txt hould be in the "Platforms\Common" folder
-pip install -r ..\Common\requirements.txt
 pip3 install -r ..\Common\requirements.txt


### PR DESCRIPTION
## What does this PR do?

House-keeping updates for references to the previous version of Python (3.7)

* Update references to Python 3.7(.12) to 3.10(.5) in scripts, comments, etc
* Also Remove unnecessary libffi installation for ubuntu 20.04

## How was this PR tested?

Most of the changes are in comments, messages only, not any direct code. The only scripting code that is affected is used to configure new build nodes.


