### PR TITLE
Remove use of the OSAllocator in the Legacy AZ::IO::Archive

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
@@ -1945,12 +1945,12 @@ namespace AZ::IO
 
     void* Archive::PoolMalloc(size_t size)
     {
-        return AZ::AllocatorInstance<AZ::OSAllocator>::Get().Allocate(size, 1, 0, "Archive::Malloc");
+        return azmalloc(size);
     }
 
     void Archive::PoolFree(void* p)
     {
-        return AZ::AllocatorInstance<AZ::OSAllocator>::Get().DeAllocate(p);
+        azfree(p);
     }
 
     // gets the current archive priority
@@ -1966,33 +1966,6 @@ namespace AZ::IO
     }
 
     //////////////////////////////////////////////////////////////////////////
-
-
-    AZStd::intrusive_ptr<AZ::IO::MemoryBlock> Archive::PoolAllocMemoryBlock(size_t size, const char* usage, size_t alignment)
-    {
-        if (!AZ::AllocatorInstance<AZ::OSAllocator>::IsReady())
-        {
-            AZ_Error("Archive", false, "OSAllocator is not ready. It cannot be used to allocate a MemoryBlock");
-            return {};
-        }
-        AZ::IAllocator* allocator = &AZ::AllocatorInstance<AZ::OSAllocator>::Get();
-        AZStd::intrusive_ptr<AZ::IO::MemoryBlock> memoryBlock{ new (allocator->Allocate(sizeof(AZ::IO::MemoryBlock), alignof(AZ::IO::MemoryBlock))) AZ::IO::MemoryBlock{AZ::IO::MemoryBlockDeleter{ &AZ::AllocatorInstance<AZ::OSAllocator>::Get() }} };
-        auto CreateFunc = [](size_t byteSize, size_t byteAlignment, const char* name)
-        {
-            return reinterpret_cast<uint8_t*>(AZ::AllocatorInstance<AZ::OSAllocator>::Get().Allocate(byteSize, byteAlignment, 0, name));
-        };
-        auto DeleterFunc = [](uint8_t* ptrArray)
-        {
-            if (ptrArray)
-            {
-                AZ::AllocatorInstance<AZ::OSAllocator>::Get().DeAllocate(ptrArray);
-            }
-        };
-        memoryBlock->m_address = AZ::IO::MemoryBlock::AddressPtr{ CreateFunc(size, alignment, usage), AZ::IO::MemoryBlock::AddressDeleter{DeleterFunc} };
-        memoryBlock->m_size = size;
-
-        return memoryBlock;
-    }
 
     void Archive::FindCompressionInfo(bool& found, AZ::IO::CompressionInfo& info, const AZ::IO::PathView filePath)
     {

--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.h
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.h
@@ -171,8 +171,6 @@ namespace AZ::IO
         //! Free pool
         void PoolFree(void* p) override;
 
-        AZStd::intrusive_ptr<AZ::IO::MemoryBlock> PoolAllocMemoryBlock(size_t nSize, const char* sUsage, size_t nAlign) override;
-
         // interface IArchive ---------------------------------------------------------------------------
 
         void RegisterFileAccessSink(IArchiveFileAccessSink* pSink) override;

--- a/Code/Framework/AzFramework/AzFramework/Archive/IArchive.h
+++ b/Code/Framework/AzFramework/AzFramework/Archive/IArchive.h
@@ -32,60 +32,24 @@ namespace AZ::IO
     using PathString = AZ::IO::FixedMaxPathString;
     using StackString = AZStd::fixed_string<512>;
 
-    struct MemoryBlock;
-    struct MemoryBlockDeleter
-    {
-        void operator()(const AZStd::intrusive_refcount<AZStd::atomic_uint, MemoryBlockDeleter>* ptr) const;
-        AZ::IAllocator* m_allocator{};
-    };
     struct MemoryBlock
-        : AZStd::intrusive_refcount<AZStd::atomic_uint, MemoryBlockDeleter>
+        : AZStd::intrusive_base
     {
+        AZ_CLASS_ALLOCATOR(MemoryBlock, AZ::SystemAllocator, 0);
         MemoryBlock() = default;
-        MemoryBlock(MemoryBlockDeleter deleter)
-            : AZStd::intrusive_refcount<AZStd::atomic_uint, MemoryBlockDeleter>{ deleter }
-        {}
+
         struct AddressDeleter
         {
-            using DeleteFunc = void(*)(uint8_t*);
-            AddressDeleter()
-                : m_deleteFunc{ nullptr }
-            {}
-            AddressDeleter(DeleteFunc deleteFunc)
-                : m_deleteFunc{ deleteFunc }
-            {}
             void operator()(uint8_t* ptr) const
             {
-                if (m_deleteFunc)
-                {
-                    m_deleteFunc(ptr);
-                }
-                else
-                {
-                    delete[] ptr;
-                }
+                azfree(ptr);
             }
-            DeleteFunc m_deleteFunc;
         };
         using AddressPtr = AZStd::unique_ptr<uint8_t[], AddressDeleter>;
 
         AddressPtr m_address;
         size_t m_size{};
     };
-
-    inline void MemoryBlockDeleter::operator()(const AZStd::intrusive_refcount<AZStd::atomic_uint, MemoryBlockDeleter>* ptr) const
-    {
-        auto address = const_cast<MemoryBlock*>(static_cast<const MemoryBlock*>(ptr));
-        if (m_allocator)
-        {
-            address ->~MemoryBlock();
-            m_allocator->DeAllocate(address);
-        }
-        else
-        {
-            delete address;
-        }
-    }
 
     struct IArchiveFileAccessSink
     {
@@ -193,10 +157,6 @@ namespace AZ::IO
         virtual void* PoolMalloc(size_t size) = 0;
         //! Free pool
         virtual void PoolFree(void* p) = 0;
-
-        // Return an interface to the Memory Block allocated on the File Pool memory.
-        // sUsage indicates for what usage this memory was requested.
-        virtual AZStd::intrusive_ptr<AZ::IO::MemoryBlock> PoolAllocMemoryBlock(size_t nSize, const char* sUsage, size_t nAlign = 1) = 0;
 
         // Arguments:
         virtual ArchiveFileIterator FindFirst(AZStd::string_view pDir, FileSearchLocation searchType = FileSearchLocation::InPak) = 0;

--- a/Code/Framework/AzFramework/AzFramework/Archive/ZipDirCache.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/ZipDirCache.cpp
@@ -35,27 +35,11 @@ namespace AZ::IO::ZipDir
 
     namespace ZipDirCacheInternal
     {
-        static AZStd::intrusive_ptr<AZ::IO::MemoryBlock> CreateMemoryBlock(size_t size, const char* usage)
+        [[nodiscard]] static AZStd::intrusive_ptr<AZ::IO::MemoryBlock> CreateMemoryBlock(size_t size)
         {
-            if (!AZ::AllocatorInstance<AZ::OSAllocator>::IsReady())
-            {
-                AZ_Error("Archive", false, "OSAllocator is not ready. It cannot be used to allocate a MemoryBlock");
-                return {};
-            }
-            AZ::IAllocator* allocator = &AZ::AllocatorInstance<AZ::OSAllocator>::Get();
-            AZStd::intrusive_ptr<AZ::IO::MemoryBlock> memoryBlock{ new (allocator->Allocate(sizeof(AZ::IO::MemoryBlock), alignof(AZ::IO::MemoryBlock))) AZ::IO::MemoryBlock{AZ::IO::MemoryBlockDeleter{ &AZ::AllocatorInstance<AZ::OSAllocator>::Get() }} };
-            auto CreateFunc = [](size_t byteSize, size_t byteAlignment, const char* name)
-            {
-                return reinterpret_cast<uint8_t*>(AZ::AllocatorInstance<AZ::OSAllocator>::Get().Allocate(byteSize, byteAlignment, 0, name));
-            };
-            auto DeleterFunc = [](uint8_t* ptrArray)
-            {
-                if (ptrArray)
-                {
-                    AZ::AllocatorInstance<AZ::OSAllocator>::Get().DeAllocate(ptrArray);
-                }
-            };
-            memoryBlock->m_address = AZ::IO::MemoryBlock::AddressPtr{ CreateFunc(size, alignof(uint8_t), usage), AZ::IO::MemoryBlock::AddressDeleter{DeleterFunc} };
+            AZStd::intrusive_ptr<AZ::IO::MemoryBlock> memoryBlock{ aznew AZ::IO::MemoryBlock{} };
+
+            memoryBlock->m_address.reset(reinterpret_cast<uint8_t*>(azmalloc(size, alignof(uint8_t))));
             memoryBlock->m_size = size;
 
             return memoryBlock;
@@ -137,20 +121,7 @@ namespace AZ::IO::ZipDir
         bool m_bCommitted;
     };
 
-    Cache::Cache()
-        : Cache{ !AZ::AllocatorInstance<AZ::OSAllocator>::IsReady() ? &AZ::AllocatorInstance<AZ::OSAllocator>::Get() : nullptr }
-    {
-    }
-
-    Cache::Cache(AZ::IAllocator* allocator)
-        : m_fileHandle(AZ::IO::InvalidHandle)
-        , m_nFlags(0)
-        , m_lCDROffset(0)
-        , m_encryptedHeaders(ZipFile::HEADERS_NOT_ENCRYPTED)
-        , m_allocator{ allocator }
-    {
-        AZ_Assert(allocator, "IAllocator object is required in order to allocated memory for the ZipDir Cache operations");
-    }
+    Cache::Cache() = default;
 
     void Cache::Close()
     {
@@ -178,7 +149,6 @@ namespace AZ::IO::ZipDir
                 m_fileHandle = AZ::IO::InvalidHandle;
             }
         }
-        m_allocator = nullptr;
         m_treeDir.Clear();
     }
 
@@ -215,7 +185,7 @@ namespace AZ::IO::ZipDir
         const size_t maxChunk = 1 << 20;
         size_t sizeLeft = size;
         size_t sizeToWrite;
-        AZStd::intrusive_ptr<AZ::IO::MemoryBlock> memoryBlock = ZipDirCacheInternal::CreateMemoryBlock(maxChunk, "ZipDir::Cache::WriteNullData");
+        AZStd::intrusive_ptr<AZ::IO::MemoryBlock> memoryBlock = ZipDirCacheInternal::CreateMemoryBlock(maxChunk);
         if (memoryBlock)
         {
             return ZD_ERROR_IO_FAILED;
@@ -272,7 +242,7 @@ namespace AZ::IO::ZipDir
         {
         case ZipFile::METHOD_DEFLATE:
             nSizeCompressed = GetCompressedSizeEstimate(nSize, codec);
-            memoryBlock = ZipDirCacheInternal::CreateMemoryBlock(nSizeCompressed, "Cache::UpdateFile");
+            memoryBlock = ZipDirCacheInternal::CreateMemoryBlock(nSizeCompressed);
             pCompressed = memoryBlock->m_address.get();
             dataBuffer = pCompressed;
 
@@ -718,7 +688,7 @@ namespace AZ::IO::ZipDir
                 return ZD_ERROR_INVALID_CALL;
             }
 
-            memoryBlock = ZipDirCacheInternal::CreateMemoryBlock(pFileEntry->desc.lSizeCompressed, "Cache::ReadFile");
+            memoryBlock = ZipDirCacheInternal::CreateMemoryBlock(pFileEntry->desc.lSizeCompressed);
             pBuffer = memoryBlock->m_address.get();
         }
 
@@ -811,7 +781,7 @@ namespace AZ::IO::ZipDir
         FileRecordList arrFiles(GetRoot());
         //arrFiles.SortByFileOffset();
         size_t nSizeCDR = arrFiles.GetStats().nSizeCDR;
-        void* pCDR = m_allocator->Allocate(nSizeCDR, alignof(uint8_t), 0, "Cache::WriteCDR");
+        void* pCDR = azmalloc(nSizeCDR, alignof(uint8_t));
         [[maybe_unused]] size_t nSizeCDRSerialized = arrFiles.MakeZipCDR(m_lCDROffset, pCDR);
         AZ_Assert(nSizeCDRSerialized == nSizeCDR, "Serialized CDR size %zu does not match size in memory %zu", nSizeCDRSerialized, nSizeCDR);
         if (m_encryptedHeaders == ZipFile::HEADERS_ENCRYPTED_TEA)
@@ -902,7 +872,7 @@ namespace AZ::IO::ZipDir
             }
 
             // allocate memory for the file compressed data
