### PR TITLE
Disable intermittent XML failures in Stabilization

### DIFF
--- a/scripts/ctest/CMakeLists.txt
+++ b/scripts/ctest/CMakeLists.txt
@@ -18,30 +18,32 @@ endif()
 ################################################################################
 
 if(PAL_TRAIT_TEST_PYTEST_SUPPORTED)
-    foreach(suite_name ${LY_TEST_GLOBAL_KNOWN_SUITE_NAMES})
-        ly_add_pytest(
-            NAME pytest_sanity_${suite_name}_no_gpu
-            PATH ${CMAKE_CURRENT_LIST_DIR}/sanity_test.py
-            TEST_SUITE ${suite_name}
-        )
+    # Disabled due to intermittent XML error in https://github.com/o3de/o3de/issues/11667
+    # foreach(suite_name ${LY_TEST_GLOBAL_KNOWN_SUITE_NAMES})
+    #     ly_add_pytest(
+    #         NAME pytest_sanity_${suite_name}_no_gpu
+    #         PATH ${CMAKE_CURRENT_LIST_DIR}/sanity_test.py
+    #         TEST_SUITE ${suite_name}
+    #     )
 
-        ly_add_pytest(
-            NAME pytest_sanity_${suite_name}_requires_gpu
-            PATH ${CMAKE_CURRENT_LIST_DIR}/sanity_test.py
-            TEST_SUITE ${suite_name}
-            TEST_REQUIRES gpu
-        )
-    endforeach()
+    #     ly_add_pytest(
+    #         NAME pytest_sanity_${suite_name}_requires_gpu
+    #         PATH ${CMAKE_CURRENT_LIST_DIR}/sanity_test.py
+    #         TEST_SUITE ${suite_name}
+    #         TEST_REQUIRES gpu
+    #     )
+    # endforeach()
 
-    # add a custom test which makes sure that the test filtering works!
-    ly_add_test(
-        NAME cli_test_driver
-        EXCLUDE_TEST_RUN_TARGET_FROM_IDE
-        TEST_COMMAND ${LY_PYTHON_CMD} ${CMAKE_CURRENT_LIST_DIR}/ctest_driver_test.py
-            -x ${CMAKE_CTEST_COMMAND} 
-            --build-path ${CMAKE_BINARY_DIR}
-            --config $<CONFIG>
-        TEST_LIBRARY pytest
-    )
+    # Disabled due to dependency on the test above
+    # # add a custom test which makes sure that the test filtering works!
+    # ly_add_test(
+    #     NAME cli_test_driver
+    #     EXCLUDE_TEST_RUN_TARGET_FROM_IDE
+    #     TEST_COMMAND ${LY_PYTHON_CMD} ${CMAKE_CURRENT_LIST_DIR}/ctest_driver_test.py
+    #         -x ${CMAKE_CTEST_COMMAND} 
+    #         --build-path ${CMAKE_BINARY_DIR}
+    #         --config $<CONFIG>
+    #     TEST_LIBRARY pytest
+    # )
 
 endif()


### PR DESCRIPTION
Signed-off-by: sweeneys <sweeneys@amazon.com>

## What does this PR do?

Disables tests encountering test framework-level failures with a ~1/50 rate, which no other tests are encountering. The tests themselves are consistently passing, but the framework fails on teardown. The underlying failure may have started appearing after the Python interpreter upgrade, and needs further investigation in https://github.com/o3de/o3de/issues/11667

This applies https://github.com/o3de/o3de/pull/11871 to stabilization. If this change is not performed, automated test runs in Stabilization will continue to intermittently error at around a 1/50 rate. However this will not impact the stability of the actual O3DE production code.

## How was this PR tested?

Verified locally and in development.
