### PR TITLE
Call material preview ready notification on main thread

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -297,16 +297,23 @@ namespace AZ
             [[maybe_unused]] const AZ::Render::MaterialAssignmentId& materialAssignmentId,
             [[maybe_unused]] const QPixmap& pixmap)
         {
-            PurgePreviews();
+            // Since the "preview rendered" event is not called on the main thread, queue
+            // the handling code to be executed on the main thread. This prevents any non
+            // thread-safe code, such as Qt updates, from running on alternate threads
+            AZ::SystemTickBus::QueueFunction(
+                [=]()
+                {
+                    PurgePreviews();
 
-            // Caching preview so the image will not have to be regenerated every time it's requested
-            m_materialPreviews[entityId][materialAssignmentId] = pixmap;
+                    // Caching preview so the image will not have to be regenerated every time it's requested
+                    m_materialPreviews[entityId][materialAssignmentId] = pixmap;
 
-            AZ::Render::EditorMaterialSystemComponentNotificationBus::Broadcast(
-                &AZ::Render::EditorMaterialSystemComponentNotificationBus::Events::OnRenderMaterialPreviewReady,
-                entityId,
-                materialAssignmentId,
-                pixmap);
+                    AZ::Render::EditorMaterialSystemComponentNotificationBus::Broadcast(
+                        &AZ::Render::EditorMaterialSystemComponentNotificationBus::Events::OnRenderMaterialPreviewReady,
+                        entityId,
+                        materialAssignmentId,
+                        pixmap);
+                });
         }
 
         void EditorMaterialSystemComponent::OnMaterialSlotLayoutChanged()


### PR DESCRIPTION
Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

## What does this PR do?

When a material preview is done rendering, it sends a callback from the thread that finished rendering. However, code that listens and handles this notification is not thread safe. This PR queues the callback to be sent on the main thread.

Fixes issue #11757. The UI Editor's Properties Pane listens to ToolsApplicationEvents::InvalidatePropertyDisplay to update script component properties when a script changes. This was being called on a thread other than the main thread via the material preview callback and left the property pane's Qtimer in a bad state thinking that it was still active but having a time remaining of -1.

## How was this PR tested?

Tested repro steps in GHI.
