### PR TITLE
Extracted out the host OS conditions for presets to their own presets

### DIFF
--- a/cmake/Platform/Android/CMakePresets.json
+++ b/cmake/Platform/Android/CMakePresets.json
@@ -18,16 +18,7 @@
         "android-ninja",
         "android-unity",
         "android-non-monolithic"
-      ],
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": [
-          "Darwin",
-          "Linux",
-          "Windows"
-        ]
-      }
+      ]
     },
     {
       "name": "android-mono-default",
@@ -38,16 +29,7 @@
         "android-ninja",
         "android-unity",
         "android-monolithic"
-      ],
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": [
-          "Darwin",
-          "Linux",
-          "Windows"
-        ]
-      }
+      ]
     },
     {
       "name": "android-unity",
@@ -56,17 +38,9 @@
       "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
       "binaryDir": "${sourceDir}/build/android",
       "inherits": [
-        "unity"
-      ],
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": [
-          "Darwin",
-          "Linux",
-          "Windows"
-        ]
-      }
+        "unity",
+        "host-windows-linux-mac"
+      ]
     },
     {
       "name": "android-no-unity",
@@ -75,17 +49,9 @@
       "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
       "binaryDir": "${sourceDir}/build/android_no_unity",
       "inherits": [
-        "no-unity"
-      ],
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": [
-          "Darwin",
-          "Linux",
-          "Windows"
-        ]
-      }
+        "no-unity",
+        "host-windows-linux-mac"
+      ]
     },
     {
       "name": "android-non-monolithic",
@@ -93,17 +59,9 @@
       "description": "Default configuration for non-monolithic builds",
       "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
       "inherits": [
-        "non-monolithic"
-      ],
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": [
-          "Darwin",
-          "Linux",
-          "Windows"
-        ]
-      }
+        "non-monolithic",
+        "host-windows-linux-mac"
+      ]
     },
     {
       "name": "android-monolithic",
@@ -112,17 +70,9 @@
       "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
       "binaryDir": "${sourceDir}/build/android_mono",
       "inherits": [
-        "monolithic"
-      ],
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": [
-          "Darwin",
-          "Linux",
-          "Windows"
-        ]
-      }
+        "monolithic",
+        "host-windows-linux-mac"
+      ]
     },
     {
       "name": "android-ninja",
@@ -132,16 +82,7 @@
       "binaryDir": "${sourceDir}/build/android_ninja",
       "inherits": [
         "android-ninja-unity"
-      ],
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": [
-          "Darwin",
-          "Linux",
-          "Windows"
-        ]
-      }
+      ]
     },
     {
       "name": "android-ninja-unity",
@@ -152,16 +93,7 @@
       "inherits": [
         "ninja-multi-config",
         "android-unity"
-      ],
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": [
-          "Darwin",
-          "Linux",
-          "Windows"
-        ]
-      }
+      ]
     },
     {
       "name": "android-ninja-no-unity",
@@ -172,16 +104,7 @@
       "inherits": [
         "ninja-multi-config",
         "android-no-unity"
-      ],
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": [
-          "Darwin",
-          "Linux",
-          "Windows"
-        ]
-      }
+      ]
     }
   ],
   "buildPresets": [
@@ -190,15 +113,9 @@
       "displayName": "Android",
       "description": "Builds all targets for Android",
       "configurePreset": "android-default",
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": [
-          "Darwin",
-          "Linux",
-          "Windows"
-        ]
-      }
+      "inherits": [
+        "host-windows-linux-mac"
+      ]
     },
     {
       "name": "android-install",
@@ -206,32 +123,18 @@
       "description": "Builds the \"install\" target for Android, which builds all target and runs the CMake --install step",
       "configurePreset": "android-default",
       "inherits": [
-        "install"
-      ],
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": [
-          "Darwin",
-          "Linux",
-          "Windows"
-        ]
-      }
+        "install",
+        "host-windows-linux-mac"
+      ]
     },
     {
       "name": "android-mono-default",
       "displayName": "Android Monolithic",
       "description": "Builds all targets for Android in the monolithic permutation",
       "configurePreset": "android-mono-default",
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": [
-          "Darwin",
-          "Linux",
-          "Windows"
-        ]
-      }
+      "inherits": [
+        "host-windows-linux-mac"
+      ]
     },
     {
       "name": "android-mono-install",
@@ -239,17 +142,9 @@
       "description": "Builds the \"install\" target for android monolithic permutation, which builds all target and runs the CMake --install step",
       "configurePreset": "android-mono-default",
       "inherits": [
-        "install"
-      ],
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": [
-          "Darwin",
-          "Linux",
-          "Windows"
-        ]
-      }
+        "install",
+        "host-windows-linux-mac"
+      ]
     }
   ],
   "testPresets": []

