### PR TITLE
Fix for Eliding Label spacing in shared columns

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -110,6 +110,11 @@ namespace AZ::DocumentPropertyEditor::Nodes
         //! Useful for things like the "add container entry" button.
         static constexpr auto SharePriorColumn = AttributeDefinition<bool>("SharePriorColumn");
 
+        //! DEPENDENT attribute - must be used inside a SharedColumn.
+        //! If set to true, specifies that this PropertyEditor should only take up as much space as its minimum width.
+        //! Useful for placing things like "add container entry" and "remove all elements" next to each other
+        static constexpr auto UseMinimumWidth = AttributeDefinition<bool>("SharePriorColumn");
+
         //! Specifies the alignment options for a PropertyEditor that has the Alignment attribute.
         enum class Align : AZ::u8
         {

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -335,6 +335,7 @@ namespace AZ::DocumentPropertyEditor
                 {
                     m_builder.BeginPropertyEditor<Nodes::ContainerActionButton>();
                     m_builder.Attribute(Nodes::PropertyEditor::SharePriorColumn, true);
+                    m_builder.Attribute(Nodes::PropertyEditor::Alignment, Nodes::PropertyEditor::Align::AlignRight);
                     m_builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::RemoveElement);
                     m_builder.AddMessageHandler(m_adapter, Nodes::ContainerActionButton::OnActivate.GetName());
                     m_builder.EndPropertyEditor();

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -335,6 +335,7 @@ namespace AZ::DocumentPropertyEditor
                 {
                     m_builder.BeginPropertyEditor<Nodes::ContainerActionButton>();
                     m_builder.Attribute(Nodes::PropertyEditor::SharePriorColumn, true);
+                    m_builder.Attribute(Nodes::PropertyEditor::UseMinimumWidth, true);
                     m_builder.Attribute(Nodes::PropertyEditor::Alignment, Nodes::PropertyEditor::Align::AlignRight);
                     m_builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::RemoveElement);
                     m_builder.AddMessageHandler(m_adapter, Nodes::ContainerActionButton::OnActivate.GetName());
@@ -415,11 +416,13 @@ namespace AZ::DocumentPropertyEditor
                     {
                         m_builder.BeginPropertyEditor<Nodes::ContainerActionButton>();
                         m_builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::AddElement);
+                        m_builder.Attribute(Nodes::PropertyEditor::UseMinimumWidth, true);
                         m_builder.AddMessageHandler(m_adapter, Nodes::ContainerActionButton::OnActivate.GetName());
                         m_builder.EndPropertyEditor();
 
                         m_builder.BeginPropertyEditor<Nodes::ContainerActionButton>();
                         m_builder.Attribute(Nodes::PropertyEditor::SharePriorColumn, true);
+                        m_builder.Attribute(Nodes::PropertyEditor::UseMinimumWidth, true);
                         m_builder.Attribute(Nodes::PropertyEditor::Alignment, Nodes::PropertyEditor::Align::AlignRight);
                         m_builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::Clear);
                         m_builder.AddMessageHandler(m_adapter, Nodes::ContainerActionButton::OnActivate.GetName());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -227,8 +227,10 @@ namespace AzToolsFramework
                         }
                         sharedColumnLayout->addItem(itemAt(layoutIndex + sharedWidgetIndex));
 
