### PR TITLE
Change prefab edit mode behavior to overlap with component mode.

### DIFF
--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/State/FocusedEntityState.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/State/FocusedEntityState.cpp
@@ -47,14 +47,17 @@ namespace AZ::Render
         [[maybe_unused]] const AzToolsFramework::ViewportEditorModesInterface& editorModeState,
         AzToolsFramework::ViewportEditorMode mode)
     {
-        m_inFocusMode = (mode == AzToolsFramework::ViewportEditorMode::Focus);
+        if (AzToolsFramework::ViewportEditorMode::Focus == mode)
+        {
+            m_inFocusMode = true;
+        }
     }
     void FocusedEntityState::OnEditorModeDeactivated(
         [[maybe_unused]] const AzToolsFramework::ViewportEditorModesInterface& editorModeState, AzToolsFramework::ViewportEditorMode mode)
     {
-        if (m_inFocusMode)
+        if (AzToolsFramework::ViewportEditorMode::Focus == mode)
         {
-            m_inFocusMode = mode != AzToolsFramework::ViewportEditorMode::Focus;
+            m_inFocusMode = false;
         }
     }
 


### PR DESCRIPTION
Signed-off-by: John <jonawals@amazon.com>

## What does this PR do?

This PR changes the behavior of Prefab Edit Mode visual effect such that it is only disengaged when prefab editing mode is exited. This allows for other modes such as Component Mode visual effect to be nested within the Prefab Edit Mode visual effect.

See https://github.com/o3de/o3de/issues/11444 for more details.

## How was this PR tested?

This PR was tested manually within the editor.