### PR TITLE
Fixed node connections disappearing from terrain extenders

### DIFF
--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/BaseNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/BaseNode.cpp
@@ -98,6 +98,7 @@ namespace LandscapeCanvas
             || baseNodeType == LandscapeCanvas::BaseNode::VegetationAreaFilter
             || baseNodeType == LandscapeCanvas::BaseNode::VegetationAreaSelector
             || baseNodeType == LandscapeCanvas::BaseNode::TerrainExtender
+            || baseNodeType == LandscapeCanvas::BaseNode::TerrainSurfaceExtender
             ;
     }
 } // namespace LandscapeCanvas

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/BaseNode.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/BaseNode.h
@@ -47,6 +47,7 @@ namespace LandscapeCanvas
             GradientModifier,
             TerrainArea,
             TerrainExtender,
+            TerrainSurfaceExtender,
             VegetationAreaModifier,
             VegetationAreaFilter,
             VegetationAreaSelector

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Nodes/Terrain/TerrainSurfaceGradientListNode.cpp
@@ -53,7 +53,7 @@ namespace LandscapeCanvas
 
     const BaseNode::BaseNodeType TerrainSurfaceGradientListNode::GetBaseNodeType() const
     {
-        return BaseNode::TerrainExtender;
+        return BaseNode::TerrainSurfaceExtender;
     }
 
     const char* TerrainSurfaceGradientListNode::GetTitle() const


### PR DESCRIPTION
## What does this PR do?

Fixes #11917 

This fixes an issue where connections made in Landscape Canvas with the Terrain Height Gradient List and Terrain Surface Gradient List extender nodes were being removed when the graph was re-opened. This was due to the properties for these components not being properly parsed on graph open, so the connections were being removed because it thought they weren't valid connections anymore.

Before this change, running the scenario in the gif below would result in no connections being present on the graph when re-opened.

![ReopenGraphWithTerrainExtenders](https://user-images.githubusercontent.com/7519264/191079403-ee52070b-769c-4ee6-8676-282dc16cb01d.gif)

## How was this PR tested?

Tested the steps in #11917 as well as manual testing + running the Landscape Canvas automated tests.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>