### PR TITLE
Fix compile error on Mac

### DIFF
--- a/Code/Framework/AzCore/Platform/Mac/AzCore/Platform_Mac.cpp
+++ b/Code/Framework/AzCore/Platform/Mac/AzCore/Platform_Mac.cpp
@@ -36,7 +36,7 @@ namespace AZ
                 AZ_Error("System", result == 0, "gethostuuid() failed with code %d", result);  
                 Sha1 hash;
                 AZ::u32 digest[5] = { 0 };
-                hash.ProcessBytes(&hostId, sizeof(hostId));
+                hash.ProcessBytes(reinterpret_cast<AZStd::byte const*>(&hostId), sizeof(hostId));
                 hash.GetDigest(digest);
                 s_machineId = digest[0];
 


### PR DESCRIPTION
## What does this PR do?

Fix for the following compile error on Mac
```
In file included from /Users/github/o3de/build/mac_xcode/Code/Framework/AzCore/CMakeFiles/AzCore.dir/Unity/unity_30_cxx.cxx:9: /Users/github/o3de/Code/Framework/AzCore/Platform/Mac/AzCore/Platform_Mac.cpp:39:22: error: no matching member function for call to
      'ProcessBytes'
                hash.ProcessBytes(&hostId, sizeof(hostId));
                ~~~~~^~~~~~~~~~~~
In file included from /Users/github/o3de/build/mac_xcode/Code/Framework/AzCore/CMakeFiles/AzCore.dir/Unity/unity_30_cxx.cxx:5: In file included from /Users/github/o3de/Code/Framework/AzCore/Platform/Common/Apple/AzCore/Module/DynamicModuleHandle_Apple.cpp:9: In file included from /Users/github/o3de/Code/Framework/AzCore/AzCore/std/string/osstring.h:11: In file included from /Users/github/o3de/Code/Framework/AzCore/AzCore/std/string/string.h:21: In file included from /Users/github/o3de/Code/Framework/AzCore/AzCore/std/allocator.h:13: In file included from /Users/github/o3de/Code/Framework/AzCore/AzCore/RTTI/TypeInfoSimple.h:10: In file included from /Users/github/o3de/Code/Framework/AzCore/AzCore/Math/Uuid.h:202: In file included from /Users/github/o3de/Code/Framework/AzCore/AzCore/Math/Uuid.inl:9: /Users/github/o3de/Code/Framework/AzCore/AzCore/Math/Sha1.h:86:33: note: candidate function not viable: no known conversion from
      'uuid_t *' (aka 'unsigned char (*)[16]') to 'const AZStd::byte *' for 1st argument
    inline constexpr void Sha1::ProcessBytes(AZStd::byte const* buffer, size_t byteCount)
                                ^
/Users/github/o3de/Code/Framework/AzCore/AzCore/Math/Sha1.h:78:33: note: candidate function not viable: requires single argument
      'byteSpan', but 2 arguments were provided
    inline constexpr void Sha1::ProcessBytes(AZStd::span<AZStd::byte const> byteSpan)
```

## How was this PR tested?

Built on Mac successfully

