### PR TITLE
Fixed titles/sub-titles in LC nodes not working in debug

### DIFF
--- a/Gems/LandscapeCanvas/Code/Source/Editor/Core/Core.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Core/Core.h
@@ -40,11 +40,11 @@ namespace LandscapeCanvas
     static constexpr const char* OUTPUT_IMAGE_SLOT_ID = "OutputImage";
 
     // Category title labels
-    static const QString GRADIENT_TITLE = QObject::tr("Gradient");
-    static const QString GRADIENT_GENERATOR_TITLE = QObject::tr("Gradient");
-    static const QString GRADIENT_MODIFIER_TITLE = QObject::tr("Gradient Modifier");
-    static const QString VEGETATION_AREA_TITLE = QObject::tr("Vegetation Area");
-    static const QString TERRAIN_TITLE = QObject::tr("Terrain");
+    static const char* GRADIENT_TITLE = "Gradient";
+    static const char* GRADIENT_GENERATOR_TITLE = "Gradient";
+    static const char* GRADIENT_MODIFIER_TITLE = "Gradient Modifier";
+    static const char* VEGETATION_AREA_TITLE = "Vegetation Area";
+    static const char* TERRAIN_TITLE = "Terrain";
 
     // Connection slot labels
     static const QString PREVIEW_BOUNDS_SLOT_LABEL = QObject::tr("Preview Bounds");

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -326,7 +326,7 @@ namespace LandscapeCanvasEditor
     }
 
 #define REGISTER_NODE_PALETTE_ITEM(category, TYPE, editorId) \
-    category->CreateChildNode<GraphModelIntegration::StandardNodePaletteItem<TYPE>>(TYPE::TITLE.toUtf8().constData(), editorId);
+    category->CreateChildNode<GraphModelIntegration::StandardNodePaletteItem<TYPE>>(TYPE::TITLE, editorId);
 
     GraphCanvas::GraphCanvasTreeItem* LandscapeCanvasConfig::CreateNodePaletteRoot()
     {
@@ -416,7 +416,7 @@ namespace LandscapeCanvasEditor
     LandscapeCanvas::LandscapeCanvasNodeFactoryRequestBus::BroadcastResult(componentTypeId, &LandscapeCanvas::LandscapeCanvasNodeFactoryRequests::GetComponentTypeId, azrtti_typeid<TYPE>()); \
     if (!AzToolsFramework::EntityHasComponentOfType(entityId, componentTypeId)) \
     { \
-        category->CreateChildNode<GraphModelIntegration::StandardNodePaletteItem<TYPE>>(TYPE::TITLE.toUtf8().constData(), editorId); \
+        category->CreateChildNode<GraphModelIntegration::StandardNodePaletteItem<TYPE>>(TYPE::TITLE, editorId); \
     } \
 } \
 

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/AltitudeFilterNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/AltitudeFilterNode.cpp
@@ -32,7 +32,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString AltitudeFilterNode::TITLE = QObject::tr("Altitude Filter");
+    const char* AltitudeFilterNode::TITLE = "Altitude Filter";
 
     AltitudeFilterNode::AltitudeFilterNode(GraphModel::GraphPtr graph)
         : BaseAreaFilterNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/AltitudeFilterNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/AltitudeFilterNode.h
@@ -33,10 +33,10 @@ namespace LandscapeCanvas
         AltitudeFilterNode() = default;
         explicit AltitudeFilterNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override
         {
-            return TITLE.toUtf8().constData();
+            return TITLE;
         }
 
     protected:

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/DistanceBetweenFilterNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/DistanceBetweenFilterNode.cpp
@@ -29,7 +29,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString DistanceBetweenFilterNode::TITLE = QObject::tr("Distance Between Filter");
+    const char* DistanceBetweenFilterNode::TITLE = "Distance Between Filter";
 
     DistanceBetweenFilterNode::DistanceBetweenFilterNode(GraphModel::GraphPtr graph)
         : BaseAreaFilterNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/DistanceBetweenFilterNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/DistanceBetweenFilterNode.h
@@ -33,10 +33,10 @@ namespace LandscapeCanvas
         DistanceBetweenFilterNode() = default;
         explicit DistanceBetweenFilterNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override
         {
-            return TITLE.toUtf8().constData();
+            return TITLE;
         }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/DistributionFilterNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/DistributionFilterNode.cpp
@@ -32,7 +32,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString DistributionFilterNode::TITLE = QObject::tr("Distribution Filter");
+    const char* DistributionFilterNode::TITLE = "Distribution Filter";
 
     DistributionFilterNode::DistributionFilterNode(GraphModel::GraphPtr graph)
         : BaseAreaFilterNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/DistributionFilterNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/DistributionFilterNode.h
