### PR TITLE
DPE: Enable expansion state saving

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
@@ -340,6 +340,10 @@ namespace AzToolsFramework
             auto serializeContext = AZ::EntityUtils::GetApplicationSerializeContext();
             serializeContext->CloneObjectInplace((*m_inMemoryAsset.GetData()), asset.GetData());
 
+            // Make sure the saved state key is reset since this could be a file opened with the same property editor isntance
+            m_savedStateKey = AZ::Crc32();
+            m_savedStateKey.Add(&asset.GetId(), sizeof(AZ::Data::AssetId));
+
             UpdatePropertyEditor(m_inMemoryAsset);
 
             SetupHeader();
@@ -364,19 +368,18 @@ namespace AzToolsFramework
 
         void AssetEditorWidget::UpdatePropertyEditor(AZ::Data::Asset<AZ::Data::AssetData>& asset)
         {
-            AZ::Crc32 saveStateKey;
-            saveStateKey.Add(&asset.GetId(), sizeof(AZ::Data::AssetId));
-
             if (m_useDPE)
             {
                 m_adapter->SetValue(asset.Get(), asset.GetType());
                 m_dpe->SetAdapter(m_adapter);
                 m_dpe->setEnabled(true);
+
+                m_dpe->SetSavedStateKey(m_savedStateKey, "AssetEditor");
             }
             else
             {
                 m_propertyEditor->ClearInstances();
-                m_propertyEditor->SetSavedStateKey(saveStateKey);
+                m_propertyEditor->SetSavedStateKey(m_savedStateKey);
                 m_propertyEditor->AddInstance(asset.Get(), asset.GetType(), nullptr);
 
                 m_propertyEditor->InvalidateAll();
@@ -952,6 +955,10 @@ namespace AzToolsFramework
                 m_propertyEditor->ClearInstances();
             }
             m_currentAsset = "New Asset";
+
+            // Make sure the saved state key is reset since this could be a file opened with the same property editor isntance
+            m_savedStateKey = AZ::Crc32();
+            m_savedStateKey.Add(&newAssetId, sizeof(AZ::Data::AssetId));
 
             UpdatePropertyEditor(m_inMemoryAsset);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
@@ -341,8 +341,7 @@ namespace AzToolsFramework
             serializeContext->CloneObjectInplace((*m_inMemoryAsset.GetData()), asset.GetData());
 
             // Make sure the saved state key is reset since this could be a file opened with the same property editor isntance
-            m_savedStateKey = AZ::Crc32();
-            m_savedStateKey.Add(&asset.GetId(), sizeof(AZ::Data::AssetId));
+            m_savedStateKey = AZ::Crc32(&asset.GetId(), sizeof(AZ::Data::AssetId));
 
             UpdatePropertyEditor(m_inMemoryAsset);
 
@@ -957,8 +956,7 @@ namespace AzToolsFramework
             m_currentAsset = "New Asset";
 
             // Make sure the saved state key is reset since this could be a file opened with the same property editor isntance
-            m_savedStateKey = AZ::Crc32();
-            m_savedStateKey.Add(&newAssetId, sizeof(AZ::Data::AssetId));
+            m_savedStateKey = AZ::Crc32(&newAssetId, sizeof(AZ::Data::AssetId));
 
             UpdatePropertyEditor(m_inMemoryAsset);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
@@ -179,6 +179,7 @@ namespace AzToolsFramework
             AZStd::unique_ptr< Ui::AssetEditorStatusBar > m_statusBar;
 
             AZ::DocumentPropertyEditor::ReflectionAdapter::PropertyChangeEvent::Handler m_propertyChangeHandler;
+            AZ::Crc32 m_savedStateKey;
 
             void PopulateGenericAssetTypes();
             void CreateAssetImpl(AZ::Data::AssetType assetType);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -76,6 +76,7 @@ namespace AzToolsFramework
                     m_expanderWidget->setCheckState(newCheckState);
                 }
             }
+
             emit expanderChanged(expanded);
         }
     }
