### PR TITLE
Material Canvas: Fixing screen turning red from invalid entity bounds

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ViewportInputBehaviorController/ViewportInputBehavior.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ViewportInputBehaviorController/ViewportInputBehavior.h
@@ -52,12 +52,11 @@ namespace AtomToolsFramework
         float m_y = {};
         //! delta scroll wheel accumulated during current frame
         float m_z = {};
-        //! object radius
-        float m_radius = 1.0f;
 
         AZ::EntityId m_cameraEntityId;
         AZ::Vector3 m_objectPosition = AZ::Vector3::CreateZero();
-        float m_distanceToObject = {};
+        float m_objectDistance = 0.5f;
+        float m_objectRadius = 1.0f;
         ViewportInputBehaviorControllerInterface* m_controller = {};
 
     private:

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ViewportInputBehaviorController/ViewportInputBehaviorController.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ViewportInputBehaviorController/ViewportInputBehaviorController.h
@@ -57,8 +57,9 @@ namespace AtomToolsFramework
         const AZ::EntityId& GetEnvironmentEntityId() const override;
         const AZ::Vector3& GetObjectPosition() const override;
         void SetObjectPosition(const AZ::Vector3& objectPosition) override;
-        float GetDistanceToObject() const override;
-        float GetRadius() const override;
+        float GetObjectRadiusMin() const override;
+        float GetObjectRadius() const override;
+        float GetObjectDistance() const override;
         void Reset() override;
         void SetFieldOfView(float value) override;
         bool IsCameraCentered() const override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ViewportInputBehaviorController/ViewportInputBehaviorControllerInterface.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ViewportInputBehaviorController/ViewportInputBehaviorControllerInterface.h
@@ -34,11 +34,14 @@ namespace AtomToolsFramework
         //! @param objectPosition world space position to point camera at
         virtual void SetObjectPosition(const AZ::Vector3& objectPosition) = 0;
 
-        //! Get distance between camera and its object
-        virtual float GetDistanceToObject() const = 0;
+        //! Get the minimum radius of the object entity bounding box
+        virtual float GetObjectRadiusMin() const = 0;
 
-        //! Get bounding sphere radius of the active object
-        virtual float GetRadius() const = 0;
+        //! Get the radius of the object entity bounding box
+        virtual float GetObjectRadius() const = 0;
+
+        //! Get distance between camera and its object
+        virtual float GetObjectDistance() const = 0;
 
         //! Reset camera to default position and rotation 
         virtual void Reset() = 0;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportContent.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportContent.cpp
@@ -55,17 +55,25 @@ namespace AtomToolsFramework
 
     AZ::Aabb EntityPreviewViewportContent::GetObjectLocalBounds() const
     {
-        AZ::Aabb objectBounds = AZ::Aabb::CreateCenterRadius(AZ::Vector3::CreateZero(), 0.5f);
+        AZ::Aabb objectBounds = AZ::Aabb::CreateNull();
         AzFramework::BoundsRequestBus::EventResult(
             objectBounds, GetObjectEntityId(), &AzFramework::BoundsRequestBus::Events::GetLocalBounds);
+        if (!objectBounds.IsValid() || !objectBounds.IsFinite())
+        {
+            objectBounds = AZ::Aabb::CreateCenterRadius(AZ::Vector3::CreateZero(), 0.5f);
+        }
         return objectBounds;
     }
 
     AZ::Aabb EntityPreviewViewportContent::GetObjectWorldBounds() const
     {
-        AZ::Aabb objectBounds = AZ::Aabb::CreateCenterRadius(AZ::Vector3::CreateZero(), 0.5f);
+        AZ::Aabb objectBounds = AZ::Aabb::CreateNull();
         AzFramework::BoundsRequestBus::EventResult(
             objectBounds, GetObjectEntityId(), &AzFramework::BoundsRequestBus::Events::GetWorldBounds);
+        if (!objectBounds.IsValid() || !objectBounds.IsFinite())
+        {
+            objectBounds = AZ::Aabb::CreateCenterRadius(AZ::Vector3::CreateZero(), 0.5f);
+        }
         return objectBounds;
     }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ViewportInputBehaviorController/DollyCameraBehavior.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ViewportInputBehaviorController/DollyCameraBehavior.cpp
