### PR TITLE
Android script updates

### DIFF
--- a/cmake/Tools/Platform/Android/android_deployment.py
+++ b/cmake/Tools/Platform/Android/android_deployment.py
@@ -17,8 +17,6 @@ import time
 import pathlib
 import shutil
 
-from distutils.version import LooseVersion
-
 # Resolve the common python module
 ROOT_DEV_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
 if ROOT_DEV_PATH not in sys.path:

--- a/cmake/Tools/Platform/Android/android_support.py
+++ b/cmake/Tools/Platform/Android/android_support.py
@@ -1570,27 +1570,27 @@ class AndroidSDKResolver(object):
     Class that manages the Android SDK tool to validate, install packages (e.g. built tools, sdk platforms, ndk, etc)
     """
 
-    class InstalledPackage(object):
+    class BasePackage(object):
+        def __init__(self, components):
+            self.path = components[0]
+            self.version = Version(components[1].strip().replace(' ', '.'))  # Fix for versions that have spaces between the version number and potential non-numeric versioning (PEP-0440)
+            self.description = components[2]
+
+    class InstalledPackage(BasePackage):
         def __init__(self, installed_package_components):
+            super().__init__(installed_package_components)
             assert len(installed_package_components) == 4, '4 sections expected for installed package components (path, version, description, location)'
-            self.path = installed_package_components[0]
-            self.version = Version(installed_package_components[1].strip().replace(' ', '.'))  # Fix for versions that have spaces between the version number and potential non-numeric versioning (PEP-0440)
-            self.description = installed_package_components[2]
             self.location = installed_package_components[3]
 
-    class AvailablePackage(object):
+    class AvailablePackage(BasePackage):
         def __init__(self, available_package_components):
+            super().__init__(available_package_components)
             assert len(available_package_components) == 3, '3 sections expected for installed package components (path, version, description)'
-            self.path = available_package_components[0]
-            self.version = Version(available_package_components[1].strip().replace(' ', '.')) # Fix for versions that have spaces between the version number and potential non-numeric versioning (PEP-0440)
-            self.description = available_package_components[2]
 
-    class AvailableUpdate(object):
+    class AvailableUpdate(BasePackage):
         def __init__(self, available_update_components):
+            super().__init__(available_update_components)
             assert len(available_update_components) == 3, '3 sections expected for installed package components (path, version, available)'
-            self.path = available_update_components[0]
-            self.version = Version(available_update_components[1].strip().replace(' ', '.')) # Fix for versions that have spaces between the version number and potential non-numeric versioning (PEP-0440)
-            self.available = available_update_components[2]
 
     def __init__(self, android_sdk_path, command_line_tools_version):
 

--- a/cmake/Tools/Platform/Android/android_support.py
+++ b/cmake/Tools/Platform/Android/android_support.py
@@ -22,7 +22,8 @@ import sys
 import subprocess
 import pathlib
 
-from distutils.version import LooseVersion
+from packaging.version import Version
+
 
 # Resolve the common python module
 ROOT_DEV_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
@@ -1552,16 +1553,16 @@ class AndroidGradlePluginInfo(object):
                                       f"Only the following version(s) are supported: {','.join(ANDROID_GRADLE_PLUGIN_COMPATIBILITY_MAP.keys())}")
 
         details = ANDROID_GRADLE_PLUGIN_COMPATIBILITY_MAP[android_gradle_plugin_version]
-        self.default_sdk_build_tools_version = LooseVersion(details.get('sdk_build'))
+        self.default_sdk_build_tools_version = Version(details.get('sdk_build'))
 
-        self.default_ndk_version = LooseVersion(details.get('default_ndk'))
+        self.default_ndk_version = Version(details.get('default_ndk'))
 
-        self.min_gradle_version = LooseVersion(details.get('min_gradle_version'))
+        self.min_gradle_version = Version(details.get('min_gradle_version'))
 
-        self.min_cmake_version = LooseVersion(details.get('min_cmake_version'))
+        self.min_cmake_version = Version(details.get('min_cmake_version'))
 
         max_cmake_version_number = details.get('max_cmake_version')
-        self.max_cmake_version = None if max_cmake_version_number is None else LooseVersion(max_cmake_version_number)
+        self.max_cmake_version = None if max_cmake_version_number is None else Version(max_cmake_version_number)
 
 
 class AndroidSDKResolver(object):
@@ -1573,7 +1574,7 @@ class AndroidSDKResolver(object):
         def __init__(self, installed_package_components):
             assert len(installed_package_components) == 4, '4 sections expected for installed package components (path, version, description, location)'
             self.path = installed_package_components[0]
-            self.version = LooseVersion(installed_package_components[1])
+            self.version = Version(installed_package_components[1].strip().replace(' ', '.'))  # Fix for versions that have spaces between the version number and potential non-numeric versioning (PEP-0440)
             self.description = installed_package_components[2]
             self.location = installed_package_components[3]
 
@@ -1581,14 +1582,14 @@ class AndroidSDKResolver(object):
         def __init__(self, available_package_components):
             assert len(available_package_components) == 3, '3 sections expected for installed package components (path, version, description)'
             self.path = available_package_components[0]
-            self.version = LooseVersion(available_package_components[1])
+            self.version = Version(available_package_components[1].strip().replace(' ', '.')) # Fix for versions that have spaces between the version number and potential non-numeric versioning (PEP-0440)
             self.description = available_package_components[2]
 
     class AvailableUpdate(object):
         def __init__(self, available_update_components):
             assert len(available_update_components) == 3, '3 sections expected for installed package components (path, version, available)'
             self.path = available_update_components[0]
-            self.version = LooseVersion(available_update_components[1])
+            self.version = Version(available_update_components[1].strip().replace(' ', '.')) # Fix for versions that have spaces between the version number and potential non-numeric versioning (PEP-0440)
             self.available = available_update_components[2]
 
     def __init__(self, android_sdk_path, command_line_tools_version):

--- a/cmake/Tools/Platform/Android/generate_android_project.py
+++ b/cmake/Tools/Platform/Android/generate_android_project.py
@@ -14,7 +14,7 @@ import platform
 import re
 import sys
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 ROOT_DEV_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
 if ROOT_DEV_PATH not in sys.path:
@@ -24,8 +24,8 @@ from cmake.Tools import common
 from cmake.Tools.Platform.Android import android_support
 
 GRADLE_ARGUMENT_NAME = '--gradle-install-path'
-GRADLE_MIN_VERSION = LooseVersion('6.5')
-GRADLE_MAX_VERSION = LooseVersion('7.0.2')
+GRADLE_MIN_VERSION = Version('6.5')
+GRADLE_MAX_VERSION = Version('7.0.2')
 GRADLE_VERSION_REGEX = re.compile(r"Gradle\s(\d+.\d+.?\d*)")
 GRADLE_EXECUTABLE = 'gradle.bat' if platform.system() == 'Windows' else 'gradle'
 
@@ -45,7 +45,7 @@ def verify_gradle(override_gradle_path=None):
 
 
 CMAKE_ARGUMENT_NAME = '--cmake-install-path'
-CMAKE_MIN_VERSION = LooseVersion('3.20.0')
+CMAKE_MIN_VERSION = Version('3.20.0')
 CMAKE_VERSION_REGEX = re.compile(r'cmake version (\d+.\d+.?\d*)')
 CMAKE_EXECUTABLE = 'cmake'
 
@@ -114,7 +114,7 @@ MIN_NATIVE_API_LEVEL = 24       # The minimum Native API level that is supported
 ANDROID_NDK_PLATFORM_ARGUMENT_NAME = '--android-ndk-version'
 
 ANDROID_GRADLE_PLUGIN_ARGUMENT_NAME = '--gradle-plugin-version'
-ANDROID_GRADLE_MIN_PLUGIN_VERSION = LooseVersion("4.2.2")
+ANDROID_GRADLE_MIN_PLUGIN_VERSION = Version("4.2.2")
 
 # Constants for asset-related options for APK generation
 INCLUDE_APK_ASSETS_ARGUMENT_NAME = "--include-apk-assets"
@@ -325,7 +325,7 @@ def main(args):
 
     # Use the SDK Resolver to make sure the build tools and ndk
     android_sdk = android_support.AndroidSDKResolver(android_sdk_path=parsed_args.get_argument(ANDROID_SDK_ARGUMENT_NAME),
-                                                command_line_tools_version=parsed_args.get_argument(ANDROID_SDK_COMMAND_LINE_TOOLS_VER))
+                                                     command_line_tools_version=parsed_args.get_argument(ANDROID_SDK_COMMAND_LINE_TOOLS_VER))
 
     # If no SDK platform is provided, check for any installed one
     if android_sdk_platform_version < 0:

--- a/cmake/Tools/Platform/Android/generate_android_project.py
+++ b/cmake/Tools/Platform/Android/generate_android_project.py
@@ -23,6 +23,14 @@ if ROOT_DEV_PATH not in sys.path:
 from cmake.Tools import common
 from cmake.Tools.Platform.Android import android_support
 
+
+O3DE_SCRIPTS_PATH = os.path.join(ROOT_DEV_PATH, 'scripts', 'o3de')
+if O3DE_SCRIPTS_PATH not in sys.path:
+    sys.path.append(O3DE_SCRIPTS_PATH)
+
+from o3de import manifest
+
+
 GRADLE_ARGUMENT_NAME = '--gradle-install-path'
 GRADLE_MIN_VERSION = Version('6.5')
 GRADLE_MAX_VERSION = Version('7.0.2')
@@ -126,8 +134,8 @@ ALL_ASSET_MODES = [ASSET_MODE_PAK, ASSET_MODE_LOOSE, ASSET_MODE_VFS]
 ASSET_TYPE_ARGUMENT_NAME = '--asset-type'
 DEFAULT_ASSET_TYPE = 'android'
 
-DEFAULT_3RD_PARTY_PATH = str(pathlib.Path(os.path.expanduser('~')) / '.o3de' / '3rdParty')
-
+manifest_json = manifest.load_o3de_manifest()
+DEFAULT_3RD_PARTY_PATH = manifest_json.get('default_third_party_folder', manifest.get_o3de_third_party_folder())
 
 def wrap_parsed_args(parsed_args):
     """

