### PR TITLE
Fix alt-tab issue with mouse move causing camera reset

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Input/Channels/InputChannelDigitalWithSharedModifierKeyStates.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Channels/InputChannelDigitalWithSharedModifierKeyStates.h
@@ -53,14 +53,13 @@ namespace AzFramework
         //! \return True if the modifier key is active, false otherwise
         bool IsActive(ModifierKeyMask modifierKey) const;
 
-    private:
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Set the active state of the specified modifier key
         //! \param[in] modifierKey The modifier key to set
         //! \param[in] active The active state to set
         void SetActive(ModifierKeyMask modifierKey, bool active);
-        friend class InputChannelDigitalWithSharedModifierKeyStates;
 
+    private:
         ModifierKeyMask m_activeModifierKeys = ModifierKeyMask::None; //!< Active modifier keys
     };
 

--- a/Code/Framework/AzFramework/Tests/CameraInputTests.cpp
+++ b/Code/Framework/AzFramework/Tests/CameraInputTests.cpp
@@ -15,6 +15,13 @@
 
 namespace UnitTest
 {
+    static AzFramework::ModifierKeyStates OrbitModifierKeyStates(const AzFramework::InputChannelId orbitChannelId)
+    {
+        AzFramework::ModifierKeyStates modifierKeyStates;
+        modifierKeyStates.SetActive(AzFramework::GetCorrespondingModifierKeyMask(orbitChannelId), true);
+        return modifierKeyStates;
+    }
+
     class CameraInputFixture : public AllocatorsTestFixture
     {
     public:
@@ -112,21 +119,23 @@ namespace UnitTest
 
     TEST_F(CameraInputFixture, BeginAndEndOrbitCameraInputConsumesCorrectEvents)
     {
+        const AzFramework::ModifierKeyStates orbitModifierKeystate = OrbitModifierKeyStates(m_orbitChannelId);
+
         // begin orbit camera
         const bool consumed1 = HandleEventAndUpdate(AzFramework::InputState{
             AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceKeyboard::Key::ModifierAltL, AzFramework::InputChannel::State::Began },
-            AzFramework::ModifierKeyStates{} });
+            orbitModifierKeystate });
         // begin listening for orbit rotate (click detector) - event is not consumed
         const bool consumed2 = HandleEventAndUpdate(AzFramework::InputState{
             AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Left, AzFramework::InputChannel::State::Began },
-            AzFramework::ModifierKeyStates{} });
+            orbitModifierKeystate });
         // begin orbit rotate (mouse has moved sufficient distance to initiate)
         const bool consumed3 =
-            HandleEventAndUpdate(AzFramework::InputState{ AzFramework::HorizontalMotionEvent{ 5 }, AzFramework::ModifierKeyStates{} });
+            HandleEventAndUpdate(AzFramework::InputState{ AzFramework::HorizontalMotionEvent{ 5 }, orbitModifierKeystate });
         // end orbit (mouse up) - event is not consumed
         const bool consumed4 = HandleEventAndUpdate(AzFramework::InputState{
             AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Left, AzFramework::InputChannel::State::Ended },
-            AzFramework::ModifierKeyStates{} });
+            orbitModifierKeystate });
 
         const auto allConsumed = AZStd::vector<bool>{ consumed1, consumed2, consumed3, consumed4 };
 
@@ -357,19 +366,20 @@ namespace UnitTest
 
     TEST_F(CameraInputFixture, OrbitRotateCameraInputRotatesPitchOffsetByNinetyDegreesWithRequiredPixelDelta)
     {
+        const AzFramework::ModifierKeyStates orbitModifierKeystate = OrbitModifierKeyStates(m_orbitChannelId);
+
         const auto cameraStartingPosition = AZ::Vector3::CreateAxisY(-20.0f);
         m_targetCamera.m_pivot = cameraStartingPosition;
 
         m_pivot = AZ::Vector3::CreateAxisY(-10.0f);
 
-        HandleEventAndUpdate(
-            AzFramework::InputState{ AzFramework::DiscreteInputEvent{ m_orbitChannelId, AzFramework::InputChannel::State::Began },
-                                     AzFramework::ModifierKeyStates{} });
+        HandleEventAndUpdate(AzFramework::InputState{
+            AzFramework::DiscreteInputEvent{ m_orbitChannelId, AzFramework::InputChannel::State::Began }, orbitModifierKeystate });
         HandleEventAndUpdate(AzFramework::InputState{
             AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Left, AzFramework::InputChannel::State::Began },
-            AzFramework::ModifierKeyStates{} });
+            orbitModifierKeystate });
         HandleEventAndUpdate(
-            AzFramework::InputState{ AzFramework::VerticalMotionEvent{ PixelMotionDelta90Degrees }, AzFramework::ModifierKeyStates{} });
+            AzFramework::InputState{ AzFramework::VerticalMotionEvent{ PixelMotionDelta90Degrees }, orbitModifierKeystate });
 
         const auto expectedCameraEndingPosition = AZ::Vector3(0.0f, -10.0f, 10.0f);
         const float expectedPitch = AzFramework::ClampPitchRotation(-AZ::Constants::HalfPi);
