### PR TITLE
[Atom] Add indirect raytracing command

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/IndirectRendering.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/IndirectRendering.azsli
@@ -33,6 +33,13 @@ struct DispatchIndirectCommand
     uint m_threadGroupCountZ;
 };
 
+struct DispatchRaysIndirectCommand
+{
+    uint m_width;
+    uint m_height;
+    uint m_depth;
+};
+
 struct VertexViewIndirectCommand
 {
     uint4 m_vertexArguments;

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -333,15 +333,15 @@ namespace AZ
 
                 RHI::Size imageSize = outputAttachment->m_descriptor.m_image.m_size;
 
-                dispatchRaysItem.m_width = imageSize.m_width;
-                dispatchRaysItem.m_height = imageSize.m_height;
-                dispatchRaysItem.m_depth = imageSize.m_depth;
+                dispatchRaysItem.m_arguments.m_direct.m_width = imageSize.m_width;
+                dispatchRaysItem.m_arguments.m_direct.m_height = imageSize.m_height;
+                dispatchRaysItem.m_arguments.m_direct.m_depth = imageSize.m_depth;
             }
             else
             {
-                dispatchRaysItem.m_width = m_passData->m_threadCountX;
-                dispatchRaysItem.m_height = m_passData->m_threadCountY;
-                dispatchRaysItem.m_depth = m_passData->m_threadCountZ;
+                dispatchRaysItem.m_arguments.m_direct.m_width = m_passData->m_threadCountX;
+                dispatchRaysItem.m_arguments.m_direct.m_height = m_passData->m_threadCountY;
+                dispatchRaysItem.m_arguments.m_direct.m_depth = m_passData->m_threadCountZ;
             }
 
             // bind RayTracingGlobal, RayTracingScene, and View Srgs

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/IndirectBufferLayout.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/IndirectBufferLayout.h
@@ -26,6 +26,7 @@ namespace AZ
             Draw,               // A Draw operation
             DrawIndexed,        // An Indexed Draw operation
             Dispatch,           // A Dispatch operation
+            DispatchRays,       // A Ray Tracing operation
             VertexBufferView,   // Set a Vertex Buffer View into a specific slot
             IndexBufferView,    // Set the Index Buffer View
             RootConstants     // Set the values of all Inline Constants
@@ -97,9 +98,10 @@ namespace AZ
         enum class IndirectBufferLayoutType : uint8_t
         {
             Undefined = 0,
-            LinearDraw, // The main command is a draw
-            IndexedDraw,// The main command is an indexed draw
-            Dispach     // The main command is a dispatch
+            LinearDraw,  // The main command is a draw
+            IndexedDraw, // The main command is an indexed draw
+            Dispatch,    // The main command is a dispatch
+            DispatchRays,// The main command is a ray dispatch
         };
 
         /// Index of a command in an IndirectBufferLayout.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysItem.h
@@ -21,15 +21,72 @@ namespace AZ
         class ImageView;
         class BufferView;
 
+        //! Arguments used when submitting a (direct) dispatch rays call into a CommandList.
+        struct DispatchRaysDirect
+        {
+            DispatchRaysDirect() = default;
+
+            DispatchRaysDirect(uint32_t width, uint32_t height, uint32_t depth)
+                : m_width(width)
+                , m_height(height)
+                , m_depth(depth)
+            {
+            }
+
+            uint32_t m_width = 1;
+            uint32_t m_height = 1;
+            uint32_t m_depth = 1;
+        };
+
+        //! Arguments used when submitting an indirect dispatch rays call into a CommandList.
+        //! The indirect dispatch arguments are the same ones as the indirect draw ones.
+        using DispatchRaysIndirect = IndirectArguments;
+
+        enum class DispatchRaysType : uint8_t
+        {
+            Direct = 0, // A dispatch rays call where the arguments are pass directly to the submit function.
+            Indirect // An indirect dispatch rays call that uses a buffer that contains the arguments.
+        };
+
+        //! Encapsulates the arguments that are specific to a type of dispatch.
+        //! It uses a union to be able to store all possible arguments.
+        struct DispatchRaysArguments
+        {
+            AZ_TYPE_INFO(DispatchArguments, "F8BE4C19-F35D-4545-B17F-3C2B4D7EF4FF");
+
+            DispatchRaysArguments()
+                : DispatchRaysArguments(DispatchRaysDirect{})
+            {
+            }
+
+            DispatchRaysArguments(const DispatchRaysDirect& direct)
+                : m_type{ DispatchRaysType::Direct }
+                , m_direct{ direct }
+            {
+            }
+
+            DispatchRaysArguments(const DispatchRaysIndirect& indirect)
+                : m_type{ DispatchRaysType::Indirect }
+                , m_indirect{ indirect }
+            {
+            }
+
+            DispatchRaysType m_type;
+            union {
+                /// Arguments for a direct dispatch.
+                DispatchRaysDirect m_direct;
+                /// Arguments for an indirect dispatch.
+                DispatchRaysIndirect m_indirect;
+            };
+        };
+
         //! Encapsulates all the necessary information for doing a ray tracing dispatch call.
         struct DispatchRaysItem
         {
             DispatchRaysItem() = default;
 
-            /// The number of rays to cast
-            uint32_t m_width = 0;
-            uint32_t m_height = 0;
-            uint32_t m_depth = 0;
+            /// Arguments specific to a dispatch type.
+            DispatchRaysArguments m_arguments;
 
             /// Ray tracing pipeline state
             const RayTracingPipelineState* m_rayTracingPipelineState = nullptr;
@@ -44,5 +101,5 @@ namespace AZ
             /// Global shader pipeline state
             const PipelineState* m_globalPipelineState = nullptr;
         };
