### PR TITLE
Add prefab edit mode setting persistence to registry.

### DIFF
--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -269,6 +269,7 @@ AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     SettingOutcome SetValue(const AZStd::string_view path, const AZStd::any& value) override;
     AzToolsFramework::ConsoleColorTheme GetConsoleColorTheme() const override;
     AZ::u64 GetMaxNumberOfItemsShownInSearchView() const override;
+    void SaveSettingsRegistryFile() override;
 
     void ConvertPath(const AZStd::string_view sourcePath, AZStd::string& category, AZStd::string& attribute);
 
@@ -279,8 +280,6 @@ AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     // because its state is updateable through the main status bar
     void SaveEnableSourceControlFlag(bool triggerUpdate = false);
     void LoadEnableSourceControlFlag();
-
-    void SaveSettingsRegistryFile();
 
     void PostInitApply();
 

--- a/Code/Editor/ViewportTitleDlg.cpp
+++ b/Code/Editor/ViewportTitleDlg.cpp
@@ -46,6 +46,7 @@
 #include <AzToolsFramework/Viewport/ViewportSettings.h>
 #include <AzToolsFramework/ViewportSelection/EditorTransformComponentSelectionRequestBus.h>
 #include <AzQtComponents/Components/Widgets/CheckBox.h>
+#include <Editor/EditorSettingsAPIBus.h>
 #include <EditorModeFeedback/EditorStateRequestsBus.h>
 
 #include <LmbrCentral/Audio/AudioSystemComponentBus.h>
@@ -106,7 +107,7 @@ CViewportTitleDlg::CViewportTitleDlg(QWidget* pParent)
     LoadCustomPresets("AspectRatioPresets", "AspectRatioPreset", m_customAspectRatioPresets);
     LoadCustomPresets("ResPresets", "ResPreset", m_customResPresets);
 
-    SetupEditModeMenu();
+    SetupPrefabEditModeMenu();
     SetupCameraDropdownMenu();
     SetupResolutionDropdownMenu();
     SetupViewportInformationMenu();
@@ -217,11 +218,13 @@ void CViewportTitleDlg::SetupResolutionDropdownMenu()
     m_ui->m_resolutionMenu->setPopupMode(QToolButton::InstantPopup);
 }
 
-void CViewportTitleDlg::SetupEditModeMenu()
+void CViewportTitleDlg::SetupPrefabEditModeMenu()
 {
-    m_ui->m_editModeMenu->setMenu(GetEditModeMenu());
-    m_ui->m_editModeMenu->setAutoRaise(true);
-    m_ui->m_editModeMenu->setPopupMode(QToolButton::InstantPopup);
+    m_prefabEditMode = AzToolsFramework::PrefabEditModeEffectEnabled() ? PrefabEditModeUXSetting::Monochromatic : PrefabEditModeUXSetting::Normal;
+    m_ui->m_prefabEditModeMenu->setMenu(GetPrefabEditModeMenu());
+    m_ui->m_prefabEditModeMenu->setAutoRaise(true);
+    m_ui->m_prefabEditModeMenu->setPopupMode(QToolButton::InstantPopup);
+    UpdatePrefabEditMode();
 }
 
 void CViewportTitleDlg::SetupViewportInformationMenu()
@@ -456,16 +459,16 @@ void CViewportTitleDlg::OnMaximize()
     }
 }
 
-void CViewportTitleDlg::SetNormalEditMode()
+void CViewportTitleDlg::SetNormalPrefabEditMode()
 {
-    m_editMode = FocusModeUxSetting::Normal;
-    UpdateEditMode();
+    m_prefabEditMode = PrefabEditModeUXSetting::Normal;
+    UpdatePrefabEditMode();
 }
 
-void CViewportTitleDlg::SetMonochromaticEditMode()
+void CViewportTitleDlg::SetMonochromaticPrefabEditMode()
 {
-    m_editMode = FocusModeUxSetting::Monochromatic;
-    UpdateEditMode();
+    m_prefabEditMode = PrefabEditModeUXSetting::Monochromatic;
+    UpdatePrefabEditMode();
 }
 
 void CViewportTitleDlg::SetNoViewportInfo()