@@ -33,10 +33,10 @@ namespace LandscapeCanvas
         DistributionFilterNode() = default;
         explicit DistributionFilterNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override
         {
-            return TITLE.toUtf8().constData();
+            return TITLE;
         }
 
     protected:

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/ShapeIntersectionFilterNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/ShapeIntersectionFilterNode.cpp
@@ -32,7 +32,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString ShapeIntersectionFilterNode::TITLE = QObject::tr("Shape Intersection Filter");
+    const char* ShapeIntersectionFilterNode::TITLE = "Shape Intersection Filter";
 
     ShapeIntersectionFilterNode::ShapeIntersectionFilterNode(GraphModel::GraphPtr graph)
         : BaseAreaFilterNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/ShapeIntersectionFilterNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/ShapeIntersectionFilterNode.h
@@ -33,10 +33,10 @@ namespace LandscapeCanvas
         ShapeIntersectionFilterNode() = default;
         explicit ShapeIntersectionFilterNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override
         {
-            return TITLE.toUtf8().constData();
+            return TITLE;
         }
 
     protected:

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/SlopeFilterNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/SlopeFilterNode.cpp
@@ -29,7 +29,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString SlopeFilterNode::TITLE = QObject::tr("Slope Filter");
+    const char* SlopeFilterNode::TITLE = "Slope Filter";
 
     SlopeFilterNode::SlopeFilterNode(GraphModel::GraphPtr graph)
         : BaseAreaFilterNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/SlopeFilterNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/SlopeFilterNode.h
@@ -33,10 +33,10 @@ namespace LandscapeCanvas
         SlopeFilterNode() = default;
         explicit SlopeFilterNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override
         {
-            return TITLE.toUtf8().constData();
+            return TITLE;
         }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/SurfaceMaskDepthFilterNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/SurfaceMaskDepthFilterNode.cpp
@@ -29,7 +29,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString SurfaceMaskDepthFilterNode::TITLE = QObject::tr("Surface Mask Depth Filter");
+    const char* SurfaceMaskDepthFilterNode::TITLE = "Surface Mask Depth Filter";
 
     SurfaceMaskDepthFilterNode::SurfaceMaskDepthFilterNode(GraphModel::GraphPtr graph)
         : BaseAreaFilterNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/SurfaceMaskDepthFilterNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/SurfaceMaskDepthFilterNode.h
@@ -33,10 +33,10 @@ namespace LandscapeCanvas
         SurfaceMaskDepthFilterNode() = default;
         explicit SurfaceMaskDepthFilterNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override
         {
-            return TITLE.toUtf8().constData();
+            return TITLE;
         }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/SurfaceMaskFilterNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/SurfaceMaskFilterNode.cpp
@@ -29,7 +29,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString SurfaceMaskFilterNode::TITLE = QObject::tr("Surface Mask Filter");
+    const char* SurfaceMaskFilterNode::TITLE = "Surface Mask Filter";
 
     SurfaceMaskFilterNode::SurfaceMaskFilterNode(GraphModel::GraphPtr graph)
         : BaseAreaFilterNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/SurfaceMaskFilterNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaFilters/SurfaceMaskFilterNode.h
@@ -33,10 +33,10 @@ namespace LandscapeCanvas
         SurfaceMaskFilterNode() = default;
         explicit SurfaceMaskFilterNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override
         {
-            return TITLE.toUtf8().constData();
+            return TITLE;
         }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/PositionModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/PositionModifierNode.cpp
@@ -32,7 +32,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString PositionModifierNode::TITLE = QObject::tr("Position Modifier");
+    const char* PositionModifierNode::TITLE = "Position Modifier";
 
     PositionModifierNode::PositionModifierNode(GraphModel::GraphPtr graph)
         : BaseAreaModifierNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/PositionModifierNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/PositionModifierNode.h
@@ -33,10 +33,10 @@ namespace LandscapeCanvas
         PositionModifierNode() = default;
         explicit PositionModifierNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override
         {
-            return TITLE.toUtf8().constData();
+            return TITLE;
         }
 
     protected:

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/RotationModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/RotationModifierNode.cpp
@@ -32,7 +32,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString RotationModifierNode::TITLE = QObject::tr("Rotation Modifier");
+    const char* RotationModifierNode::TITLE = "Rotation Modifier";
 
     RotationModifierNode::RotationModifierNode(GraphModel::GraphPtr graph)
         : BaseAreaModifierNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/RotationModifierNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/RotationModifierNode.h
@@ -33,10 +33,10 @@ namespace LandscapeCanvas
         RotationModifierNode() = default;
         explicit RotationModifierNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override
         {
-            return TITLE.toUtf8().constData();
+            return TITLE;
         }
 
     protected:

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/ScaleModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/ScaleModifierNode.cpp
@@ -32,7 +32,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString ScaleModifierNode::TITLE = QObject::tr("Scale Modifier");
+    const char* ScaleModifierNode::TITLE = "Scale Modifier";
 
     ScaleModifierNode::ScaleModifierNode(GraphModel::GraphPtr graph)
         : BaseAreaModifierNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/ScaleModifierNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/ScaleModifierNode.h