--- a/cmake/Tools/Platform/Android/generate_android_project.py
+++ b/cmake/Tools/Platform/Android/generate_android_project.py
@@ -126,6 +126,8 @@ ALL_ASSET_MODES = [ASSET_MODE_PAK, ASSET_MODE_LOOSE, ASSET_MODE_VFS]
 ASSET_TYPE_ARGUMENT_NAME = '--asset-type'
 DEFAULT_ASSET_TYPE = 'android'
 
+DEFAULT_3RD_PARTY_PATH = str(pathlib.Path(os.path.expanduser('~')) / '.o3de' / '3rdParty')
+
 
 def wrap_parsed_args(parsed_args):
     """
@@ -164,8 +166,8 @@ def main(args):
                         required=True)
 
     parser.add_argument('--third-party-path',
-                        help='The path to the 3rd Party root directory',
-                        required=True)
+                        help=f'The path to the 3rd Party root directory (defaults to {DEFAULT_3RD_PARTY_PATH})',
+                        default=DEFAULT_3RD_PARTY_PATH)
 
     parser.add_argument(ANDROID_SDK_ARGUMENT_NAME,
                         help='The path to the android SDK',

--- a/cmake/Tools/Platform/Android/generate_android_project.py
+++ b/cmake/Tools/Platform/Android/generate_android_project.py
@@ -135,7 +135,8 @@ ASSET_TYPE_ARGUMENT_NAME = '--asset-type'
 DEFAULT_ASSET_TYPE = 'android'
 
 manifest_json = manifest.load_o3de_manifest()
-DEFAULT_3RD_PARTY_PATH = manifest_json.get('default_third_party_folder', manifest.get_o3de_third_party_folder())
+DEFAULT_3RD_PARTY_PATH = pathlib.Path(manifest_json.get('default_third_party_folder', manifest.get_o3de_third_party_folder()))
+
 
 def wrap_parsed_args(parsed_args):
     """
