### PR TITLE
Prefab | Add prefab undo cache update in instantiate-prefab workflow

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -452,6 +452,9 @@ namespace AzToolsFramework
 
                 CreateLink(instanceToCreate->get(), instanceToParentUnder->get().GetTemplateId(), undoBatch.GetUndoBatch(), AZStd::move(patch));
 
+                m_prefabUndoCache.UpdateCache(containerEntityId);
+                m_prefabUndoCache.UpdateCache(parent);
+
                 AzToolsFramework::ToolsApplicationRequestBus::Broadcast(
                     &AzToolsFramework::ToolsApplicationRequestBus::Events::ClearDirtyEntities);
             }


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

Fix: #11756 (multiple-save issue in instantiate-prefab)

This PR is a temp fix to add prefab undo cache update in instantiate-prefab workflow. After this change, it will no longer put in-memory DOMs in weird states and not generate unexpected patches which lead to multiple-save issue.

**Follow-Up:** As we are removing DOM cache in prefab undo cache in development, a follow-up of this change would be add parent DOM update in the instantiate-prefab workflow. This is needed in the case where DOM cache is removed; otherwise the same issue will still occur.

## How was this PR tested?

- [x] Manually tested in editor
- [x] All tests passed