### PR TITLE
Fixes for Linux/GCC build errors

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -296,7 +296,7 @@ namespace AZ
                 T* arrayPtr = reinterpret_cast<T*>(instance);
                 // forward_list can only erase the element after the found one
                 // so keep track of the element before the last
-                typename T::iterator prevIter{};
+                [[maybe_unused]] typename T::iterator prevIter{};
                 if constexpr (IsForwardList_v<T>)
                 {
                     prevIter = arrayPtr->before_begin();

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -7805,7 +7805,7 @@ namespace UnitTest
         DataType::Reflect(*this->GetSerializeContext());
 
         // Add 3 items to the container
-        typename TypeParam::iterator insertIter{};
+        [[maybe_unused]] typename TypeParam::iterator insertIter{};
         if constexpr (AZStd::same_as<TypeParam, AZStd::forward_list<int>>)
         {
             insertIter = this->m_holder.m_data.before_begin();

--- a/Gems/GradientSignal/Code/CMakeLists.txt
+++ b/Gems/GradientSignal/Code/CMakeLists.txt
@@ -186,6 +186,8 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
             NAMESPACE Gem
             FILES_CMAKE
                 gradientsignal_editor_tests_files.cmake
+            PLATFORM_INCLUDE_FILES
+                Source/Platform/Common/${PAL_TRAIT_COMPILER_ID}/gradient_signal_editor_${PAL_TRAIT_COMPILER_ID_LOWERCASE}.cmake
             INCLUDE_DIRECTORIES
                 PRIVATE
                     .

--- a/Gems/NvCloth/Code/Source/Pipeline/SceneAPIExt/ClothRule.cpp
+++ b/Gems/NvCloth/Code/Source/Pipeline/SceneAPIExt/ClothRule.cpp
@@ -12,7 +12,6 @@
 
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IMeshData.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexColorData.h>
-#include <SceneAPI/SceneData/Groups/MeshGroup.h>
 
 #include <Pipeline/SceneAPIExt/ClothRule.h>
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/ClientTransceiver.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/ClientTransceiver.cpp
@@ -168,7 +168,7 @@ namespace ScriptCanvas
         AzFramework::RemoteToolsEndpointInfo ClientTransceiver::GetNetworkTarget()
         {
             AzFramework::RemoteToolsEndpointInfo targetInfo;
-            if (AzFramework::IRemoteTools* remoteTools = RemoteToolsInterface::Get())
+            if (RemoteToolsInterface::Get())
             {
                 targetInfo = RemoteToolsInterface::Get()->GetDesiredEndpoint(ScriptCanvas::RemoteToolsKey);
             }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/ClientTransceiver.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/ClientTransceiver.cpp
@@ -168,9 +168,9 @@ namespace ScriptCanvas
         AzFramework::RemoteToolsEndpointInfo ClientTransceiver::GetNetworkTarget()
         {
             AzFramework::RemoteToolsEndpointInfo targetInfo;
-            if (RemoteToolsInterface::Get())
+            if (AzFramework::IRemoteTools* remoteTools = RemoteToolsInterface::Get())
             {
-                targetInfo = RemoteToolsInterface::Get()->GetDesiredEndpoint(ScriptCanvas::RemoteToolsKey);
+                targetInfo = remoteTools->GetDesiredEndpoint(ScriptCanvas::RemoteToolsKey);
             }
 
             if (!targetInfo.GetPersistentId())


### PR DESCRIPTION
## What does this PR do?

1. Fixes a few 'unused-but-set-variable' gcc errors, such as
```               from /home/github/o3de/Code/Framework/AzCore/./AzCore/Component/EntityUtils.h:12,
                 from /home/github/o3de/Code/Framework/AzCore/AzCore/Component/EntityUtils.cpp:9:
/home/github/o3de/Code/Framework/AzCore/./AzCore/Serialization/AZStdContainers.inl: In instantiation of ‘bool AZ::Internal::AZStdBasicContainer<T, IsStableIterators>::RemoveElement(void*, const void*, AZ::SerializeContext*) [with T = AZStd::vector<AZ::Entity*>; bool IsStableIterators = false]’:
/home/github/o3de/Code/Framework/AzCore/./AzCore/Serialization/AZStdContainers.inl:294:21:   required from here
/home/github/o3de/Code/Framework/AzCore/./AzCore/Serialization/AZStdContainers.inl:299:38: error: variable ‘prevIter’ set but not used [-Werror=unused-but-set-variable]
  299 |                 typename T::iterator prevIter{};
      |                                      ^~~~~~~~
cc1plus: all warnings being treated as errors
```
2. Fixes an undefined reference issue caused by an unnecessary include to SceneData from a target that does not have a dependency on it (NvCloth.Editor.Static)
```
o3de/build/linux_gcc/bin/profile/libNvCloth.Editor.Gem.so dbg MODULE_LIBRARY DETACH
    /usr/bin/ld: lib/profile/libNvCloth.Editor.Static.a(ClothRule.cpp.o):(.data.rel.ro._ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE[_ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE]+0x50): undefined reference to `AZ::SceneAPI::SceneData::SceneNodeSelectionList::GetSelectedNodeCount() const'
```

## How was this PR tested?
Built on Linux Ubuntu 20.04 LTS with GCC

