### PR TITLE
11309 Fix for editor lock when entering component mode.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
@@ -185,7 +185,7 @@ namespace AzToolsFramework
         void ComponentModeDelegate::OnComponentModeEnterButtonPressed()
         {
             // Check the entity hasn't been deselected but we haven't been told yet.
-            if (!IsSelected(m_entityComponentIdPair.GetEntityId())
+            if (!IsSelected(m_entityComponentIdPair.GetEntityId()))
             {
                 return;
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
@@ -186,7 +186,8 @@ namespace AzToolsFramework
         {
             // Check the entity hasn't been deselected but we haven't been told yet.
             bool isSelected = false;
-            ToolsApplicationRequests::Bus::BroadcastResult(isSelected, &ToolsApplicationRequests::IsSelected, m_entityComponentIdPair.GetEntityId());
+
+            isSelected = IsSelected(m_entityComponentIdPair.GetEntityId());
             if (!isSelected)
             {
                 return;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
@@ -184,6 +184,14 @@ namespace AzToolsFramework
 
         void ComponentModeDelegate::OnComponentModeEnterButtonPressed()
         {
+            // Check the entity hasn't been deselected but we haven't been told yet.
+            bool isSelected = false;
+            ToolsApplicationRequests::Bus::BroadcastResult(isSelected, &ToolsApplicationRequests::IsSelected, m_entityComponentIdPair.GetEntityId());
+            if (!isSelected)
+            {
+                return;
+            }
+
             // ensure we aren't already in ComponentMode and are not also attempting to enter game mode
             if (!InComponentMode() && !EditorRequestingGame())
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
@@ -185,10 +185,7 @@ namespace AzToolsFramework
         void ComponentModeDelegate::OnComponentModeEnterButtonPressed()
         {
             // Check the entity hasn't been deselected but we haven't been told yet.
-            bool isSelected = false;
-
-            isSelected = IsSelected(m_entityComponentIdPair.GetEntityId());
-            if (!isSelected)
+            if (!IsSelected(m_entityComponentIdPair.GetEntityId())
             {
                 return;
             }


### PR DESCRIPTION
Signed-off-by: sphrose <82213493+sphrose@users.noreply.github.com>

## What does this PR do?

This PR fixes a potential editor hang when pressing escape immediately before attempting to enter component mode. The current entity is deselected but the information hasn't yet reached the component mode system, so all the editor ends up disabled.

Issue: https://github.com/o3de/o3de/issues/11309

## How was this PR tested?

The duplication instructions were followed multiple times with no issues. Debugging text was added so I could see the times when the added code prevented the issue from happening.