-    }
-}
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysItem.h
@@ -52,7 +52,7 @@ namespace AZ
         //! It uses a union to be able to store all possible arguments.
         struct DispatchRaysArguments
         {
-            AZ_TYPE_INFO(DispatchArguments, "F8BE4C19-F35D-4545-B17F-3C2B4D7EF4FF");
+            AZ_TYPE_INFO(DispatchRaysArguments, "F8BE4C19-F35D-4545-B17F-3C2B4D7EF4FF");
 
             DispatchRaysArguments()
                 : DispatchRaysArguments(DispatchRaysDirect{})

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/IndirectBufferLayout.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/IndirectBufferLayout.cpp
@@ -94,8 +94,11 @@ namespace AZ
                 case IndirectCommandType::DrawIndexed:
                     result = SetType(IndirectBufferLayoutType::IndexedDraw);
                     break;
-                 case IndirectCommandType::Dispatch:
-                    result = SetType(IndirectBufferLayoutType::Dispach);
+                case IndirectCommandType::Dispatch:
+                    result = SetType(IndirectBufferLayoutType::Dispatch);
+                    break;
+                case IndirectCommandType::DispatchRays:
+                    result = SetType(IndirectBufferLayoutType::DispatchRays);
                     break;
                  default:
                      // Skip command
@@ -190,6 +193,7 @@ namespace AZ
                 case IndirectCommandType::Draw:
                 case IndirectCommandType::DrawIndexed:
                 case IndirectCommandType::Dispatch:
+                case IndirectCommandType::DispatchRays:
                 case IndirectCommandType::IndexBufferView:
                 case IndirectCommandType::RootConstants:
                 case IndirectCommandType::VertexBufferView:

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
@@ -355,7 +355,7 @@ namespace AZ
                 return;
             }
 