@@ -33,10 +33,10 @@ namespace LandscapeCanvas
         ScaleModifierNode() = default;
         explicit ScaleModifierNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override
         {
-            return TITLE.toUtf8().constData();
+            return TITLE;
         }
 
     protected:

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/SlopeAlignmentModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/SlopeAlignmentModifierNode.cpp
@@ -32,7 +32,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString SlopeAlignmentModifierNode::TITLE = QObject::tr("Slope Alignment Modifier");
+    const char* SlopeAlignmentModifierNode::TITLE = "Slope Alignment Modifier";
 
     SlopeAlignmentModifierNode::SlopeAlignmentModifierNode(GraphModel::GraphPtr graph)
         : BaseAreaModifierNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/SlopeAlignmentModifierNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaModifiers/SlopeAlignmentModifierNode.h
@@ -33,10 +33,10 @@ namespace LandscapeCanvas
         SlopeAlignmentModifierNode() = default;
         explicit SlopeAlignmentModifierNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override
         {
-            return TITLE.toUtf8().constData();
+            return TITLE;
         }
 
     protected:

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaSelectors/AssetWeightSelectorNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaSelectors/AssetWeightSelectorNode.cpp
@@ -42,7 +42,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString AssetWeightSelectorNode::TITLE = QObject::tr("Vegetation Asset Weight Selector");
+    const char* AssetWeightSelectorNode::TITLE = "Vegetation Asset Weight Selector";
 
     AssetWeightSelectorNode::AssetWeightSelectorNode(GraphModel::GraphPtr graph)
         : BaseNode(graph)
@@ -58,7 +58,7 @@ namespace LandscapeCanvas
 
     const char* AssetWeightSelectorNode::GetTitle() const
     {
-        return TITLE.toUtf8().constData();
+        return TITLE;
     }
 
     void AssetWeightSelectorNode::RegisterSlots()

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaSelectors/AssetWeightSelectorNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/AreaSelectors/AssetWeightSelectorNode.h
@@ -36,7 +36,7 @@ namespace LandscapeCanvas
 
         const BaseNodeType GetBaseNodeType() const override;
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override;
 
     protected:

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/AreaBlenderNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/AreaBlenderNode.cpp
@@ -32,7 +32,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString AreaBlenderNode::TITLE = QObject::tr("Vegetation Layer Blender");
+    const char* AreaBlenderNode::TITLE = "Vegetation Layer Blender";
 
     AreaBlenderNode::AreaBlenderNode(GraphModel::GraphPtr graph)
         : BaseAreaNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/AreaBlenderNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/AreaBlenderNode.h
@@ -34,8 +34,8 @@ namespace LandscapeCanvas
         AreaBlenderNode() = default;
         explicit AreaBlenderNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
 
     protected:
         void RegisterSlots() override;

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/BaseAreaNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/BaseAreaNode.h
@@ -32,7 +32,7 @@ namespace LandscapeCanvas
 
         const char* GetSubTitle() const override
         {
-            return LandscapeCanvas::VEGETATION_AREA_TITLE.toUtf8().constData();
+            return LandscapeCanvas::VEGETATION_AREA_TITLE;
         }
 
         GraphModel::NodeType GetNodeType() const override

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/BlockerAreaNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/BlockerAreaNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString BlockerAreaNode::TITLE = QObject::tr("Vegetation Layer Blocker");
+    const char* BlockerAreaNode::TITLE = "Vegetation Layer Blocker";
 
     BlockerAreaNode::BlockerAreaNode(GraphModel::GraphPtr graph)
         : BaseAreaNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/BlockerAreaNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/BlockerAreaNode.h
@@ -34,7 +34,7 @@ namespace LandscapeCanvas
         BlockerAreaNode() = default;
         explicit BlockerAreaNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/MeshBlockerAreaNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/MeshBlockerAreaNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString MeshBlockerAreaNode::TITLE = QObject::tr("Vegetation Layer Blocker (Mesh)");
+    const char* MeshBlockerAreaNode::TITLE = "Vegetation Layer Blocker (Mesh)";
 
     MeshBlockerAreaNode::MeshBlockerAreaNode(GraphModel::GraphPtr graph)
         : BaseAreaNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/MeshBlockerAreaNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/MeshBlockerAreaNode.h
@@ -34,8 +34,8 @@ namespace LandscapeCanvas
         MeshBlockerAreaNode() = default;
         explicit MeshBlockerAreaNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
 
     protected:
         void RegisterSlots() override;

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/SpawnerAreaNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/SpawnerAreaNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString SpawnerAreaNode::TITLE = QObject::tr("Vegetation Layer Spawner");
+    const char* SpawnerAreaNode::TITLE = "Vegetation Layer Spawner";
 
     SpawnerAreaNode::SpawnerAreaNode(GraphModel::GraphPtr graph)
         : BaseAreaNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/SpawnerAreaNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Areas/SpawnerAreaNode.h
@@ -34,7 +34,7 @@ namespace LandscapeCanvas
         SpawnerAreaNode() = default;
         explicit SpawnerAreaNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/BaseGradientModifierNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/BaseGradientModifierNode.h
