### PR TITLE
Fix for #11824. On initialization, terrain wasn't correctly updating zmin and zmax.

### DIFF
--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
@@ -85,7 +85,7 @@ namespace Terrain
                 }
             }
         );
-        OnTerrainDataChanged(AZ::Aabb::CreateNull(), TerrainDataChangedMask::HeightData);
+        OnTerrainDataChanged(AZ::Aabb::CreateNull(), TerrainDataChangedMask(TerrainDataChangedMask::HeightData | TerrainDataChangedMask::Settings));
         m_meshManager.Initialize(*GetParentScene());
     }
 


### PR DESCRIPTION
## What does this PR do?
On initialization, terrain wasn't correctly updating zmin and zmax. This caused terrain to not render when settings changed because zmin and zmax initialize to 0.

Fixes: #11824

## How was this PR tested?

Tested terrain levels to make sure updating terrain settings were reflected immediately and terrain continued to render as expected.
