### PR TITLE
fix for animation editor picking not working until render options are…

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.cpp
@@ -119,6 +119,7 @@ namespace EMStudio
         SetupManipulators();
 
         m_picking = AZStd::make_unique<EMotionFX::Picking>();
+        m_picking->SetRenderFlags(GetRenderOptions()->GetRenderFlags());
 
         SetupMetrics();
 


### PR DESCRIPTION
## What does this PR do?
Fixes #12050 which was caused by animation editor picking not receiving render flags when picking is initialized, only when the render options are updated

## How was this PR tested?
Manual testing in the animation editor.