@@ -30,7 +30,7 @@ namespace LandscapeCanvas
         BaseGradientModifierNode() = default;
         explicit BaseGradientModifierNode(GraphModel::GraphPtr graph);
 
-        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_MODIFIER_TITLE.toUtf8().constData(); }
+        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_MODIFIER_TITLE; }
 
         const BaseNodeType GetBaseNodeType() const override { return BaseNode::GradientModifier; }
 

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/DitherGradientModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/DitherGradientModifierNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString DitherGradientModifierNode::TITLE = QObject::tr("Dither");
+    const char* DitherGradientModifierNode::TITLE = "Dither";
 
     DitherGradientModifierNode::DitherGradientModifierNode(GraphModel::GraphPtr graph)
         : BaseGradientModifierNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/DitherGradientModifierNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/DitherGradientModifierNode.h
@@ -33,7 +33,7 @@ namespace LandscapeCanvas
         DitherGradientModifierNode() = default;
         explicit DitherGradientModifierNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/GradientMixerNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/GradientMixerNode.cpp
@@ -42,7 +42,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString GradientMixerNode::TITLE = QObject::tr("Gradient Mixer");
+    const char* GradientMixerNode::TITLE = "Gradient Mixer";
 
     GradientMixerNode::GradientMixerNode(GraphModel::GraphPtr graph)
         : BaseNode(graph)
@@ -53,12 +53,12 @@ namespace LandscapeCanvas
 
     const char* GradientMixerNode::GetTitle() const
     {
-        return TITLE.toUtf8().constData();
+        return TITLE;
     }
 
     const char* GradientMixerNode::GetSubTitle() const
     {
-        return GRADIENT_MODIFIER_TITLE.toUtf8().constData();
+        return GRADIENT_MODIFIER_TITLE;
     }
 
     const BaseNode::BaseNodeType GradientMixerNode::GetBaseNodeType() const

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/GradientMixerNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/GradientMixerNode.h
@@ -30,7 +30,7 @@ namespace LandscapeCanvas
         GradientMixerNode() = default;
         explicit GradientMixerNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override;
         const char* GetSubTitle() const override;
         const BaseNodeType GetBaseNodeType() const override;

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/InvertGradientModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/InvertGradientModifierNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString InvertGradientModifierNode::TITLE = QObject::tr("Invert");
+    const char* InvertGradientModifierNode::TITLE = "Invert";
 
     InvertGradientModifierNode::InvertGradientModifierNode(GraphModel::GraphPtr graph)
         : BaseGradientModifierNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/InvertGradientModifierNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/InvertGradientModifierNode.h
@@ -33,7 +33,7 @@ namespace LandscapeCanvas
         InvertGradientModifierNode() = default;
         explicit InvertGradientModifierNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/LevelsGradientModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/LevelsGradientModifierNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString LevelsGradientModifierNode::TITLE = QObject::tr("Levels");
+    const char* LevelsGradientModifierNode::TITLE = "Levels";
 
     LevelsGradientModifierNode::LevelsGradientModifierNode(GraphModel::GraphPtr graph)
         : BaseGradientModifierNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/LevelsGradientModifierNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/LevelsGradientModifierNode.h
@@ -33,7 +33,7 @@ namespace LandscapeCanvas
         LevelsGradientModifierNode() = default;
         explicit LevelsGradientModifierNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/PosterizeGradientModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/PosterizeGradientModifierNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString PosterizeGradientModifierNode::TITLE = QObject::tr("Posterize");
+    const char* PosterizeGradientModifierNode::TITLE = "Posterize";
 
     PosterizeGradientModifierNode::PosterizeGradientModifierNode(GraphModel::GraphPtr graph)
         : BaseGradientModifierNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/PosterizeGradientModifierNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/PosterizeGradientModifierNode.h
@@ -33,7 +33,7 @@ namespace LandscapeCanvas
         PosterizeGradientModifierNode() = default;
         explicit PosterizeGradientModifierNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/SmoothStepGradientModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/SmoothStepGradientModifierNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString SmoothStepGradientModifierNode::TITLE = QObject::tr("Smooth-Step");
+    const char* SmoothStepGradientModifierNode::TITLE = "Smooth-Step";
 
     SmoothStepGradientModifierNode::SmoothStepGradientModifierNode(GraphModel::GraphPtr graph)
         : BaseGradientModifierNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/SmoothStepGradientModifierNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/SmoothStepGradientModifierNode.h
@@ -33,7 +33,7 @@ namespace LandscapeCanvas
         SmoothStepGradientModifierNode() = default;
         explicit SmoothStepGradientModifierNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/ThresholdGradientModifierNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/ThresholdGradientModifierNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString ThresholdGradientModifierNode::TITLE = QObject::tr("Threshold");
+    const char* ThresholdGradientModifierNode::TITLE = "Threshold";
 
     ThresholdGradientModifierNode::ThresholdGradientModifierNode(GraphModel::GraphPtr graph)
         : BaseGradientModifierNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/ThresholdGradientModifierNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/GradientModifiers/ThresholdGradientModifierNode.h
