### PR TITLE
Cherry-picks https://github.com/o3de/o3de/pull/11992

### DIFF
--- a/AutomatedTesting/Assets/TestAnim/scene_export_actor.py
+++ b/AutomatedTesting/Assets/TestAnim/scene_export_actor.py
@@ -205,10 +205,12 @@ def on_update_manifest(args):
         log_exception_traceback()
     except:
         log_exception_traceback()
-
-    global sceneJobHandler
-    sceneJobHandler.disconnect()
-    sceneJobHandler = None
+    finally:
+        global sceneJobHandler
+        # do not delete or set sceneJobHandler to None, just disconnect from it.
+        # this call is occuring while the scene Job Handler itself is in the callstack, so deleting it here
+        # would cause a crash.
+        sceneJobHandler.disconnect()
 
 # try to create SceneAPI handler for processing
 try:

--- a/AutomatedTesting/Assets/TestAnim/scene_export_motion.py
+++ b/AutomatedTesting/Assets/TestAnim/scene_export_motion.py
@@ -50,10 +50,12 @@ def on_update_manifest(args):
         scene_export_utils.log_exception_traceback()
     except:
         scene_export_utils.log_exception_traceback()
-
-    global sceneJobHandler
-    sceneJobHandler.disconnect()
-    sceneJobHandler = None
+    finally:
+        global sceneJobHandler
+        # do not delete or set sceneJobHandler to None, just disconnect from it.
+        # this call is occuring while the scene Job Handler itself is in the callstack, so deleting it here
+        # would cause a crash.
+        sceneJobHandler.disconnect()
 
 # try to create SceneAPI handler for processing
 try:

--- a/AutomatedTesting/Assets/ap_test_assets/script_reinsert.py
+++ b/AutomatedTesting/Assets/ap_test_assets/script_reinsert.py
@@ -10,8 +10,10 @@ sceneJobHandler = None
 
 def clear_sceneJobHandler():
     global sceneJobHandler
+    # do not delete or set sceneJobHandler to None, just disconnect from it.
+    # this call is occuring while the scene Job Handler itself is in the callstack, so deleting it here
+    # would cause a crash.
     sceneJobHandler.disconnect()
-    sceneJobHandler = None
 
 def on_prepare_for_export(args): 
     print (f'on_prepare_for_export')
@@ -68,11 +70,10 @@ def on_update_manifest(args):
 try:
     import azlmbr.scene as sceneApi
     
-    if sceneJobHandler is None:
-        sceneJobHandler = sceneApi.ScriptBuildingNotificationBusHandler()
-        sceneJobHandler.connect()
-        sceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
-        sceneJobHandler.add_callback('OnPrepareForExport', on_prepare_for_export)
+    sceneJobHandler = sceneApi.ScriptBuildingNotificationBusHandler()
+    sceneJobHandler.connect()
+    sceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
+    sceneJobHandler.add_callback('OnPrepareForExport', on_prepare_for_export)
 
 except:
     sceneJobHandler = None

--- a/AutomatedTesting/Editor/Scripts/auto_lod.py
+++ b/AutomatedTesting/Editor/Scripts/auto_lod.py
@@ -109,16 +109,18 @@ def on_update_manifest(args):
         log_exception_traceback()
     except:
         log_exception_traceback()
-
-    global sceneJobHandler
-    sceneJobHandler = None
+    finally:
+        global sceneJobHandler
+        # do not delete or set sceneJobHandler to None, just disconnect from it.
+        # this call is occuring while the scene Job Handler itself is in the callstack, so deleting it here
+        # would cause a crash.
+        sceneJobHandler.disconnect()
 
 # try to create SceneAPI handler for processing
 try:
     import azlmbr.scene as sceneApi
-    if (sceneJobHandler == None):
-        sceneJobHandler = sceneApi.ScriptBuildingNotificationBusHandler()
-        sceneJobHandler.connect()
-        sceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
+    sceneJobHandler = sceneApi.ScriptBuildingNotificationBusHandler()
+    sceneJobHandler.connect()
+    sceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
 except:
     sceneJobHandler = None

--- a/AutomatedTesting/Editor/Scripts/scene_mesh_to_prefab.py
+++ b/AutomatedTesting/Editor/Scripts/scene_mesh_to_prefab.py
@@ -235,18 +235,19 @@ def on_update_manifest(args):
         log_exception_traceback()
 
     global sceneJobHandler
+    # do not delete or set sceneJobHandler to None, just disconnect from it.
+    # this call is occuring while the scene Job Handler itself is in the callstack, so deleting it here
+    # would cause a crash.
     sceneJobHandler.disconnect()
-    sceneJobHandler = None
     return data
 
 
 # try to create SceneAPI handler for processing
 try:
     import azlmbr.scene as sceneApi