--- a/cmake/Platform/Common/CMakePresets.json
+++ b/cmake/Platform/Common/CMakePresets.json
@@ -89,11 +89,96 @@
             }
         },
         {
+            "name": "makefiles",
+            "displayName": "Unix Makefiles",
+            "description": "Configure using Unix Makefile generator",
+            "generator": "Unix Makefiles",
+            "hidden": true
+        },
+        {
             "name": "ninja-multi-config",
             "displayName": "Ninja Multi-Config",
-            "description": "Default build using Ninja Multi-Config generator",
+            "description": "Configure using Ninja Multi-Config generator",
             "hidden": true,
             "generator": "Ninja Multi-Config"
+        },
+        {
+            "name": "vs2022",
+            "displayName": "Visual Studio 2022",
+            "description": "Configure using VS2022 generator",
+            "generator": "Visual Studio 17 2022",
+            "hidden": true,
+            "inherits": [
+                "host-windows"
+            ]
+        },
+        {
+            "name": "vs2019",
+            "displayName": "Visual Studio 2019",
+            "description": "Configure using VS2019 generator",
+            "generator": "Visual Studio 16 2019",
+            "hidden": true,
+            "inherits": [
+                "host-windows"
+            ]
+        },
+        {
+            "name": "xcode",
+            "displayName": "Xcode",
+            "description": "Configure using Xcode generator",
+            "generator": "Xcode",
+            "hidden": true,
+            "inherits": [
+                "host-mac"
+            ]
+        },
+        {
+            "name": "host-windows",
+            "displayName": "Host OS - Windows",
+            "description": "Specifies Windows host condition for configure preset",
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "host-linux",
+            "displayName": "Host OS - Linux",
+            "description": "Specifies Linux host condition for configure preset",
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "host-mac",
+            "displayName": "Host OS - Mac",
+            "description": "Specifies Mac host condition for configure preset",
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            }
+        },
+        {
+            "name": "host-windows-linux-mac",
+            "displayName": "Host OS - Any",
+            "description": "Allows Windows, Linux or Mac to be used for host condition for configure preset",
+            "hidden": true,
+            "condition": {
+                "type": "inList",
+                "string": "${hostSystemName}",
+                "list": [
+                  "Darwin",
+                  "Linux",
+                  "Windows"
+                ]
+              }
         }
     ],
     "buildPresets": [
@@ -149,6 +234,58 @@
             "configurePreset": "default",
             "inherits": [ "profile"],
             "targets": ["TEST_SUITE_main", "TEST_SUITE_smoke"]
+        },
+        {
+            "name": "host-windows",
+            "displayName": "Host OS - Windows",
+            "description": "Specifies Windows host condition for build preset",
+            "hidden": true,
+            "configurePreset": "default",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "host-linux",
+            "displayName": "Host OS - Linux",
+            "description": "Specifies Linux host condition for build preset",
+            "hidden": true,
+            "configurePreset": "default",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "host-mac",
+            "displayName": "Host OS - Mac",
+            "description": "Specifies Mac host condition for build preset",
+            "hidden": true,
+            "configurePreset": "default",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            }
+        },
+        {
+            "name": "host-windows-linux-mac",
+            "displayName": "Host OS - Any",
+            "description": "Allows Windows, Linux or Mac to be used for host condition for build preset",
+            "hidden": true,
+            "configurePreset": "default",
+            "condition": {
+                "type": "inList",
+                "string": "${hostSystemName}",
+                "list": [
+                  "Darwin",
+                  "Linux",
+                  "Windows"
+                ]
+              }
         }
     ],
     "testPresets": [
@@ -193,6 +330,42 @@
             "configuration": "profile",
             "output": {
                 "outputLogFile": "Ctest-${presetName}-profile.log"
+            }
+        },
+        {
+            "name": "host-windows",
+            "displayName": "Host OS - Windows",
+            "description": "Specifies Windows host condition for test preset",
+            "hidden": true,
+            "configurePreset": "default",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "host-linux",
+            "displayName": "Host OS - Linux",
+            "description": "Specifies Linux host condition for test preset",
+            "hidden": true,
+            "configurePreset": "default",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "host-mac",
+            "displayName": "Host OS - Mac",
+            "description": "Specifies Mac host condition for test preset",
+            "hidden": true,
+            "configurePreset": "default",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
             }
         }
     ]

