### PR TITLE
Material Editor: Fixing bug creating and loading child materials from source data + upgrade material Python script

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
@@ -339,7 +339,7 @@ namespace AZ
                 }
 
                 // Record the material source data and its absolute path so that asset references can be resolved relative to it
-                parentSourceDataStack.emplace_back(parentSourceAbsPath, AZStd::move(parentSourceData));
+                parentSourceDataStack.emplace_back(parentSourceAbsPath, parentSourceData);
 
                 // Get the location of the next parent material and push the source data onto the stack 
                 parentSourceRelPath = parentSourceData.m_parentMaterial;

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
@@ -303,7 +303,7 @@ namespace AZ
 
             // Load and build a stack of MaterialSourceData from all of the parent materials in the hierarchy. Properties from the source
             // data will be applied in reverse to the asset creator.
-            AZStd::vector<MaterialSourceData> parentSourceDataStack;
+            AZStd::vector<AZStd::pair<AZStd::string, MaterialSourceData>> parentSourceDataStack;
 
             AZStd::string parentSourceRelPath = m_parentMaterial;
             AZStd::string parentSourceAbsPath = AssetUtils::ResolvePathReference(materialSourceFilePath, parentSourceRelPath);
@@ -338,13 +338,15 @@ namespace AZ
                     return Failure();
                 }
 
+                // Record the material source data and its absolute path so that asset references can be resolved relative to it
+                parentSourceDataStack.emplace_back(parentSourceAbsPath, AZStd::move(parentSourceData));
+
                 // Get the location of the next parent material and push the source data onto the stack 
                 parentSourceRelPath = parentSourceData.m_parentMaterial;
                 parentSourceAbsPath = AssetUtils::ResolvePathReference(parentSourceAbsPath, parentSourceRelPath);
-                parentSourceDataStack.emplace_back(AZStd::move(parentSourceData));
             }
             
-            // Unlike CreateMaterialAsset(), we can always finalize the material here because we loaded created the MaterialTypeAsset from
+            // Unlike CreateMaterialAsset(), we can always finalize the material here because we created the MaterialTypeAsset from
             // the source .materialtype file, so the necessary data is always available.
             // (In case you are wondering why we don't use CreateMaterialAssetFromSourceData in MaterialBuilder: that would require a
             // source dependency between the .materialtype and .material file, which would cause all .material files to rebuild when you
@@ -358,12 +360,20 @@ namespace AZ
             
             materialAssetCreator.SetMaterialTypeVersion(m_materialTypeVersion);
 
+            // Traverse the parent source data stack in reverse, applying properties from each material parent source data on to the asset
+            // creator. This will manually accumulate all material property values in the hierarchy.
             while (!parentSourceDataStack.empty())
             {
-                parentSourceDataStack.back().ApplyPropertiesToAssetCreator(materialAssetCreator, materialSourceFilePath);
+                // Images and other assets must be resolved relative to the parent source data absolute path, not the path passed into this
+                // function that is the final material being created.
+                const auto& parentPath = parentSourceDataStack.back().first;
+                const auto& parentData = parentSourceDataStack.back().second;
+                parentData.ApplyPropertiesToAssetCreator(materialAssetCreator, parentPath);
                 parentSourceDataStack.pop_back();
             }
 
+            // Finally, apply properties from the source data that was initially requested. This could also go into the stack but is being
+            // used for other purposes.
             ApplyPropertiesToAssetCreator(materialAssetCreator, materialSourceFilePath);
 
             Data::Asset<MaterialAsset> material;
@@ -379,7 +389,7 @@ namespace AZ
 
             return Failure();
         }