@@ -21,10 +21,10 @@ namespace AtomToolsFramework
 
     void DollyCameraBehavior::TickInternal([[maybe_unused]] float x, float y, [[maybe_unused]] float z)
     {
-        m_distanceToObject = m_distanceToObject + y;
+        m_objectDistance += y;
         AZ::Transform transform = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(transform, m_cameraEntityId, &AZ::TransformBus::Events::GetWorldTM);
-        AZ::Vector3 position = m_objectPosition - transform.GetRotation().TransformVector(AZ::Vector3::CreateAxisY(m_distanceToObject));
+        AZ::Vector3 position = m_objectPosition - transform.GetRotation().TransformVector(AZ::Vector3::CreateAxisY(m_objectDistance));
         AZ::TransformBus::Event(m_cameraEntityId, &AZ::TransformBus::Events::SetWorldTranslation, position);
     }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ViewportInputBehaviorController/OrbitCameraBehavior.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ViewportInputBehaviorController/OrbitCameraBehavior.cpp
@@ -34,7 +34,7 @@ namespace AtomToolsFramework
         rotation =
             AZ::Quaternion::CreateFromAxisAngle(AZ::Vector3::CreateAxisZ(), -x) * AZ::Quaternion::CreateFromAxisAngle(right, -y) * rotation;
         rotation.Normalize();
-        AZ::Vector3 position = rotation.TransformVector(AZ::Vector3(0, -m_distanceToObject, 0)) + m_objectPosition;
+        AZ::Vector3 position = rotation.TransformVector(AZ::Vector3(0.0f, -m_objectDistance, 0.0f)) + m_objectPosition;
         transform = AZ::Transform::CreateFromQuaternionAndTranslation(rotation, position);
         AZ::TransformBus::Event(m_cameraEntityId, &AZ::TransformBus::Events::SetWorldTM, transform);
     }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ViewportInputBehaviorController/PanCameraBehavior.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ViewportInputBehaviorController/PanCameraBehavior.cpp
@@ -20,10 +20,10 @@ namespace AtomToolsFramework
 
     void PanCameraBehavior::End()
     {
-        float distanceToObject = m_controller->GetDistanceToObject();
+        float objectDistance = m_controller->GetObjectDistance();
         AZ::Transform transform = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(transform, m_cameraEntityId, &AZ::TransformBus::Events::GetWorldTM);
-        AZ::Vector3 objectPosition = transform.GetTranslation() + transform.GetBasisY() * distanceToObject;
+        AZ::Vector3 objectPosition = transform.GetTranslation() + transform.GetBasisY() * objectDistance;
         m_controller->SetObjectPosition(objectPosition);
     }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ViewportInputBehaviorController/RotateCameraBehavior.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ViewportInputBehaviorController/RotateCameraBehavior.cpp
@@ -21,10 +21,10 @@ namespace AtomToolsFramework
 
     void RotateCameraBehavior::End()
     {
-        float distanceToObject = m_controller->GetDistanceToObject();
+        float objectDistance = m_controller->GetObjectDistance();
         AZ::Transform transform = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(transform, m_cameraEntityId, &AZ::TransformBus::Events::GetWorldTM);
-        AZ::Vector3 objectPosition = transform.GetTranslation() + transform.GetBasisY() * distanceToObject;
+        AZ::Vector3 objectPosition = transform.GetTranslation() + transform.GetBasisY() * objectDistance;
         m_controller->SetObjectPosition(objectPosition);
     }
 


### PR DESCRIPTION
## What does this PR do?

This change fixes an issue with the material canvas and material editor viewport turning red momentarily on startup and anytime the viewport model is invalid or deleted. This is caused because requesting the object entity local and world bounds returns an invalid bounding box if no model is loaded.

This change also renames a handful of variables and functions.

https://github.com/o3de/o3de/issues/10879
Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Verified that using both material editor and material canvas, starting both tools, moving the camera in different modes, deleting and switching between different models