@@ -33,7 +33,7 @@ namespace LandscapeCanvas
         ThresholdGradientModifierNode() = default;
         explicit ThresholdGradientModifierNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/AltitudeGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/AltitudeGradientNode.cpp
@@ -32,7 +32,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString AltitudeGradientNode::TITLE = QObject::tr("Altitude");
+    const char* AltitudeGradientNode::TITLE = "Altitude";
 
     AltitudeGradientNode::AltitudeGradientNode(GraphModel::GraphPtr graph)
         : BaseGradientNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/AltitudeGradientNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/AltitudeGradientNode.h
@@ -34,9 +34,9 @@ namespace LandscapeCanvas
         AltitudeGradientNode() = default;
         explicit AltitudeGradientNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
-        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
+        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_TITLE; }
 
     protected:
         void RegisterSlots() override;

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ConstantGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ConstantGradientNode.cpp
@@ -29,7 +29,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString ConstantGradientNode::TITLE = QObject::tr("Constant");
+    const char* ConstantGradientNode::TITLE = "Constant";
 
     ConstantGradientNode::ConstantGradientNode(GraphModel::GraphPtr graph)
         : BaseGradientNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ConstantGradientNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ConstantGradientNode.h
@@ -34,8 +34,8 @@ namespace LandscapeCanvas
         ConstantGradientNode() = default;
         explicit ConstantGradientNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
-        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
+        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/FastNoiseGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/FastNoiseGradientNode.cpp
@@ -29,7 +29,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString FastNoiseGradientNode::TITLE = QObject::tr("FastNoise");
+    const char* FastNoiseGradientNode::TITLE = "FastNoise";
 
     FastNoiseGradientNode::FastNoiseGradientNode(GraphModel::GraphPtr graph)
         : BaseGradientNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/FastNoiseGradientNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/FastNoiseGradientNode.h
@@ -33,9 +33,9 @@ namespace LandscapeCanvas
         FastNoiseGradientNode() = default;
         explicit FastNoiseGradientNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
-        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_GENERATOR_TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
+        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_GENERATOR_TITLE; }
 
         const BaseNodeType GetBaseNodeType() const override { return BaseNode::GradientGenerator; }
     };

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/GradientBakerNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/GradientBakerNode.cpp
@@ -29,7 +29,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString GradientBakerNode::TITLE = QObject::tr("Gradient Baker");
+    const char* GradientBakerNode::TITLE = "Gradient Baker";
 
     GradientBakerNode::GradientBakerNode(GraphModel::GraphPtr graph)
         : BaseGradientNode(graph)
@@ -40,12 +40,12 @@ namespace LandscapeCanvas
 
     const char* GradientBakerNode::GetTitle() const
     {
-        return TITLE.toUtf8().constData();
+        return TITLE;
     }
 
     const char* GradientBakerNode::GetSubTitle() const
     {
-        return GRADIENT_GENERATOR_TITLE.toUtf8().constData();
+        return GRADIENT_GENERATOR_TITLE;
     }
 
     const BaseNode::BaseNodeType GradientBakerNode::GetBaseNodeType() const

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/GradientBakerNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/GradientBakerNode.h
@@ -31,7 +31,7 @@ namespace LandscapeCanvas
         GradientBakerNode() = default;
         explicit GradientBakerNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override;
         const char* GetSubTitle() const override;
         const BaseNodeType GetBaseNodeType() const override;

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ImageGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ImageGradientNode.cpp
@@ -29,7 +29,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString ImageGradientNode::TITLE = QObject::tr("Image");
+    const char* ImageGradientNode::TITLE = "Image";
 
     ImageGradientNode::ImageGradientNode(GraphModel::GraphPtr graph)
         : BaseGradientNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ImageGradientNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ImageGradientNode.h
@@ -34,9 +34,9 @@ namespace LandscapeCanvas
         ImageGradientNode() = default;
         explicit ImageGradientNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
-        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
+        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_TITLE; }
 
     protected:
         void RegisterSlots() override;

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/PerlinNoiseGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/PerlinNoiseGradientNode.cpp
@@ -29,7 +29,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString PerlinNoiseGradientNode::TITLE = QObject::tr("Perlin Noise");
+    const char* PerlinNoiseGradientNode::TITLE = "Perlin Noise";
 
     PerlinNoiseGradientNode::PerlinNoiseGradientNode(GraphModel::GraphPtr graph)
         : BaseGradientNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/PerlinNoiseGradientNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/PerlinNoiseGradientNode.h
@@ -34,9 +34,9 @@ namespace LandscapeCanvas
         PerlinNoiseGradientNode() = default;
         explicit PerlinNoiseGradientNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
-        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_GENERATOR_TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
+        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_GENERATOR_TITLE; }
 
         const BaseNodeType GetBaseNodeType() const override { return BaseNode::GradientGenerator; }
     };

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/RandomNoiseGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/RandomNoiseGradientNode.cpp
@@ -29,7 +29,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString RandomNoiseGradientNode::TITLE = QObject::tr("Random Noise");
+    const char* RandomNoiseGradientNode::TITLE = "Random Noise";
 
     RandomNoiseGradientNode::RandomNoiseGradientNode(GraphModel::GraphPtr graph)
         : BaseGradientNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/RandomNoiseGradientNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/RandomNoiseGradientNode.h