--- a/cmake/Platform/Linux/CMakePresets.json
+++ b/cmake/Platform/Linux/CMakePresets.json
@@ -17,12 +17,7 @@
                 "linux-ninja",
                 "linux-unity",
                 "linux-non-monolithic"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         },
         {
             "name": "linux-mono-default",
@@ -32,12 +27,7 @@
                 "linux-ninja",
                 "linux-unity",
                 "linux-monolithic"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         },
         {
             "name": "linux-clang-default",
@@ -48,12 +38,7 @@
                 "linux-ninja",
                 "linux-clang",
                 "linux-non-monolithic"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         },
         {
             "name": "linux-gcc-default",
@@ -64,12 +49,7 @@
                 "linux-ninja",
                 "linux-gcc",
                 "linux-non-monolithic"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         },
         {
             "name": "linux-unity",
@@ -77,13 +57,9 @@
             "description": "Linux build which uses unity files",
             "binaryDir": "${sourceDir}/build/linux",
             "inherits": [
-                "unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+                "unity",
+                "host-linux"
+            ]
         },
         {
             "name": "linux-no-unity",
@@ -91,26 +67,18 @@
             "description": "Linux build which uses unity files",
             "binaryDir": "${sourceDir}/build/linux_no_unity",
             "inherits": [
-                "no-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+                "no-unity",
+                "host-linux"
+            ]
         },
         {
             "name": "linux-non-monolithic",
             "displayName": "Linux Non-monolithic",
             "description": "Default configuration for non-monolithic builds",
             "inherits": [
-                "non-monolithic"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+                "non-monolithic",
+                "host-linux"
+            ]
         },
         {
             "name": "linux-monolithic",
@@ -118,13 +86,9 @@
             "description": "Default configuration for monolithic builds",
             "binaryDir": "${sourceDir}/build/linux_mono",
             "inherits": [
-                "monolithic"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+                "monolithic",
+                "host-linux"
+            ]
         },
         {
             "name": "linux-ninja",
@@ -132,13 +96,9 @@
             "description": "Configure Linux using with the Ninja generator",
             "binaryDir": "${sourceDir}/build/linux_ninja",
             "inherits": [
-                "ninja-multi-config"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+                "ninja-multi-config",
+                "host-linux"
+            ]
         },
         {
             "name": "linux-ninja-unity",
@@ -148,12 +108,7 @@
             "inherits": [
                 "ninja-multi-config",
                 "linux-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         },
         {
             "name": "linux-ninja-no-unity",
@@ -163,54 +118,37 @@
             "inherits": [
                 "ninja-multi-config",
                 "linux-no-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         },
         {
             "name": "linux-makefiles",
             "displayName": "Linux Unix Makefiles",
             "description": "Configure Linux using with the Unix Makefiles generator",
             "binaryDir": "${sourceDir}/build/linux_makefiles",
-            "generator": "Unix Makefiles",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            "inherits": [
+                "makefiles",
+                "host-linux"
+            ]
         },
         {
             "name": "linux-makefiles-unity",
             "displayName": "Linux Unix Makefiles Unity",
             "description": "Configure Linux with the Unix Makefiles generator + Unity Builds",
             "binaryDir": "${sourceDir}/build/linux_makefiles_unity",
-            "generator": "Unix Makefiles",
             "inherits": [
+                "makefiles",
                 "linux-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         },
         {
             "name": "linux-makefiles-no-unity",
             "displayName": "Linux Unix Makefiles without Unity",
             "description": "Configure Linux with the Unix Makefiles Generator without unity builds",
             "binaryDir": "${sourceDir}/build/linux_makefiles_no_unity",
-            "generator": "Unix Makefiles",
             "inherits": [
+                "makefiles",
                 "linux-no-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         },
         {
             "name": "linux-clang",
@@ -219,12 +157,7 @@
             "binaryDir": "${sourceDir}/build/linux_clang",
             "inherits":[
                 "linux-clang-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         },
         {
             "name": "linux-clang-unity",
@@ -243,12 +176,7 @@
             },
             "inherits": [
                 "linux-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         },
         {
             "name": "linux-clang-no-unity",
@@ -267,12 +195,7 @@
             },
             "inherits": [
                 "linux-no-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         },
         {
             "name": "linux-gcc",
@@ -281,12 +204,7 @@
             "binaryDir": "${sourceDir}/build/linux_gcc",
             "inherits":[
                 "linux-gcc-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         },
         {
             "name": "linux-gcc-unity",
@@ -305,12 +223,7 @@
             },
             "inherits": [
                 "linux-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         },
         {
             "name": "linux-gcc-no-unity",
@@ -329,12 +242,7 @@
             },
             "inherits": [
                 "linux-no-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            ]
         }
     ],
     "buildPresets": [
@@ -343,11 +251,9 @@
             "displayName": "Linux",
             "description": "Builds all targets for Linux",
             "configurePreset": "linux-default",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            "inherits":[
+                "host-linux"
+            ]
         },
         {
             "name": "linux-install",
@@ -355,24 +261,18 @@
             "description": "Builds the \"install\" target for Linux, which builds all target and runs the CMake --install step",
             "configurePreset": "linux-default",
             "inherits": [
-                "install"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+                "install",
+                "host-linux"
+            ]
         },
         {
             "name": "linux-mono-default",
             "displayName": "Linux Monolithic",
             "description": "Builds all targets for Linux in the monolithic permutation",
             "configurePreset": "linux-mono-default",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+            "inherits":[
+                "host-linux"
+            ]
         },
         {
             "name": "linux-mono-install",
@@ -380,13 +280,9 @@
             "description": "Builds the \"install\" target for linux monolithic permutation, which builds all target and runs the CMake --install step",
             "configurePreset": "linux-mono-default",
             "inherits": [
-                "install"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+                "install",
+                "host-linux"
+            ]
         },
         {
             "name": "linux-editor",
@@ -394,13 +290,9 @@
             "description": "Builds the Editor application for Linux",
             "configurePreset": "linux-default",
             "inherits": [
-                "editor"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+                "editor",
+                "host-linux"
+            ]
         },
         {
             "name": "linux-assetprocessor",
@@ -408,13 +300,9 @@
             "description": "Builds the AssetProcessor application for Linux",
             "configurePreset": "linux-default",
             "inherits": [
-                "assetprocessor"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+                "assetprocessor",
+                "host-linux"
+            ]
         },
         {
             "name": "linux-test",
@@ -422,13 +310,9 @@
             "description": "Builds the TEST_SUITE_smoke/TEST_SUITE_main custom targets for Linux",
             "configurePreset": "linux-default",
             "inherits": [
-                "test-default"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+                "test-default",
+                "host-linux"
+            ]
         }
     ],
     "testPresets": [
@@ -438,13 +322,9 @@
             "description": "Runs the Smoke + Main Test Suite. Requires the linux-test build preset to have completed successfully",
             "configurePreset": "linux-default",
             "inherits": [
-                "test-default"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+                "test-default",
+                "host-linux"
+            ]
         },
         {
             "name": "linux-test-debug",
@@ -452,13 +332,9 @@
             "description": "Runs the Smoke + Main Test Suite in debug configuration. Requires the linux-test build preset to have completed successfully",
             "configurePreset": "linux-default",
             "inherits": [
-                "test-default-debug"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+                "test-default-debug",
+                "host-linux"
+            ]
         },
         {
             "name": "linux-test-profile",
@@ -466,13 +342,9 @@
             "description": "Runs the Smoke + Main Test Suite in profile configuration. Requires the linux-test build preset to have completed successfully",
             "configurePreset": "linux-default",
             "inherits": [
-                "test-default-profile"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
+                "test-default-profile",
+                "host-linux"
+            ]
         }
     ]
 }

--- a/cmake/Platform/Mac/CMakePresets.json
+++ b/cmake/Platform/Mac/CMakePresets.json
@@ -17,12 +17,7 @@
         "mac-xcode",
         "mac-unity",
         "mac-non-monolithic"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      ]
     },
     {
       "name": "mac-mono-default",
@@ -32,12 +27,7 @@
         "mac-ninja",
         "mac-unity",
         "mac-monolithic"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      ]
     },
     {
       "name": "mac-unity",
@@ -45,13 +35,9 @@
       "description": "Mac build which uses unity files",
       "binaryDir": "${sourceDir}/build/mac",
       "inherits": [
-        "unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "unity",
+        "host-mac"
+      ]
     },
     {
       "name": "mac-no-unity",
@@ -59,26 +45,18 @@
       "description": "Mac build which uses unity files",
       "binaryDir": "${sourceDir}/build/mac_no_unity",
       "inherits": [
-        "no-unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "no-unity",
+        "host-mac"
+      ]
     },
     {
       "name": "mac-non-monolithic",
       "displayName": "Mac Non-Monolithic",
       "description": "Default configuration for non-monolithic builds",
       "inherits": [
-        "non-monolithic"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "non-monolithic",
+        "host-mac"
+      ]
     },
     {
       "name": "mac-monolithic",
@@ -86,55 +64,38 @@
       "description": "Default configuration for monolithic builds",
       "binaryDir": "${sourceDir}/build/mac_mono",
       "inherits": [
-        "monolithic"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "monolithic",
+        "host-mac"
+      ]
     },
     {
       "name": "mac-xcode",
       "displayName": "Mac Xcode",
       "description": "Configure Mac using with the Xcode generator",
       "binaryDir": "${sourceDir}/build/mac_xcode",
-      "generator": "Xcode",
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      "inherits":[
+        "xcode"
+      ]
     },
     {
       "name": "mac-xcode-unity",
       "displayName": "Mac Xcode Unity",
       "description": "Configure Mac with the Xcode generator + Unity Builds",
       "binaryDir": "${sourceDir}/build/mac_xcode_unity",
-      "generator": "Xcode",
       "inherits": [
-        "mac-unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "mac-unity",
+        "xcode"
+      ]
     },
     {
       "name": "mac-xcode-no-unity",
       "displayName": "Mac Xcode without Unity",
       "description": "Configure Mac with the Xcode Generator without unity builds",
       "binaryDir": "${sourceDir}/build/mac_xcode_no_unity",
-      "generator": "Xcode",
       "inherits": [
-        "mac-no-unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "mac-no-unity",
+        "xcode"
+      ]
     },
     {
       "name": "mac-ninja",
@@ -143,12 +104,7 @@
       "binaryDir": "${sourceDir}/build/mac_ninja",
       "inherits": [
         "mac-ninja-unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      ]
     },
     {
       "name": "mac-ninja-unity",
@@ -158,12 +114,7 @@
       "inherits": [
         "ninja-multi-config",
         "mac-unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      ]
     },
     {
       "name": "mac-ninja-no-unity",
@@ -173,12 +124,7 @@
       "inherits": [
         "ninja-multi-config",
         "mac-no-unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      ]
     }
   ],
   "buildPresets": [
@@ -187,11 +133,9 @@
       "displayName": "Mac",
       "description": "Builds all targets for Mac",
       "configurePreset": "mac-default",
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      "inherits":[
+        "host-mac"
+      ]
     },
     {
       "name": "mac-install",
@@ -199,7 +143,8 @@
       "description": "Builds the \"install\" target for Mac, which builds all target and runs the CMake --install step",
       "configurePreset": "mac-default",
       "inherits": [
-        "install"
+        "install",
+        "host-mac"
       ],
       "condition": {
         "type": "equals",
@@ -212,11 +157,9 @@
       "displayName": "Mac Monolithic",
       "description": "Builds all targets for Mac in the monolithic permutation",
       "configurePreset": "mac-mono-default",
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      "inherits":[
+        "host-mac"
+      ]
     },
     {
       "name": "mac-mono-install",
@@ -224,13 +167,9 @@
       "description": "Builds the \"install\" target for mac monolithic permutation, which builds all target and runs the CMake --install step",
       "configurePreset": "mac-mono-default",
       "inherits": [
-        "install"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "install",
+        "host-mac"
+      ]
     },
     {
       "name": "mac-editor",
@@ -238,13 +177,9 @@
       "description": "Builds the Editor application for Mac",
       "configurePreset": "mac-default",
       "inherits": [
-        "editor"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "editor",
+        "host-mac"
+      ]
     },
     {
       "name": "mac-assetprocessor",
@@ -252,13 +187,9 @@
       "description": "Builds the AssetProcessor application for Mac",
       "configurePreset": "mac-default",
       "inherits": [
-        "assetprocessor"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "assetprocessor",
+        "host-mac"
+      ]
     },
     {
       "name": "mac-test",
@@ -266,13 +197,9 @@
       "description": "Builds the TEST_SUITE_smoke/TEST_SUITE_main custom targets for Mac",
       "configurePreset": "mac-default",
       "inherits": [
-        "test-default"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "test-default",
+        "host-mac"
+      ]
     }
   ],
   "testPresets": [
@@ -282,13 +209,9 @@
       "description": "Runs the Smoke + Main Test Suite. Requires the mac-test build preset to have completed successfully",
       "configurePreset": "mac-default",
       "inherits": [
-        "test-default"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "test-default",
+        "host-mac"
+      ]
     },
     {
       "name": "mac-test-debug",
@@ -296,13 +219,9 @@
       "description": "Runs the Smoke + Main Test Suite in debug configuration. Requires the mac-test build preset to have completed successfully",
       "configurePreset": "mac-default",
       "inherits": [
-        "test-default-debug"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "test-default-debug",
+        "host-mac"
+      ]
     },
     {
       "name": "mac-test-profile",
@@ -310,13 +229,9 @@
       "description": "Runs the Smoke + Main Test Suite in profile configuration. Requires the mac-test build preset to have completed successfully",
       "configurePreset": "mac-default",
       "inherits": [
-        "test-default-profile"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "test-default-profile",
+        "host-mac"
+      ]
     }
   ]
 }

--- a/cmake/Platform/Windows/CMakePresets.json
+++ b/cmake/Platform/Windows/CMakePresets.json
@@ -15,12 +15,7 @@
             "description": "Default Windows",
             "inherits": [
                 "windows-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+            ]
         },
         {
             "name": "windows-mono-default",
@@ -29,12 +24,7 @@
             "inherits": [
                 "windows-unity",
                 "windows-monolithic"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+            ]
         },
         {
             "name": "windows-unity",
@@ -42,13 +32,9 @@
             "description": "Windows build which uses unity files",
             "binaryDir": "${sourceDir}/build/windows",
             "inherits": [
-                "unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "unity",
+                "host-windows"
+            ]
         },
         {
             "name": "windows-no-unity",
@@ -56,26 +42,18 @@
             "description": "Windows build which uses unity files",
             "binaryDir": "${sourceDir}/build/windows",
             "inherits": [
-                "no-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "no-unity",
+                "host-windows"
+            ]
         },
         {
             "name": "windows-non-monolithic",
             "displayName": "Windows Non-Monolithic",
             "description": "Default configuration for non-monolithic builds",
             "inherits": [
-                "non-monolithic"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "non-monolithic",
+                "host-windows"
+            ]
         },
         {
             "name": "windows-monolithic",
@@ -83,13 +61,9 @@
             "description": "Default configuration for monolithic builds",
             "binaryDir": "${sourceDir}/build/windows_mono",
             "inherits": [
-                "monolithic"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "monolithic",
+                "host-windows"
+            ]
         },
         {
             "name": "windows-vs",
@@ -97,64 +71,43 @@
             "description": "Configure Windows with the Visual Studio IDE",
             "inherits": [
                 "windows-vs-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+            ]
         },
         {
             "name": "windows-vs-unity",
             "displayName": "Windows Visual Studio Unity",
             "description": "Configure Windows with the Visual Studio IDE + Unity Builds",
             "inherits": [
-                "windows-vs2019",
-                "windows-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "windows-vs2022",
+                "unity"
+            ]
         },
         {
             "name": "windows-vs-no-unity",
             "displayName": "Windows Visual Studio without Unity",
             "description": "Configure Windows with the Visual Studio IDE without unity builds",
             "inherits": [
-                "windows-vs2019",
-                "windows-no-unity"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "windows-vs2022",
+                "no-unity"
+            ]
         },
         {
             "name": "windows-vs2019",
             "displayName": "Windows Visual Studio 2019",
             "description": "Configure Windows to use the VS2019 generator",
             "binaryDir": "${sourceDir}/build/windows_vs2019",
-            "generator": "Visual Studio 16",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+            "inherits": [
+                "vs2019"
+            ]
         },
         {
             "name": "windows-vs2022",
             "displayName": "Windows Visual Studio 2022",
             "description": "Configure Windows to use the VS2022 generator",
             "binaryDir": "${sourceDir}/build/windows_vs2022",
-            "generator": "Visual Studio 17",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+            "inherits": [
+                "vs2022"
+            ]
         },
         {
             "name": "windows-ninja",
@@ -162,13 +115,9 @@
             "description": "Configure Windows using the Ninja Multi-Config genrator",
             "binaryDir": "${sourceDir}/build/windows_ninja",
             "inherits": [
-                "ninja-multi-config"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "ninja-multi-config",
+                "host-windows"
+            ]
         }
     ],
     "buildPresets": [
@@ -177,11 +126,9 @@
             "displayName": "Windows",
             "description": "Builds all targets for Windows",
             "configurePreset": "windows-default",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+            "inherits": [
+                "host-windows"
+            ]
         },
         {
             "name": "windows-install",
@@ -189,24 +136,18 @@
             "description": "Builds the \"install\" target for windows, which builds all target and runs the CMake --install step",
             "configurePreset": "windows-default",
             "inherits": [
-                "install"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "install",
+                "host-windows"
+            ]
         },
         {
             "name": "windows-mono-default",
             "displayName": "Windows Monolithic",
             "description": "Builds all targets for Windows in the monolithic permutation",
             "configurePreset": "windows-mono-default",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+            "inherits": [
+                "host-windows"
+            ]
         },
         {
             "name": "windows-mono-install",
@@ -214,13 +155,9 @@
             "description": "Builds the \"install\" target for windows monolithic permutation, which builds all target and runs the CMake --install step",
             "configurePreset": "windows-mono-default",
             "inherits": [
-                "install"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "install",
+                "host-windows"
+            ]
         },
         {
             "name": "windows-editor",
@@ -228,13 +165,9 @@
             "description": "Builds the Editor application for Windows",
             "configurePreset": "windows-default",
             "inherits": [
-                "editor"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "editor",
+                "host-windows"
+            ]
         },
         {
             "name": "windows-assetprocessor",
@@ -242,13 +175,9 @@
             "description": "Builds the AssetProcessor application for windows",
             "configurePreset": "windows-default",
             "inherits": [
-                "assetprocessor"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "assetprocessor",
+                "host-windows"
+            ]
         },
         {
             "name": "windows-test",
@@ -256,13 +185,9 @@
             "description": "Builds the TEST_SUITE_smoke/TEST_SUITE_main custom targets for Windows",
             "configurePreset": "windows-default",
             "inherits": [
-                "test-default"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "test-default",
+                "host-windows"
+            ]
         }
     ],
     "testPresets": [
@@ -272,13 +197,9 @@
             "description": "Runs the Smoke + Main Test Suite. Requires the windows-test build preset to have completed successfully",
             "configurePreset": "windows-default",
             "inherits": [
-                "test-default"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "test-default",
+                "host-windows"
+            ]
         },
         {
             "name": "windows-test-debug",
@@ -286,27 +207,19 @@
             "description": "Runs the Smoke + Main Test Suite in debug configuration. Requires the windows-test build preset to have completed successfully",
             "configurePreset": "windows-default",
             "inherits": [
-                "test-default-debug"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "test-default-debug",
+                "host-windows"
+            ]
         },
         {
-            "name": "Windows-test-profile",
+            "name": "windows-test-profile",
             "displayName": "Windows CTest profile",
             "description": "Runs the Smoke + Main Test Suite in profile configuration. Requires the windows test build preset to have completed successfully",
             "configurePreset": "windows-default",
             "inherits": [
-                "test-default-profile"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
+                "test-default-profile",
+                "host-windows"
+            ]
         }
     ]
 }

--- a/cmake/Platform/iOS/CMakePresets.json
+++ b/cmake/Platform/iOS/CMakePresets.json
@@ -18,12 +18,7 @@
         "ios-xcode",
         "ios-unity",
         "ios-monolithic"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      ]
     },
     {
       "name": "ios-mono-default",
@@ -34,12 +29,7 @@
         "ios-ninja",
         "ios-unity",
         "ios-monolithic"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      ]
     },
     {
       "name": "ios-unity",
@@ -48,13 +38,9 @@
       "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
       "binaryDir": "${sourceDir}/build/ios",
       "inherits": [
-        "unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "unity",
+        "host-mac"
+      ]
     },
     {
       "name": "ios-no-unity",
@@ -63,13 +49,9 @@
       "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
       "binaryDir": "${sourceDir}/build/ios_no_unity",
       "inherits": [
-        "no-unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "no-unity",
+        "host-mac"
+      ]
     },
     {
       "name": "ios-non-monolithic",
@@ -77,13 +59,9 @@
       "description": "Default configuration for non-monolithic builds",
       "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
       "inherits": [
-        "non-monolithic"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "non-monolithic",
+        "host-mac"
+      ]
     },
     {
       "name": "ios-monolithic",
@@ -92,13 +70,9 @@
       "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
       "binaryDir": "${sourceDir}/build/ios_mono",
       "inherits": [
-        "monolithic"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "monolithic",
+        "host-mac"
+      ]
     },
     {
       "name": "ios-xcode",
@@ -106,12 +80,9 @@
       "description": "Configure iOS using with the Xcode generator",
       "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
       "binaryDir": "${sourceDir}/build/ios_xcode",
-      "generator": "Xcode",
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      "inherits": [
+        "xcode"
+      ]
     },
     {
       "name": "ios-xcode-unity",
@@ -119,15 +90,10 @@
       "description": "Configure iOS with the Xcode generator + Unity Builds",
       "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
       "binaryDir": "${sourceDir}/build/ios_xcode_unity",
-      "generator": "Xcode",
       "inherits": [
-        "ios-unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "ios-unity",
+        "xcode"
+      ]
     },
     {
       "name": "ios-xcode-no-unity",
@@ -135,15 +101,10 @@
       "description": "Configure iOS with the Xcode Generator without unity builds",
       "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
       "binaryDir": "${sourceDir}/build/ios_xcode_no_unity",
-      "generator": "Xcode",
       "inherits": [
-        "ios-no-unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "ios-no-unity",
+        "xcode"
+      ]
     },
     {
       "name": "ios-ninja",
@@ -153,12 +114,7 @@
       "binaryDir": "${sourceDir}/build/ios_ninja",
       "inherits": [
         "ios-ninja-unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      ]
     },
     {
       "name": "ios-ninja-unity",
@@ -169,12 +125,7 @@
       "inherits": [
         "ninja-multi-config",
         "ios-unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      ]
     },
     {
       "name": "ios-ninja-no-unity",
@@ -185,12 +136,7 @@
       "inherits": [
         "ninja-multi-config",
         "ios-no-unity"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      ]
     }
   ],
   "buildPresets": [
@@ -199,11 +145,9 @@
       "displayName": "iOS",
       "description": "Builds all targets for iOS",
       "configurePreset": "ios-default",
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      "inherits": [
+        "host-mac"
+      ]
     },
     {
       "name": "ios-install",
@@ -211,24 +155,18 @@
       "description": "Builds the \"install\" target for iOS, which builds all target and runs the CMake --install step",
       "configurePreset": "ios-default",
       "inherits": [
-        "install"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "install",
+        "host-mac"
+      ]
     },
     {
       "name": "ios-mono-default",
       "displayName": "iOS Mono",
       "description": "Builds all targets for iOS in the monolithic permutation",
       "configurePreset": "ios-mono-default",
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+      "inherits": [
+        "host-mac"
+      ]
     },
     {
       "name": "ios-mono-install",
@@ -236,13 +174,9 @@
       "description": "Builds the \"install\" target for ios monolithic permutation, which builds all target and runs the CMake --install step",
       "configurePreset": "ios-mono-default",
       "inherits": [
-        "install"
-      ],
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      }
+        "install",
+        "host-mac"
+      ]
     }
   ],
   "testPresets": []


