### PR TITLE
DPE: Support horizontal rules in AssetEditor similar to the RPE

### DIFF
--- a/Code/Editor/Style/Editor.qss
+++ b/Code/Editor/Style/Editor.qss
@@ -95,6 +95,7 @@ Ui--AssetEditorHeader #Location
 }
 
 #AssetEditorWidgetPropertyEditor AzToolsFramework--PropertyRowWidget[getLevel="1"][hasChildRows="true"]
+, #AssetEditorWidgetPropertyEditor AzToolsFramework--DPERowWidget[getLevel="2"][hasChildRows="true"]
 {
     border-top: 1px solid rgba(255, 255, 255, 0.2);
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -374,7 +374,7 @@ namespace AzToolsFramework
     }
 
     DPERowWidget::DPERowWidget(int depth, DPERowWidget* parentRow)
-        : QWidget(nullptr) // parent will be set when the row is added to its layout
+        : QFrame(nullptr) // parent will be set when the row is added to its layout
         , m_parentRow(parentRow)
         , m_depth(depth)
         , m_columnLayout(new DPELayout(depth, this))
@@ -958,6 +958,16 @@ namespace AzToolsFramework
     const AZ::Dom::Path DPERowWidget::GetPath() const
     {
         return m_domPath;
+    }
+
+    bool DPERowWidget::HasChildRows() const
+    {
+        return !m_domOrderedChildren.empty();
+    }
+
+    int DPERowWidget::GetLevel() const
+    {
+        return m_depth;
     }
 
     DocumentPropertyEditor::DocumentPropertyEditor(QWidget* parentWidget)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -89,9 +89,12 @@ namespace AzToolsFramework
         mutable QSize m_cachedMinLayoutSize;
     };
 
-    class DPERowWidget : public QWidget
+    class DPERowWidget : public QFrame
     {
         Q_OBJECT
+        Q_PROPERTY(bool hasChildRows READ HasChildRows);
+        Q_PROPERTY(int getLevel READ GetLevel);
+
         friend class DocumentPropertyEditor;
 
     public:
@@ -114,6 +117,9 @@ namespace AzToolsFramework
         bool IsExpanded() const;
 
         const AZ::Dom::Path GetPath() const;
+
+        bool HasChildRows() const;
+        int GetLevel() const;
 
     protected slots:
         void onExpanderChanged(int expanderState);


### PR DESCRIPTION
**Description**
Horizontal rules which show in the AssetEditor for top level container elements were not showing up when the DocumentPropertyEditor (DPE) was enabled in place of the ReflectedPropertyEditor.

This PR enables those horizontal rules in the AssetEditor when using the DPE.

DPE in AssetEditor with horizontal rules:

![dpeWithhorizontalRules](https://user-images.githubusercontent.com/104796591/190789973-5eb0252f-719d-420c-adce-87f7430aab34.jpg)

**Testing**
- Verified that assets which normally have horizontal rules in the AssetEditor using the RPE also have them with the DPE