### PR TITLE
Script Canvas: Support for selecting asset IDs from nodes

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.cpp
@@ -155,9 +155,10 @@ namespace AzToolsFramework
                 return m_title;
             }
 
-            if (GetDisplayFilter())
+            auto displayFilter = GetDisplayFilter();
+            if (displayFilter && !displayFilter->GetName().isEmpty())
             {
-                return GetDisplayFilter()->GetName();
+                return displayFilter->GetName();
             }
 
             return "Asset";

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.cpp
@@ -150,7 +150,17 @@ namespace AzToolsFramework
 
         QString AssetSelectionModel::GetTitle() const
         {
-            return m_title.isEmpty() ? GetDisplayFilter()->GetName() : m_title;
+            if (!m_title.isEmpty())
+            {
+                return m_title;
+            }
+
+            if (GetDisplayFilter())
+            {
+                return GetDisplayFilter()->GetName();
+            }
+
+            return "Asset";
         }
 
         AssetSelectionModel AssetSelectionModel::AssetTypeSelection(const AZ::Data::AssetType& assetType, bool multiselect)
@@ -167,27 +177,32 @@ namespace AzToolsFramework
 
         AssetSelectionModel AssetSelectionModel::AssetTypesSelection(const AZStd::vector<AZ::Data::AssetType>& assetTypes, bool multiselect) 
         {
+            // If no asset types were specified then allow unfiltered asset selection.
+            if (assetTypes.empty())
+            {
+                return EverythingSelection(multiselect);
+            }
+
             AssetSelectionModel selection;
 
             CompositeFilter* anyAssetTypeFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::OR);
             anyAssetTypeFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
             auto anyAssetTypeFilterPtr = FilterConstType(anyAssetTypeFilter);
 
-            for (const auto& assetType : assetTypes) {
+            for (const auto& assetType : assetTypes)
+            {
                 AssetTypeFilter* assetTypeFilter = new AssetTypeFilter();
                 assetTypeFilter->SetAssetType(assetType);
                 anyAssetTypeFilter->AddFilter(FilterConstType(assetTypeFilter));
             }
-
-            selection.SetDisplayFilter(anyAssetTypeFilterPtr);
 
             CompositeFilter* compFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
             compFilter->AddFilter(anyAssetTypeFilterPtr);
             compFilter->AddFilter(EntryTypeNoFoldersFilter());
 
             selection.SetSelectionFilter(FilterConstType(compFilter));
+            selection.SetDisplayFilter(anyAssetTypeFilterPtr);
             selection.SetMultiselect(multiselect);
-
             return selection;
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -787,7 +787,7 @@ namespace AzToolsFramework
         }
 
         QMessageBox::warning(GetActiveWindow(), tr("Unable to Edit Asset"),
-            QObject::QObject::tr("No callback is provided and no associated editor could be found."), QMessageBox::Ok, QMessageBox::Ok);
+            QObject::tr("No callback is provided and no associated editor could be found."), QMessageBox::Ok, QMessageBox::Ok);
     }
 
     void PropertyAssetCtrl::PopupAssetPicker()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -787,7 +787,7 @@ namespace AzToolsFramework
         }
 
         QMessageBox::warning(GetActiveWindow(), tr("Unable to Edit Asset"),
-            tr("No callback is provided and no associated editor could be found."), QMessageBox::Ok, QMessageBox::Ok);
+            QObject::QObject::tr("No callback is provided and no associated editor could be found."), QMessageBox::Ok, QMessageBox::Ok);
     }
 
     void PropertyAssetCtrl::PopupAssetPicker()
@@ -1362,7 +1362,7 @@ namespace AzToolsFramework
         return newCtrl;
     }
 
-    void AssetPropertyHandlerDefault::ConsumeAttributeInternal(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
+    void ConsumeAttributeForPropertyAssetCtrl(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
     {
         (void)debugName;
 
@@ -1380,7 +1380,7 @@ namespace AzToolsFramework
             // This is assumed to be an Asset Browser path to a specific folder to be used as a default by the asset picker if provided
             GUI->SetDefaultDirectoryCallback(azdynamic_cast<PropertyAssetCtrl::DefaultDirectoryCallbackType*>(attrValue->GetAttribute()));
         }
-        else if (attrib == AZ_CRC("EditCallback", 0xb74f2ee1))
+        else if (attrib == AZ_CRC_CE("EditCallback"))
         {
             PropertyAssetCtrl::EditCallbackType* func = azdynamic_cast<PropertyAssetCtrl::EditCallbackType*>(attrValue->GetAttribute());
             if (func)
@@ -1393,7 +1393,7 @@ namespace AzToolsFramework
                 GUI->SetEditNotifyCallback(nullptr);
             }
         }
-        else if (attrib == AZ_CRC("EditButton", 0x898c35dc))
+        else if (attrib == AZ_CRC_CE("EditButton"))
         {
             GUI->SetEditButtonVisible(true);
 
@@ -1415,12 +1415,12 @@ namespace AzToolsFramework
                 GUI->SetEditButtonIcon(QIcon(path));
             }
         }