@@ -175,6 +176,7 @@ def main(args):
 
     parser.add_argument('--third-party-path',
                         help=f'The path to the 3rd Party root directory (defaults to {DEFAULT_3RD_PARTY_PATH})',
+                        type=pathlib.Path,
                         default=DEFAULT_3RD_PARTY_PATH)
 
     parser.add_argument(ANDROID_SDK_ARGUMENT_NAME,

--- a/cmake/Tools/Platform/Android/unit_test_android_deployment.py
+++ b/cmake/Tools/Platform/Android/unit_test_android_deployment.py
@@ -78,7 +78,8 @@ def test_resolve_adb_tool(tmpdir):
     dummy_adb_file.write('adb')
 
     result = android_deployment.AndroidDeployment.resolve_adb_tool(pathlib.Path(tmpdir.join(sdk_path).realpath()))
-    assert pathlib.Path(dummy_adb_file.realpath()) == result
+    adb_name = os.path.basename(result).lower()
+    assert adb_name == adb_target
 
 
 @patch('subprocess.check_output', return_value=b'PASS')

--- a/cmake/Tools/Platform/Android/unit_test_android_deployment.py
+++ b/cmake/Tools/Platform/Android/unit_test_android_deployment.py
@@ -784,10 +784,6 @@ def test_execute_incremental_deploy_success(tmpdir, test_config, test_package_na
     tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/build/outputs/apk/{test_config}/app-{test_config}.apk").ensure()
     expected_apk_path = str(tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/build/outputs/apk/{test_config}/app-{test_config}.apk").realpath())
 
-    #tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_GAME_NAME}/Cache/{TEST_ASSET_TYPE}/dummy.txt").ensure()
-    #tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/assets/Registry/dummy.txt").ensure()
-    # "C:\Users\spham\AppData\Local\Temp\pytest-of-spham\pytest-150\test_execute_incremental_deplo0\Foo\android_gradle_test\app\src\assets"
-
     tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/assets/Registry/dummy.txt").ensure()
     expected_registry_path = str(tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/main/assets/Registry").realpath())
 

--- a/cmake/Tools/Platform/Android/unit_test_android_deployment.py
+++ b/cmake/Tools/Platform/Android/unit_test_android_deployment.py
@@ -560,8 +560,6 @@ def test_update_device_file_timestamp(tmpdir):
 
     tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/assets/deploy.timestamp").ensure()
 
-    # C:\Users\spham\AppData\Local\Temp\pytest-of-spham\pytest-168\test_update_device_file_timest0\Foo\android_gradle_test\app\src\assets\deploy.timestamp
-
     mock_dev_root = tmpdir.join(TEST_DEV_ROOT).realpath()
 
     with patch.object(android_deployment.AndroidDeployment, 'read_android_settings', return_value={}), \
@@ -717,8 +715,6 @@ def test_execute_clean_deploy_success(tmpdir, test_game_name, test_config, test_
                 return "SUCCESS"
             elif match_arg_list(arg_list, ['push', expected_registry_path, expected_storage_registry_path]):
                 return "SUCCESS"
-            #['push', 'C:\\Users\\spham\\AppData\\Local\\Temp\\pytest-of-spham\\pytest-156\\test_execute_clean_deploy_succ0\\Foo\\android_gradle_test\\app\\src\\assets/.', '/data/fool_storage/Android/data/org.o3de.foo/files']
-
         raise AssertionError
 
     def _mock_adb_shell(command, device_id):

--- a/cmake/Tools/Platform/Android/unit_test_android_deployment.py
+++ b/cmake/Tools/Platform/Android/unit_test_android_deployment.py
@@ -558,8 +558,9 @@ def test_get_device_file_timestamp_bad_timestamp_file(mock_adb_shell):
 
 def test_update_device_file_timestamp(tmpdir):
 
-    cache_dir = f'{TEST_DEV_ROOT}/{TEST_GAME_NAME}/Cache/{TEST_ASSET_TYPE}'
-    tmpdir.ensure(f'{cache_dir}/foo.txt')
+    tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/assets/deploy.timestamp").ensure()
+
+    # C:\Users\spham\AppData\Local\Temp\pytest-of-spham\pytest-168\test_update_device_file_timest0\Foo\android_gradle_test\app\src\assets\deploy.timestamp
 
     mock_dev_root = tmpdir.join(TEST_DEV_ROOT).realpath()
 
@@ -573,7 +574,7 @@ def test_update_device_file_timestamp(tmpdir):
                                                     game_name=TEST_GAME_NAME,
                                                     asset_mode=TEST_ASSET_MODE,
                                                     asset_type=TEST_ASSET_TYPE,
-                                                    embedded_assets=True,
+                                                    embedded_assets=False,
                                                     android_device_filter=None,
                                                     clean_deploy=False,
                                                     deployment_type=android_deployment.AndroidDeployment.DEPLOY_ASSETS_ONLY,
@@ -605,8 +606,8 @@ def test_execute_success(tmpdir, test_config, test_package_name, test_device_sto
     tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/build/outputs/apk/{test_config}/app-{test_config}.apk").ensure()
     expected_apk_path = str(tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/build/outputs/apk/{test_config}/app-{test_config}.apk").realpath())
 
-    tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_GAME_NAME}/Cache/{TEST_ASSET_TYPE}/dummy.txt").ensure()
-    expected_asset_path = str(tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_GAME_NAME}/Cache/{TEST_ASSET_TYPE}").realpath())
+    tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/assets/dummy.txt").ensure()
+    expected_asset_path = str(tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/assets").realpath())
 
     tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/main/assets/Registry/dummy.txt").ensure()
     expected_registry_path = str(tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/main/assets/Registry").realpath())
@@ -624,9 +625,17 @@ def test_execute_success(tmpdir, test_config, test_package_name, test_device_sto
                 return "SUCCESS"
             elif match_arg_list(arg_list, ['install', '-t', '-r', expected_apk_path]):
                 return "SUCCESS"
-            elif match_arg_list(arg_list, ['push', expected_asset_path, f'{test_device_storage_path}/Android/data/{test_package_name}/files']):
+            elif match_arg_list(arg_list, ['push', f'{expected_asset_path}/.', f'{test_device_storage_path}/Android/data/{test_package_name}/files']):
                 return "SUCCESS"
             elif match_arg_list(arg_list, ['push', expected_registry_path, expected_storage_registry_path]):
+                return "SUCCESS"
+            elif match_arg_list(arg_list, ['shell', 'cmd', 'package', 'list', 'packages', test_package_name]):
+                return "SUCCESS"
+            elif match_arg_list(arg_list, ['shell', f'mkdir {test_device_storage_path}/Android/data/{test_package_name}']):
+                return "SUCCESS"
+            elif match_arg_list(arg_list, ['shell', f'mkdir {test_device_storage_path}/Android/data/{test_package_name}/files']):
+                return "SUCCESS"
+            elif match_arg_list(arg_list, ['shell', f'mkdir {test_device_storage_path}/Android/data/{test_package_name}/files']):
                 return "SUCCESS"
 
         raise AssertionError
@@ -638,7 +647,7 @@ def test_execute_success(tmpdir, test_config, test_package_name, test_device_sto
          patch.object(android_deployment.AndroidDeployment, 'read_android_settings', return_value={'package_name': test_package_name}), \
          patch.object(android_deployment.AndroidDeployment, 'resolve_adb_tool', return_value=pathlib.Path("Foo")), \
          patch.object(android_deployment.AndroidDeployment, 'adb_call', wraps=_mock_adb_call) as mock_adb_call, \
-         patch.object(pathlib.Path, 'glob', return_value=["foo.bar"]):
+         patch.object(pathlib.Path, 'glob', return_value=[pathlib.Path("foo.bar")]):
 
         inst = android_deployment.AndroidDeployment(dev_root=mock_dev_root,
                                                     build_dir=TEST_BUILD_DIR,
@@ -655,7 +664,7 @@ def test_execute_success(tmpdir, test_config, test_package_name, test_device_sto
         inst.execute()
 
         mock_update_device_file_timestamp.assert_called_once()
-        assert mock_adb_call.call_count == 5
+        assert mock_adb_call.call_count == 6
 
 
 @pytest.mark.parametrize(
@@ -677,10 +686,9 @@ def test_execute_clean_deploy_success(tmpdir, test_game_name, test_config, test_
     tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/build/outputs/apk/{test_config}/app-{test_config}.apk").ensure()
     expected_apk_path = str(tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/build/outputs/apk/{test_config}/app-{test_config}.apk").realpath())
 
-    tmpdir.join(f"{TEST_DEV_ROOT}/{test_game_name}/Cache/{test_asset_type}/dummy.txt").ensure()
-    expected_asset_path = str(tmpdir.join(f"{TEST_DEV_ROOT}/{test_game_name}/Cache/{test_asset_type}").realpath())
+    tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/assets/Registry/dummy.txt").ensure()
+    expected_asset_path = str(tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/assets").realpath())
 
-    tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/main/assets/Registry/dummy.txt").ensure()
     expected_registry_path = str(tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/main/assets/Registry").realpath())
 
     expected_storage_path = f'{test_device_storage_path}/Android/data/{test_package_name}/files'
@@ -703,15 +711,18 @@ def test_execute_clean_deploy_success(tmpdir, test_game_name, test_config, test_
                 return test_package_name
             elif match_arg_list(arg_list, ['uninstall', test_package_name]):
                 return "SUCCESS"
-            elif match_arg_list(arg_list, ['push', expected_asset_path, expected_storage_path]):
+            elif match_arg_list(arg_list, ['push', f'{expected_asset_path}/.', expected_storage_path]):
                 return "SUCCESS"
             elif match_arg_list(arg_list, ['push', expected_registry_path, expected_storage_registry_path]):
                 return "SUCCESS"
+            elif match_arg_list(arg_list, ['push', expected_registry_path, expected_storage_registry_path]):
+                return "SUCCESS"
+            #['push', 'C:\\Users\\spham\\AppData\\Local\\Temp\\pytest-of-spham\\pytest-156\\test_execute_clean_deploy_succ0\\Foo\\android_gradle_test\\app\\src\\assets/.', '/data/fool_storage/Android/data/org.o3de.foo/files']
 
         raise AssertionError
 
     def _mock_adb_shell(command, device_id):
-        assert command.startswith('rm -rf')
+        assert command.startswith('rm -rf') or command.startswith('mkdir')
 
     def _mock_adb_ls(path, device_id, args=None):
         if path == "/foo/bar":
@@ -730,7 +741,7 @@ def test_execute_clean_deploy_success(tmpdir, test_game_name, test_config, test_
          patch.object(android_deployment.AndroidDeployment, 'adb_call', wraps=_mock_adb_call) as mock_adb_call, \
          patch.object(android_deployment.AndroidDeployment, 'adb_shell', wraps=_mock_adb_shell) as mock_adb_shell, \
          patch.object(android_deployment.AndroidDeployment, 'adb_ls', wraps=_mock_adb_ls), \
-         patch.object(pathlib.Path, 'glob', return_value=["foo.bar"]):
+         patch.object(pathlib.Path, 'glob', return_value=[pathlib.Path("foo.bar")]):
 
         inst = android_deployment.AndroidDeployment(dev_root=mock_dev_root,
                                                     build_dir=TEST_BUILD_DIR,
@@ -746,8 +757,8 @@ def test_execute_clean_deploy_success(tmpdir, test_game_name, test_config, test_
 
         inst.execute()
 
-        assert mock_adb_call.call_count == 7
-        mock_adb_shell.assert_called_once()
+        assert mock_adb_call.call_count == 6
+        mock_adb_shell.assert_called()
         mock_update_device_file_timestamp.assert_called_once()
         mock_get_device_file_timestamp.assert_called_once()
         mock_detect_device_storage_path.assert_called_once()
@@ -773,9 +784,11 @@ def test_execute_incremental_deploy_success(tmpdir, test_config, test_package_na
     tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/build/outputs/apk/{test_config}/app-{test_config}.apk").ensure()
     expected_apk_path = str(tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/build/outputs/apk/{test_config}/app-{test_config}.apk").realpath())
 
-    tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_GAME_NAME}/Cache/{TEST_ASSET_TYPE}/dummy.txt").ensure()
+    #tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_GAME_NAME}/Cache/{TEST_ASSET_TYPE}/dummy.txt").ensure()
+    #tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/assets/Registry/dummy.txt").ensure()
+    # "C:\Users\spham\AppData\Local\Temp\pytest-of-spham\pytest-150\test_execute_incremental_deplo0\Foo\android_gradle_test\app\src\assets"
 
-    tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/main/assets/Registry/dummy.txt").ensure()
+    tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/assets/Registry/dummy.txt").ensure()
     expected_registry_path = str(tmpdir.join(f"{TEST_DEV_ROOT}/{TEST_BUILD_DIR}/app/src/main/assets/Registry").realpath())
 
     expected_storage_registry_path = f'{test_device_storage_path}/Android/data/{test_package_name}/files/Registry'
@@ -791,6 +804,12 @@ def test_execute_incremental_deploy_success(tmpdir, test_config, test_package_na
             elif match_arg_list(arg_list, ['install', '-t', '-r', expected_apk_path]):
                 return "SUCCESS"
             elif match_arg_list(arg_list, ['push', expected_registry_path, expected_storage_registry_path]):
+                return "SUCCESS"
+            elif match_arg_list(arg_list, ['shell', 'cmd', 'package', 'list', 'packages', test_package_name]):
+                return "SUCCESS"
+            elif match_arg_list(arg_list, ['shell', f'mkdir {test_device_storage_path}/Android/data/{test_package_name}']):
+                return "SUCCESS"
+            elif match_arg_list(arg_list, ['shell', f'mkdir {test_device_storage_path}/Android/data/{test_package_name}/files']):
                 return "SUCCESS"
             elif len(arg_list) == 3 and arg_list[0] == 'push' and arg_list[1] == 'foo.bar':
                 return "SUCCESS"
@@ -808,7 +827,7 @@ def test_execute_incremental_deploy_success(tmpdir, test_config, test_package_na
          patch.object(android_deployment.AndroidDeployment, 'resolve_adb_tool', return_value=pathlib.Path("Foo")), \
          patch.object(android_deployment.AndroidDeployment, 'adb_call', wraps=_mock_adb_call) as mock_adb_call, \
          patch.object(android_deployment.AndroidDeployment, 'should_copy_file', wraps=_mock_should_copy_file), \
-         patch.object(pathlib.Path, 'glob', return_value=["foo.bar", "no.bar"]):
+         patch.object(pathlib.Path, 'glob', return_value=[pathlib.Path("foo.bar"), pathlib.Path("no.bar")]):
 
         inst = android_deployment.AndroidDeployment(dev_root=mock_dev_root,
                                                     build_dir=TEST_BUILD_DIR,

--- a/cmake/Tools/Platform/Android/unit_test_generate_android_project.py
+++ b/cmake/Tools/Platform/Android/unit_test_generate_android_project.py
@@ -12,7 +12,7 @@ import platform
 import subprocess
 import sys
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 ROOT_DEV_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), '..', '..'))
 if ROOT_DEV_PATH not in sys.path:
@@ -23,12 +23,12 @@ from cmake.Tools.Platform.Android import android_support, generate_android_proje
 
 @pytest.mark.parametrize(
     "from_override, version_str, expected_result", [
-        pytest.param(False, b"Gradle 4.10.1", LooseVersion('4.10.1'), id='equalMinVersion'),
-        pytest.param(False, b"Gradle 5.6.4", LooseVersion('5.6.4'), id='equalMaxVersion'),
+        pytest.param(False, b"Gradle 4.10.1", Version('4.10.1'), id='equalMinVersion'),
+        pytest.param(False, b"Gradle 5.6.4", Version('5.6.4'), id='equalMaxVersion'),
         pytest.param(False, b"Gradle 1.0", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR), id='lessThanMinVersion'),
         pytest.param(False, b"Gradle 26.3", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR), id='greaterThanMaxVersion'),
-        pytest.param(True, b"Gradle 4.10.1", LooseVersion('4.10.1')),
-        pytest.param(True, b"Gradle 5.6.4", LooseVersion('5.6.4')),
+        pytest.param(True, b"Gradle 4.10.1", Version('4.10.1')),
+        pytest.param(True, b"Gradle 5.6.4", Version('5.6.4')),
         pytest.param(True, b"Gradle 1.0", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR)),
         pytest.param(True, b"Gradle 26.3", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR))
     ]
@@ -57,7 +57,7 @@ def test_verify_gradle(tmpdir, from_override, version_str, expected_result):
 
     try:
         result_version, result_override_path = generate_android_project.verify_gradle(override_gradle_install_path)
-        assert isinstance(expected_result, LooseVersion)
+        assert isinstance(expected_result, Version)
         assert result_version == expected_result
         if from_override:
             assert os.path.normpath(result_override_path) == os.path.normpath(os.path.join(override_gradle_install_path, 'bin', gradle_script))
@@ -77,10 +77,10 @@ def test_verify_gradle(tmpdir, from_override, version_str, expected_result):
 @pytest.mark.parametrize(
     "from_override, version_str, expected_result", [
         pytest.param(False, f"cmake version {generate_android_project.CMAKE_MIN_VERSION}\nKit Ware", generate_android_project.CMAKE_MIN_VERSION, id='equalMinVersion'),
-        pytest.param(False, "cmake version 4.0.0\nKit Ware", LooseVersion('4.0.0'), id='greaterThanMinVersion'),
+        pytest.param(False, "cmake version 4.0.0\nKit Ware", Version('4.0.0'), id='greaterThanMinVersion'),
         pytest.param(False, "cmake version 1.0.0\nKit Ware", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR), id='lessThanMinVersion'),
         pytest.param(True, f"cmake version {generate_android_project.CMAKE_MIN_VERSION}\nKit Ware", generate_android_project.CMAKE_MIN_VERSION, id='override_equalMinVersion'),
-        pytest.param(True, "cmake version 4.0.0\nKit Ware", LooseVersion('4.0.0'), id='override_greaterThanMinVersion'),
+        pytest.param(True, "cmake version 4.0.0\nKit Ware", Version('4.0.0'), id='override_greaterThanMinVersion'),
         pytest.param(True, "cmake version 1.0.0\nKit Ware", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR), id='override_lessThanMinVersion'),
     ]
 )
@@ -108,7 +108,7 @@ def test_verify_cmake(tmpdir, from_override, version_str, expected_result):
 
     try:
         result_version, result_override_path = generate_android_project.verify_cmake(override_cmake_install_path)
-        assert isinstance(expected_result, LooseVersion)
+        assert isinstance(expected_result, Version)
         assert result_version == expected_result
         if from_override:
             assert os.path.normpath(result_override_path) == os.path.normpath(os.path.join(override_cmake_install_path, 'bin', cmake_exe))
@@ -124,10 +124,10 @@ def test_verify_cmake(tmpdir, from_override, version_str, expected_result):
 
 @pytest.mark.parametrize(
     "from_override, version_str, expected_result", [
-        pytest.param(False, b"1.0.0", LooseVersion('1.0.0')),
-        pytest.param(False, b"1.10.0", LooseVersion('1.10.0')),
-        pytest.param(True, b"1.0.0", LooseVersion('1.0.0')),
-        pytest.param(True, b"1.10.0", LooseVersion('1.10.0'))
+        pytest.param(False, b"1.0.0", Version('1.0.0')),
+        pytest.param(False, b"1.10.0", Version('1.10.0')),
+        pytest.param(True, b"1.0.0", Version('1.0.0')),
+        pytest.param(True, b"1.10.0", Version('1.10.0'))
     ]
 )
 def test_verify_ninja(tmpdir, from_override, version_str, expected_result):
@@ -154,7 +154,7 @@ def test_verify_ninja(tmpdir, from_override, version_str, expected_result):
 
     try:
         result_version, result_override_path = generate_android_project.verify_ninja(override_cmake_install_path)
-        assert isinstance(expected_result, LooseVersion)
+        assert isinstance(expected_result, Version)
         assert result_version == expected_result
         if from_override:
             assert os.path.normpath(result_override_path) == os.path.normpath(os.path.join(override_cmake_install_path, ninja_exe))

--- a/cmake/Tools/Platform/Android/unit_test_generate_android_project.py
+++ b/cmake/Tools/Platform/Android/unit_test_generate_android_project.py
@@ -76,12 +76,12 @@ def test_verify_gradle(tmpdir, from_override, version_str, expected_result):
 
 @pytest.mark.parametrize(
     "from_override, version_str, expected_result", [
-        pytest.param(False, b"cmake version 3.17.0\nKit Ware", LooseVersion('3.17.0'), id='equalMinVersion'),
-        pytest.param(False, b"cmake version 4.0.0\nKit Ware", LooseVersion('4.0.0'), id='greaterThanMinVersion'),
-        pytest.param(False, b"cmake version 1.0.0\nKit Ware", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR), id='lessThanMinVersion'),
-        pytest.param(True, b"cmake version 3.17.0\nKit Ware", LooseVersion('3.17.0'), id='override_equalMinVersion'),
-        pytest.param(True, b"cmake version 4.0.0\nKit Ware", LooseVersion('4.0.0'), id='override_greaterThanMinVersion'),
-        pytest.param(True, b"cmake version 1.0.0\nKit Ware", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR), id='override_lessThanMinVersion'),
+        pytest.param(False, f"cmake version {generate_android_project.CMAKE_MIN_VERSION}\nKit Ware", generate_android_project.CMAKE_MIN_VERSION, id='equalMinVersion'),
+        pytest.param(False, "cmake version 4.0.0\nKit Ware", LooseVersion('4.0.0'), id='greaterThanMinVersion'),
+        pytest.param(False, "cmake version 1.0.0\nKit Ware", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR), id='lessThanMinVersion'),
+        pytest.param(True, f"cmake version {generate_android_project.CMAKE_MIN_VERSION}\nKit Ware", generate_android_project.CMAKE_MIN_VERSION, id='override_equalMinVersion'),
+        pytest.param(True, "cmake version 4.0.0\nKit Ware", LooseVersion('4.0.0'), id='override_greaterThanMinVersion'),
+        pytest.param(True, "cmake version 1.0.0\nKit Ware", common.LmbrCmdError('error', common.ERROR_CODE_ENVIRONMENT_ERROR), id='override_lessThanMinVersion'),
     ]
 )
 def test_verify_cmake(tmpdir, from_override, version_str, expected_result):
@@ -95,14 +95,14 @@ def test_verify_cmake(tmpdir, from_override, version_str, expected_result):
     else:
         override_cmake_install_path = None
 
-    def _mock_check_output(args, shell):
+    def _mock_check_output(args, shell, stderr):
         assert args
         assert shell is True
         if from_override:
             assert args[0] == os.path.normpath(f'{override_cmake_install_path}/bin/{cmake_exe}')
         assert args[1] == '--version'
 
-        return version_str
+        return version_str.encode('utf-8', 'ignore')
 
     subprocess.check_output = _mock_check_output
 
@@ -141,7 +141,7 @@ def test_verify_ninja(tmpdir, from_override, version_str, expected_result):
     else:
         override_cmake_install_path = None
 
-    def _mock_check_output(args, shell):
+    def _mock_check_output(args, shell, stderr):
         assert args
         assert shell is True
         if from_override:

--- a/cmake/Tools/common.py
+++ b/cmake/Tools/common.py
@@ -20,7 +20,7 @@ import pathlib
 import platform
 
 from subprocess import CalledProcessError
-from distutils.version import LooseVersion
+from packaging.version import Version
 from cmake.Tools import layout_tool
 
 # Text encoding Constants for reading/writing to files.
@@ -322,9 +322,9 @@ def verify_tool(override_tool_path, tool_name, tool_filename, argument_name, too
         if not version_match:
             raise RuntimeError()
 
-        # Since we are doing a compare, strip out any non-numeric and non . character from the version otherwise we will get a TypeError on the LooseVersion comparison
+        # Since we are doing a compare, strip out any non-numeric and non . character from the version otherwise we will get a TypeError on the Version comparison
         result_version_str = re.sub(r"[^\.0-9]", "", str(version_match.group(1)).strip())
-        result_version = LooseVersion(result_version_str)
+        result_version = Version(result_version_str)
 
         if min_version and result_version < min_version:
             raise LmbrCmdError(f"The {tool_desc} does not meet the minimum version of {tool_name} required ({str(min_version)}).",


### PR DESCRIPTION
## What does this PR do?

* Updates the android unit tests to reflect recent changes to the android deployment scripts 
* Updated ```generate_android_project.py``` to default the argument of ```--third-party-path``` to the O3DE default
* Resolved the following deprecation warning
   ```
   DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
   ```

Note, the changes were made to reflect the updated expect values, mocks, etc. They assume that the updates to the android deployment scripts were tested properly.

## How was this PR tested?

Run unit test against the android python scripts (on windows)
```
cd cmake\Tools\Platform\Android

..\..\..\..\python\python.cmd -m pytest
```

