### PR TITLE
Hide prefab reference assignment in node inspector

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.cpp
@@ -379,9 +379,11 @@ namespace AzFramework
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<EntitySpawnTicket>(
-                    "EntitySpawnTicket",
-                    "EntitySpawnTicket is an object used to spawn, identify, and track the spawned entities associated with the ticket.");
+                // Hide EntitySpawnTicket in editContext, as there is no proper edit time constructor
+                editContext->Class<EntitySpawnTicket>("EntitySpawnTicket",
+                        "EntitySpawnTicket is an object used to spawn, identify, and track the spawned entities associated with the ticket.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide);
             }
         }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
@@ -280,7 +280,7 @@ void Nodes::{{ nodeableNodeName }}::Reflect(AZ::ReflectContext* context)
                 {{preEdit}}->Attribute(AZ::Edit::Attributes::Category, "{{ attribute_Category }}"){{postEdit}}
 {% endif %}
 {% if attribute_HideProperty is defined %}
-                {{preEdit}}->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::HideChildren){{postEdit}}
+                {{preEdit}}->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide){{postEdit}}
 {% else %}
                 {{preEdit}}->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly){{postEdit}}
 {% endif %}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
@@ -37,6 +37,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 {%- set attribute_PreferredClassName = macros.CleanName(Class.attrib['PreferredClassName']) %}
 {%- set attribute_Description = Class.attrib['Description']  %}
 {%- set attribute_Category = Class.attrib['Category']  %}
+{%- set attribute_HideProperty = Class.attrib['HideProperty']%}
 {%- set attribute_Uuid = Class.attrib['Uuid']  %}
 {%- set attribute_Icon = Class.attrib['Icon']  %}
 {%- set attribute_GeneratePropertyFriend = Class.attrib['GeneratePropertyFriend']  %}
@@ -182,13 +183,13 @@ void {{attribute_QualifiedName}}::Reflect(AZ::ReflectContext* context)
                        {{preEdit}}->ClassElement(AZ::Edit::ClassElements::EditorData, ""){{postEdit}}
                        {{preEdit}}->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly){{postEdit}}
 {% if attribute_Category is defined %}
-                        {{preEdit}}->Attribute(AZ::Edit::Attributes::Category, "{{ attribute_Category }}"){{postEdit}}
+                       {{preEdit}}->Attribute(AZ::Edit::Attributes::Category, "{{ attribute_Category }}"){{postEdit}}
 {%- endif %}
 {% if attribute_Icon is defined %}
-                        {{preEdit}}->Attribute(AZ::Edit::Attributes::Icon, "{{ attribute_Icon }}"){{postEdit}}
+                       {{preEdit}}->Attribute(AZ::Edit::Attributes::Icon, "{{ attribute_Icon }}"){{postEdit}}
 {%- endif %}
 {% if attribute_Deprecated is defined %}
-                        {{preEdit}}->Attribute(AZ::Edit::Attributes::Deprecated, "{{ attribute_Deprecated }}"){{postEdit}}
+                       {{preEdit}}->Attribute(AZ::Edit::Attributes::Deprecated, "{{ attribute_Deprecated }}"){{postEdit}}
 {%- endif %}
 {% set uihandler = 'AZ::Edit::UIHandlers::Default' %}
 {% for item in Class.iter('Property') %}
@@ -200,10 +201,10 @@ void {{attribute_QualifiedName}}::Reflect(AZ::ReflectContext* context)
     {% set description = item.attrib['Description'] %}
 {% endif %}
 
-                        // {{ item.attrib['Name'] }}
-                        {{preEdit}}->DataElement({{ uihandler }}, &{{ attribute_Name }}::{{ item.attrib['Name'] }}, "{{ item.attrib['Name'] }}", "{{ description }}"){{postEdit}}
+                       // {{ item.attrib['Name'] }}
+                       {{preEdit}}->DataElement({{ uihandler }}, &{{ attribute_Name }}::{{ item.attrib['Name'] }}, "{{ item.attrib['Name'] }}", "{{ description }}"){{postEdit}}
 {%          for EditAttribute in item.iter('EditAttribute') %}
-                        {{preEdit}}->Attribute({{ EditAttribute.attrib['Key'] }}, {{ EditAttribute.attrib['Value'] }}){{postEdit}}
+                       {{preEdit}}->Attribute({{ EditAttribute.attrib['Key'] }}, {{ EditAttribute.attrib['Value'] }}){{postEdit}}
 {%          endfor %}
 {% endfor %}
                             ;
@@ -278,7 +279,11 @@ void Nodes::{{ nodeableNodeName }}::Reflect(AZ::ReflectContext* context)
 {% if attribute_Category is defined %}
                 {{preEdit}}->Attribute(AZ::Edit::Attributes::Category, "{{ attribute_Category }}"){{postEdit}}
 {% endif %}
+{% if attribute_HideProperty is defined %}
+                {{preEdit}}->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::HideChildren){{postEdit}}
+{% else %}
                 {{preEdit}}->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly){{postEdit}}
+{% endif %}
                 {{preEdit}}->Attribute(AZ::Edit::Attributes::AutoExpand, true){{postEdit}}
                 ;
 {% if ExtendReflectionEdit is defined %}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/CreateSpawnTicketNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/CreateSpawnTicketNodeable.ScriptCanvasNodeable.xml
@@ -6,7 +6,8 @@
         PreferredClassName="CreateSpawnTicket"
         Category="Prefab/Spawning"
         Namespace="ScriptCanvas"
-        Description="Creates a spawn ticket using provided prefab">
+        Description="Creates a spawn ticket using provided prefab"
+        HideProperty="true">
 
         <Input Name="Create Ticket" OutputName="Ticket Created">
             <Parameter Name="Prefab" Type="const AzFramework::Scripts::SpawnableScriptAssetRef&amp;" Description="Prefab source asset to spawn"/>


### PR DESCRIPTION
Signed-off-by: onecent1101 <liug@amazon.com>

## What does this PR do?
Asset type is not fully supported through node input slot assignment.
To clear confusion, hide the assignment through node inspector for CreateSpawningTicket node.

## How was this PR tested?
Confirmed the fix in Editor. User could use graph variable instead at current phase.
![createspawnticket](https://user-images.githubusercontent.com/5900509/190476215-04d1447e-4675-4353-bd65-0e81ff6f2c50.PNG)