@@ -384,19 +394,20 @@ namespace UnitTest
 
     TEST_F(CameraInputFixture, OrbitRotateCameraInputRotatesYawOffsetByNinetyDegreesWithRequiredPixelDelta)
     {
+        const AzFramework::ModifierKeyStates orbitModifierKeystate = OrbitModifierKeyStates(m_orbitChannelId);
+
         const auto cameraStartingPosition = AZ::Vector3(15.0f, -20.0f, 0.0f);
         m_targetCamera.m_pivot = cameraStartingPosition;
 
         m_pivot = AZ::Vector3(10.0f, -10.0f, 0.0f);
 
-        HandleEventAndUpdate(
-            AzFramework::InputState{ AzFramework::DiscreteInputEvent{ m_orbitChannelId, AzFramework::InputChannel::State::Began },
-                                     AzFramework::ModifierKeyStates{} });
+        HandleEventAndUpdate(AzFramework::InputState{
+            AzFramework::DiscreteInputEvent{ m_orbitChannelId, AzFramework::InputChannel::State::Began }, orbitModifierKeystate });
         HandleEventAndUpdate(AzFramework::InputState{
             AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Left, AzFramework::InputChannel::State::Began },
-            AzFramework::ModifierKeyStates{} });
+            orbitModifierKeystate });
         HandleEventAndUpdate(
-            AzFramework::InputState{ AzFramework::HorizontalMotionEvent{ -PixelMotionDelta90Degrees }, AzFramework::ModifierKeyStates{} });
+            AzFramework::InputState{ AzFramework::HorizontalMotionEvent{ -PixelMotionDelta90Degrees }, orbitModifierKeystate });
 
         const auto expectedCameraEndingPosition = AZ::Vector3(20.0f, -5.0f, 0.0f);
         const float expectedYaw = AzFramework::WrapYawRotation(AZ::Constants::HalfPi);


### PR DESCRIPTION
## What does this PR do?

This PR fixes a really annoying bug that would cause the camera to move to the origin when pressing `Alt-Tab` and moving the mouse at the same time (see attached videos for before/after).

## How was this PR tested?

This was tested in the Editor manually. An integration test for the camera was also created to mimic the issue and show that the new code fixes it.

### Before

```
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from CameraInputFixture
[ RUN      ] CameraInputFixture.OrbitRotateCameraInputDoesNotResetPositionWithInconsitentEventAndUpdate
D:/o3de-2/Code/Framework/AzFramework/Tests/CameraInputTests.cpp(621): error: Value of: m_camera.Translation()
Expected: is close tolerance ((X: 0, Y: -20, Z: 0), 0.01)
  Actual: (X: 0, Y: -10, Z: 0) (of type class AZ::Vector3)
[  FAILED  ] CameraInputFixture.OrbitRotateCameraInputDoesNotResetPositionWithInconsitentEventAndUpdate (1 ms)
[----------] 1 test from CameraInputFixture (2 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (3 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] CameraInputFixture.OrbitRotateCameraInputDoesNotResetPositionWithInconsitentEventAndUpdate
```

### After

```
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from CameraInputFixture
[ RUN      ] CameraInputFixture.OrbitRotateCameraInputDoesNotResetPositionWithInconsitentEventAndUpdate
[       OK ] CameraInputFixture.OrbitRotateCameraInputDoesNotResetPositionWithInconsitentEventAndUpdate (1 ms)
[----------] 1 test from CameraInputFixture (1 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (2 ms total)
[  PASSED  ] 1 test.
```

## Behavior

### Before

https://user-images.githubusercontent.com/82228511/190201107-e896ab0f-bfa4-4160-9e2c-11df2cd6ea57.mp4

### After

https://user-images.githubusercontent.com/82228511/190201131-412f30c2-48a3-4cde-96c0-c32d862683cc.mp4