-        
+
         /*static*/ bool MaterialSourceData::LooksLikeImageFileReference(const MaterialPropertyValue& value)
         {
             // If the source value type is a string, there are two possible property types: Image and Enum. If there is a "." in

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -196,11 +196,15 @@ namespace AtomToolsFramework
     AZStd::set<AZStd::string> GetPathsFromMimeData(const QMimeData* mimeData);
 
     //! Collect a set of file paths from all project safe folders matching a wild card
-    AZStd::set<AZStd::string> GetPathsInSourceFoldersMatchingWildcard(const AZStd::string& wildcard);
+    AZStd::vector<AZStd::string> GetPathsInSourceFoldersMatchingWildcard(const AZStd::string& wildcard);
 
-    // Add menu actions for scripts specified in the settings registry
-    // @param menu The menu where the actions will be inserted
-    // @param registryKey The path to the registry setting where script categories are registered
-    // @param arguments The list of arguments passed into the script when executed
+    //! Add menu actions for scripts specified in the settings registry
+    //! @param menu The menu where the actions will be inserted
+    //! @param registryKey The path to the registry setting where script categories are registered
+    //! @param arguments The list of arguments passed into the script when executed
     void AddRegisteredScriptToMenu(QMenu* menu, const AZStd::string& registryKey, const AZStd::vector<AZStd::string>& arguments);
+
+    //! Reflect utility functions to behavior context
+    void ReflectUtilFunctions(AZ::ReflectContext* context);
+
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -104,10 +104,11 @@ namespace AtomToolsFramework
 
         AzToolsFramework::QTreeViewWithStateSaving::Reflect(context);
         AzToolsFramework::QWidgetSavedState::Reflect(context);
+        ReflectUtilFunctions(context);
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
-            // this will put these methods into the 'azlmbr.AtomTools.general' module
+            // This will put these methods into the 'azlmbr.atomtools.general' module
             auto addGeneral = [](AZ::BehaviorContext::GlobalMethodBuilder methodBuilder)
             {
                 methodBuilder->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeManager.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeManager.cpp
@@ -50,7 +50,7 @@ namespace AtomToolsFramework
     void DynamicNodeManager::LoadConfigFiles(const AZStd::string& extension)
     {
         // Load and register all discovered dynamic node configuration
-        for (AZStd::string configPath : GetPathsInSourceFoldersMatchingWildcard(AZStd::string::format("*.%s", extension.c_str())))
+        for (const auto& configPath : GetPathsInSourceFoldersMatchingWildcard(AZStd::string::format("*.%s", extension.c_str())))
         {
             DynamicNodeConfig config;
             if (config.Load(configPath))

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -18,6 +18,8 @@
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/StringFunc/StringFunc.h>
 #include <AzCore/Utils/Utils.h>
+#include <AzCore/std/algorithm.h>
+#include <AzCore/std/sort.h>
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/FileFunc/FileFunc.h>
 #include <AzQtComponents/Components/Widgets/FileDialog.h>
@@ -434,9 +436,9 @@ namespace AtomToolsFramework
         return paths;
     }
 
-    AZStd::set<AZStd::string> GetPathsInSourceFoldersMatchingWildcard(const AZStd::string& wildcard)
+    AZStd::vector<AZStd::string> GetPathsInSourceFoldersMatchingWildcard(const AZStd::string& wildcard)
     {
-        AZStd::set<AZStd::string> results;
+        AZStd::vector<AZStd::string> results;
         AZStd::vector<AZStd::string> scanFolders;
         AzToolsFramework::AssetSystemRequestBus::Broadcast(
             &AzToolsFramework::AssetSystem::AssetSystemRequest::GetAssetSafeFolders, scanFolders);
@@ -449,11 +451,17 @@ namespace AtomToolsFramework
                 {
                     if (ValidateDocumentPath(path))
                     {
-                        results.insert(path);
+                        results.push_back(path);
                     }
                 }
             }
         }
+
+        // Sorting the container and removing duplicate paths. This isn't entirely necessary but the function previously returned a sorted
+        // set so preserving behavior.
+        AZStd::sort(results.begin(), results.end());
+        results.erase(AZStd::unique(results.begin(), results.end()), results.end());
+
         return results;
     }
 
@@ -515,5 +523,35 @@ namespace AtomToolsFramework
                 });
             }
         });
