### PR TITLE
Prism/create gem display name fix

### DIFF
--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -214,7 +214,7 @@ namespace O3DE::ProjectManager
 
         m_gemDisplayName = new FormLineEditWidget(
             tr("Gem Display name*"), "", tr("The name displayed in the Gem Catalog"), tr("A gem display name is required."));
-        m_gemDisplayName->lineEdit()->setValidator(new QRegularExpressionValidator(QRegularExpression("\\w+"), this));
+        m_gemDisplayName->lineEdit()->setValidator(new QRegularExpressionValidator(QRegularExpression("( |\\w)+"), this));
         gemDetailsLayout->addWidget(m_gemDisplayName);
 
         m_gemSummary = new FormLineEditWidget(tr("Gem Summary"), "", tr("A short description of your Gem"), "");


### PR DESCRIPTION
## What does this PR do?

For the project manager, there was functionality added for creating new gems via a workflow, written in the file CreateAGemScreen.cpp.

However when @AMZN-alexpete and I were testing the functionality, we discovered that the `Gem Display name` field did not allow for whitespace when typing out the name, which was incorrect behavior for that field. This is because the display name is meant for user benefit, and not for internal use.

![image (4)](https://user-images.githubusercontent.com/112996779/190546098-26038da4-e81d-49a3-b11f-a5a42f00dfa7.png)

With the help of @AMZN-Phil, I updated the validator for the line field for display name such that it allows for either whitespace characters or alphanumerics with underscores. The regex looks as follows:

`( |\\w)+`

## How was this PR tested?

We performed user testing manually for the workflow creation page when we first found the bug, so that process was repeated again for verification. After the fix, I determined that the display name was now allowing for spaces correctly.

Here is a sample of the working code:
![image (5)](https://user-images.githubusercontent.com/112996779/190546478-7be46323-a86d-4d31-8a24-e9bca0e05b0a.png)

