### PR TITLE
implemented writing back of opaque objects and pointer types to source

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomPath.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPath.h
@@ -107,6 +107,10 @@ namespace AZ::Dom
         Path& operator/=(const Path&);
 
         bool operator==(const Path&) const;
+        bool operator!=(const Path& rhs) const
+        {
+            return !operator==(rhs);
+        }
 
         const ContainerType& GetEntries() const;
         void Push(PathEntry entry);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -435,8 +435,33 @@ namespace AZ::DocumentPropertyEditor
                     instancePointerValue,
                     access.Get(),
                     attributes,
-                    [](const Dom::Value& newValue)
+                    // this needs to write the value back into the reflected object via Json serialization
+                    [valuePointer = access.Get(), valueType = access.GetType(), this](const Dom::Value& newValue)
                     {
+                        // marshal this new value into a pointer for use by the Json serializer
+                        auto marshalledPointer = AZ::Dom::Utils::TryMarshalValueToPointer(newValue, valueType);
+
+                        rapidjson::Document buffer;
+                        JsonSerializerSettings serializeSettings;
+                        JsonDeserializerSettings deserializeSettings;
+                        serializeSettings.m_serializeContext = m_serializeContext;
+                        deserializeSettings.m_serializeContext = m_serializeContext;
+
+                        // serialize the new value to Json, using the original valuePointer as a reference object to generate a minimal diff
+                        JsonSerialization::Store(buffer, buffer.GetAllocator(), marshalledPointer, valuePointer, valueType, serializeSettings);
+
+                        // now deserialize that value into the original location
+                        JsonSerialization::Load(valuePointer, valueType, buffer, deserializeSettings);
+
+                        // NB: the returned value for serialized pointer values is instancePointerValue, but since this is passed by pointer,
+                        // it will not actually detect a changed dom value. Since we are already writing directly to the DOM before this step,
+                        // it won't affect the calling DPE, however, other DPEs pointed at the same adapter would be unaware of the change,
+                        // and wouldn't update their UI.
+                        // In future, to properly support multiple DPEs on one adapter, we will need to solve this. One way would be to store
+                        // the json serialized value (which is mostly human-readable text) as an attribute, so any change to the Json would
+                        // trigger an update. This would have the advantage of allowing opaque and pointer types to be searchable by the
+                        // string-based Filter adapter. Without this, things like Vector3 will not have searchable values by text. These
+                        // advantages would have to be measured against the size changes in the DOM and the time taken to populate and parse them.
                         return newValue;
                     },
                     false);


### PR DESCRIPTION
- fixed top level patching in DPE
- implemented write-back of opaque serialized objects and pointers
- added missing != operator

Signed-off-by: Alex Montgomery <alexmont@amazon.com>