### PR TITLE
Add Ubuntu 22.04 nightly job

### DIFF
--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -18,6 +18,20 @@
       "test_profile_nounity"
     ]
   },
+  "profile_ubuntu22_nounity_pipe": {
+    "TAGS": [
+      "periodic-incremental-daily",
+      "periodic-clean-weekly-internal",
+    ],
+    "PIPELINE_ENV":{
+      "NODE_LABEL":"linux-7058deb8-test"
+    },
+    "steps": [
+      "profile_nounity",
+      "asset_profile_nounity",
+      "test_profile_nounity"
+    ]
+  },
   "metrics": {
     "TAGS": [
       "weekly"

--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -24,7 +24,7 @@
       "periodic-clean-weekly-internal",
     ],
     "PIPELINE_ENV":{
-      "NODE_LABEL":"linux-7058deb8-test"
+      "NODE_LABEL":"linux-ubuntu-22"
     },
     "steps": [
       "profile_nounity",

--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -21,7 +21,7 @@
   "profile_ubuntu22_nounity_pipe": {
     "TAGS": [
       "periodic-incremental-daily",
-      "periodic-clean-weekly-internal",
+      "periodic-clean-weekly-internal"
     ],
     "PIPELINE_ENV":{
       "NODE_LABEL":"linux-ubuntu-22"


### PR DESCRIPTION
## What does this PR do?

Creates a Ubuntu 22.04 nightly non-unity profile job with a generic node label. We'll be moving the node configs to utilize a hashed label after we solidified the node config

## How was this PR tested?

Tested in a sandbox Jenkins instance

Signed-off-by: Mike Chang <changml@amazon.com>
