### PR TITLE
Editor | Fix shadow artifact on About Us dialog

### DIFF
--- a/Code/Editor/StartupLogoDialog.cpp
+++ b/Code/Editor/StartupLogoDialog.cpp
@@ -46,7 +46,7 @@ CStartupLogoDialog::CStartupLogoDialog(
     switch (m_dialogType)
     {
     case Loading:
-        setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
+        setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint);
         m_ui->m_pages->setCurrentIndex(0);
         setWindowTitle(tr("Starting Open 3D Engine Editor"));
         m_ui->m_TransparentConfidential->setObjectName("copyrightNotice");
@@ -58,7 +58,7 @@ CStartupLogoDialog::CStartupLogoDialog(
 
         break;
     case About:
-        setWindowFlags(Qt::FramelessWindowHint | Qt::Popup);
+        setWindowFlags(Qt::FramelessWindowHint | Qt::Popup | Qt::NoDropShadowWindowHint);
         m_ui->m_pages->setCurrentIndex(1);
         m_ui->m_transparentAllRightReserved->setObjectName("copyrightNotice");
         m_ui->m_transparentAllRightReserved->setTextFormat(Qt::RichText);


### PR DESCRIPTION
## What does this PR do?

Fixes a drop shadow artifact on the About Us dialog in the Editor.
Cherry-picks https://github.com/o3de/o3de/pull/11800 to stabilization/2210
Fixes https://github.com/o3de/o3de/issues/11684

![image](https://user-images.githubusercontent.com/82231674/190286248-326f67f6-fac3-4198-948e-b39e38c32a4a.png)