@@ -493,35 +496,39 @@ void CViewportTitleDlg::SetCompactViewportInfo()
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CViewportTitleDlg::UpdateEditMode()
+void CViewportTitleDlg::UpdatePrefabEditMode()
 {
-    if (m_editModeMenu == nullptr)
+    if (m_prefabEditModeMenu == nullptr)
     {
         // Nothing to update, just return;
         return;
     }
 
-    m_normalEditModeAction->setChecked(false);
-    m_monochromaticEditModeAction->setChecked(false);
+    m_normalPrefabEditModeAction->setChecked(false);
+    m_monochromaticPrefabEditModeAction->setChecked(false);
 
-    switch (m_editMode)
+    switch (m_prefabEditMode)
     {
-    case FocusModeUxSetting::Normal:
+    case PrefabEditModeUXSetting::Normal:
         {
-            m_normalEditModeAction->setChecked(true);
+            m_normalPrefabEditModeAction->setChecked(true);
             AZ::Render::EditorStateRequestsBus::Event(
                 AZ::Render::EditorState::FocusMode, &AZ::Render::EditorStateRequestsBus::Events::SetEnabled, false);
+            AzToolsFramework::SetPrefabEditModeEffectEnabled(false);
+            AzToolsFramework::EditorSettingsAPIBus::Broadcast(&AzToolsFramework::EditorSettingsAPIBus::Events::SaveSettingsRegistryFile);
             break;
         }
-    case FocusModeUxSetting::Monochromatic:
+    case PrefabEditModeUXSetting::Monochromatic:
         {
-            m_monochromaticEditModeAction->setChecked(true);
+            m_monochromaticPrefabEditModeAction->setChecked(true);
             AZ::Render::EditorStateRequestsBus::Event(
                 AZ::Render::EditorState::FocusMode, &AZ::Render::EditorStateRequestsBus::Events::SetEnabled, true);
+            AzToolsFramework::SetPrefabEditModeEffectEnabled(true);
+            AzToolsFramework::EditorSettingsAPIBus::Broadcast(&AzToolsFramework::EditorSettingsAPIBus::Events::SaveSettingsRegistryFile);
             break;
         }
     default:
-        AZ_Error("EditMode", false, AZStd::string::format("Unexpected edit mode: %zu", static_cast<size_t>(m_editMode)).c_str());
+        AZ_Error("PrefabEditMode", false, AZStd::string::format("Unexpected edit mode: %zu", static_cast<size_t>(m_prefabEditMode)).c_str());
     }
 }
 
@@ -775,29 +782,29 @@ QMenu* const CViewportTitleDlg::GetAspectMenu()
     return m_aspectMenu;
 }
 
-QMenu* const CViewportTitleDlg::GetEditModeMenu()
+QMenu* const CViewportTitleDlg::GetPrefabEditModeMenu()
 {
-    CreateEditModeMenu();
-    return m_editModeMenu;
+    CreatePrefabEditModeMenu();
+    return m_prefabEditModeMenu;
 }
 