-
-    if sceneJobHandler is None:
-        sceneJobHandler = sceneApi.ScriptBuildingNotificationBusHandler()
-        sceneJobHandler.connect()
-        sceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
+    
+    sceneJobHandler = sceneApi.ScriptBuildingNotificationBusHandler()
+    sceneJobHandler.connect()
+    sceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
 except:
     sceneJobHandler = None

--- a/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/export_chunks_builder.py
+++ b/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/export_chunks_builder.py
@@ -63,8 +63,10 @@ def on_update_manifest(args):
     scene = args[0]
     result = update_manifest(scene)
     global mySceneJobHandler
+    # do not delete or set sceneJobHandler to None, just disconnect from it.
+    # this call is occuring while the scene Job Handler itself is in the callstack, so deleting it here
+    # would cause a crash.
     mySceneJobHandler.disconnect()
-    mySceneJobHandler = None
     return result
 
 def main():

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/TwoSceneFiles_OneWithPythonOneWithout_PythonOnlyRunsOnFirstScene/python_builder.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/TwoSceneFiles_OneWithPythonOneWithout_PythonOnlyRunsOnFirstScene/python_builder.py
@@ -31,8 +31,10 @@ def on_update_manifest(args):
     scene = args[0]
     result = output_test_data(scene)
     global mySceneJobHandler
+    # do not delete or set sceneJobHandler to None, just disconnect from it.
+    # this call is occuring while the scene Job Handler itself is in the callstack, so deleting it here
+    # would cause a crash.
     mySceneJobHandler.disconnect()
-    mySceneJobHandler = None
     return result
 
 def main():

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/script_basics/base_example.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/script_basics/base_example.py
@@ -10,8 +10,10 @@ sceneJobHandler = None
 
 def clear_sceneJobHandler():
     global sceneJobHandler
+    # do not delete or set sceneJobHandler to None, just disconnect from it.
+    # this call is occuring while the scene Job Handler itself is in the callstack, so deleting it here
+    # would cause a crash.
     sceneJobHandler.disconnect()
-    sceneJobHandler = None
 
 def on_prepare_for_export(args): 
     print (f'on_prepare_for_export')
@@ -68,11 +70,10 @@ def on_update_manifest(args):
 try:
     import azlmbr.scene as sceneApi
     
-    if sceneJobHandler is None:
-        sceneJobHandler = sceneApi.ScriptBuildingNotificationBusHandler()
-        sceneJobHandler.connect()
-        sceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
-        sceneJobHandler.add_callback('OnPrepareForExport', on_prepare_for_export)
+    sceneJobHandler = sceneApi.ScriptBuildingNotificationBusHandler()
+    sceneJobHandler.connect()
+    sceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
+    sceneJobHandler.add_callback('OnPrepareForExport', on_prepare_for_export)
 
 except:
     sceneJobHandler = None

--- a/AutomatedTesting/TestAssets/test_chunks_builder.py
+++ b/AutomatedTesting/TestAssets/test_chunks_builder.py
@@ -43,15 +43,17 @@ def on_update_manifest(args):
     scene = args[0]
     result = update_manifest(scene)
     global mySceneJobHandler
+    # do not delete or set sceneJobHandler to None, just disconnect from it.
+    # this call is occuring while the scene Job Handler itself is in the callstack, so deleting it here
+    # would cause a crash.
     mySceneJobHandler.disconnect()
-    mySceneJobHandler = None
     return result
 
 def main():
     global mySceneJobHandler
     mySceneJobHandler = sceneApi.ScriptBuildingNotificationBusHandler()
-    mySceneJobHandler.connect()
     mySceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
+    mySceneJobHandler.connect()
 
 if __name__ == "__main__":
     main()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
@@ -152,8 +152,8 @@ namespace AzToolsFramework::ViewportUi
     {
         if (auto clusterIt = m_clusterButtonGroups.find(clusterId); clusterIt != m_clusterButtonGroups.end())
         {
-            m_clusterButtonGroups.erase(clusterIt);
             m_viewportUi->RemoveViewportUiElement(clusterIt->second->GetViewportUiElementId());
+            m_clusterButtonGroups.erase(clusterIt);
         }
     }
 
@@ -161,8 +161,8 @@ namespace AzToolsFramework::ViewportUi
     {
         if (auto switcherIt = m_switcherButtonGroups.find(switcherId); switcherIt != m_switcherButtonGroups.end())
         {
-            m_switcherButtonGroups.erase(switcherIt);
             m_viewportUi->RemoveViewportUiElement(switcherIt->second->GetViewportUiElementId());
+            m_switcherButtonGroups.erase(switcherIt);
         }
     }
 
