### PR TITLE
Fixing bugs constructing and reconciling paths to referenced assets in materials and material types

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/AssetUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/AssetUtils.cpp
@@ -7,12 +7,13 @@
  */
 
 #include <Atom/RPI.Edit/Common/AssetUtils.h>
-#include <AzFramework/StringFunc/StringFunc.h>
-#include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzCore/IO/IOUtils.h>
 #include <AzCore/IO/Path/Path.h>
+#include <AzCore/IO/FileIO.h>
 #include <AzCore/std/string/regex.h>
+#include <AzFramework/StringFunc/StringFunc.h>
 #include <AzQtComponents/Components/Widgets/FileDialog.h>
+#include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 
 namespace AZ
 {
@@ -36,77 +37,95 @@ namespace AZ
                 AZStd::string sourcePath;
                 if (assetId.IsValid())
                 {
-                    const AZStd::string& productPath = GetProductPathByAssetId(assetId);
-                    if (!productPath.empty())
+                    bool sourceFileFound = false;
+                    AZ::Data::AssetInfo assetInfo;
+                    AZStd::string watchFolder;
+
+                    AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+                        sourceFileFound,
+                        &AzToolsFramework::AssetSystem::AssetSystemRequest::GetSourceInfoBySourceUUID,
+                        assetId.m_guid,
+                        assetInfo,
+                        watchFolder);
+
+                    if (sourceFileFound)
                     {
-                        bool sourceFileFound = false;
-                        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(sourceFileFound, &AzToolsFramework::AssetSystem::AssetSystemRequest::GetFullSourcePathFromRelativeProductPath, productPath, sourcePath);
-                        AZ::StringFunc::Path::Normalize(sourcePath);
+                        AzFramework::StringFunc::Path::ConstructFull(
+                            watchFolder.c_str(), assetInfo.m_relativePath.c_str(), sourcePath, true);
                     }
                 }
                 return sourcePath;
             }
 
-            AZStd::string ResolvePathReference(const AZStd::string& originatingSourceFilePath, const AZStd::string& referencedSourceFilePath)
+            AZStd::string ResolvePathReference(
+                const AZStd::string& originatingSourceFilePath, const AZStd::string& referencedSourceFilePath)
             {
-                // The IsAbsolute part prevents "second join parameter is an absolute path" warnings in StringFunc::Path::Join below
-                if (referencedSourceFilePath.empty() || AZ::IO::PathView{referencedSourceFilePath}.IsAbsolute())
+                // Convert incoming paths containing aliases into absolute paths
+                AZ::IO::FixedMaxPath originatingPath;
+                AZ::IO::FileIOBase::GetInstance()->ReplaceAlias(originatingPath, AZ::IO::PathView{ originatingSourceFilePath });
+                AZ::IO::FixedMaxPath referencedPath;
+                AZ::IO::FileIOBase::GetInstance()->ReplaceAlias(referencedPath, AZ::IO::PathView{ referencedSourceFilePath });
+
+                // If the referenced path is empty or absolute then the path does not need to be resolved and can be returned immediately
+                if (referencedPath.empty() || referencedPath.IsAbsolute())
                 {
-                    return referencedSourceFilePath;
+                    return referencedPath.LexicallyNormal().String();
                 }
 
-                AZStd::string normalizedReferencedPath = referencedSourceFilePath;
-                AzFramework::StringFunc::Path::Normalize(normalizedReferencedPath);
-
-                AZStd::string originatingSourceFolder = originatingSourceFilePath;
-                AzFramework::StringFunc::Path::StripFullName(originatingSourceFolder);
-
-                AZStd::string pathFromOriginatingFolder;
-                AzFramework::StringFunc::Path::Join(originatingSourceFolder.c_str(), referencedSourceFilePath.c_str(), pathFromOriginatingFolder);
+                // Compose a path from the originating source file folder to the referenced source file
+                AZ::IO::FixedMaxPath combinedPath = originatingPath.ParentPath();
+                combinedPath /= referencedPath;
 
                 bool assetFound = false;
                 AZ::Data::AssetInfo sourceInfo;
                 AZStd::string watchFolder;
 
                 // Try to find the source file starting at the originatingSourceFilePath, and return the full path
-                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(assetFound, &AzToolsFramework::AssetSystem::AssetSystemRequest::GetSourceInfoBySourcePath, pathFromOriginatingFolder.c_str(), sourceInfo, watchFolder);
+                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+                    assetFound,
+                    &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath,
+                    combinedPath.c_str(),
+                    sourceInfo,
+                    watchFolder);
                 if (assetFound)
                 {
-                    AZStd::string fullSourcePath;
-                    // Construct fails if either of the watchFolder (root) or the pathFromOriginatingFolder is empty.
+                    // Construct fails if either of the watchFolder (root) or the combinedPath is empty.
                     // For some testing purposes, root can be empty.
-                    if (AzFramework::StringFunc::Path::ConstructFull(watchFolder.c_str(), pathFromOriginatingFolder.c_str(), fullSourcePath, true))
+                    AZStd::string fullSourcePath;
+                    if (AzFramework::StringFunc::Path::ConstructFull(watchFolder.c_str(), combinedPath.c_str(), fullSourcePath, true))
                     {
                         return fullSourcePath;
                     }
-                    else
-                    {
-                        return pathFromOriginatingFolder;
-                    }
+
+                    return combinedPath.LexicallyNormal().String();
                 }
 
                 // Try to find the source file starting at the asset root, and return the full path