@@ -573,6 +574,8 @@ namespace AzToolsFramework
     {
         Clear();
 
+        m_domPath = BuildDomPath();
+
         // determine whether this node should be expanded
         auto forceExpandAttribute = AZ::Dpe::Nodes::Row::ForceAutoExpand.ExtractFromDomNode(domArray);
         if (forceExpandAttribute.has_value())
@@ -583,10 +586,15 @@ namespace AzToolsFramework
         else
         {
             // nothing forced, so the user's saved expansion state, if it exists, should be used
-            auto savedState = GetDPE()->GetSavedExpanderStateForRow(this);
-            if (savedState != DocumentPropertyEditor::ExpanderState::NotSet)
+            DocumentPropertyEditor* dpe = GetDPE();
+            if (dpe->IsRecursiveExpansionOngoing())
             {
-                SetExpanded(savedState == DocumentPropertyEditor::ExpanderState::Expanded);
+                SetExpanded(true);
+                dpe->SetSavedExpanderStateForRow(m_domPath, true);
+            }
+            else if (dpe->HasSavedExpanderStateForRow(m_domPath))
+            {
+                SetExpanded(dpe->GetSavedExpanderStateForRow(m_domPath));
             }
             else
             {
@@ -651,7 +659,7 @@ namespace AzToolsFramework
                 if (rowToRemove)
                 {
                     // we're removing a row, remove any associated saved expander state
-                    GetDPE()->RemoveExpanderStateForRow(rowToRemove);
+                    GetDPE()->RemoveExpanderStateForRow(rowToRemove->GetPath());
                 }
 
                 delete (*childIterator); // deleting the widget also automatically removes it from the layout
@@ -789,6 +797,49 @@ namespace AzToolsFramework
         return lastDescendant;
     }
 
+    AZ::Dom::Path DPERowWidget::BuildDomPath()
+    {
+        auto pathToRoot = GetDPE()->GetPathToRoot(this);
+        AZ::Dom::Path rowPath = AZ::Dom::Path();
+
+        auto reverseIndexIter = pathToRoot.rbegin();
+        for (reverseIndexIter; reverseIndexIter != pathToRoot.rend(); ++reverseIndexIter)
+        {
+            rowPath.Push(*reverseIndexIter);
+        }
+
+        return rowPath;
+    }
+
+    void DPERowWidget::SaveExpanderStatesForChildRows(bool isExpanded)
+    {
+        AZStd::stack<DPERowWidget*> stack;
+
+        const auto pushAllChildRowsToStack = [&stack](AZStd::deque<QWidget*> children)
+        {
+            for (auto& child : children)
+            {
+                DPERowWidget* row = qobject_cast<DPERowWidget*>(child);
+                if (row)
+                {
+                    stack.push(row);
+                }
+            }
+        };
+
+        pushAllChildRowsToStack(m_domOrderedChildren);
+
+        while (!stack.empty())
+        {
+            DPERowWidget* row = stack.top();
+            stack.pop();
+
+            pushAllChildRowsToStack(row->m_domOrderedChildren);
+
+            GetDPE()->SetSavedExpanderStateForRow(row->GetPath(), isExpanded);
+        }
+    }
+
     void DPERowWidget::SetExpanded(bool expanded, bool recurseToChildRows)
     {
         m_columnLayout->SetExpanded(expanded);
@@ -813,8 +864,17 @@ namespace AzToolsFramework
 
     void DPERowWidget::onExpanderChanged(int expanderState)
     {
-        if (expanderState == Qt::Unchecked)
+        DocumentPropertyEditor* dpe = GetDPE();
+        bool isExpanded = expanderState != Qt::Unchecked;
+
+        if (!isExpanded)
         {
+            if (QGuiApplication::keyboardModifiers().testFlag(Qt::ShiftModifier))
+            {
+                // Store collapsed state for all children before deletion if shift was pressed
+                SaveExpanderStatesForChildRows(false);
+            }
+
             // expander is collapsed; search for row children and delete them,
             // which will zero out their QPointer in the deque, and remove them from the layout
             for (auto& currentChild : m_domOrderedChildren)
@@ -829,7 +889,13 @@ namespace AzToolsFramework
         }
         else
         {
-            auto myValue = GetDPE()->GetDomValueForRow(this);
+            if (QGuiApplication::keyboardModifiers().testFlag(Qt::ShiftModifier))
+            {
+                // Flag DPE as in the middle of a recursive expand operation if shift was pressed
+                dpe->SetRecursiveExpansionOngoing(true);
+            }
+
+            auto myValue = dpe->GetDomValueForRow(this);
             AZ_Assert(myValue.ArraySize() == m_domOrderedChildren.size(), "known child count does not match child count!");
             for (int valueIndex = 0; valueIndex < m_domOrderedChildren.size(); ++valueIndex)
             {
@@ -838,11 +904,16 @@ namespace AzToolsFramework
                     AddChildFromDomValue(myValue[valueIndex], valueIndex);
                 }
             }
+
+            dpe->SetRecursiveExpansionOngoing(false);
         }
-        GetDPE()->SetSavedExpanderStateForRow(
-            this,
-            (expanderState == Qt::Unchecked ? DocumentPropertyEditor::ExpanderState::Collapsed
-                                            : DocumentPropertyEditor::ExpanderState::Expanded));
+
+        dpe->SetSavedExpanderStateForRow(m_domPath, isExpanded);
+    }
+
+    const AZ::Dom::Path DPERowWidget::GetPath() const
+    {
+        return m_domPath;
     }
 
     DocumentPropertyEditor::DocumentPropertyEditor(QWidget* parentWidget)
@@ -899,6 +970,9 @@ namespace AzToolsFramework
             });
         m_adapter->ConnectMessageHandler(m_domMessageHandler);
 
+        // Free the settings ptr which in turn saves any in-memory settings to disk
+        m_dpeSettings.reset();
+
         // populate the view from the full adapter contents, just like a reset
         HandleReset();
     }
@@ -911,7 +985,6 @@ namespace AzToolsFramework
         }
 
         m_domOrderedRows.clear();
-        m_expanderPaths.clear();
     }
 
     void DocumentPropertyEditor::AddAfterWidget(QWidget* precursor, QWidget* widgetToAdd)
@@ -923,98 +996,71 @@ namespace AzToolsFramework
         }
     }
 
-    void DocumentPropertyEditor::SetSavedExpanderStateForRow(DPERowWidget* row, DocumentPropertyEditor::ExpanderState expanderState)
+    void DocumentPropertyEditor::SetSavedStateKey(AZ::u32 key, AZStd::string propertyEditorName)
     {
-        // Get the index of each dom child going up the chain. We can then reverse this
-        // and use these indices to mark a path to expanded/collapsed nodes
-        AZStd::vector<size_t> reversePath = GetPathToRoot(row);
+        // We need to append some alphabetical characters to the key or it will be treated as a very large json array index
+        AZStd::string_view keyStr = AZStd::string::format("uuid%s", AZStd::to_string(key).c_str());
+        m_dpeSettings = AZStd::make_unique<DocumentPropertyEditorSettings>(keyStr, propertyEditorName);
 
-        if (!reversePath.empty())
+        if (m_dpeSettings && m_dpeSettings->WereSettingsLoaded())
         {
-            // create new pathNodes when necessary implicitly by indexing into each map,
-            // then set the expander state on the final node
-            auto reverseIter = reversePath.rbegin();
-            auto* currPathNode = &m_expanderPaths[*(reverseIter++)];
+            m_dpeSettings->SetCleanExpanderStateCallback(
+                [this](DocumentPropertyEditorSettings::ExpanderStateMap& storedStates)
+                {
+                    bool wereChangesMade = false;
+                    auto rootValue = m_adapter->GetContents();
+                    auto iter = storedStates.begin();
+                    while (iter != storedStates.end())
+                    {
+                        if (auto value = rootValue.FindChild(AZ::Dom::Path(iter->first)); !value)
+                        {
+                            iter = storedStates.erase(iter);
+                            wereChangesMade = true;
+                        }
+                        else
+                        {
+                            ++iter;
+                        }
+                    }
+                    return wereChangesMade;
+                });
 
-            while (reverseIter != reversePath.rend())
-            {
-                currPathNode = &currPathNode->nextNode[*(reverseIter++)];
-            }
-            currPathNode->expanderState = expanderState;
+            // We need to rebuild the view using the stored expander states
+            HandleReset();
         }
     }
 