### PR DESCRIPTION
Updated the generator for VS2022 and VS2019 to use the name of "Visual Studio 17 2022" and "Visual Studio 16 2019"
Apparently there is a bug where if the generator of "Visual Studio 17" or "Visual Studio 16" is specified as the "generator" value in the preset, it doesn't show up in the --list-presets command(though it is usable).

Fixed the naming of the windows-test-profile test preset

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Verified that the VS2019 and VS2022 configure presets appear
```
C:\code\o3de>cmake --list-presets
Available configure presets:

  "windows-automated-testing"        - Windows + Automated Testing project
  "windows-automated-testing-vs2019" - Windows + Automated Testing project + VS2019
  "android-automated-testing"        - Android + Automated Testing project
  "android-default"                  - Android
  "android-mono-default"             - Android Monolithic with Unity and Ninja
  "android-unity"                    - Android Unity
  "android-no-unity"                 - Android without Unity
  "android-non-monolithic"           - Android Non-Monolithic
  "android-monolithic"               - Android Monolithic
  "android-ninja"                    - Android Ninja
  "android-ninja-unity"              - Android Ninja Unity
  "android-ninja-no-unity"           - Android Ninja without Unity
  "windows-default"                  - Windows
  "windows-mono-default"             - Windows Monolithic with Unity and Visual Studio
  "windows-unity"                    - Windows Unity
  "windows-no-unity"                 - Windows without Unity
  "windows-non-monolithic"           - Windows Non-Monolithic
  "windows-monolithic"               - Windows Monolithic
  "windows-vs"                       - Windows Visual Studio
  "windows-vs-unity"                 - Windows Visual Studio Unity
  "windows-vs-no-unity"              - Windows Visual Studio without Unity
  "windows-vs2019"                   - Windows Visual Studio 2019
  "windows-vs2022"                   - Windows Visual Studio 2022
  "windows-ninja"                    - Windows Ninja
```

```
C:\code\o3de>cmake --build --list-presets
Available build presets:

  "windows-automated-testing-launchers" - Windows + Automated Testing project
  "windows-test-profile"                - Windows CTest profile
  "android-default"                     - Android
  "android-install"                     - Android install
  "android-mono-default"                - Android Monolithic
  "android-mono-install"                - Android Monolithic install
  "windows-default"                     - Windows
  "windows-install"                     - Windows install
  "windows-mono-default"                - Windows Monolithic
  "windows-mono-install"                - Windows Monolithic install
  "windows-editor"                      - Windows Editor
  "windows-assetprocessor"              - Windows AssetProcessor
  "windows-test"                        - Windows CTest
```