@@ -246,8 +246,8 @@ namespace AzToolsFramework::ViewportUi
     {
         if (auto textFieldIt = m_textFields.find(textFieldId); textFieldIt != m_textFields.end())
         {
-            m_textFields.erase(textFieldIt);
             m_viewportUi->RemoveViewportUiElement(textFieldIt->second->m_viewportId);
+            m_textFields.erase(textFieldIt);
         }
     }
 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingResourceList.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingResourceList.h
@@ -144,6 +144,9 @@ namespace AZ
                     m_indirectionList.SetEntry(itLast->second.m_indirectionIndex, resourceIndex);                 
                 }
 
+                // cache the indirection index so that its okay to erase the iterator
+                uint32_t cachedIndirectionIndex = it->second.m_indirectionIndex;
+
                 // remove the last entry from the resource list
                 m_resources.pop_back();
 
@@ -151,7 +154,7 @@ namespace AZ
                 m_resourceMap.erase(it);
 
                 // remove the entry from the indirection list
-                m_indirectionList.RemoveEntry(it->second.m_indirectionIndex);
+                m_indirectionList.RemoveEntry(cachedIndirectionIndex);
             }
         }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
@@ -130,8 +130,19 @@ namespace AtomToolsFramework
             m_currentCaptureRequest = m_captureRequestQueue.front();
             m_captureRequestQueue.pop();
 
-            m_state.reset();
-            m_state.reset(new PreviewRendererLoadState(this));
+            bool canCapture = false;
+            AZ::Render::FrameCaptureRequestBus::BroadcastResult(canCapture, &AZ::Render::FrameCaptureRequestBus::Events::CanCapture);
+
+            // if we're not on a device that can capture, immediately trigger the "failed" state.
+            if (!canCapture)
+            {
+                CancelCaptureRequest();
+            }
+            else
+            {
+                m_state.reset();
+                m_state.reset(new PreviewRendererLoadState(this));
+            }
         }
     }
 

--- a/Gems/Blast/Editor/Scripts/blast_chunk_processor.py
+++ b/Gems/Blast/Editor/Scripts/blast_chunk_processor.py
@@ -140,17 +140,18 @@ def on_update_manifest(args):
         scene = args[0]
         return update_manifest(scene)
     except:
-        global sceneJobHandler
-        sceneJobHandler = None
         log_exception_traceback()
+    finally:
+        global sceneJobHandler
+        sceneJobHandler.disconnect()
 
 # try to create SceneAPI handler for processing
 try:
     import azlmbr.scene as sceneApi
-    if (sceneJobHandler == None):
-        sceneJobHandler = sceneApi.ScriptBuildingNotificationBusHandler()
-        sceneJobHandler.connect()
-        sceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
-        sceneJobHandler.add_callback('OnPrepareForExport', on_prepare_for_export)
+    sceneJobHandler = sceneApi.ScriptBuildingNotificationBusHandler()
+    sceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
+    sceneJobHandler.add_callback('OnPrepareForExport', on_prepare_for_export)
+    sceneJobHandler.connect()
+        
 except:
     sceneJobHandler = None


### PR DESCRIPTION
From stabilization to development.

Fixes several memory/heap corruption bugs

These would eventually cause random crashes.  They were detected by turning AzCore SystemAllocator to use the OS malloc and free (That change is not included in this change), and then using the Microsoft Debug CRT allocators with heap corruption detection features enabled.

The specific errors are as follows:
 - Python files:  Deleting an event handler while inside the event handler invalidates the 'this' pointer which is then subsequently used.
 - Settings Registry:  Mutating the settings registry while iterating over it in a visitor pattern.  The iterators are invalidated as the document changes out from onder them and will cause random crashes depending on memory reuse.  Added automatic detection for this problem and fixed the instances where found.
 - Viewport UI Manager:  invalidating an iterator by calling erase on it, but then still using it afterwards.
 - PreviewRenderer.cpp - the null RHI cannot take screenshot captures so the threads that are responsible for doing this cannot terminate
   and wait forever.   This changes it so they fail immediately,
   in the null renderer, which allows the app to shut down gracefully
   without corrupting the heap.
 - RayTracingResourceList - using an iterator after invalidating it.

Note that these fix the kind of use-after-free errors that will cause random, unexpected failures at any point after any of them occur as they may modify or read from invalid memory.

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>

* As per PR comments.

* Added symmetric Lock For Reading / Writing functions
* Lock for writing will check that nobody is currently iterating
* Updated all locations that previously locked the mutex directly to either lock for reading or writing, based on whether they make changes to the registry or not (regardless of what kind of changes).

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>

* Updated, as per comments on pull request.

Tested manually (opening levels and poking around). Tested by deleting cache and rebuilding all assets. Tested by running python automated Tests.
Tested by running AzCore unit tests.

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>

## What does this PR do?

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

_Please add links to any issues, RFCs or other items that are relevant to this PR._

## How was this PR tested?

_Please describe any testing performed._