-        else if (attrib == AZ_CRC("EditDescription", 0x9b52634a))
+        else if (attrib == AZ_CRC_CE("EditDescription"))
         {
             AZStd::string buttonTooltip;
             if (attrValue->Read<AZStd::string>(buttonTooltip))
             {
-                GUI->SetEditButtonTooltip(tr(buttonTooltip.c_str()));
+                GUI->SetEditButtonTooltip(QObject::tr(buttonTooltip.c_str()));
             }
         }
         else if (attrib == AZ_CRC_CE("DisableEditButtonWhenNoAssetSelected"))
@@ -1577,7 +1577,7 @@ namespace AzToolsFramework
 
     void AssetPropertyHandlerDefault::ConsumeAttribute(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
     {
-        ConsumeAttributeInternal(GUI, attrib, attrValue, debugName);
+        ConsumeAttributeForPropertyAssetCtrl(GUI, attrib, attrValue, debugName);
     }
 
     void AssetPropertyHandlerDefault::WriteGUIValuesIntoPropertyInternal(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node)
@@ -1625,10 +1625,45 @@ namespace AzToolsFramework
         return ReadValuesIntoGUIInternal(index, GUI, instance, node);
     }
 
+    QWidget* AssetIdPropertyHandlerDefault::CreateGUI(QWidget* pParent)
+    {
+        PropertyAssetCtrl* newCtrl = aznew PropertyAssetCtrl(pParent);
+        connect(newCtrl, &PropertyAssetCtrl::OnAssetIDChanged, this, [newCtrl](AZ::Data::AssetId newAssetID)
+        {
+            (void)newAssetID;
+            EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
+        });
+        return newCtrl;
+    }
+
+    void AssetIdPropertyHandlerDefault::ConsumeAttribute(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
+    {
+        ConsumeAttributeForPropertyAssetCtrl(GUI, attrib, attrValue, debugName);
+    }
+
+    void AssetIdPropertyHandlerDefault::WriteGUIValuesIntoProperty(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node)
+    {
+        (void)index;
+        (void)node;
+        instance = GUI->GetSelectedAssetID();
+    }
+
+    bool AssetIdPropertyHandlerDefault::ReadValuesIntoGUI(size_t index, PropertyAssetCtrl* GUI, const property_t& instance, InstanceDataNode* node)
+    {
+        (void)index;
+        (void)node;
+
+        GUI->blockSignals(true);
+        GUI->SetSelectedAssetID(instance);
+        GUI->SetEditNotifyTarget(node->GetParent()->GetInstance(0));
+        GUI->blockSignals(false);
+        return false;
+    }
+
     QWidget* SimpleAssetPropertyHandlerDefault::CreateGUI(QWidget* pParent)
     {
         PropertyAssetCtrl* newCtrl = aznew PropertyAssetCtrl(pParent);
-
         connect(newCtrl, &PropertyAssetCtrl::OnAssetIDChanged, this, [newCtrl](AZ::Data::AssetId newAssetID)
         {
             (void)newAssetID;
@@ -1640,67 +1675,7 @@ namespace AzToolsFramework
 
     void SimpleAssetPropertyHandlerDefault::ConsumeAttribute(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
     {
-        Q_UNUSED(debugName);
-
-        if (attrib == AZ_CRC("BrowseIcon", 0x507d7a4f))
-        {
-            AZStd::string iconPath;
-            attrValue->Read<AZStd::string>(iconPath);
-
-            if (!iconPath.empty())
-            {
-                GUI->SetBrowseButtonIcon(QIcon(iconPath.c_str()));
-            }
-        }
-        else if (attrib == AZ_CRC("EditCallback", 0xb74f2ee1))
-        {
-            PropertyAssetCtrl::EditCallbackType* func = azdynamic_cast<PropertyAssetCtrl::EditCallbackType*>(attrValue->GetAttribute());
-            if (func)
-            {
-                GUI->SetEditButtonVisible(true);
-                GUI->SetEditNotifyCallback(func);
-            }
-            else
-            {
-                GUI->SetEditNotifyCallback(nullptr);
-            }
-        }
-        else if (attrib == AZ_CRC("EditButton", 0x898c35dc))
-        {
-            GUI->SetEditButtonVisible(true);
-
-            AZStd::string iconPath;
-            attrValue->Read<AZStd::string>(iconPath);
-
-            if (!iconPath.empty())
-            {
-                QString path(iconPath.c_str());
-
-                if (!QFile::exists(path))
-                {
-                    AZ::IO::FixedMaxPathString engineRoot = AZ::Utils::GetEnginePath();
-                    QDir engineDir = !engineRoot.empty() ? QDir(QString(engineRoot.c_str())) : QDir::current();
-
-                    path = engineDir.absoluteFilePath(iconPath.c_str());
-                }
-
-                GUI->SetEditButtonIcon(QIcon(path));
-            }
-        }
-        else if (attrib == AZ_CRC("EditDescription", 0x9b52634a))
-        {
-            AZStd::string buttonTooltip;
-            if (attrValue->Read<AZStd::string>(buttonTooltip))
-            {
-                GUI->SetEditButtonTooltip(tr(buttonTooltip.c_str()));
-            }
-        }
-        else if (attrib == AZ_CRC_CE("DisableEditButtonWhenNoAssetSelected"))
-        {
-            bool disableEditButtonWhenNoAssetSelected = false;
-            attrValue->Read<bool>(disableEditButtonWhenNoAssetSelected);
-            GUI->SetDisableEditButtonWhenNoAssetSelected(disableEditButtonWhenNoAssetSelected);
-        }
+        ConsumeAttributeForPropertyAssetCtrl(GUI, attrib, attrValue, debugName);
     }
 
     void SimpleAssetPropertyHandlerDefault::WriteGUIValuesIntoProperty(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node)
@@ -1738,8 +1713,12 @@ namespace AzToolsFramework
 
     void RegisterAssetPropertyHandler()
     {
-        PropertyTypeRegistrationMessages::Bus::Broadcast(&PropertyTypeRegistrationMessages::RegisterPropertyType, aznew AssetPropertyHandlerDefault());
-        PropertyTypeRegistrationMessages::Bus::Broadcast(&PropertyTypeRegistrationMessages::RegisterPropertyType, aznew SimpleAssetPropertyHandlerDefault());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::RegisterPropertyType, aznew AssetPropertyHandlerDefault());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::RegisterPropertyType, aznew AssetIdPropertyHandlerDefault());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::RegisterPropertyType, aznew SimpleAssetPropertyHandlerDefault());
     }
 }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -792,8 +792,6 @@ namespace AzToolsFramework
 
     void PropertyAssetCtrl::PopupAssetPicker()
     {
-        AZ_Assert(!GetSelectableAssetTypes().empty(), "No asset type was assigned.");
-
         // Request the AssetBrowser Dialog and set a type filter
         AssetSelectionModel selection = GetAssetSelectionModel();
         selection.SetSelectedAssetId(m_selectedAssetID);
@@ -994,11 +992,6 @@ namespace AzToolsFramework
         UpdateThumbnail();
 
         UpdateEditButton();
-
-        if (m_currentAssetType == AZ::Data::s_invalidAssetType)
-        {
-            return;
-        }
 
         const AZStd::string& folderPath = GetFolderSelection();
         if (!folderPath.empty())

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
@@ -270,6 +270,9 @@ namespace AzToolsFramework
         void UpdateEditButton();
     };
 
+    // Shared function that processes all attributes for any handler using PropertyAssetCtrl
+    void ConsumeAttributeForPropertyAssetCtrl(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName);
+
     class AssetPropertyHandlerDefault
         : QObject
         , public PropertyHandler<AZ::Data::Asset<AZ::Data::AssetData>, PropertyAssetCtrl>
@@ -281,14 +284,13 @@ namespace AzToolsFramework
         AZ_CLASS_ALLOCATOR(AssetPropertyHandlerDefault, AZ::SystemAllocator, 0);
 
         virtual const AZ::Uuid& GetHandledType() const override;
-        virtual AZ::u32 GetHandlerName(void) const override { return AZ_CRC("Asset", 0x02af5a5c); }
+        virtual AZ::u32 GetHandlerName(void) const override { return AZ_CRC_CE("Asset"); }
         virtual bool IsDefaultHandler() const override { return true; }
         virtual QWidget* GetFirstInTabOrder(PropertyAssetCtrl* widget) override { return widget->GetFirstInTabOrder(); }
         virtual QWidget* GetLastInTabOrder(PropertyAssetCtrl* widget) override { return widget->GetLastInTabOrder(); }
         virtual void UpdateWidgetInternalTabbing(PropertyAssetCtrl* widget) override { widget->UpdateTabOrder(); }
 
         virtual QWidget* CreateGUI(QWidget* pParent) override;
-        static void ConsumeAttributeInternal(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName);
         void ConsumeAttribute(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
         static void WriteGUIValuesIntoPropertyInternal(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node);
         virtual void WriteGUIValuesIntoProperty(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
@@ -305,6 +307,27 @@ namespace AzToolsFramework
         }
     };
 
+    class AssetIdPropertyHandlerDefault
+        : QObject
+        , public PropertyHandler<AZ::Data::AssetId, PropertyAssetCtrl>
+    {
+        Q_OBJECT
+
+    public:
+        AZ_CLASS_ALLOCATOR(AssetIdPropertyHandlerDefault, AZ::SystemAllocator, 0);
+
+        virtual AZ::u32 GetHandlerName(void) const override { return AZ_CRC_CE("AssetId"); }
+        virtual bool IsDefaultHandler() const override { return true; }
+        virtual QWidget* GetFirstInTabOrder(PropertyAssetCtrl* widget) override { return widget->GetFirstInTabOrder(); }
+        virtual QWidget* GetLastInTabOrder(PropertyAssetCtrl* widget) override { return widget->GetLastInTabOrder(); }
+        virtual void UpdateWidgetInternalTabbing(PropertyAssetCtrl* widget) override { widget->UpdateTabOrder(); }
+
+        virtual QWidget* CreateGUI(QWidget* pParent) override;
+        virtual void ConsumeAttribute(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
+        virtual void WriteGUIValuesIntoProperty(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
+        virtual bool ReadValuesIntoGUI(size_t index, PropertyAssetCtrl* GUI, const property_t& instance, InstanceDataNode* node)  override;
+    };
+
     class SimpleAssetPropertyHandlerDefault
         : QObject
         , public PropertyHandler<AzFramework::SimpleAssetReferenceBase, PropertyAssetCtrl>
@@ -315,7 +338,7 @@ namespace AzToolsFramework
     public:
         AZ_CLASS_ALLOCATOR(SimpleAssetPropertyHandlerDefault, AZ::SystemAllocator, 0);
 
-        virtual AZ::u32 GetHandlerName(void) const override { return AZ_CRC("SimpleAssetRef", 0x49f51d54); }
+        virtual AZ::u32 GetHandlerName(void) const override { return AZ_CRC_CE("SimpleAssetRef"); }
         virtual bool IsDefaultHandler() const override { return true; }
         virtual QWidget* GetFirstInTabOrder(PropertyAssetCtrl* widget) override { return widget->GetFirstInTabOrder(); }
         virtual QWidget* GetLastInTabOrder(PropertyAssetCtrl* widget) override { return widget->GetLastInTabOrder(); }

--- a/Gems/GradientSignal/Code/Source/Editor/EditorStreamingImageAssetCtrl.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorStreamingImageAssetCtrl.cpp
@@ -138,8 +138,8 @@ namespace GradientSignal
 
     void StreamingImagePropertyHandler::ConsumeAttribute(StreamingImagePropertyAssetCtrl* GUI, AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue, const char* debugName)
     {
-        // Let the AssetPropertyHandlerDefault handle all of the attributes
-        AzToolsFramework::AssetPropertyHandlerDefault::ConsumeAttributeInternal(GUI, attrib, attrValue, debugName);
+        // Let ConsumeAttributeForPropertyAssetCtrl handle all of the attributes
+        AzToolsFramework::ConsumeAttributeForPropertyAssetCtrl(GUI, attrib, attrValue, debugName);
     }
 
     void StreamingImagePropertyHandler::WriteGUIValuesIntoProperty(size_t index, StreamingImagePropertyAssetCtrl* GUI, property_t& instance, AzToolsFramework::InstanceDataNode* node)

--- a/Gems/ScriptCanvas/Code/Editor/GraphCanvas/DataInterfaces/ScriptCanvasAssetIdDataInterface.h
+++ b/Gems/ScriptCanvas/Code/Editor/GraphCanvas/DataInterfaces/ScriptCanvasAssetIdDataInterface.h
@@ -67,13 +67,12 @@ namespace ScriptCanvasEditor
 
         AZ::Data::AssetType GetAssetType() const override
         {
-            return AZ::AzTypeInfo<AZ::DynamicSliceAsset>::Uuid(); //hardcoded for DynamicSliceAsset until the slot definitions can be queried for this
+            return AZ::Uuid::CreateNull(); //hardcoded until the slot definitions can be queried for this
         }
 
         AZStd::string GetStringFilter() const override
         {
-            return AZ::DynamicSliceAsset::GetFileFilter(); //hardcoded for DynamicSliceAsset until the slot definitions can be queried for this
+            return "*.*"; // hardcoded until the slot definitions can be queried for this
         }
-        ////
     };
 }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
@@ -120,8 +120,8 @@ namespace ScriptCanvasEditor
 
     void SourceHandlePropertyHandler::ConsumeAttribute(SourceHandlePropertyAssetCtrl* GUI, AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue, const char* debugName)
     {
-        // Let the AssetPropertyHandlerDefault handle all of the common attributes
-        AzToolsFramework::AssetPropertyHandlerDefault::ConsumeAttributeInternal(GUI, attrib, attrValue, debugName);
+        // Let ConsumeAttributeForPropertyAssetCtrl handle all of the common attributes
+        AzToolsFramework::ConsumeAttributeForPropertyAssetCtrl(GUI, attrib, attrValue, debugName);
 
         if (attrib == AZ::Edit::Attributes::SourceAssetFilterPattern)
         {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToLuaUtility.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToLuaUtility.cpp
@@ -72,6 +72,7 @@ namespace ScriptCanvas
             case Data::eType::BehaviorContextObject:
             case Data::eType::Color:
             case Data::eType::CRC:
+            case Data::eType::AssetId:
             case Data::eType::EntityID:
             case Data::eType::NamedEntityID:
             case Data::eType::Matrix3x3:
@@ -115,6 +116,7 @@ namespace ScriptCanvas
             case Data::eType::BehaviorContextObject:
             case Data::eType::Color:
             case Data::eType::CRC:
+            case Data::eType::AssetId:
             case Data::eType::EntityID:
             case Data::eType::NamedEntityID:
             case Data::eType::Matrix3x3:
@@ -146,6 +148,7 @@ namespace ScriptCanvas
             case Data::eType::Boolean:
             case Data::eType::Number:
             case Data::eType::String:
+            case Data::eType::AssetId:
             case Data::eType::EntityID:
             case Data::eType::NamedEntityID:
             case Data::eType::BehaviorContextObject:
@@ -383,8 +386,18 @@ namespace ScriptCanvas
             case Data::eType::String:
             {
                 const AZStd::string& formattedString = *datum.GetAs<Data::StringType>();
-                const AZStd::string bracketString = MakeLongBracketString(formattedString);
-                return AZStd::string::format("[%s[%s]%s]", bracketString.c_str(), formattedString.c_str(), bracketString.c_str());
+                return MakeRuntimeSafeStringLiteral(formattedString);
+            }
+
+            case Data::eType::AssetId:
+            {
+                const AZ::Data::AssetId& value = *datum.GetAs<Data::AssetIdType>();
+                if (value.IsValid())
+                {
+                    const AZStd::string valueString = MakeRuntimeSafeStringLiteral(value.ToString<AZStd::string>());
+                    return AZStd::string::format("AssetId.CreateString(%s)", valueString.c_str());
+                }
+                return "AssetId()";
             }
 
             case Data::eType::EntityID:


### PR DESCRIPTION
## What does this PR do?

This change updates script canvas to support picking, assigning, and generating code for asset IDs. This should resolve issues with the material component, decal component, image-based lighting, gradients, and any other component that requires assets to be assigned from script canvas. While users can now select assets, the script canvas asset picker is now completely unfiltered instead of filtered exclusively to dynamic slices. Additional work will be required to provide script canvas with the necessary asset type info in order to properly filter the asset picker.

https://github.com/o3de/o3de/issues/11307

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

verify that assets can be assigned to the material component from script canvas hand at the materials are applied when scripts are run in game mode.  

![image](https://user-images.githubusercontent.com/82461473/190526810-f0fb1613-c1b2-409d-9c04-bd0c50daf8e5.png)
![image](https://user-images.githubusercontent.com/82461473/190526875-a9209b34-7609-441a-8594-ed755bb05af6.png)
![image](https://user-images.githubusercontent.com/82461473/190526999-5cb930e6-76d4-45ea-a437-7a0a97ac6171.png)
![image](https://user-images.githubusercontent.com/82461473/190527042-99902d85-580b-4be9-9384-5ac82ae7e61f.png)
![image](https://user-images.githubusercontent.com/82461473/190527146-d5d4f53b-88c4-4db8-9f59-d08f9cf05082.png)