### PR TITLE
P4 | Change SourceControl settings to only rely on SettingsRegistry instead of Windows Registry

### DIFF
--- a/Code/Editor/EditorPreferencesPageGeneral.h
+++ b/Code/Editor/EditorPreferencesPageGeneral.h
@@ -45,7 +45,7 @@ private:
         AZ_TYPE_INFO(GeneralSettings, "{C2AE8F6D-7AA6-499E-A3E8-ECCD0AC6F3D2}")
 
         bool m_previewPanel;
-        bool m_enableSourceControl;
+        bool m_enableSourceControl = false;
         bool m_clearConsoleOnGameModeStart;
         AzToolsFramework::ConsoleColorTheme m_consoleBackgroundColorTheme;
         bool m_autoLoadLastLevel;

--- a/Code/Editor/MainWindow.cpp
+++ b/Code/Editor/MainWindow.cpp
@@ -1966,6 +1966,7 @@ void MainWindow::ConnectivityStateChanged(const AzToolsFramework::SourceControlS
 
     gSettings.enableSourceControl = connected;
     gSettings.SaveEnableSourceControlFlag(false);
+    gSettings.SaveSettingsRegistryFile();
 }
 
 void MainWindow::OnGotoSelected()

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -911,14 +911,19 @@ void EnableSourceControl(bool enable)
 
 void SEditorSettings::SaveEnableSourceControlFlag(bool triggerUpdate /*= false*/)
 {
-    // Track the original source control value
-    bool originalSourceControlFlag;
-    LoadValue("Settings", "EnableSourceControl", originalSourceControlFlag);
+    constexpr AZStd::string_view enableSourceControlKey = "/Amazon/Settings/EnableSourceControl";
 
-    // Update only on change
-    if (originalSourceControlFlag != enableSourceControl)
+    if (auto* registry = AZ::SettingsRegistry::Get())
     {
-        SaveValue("Settings", "EnableSourceControl", enableSourceControl);
+        // Track the original source control value
+        bool originalSourceControlFlag;
+        registry->Get(originalSourceControlFlag, enableSourceControlKey);
+
+        // Update only on change
+        if (originalSourceControlFlag != enableSourceControl)
+        {
+            registry->Set(enableSourceControlKey, enableSourceControl);
+        }
 
         // If we are triggering any update for the source control flag, then set the control state
         if (triggerUpdate)
@@ -931,21 +936,16 @@ void SEditorSettings::SaveEnableSourceControlFlag(bool triggerUpdate /*= false*/
 void SEditorSettings::LoadEnableSourceControlFlag()
 {
     constexpr AZStd::string_view enableSourceControlKey = "/Amazon/Settings/EnableSourceControl";
-    bool sourceControlEnabledInSettingsRegistry{};
-    if (auto registry = AZ::SettingsRegistry::Get(); registry != nullptr &&
-        registry->Get(sourceControlEnabledInSettingsRegistry, enableSourceControlKey))
+    
+    if (const auto* registry = AZ::SettingsRegistry::Get())
     {
-        // Have the SettingsRegistry able to disable the SourceControl Connection
-        // only if the "EnableSourceControl" key is found
-        if (!sourceControlEnabledInSettingsRegistry)
+        bool potentialValue;
+        if (registry->Get(potentialValue, enableSourceControlKey))
         {
-            EnableSourceControl(false);
-            return;
+            enableSourceControl = AZStd::move(potentialValue);
         }
     }
-    // Use the QSettings "EnableSourceControl" value if the SettingsRegistry
-    // hasn't disabled the SourceControlAPI
-    LoadValue("Settings", "EnableSourceControl", enableSourceControl);
+
     EnableSourceControl(enableSourceControl);
 }
 
@@ -1058,9 +1058,11 @@ void SEditorSettings::SaveSettingsRegistryFile()
     dumperSettings.m_prettifyOutput = true;
     dumperSettings.m_includeFilter = [](AZStd::string_view path)
     {
+        AZStd::string_view amazonSettingsPrefixPath("/Amazon/Settings");
         AZStd::string_view amazonPrefixPath("/Amazon/Preferences");
         AZStd::string_view o3dePrefixPath("/O3DE/Preferences");
-        return amazonPrefixPath.starts_with(path.substr(0, amazonPrefixPath.size())) ||
+        return amazonSettingsPrefixPath.starts_with(path.substr(0, amazonSettingsPrefixPath.size())) ||
+            amazonPrefixPath.starts_with(path.substr(0, amazonPrefixPath.size())) ||
             o3dePrefixPath.starts_with(path.substr(0, o3dePrefixPath.size()));
     };
 
@@ -1084,26 +1086,6 @@ void SEditorSettings::SaveSettingsRegistryFile()
 
     AZ_Warning("SEditorSettings", saved, R"(Unable to save Editor Preferences registry file to path "%s"\n)",
         editorPreferencesFilePath.c_str());
-}
-
-bool SEditorSettings::SetSettingsRegistry_Bool(const char* key, bool value)
-{
-    if (auto registry = AZ::SettingsRegistry::Get(); registry != nullptr)
-    {
-        return registry->Set(key, value);
-    }
-
-    return false;
-}
-
-bool SEditorSettings::GetSettingsRegistry_Bool(const char* key, bool& value)
-{
-    if (auto registry = AZ::SettingsRegistry::Get(); registry != nullptr)
-    {
-        return registry->Get(value, key);
-    }
-
-    return false;
 }
 
 AzToolsFramework::ConsoleColorTheme SEditorSettings::GetConsoleColorTheme() const

--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -278,8 +278,9 @@ AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     // need to expose updating of the source control enable/disable flag
     // because its state is updateable through the main status bar
     void SaveEnableSourceControlFlag(bool triggerUpdate = false);
-
     void LoadEnableSourceControlFlag();
+
+    void SaveSettingsRegistryFile();
 
     void PostInitApply();
 
@@ -353,7 +354,7 @@ AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     SSnapSettings snap;
 
     //! Source Control Enabling.
-    bool enableSourceControl;
+    bool enableSourceControl = false;
     bool clearConsoleOnGameModeStart;
 
     //! Text editor.
@@ -443,20 +444,6 @@ private:
     void LoadValue(const char* sSection, const char* sKey, QString& value);
 
     void SaveCloudSettings();
-
-    void SaveSettingsRegistryFile();
-
-    //! Set a boolean setting value from the registry.
-    //! \param key[in] The key to set.
-    //! \param value[in] The new value for the setting.
-    //! \return Whether the value for the key was correctly set in the registry.
-    bool SetSettingsRegistry_Bool(const char* key, bool value);
-
-    //! Gets a boolean setting value from the registry.
-    //! \param key[in] The key to query.
-    //! \param value[out] The variable the queried value will be saved to, by reference.
-    //! \return Whether a value for the key was found in the registry.
-    bool GetSettingsRegistry_Bool(const char* key, bool& value);
 };
 
 //! Single instance of editor settings for fast access.


### PR DESCRIPTION
Addresses issue with P4 being enabled by default on new installs despite the setting being marked as disabled by default. That was likely due to the previous code relying on both settings registry and windows registry to determine the activation status; new code streamlines the setting to be in line with other settings relying on the settings registry (namely the viewport ones).

Note that this change may result in the Source Control setting being disabled for users that have it enabled on their local installation and rebuild with this commit, since the source of the setting has changed. The solution is just to re-enable P4 manually, no data loss is introduced (P4 settings will not be lost).

Closes #8408