+    }
+
+    void ReflectUtilFunctions(AZ::ReflectContext* context)
+    {
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            // This will put these methods into the 'azlmbr.atomtools.util' module
+            auto addUtilFunc = [](AZ::BehaviorContext::GlobalMethodBuilder methodBuilder)
+            {
+                methodBuilder->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "Editor")
+                    ->Attribute(AZ::Script::Attributes::Module, "atomtools.util");
+            };
+
+            addUtilFunc(behaviorContext->Method("GetSymbolNameFromText", GetSymbolNameFromText, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetDisplayNameFromText", GetDisplayNameFromText, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetDisplayNameFromPath", GetDisplayNameFromPath, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetSaveFilePath", GetSaveFilePath, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetUniqueFilePath", GetUniqueFilePath, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetUniqueDefaultSaveFilePath", GetUniqueDefaultSaveFilePath, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetUniqueDuplicateFilePath", GetUniqueDuplicateFilePath, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("ValidateDocumentPath", ValidateDocumentPath, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("IsDocumentPathInSupportedFolder", IsDocumentPathInSupportedFolder, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("IsDocumentPathEditable", IsDocumentPathEditable, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("IsDocumentPathPreviewable", IsDocumentPathPreviewable, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetPathToExteralReference", GetPathToExteralReference, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetPathWithoutAlias", GetPathWithoutAlias, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetPathWithAlias", GetPathWithAlias, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetPathsInSourceFoldersMatchingWildcard", GetPathsInSourceFoldersMatchingWildcard, nullptr, ""));
+        }
     }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -457,8 +457,8 @@ namespace AtomToolsFramework
             }
         }
 
-        // Sorting the container and removing duplicate paths. This isn't entirely necessary but the function previously returned a sorted
-        // set so preserving behavior.
+        // Sorting the container and removing duplicate paths to ensure uniqueness in case of nested or overlapping scan folders.
+        // This was previously done automatically with a set but using a vector for compatibility with behavior context and Python. 
         AZStd::sort(results.begin(), results.end());
         results.erase(AZStd::unique(results.begin(), results.end()), results.end());
 

--- a/Gems/Atom/Tools/MaterialEditor/Scripts/UpgradeAllMaterials.py
+++ b/Gems/Atom/Tools/MaterialEditor/Scripts/UpgradeAllMaterials.py
@@ -1,0 +1,31 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+import sys
+import os
+import azlmbr.bus
+import azlmbr.paths
+import collections
+
+def main():
+
+    documentId = azlmbr.atomtools.AtomToolsDocumentSystemRequestBus(azlmbr.bus.Broadcast, 'CreateDocumentFromTypeName', 'Material')
+
+    if documentId.IsNull():
+        print("The material document could not be opened")
+        return
+
+    for path in azlmbr.atomtools.util.GetPathsInSourceFoldersMatchingWildcard('*.material'):
+        if azlmbr.atomtools.util.IsDocumentPathEditable(path):
+            if azlmbr.atomtools.AtomToolsDocumentRequestBus(azlmbr.bus.Event, 'Open', documentId, path):
+                azlmbr.atomtools.AtomToolsDocumentRequestBus(azlmbr.bus.Event, 'Save', documentId)
+
+    azlmbr.atomtools.AtomToolsDocumentSystemRequestBus(azlmbr.bus.Broadcast, 'DestroyDocument', documentId)
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## What does this PR do?

This change resolves an issue with the material editor loading and creating child materials. Material source data asset references were being resolved relative to the final child material instead of the parent materials containing the reference.

In addition to resolving the issue, functions were registered with the behavior context to support a Python script for loading and resaving all materials in a project and its active gems. This script is useful for testing material editor serialization as well as upgrading materials to the latest material type version. Upgrading to the latest material type version will eradicate warning message box spam for older materials, reorganize, and rename material properties to the latest version so it does not have to be done at runtime.   

Resaved materials will be submitted in a separate PR.

https://github.com/o3de/o3de/issues/2841

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

These changes were tested by running the accompanying script that loads and resaves all materials used in the current project. The white box default material was failing because it used a parent material that lived in a different folder and contained image asset references relative to that folder.