-                        // If a widget should be expanded, stretch it
-                        if (itemAt(layoutIndex + sharedWidgetIndex)->minimumSize().width() > 18)
+                        //! Stretch labels and large widgets to fill the space they are given,
+                        //! overrides alignment since the stretched widget acts as a spacer
+                        auto* elidingLabel = qobject_cast<AzQtComponents::ElidingLabel*>(currentWidget);
+                        if (itemAt(layoutIndex + sharedWidgetIndex)->minimumSize().width() > 18 || elidingLabel)
                         {
                             sharedColumnLayout->setStretch(sharedColumnLayout->count() - 1, 1);
                             stretchWidget = true;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -556,7 +556,7 @@ namespace AzToolsFramework
 
                 // If the UseMinimumWidth attribute is present, add the widget to set of widgets using their minimum width
                 auto minimumWidth = AZ::Dpe::Nodes::PropertyEditor::UseMinimumWidth.ExtractFromDomNode(childValue);
-                if (sharePrior.has_value() && sharePrior.value())
+                if (minimumWidth.has_value() && minimumWidth.value())
                 {
                     m_columnLayout->AddMinimumWidthWidget(addedWidget);
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -185,6 +185,8 @@ namespace AzToolsFramework
 
             // used to iterate through the vector containing a shared column's first widget and size
             int sharedVectorIndex = 0;
+            // maximum width of small widgets, such as ContainerActionButtons
+            constexpr int maxWidth = 18;
             // iterate over each item, laying them left to right
             int layoutIndex = 0;
             const int itemCountActual = count();
@@ -230,7 +232,7 @@ namespace AzToolsFramework
                         //! Stretch labels and large widgets to fill the space they are given,
                         //! overrides alignment since the stretched widget acts as a spacer
                         auto* elidingLabel = qobject_cast<AzQtComponents::ElidingLabel*>(currentWidget);
-                        if (itemAt(layoutIndex + sharedWidgetIndex)->minimumSize().width() > 18 || elidingLabel)
+                        if (itemAt(layoutIndex + sharedWidgetIndex)->minimumSize().width() > maxWidth || elidingLabel)
                         {
                             sharedColumnLayout->setStretch(sharedColumnLayout->count() - 1, 1);
                             stretchWidget = true;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -185,8 +185,6 @@ namespace AzToolsFramework
 
             // used to iterate through the vector containing a shared column's first widget and size
             int sharedVectorIndex = 0;
-            // maximum width of small widgets, such as ContainerActionButtons
-            constexpr int maxWidth = 18;
             // iterate over each item, laying them left to right
             int layoutIndex = 0;
             const int itemCountActual = count();
@@ -201,7 +199,9 @@ namespace AzToolsFramework
                     int numItems = m_sharePriorColumn[sharedVectorIndex].second;
                     int sharedWidgetIndex = 0;
                     // values used to remember the alignment of each widget
-                    bool startSpacer = false, endSpacer = false, stretchWidget = false;
+                    bool startSpacer = false, endSpacer = false;
+                    // number of widgets that should be set to their minimum size
+                    int minWidthCount = 0;
 
                     // Iterate over each item in the current shared column, adding them to a single layout
                     while (sharedWidgetIndex < numItems)
@@ -229,28 +229,33 @@ namespace AzToolsFramework
                         }
                         sharedColumnLayout->addItem(itemAt(layoutIndex + sharedWidgetIndex));
 
-                        //! Stretch labels and large widgets to fill the space they are given,
-                        //! overrides alignment since the stretched widget acts as a spacer
-                        auto* elidingLabel = qobject_cast<AzQtComponents::ElidingLabel*>(currentWidget);
-                        if (itemAt(layoutIndex + sharedWidgetIndex)->minimumSize().width() > maxWidth || elidingLabel)
+                        // If a widget should only take up its minimum width, do not stretch it
+                        if (m_minimumWidthWidgets.contains(currentWidget))
+                        {
+                            minWidthCount++;
+                        }
+                        else
                         {
                             sharedColumnLayout->setStretch(sharedColumnLayout->count() - 1, 1);
-                            stretchWidget = true;
                         }
                         sharedWidgetIndex++;
                     }
-                    // If all widgets in a column should be right aligned or center aligned
-                    if (startSpacer && !stretchWidget)
+
+                    // if all widgets in this shared column take up only their minimum width, set the appropriate alignment with spacers
+                    if (minWidthCount == numItems)
                     {
-                        QSpacerItem* spacer = new QSpacerItem(perItemWidth, 1, QSizePolicy::Expanding, QSizePolicy::Fixed);
-                        sharedColumnLayout->insertSpacerItem(0, spacer);
+                        if (startSpacer)
+                        {
+                            QSpacerItem* spacer = new QSpacerItem(perItemWidth, 1, QSizePolicy::Expanding, QSizePolicy::Fixed);
+                            sharedColumnLayout->insertSpacerItem(0, spacer);
+                        }
+                        if (endSpacer)
+                        {
+                            QSpacerItem* spacer = new QSpacerItem(perItemWidth, 1, QSizePolicy::Expanding, QSizePolicy::Fixed);
+                            sharedColumnLayout->addSpacerItem(spacer);
+                        }
                     }
-                    // If all widgets in a column should be left aligned or center aligned
-                    if (endSpacer && !stretchWidget)
-                    {
-                        QSpacerItem* spacer = new QSpacerItem(perItemWidth, 1, QSizePolicy::Expanding, QSizePolicy::Fixed);
-                        sharedColumnLayout->addSpacerItem(spacer);
-                    }
+
                     // Special case if this is the first column in a row
                     if (layoutIndex == 0)
                     {
@@ -360,6 +365,11 @@ namespace AzToolsFramework
     void DPELayout::WidgetAlignment(QWidget* alignedWidget, Qt::Alignment widgetAlignment)
     {
         m_widgetAlignment[alignedWidget] = widgetAlignment;
+    }
+
+    void DPELayout::AddMinimumWidthWidget(QWidget* widget)
+    {
+        m_minimumWidthWidgets.insert(widget);
     }
 
     DPERowWidget::DPERowWidget(int depth, DPERowWidget* parentRow)
@@ -531,7 +541,7 @@ namespace AzToolsFramework
                     m_columnLayout->WidgetAlignment(addedWidget, widgetAlignment);
                 }
 
-                //! If the sharePrior attribute is present, add the previous widget to the column layout.
+                //! If the SharePrior attribute is present, add the previous widget to the column layout.
                 //! Set the SharePrior boolean so we know to create a new shared column layout, or add to an existing one
                 auto sharePrior = AZ::Dpe::Nodes::PropertyEditor::SharePriorColumn.ExtractFromDomNode(childValue);
                 if (sharePrior.has_value() && sharePrior.value())
@@ -542,6 +552,13 @@ namespace AzToolsFramework
                 else
                 {
                     m_columnLayout->SetSharePrior(false);
+                }
+
+                // If the UseMinimumWidth attribute is present, add the widget to set of widgets using their minimum width
+                auto minimumWidth = AZ::Dpe::Nodes::PropertyEditor::UseMinimumWidth.ExtractFromDomNode(childValue);
+                if (sharePrior.has_value() && sharePrior.value())
+                {
+                    m_columnLayout->AddMinimumWidthWidget(addedWidget);
                 }
 
                 m_columnLayout->insertWidget(priorColumnIndex + 1, addedWidget);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -47,6 +47,7 @@ namespace AzToolsFramework
         bool ShouldSharePrior();
         int SharedWidgetCount();
         void WidgetAlignment(QWidget* alignedWidget, Qt::Alignment widgetAlignment);
+        void AddMinimumWidthWidget(QWidget* widget);
 
 
         // QLayout overrides
@@ -77,8 +78,12 @@ namespace AzToolsFramework
         AZStd::vector<AZStd::pair<QWidget*, int>> m_sharePriorColumn;
 
         //! Map containing all widgets that have special alignment.
-        //! Each widget will be aligned according to its value, where 0 = LEFT align, 1 = CENTER align, and 2 = RIGHT align.
+        //! Each widget will be aligned according to its Qt::Alignment value.
         AZStd::unordered_map<QWidget*, Qt::Alignment> m_widgetAlignment;
+
+        //! Vector containing all widgets that have the UseMinimumWidth attribute.
+        //! Dependent attribute that forces widgets to use their minimum width within a shared column.
+        AZStd::unordered_set<QWidget*> m_minimumWidthWidgets;
 
     private:
         // These cached sizes must be mutable since they are set inside of an overidden const function


### PR DESCRIPTION
Signed-off-by: Daniel Tamkin <jotamkin@amazon.com>

## What does this PR do?

Fix for Eliding Labels not taking up enough space within a DPE shared column.

## How was this PR tested?

Launched the editor and the debug view standalone to ensure that Eliding labels are taking the appropriate amount of space.

Before:
![image](https://user-images.githubusercontent.com/84731577/189447298-ee777e04-df5d-4caa-a830-dd1bfd99ce64.png)

After:
![image](https://user-images.githubusercontent.com/84731577/189447314-76eda6a0-34ba-4205-a423-2fa5207fd765.png)