-void CViewportTitleDlg::CreateEditModeMenu()
+void CViewportTitleDlg::CreatePrefabEditModeMenu()
 {
-    if (m_editModeMenu == nullptr)
+    if (m_prefabEditModeMenu == nullptr)
     {
-        m_editModeMenu = new QMenu("Edit Mode");
+        m_prefabEditModeMenu = new QMenu("Edit Mode");
 
-        m_normalEditModeAction = new QAction(tr("Normal"), m_editModeMenu);
-        m_normalEditModeAction->setCheckable(true);
-        connect(m_normalEditModeAction, &QAction::triggered, this, &CViewportTitleDlg::SetNormalEditMode);
-        m_editModeMenu->addAction(m_normalEditModeAction);
+        m_normalPrefabEditModeAction = new QAction(tr("Normal"), m_prefabEditModeMenu);
+        m_normalPrefabEditModeAction->setCheckable(true);
+        connect(m_normalPrefabEditModeAction, &QAction::triggered, this, &CViewportTitleDlg::SetNormalPrefabEditMode);
+        m_prefabEditModeMenu->addAction(m_normalPrefabEditModeAction);
 
-        m_monochromaticEditModeAction = new QAction(tr("Monochromatic"), m_editModeMenu);
-        m_monochromaticEditModeAction->setCheckable(true);
-        connect(m_monochromaticEditModeAction, &QAction::triggered, this, &CViewportTitleDlg::SetMonochromaticEditMode);
-        m_editModeMenu->addAction(m_monochromaticEditModeAction);
+        m_monochromaticPrefabEditModeAction = new QAction(tr("Monochromatic"), m_prefabEditModeMenu);
+        m_monochromaticPrefabEditModeAction->setCheckable(true);
+        connect(m_monochromaticPrefabEditModeAction, &QAction::triggered, this, &CViewportTitleDlg::SetMonochromaticPrefabEditMode);
+        m_prefabEditModeMenu->addAction(m_monochromaticPrefabEditModeAction);
 
-        UpdateEditMode();
+        UpdatePrefabEditMode();
     }
 }
 

--- a/Code/Editor/ViewportTitleDlg.h
+++ b/Code/Editor/ViewportTitleDlg.h
@@ -82,12 +82,12 @@ protected:
     void OnSystemEvent(ESystemEvent event, UINT_PTR wparam, UINT_PTR lparam) override;
 
     void OnMaximize();
-    void UpdateEditMode();
+    void UpdatePrefabEditMode();
     void UpdateDisplayInfo();
 
     void SetupCameraDropdownMenu();
     void SetupResolutionDropdownMenu();
-    void SetupEditModeMenu();
+    void SetupPrefabEditModeMenu();
     void SetupViewportInformationMenu();
     void SetupOverflowMenu();
     void SetupHelpersButton();
@@ -124,10 +124,10 @@ protected:
     void OnMenuResolutionCustom();
     void CreateResolutionMenu();
     
-    void CreateEditModeMenu();
-    QMenu* const GetEditModeMenu();
-    void SetNormalEditMode();
-    void SetMonochromaticEditMode();
+    void CreatePrefabEditModeMenu();
+    QMenu* const GetPrefabEditModeMenu();
+    void SetNormalPrefabEditMode();
+    void SetMonochromaticPrefabEditMode();
 
     void CreateViewportInformationMenu();
     QMenu* const GetViewportInformationMenu();
@@ -156,12 +156,12 @@ protected:
 
     void UpdateOverFlowMenuState();
 
-    QAction* m_normalEditModeAction = nullptr;
-    QAction* m_monochromaticEditModeAction = nullptr;
+    QAction* m_normalPrefabEditModeAction = nullptr;
+    QAction* m_monochromaticPrefabEditModeAction = nullptr;
     QMenu* m_fovMenu = nullptr;
     QMenu* m_aspectMenu = nullptr;
     QMenu* m_resolutionMenu = nullptr;
-    QMenu* m_editModeMenu = nullptr;
+    QMenu* m_prefabEditModeMenu = nullptr;
     QMenu* m_viewportInformationMenu = nullptr;
     QMenu* m_helpersMenu = nullptr;
     QAction* m_helpersAction = nullptr;
@@ -184,15 +184,15 @@ protected:
 
     QScopedPointer<Ui::ViewportTitleDlg> m_ui;
 
-    //! The different edit mode effects available in the Edit mode menu.
-    enum class FocusModeUxSetting
+    //! The different prefab edit mode effects available in the Edit mode menu.
+    enum class PrefabEditModeUXSetting
     {
         Normal, //!< No effect.
         Monochromatic //!< Monochromatic effect.
     };
 
     //! The currently active edit mode effect.
-    FocusModeUxSetting m_editMode = FocusModeUxSetting::Monochromatic;
+    PrefabEditModeUXSetting m_prefabEditMode = PrefabEditModeUXSetting::Monochromatic;
 };
 
 namespace AzToolsFramework