-            const PipelineLayout* globalPipelineLayout = globalPipelineState->GetPipelineLayout();              
+            const PipelineLayout* globalPipelineLayout = globalPipelineState->GetPipelineLayout();
             if (!globalPipelineLayout)
             {
                 AZ_Assert(false, "Pipeline layout is null.");
@@ -381,7 +381,7 @@ namespace AZ
 
                 for (uint32_t unboundedArrayIndex = 0; unboundedArrayIndex < ShaderResourceGroupCompiledData::MaxUnboundedArrays; ++unboundedArrayIndex)
                 {
-                    if (binding.m_bindlessTable.IsValid() 
+                    if (binding.m_bindlessTable.IsValid()
                         && compiledData.m_gpuUnboundedArraysDescriptorHandles[unboundedArrayIndex].ptr)
                     {
                         GetCommandList()->SetComputeRootDescriptorTable(
@@ -411,31 +411,50 @@ namespace AZ
             // set RayTracing pipeline state
             commandList->SetPipelineState1(rayTracingPipelineState->Get());
 
-            // setup DispatchRays() shader table and ray counts
-            const RayTracingShaderTable* shaderTable = static_cast<const RayTracingShaderTable*>(dispatchRaysItem.m_rayTracingShaderTable);
-            const RayTracingShaderTable::ShaderTableBuffers& shaderTableBuffers = shaderTable->GetBuffers();
+            switch (dispatchRaysItem.m_arguments.m_type)
+            {
+            case RHI::DispatchRaysType::Direct:
+                {
+                    // setup DispatchRays() shader table and ray counts
+                    const RayTracingShaderTable* shaderTable =
+                        static_cast<const RayTracingShaderTable*>(dispatchRaysItem.m_rayTracingShaderTable);
+                    const RayTracingShaderTable::ShaderTableBuffers& shaderTableBuffers = shaderTable->GetBuffers();
 
-            D3D12_DISPATCH_RAYS_DESC desc = {};
-            desc.RayGenerationShaderRecord.StartAddress = shaderTableBuffers.m_rayGenerationTable->GetMemoryView().GetGpuAddress();
-            desc.RayGenerationShaderRecord.SizeInBytes = shaderTableBuffers.m_rayGenerationTableSize;
-            
-            desc.MissShaderTable.StartAddress = shaderTableBuffers.m_missTable ? shaderTableBuffers.m_missTable->GetMemoryView().GetGpuAddress() : 0;
-            desc.MissShaderTable.SizeInBytes = shaderTableBuffers.m_missTableSize;
-            desc.MissShaderTable.StrideInBytes = shaderTableBuffers.m_missTableStride;
+                    D3D12_DISPATCH_RAYS_DESC desc = {};
+                    desc.RayGenerationShaderRecord.StartAddress = shaderTableBuffers.m_rayGenerationTable->GetMemoryView().GetGpuAddress();
+                    desc.RayGenerationShaderRecord.SizeInBytes = shaderTableBuffers.m_rayGenerationTableSize;
 
-            desc.CallableShaderTable.StartAddress = shaderTableBuffers.m_callableTable ? shaderTableBuffers.m_callableTable->GetMemoryView().GetGpuAddress() : 0;
-            desc.CallableShaderTable.SizeInBytes = shaderTableBuffers.m_callableTableSize;
-            desc.CallableShaderTable.StrideInBytes = shaderTableBuffers.m_callableTableStride;
-            
-            desc.HitGroupTable.StartAddress = shaderTableBuffers.m_hitGroupTable->GetMemoryView().GetGpuAddress();
-            desc.HitGroupTable.SizeInBytes = shaderTableBuffers.m_hitGroupTableSize;
-            desc.HitGroupTable.StrideInBytes = shaderTableBuffers.m_hitGroupTableStride;
+                    desc.MissShaderTable.StartAddress =
+                        shaderTableBuffers.m_missTable ? shaderTableBuffers.m_missTable->GetMemoryView().GetGpuAddress() : 0;
+                    desc.MissShaderTable.SizeInBytes = shaderTableBuffers.m_missTableSize;
+                    desc.MissShaderTable.StrideInBytes = shaderTableBuffers.m_missTableStride;
 
-            desc.Width = dispatchRaysItem.m_width;
-            desc.Height = dispatchRaysItem.m_height;
-            desc.Depth = dispatchRaysItem.m_depth;
-           
-            commandList->DispatchRays(&desc);
+                    desc.CallableShaderTable.StartAddress =
+                        shaderTableBuffers.m_callableTable ? shaderTableBuffers.m_callableTable->GetMemoryView().GetGpuAddress() : 0;
+                    desc.CallableShaderTable.SizeInBytes = shaderTableBuffers.m_callableTableSize;
+                    desc.CallableShaderTable.StrideInBytes = shaderTableBuffers.m_callableTableStride;
+
+                    desc.HitGroupTable.StartAddress = shaderTableBuffers.m_hitGroupTable->GetMemoryView().GetGpuAddress();
+                    desc.HitGroupTable.SizeInBytes = shaderTableBuffers.m_hitGroupTableSize;
+                    desc.HitGroupTable.StrideInBytes = shaderTableBuffers.m_hitGroupTableStride;
+
+                    desc.Width = dispatchRaysItem.m_arguments.m_direct.m_width;
+                    desc.Height = dispatchRaysItem.m_arguments.m_direct.m_height;
+                    desc.Depth = dispatchRaysItem.m_arguments.m_direct.m_depth;
+
+                    commandList->DispatchRays(&desc);
+
+                    break;
+                }
+            case RHI::DispatchRaysType::Indirect:
+                {
+                    ExecuteIndirect(dispatchRaysItem.m_arguments.m_indirect);
+                    break;
+                }
+            default:
+                AZ_Assert(false, "Invalid dispatch type");
+                break;
+            }
 #endif
         }
 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/IndirectBufferSignature.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/IndirectBufferSignature.cpp
@@ -53,6 +53,10 @@ namespace AZ
                     argDesc.Type = D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH;
                     m_stride += sizeof(D3D12_DISPATCH_ARGUMENTS);
                     break;
+                case RHI::IndirectCommandType::DispatchRays:
+                    argDesc.Type = D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH_RAYS;
+                    m_stride += sizeof(D3D12_DISPATCH_RAYS_DESC);
+                    break;
                 case RHI::IndirectCommandType::VertexBufferView:
                     argDesc.Type = D3D12_INDIRECT_ARGUMENT_TYPE_VERTEX_BUFFER_VIEW;
                     argDesc.VertexBuffer.Slot = command.m_vertexBufferArgs.m_slot;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Conversion.cpp
@@ -652,7 +652,7 @@ namespace AZ
                     bindFlags,
                     RHI::BufferBindFlags::InputAssembly | RHI::BufferBindFlags::DynamicInputAssembly |
                         RHI::BufferBindFlags::RayTracingShaderTable | RHI::BufferBindFlags::RayTracingAccelerationStructure |
-                        RHI::BufferBindFlags::RayTracingScratchBuffer))
+                        RHI::BufferBindFlags::RayTracingScratchBuffer | RHI::BufferBindFlags::Indirect))
             {
                 usageFlags |=  VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
             }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/IndirectBufferSignature.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/IndirectBufferSignature.cpp