-                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(assetFound, &AzToolsFramework::AssetSystem::AssetSystemRequest::GetSourceInfoBySourcePath, normalizedReferencedPath.c_str(), sourceInfo, watchFolder);
+                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+                    assetFound,
+                    &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath,
+                    referencedPath.c_str(),
+                    sourceInfo,
+                    watchFolder);
                 if (assetFound)
                 {
-                    AZStd::string fullSourcePath;
-                    // Construct fails if either of the watchFolder (root) or the normalizedReferencedPath is empty.
+                    // Construct fails if either of the watchFolder (root) or the referencedPath is empty.
                     // For some testing purposes, root can be empty.
-                    if (AzFramework::StringFunc::Path::ConstructFull(watchFolder.c_str(), normalizedReferencedPath.c_str(), fullSourcePath, true))
+                    AZStd::string fullSourcePath;
+                    if (AzFramework::StringFunc::Path::ConstructFull(watchFolder.c_str(), referencedPath.c_str(), fullSourcePath, true))
                     {
                         return fullSourcePath;
                     }
-                    else
-                    {
-                        return normalizedReferencedPath;
-                    }
+
+                    return referencedPath.LexicallyNormal().String();
                 }
 
-                // If no source file could be found, just return the original reference path. Something else will probably fail and report errors.
-                return normalizedReferencedPath;
+                // If no source file was found, return the original reference path. Something else will probably fail and report errors.
+                return referencedPath.LexicallyNormal().String();
             }
 