-    DocumentPropertyEditor::ExpanderState DocumentPropertyEditor::GetSavedExpanderStateForRow(DPERowWidget* row) const
+    void DocumentPropertyEditor::SetSavedExpanderStateForRow(const AZ::Dom::Path& rowPath, bool isExpanded)
     {
-        // default to NotSet; if a particular index is not recorded in m_expanderPaths,
-        // it is considered not set
-        ExpanderState retval = ExpanderState::NotSet;
-
-        AZStd::vector<size_t> reversePath = GetPathToRoot(row);
-        auto reverseIter = reversePath.rbegin();
-        if (!reversePath.empty())
+        if (m_dpeSettings)
         {
-            auto firstNodeIter = m_expanderPaths.find(*(reverseIter++));
-            if (firstNodeIter != m_expanderPaths.end())
-            {
-                const ExpanderPathNode* currPathNode = &firstNodeIter->second;
-
-                // search the existing path tree to see if there's an expander entry for the given node
-                while (currPathNode && reverseIter != reversePath.rend())
-                {
-                    auto nextPathNodeIter = currPathNode->nextNode.find((*reverseIter++));
-                    if (nextPathNodeIter != currPathNode->nextNode.end())
-                    {
-                        currPathNode = &(nextPathNodeIter->second);
-                    }
-                    else
-                    {
-                        currPathNode = nullptr;
-                    }
-                }
-                if (currPathNode)
-                {
-                    // full path exists in the tree, return its expander state
-                    retval = currPathNode->expanderState;
-                }
-            }
+            m_dpeSettings->SetExpanderStateForRow(rowPath, isExpanded);
         }
-        return retval;
     }
 
-    void DocumentPropertyEditor::RemoveExpanderStateForRow(DPERowWidget* row)
+    bool DocumentPropertyEditor::GetSavedExpanderStateForRow(const AZ::Dom::Path& rowPath)
     {
-        AZStd::vector<size_t> reversePath = GetPathToRoot(row);
-        const auto pathLength = reversePath.size();
-        auto reverseIter = reversePath.rbegin();
-
-        if (pathLength > 0)
+        if (m_dpeSettings)
         {
-            auto firstNodeIter = m_expanderPaths.find(*(reverseIter++));
-            if (firstNodeIter != m_expanderPaths.end())
-            {
-                if (pathLength == 1)
-                {
-                    m_expanderPaths.erase(firstNodeIter);
-                }
-                else
-                {
-                    ExpanderPathNode* currPathNode = &firstNodeIter->second;
-                    auto nextPathNodeIter = currPathNode->nextNode.find((*reverseIter++));
-                    while (reverseIter != reversePath.rend() && nextPathNodeIter != currPathNode->nextNode.end())
-                    {
-                        currPathNode = &(nextPathNodeIter->second);
-                        nextPathNodeIter = currPathNode->nextNode.find((*reverseIter++));
-                    }
+            return m_dpeSettings->GetExpanderStateForRow(rowPath);
+        }
+        return false;
+    }
 
-                    // if we reached the end of the row path, and have valid expander state at that location,
-                    // prune the entry and all its children from the expander tree
-                    if (reverseIter == reversePath.rend() && nextPathNodeIter != currPathNode->nextNode.end())
-                    {
-                        currPathNode->nextNode.erase(nextPathNodeIter);
-                    }
-                }
-            }
+    bool DocumentPropertyEditor::HasSavedExpanderStateForRow(const AZ::Dom::Path& rowPath) const
+    {
+        if (m_dpeSettings)
+        {
+            return m_dpeSettings->HasSavedExpanderStateForRow(rowPath);
+        }
+        return false;
+    }
+
+    void DocumentPropertyEditor::RemoveExpanderStateForRow(const AZ::Dom::Path& rowPath)
+    {
+        if (m_dpeSettings)
+        {
+            return m_dpeSettings->RemoveExpanderStateForRow(rowPath);
         }
     }
 
@@ -1127,6 +1173,16 @@ namespace AzToolsFramework
         return pathToRoot;
     }
 
+    bool DocumentPropertyEditor::IsRecursiveExpansionOngoing()
+    {
+        return m_isRecursiveExpansionOngoing;
+    }
+
+    void DocumentPropertyEditor::SetRecursiveExpansionOngoing(bool isExpanding)
+    {
+        m_isRecursiveExpansionOngoing = isExpanding;
+    }
+
     void DocumentPropertyEditor::HandleReset()
     {
         // clear any pre-existing DPERowWidgets
@@ -1148,6 +1204,7 @@ namespace AzToolsFramework
         }
         m_layout->addStretch();
     }
+
     void DocumentPropertyEditor::HandleDomChange(const AZ::Dom::Patch& patch)
     {
         for (auto operationIterator = patch.begin(), endIterator = patch.end(); operationIterator != endIterator; ++operationIterator)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1008,7 +1008,7 @@ namespace AzToolsFramework
                 {
                     auto rootValue = m_adapter->GetContents();
                     auto numErased = AZStd::erase_if(storedStates,
-                        [&rootValue](AZStd::pair<AZStd::string, bool> statePair)
+                        [&rootValue](const AZStd::pair<AZStd::string, bool>& statePair)
                         {
                             return !rootValue.FindChild(AZ::Dom::Path(statePair.first)) ? true : false;
                         });

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1028,7 +1028,7 @@ namespace AzToolsFramework
         }
     }
 
