### PR TITLE
Improved handling of action after deleting wrapped nodes

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/SceneBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/SceneBus.h
@@ -406,8 +406,6 @@ namespace GraphCanvas
         virtual void OnNodeAdded(const AZ::EntityId& /*nodeId*/, bool /*isPaste*/) {}
         //! A node has been removed from the scene.
         virtual void OnNodeRemoved(const AZ::EntityId& /*nodeId*/) {}
-        //! A node is about to be removed from the scene.
-        virtual void PreOnNodeRemoved(const AZ::EntityId& /*nodeId*/) {}
         //! A node in the scene has been selected
         virtual void OnNodeSelected(const AZ::EntityId& /*nodeId*/, bool /*selected*/) {}
 

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphController.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphController.h
@@ -136,7 +136,6 @@ namespace GraphModelIntegration
         // GraphCanvas::SceneNotificationBus, connections
         void OnNodeAdded(const AZ::EntityId& nodeUiId, bool isPaste) override;
         void OnNodeRemoved(const AZ::EntityId& nodeUiId) override;
-        void PreOnNodeRemoved(const AZ::EntityId& nodeUiId) override;
         void OnConnectionRemoved(const AZ::EntityId& connectionUiId) override;
         void OnEntitiesSerialized(GraphCanvas::GraphSerialization& serializationTarget) override;
         void OnEntitiesDeserialized(const GraphCanvas::GraphSerialization& serializationSource) override;

--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -845,6 +845,8 @@ namespace GraphModelIntegration
         const GraphModel::NodePtr node = m_elementMap.Find<GraphModel::Node>(nodeUiId);
         if (node)
         {
+            GraphControllerNotificationBus::Event(m_graphCanvasSceneId, &GraphControllerNotifications::PreOnGraphModelNodeRemoved, node);
+
             GraphCanvas::ScopedGraphUndoBatch undoBatch(m_graphCanvasSceneId);
 
             // Remove any thumbnail reference for this node when it is removed from the graph
@@ -862,15 +864,6 @@ namespace GraphModelIntegration
             m_elementMap.Remove(node);
 
             GraphControllerNotificationBus::Event(m_graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelNodeRemoved, node);
-        }
-    }
-
-    void GraphController::PreOnNodeRemoved(const AZ::EntityId& nodeUiId)
-    {
-        const GraphModel::NodePtr node = m_elementMap.Find<GraphModel::Node>(nodeUiId);
-        if (node)
-        {
-            GraphControllerNotificationBus::Event(m_graphCanvasSceneId, &GraphControllerNotifications::PreOnGraphModelNodeRemoved, node);
         }
     }
 

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
@@ -278,6 +278,7 @@ namespace LandscapeCanvasEditor
 
         using DeletedNodePositionsMap = AZStd::unordered_map<AZ::EntityComponentIdPair, AZ::Vector2>;
         AZStd::unordered_map<GraphCanvas::GraphId, DeletedNodePositionsMap> m_deletedNodePositions;
+        GraphModel::NodePtrList m_deletedWrappedNodes;
         AzToolsFramework::EntityIdList m_queuedEntityDeletes;
 
         AzToolsFramework::EntityIdList m_ignoreEntityComponentPropertyChanges;


### PR DESCRIPTION
## What does this PR do?

Fixes #11987 

When you delete nodes in Landscape Canvas, it will automatically delete the corresponding component (and Entity if applicable) for you. For wrapped nodes, it only deletes the component, since the wrapper node corresponds to a separate component so the Entity should remain. The Macro Material and Surface Material nodes are the first nodes that are able to be wrapped but also standalone. The logic for when to delete the whole entity vs. just the component was only doing a type check, not looking if the node was actually wrapped, so updated the logic to be more generic/future proof.

- Removed the `PreOnNodeRemoved` that was no longer in-use by GraphCanvas
- Updated the `GraphController` to properly trigger the pre-node removal event
- Updated logic to actually check if a node was wrapped or not to decide if it should remove just the component or the whole entity

## How was this PR tested?

Manually tested workflows in the Editor and verified #11987 is fixed. Also ran automated tests.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>