-            FileDataRecordPtr pFile = FileDataRecord::New(*it, m_allocator);
+            FileDataRecordPtr pFile = aznew FileDataRecord(*it);
 
             if (!pFile)
             {

--- a/Code/Framework/AzFramework/AzFramework/Archive/ZipDirCache.h
+++ b/Code/Framework/AzFramework/AzFramework/Archive/ZipDirCache.h
@@ -40,7 +40,6 @@ namespace AZ::IO::ZipDir
         inline static constexpr int compressedBlockHeaderSizeInBytes = 4; //number of bytes we need in front of the compressed block to indicate which compressor was used
 
         Cache();
-        explicit Cache(AZ::IAllocator* allocator);
 
         ~Cache()
         {
@@ -85,7 +84,7 @@ namespace AZ::IO::ZipDir
 
         void Free(void* ptr)
         {
-            m_allocator->DeAllocate(ptr);
+            azfree(ptr);
         }
 
         // refreshes information about the given file entry into this file entry
@@ -132,8 +131,7 @@ namespace AZ::IO::ZipDir
         friend class CacheFactory;
         friend class FileEntryTransactionAdd;
         FileEntryTree m_treeDir;
-        AZ::IO::HandleType m_fileHandle;
-        AZ::IAllocator* m_allocator;
+        AZ::IO::HandleType m_fileHandle = AZ::IO::InvalidHandle;
         AZ::IO::Path m_strFilePath;
 
         // String Pool for persistently storing paths as long as they reside in the cache
@@ -141,7 +139,7 @@ namespace AZ::IO::ZipDir
 
         // offset to the start of CDR in the file,even if there's no CDR there currently
         // when a new file is added, it can start from here, but this value will need to be updated then
-        uint32_t m_lCDROffset;
+        uint32_t m_lCDROffset = 0;
 
         enum
         {
@@ -155,12 +153,12 @@ namespace AZ::IO::ZipDir
             // when this is set, compact operation is not performed
             FLAGS_DONT_COMPACT = 1 << 3
         };
-        uint32_t m_nFlags;
+        uint32_t m_nFlags = 0;
 
         // CDR buffer.
         AZStd::vector<uint8_t> m_CDR_buffer;
 
-        ZipFile::EHeaderEncryptionType m_encryptedHeaders;
+        ZipFile::EHeaderEncryptionType m_encryptedHeaders = ZipFile::HEADERS_NOT_ENCRYPTED;
         ZipFile::EHeaderSignatureType m_signedHeaders;
 
         // Zip Headers

--- a/Code/Framework/AzFramework/AzFramework/Archive/ZipDirCacheFactory.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/ZipDirCacheFactory.cpp
@@ -60,7 +60,7 @@ namespace AZ::IO::ZipDir
     {
         m_szFilename = szFileName;
 
-        CachePtr pCache{ new Cache{ &AZ::AllocatorInstance<AZ::OSAllocator>::Get()} };
+        CachePtr pCache{ aznew Cache{} };
         // opens the given zip file and connects to it. Creates a new file if no such file exists
         // if successful, returns true.
         if (!(m_nFlags & FLAGS_DONT_MEMORIZE_ZIP_PATH))

--- a/Code/Framework/AzFramework/AzFramework/Archive/ZipDirList.h
+++ b/Code/Framework/AzFramework/AzFramework/Archive/ZipDirList.h
@@ -9,10 +9,11 @@
 
 #pragma once
 
-#include <AzCore/std/smart_ptr/intrusive_refcount.h>
+#include <AzCore/std/smart_ptr/intrusive_base.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/containers/set.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
 
 namespace AZ::IO::ZipDir
 {
@@ -23,22 +24,23 @@ namespace AZ::IO::ZipDir
         FileEntryBase* pFileEntryBase{}; // the file entry itself
     };
 
-    struct FileDataRecord;
-    struct FileDataRecordDeleter
-    {
-        void operator()(const AZStd::intrusive_refcount<AZStd::atomic_uint, FileDataRecordDeleter>* ptr) const;
-
-        AZ::IAllocator* m_allocator{};
-    };
     struct FileDataRecord
         : public FileRecord
-        , public AZStd::intrusive_refcount<AZStd::atomic_uint, FileDataRecordDeleter>
+        , public AZStd::intrusive_base
     {
-        FileDataRecord();
+        AZ_CLASS_ALLOCATOR(FileDataRecord, AZ::SystemAllocator, 0);
+        FileDataRecord(const FileRecord& rThat);
 
-        static auto New(const FileRecord& rThat, AZ::IAllocator* allocator) ->AZStd::intrusive_ptr<FileDataRecord>;
-
-        void* GetData() {return this + 1; }
+        void* GetData() {return m_data.get(); }
+    private:
+        struct DataDeleter
+        {
+            void operator()(void* ptr) const
+            {
+                azfree(ptr);
+            }
+        };
+        AZStd::unique_ptr<AZStd::byte[], DataDeleter> m_data;
     };
 
     using FileDataRecordPtr = AZStd::intrusive_ptr<FileDataRecord>;

--- a/Code/Legacy/CryCommon/Mocks/ICryPakMock.h
+++ b/Code/Legacy/CryCommon/Mocks/ICryPakMock.h
@@ -52,7 +52,6 @@ struct CryPakMock
     MOCK_METHOD1(FFlush, int(AZ::IO::HandleType handle));
     MOCK_METHOD1(PoolMalloc, void*(size_t size));
     MOCK_METHOD1(PoolFree, void(void* p));
-    MOCK_METHOD3(PoolAllocMemoryBlock, AZStd::intrusive_ptr<AZ::IO::MemoryBlock> (size_t nSize, const char* sUsage, size_t nAlign));
     MOCK_METHOD2(FindFirst, AZ::IO::ArchiveFileIterator(AZStd::string_view pDir, AZ::IO::FileSearchLocation));
     MOCK_METHOD1(FindNext, AZ::IO::ArchiveFileIterator(AZ::IO::ArchiveFileIterator handle));
     MOCK_METHOD1(FindClose, bool(AZ::IO::ArchiveFileIterator));


### PR DESCRIPTION
The IArchive::MemoryBlock now uses the SystemAllocator for its allocations now.

The MemoryBlock AddressPtr byte array now just uses azmalloc and azfree

Simplified the FileDataRecord class to inherit from AZStd::intrusive_base and use the SystemAllocator. The FileDataRecord also now in it's constructor allocates a byte array for it's data payload.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Use the Asset Cache Server feature to create zip files of products assets
