### PR TITLE
[Terrain] Fix invalid AABB asserts in debug builds.

### DIFF
--- a/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.cpp
@@ -267,8 +267,11 @@ namespace Terrain
         AZ::Color outlineColor(1.0f, 0.0f, 0.0f, 1.0f);
         AZ::Aabb aabb = GetWorldBounds();
 
-        debugDisplay.SetColor(outlineColor);
-        debugDisplay.DrawWireBox(aabb.GetMin(), aabb.GetMax());
+        if (aabb.IsValid())
+        {
+            debugDisplay.SetColor(outlineColor);
+            debugDisplay.DrawWireBox(aabb.GetMin(), aabb.GetMax());
+        }
     }
 
     void TerrainWorldDebuggerComponent::DrawQueries(

--- a/Gems/Terrain/Code/Source/TerrainRaycast/TerrainRaycastContext.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRaycast/TerrainRaycastContext.cpp
@@ -110,6 +110,12 @@ namespace
                                                  const AZ::Vector3& rayEnd,
                                                  AzFramework::RenderGeometry::RayResult& result)
     {
+        if (!terrainWorldBounds.IsValid())
+        {
+            // There is no terrain to intersect.
+            return;
+        }
+
         // Find the nearest intersection (if any) between the ray and terrain world bounds.
         // Note that the ray might (and often will) start inside the terrain world bounds.
         AZ::Vector3 clippedRayStart = rayStart;


### PR DESCRIPTION
## What does this PR do?

This fixes some "invalid AABB" asserts that can occur when running in debug. The asserts themselves were warning about harmless cases, but these changes prevent the asserts from happening at all.

## How was this PR tested?

Ran a debug build and verified that the asserts no longer occurred.