@@ -33,9 +33,9 @@ namespace LandscapeCanvas
         RandomNoiseGradientNode() = default;
         explicit RandomNoiseGradientNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
-        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_GENERATOR_TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
+        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_GENERATOR_TITLE; }
 
         const BaseNodeType GetBaseNodeType() const override { return BaseNode::GradientGenerator; }
     };

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ShapeAreaFalloffGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ShapeAreaFalloffGradientNode.cpp
@@ -32,7 +32,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString ShapeAreaFalloffGradientNode::TITLE = QObject::tr("Shape Falloff");
+    const char* ShapeAreaFalloffGradientNode::TITLE = "Shape Falloff";
 
     ShapeAreaFalloffGradientNode::ShapeAreaFalloffGradientNode(GraphModel::GraphPtr graph)
         : BaseGradientNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ShapeAreaFalloffGradientNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/ShapeAreaFalloffGradientNode.h
@@ -34,9 +34,9 @@ namespace LandscapeCanvas
         ShapeAreaFalloffGradientNode() = default;
         explicit ShapeAreaFalloffGradientNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
-        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
+        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_TITLE; }
 
     protected:
         void RegisterSlots() override;

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/SlopeGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/SlopeGradientNode.cpp
@@ -29,7 +29,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString SlopeGradientNode::TITLE = QObject::tr("Slope");
+    const char* SlopeGradientNode::TITLE = "Slope";
 
     SlopeGradientNode::SlopeGradientNode(GraphModel::GraphPtr graph)
         : BaseGradientNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/SlopeGradientNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/SlopeGradientNode.h
@@ -34,8 +34,8 @@ namespace LandscapeCanvas
         SlopeGradientNode() = default;
         explicit SlopeGradientNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
-        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
+        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/SurfaceMaskGradientNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/SurfaceMaskGradientNode.cpp
@@ -29,7 +29,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString SurfaceMaskGradientNode::TITLE = QObject::tr("Surface Mask");
+    const char* SurfaceMaskGradientNode::TITLE = "Surface Mask";
 
     SurfaceMaskGradientNode::SurfaceMaskGradientNode(GraphModel::GraphPtr graph)
         : BaseGradientNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/SurfaceMaskGradientNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Gradients/SurfaceMaskGradientNode.h
@@ -34,8 +34,8 @@ namespace LandscapeCanvas
         SurfaceMaskGradientNode() = default;
         explicit SurfaceMaskGradientNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