-    bool DocumentPropertyEditor::GetSavedExpanderStateForRow(const AZ::Dom::Path& rowPath)
+    bool DocumentPropertyEditor::GetSavedExpanderStateForRow(const AZ::Dom::Path& rowPath) const
     {
         if (m_dpeSettings)
         {
@@ -1163,7 +1163,7 @@ namespace AzToolsFramework
         return pathToRoot;
     }
 
-    bool DocumentPropertyEditor::IsRecursiveExpansionOngoing()
+    bool DocumentPropertyEditor::IsRecursiveExpansionOngoing() const
     {
         return m_isRecursiveExpansionOngoing;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -9,12 +9,10 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
-#include <AzCore/DOM/Backends/JSON/JsonBackend.h>
-#include <AzCore/Interface/Interface.h>
-#include <AzCore/Memory/SystemAllocator.h>
 #include <AzFramework/DocumentPropertyEditor/DocumentAdapter.h>
 #include <AzToolsFramework/UI/DocumentPropertyEditor/IPropertyEditor.h>
 #include <AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.h>
+#include <AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.h>
 
 #include <QHBoxLayout>
 #include <QScrollArea>
@@ -115,6 +113,8 @@ namespace AzToolsFramework
         void SetExpanded(bool expanded, bool recurseToChildRows = false);
         bool IsExpanded() const;
 
+        const AZ::Dom::Path GetPath() const;
+
     protected slots:
         void onExpanderChanged(int expanderState);
 
@@ -122,9 +122,15 @@ namespace AzToolsFramework
         DocumentPropertyEditor* GetDPE() const;
         void AddDomChildWidget(int domIndex, QWidget* childWidget);
 
+        AZ::Dom::Path BuildDomPath();
+        void SaveExpanderStatesForChildRows(bool isExpanded);
+
         DPERowWidget* m_parentRow = nullptr;
         int m_depth = 0; //!< number of levels deep in the tree. Used for indentation
         DPELayout* m_columnLayout = nullptr;
+
+        // This widget's indexed path from the root
+        AZ::Dom::Path m_domPath;
 
         //! widget children in DOM specified order; mix of row and column widgets
         AZStd::deque<QWidget*> m_domOrderedChildren;
@@ -151,20 +157,15 @@ namespace AzToolsFramework
         }
         void AddAfterWidget(QWidget* precursor, QWidget* widgetToAdd);
 
-        enum class ExpanderState : uint8_t
-        {
-            NotSet,
-            Collapsed,
-            Expanded
-        };
-
-        void SetSavedExpanderStateForRow(DPERowWidget* row, ExpanderState expanderState);
-        ExpanderState GetSavedExpanderStateForRow(DPERowWidget* row) const;
-        void RemoveExpanderStateForRow(DPERowWidget* row);
+        void SetSavedExpanderStateForRow(const AZ::Dom::Path& rowPath, bool isExpanded);
+        bool GetSavedExpanderStateForRow(const AZ::Dom::Path& rowPath);
+        bool HasSavedExpanderStateForRow(const AZ::Dom::Path& rowPath) const;
+        void RemoveExpanderStateForRow(const AZ::Dom::Path& rowPath);
         void ExpandAll();
         void CollapseAll();
 
-        // IPropertyEditor overrides to be added ...
+        // IPropertyEditor overrides
+        void SetSavedStateKey(AZ::u32 key, AZStd::string propertyEditorName = "") override;
 
         AZ::Dom::Value GetDomValueForRow(DPERowWidget* row) const;
 
@@ -177,6 +178,11 @@ namespace AzToolsFramework
 
         static bool ShouldReplaceRPE();
 
+        AZStd::vector<size_t> GetPathToRoot(DPERowWidget* row) const;
+
+        bool IsRecursiveExpansionOngoing();
+        void SetRecursiveExpansionOngoing(bool isExpanding);
+
     public slots:
         //! set the DOM adapter for this DPE to inspect
         void SetAdapter(AZ::DocumentPropertyEditor::DocumentAdapterPtr theAdapter);
@@ -185,7 +191,6 @@ namespace AzToolsFramework
     protected:
         QVBoxLayout* GetVerticalLayout();
         void AddRowFromValue(const AZ::Dom::Value& domValue, int rowIndex);
-        AZStd::vector<size_t> GetPathToRoot(DPERowWidget* row) const;
 
         void HandleReset();
         void HandleDomChange(const AZ::Dom::Patch& patch);
@@ -199,20 +204,13 @@ namespace AzToolsFramework
 
         QVBoxLayout* m_layout = nullptr;
 
+        AZStd::unique_ptr<DocumentPropertyEditorSettings> m_dpeSettings;
+        bool m_isRecursiveExpansionOngoing = false;
+
         bool m_spawnDebugView = false;
 
         QTimer* m_handlerCleanupTimer;
         AZStd::vector<AZStd::unique_ptr<PropertyHandlerWidgetInterface>> m_unusedHandlers;
         AZStd::deque<DPERowWidget*> m_domOrderedRows;
-
-        //! tree nodes to keep track of expander state explicitly changed by the user
-        struct ExpanderPathNode
-        {
-            ExpanderState expanderState = ExpanderState::NotSet;
-            AZStd::unordered_map<size_t, ExpanderPathNode> nextNode;
-        };
-
-        //! hierarchical dom index to expander state tree
-        AZStd::unordered_map<size_t, ExpanderPathNode> m_expanderPaths;
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -158,14 +158,14 @@ namespace AzToolsFramework
         void AddAfterWidget(QWidget* precursor, QWidget* widgetToAdd);
 
         void SetSavedExpanderStateForRow(const AZ::Dom::Path& rowPath, bool isExpanded);
-        bool GetSavedExpanderStateForRow(const AZ::Dom::Path& rowPath);
+        bool GetSavedExpanderStateForRow(const AZ::Dom::Path& rowPath) const;
         bool HasSavedExpanderStateForRow(const AZ::Dom::Path& rowPath) const;
         void RemoveExpanderStateForRow(const AZ::Dom::Path& rowPath);
         void ExpandAll();
         void CollapseAll();
 
         // IPropertyEditor overrides
-        void SetSavedStateKey(AZ::u32 key, AZStd::string propertyEditorName = "") override;
+        void SetSavedStateKey(AZ::u32 key, AZStd::string propertyEditorName = {}) override;
 
         AZ::Dom::Value GetDomValueForRow(DPERowWidget* row) const;
 
@@ -180,7 +180,7 @@ namespace AzToolsFramework
 
         AZStd::vector<size_t> GetPathToRoot(DPERowWidget* row) const;
 
-        bool IsRecursiveExpansionOngoing();
+        bool IsRecursiveExpansionOngoing() const;
         void SetRecursiveExpansionOngoing(bool isExpanding);
 
     public slots:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "DocumentPropertyEditor.h"
+
+namespace AzToolsFramework
+{
+    DocumentPropertyEditorSettings::DocumentPropertyEditorSettings(
+        const AZStd::string& settingsRegistryKey,
+        const AZStd::string& propertyEditorName)
+    {
+        m_settingsRegistryBasePath = AZStd::string::format("%s/%s", RootSettingsRegistryPath, propertyEditorName.c_str());
+        m_settingsRegistryDocumentKey = settingsRegistryKey;
+        m_fullSettingsRegistryPath = AZStd::string::format("%s/%s",
+            m_settingsRegistryBasePath.c_str(), m_settingsRegistryDocumentKey.c_str());
+
+        m_fullSettingsFilepath = AZStd::string::format("%s/%s_settings.%s",
+            RootSettingsFilepath, propertyEditorName.c_str(), SettingsRegistrar::SettingsRegistryFileExt);
+
+        m_wereSettingsLoaded = LoadExpanderStates();
+    }
+
+    DocumentPropertyEditorSettings::~DocumentPropertyEditorSettings()
+    {
+        SaveAndCleanExpanderStates();
+    }
+
+    void DocumentPropertyEditorSettings::SaveExpanderStates()
+    {
+        m_settingsRegistrar.StoreObjectSettings(m_fullSettingsRegistryPath, this);
+
+        // Configuration that the dumper util will use when collecting our data from the SettingsRegistry
+        AZ::SettingsRegistryMergeUtils::DumperSettings dumperSettings;
+        dumperSettings.m_prettifyOutput = true;
+        dumperSettings.m_includeFilter = [pathFilter = m_settingsRegistryBasePath](AZStd::string_view path)
+        {
+            return pathFilter.starts_with(path.substr(0, pathFilter.size()));
+        };
+        dumperSettings.m_jsonPointerPrefix = m_settingsRegistryBasePath;
+
+        auto outcome = m_settingsRegistrar.SaveSettingsToFile(m_fullSettingsFilepath, dumperSettings, m_settingsRegistryBasePath);
+        if (!outcome.IsSuccess())
+        {
+            AZ_Warning("DocumentPropertyEditorSettings", false, outcome.GetError().c_str());
+        }
+    }
+
+    bool DocumentPropertyEditorSettings::LoadExpanderStates()
+    {
+        auto loadOutcome = m_settingsRegistrar.LoadSettingsFromFile(m_fullSettingsFilepath);
+        if (loadOutcome.IsSuccess())
+        {
+            auto getOutcome = m_settingsRegistrar.GetObjectSettings(this, m_fullSettingsRegistryPath);
+            if (!getOutcome.IsSuccess())
+            {
+                AZ_Warning("DocumentPropertyEditorSettings", false, getOutcome.GetError().c_str());
+                return false;
+            }
+        }
+        else
+        {
+            AZ_Warning("DocumentPropertyEditorSettings", false, loadOutcome.GetError().c_str());
+            return false;
+        }
+
+        return true;
+    }
+
+    void DocumentPropertyEditorSettings::SaveAndCleanExpanderStates()
+    {
+        // Attempt to remove old settings from registry if the local state was successfully cleaned
+        // This way we save and dump to file the most accurate expander settings
+        if (m_cleanExpanderStateCallback && m_cleanExpanderStateCallback(m_expandedElementStates))
+        {
+            if (!m_settingsRegistrar.RemoveSettingFromRegistry(m_fullSettingsRegistryPath))
+            {
+                AZ_Warning("DocumentPropertyEditorSettings", false,
+                    "Failed to clean registry state %s before saving", m_fullSettingsRegistryPath.c_str());
+            }
+        }
+
+        if (!m_expandedElementStates.empty())
+        {
+            SaveExpanderStates();
+        }
+    }
+
+    void DocumentPropertyEditorSettings::SetExpanderStateForRow(const AZ::Dom::Path& rowPath, bool isExpanded)
+    {      
+        m_expandedElementStates[rowPath.ToString()] = isExpanded;
+    }
+
+    bool DocumentPropertyEditorSettings::GetExpanderStateForRow(const AZ::Dom::Path& rowPath)
+    {
+        AZStd::string_view strPath = rowPath.ToString();
+        if (m_expandedElementStates.contains(strPath))
+        {
+            return m_expandedElementStates[strPath];
+        }
+        return false;
+    }
+
+    bool DocumentPropertyEditorSettings::HasSavedExpanderStateForRow(const AZ::Dom::Path& rowPath) const
+    {
+        return m_expandedElementStates.contains(rowPath.ToString());
+    }
+
+    void DocumentPropertyEditorSettings::RemoveExpanderStateForRow(const AZ::Dom::Path& rowPath)
+    {
+        const AZStd::string& strPath = rowPath.ToString();
+        if (m_expandedElementStates.contains(strPath))
+        {
+            m_expandedElementStates.erase(strPath);
+        }
+    }
+
+    void DocumentPropertyEditorSettings::SetCleanExpanderStateCallback(CleanExpanderStateCallback function)
+    {
+        m_cleanExpanderStateCallback = function;
+    }
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.cpp
@@ -8,6 +8,8 @@
 
 #include "DocumentPropertyEditor.h"
 
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+
 namespace AzToolsFramework
 {
     DocumentPropertyEditorSettings::DocumentPropertyEditorSettings(
@@ -38,7 +40,7 @@ namespace AzToolsFramework
         dumperSettings.m_prettifyOutput = true;
         dumperSettings.m_includeFilter = [pathFilter = m_settingsRegistryBasePath](AZStd::string_view path)
         {
-            return pathFilter.starts_with(path.substr(0, pathFilter.size()));
+            return AZ::SettingsRegistryMergeUtils::IsPathAncestorDescendantOrEqual(pathFilter, path);
         };
         dumperSettings.m_jsonPointerPrefix = m_settingsRegistryBasePath;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.h
@@ -48,10 +48,10 @@ namespace AzToolsFramework
         void SetCleanExpanderStateCallback(CleanExpanderStateCallback function);
 
         //! Root filepath for DocumentPropertyEditor settings files
-        static constexpr char RootSettingsFilepath[] = "user/Registry/DocumentPropertyEditor";
+        static constexpr const char* RootSettingsFilepath = "user/Registry/DocumentPropertyEditor";
 
         //! Root SettingsRegistry path where DPE settings are stored
-        static constexpr char RootSettingsRegistryPath[] = "/O3DE/DocumentPropertyEditor";
+        static constexpr const char* RootSettingsRegistryPath = "/O3DE/DocumentPropertyEditor";
 
         //! Serialized map of expanded element states
         ExpanderStateMap m_expandedElementStates;
@@ -69,9 +69,9 @@ namespace AzToolsFramework
 
         SettingsRegistrar m_settingsRegistrar;
 
-        AZStd::string m_fullSettingsFilepath;
+        AZ::IO::Path m_settingsFilepath;
+
         AZStd::string m_fullSettingsRegistryPath;
         AZStd::string m_settingsRegistryBasePath;
-        AZStd::string m_settingsRegistryDocumentKey;
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.h>
+
+namespace AzToolsFramework
+{
+    //! This serializable class stores and loads the DocumentPropertyEditor settings such as tree node expansion state.
+    class DocumentPropertyEditorSettings
+    {
+    public:
+        AZ_RTTI(DocumentPropertyEditorSettings, "{7DECB0A1-A1AB-41B2-B31F-E52D3C3014A6}");
+
+        using ExpanderStateMap = AZStd::unordered_map<AZStd::string, bool>;
+        using CleanExpanderStateCallback = AZStd::function<bool(ExpanderStateMap&)>;
+
+        // Default ctor is required by SerializeContext but is not intended for use otherwise
+        DocumentPropertyEditorSettings() = default;
+        DocumentPropertyEditorSettings(const AZStd::string& settingsRegistryKey, const AZStd::string& propertyEditorName);
+
+        virtual ~DocumentPropertyEditorSettings();
+
+        static void Reflect(AZ::ReflectContext* context)
+        {
+            AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+            if (serializeContext)
+            {
+                serializeContext->Class<DocumentPropertyEditorSettings>()->Version(0)->Field(
+                    "ExpandedElements", &DocumentPropertyEditorSettings::m_expandedElementStates);
+            }
+        }
+
+        void SetExpanderStateForRow(const AZ::Dom::Path& rowPath, bool isExpanded);
+        bool GetExpanderStateForRow(const AZ::Dom::Path& rowPath);
+        bool HasSavedExpanderStateForRow(const AZ::Dom::Path& rowPath) const;
+        void RemoveExpanderStateForRow(const AZ::Dom::Path& rowPath);
+
+        bool WereSettingsLoaded() const { return m_wereSettingsLoaded; };
+
+        void SetCleanExpanderStateCallback(CleanExpanderStateCallback function);
+
+        //! Root filepath for DocumentPropertyEditor settings files
+        static constexpr char RootSettingsFilepath[] = "user/Registry/DocumentPropertyEditor";
+
+        //! Root SettingsRegistry path where DPE settings are stored
+        static constexpr char RootSettingsRegistryPath[] = "/O3DE/DocumentPropertyEditor";
+
+        //! Serialized map of expanded element states
+        ExpanderStateMap m_expandedElementStates;
+
+    private:
+        void SaveExpanderStates();
+        bool LoadExpanderStates();
+
+        void SaveAndCleanExpanderStates();
+
+        //! Optional callback to clean locally stored state before saving
+        CleanExpanderStateCallback m_cleanExpanderStateCallback;
+
+        bool m_wereSettingsLoaded = false;
+
+        SettingsRegistrar m_settingsRegistrar;
+
+        AZStd::string m_fullSettingsFilepath;
+        AZStd::string m_fullSettingsRegistryPath;
+        AZStd::string m_settingsRegistryBasePath;
+        AZStd::string m_settingsRegistryDocumentKey;
+    };
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/IPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/IPropertyEditor.h
@@ -55,7 +55,7 @@ namespace AzToolsFramework
             using DynamicEditDataProvider = AZStd::function<const AZ::Edit::ElementData*(const void* /*objectPtr*/, const AZ::SerializeContext::ClassData* /*classData*/)>;
             virtual void SetDynamicEditDataProvider([[maybe_unused]] DynamicEditDataProvider provider) {};
 
-            virtual void SetSavedStateKey([[maybe_unused]] AZ::u32 key, [[maybe_unused]] AZStd::string propertyEditorName = "") {}
+            virtual void SetSavedStateKey([[maybe_unused]] AZ::u32 key, [[maybe_unused]] AZStd::string propertyEditorName = {}) {}
 
             virtual bool HasFilteredOutNodes() const
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/IPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/IPropertyEditor.h
@@ -55,7 +55,7 @@ namespace AzToolsFramework
             using DynamicEditDataProvider = AZStd::function<const AZ::Edit::ElementData*(const void* /*objectPtr*/, const AZ::SerializeContext::ClassData* /*classData*/)>;
             virtual void SetDynamicEditDataProvider([[maybe_unused]] DynamicEditDataProvider provider) {};
 
-            virtual void SetSavedStateKey([[maybe_unused]] AZ::u32 key) {};
+            virtual void SetSavedStateKey([[maybe_unused]] AZ::u32 key, [[maybe_unused]] AZStd::string propertyEditorName = "") {}
 
             virtual bool HasFilteredOutNodes() const
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SettingsRegistrar.h"
+
+#include <AzCore/IO/ByteContainerStream.h>
+#include <AzCore/IO/FileIO.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+
+namespace AzToolsFramework
+{
+    AZ::Outcome<void, AZStd::string> SettingsRegistrar::SaveSettingsToFile(
+        const AZStd::string& relativeFilepath,
+        AZ::SettingsRegistryMergeUtils::DumperSettings dumperSettings,
+        const AZStd::string& rootSearchKey) const
+    {
+        AZ::SettingsRegistryInterface* registry = AZ::SettingsRegistry::Get();
+        if (!registry)
+        {
+            return AZ::Failure(AZStd::string::format("Failed to access global settings registry"));
+        }
+
+        constexpr const char* setregFileExt = ".setreg";
+        if (AZ::IO::Path(relativeFilepath).Extension() != setregFileExt)
+        {
+            return AZ::Failure(AZStd::string::format(
+                "Failed to save settings to file '%s': file must be of type '.setreg'", relativeFilepath.c_str()));
+        }
+
+        AZ::IO::FixedMaxPath fullSettingsPath = AZ::Utils::GetProjectPath();
+        fullSettingsPath /= relativeFilepath;
+        const char* posixSettingsPath = fullSettingsPath.AsPosix().c_str();
+
+        AZStd::string stringBuffer;
+        AZ::IO::ByteContainerStream stringStream(&stringBuffer);
+        if (!AZ::SettingsRegistryMergeUtils::DumpSettingsRegistryToStream(*registry, rootSearchKey, stringStream, dumperSettings))
+        {
+            return AZ::Failure(AZStd::string::format(
+                "Failed to save settings to file '%s': failed to retrieve settings from registry", posixSettingsPath));
+        }
+
+        constexpr auto openMode = AZ::IO::SystemFile::SF_OPEN_CREATE
+            | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH
+            | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY;
+        if (AZ::IO::SystemFile outputFile; outputFile.Open(posixSettingsPath, openMode))
+        {
+            if(outputFile.Write(stringBuffer.data(), stringBuffer.size()) != stringBuffer.size())
+            {
+                return AZ::Failure(AZStd::string::format(
+                    "Failed to save settings to file '%s': incomplete contents written", posixSettingsPath));
+            }
+        }
+
+        return AZ::Success();
+    }
+
+    AZ::Outcome<void, AZStd::string> SettingsRegistrar::LoadSettingsFromFile(
+        AZStd::string_view relativeFilepath,
+        AZStd::string_view anchorKey,
+        AZ::SettingsRegistryInterface::Format format) const
+    {
+        AZ::SettingsRegistryInterface* registry = AZ::SettingsRegistry::Get();
+        if (!registry)
+        {
+            return AZ::Failure(AZStd::string::format("Failed to access global settings registry"));
+        }
+
+        AZ::IO::FixedMaxPath fullSettingsPath = AZ::Utils::GetProjectPath();
+        fullSettingsPath /= relativeFilepath;
+        const char* posixSettingsPath = fullSettingsPath.AsPosix().c_str();
+
+        if (!AZ::IO::FileIOBase::GetInstance()->Exists(fullSettingsPath.c_str()))
+        {
+            return AZ::Failure(AZStd::string::format("Settings file does not exist: '%s'", posixSettingsPath)); 
+        }
+
+        if (registry->MergeSettingsFile(posixSettingsPath, format, anchorKey))
+        {
+            return AZ::Success();
+        }
+        else
+        {
+            return AZ::Failure(AZStd::string::format("Failed to merge settings file '%s': check log for errors", posixSettingsPath));
+        }
+    }
+
+    bool SettingsRegistrar::RemoveSettingFromRegistry(AZStd::string_view registryPath) const
+    {
+        AZ::SettingsRegistryInterface* registry = AZ::SettingsRegistry::Get();
+        if (!registry)
+        {
+            return false;
+        }
+        return registry->Remove(registryPath);
+    }
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/string/string_view.h>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/Utils/Utils.h>
+
+namespace AzToolsFramework
+{
+    //! Class wrapping file management required to save SettingsRegistry data to file as well as load
+    //! json data from file to the SettingsRegistry.
+    class SettingsRegistrar
+    {
+    public:
+        //! Saves all settings stored at the given SettingsRegistry key into a file at the given filepath. The
+        //! file and directory structure will be created if it does now exist. The file open mode is set to
+        //! overwrite existing file contents.
+        //! The DumperSettings can be used to narrow down the settings data dumped to file by
+        //! providing an filter function.
+        //! Specifying a json pointer path prefix in the DumperSettings may be required in order
+        //! for the dumped json data to match the in-memory path structure.
+        //! The path passed to this function is expected to be relative to the project root.
+        AZ::Outcome<void, AZStd::string> SaveSettingsToFile(
+            const AZStd::string& relativeFilepath,
+            AZ::SettingsRegistryMergeUtils::DumperSettings dumperSettings,
+            const AZStd::string& rootSearchKey = "") const;
+
+        //! Loads settings from the provided '.setreg' file and merges settings into the SettingsRegistry
+        //! at the given anchor key.
+        //! The path passed to this function is expected to be relative to the project root.
+        AZ::Outcome<void, AZStd::string> LoadSettingsFromFile(
+            AZStd::string_view relativeFilepath,
+            AZStd::string_view anchorKey = "",
+            AZ::SettingsRegistryInterface::Format format = AZ::SettingsRegistryInterface::Format::JsonMergePatch) const;
+
+        //! Attempts to retrieve settings stored at the given registry path and put them in the provided object.
+        //! The provided object is expected to be intialized before being passed to this function and it must
+        //! be AZ_RTTI enabled.
+        template<typename AzRttiEnabled_T>
+        AZ::Outcome<void, AZStd::string> GetObjectSettings(AzRttiEnabled_T* outSettingsObject, AZStd::string_view registryPath) const
+        {
+            AZ::SettingsRegistryInterface* registry = AZ::SettingsRegistry::Get();
+            if (!registry)
+            {
+                return AZ::Failure(AZStd::string::format("Failed to access global settings registry for data retrieval"));
+            }
+
+            if (registry->GetObject(*outSettingsObject, registryPath))
+            {
+                return AZ::Success();
+            }
+            else
+            {
+                return AZ::Failure(AZStd::string::format("Failed to retrieve settings at path '%s'", registryPath.data()));
+            }
+        }
+
+        //! Attempts to store reflected properties of the given AZ_RTTI enabled object at the given registry path.
+        template<typename AzRttiEnabled_T>
+        AZ::Outcome<void, AZStd::string> StoreObjectSettings(AZStd::string_view registryPath, AzRttiEnabled_T* settingsObject) const
+        {
+            AZ::SettingsRegistryInterface* registry = AZ::SettingsRegistry::Get();
+            if (!registry)
+            {
+                return AZ::Failure(AZStd::string::format("Failed to access global settings registry for data storage"));
+            }
+
+            if (registry->SetObject(registryPath, *settingsObject))
+            {
+                return AZ::Success();
+            }
+            else
+            {
+                return AZ::Failure(AZStd::string::format("Failed to store settings at path '%s'", registryPath.data()));
+            }
+        }
+
+        bool RemoveSettingFromRegistry(AZStd::string_view registryPath) const;
+
+        //! The file extension expected for SettingsRegistry files.
+        static constexpr const char* SettingsRegistryFileExt = AZ::SettingsRegistryInterface::Extension;
+    };
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.h
@@ -22,31 +22,37 @@ namespace AzToolsFramework
         //! Saves all settings stored at the given SettingsRegistry key into a file at the given filepath. The
         //! file and directory structure will be created if it does now exist. The file open mode is set to
         //! overwrite existing file contents.
+        //! The path passed to this function is expected to be relative to the project root.
         //! The DumperSettings can be used to narrow down the settings data dumped to file by
         //! providing an filter function.
         //! Specifying a json pointer path prefix in the DumperSettings may be required in order
         //! for the dumped json data to match the in-memory path structure.
-        //! The path passed to this function is expected to be relative to the project root.
+        //! The anchor key specifies a path in the registry where the settings will be saved.
         AZ::Outcome<void, AZStd::string> SaveSettingsToFile(
-            const AZStd::string& relativeFilepath,
+            AZ::IO::PathView relativeFilepath,
             AZ::SettingsRegistryMergeUtils::DumperSettings dumperSettings,
-            const AZStd::string& rootSearchKey = "") const;
+            const AZStd::string& anchorKey = AZStd::string{},
+            AZ::SettingsRegistryInterface* registry = nullptr) const;
 
         //! Loads settings from the provided '.setreg' file and merges settings into the SettingsRegistry
         //! at the given anchor key.
         //! The path passed to this function is expected to be relative to the project root.
         AZ::Outcome<void, AZStd::string> LoadSettingsFromFile(
-            AZStd::string_view relativeFilepath,
-            AZStd::string_view anchorKey = "",
+            AZ::IO::PathView relativeFilepath,
+            AZStd::string_view anchorKey = AZStd::string{},
+            AZ::SettingsRegistryInterface* registry = nullptr,
             AZ::SettingsRegistryInterface::Format format = AZ::SettingsRegistryInterface::Format::JsonMergePatch) const;
 
         //! Attempts to retrieve settings stored at the given registry path and put them in the provided object.
         //! The provided object is expected to be intialized before being passed to this function and it must
         //! be AZ_RTTI enabled.
         template<typename AzRttiEnabled_T>
-        AZ::Outcome<void, AZStd::string> GetObjectSettings(AzRttiEnabled_T* outSettingsObject, AZStd::string_view registryPath) const
+        AZ::Outcome<void, AZStd::string> GetObjectSettings(
+            AzRttiEnabled_T* outSettingsObject,
+            AZStd::string_view registryPath,
+            AZ::SettingsRegistryInterface* registry = nullptr) const
         {
-            AZ::SettingsRegistryInterface* registry = AZ::SettingsRegistry::Get();
+            registry = !registry ? AZ::SettingsRegistry::Get() : registry;
             if (!registry)
             {
                 return AZ::Failure(AZStd::string::format("Failed to access global settings registry for data retrieval"));
@@ -64,9 +70,12 @@ namespace AzToolsFramework
 
         //! Attempts to store reflected properties of the given AZ_RTTI enabled object at the given registry path.
         template<typename AzRttiEnabled_T>
-        AZ::Outcome<void, AZStd::string> StoreObjectSettings(AZStd::string_view registryPath, AzRttiEnabled_T* settingsObject) const
+        AZ::Outcome<void, AZStd::string> StoreObjectSettings(
+            AZStd::string_view registryPath,
+            AzRttiEnabled_T* settingsObject,
+            AZ::SettingsRegistryInterface* registry = nullptr) const
         {
-            AZ::SettingsRegistryInterface* registry = AZ::SettingsRegistry::Get();
+            registry = !registry ? AZ::SettingsRegistry::Get() : registry;
             if (!registry)
             {
                 return AZ::Failure(AZStd::string::format("Failed to access global settings registry for data storage"));
@@ -82,7 +91,7 @@ namespace AzToolsFramework
             }
         }
 
-        bool RemoveSettingFromRegistry(AZStd::string_view registryPath) const;
+        bool RemoveSettingFromRegistry(AZStd::string_view registryPath, AZ::SettingsRegistryInterface* registry = nullptr) const;
 
         //! The file extension expected for SettingsRegistry files.
         static constexpr const char* SettingsRegistryFileExt = AZ::SettingsRegistryInterface::Extension;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.h
@@ -31,7 +31,7 @@ namespace AzToolsFramework
         AZ::Outcome<void, AZStd::string> SaveSettingsToFile(
             AZ::IO::PathView relativeFilepath,
             AZ::SettingsRegistryMergeUtils::DumperSettings dumperSettings,
-            const AZStd::string& anchorKey = AZStd::string{},
+            const AZStd::string& anchorKey = {},
             AZ::SettingsRegistryInterface* registry = nullptr) const;
 
         //! Loads settings from the provided '.setreg' file and merges settings into the SettingsRegistry
@@ -39,7 +39,7 @@ namespace AzToolsFramework
         //! The path passed to this function is expected to be relative to the project root.
         AZ::Outcome<void, AZStd::string> LoadSettingsFromFile(
             AZ::IO::PathView relativeFilepath,
-            AZStd::string_view anchorKey = AZStd::string{},
+            AZStd::string_view anchorKey = {},
             AZ::SettingsRegistryInterface* registry = nullptr,
             AZ::SettingsRegistryInterface::Format format = AZ::SettingsRegistryInterface::Format::JsonMergePatch) const;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorEntityIdContainer.h>
+#include <AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyAudioCtrlTypes.h>
 #include <AzToolsFramework/UI/PropertyEditor/GenericComboBoxCtrl.h>
 
@@ -296,6 +297,8 @@ namespace AzToolsFramework
             EditorEntityIdContainer::Reflect(context);
             AzToolsFramework::CReflectedVarAudioControl::Reflect(context);
             ReflectPropertyEditor(context);
+
+            DocumentPropertyEditorSettings::Reflect(context);
 
             // reflect data for script, serialization, editing...
             if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
@@ -1200,7 +1200,7 @@ namespace AzToolsFramework
         m_impl->m_queuedTabOrderRefresh = false;
     }
 
-    void ReflectedPropertyEditor::SetSavedStateKey(AZ::u32 key)
+    void ReflectedPropertyEditor::SetSavedStateKey(AZ::u32 key, [[maybe_unused]] AZStd::string propertyEditorName)
     {
         if (m_impl->m_savedStateKey != key)
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx
@@ -79,7 +79,8 @@ namespace AzToolsFramework
 
         void SetFilterString(AZStd::string str) override;
         AZStd::string GetFilterString();
-        void SetSavedStateKey(AZ::u32 key) override; // a settings key which is used to store and load the set of things that are expanded or not and other settings
+        // a settings key which is used to store and load the set of things that are expanded or not and other settings
+        void SetSavedStateKey([[maybe_unused]] AZ::u32 key, [[maybe_unused]] AZStd::string propertyEditorName = "") override;
 
         void QueueInvalidation(PropertyModificationRefreshLevel level) override;
         //will force any queued invalidations to happen immediately

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -373,10 +373,14 @@ set(FILES
     UI/DocumentPropertyEditor/PropertyHandlerWidget.h
     UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
     UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+    UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.cpp
+    UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.h
     UI/DocumentPropertyEditor/IPropertyEditor.h
     UI/DocumentPropertyEditor/KeyQueryDPE.cpp
     UI/DocumentPropertyEditor/KeyQueryDPE.h
     UI/DocumentPropertyEditor/KeyQueryDPE.ui
+    UI/DocumentPropertyEditor/SettingsRegistrar.cpp
+    UI/DocumentPropertyEditor/SettingsRegistrar.h
     UI/DPEDebugViewer/DPEDebugModel.cpp
     UI/DPEDebugViewer/DPEDebugModel.h
     UI/DPEDebugViewer/DPEDebugTextView.cpp


### PR DESCRIPTION
**Description**
This PR adds support for saving expanded element states in property editors which use the DocumentPropertyEditor (DPE).

Notable changes include:
- Settings files for the DPE are stored in the active project's `user/Registry` dir:
  - `[projectRoot]/user/Registry/DocumentPropertyEditor/[propertyEditor]_settings.setreg`
- Expansion state is saved when closing a property editor or when switching files, and only for user activated expansions/collapses
- Shift+click will now expand/collapse a node and all of its children
- Also fixes expansion state saving with the RPE in the AssetEditor which was not functional

Saving state when switching files and recursive shift+click expansion from a node:

![dpeSavedExpansionState](https://user-images.githubusercontent.com/104796591/190016396-07ef18fd-405d-4fbb-892f-e715801a06bb.gif)

Settings file structure:

![dpe_savedExpansionState](https://user-images.githubusercontent.com/104796591/190016409-d840137c-acb6-4bf6-be9c-996ea834dab9.jpg)

**Testing**
- Expanded/collapsed nodes in a document and verified the state persists after switching back and forth between files as well as closing and reopening the editor
- Verified that state is saved correctly to disk
- Verified expand/collapse all changes persist