--- a/Code/Editor/ViewportTitleDlg.ui
+++ b/Code/Editor/ViewportTitleDlg.ui
@@ -79,12 +79,12 @@
     </spacer>
    </item>
    <item>
-    <widget class="QToolButton" name="m_editModeMenu">
+    <widget class="QToolButton" name="m_prefabEditModeMenu">
      <property name="toolTip">
-      <string>Edit mode</string>
+      <string>Prefab Edit mode</string>
      </property>
      <property name="text">
-      <string>Edit mode</string>
+      <string>Prefab Edit mode</string>
      </property>
     </widget>
    </item>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/EditorSettingsAPIBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/EditorSettingsAPIBus.h
@@ -39,6 +39,7 @@ namespace AzToolsFramework
         virtual SettingOutcome SetValue(const AZStd::string_view path, const AZStd::any& value) = 0;
         virtual ConsoleColorTheme GetConsoleColorTheme() const = 0;
         virtual AZ::u64 GetMaxNumberOfItemsShownInSearchView() const = 0;
+        virtual void SaveSettingsRegistryFile() = 0; 
     };
 
     using EditorSettingsAPIBus = AZ::EBus<EditorSettingsAPIRequests>;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportSettings.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportSettings.cpp
@@ -25,6 +25,7 @@ namespace AzToolsFramework
     constexpr AZStd::string_view IconsVisibleSetting = "/Amazon/Preferences/Editor/IconsVisible";
     constexpr AZStd::string_view HelpersVisibleSetting = "/Amazon/Preferences/Editor/HelpersVisible";
     constexpr AZStd::string_view ComponentSwitcherEnabledSetting = "/Amazon/Preferences/Editor/ComponentSwitcherEnabled";
+    constexpr AZStd::string_view PrefabEditModeEffectEnabledSetting = "/Amazon/Preferences/Editor/PrefabEditModeEffectEnabled";
 
     bool FlipManipulatorAxesTowardsView()
     {
@@ -149,5 +150,15 @@ namespace AzToolsFramework
     bool ComponentSwitcherEnabled()
     {
         return GetRegistry(ComponentSwitcherEnabledSetting, false);
+    }
+
+    bool PrefabEditModeEffectEnabled()
+    {
+        return GetRegistry(PrefabEditModeEffectEnabledSetting, false);
+    }
+
+    void SetPrefabEditModeEffectEnabled(const bool enabled)
+    {
+        SetRegistry(PrefabEditModeEffectEnabledSetting, enabled);
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportSettings.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportSettings.h
@@ -79,4 +79,7 @@ namespace AzToolsFramework
 
     bool ComponentSwitcherEnabled();
 
+    bool PrefabEditModeEffectEnabled();
+    void SetPrefabEditModeEffectEnabled(bool enabled);
+
 } // namespace AzToolsFramework

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/State/FocusedEntityState.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/State/FocusedEntityState.cpp
@@ -10,6 +10,7 @@
 
 #include <AzToolsFramework/FocusMode/FocusModeInterface.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
+#include <AzToolsFramework/Viewport/ViewportSettings.h>
 #include <AzToolsFramework/ViewportSelection/EditorTransformComponentSelectionRequestBus.h>
 
 namespace AZ::Render
@@ -34,6 +35,7 @@ namespace AZ::Render
         : EditorStateBase(EditorState::FocusMode, "FocusMode", CreateFocusedEntityChildPasses())
     {
         AzToolsFramework::ViewportEditorModeNotificationsBus::Handler::BusConnect(AzToolsFramework::GetEntityContextId());
+        SetEnabled(AzToolsFramework::PrefabEditModeEffectEnabled());
     }
 
     FocusedEntityState::~FocusedEntityState()


### PR DESCRIPTION
Signed-off-by: John <jonawals@amazon.com>

## What does this PR do?

This PR adds the persistent registry setting to the prefab edit mode effect setting in the viewport.

## How was this PR tested?

Manual testing in Editor.
