### PR TITLE
Improved an error message about missing shader assets.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
@@ -863,7 +863,7 @@ namespace AZ
                 }
                 else
                 {
-                    materialTypeAssetCreator.ReportError("Shader '%s' not found", shaderFile.data());
+                    materialTypeAssetCreator.ReportError("Shader asset not found for source file '%s'. See above for details.", shaderFile.data());
                     return Failure();
                 }
             }


### PR DESCRIPTION
## What does this PR do?

Improved an error message that was a bit misleading.

Addresses https://github.com/o3de/o3de/issues/11893.

## How was this PR tested?
Made a local change to a .shader file to reproduce the Issue. Noted the improved error message.


