### PR TITLE
Merge pull request #11491 from thesmallcreeper/cursor-show-fix

### DIFF
--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
@@ -542,6 +542,11 @@ namespace AzFramework
                 const xcb_focus_in_event_t* focusInEvent = reinterpret_cast<const xcb_focus_in_event_t*>(event);
                 if (m_focusWindow != focusInEvent->event)
                 {
+                    if (m_focusWindow != XCB_WINDOW_NONE)
+                    {
+                        HandleCursorState(m_focusWindow, SystemCursorState::UnconstrainedAndVisible);
+                    }
+
                     m_focusWindow = focusInEvent->event;
                     HandleCursorState(m_focusWindow, m_systemCursorState);
                 }


### PR DESCRIPTION
## What does this PR do?

Cherry pick of https://github.com/o3de/o3de/commit/26673a24f2c3ae9d70564ad1c2c29ae8382788fd : 

XCB: Reset cursor state if Focus-In is not paired with Focus-Out (Fix hidden cursor bug when "Play Game")

## How was this PR tested?

Followed repro steps described in https://github.com/o3de/o3de/issues/7240