@@ -41,6 +41,9 @@ namespace AZ
                 case RHI::IndirectCommandType::Dispatch:
                     m_stride += sizeof(VkDispatchIndirectCommand);
                     break;
+                case RHI::IndirectCommandType::DispatchRays:
+                    m_stride += sizeof(VkTraceRaysIndirectCommandKHR);
+                    break;
                 default:
                     // Unsupported command types.
                     AZ_Assert(false, "Unsupported indirect command type (%d)", command.m_type);

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
@@ -354,9 +354,9 @@ namespace AZ
                     };
 
                     RHI::DispatchRaysItem dispatchRaysItem;
-                    dispatchRaysItem.m_width = diffuseProbeGrid->GetNumRaysPerProbe().m_rayCount;
-                    dispatchRaysItem.m_height = AZ::DivideAndRoundUp(diffuseProbeGrid->GetTotalProbeCount(), diffuseProbeGrid->GetFrameUpdateCount());
-                    dispatchRaysItem.m_depth = 1;
+                    dispatchRaysItem.m_arguments.m_direct.m_width = diffuseProbeGrid->GetNumRaysPerProbe().m_rayCount;
+                    dispatchRaysItem.m_arguments.m_direct.m_height = AZ::DivideAndRoundUp(diffuseProbeGrid->GetTotalProbeCount(), diffuseProbeGrid->GetFrameUpdateCount());
+                    dispatchRaysItem.m_arguments.m_direct.m_depth = 1;
                     dispatchRaysItem.m_rayTracingPipelineState = m_rayTracingPipelineState.get();
                     dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable.get();
                     dispatchRaysItem.m_shaderResourceGroupCount = RHI::ArraySize(shaderResourceGroups);

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
@@ -302,9 +302,9 @@ namespace AZ
                 };
 
                 RHI::DispatchRaysItem dispatchRaysItem;
-                dispatchRaysItem.m_width = m_outputAttachmentSize.m_width;
-                dispatchRaysItem.m_height = m_outputAttachmentSize.m_height;
-                dispatchRaysItem.m_depth = 1;
+                dispatchRaysItem.m_arguments.m_direct.m_width = m_outputAttachmentSize.m_width;
+                dispatchRaysItem.m_arguments.m_direct.m_height = m_outputAttachmentSize.m_height;
+                dispatchRaysItem.m_arguments.m_direct.m_depth = 1;
                 dispatchRaysItem.m_rayTracingPipelineState = m_rayTracingPipelineState.get();
                 dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable.get();
                 dispatchRaysItem.m_shaderResourceGroupCount = RHI::ArraySize(shaderResourceGroups);


### PR DESCRIPTION
## What does this PR do?

This PR adds support for indirect ray tracing (similar do indirect draw commands) to the Vulkan and DX12 RHI.
The accompanying change to AtomSampleViewer can be found in https://github.com/o3de/o3de-atom-sampleviewer/pull/510

## How was this PR tested?

I tested the PR with the AtomSampleViewer using Samples->Features->SSAO and changeing to RTAO in the sidebar on the right, with both Vulkan and DX12. The results looked the same before and after the change.
