### PR TITLE
Generalized the view pane options for enable/disable during Component Mode

### DIFF
--- a/Code/Editor/Controls/ConsoleSCB.cpp
+++ b/Code/Editor/Controls/ConsoleSCB.cpp
@@ -389,6 +389,10 @@ void CConsoleSCB::RegisterViewClass()
     opts.showInMenu = true;
     opts.builtInActionId = ID_VIEW_CONSOLEWINDOW;
     opts.shortcut = QKeySequence(Qt::Key_QuoteLeft);
+    // Override the default behavior for component mode enter/exit and imgui enter/exit
+    // so that we don't disable and enable the Console window.
+    opts.isDisabledInComponentMode = false;
+    opts.isDisabledInImGuiMode = false;
 
     AzToolsFramework::RegisterViewPane<CConsoleSCB>(LyViewPane::Console, LyViewPane::CategoryTools, opts);
 }

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/ComponentEntityEditorPlugin.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/ComponentEntityEditorPlugin.cpp
@@ -120,6 +120,11 @@ ComponentEntityEditorPlugin::ComponentEntityEditorPlugin([[maybe_unused]] IEdito
     ViewPaneOptions inspectorOptions;
     inspectorOptions.canHaveMultipleInstances = true;
     inspectorOptions.preferedDockingArea = Qt::RightDockWidgetArea;
+    // Override the default behavior for component mode enter/exit and imgui enter/exit
+    // so that we don't automatically disable and enable the entire Entity Inspector. This will be handled separately per-component.
+    inspectorOptions.isDisabledInComponentMode = false;
+    inspectorOptions.isDisabledInImGuiMode = false;
+
     RegisterViewPane<QComponentEntityEditorInspectorWindow>(
         LyViewPane::EntityInspector,
         LyViewPane::CategoryTools,
@@ -130,6 +135,11 @@ ComponentEntityEditorPlugin::ComponentEntityEditorPlugin([[maybe_unused]] IEdito
     pinnedInspectorOptions.preferedDockingArea = Qt::NoDockWidgetArea;
     pinnedInspectorOptions.paneRect = QRect(50, 50, 400, 700);
     pinnedInspectorOptions.showInMenu = false;
+    // Override the default behavior for component mode enter/exit and imgui enter/exit
+    // so that we don't automatically disable and enable the entire Pinned Entity Inspector. This will be handled separately per-component.
+    pinnedInspectorOptions.isDisabledInComponentMode = false;
+    pinnedInspectorOptions.isDisabledInImGuiMode = false;
+
     RegisterViewPane<QComponentEntityEditorInspectorWindow>(
         LyViewPane::EntityInspectorPinned,
         LyViewPane::CategoryTools,
@@ -145,6 +155,10 @@ ComponentEntityEditorPlugin::ComponentEntityEditorPlugin([[maybe_unused]] IEdito
         ViewPaneOptions outlinerOptions;
         outlinerOptions.canHaveMultipleInstances = true;
         outlinerOptions.preferedDockingArea = Qt::LeftDockWidgetArea;
+        // Override the default behavior for component mode enter/exit and imgui enter/exit
+        // so that we don't automatically disable and enable the Entity Outliner. This will be handled separately.
+        outlinerOptions.isDisabledInComponentMode = false;
+        outlinerOptions.isDisabledInImGuiMode = false;
 
         RegisterViewPane<QEntityOutlinerWindow>(
             LyViewPane::EntityOutliner,
@@ -164,6 +178,10 @@ ComponentEntityEditorPlugin::ComponentEntityEditorPlugin([[maybe_unused]] IEdito
         ViewPaneOptions outlinerOptions;
         outlinerOptions.canHaveMultipleInstances = true;
         outlinerOptions.preferedDockingArea = Qt::LeftDockWidgetArea;
+        // Override the default behavior for component mode enter/exit and imgui enter/exit
+        // so that we don't automatically disable and enable the Entity Outliner. This will be handled separately.
+        outlinerOptions.isDisabledInComponentMode = false;
+        outlinerOptions.isDisabledInImGuiMode = false;
 
         // this pane was originally introduced with this name, so layout settings are all saved with that name, despite the preview label being removed.
         outlinerOptions.saveKeyName = "Entity Outliner (PREVIEW)";

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ViewPaneOptions.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ViewPaneOptions.h
@@ -41,6 +41,9 @@ namespace AzToolsFramework
 
         bool showOnToolsToolbar = false;                                ///< set to true if the view pane should create a button on the tools toolbar to open/close the pane
         AZStd::string toolbarIcon;                                      ///< path to the icon to use for the toolbar button - only used if showOnToolsToolbar is set to true
+
+        bool isDisabledInComponentMode = true;                          ///< set to false if the view pane should remain enabled during component mode
+        bool isDisabledInImGuiMode = true;                              ///< set to false if the view pane should remain enabled during imgui mode
     };
 
 } // namespace AzToolsFramework


### PR DESCRIPTION
## What does this PR do?

This removes the hard-coded special behaviors for keeping the Entity Inspector, Pinned Entity Inspector, Entity Outliner, and Console windows active during Component Mode, and instead turns it into a generalized ViewPaneOption, with the option enabled for those four windows.

The behavior in the Editor remains the same, but by moving this to the ViewPaneOptions, we can now add this functionality to new view panes without needing to hardcode the view pane name in QtViewPaneManager. This will be used by the Paint Brush Settings view pane in an upcoming PR.

Note that of the four, only the Console window remains completely active. The Entity Inspector / Pinned Entity Inspector need the view panes to remain active so that they can disable all components except the one(s) being edited. It's not clear on inspection why the Entity Outliner remains enabled here, because it appears to get completely disabled through other means during Component Mode anyways.

## How was this PR tested?

Ran the Editor, entered and exited component mode, and verified that there was no discernable change in behavior to any Editor windows. Tested the 4 windows listed above as well as a variety of other tool windows.