### PR TITLE
PropertyTreeEditor | Fix crash when the ReadOnly attribute is set by a member function.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.cpp
@@ -119,10 +119,9 @@ namespace AzToolsFramework
                 buffer += "HideChildren";
             }
 
-            AZ::Attribute* attribute = nodePtr->FindAttribute(AZ::Edit::Attributes::ReadOnly);
-            if (attribute)
+            if (AZ::Attribute* attribute = nodePtr->FindAttribute(AZ::Edit::Attributes::ReadOnly))
             {
-                PropertyAttributeReader reader(nullptr, attribute);
+                PropertyAttributeReader reader(static_cast<AZ::Component*>(nodePtr->FirstInstance()), attribute);
                 bool readOnlyValue = false;
                 reader.Read<bool>(readOnlyValue);
                 if (readOnlyValue)


### PR DESCRIPTION
Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>

## What does this PR do?
Fixes an issue with PhysX components that would see a crash when the `BuildPathsListWithTypes` function of the `PropertyTreeEditor` class is called on them.

This function returns a list of component properties as follows:
```
[
   "Standard Joint Parameters|Lead-Follower Collide (bool,Visible)",
   "Angular Limit|Standard limit configuration|Damping (float,NotVisible)",
   "Standard Joint Parameters|Local Position (Vector3,Visible)",
   "Standard Joint Parameters|Local Rotation (Vector3,Visible)",
   "Standard Joint Parameters|Maximum Torque (float,NotVisible)",
   "Standard Joint Parameters|Display Setup in Viewport (unsigned char,Visible,ReadOnly)",
   "Standard Joint Parameters|Breakable (bool,Visible)",
   "Angular Limit (EditorJointLimitPairConfig,Visible)",
   "Angular Limit|Standard limit configuration|Limit (bool,Visible,ReadOnly)",
   "Angular Limit|Standard limit configuration|Stiffness (float,NotVisible)",
   "Angular Limit|Negative angular limit (float,Visible)",
   "Standard Joint Parameters (EditorJointConfig,Visible)",
   "Standard Joint Parameters|Lead Entity (EntityId,Visible)",
   "Standard Joint Parameters|Select Lead on Snap (bool,Visible)",
   "Angular Limit|Standard limit configuration|Soft limit (bool,Visible,ReadOnly)",
   "Standard Joint Parameters|Maximum Force (float,NotVisible)",
   "Angular Limit|Positive angular limit (float,Visible)",
   "Component Mode (ComponentModeDelegate,ShowChildrenOnly)",
   "Angular Limit|Standard limit configuration (EditorJointLimitConfig,ShowChildrenOnly)"
]
```

To retrieve the `ReadOnly` property, the functions uses the `PropertyAttributeReader` class to inspect the Edit Context. The current implementation of the function, though, creates the reader without passing in the pointer to the component.

```
PropertyAttributeReader reader(nullptr, attribute);
```

This works in the cases where the `ReadOnly` property is set directly. In the case of PhysX components, though, the attribute is often set as the result of a member function, like so:

```
->Attribute(AZ::Edit::Attributes::ReadOnly, &EditorJointLimitConfig::IsInComponentMode)
```

As such, the Editor would crash in such instances since the member function would be called on a nullptr.

This fix passes the component instance to the reader and ensures the function works as intended.

## How was this PR tested?

Manual test on a python script that would crash the editor, and now works as expected:
```
import azlmbr.legacy.general as general
import azlmbr.bus as bus
import azlmbr.editor as editor
import azlmbr.entity as entity

def find_entity_by_name(entity_name):
    """
    Gets an entity ID from the entity with the given entity_name
    :param entity_name: String of entity name to search for
    :return entity ID
    """
    search_filter = entity.SearchFilter()
    search_filter.names = [entity_name]
    matching_entity_list = entity.SearchBus(bus.Broadcast, 'SearchEntities', search_filter)
    if matching_entity_list:
        matching_entity = matching_entity_list[0]
        if matching_entity.IsValid():
            print(f'{entity_name} entity found with ID {matching_entity.ToString()}')
            return matching_entity
    else:
        return matching_entity_list

entityId = find_entity_by_name("Entity1")

type_ids_list = editor.EditorComponentAPIBus(bus.Broadcast, 'FindComponentTypeIdsByEntityType', ["PhysX Hinge Joint"], entity.EntityType().Game)
physXHingeJointTypeId = type_ids_list[0]

physXHingeJointComponentOutcome = editor.EditorComponentAPIBus(bus.Broadcast, 'GetComponentOfType', entityId, physXHingeJointTypeId)
physXHingeJointComponent = physXHingeJointComponentOutcome.GetValue()

build_prop_tree_outcome = editor.EditorComponentAPIBus(bus.Broadcast, "BuildComponentPropertyTreeEditor", physXHingeJointComponent)

if build_prop_tree_outcome.IsSuccess():
    property_tree_editor = build_prop_tree_outcome.GetValue()
    print(property_tree_editor.build_paths_list_with_types())
```

(Note: for this script to work, this requires a level to be open containing an entity named "Entity1" with a "PhysX Hinge Joint" on it.)