### PR TITLE
Fixing issue where hlsl and spi-rv handle modulus math differently with negative numbers. (#11833)

### DIFF
--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroHelpers.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainMacroHelpers.azsli
@@ -20,7 +20,10 @@ void SampleMacroTexture(float2 worldPosition, float2 positionDdx, float2 positio
     int macroGridResolution = TerrainSrg::m_macroMaterialGridInfo.m_tileCount1D;
     float macroTileSize = TerrainSrg::m_macroMaterialGridInfo.m_tileSize;
     int2 macroTileWorldCoord = int2(floor(worldPosition / macroTileSize));
-    uint2 macroLocalCoord = ((macroTileWorldCoord % macroGridResolution) + macroGridResolution) % macroGridResolution;
+
+    // Only do modulus math on positive numbers for platform consistency.
+    int2 macroLocalCoordSigned = (abs(macroTileWorldCoord) % macroGridResolution) * sign(macroTileWorldCoord);
+    uint2 macroLocalCoord = uint2(macroLocalCoordSigned + macroGridResolution) % macroGridResolution;
 
     uint macroTileIndex = macroGridResolution * macroLocalCoord.y + macroLocalCoord.x;
     static const uint NumMacroMaterialsPerTile = 4;


### PR DESCRIPTION
Fixing issue where hlsl and spi-rv handle modulus math differently with negative numbers. This change ensures that the modulus operation is always done with positive numbers to make sure the platform specific shaders have the same behavior.

(cherry picked from commit f73f81bff77a3ea77c720c5786a45df7ade17025)