-        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
+        const char* GetSubTitle() const override { return LandscapeCanvas::GRADIENT_TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/AxisAlignedBoxShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/AxisAlignedBoxShapeNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString AxisAlignedBoxShapeNode::TITLE = QObject::tr("Axis Aligned Box Shape");
+    const char* AxisAlignedBoxShapeNode::TITLE = "Axis Aligned Box Shape";
 
     AxisAlignedBoxShapeNode::AxisAlignedBoxShapeNode(GraphModel::GraphPtr graph)
         : BaseShapeNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/AxisAlignedBoxShapeNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/AxisAlignedBoxShapeNode.h
@@ -24,8 +24,8 @@ namespace LandscapeCanvas
         AxisAlignedBoxShapeNode() = default;
         explicit AxisAlignedBoxShapeNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
 
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/BaseShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/BaseShapeNode.cpp
@@ -23,7 +23,7 @@
 
 namespace LandscapeCanvas
 {
-    const QString BaseShapeNode::SHAPE_CATEGORY_TITLE = QObject::tr("Shape");
+    const char* BaseShapeNode::SHAPE_CATEGORY_TITLE = "Shape";
     const QString BaseShapeNode::BOUNDS_SLOT_LABEL = QObject::tr("Bounds");
     const QString BaseShapeNode::BOUNDS_OUTPUT_SLOT_DESCRIPTION = QObject::tr("Bounds output slot");
     const char* BaseShapeNode::BOUNDS_SLOT_ID = "Bounds";

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/BaseShapeNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/BaseShapeNode.h
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         AZ_RTTI(BaseShapeNode, "{1A9B84EC-22FA-4139-9D86-B158688612E2}", BaseNode);
 
         // Category sub-title
-        static const QString SHAPE_CATEGORY_TITLE;
+        static const char* SHAPE_CATEGORY_TITLE;
 
         // Connection slot ID (not translated, only used internally)
         static const char* BOUNDS_SLOT_ID;
@@ -44,7 +44,7 @@ namespace LandscapeCanvas
         BaseShapeNode() = default;
         explicit BaseShapeNode(GraphModel::GraphPtr graph);
 
-        const char* GetSubTitle() const override { return SHAPE_CATEGORY_TITLE.toUtf8().constData(); }
+        const char* GetSubTitle() const override { return SHAPE_CATEGORY_TITLE; }
 
         const BaseNodeType GetBaseNodeType() const override { return BaseNode::Shape; }
 

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/BoxShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/BoxShapeNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString BoxShapeNode::TITLE = QObject::tr("Box Shape");
+    const char* BoxShapeNode::TITLE = "Box Shape";
 
     BoxShapeNode::BoxShapeNode(GraphModel::GraphPtr graph)
         : BaseShapeNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/BoxShapeNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/BoxShapeNode.h
@@ -24,8 +24,8 @@ namespace LandscapeCanvas
         BoxShapeNode() = default;
         explicit BoxShapeNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
 
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/CapsuleShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/CapsuleShapeNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString CapsuleShapeNode::TITLE = QObject::tr("Capsule Shape");
+    const char* CapsuleShapeNode::TITLE = "Capsule Shape";
 
     CapsuleShapeNode::CapsuleShapeNode(GraphModel::GraphPtr graph)
         : BaseShapeNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/CapsuleShapeNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/CapsuleShapeNode.h
@@ -24,7 +24,7 @@ namespace LandscapeCanvas
         CapsuleShapeNode() = default;
         explicit CapsuleShapeNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/CompoundShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/CompoundShapeNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString CompoundShapeNode::TITLE = QObject::tr("Compound Shape");
+    const char* CompoundShapeNode::TITLE = "Compound Shape";
 
     CompoundShapeNode::CompoundShapeNode(GraphModel::GraphPtr graph)
         : BaseShapeNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/CompoundShapeNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/CompoundShapeNode.h
@@ -24,7 +24,7 @@ namespace LandscapeCanvas
         CompoundShapeNode() = default;
         explicit CompoundShapeNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/CylinderShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/CylinderShapeNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString CylinderShapeNode::TITLE = QObject::tr("Cylinder Shape");
+    const char* CylinderShapeNode::TITLE = "Cylinder Shape";
 
     CylinderShapeNode::CylinderShapeNode(GraphModel::GraphPtr graph)
         : BaseShapeNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/CylinderShapeNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/CylinderShapeNode.h
@@ -24,7 +24,7 @@ namespace LandscapeCanvas
         CylinderShapeNode() = default;
         explicit CylinderShapeNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/DiskShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/DiskShapeNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString DiskShapeNode::TITLE = QObject::tr("Disk Shape");
+    const char* DiskShapeNode::TITLE = "Disk Shape";
 
     DiskShapeNode::DiskShapeNode(GraphModel::GraphPtr graph)
         : BaseShapeNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/DiskShapeNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/DiskShapeNode.h
@@ -24,7 +24,7 @@ namespace LandscapeCanvas
         DiskShapeNode() = default;
         explicit DiskShapeNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/PolygonPrismShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/PolygonPrismShapeNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString PolygonPrismShapeNode::TITLE = QObject::tr("Polygon Prism Shape");
+    const char* PolygonPrismShapeNode::TITLE = "Polygon Prism Shape";
 
     PolygonPrismShapeNode::PolygonPrismShapeNode(GraphModel::GraphPtr graph)
         : BaseShapeNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/PolygonPrismShapeNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/PolygonPrismShapeNode.h
@@ -24,7 +24,7 @@ namespace LandscapeCanvas
         PolygonPrismShapeNode() = default;
         explicit PolygonPrismShapeNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/ReferenceShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/ReferenceShapeNode.cpp
@@ -39,7 +39,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString ReferenceShapeNode::TITLE = QObject::tr("Shape Reference");
+    const char* ReferenceShapeNode::TITLE = "Shape Reference";
 
     ReferenceShapeNode::ReferenceShapeNode(GraphModel::GraphPtr graph)
         : BaseNode(graph)
@@ -50,12 +50,12 @@ namespace LandscapeCanvas
 
     const char* ReferenceShapeNode::GetTitle() const
     {
-        return TITLE.toUtf8().constData();
+        return TITLE;
     }
 
     const char* ReferenceShapeNode::GetSubTitle() const
     {
-        return BaseShapeNode::SHAPE_CATEGORY_TITLE.toUtf8().constData();
+        return BaseShapeNode::SHAPE_CATEGORY_TITLE;
     }
 
     const BaseNode::BaseNodeType ReferenceShapeNode::GetBaseNodeType() const

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/ReferenceShapeNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/ReferenceShapeNode.h
@@ -23,7 +23,7 @@ namespace LandscapeCanvas
         ReferenceShapeNode() = default;
         explicit ReferenceShapeNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override;
         const char* GetSubTitle() const override;
         const BaseNodeType GetBaseNodeType() const override;

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/SphereShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/SphereShapeNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString SphereShapeNode::TITLE = QObject::tr("Sphere Shape");
+    const char* SphereShapeNode::TITLE = "Sphere Shape";
 
     SphereShapeNode::SphereShapeNode(GraphModel::GraphPtr graph)
         : BaseShapeNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/SphereShapeNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/SphereShapeNode.h
@@ -24,7 +24,7 @@ namespace LandscapeCanvas
         SphereShapeNode() = default;
         explicit SphereShapeNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/TubeShapeNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/TubeShapeNode.cpp
@@ -28,7 +28,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString TubeShapeNode::TITLE = QObject::tr("Tube Shape");
+    const char* TubeShapeNode::TITLE = "Tube Shape";
 
     TubeShapeNode::TubeShapeNode(GraphModel::GraphPtr graph)
         : BaseShapeNode(graph)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/TubeShapeNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Shapes/TubeShapeNode.h
@@ -24,7 +24,7 @@ namespace LandscapeCanvas
         TubeShapeNode() = default;
         explicit TubeShapeNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
-        const char* GetTitle() const override { return TITLE.toUtf8().constData(); }
+        static const char* TITLE;
+        const char* GetTitle() const override { return TITLE; }
     };
 }

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainHeightGradientListNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainHeightGradientListNode.cpp
@@ -42,7 +42,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString TerrainHeightGradientListNode::TITLE = QObject::tr("Terrain Height Gradient List");
+    const char* TerrainHeightGradientListNode::TITLE = "Terrain Height Gradient List";
 
     TerrainHeightGradientListNode::TerrainHeightGradientListNode(GraphModel::GraphPtr graph)
         : BaseNode(graph)
