### PR TITLE
Fix Slice Library context menu entry not expanding issue

### DIFF
--- a/Gems/LyShine/Code/Editor/AssetTreeEntry.cpp
+++ b/Gems/LyShine/Code/Editor/AssetTreeEntry.cpp
@@ -46,7 +46,9 @@ bool UISliceLibraryFilter::MatchInternal(const AzToolsFramework::AssetBrowser::A
         return false;
     }
     // entry must be located within m_pathToSearch
-    if (AzFramework::StringFunc::Find(product->GetRelativePath().c_str(), m_pathToSearch.c_str()) == AZStd::string::npos)
+    AZStd::string relativePath = product->GetRelativePath();
+    AzFramework::StringFunc::AssetDatabasePath::Normalize(relativePath);
+    if (AzFramework::StringFunc::Find(relativePath, m_pathToSearch.c_str()) == AZStd::string::npos)
     {
         return false;
     }


### PR DESCRIPTION
Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>

## What does this PR do?
This PR is for fixing GHI https://github.com/o3de/o3de/issues/11724

In UI editor, users was unable to instantiate a UI element from the slice library context menu since Slice Library context menu entry (Right-click on the canvas area, and hover over New > Element from Slice Library) doesn't expand.
![188022315-563fb66d-a6e2-40c6-b2a2-1d3a6f25dea0](https://user-images.githubusercontent.com/82238204/189740636-0f945f6a-18c2-43b7-813d-6fefee8fe067.jpg)


## How was this PR tested?
Follow repro steps from https://github.com/o3de/o3de/issues/11724 and see expected result after this fix:
<img width="680" alt="Screen Shot 2022-09-12 at 12 22 44" src="https://user-images.githubusercontent.com/82238204/189739966-f33d7785-baea-41ae-8a24-ce69de8a12bf.png">
