### PR TITLE
Significantly reduces memory usage of Editor

### DIFF
--- a/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsContainer.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsContainer.cpp
@@ -301,7 +301,7 @@ namespace ProjectSettingsTool
         return nullptr;
     }
 
-    rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>& ProjectSettingsContainer::GetProjectJsonAllocator()
+    rapidjson::RAPIDJSON_DEFAULT_ALLOCATOR& ProjectSettingsContainer::GetProjectJsonAllocator()
     {
         return m_projectJson.m_document->GetAllocator();
     }

--- a/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsContainer.h
+++ b/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsContainer.h
@@ -109,7 +109,7 @@ namespace ProjectSettingsTool
         AZStd::unique_ptr<PlistDictionary> CreatePlistDictionary(const Platform& plat);
 
         // Returns the allocator used by ProjectJson
-        rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>& GetProjectJsonAllocator();
+        rapidjson::RAPIDJSON_DEFAULT_ALLOCATOR& GetProjectJsonAllocator();
 
         static AZ::Outcome<rapidjson::Value*, void> GetJsonValue(rapidjson::Document& settings, const char* key);
 

--- a/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
+++ b/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
@@ -35,12 +35,22 @@ namespace rapidjson_ly_internal
     }
 }
 
+
 #define RAPIDJSON_NEW(x)  new(azmalloc(sizeof(x), alignof(x), AZ::SystemAllocator, "RapidJSON")) x
 #define RAPIDJSON_DELETE(x) rapidjson_ly_internal::Delete(x)
 #define RAPIDJSON_MALLOC(_size) AZ::AllocatorInstance<AZ::SystemAllocator>::Get().Allocate(_size, 16, 0, "RapidJson", __FILE__, __LINE__, 0)
 #define RAPIDJSON_REALLOC(_ptr, _newSize) _ptr ? AZ::AllocatorInstance<AZ::SystemAllocator>::Get().ReAllocate(_ptr, _newSize, 16) : RAPIDJSON_MALLOC(_newSize)
 #define RAPIDJSON_FREE(_ptr) if (_ptr) { AZ::AllocatorInstance<AZ::SystemAllocator>::Get().DeAllocate(_ptr, 0, 0); }
 #define RAPIDJSON_CLASS_ALLOCATOR(_class) AZ_CLASS_ALLOCATOR(_class, AZ::SystemAllocator, 0)
+
+// By default, RapidJSON uses its own pooling allocator that allocates in 64k chunks and then uses the
+// contents of those chunks internally.
+// However, O3DE defines the above macros, which redirect the RapidJSON allocations into the O3DE system
+// allocator, which itself is a also a chunk-based pooling allocator (HPHA).
+// This double-chunking would be wasteful, so tell RapidJSON to directly ask for allocations instead
+// of attempting to pool them.  The rapidjson::CrtAllocator just passes allocation and deallocation to the above
+// macros.
+#define RAPIDJSON_DEFAULT_ALLOCATOR CrtAllocator
 
 // Set custom namespace for AzCore's rapidjson to avoid various collisions.
 #define RAPIDJSON_NAMESPACE rapidjson_ly


### PR DESCRIPTION
This mainly affects memory usage when large levels are loaded, not tiny ones.  It has to do with the storage of JSON DOM trees in memory.

This change makes RapidJSON no longer pool its allocations itself.  Instead it directly asks the AzCore SystemAllocator for memory.  The AzCore SystemAllocator already pools memory in 64k blocks itself for small allocations and reuses the memory in those blocks when they are returned.

The memory savings are roughly 2x for any time JSON is involved. They come from the fact that RapidJSON would ask for 64K bytes PLUS 32 extra bytes for a chunk header.  This would cause the AzCore SystemAllocator to have to ask for extra chunks since the
data would not fit in 1x 64 chunk.   What makes it worse is that
this would get doubled again by the fact that AzCore asks for it
to be 64k aligned, which doubles the amount because of the way
__malloc_aligned functions.

Allocating X bytes with Y alignment on Windows will cause __malloc_aligned(x,y) to allocate at least (X + Y) actual bytes on windows, since that is the only way to ensure that there is a contiguous block of memory within the returned pointer that starts at a Y alignment but still has X bytes after it.  (NO actual OS support for actually getting aligned memory at the malloc level)

The savings here come from the fact that now all the small objects like strings and tokens and nodes and so on will all go into the AzCore's own pooling allocator (HPHASchema) in the buckets meant for small objects, instead of as extra tree allocations.  These small objects are combined together in a pooling mechanism, without the 'double chunking' occuring.  

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>

## How was this PR tested?

Using the Visual studio memory profiler.  There is a limit to the number of characters that can be in a PR header, so I will attach the performance before and afters below.
