### PR TITLE
Set smaller minimum sizes for UI animation panes

### DIFF
--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewCurveEditor.ui
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewCurveEditor.ui
@@ -10,6 +10,12 @@
     <height>285</height>
    </rect>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>50</width>
+    <height>0</height>
+   </size>
+  </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="1" column="0">
     <widget class="CUiAnimViewSplineCtrl" name="m_wndSpline" native="true"/>

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewKeyPropertiesDlg.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewKeyPropertiesDlg.cpp
@@ -73,6 +73,7 @@ CUiAnimViewKeyPropertiesDlg::CUiAnimViewKeyPropertiesDlg(QWidget* hParentWnd)
     m_wndTrackProps = new CUiAnimViewTrackPropsDlg(this);
     l->addWidget(m_wndTrackProps);
     m_wndProps = new ReflectedPropertyControl(this);
+    m_wndProps->setMinimumSize(50, 0);
     m_wndProps->Setup();
     m_wndProps->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
     l->addWidget(m_wndProps);

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewNodes.ui
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewNodes.ui
@@ -75,6 +75,12 @@
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
+     <property name="minimumSize">
+      <size>
+       <width>50</width>
+       <height>0</height>
+      </size>
+     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

## What does this PR do?

Decrease minimum size of the UI Editor's animation panes so the editor has a better chance of fitting on displays configured to have a smaller width footprint, such as setting orientation to portrait mode.

Fixes #11773, #11761

## How was this PR tested?

_Please describe any testing performed._

Tested manually using provided steps in GHI issue.