-            AZStd::vector<AZStd::string> GetPossibleDepenencyPaths(const AZStd::string& originatingSourceFilePath, const AZStd::string& referencedSourceFilePath)
+            AZStd::vector<AZStd::string> GetPossibleDepenencyPaths(
+                const AZStd::string& originatingSourceFilePath, const AZStd::string& referencedSourceFilePath)
             {
                 AZStd::vector<AZStd::string> results;
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -111,9 +111,7 @@ namespace AtomToolsFramework
     //! Generate a file path that is relative to either the source asset root or the export path
     //! @param exportPath absolute path of the file being saved
     //! @param referencePath absolute path of a file that will be treated as an external reference
-    //! @param relativeToExportPath specifies if the path is relative to the source asset root or the export path
-    AZStd::string GetPathToExteralReference(
-        const AZStd::string& exportPath, const AZStd::string& referencePath, const bool relativeToExportPath = false);
+    AZStd::string GetPathToExteralReference(const AZStd::string& exportPath, const AZStd::string& referencePath);
 
     //! Traverse up the instance data hierarchy to find a node containing the corresponding type
     template<typename T>

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -303,7 +303,6 @@ namespace AtomToolsFramework
 
         AZ::IO::FixedMaxPath referencePathWithoutAlias;
         AZ::IO::FileIOBase::GetInstance()->ReplaceAlias(referencePathWithoutAlias, AZ::IO::PathView{ referencePath });
-        const AZ::IO::PathView referenceFolder = referencePathWithoutAlias.ParentPath();
 
         // If both paths are contained underneath the same watch folder hierarchy then attempt to construct a relative path between them.
         if (GetWatchFolder(exportPath) == GetWatchFolder(referencePath))

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -273,18 +273,19 @@ namespace AtomToolsFramework
 
     AZStd::string GetWatchFolder(const AZStd::string& sourcePath)
     {
-        bool sourcePathFound = false;
-        AZ::Data::AssetInfo sourcePathInfo;
-        AZStd::string sourcePathWatchFolder;
+        bool relativePathFound = false;
+        AZStd::string relativePath;
+        AZStd::string relativePathFolder;
 
+        // GenerateRelativeSourcePath is necessary when saving new files because it allows us to get the info for files that may not exist yet. 
         AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
-            sourcePathFound,
-            &AzToolsFramework::AssetSystem::AssetSystemRequest::GetSourceInfoBySourcePath,
-            sourcePath.c_str(),
-            sourcePathInfo,
-            sourcePathWatchFolder);
+            relativePathFound,
+            &AzToolsFramework::AssetSystem::AssetSystemRequest::GenerateRelativeSourcePath,
+            sourcePath,
+            relativePath,
+            relativePathFolder);
 
-        return sourcePathWatchFolder;
+        return relativePathFolder;
     }
 
     AZStd::string GetPathToExteralReference(const AZStd::string& exportPath, const AZStd::string& referencePath)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Tests/AtomToolsFrameworkTest.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Tests/AtomToolsFrameworkTest.cpp
@@ -87,13 +87,11 @@ namespace UnitTest
 
     TEST_F(AtomToolsFrameworkTest, GetPathToExteralReference_Succeeds)
     {
-        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("", "", true), "");
-        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/materials/condor.material", "", true), "");
-        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/materials/talisman.material", "", false), "");
-        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/materials/talisman.material", "@exefolder@/root1/project/assets/textures/gold.png", true), "../textures/gold.png");
-        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/materials/talisman.material", "@exefolder@/root1/project/assets/textures/gold.png", false), "textures/gold.png");
-        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/objects/upgrades/materials/supercondor.material", "@exefolder@/root1/project/assets/materials/condor.material", true), "../../../materials/condor.material");
-        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/objects/upgrades/materials/supercondor.material", "@exefolder@/root1/project/assets/materials/condor.material", false), "materials/condor.material");
+        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("", ""), "");
+        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/materials/condor.material", ""), "");
+        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/materials/talisman.material", ""), "");
+        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/materials/talisman.material", "@exefolder@/root1/project/assets/textures/gold.png"), "../textures/gold.png");
+        ASSERT_EQ(AtomToolsFramework::GetPathToExteralReference("@exefolder@/root1/project/assets/objects/upgrades/materials/supercondor.material", "@exefolder@/root1/project/assets/materials/condor.material"), "../../../materials/condor.material");
     }
 
     TEST_F(AtomToolsFrameworkTest, IsDocumentPathInSupportedFolder_Succeeds)


### PR DESCRIPTION
## What does this PR do?

Updated functions that create and resolve references to use relative paths by default if both files are contained in the same scan folder. 
If the files are in different scan folders or the relative path cannot be created then the function falls back to using an aliased path.

Replaced calls to ResolvePath with ReplaceAlias. ResolvePath has some implicit functionality that automatically resolves non aliased paths to the product assets folder. In the usage within the tools, we just want to convert paths between aliased and non aliased.

https://github.com/o3de/o3de/issues/9445
https://github.com/o3de/o3de/issues/2841

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Updated and ran unit tests.
Resaved many existing materials to see their paths maintained or correctly updated with relative references or alias paths.
Material builder continues to function and materials load correctly with alias paths.