### PR TITLE
Fix AzNetworking unit test failures on Ubuntu 22.04

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/Utilities/QuantizedValues.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/Utilities/QuantizedValues.inl
@@ -300,12 +300,12 @@ namespace AzNetworking
         static inline void DecodeQuantizedValues(SelfType& quantizedValues)
         {
             constexpr double maximumInt     = static_cast<double>(MaxSerializedIntValue);
-            constexpr double minimumFloat   = static_cast<double>(MIN_VALUE);
+            constexpr float minimumFloat   =  static_cast<float>(MIN_VALUE);
             constexpr double convertToFloat = static_cast<double>(MAX_VALUE - MIN_VALUE) / maximumInt;
             for (int32_t i = 0; i < static_cast<int32_t>(NUM_ELEMENTS); ++i)
             {
                 const double quantized = static_cast<double>(quantizedValues.m_serializeValues[i]);
-                quantizedValues.m_quantizedValues[i] = static_cast<float>(minimumFloat + quantized * convertToFloat);
+                quantizedValues.m_quantizedValues[i] = minimumFloat + static_cast<float>(quantized * convertToFloat);
             }
         }
     };

--- a/Code/Framework/AzNetworking/AzNetworking/Utilities/QuantizedValues.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/Utilities/QuantizedValues.inl
@@ -300,12 +300,12 @@ namespace AzNetworking
         static inline void DecodeQuantizedValues(SelfType& quantizedValues)
         {
             constexpr double maximumInt     = static_cast<double>(MaxSerializedIntValue);
-            constexpr float minimumFloat   =  static_cast<float>(MIN_VALUE);
+            constexpr double minimumFloat   = static_cast<double>(MIN_VALUE);
             constexpr double convertToFloat = static_cast<double>(MAX_VALUE - MIN_VALUE) / maximumInt;
             for (int32_t i = 0; i < static_cast<int32_t>(NUM_ELEMENTS); ++i)
             {
                 const double quantized = static_cast<double>(quantizedValues.m_serializeValues[i]);
-                quantizedValues.m_quantizedValues[i] = minimumFloat + static_cast<float>(quantized * convertToFloat);
+                quantizedValues.m_quantizedValues[i] = static_cast<float>(minimumFloat + static_cast<float>(quantized * convertToFloat));
             }
         }
     };


### PR DESCRIPTION
## What does this PR do?

Fixes unit test failure on Ubuntu 22.04, related to order of operation precedence differences and overflow of doubles and floats.

Root cause not positively identified (clang version? compiler flag? linux distro?), but the behavior of the following line

```
static_cast<float>(minimumFloat + quantized * convertToFloat);
```
acts differently on Ubuntu 22.04 w/ clang-12 than the other platforms that support this unit test. This could either be caused by some precision differences or overflow optimization, but there is a difference down casting from (quantized * convertToFloat) vs (minimumFloat + quantized * convertToFloat) in one operation. 

The update does not change the behavior of the intended function, but will at least make the behavior consistent


More specifically:
```
[ RUN      ] QuantizedValues.Test1Elements4Bytes
/XXXXX/github/o3de/Code/Framework/AzNetworking/Tests/Utilities/QuantizedValuesTests.cpp:30: Failure
Expected equality of these values:
  a
    Which is: -2.1684043e-19
  b
    Which is: 0
```

## How was this PR tested?

Run Unit test on AzNetworking from the command line

```
./AzTestRunner libAzNetworking.Tests.so AzRunUnitTests
```