@@ -58,7 +58,7 @@ namespace LandscapeCanvas
 
     const char* TerrainHeightGradientListNode::GetTitle() const
     {
-        return TITLE.toUtf8().constData();
+        return TITLE;
     }
 
     void TerrainHeightGradientListNode::RegisterSlots()

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainHeightGradientListNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainHeightGradientListNode.h
@@ -36,7 +36,7 @@ namespace LandscapeCanvas
 
         const BaseNodeType GetBaseNodeType() const override;
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override;
 
     protected:

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.cpp
@@ -46,7 +46,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString TerrainLayerSpawnerNode::TITLE = QObject::tr("Terrain Layer Spawner");
+    const char* TerrainLayerSpawnerNode::TITLE = "Terrain Layer Spawner";
 
     TerrainLayerSpawnerNode::TerrainLayerSpawnerNode(GraphModel::GraphPtr graph)
         : BaseNode(graph)
@@ -57,12 +57,12 @@ namespace LandscapeCanvas
 
     const char* TerrainLayerSpawnerNode::GetTitle() const
     {
-        return TITLE.toUtf8().constData();
+        return TITLE;
     }
 
     const char* TerrainLayerSpawnerNode::GetSubTitle() const
     {
-        return LandscapeCanvas::TERRAIN_TITLE.toUtf8().constData();
+        return LandscapeCanvas::TERRAIN_TITLE;
     }
 
     GraphModel::NodeType TerrainLayerSpawnerNode::GetNodeType() const

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainLayerSpawnerNode.h
@@ -30,7 +30,7 @@ namespace LandscapeCanvas
         TerrainLayerSpawnerNode() = default;
         explicit TerrainLayerSpawnerNode(GraphModel::GraphPtr graph);
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override;
         const char* GetSubTitle() const override;
         GraphModel::NodeType GetNodeType() const override;

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.cpp
@@ -42,7 +42,7 @@ namespace LandscapeCanvas
         }
     }
 
-    const QString TerrainSurfaceGradientListNode::TITLE = QObject::tr("Terrain Surface Gradient List");
+    const char* TerrainSurfaceGradientListNode::TITLE = "Terrain Surface Gradient List";
 
     TerrainSurfaceGradientListNode::TerrainSurfaceGradientListNode(GraphModel::GraphPtr graph)
         : BaseNode(graph)
@@ -58,7 +58,7 @@ namespace LandscapeCanvas
 
     const char* TerrainSurfaceGradientListNode::GetTitle() const
     {
-        return TITLE.toUtf8().constData();
+        return TITLE;
     }
 
     void TerrainSurfaceGradientListNode::RegisterSlots()

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.h
@@ -36,7 +36,7 @@ namespace LandscapeCanvas
 
         const BaseNodeType GetBaseNodeType() const override;
 
-        static const QString TITLE;
+        static const char* TITLE;
         const char* GetTitle() const override;
 
     protected:


### PR DESCRIPTION
## What does this PR do?

Fixes #4872 

The titles/sub-titles of the Landscape Canvas nodes were being stored as static QString's but then were returning as `TITLE.toUtf8().constData()` which is pointing at freed memory, leading to garbage string values being displayed in debug builds. These were static since they needed to be accessed before the nodes were actually created in order to populate the node palettes, but because of this they were actually being constructed too early to take advantage of Qt's translation system anyways, so have switched them all to `const char*`. This will also unblock current ongoing efforts to optimize rapidjson, for which the new memory allocator is stricter on using freed memory.

There is a future backlog task to move the node generation to be data-driven which will simplify this even further.

## How was this PR tested?

Launched debug Editor and verified all the node titles/sub-titles show up correctly now.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>