### PR TITLE
Fix TaskGraph race condition in CompiledTaskGraph::Release

### DIFF
--- a/Code/Framework/AzCore/AzCore/Task/TaskExecutor.h
+++ b/Code/Framework/AzCore/AzCore/Task/TaskExecutor.h
@@ -16,36 +16,61 @@
 #include <AzCore/std/parallel/binary_semaphore.h>
 #include <AzCore/Memory/PoolAllocator.h>
 
+#define ENABLE_COMPILED_TASK_GRAPH_EVENT_TRACKING AZ_DEBUG_BUILD
+
 namespace AZ
 {
     class TaskGraphEvent;
     class TaskGraph;
+    class TaskExecutor;
 
     namespace Internal
     {
-        class CompiledTaskGraph;
+        class CompiledTaskGraphTracker;
 
-        /////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // DEBUG code
-        // Implement basic CompiledTaskGraph deletion breadcrumbs to help debug
+        // Implement basic CompiledTaskGraph event breadcrumbs to help debug
         // https://github.com/o3de/o3de/issues/12015
-        class CompiledTaskGraphDeallocationTracker final
+        enum CTGEvent
+        {
+            None,
+            Allocated,
+            Deallocated,
+            Submitted,
+            Signalled,
+        };
+        class CompiledTaskGraphTracker final
         {
         public:
-            void WriteDeallocationData(const CompiledTaskGraph* ctg);
+            CompiledTaskGraphTracker(TaskExecutor* executor [[maybe_unused]])
+#ifdef ENABLE_COMPILED_TASK_GRAPH_EVENT_TRACKING
+                : m_taskExecutor(executor)
+#endif
+            {};
+#ifdef ENABLE_COMPILED_TASK_GRAPH_EVENT_TRACKING
+            void WriteEventInfo(const CompiledTaskGraph* ctg, CTGEvent eventCode, const char* identifier);
+#else
+            void WriteEventInfo(const CompiledTaskGraph* ctg [[maybe_unused]], CTGEvent eventCode [[maybe_unused]], const char* identifier [[maybe_unused]]) {};
+#endif
 
         private:
-            static constexpr uint32_t NumTrackedRecentDeallocations = 32u;
-            struct DeallocationData
+#ifdef ENABLE_COMPILED_TASK_GRAPH_EVENT_TRACKING
+            static constexpr uint32_t NumTrackedRecentEvents = 1024u;
+            struct CTGEventData
             {
-                const char* m_parentLabel = nullptr;
                 const CompiledTaskGraph* m_ctg = nullptr;
+                const char* m_parentLabel = nullptr;
+                const char* m_identifier = nullptr;
+                const char* m_threadName = nullptr;
+                uint32_t m_remainingCount = 0;
+                CTGEvent m_eventCode = CTGEvent::None;
+                bool m_retained = true;
             };
-            DeallocationData m_recentDeallocations[NumTrackedRecentDeallocations]; // deallocation breadcrumbs to help look for a double delete
-            uint32_t m_nextDeallocationSlot = 0;
-            AZStd::mutex m_deallocationMutex;
+            TaskExecutor* m_taskExecutor = nullptr;
+            CTGEventData m_recentEvents[NumTrackedRecentEvents]; // Allocation breadcrumbs to help look for a double delete
+            uint32_t m_nextEventSlot = 0;
+            AZStd::mutex m_mutex;
+#endif
         };
-        ////////////////////////////////////////////////////////////////////////////////////////////////
 
         class CompiledTaskGraph final
         {
@@ -59,8 +84,6 @@ namespace AZ
                 TaskGraph* parent,
                 const char* parentLabel);
 
-            ~CompiledTaskGraph();
-
             AZStd::vector<Task>& Tasks() noexcept
             {
                 return m_tasks;
@@ -68,10 +91,12 @@ namespace AZ
 
             // Indicate that a constituent task has finished and decrement a counter to determine if the
             // graph should be freed (returns the value after atomic decrement)
-            uint32_t Release(CompiledTaskGraphDeallocationTracker& deallocationTracker);
+            uint32_t Release(CompiledTaskGraphTracker& allocationTracker);
 
             // Debug access
             const char* GetParentLabel() const { return m_parentLabel; }
+            bool IsRetained() const { return m_parent != nullptr; }
+            uint32_t GetRemainingCount() const { return m_remaining.load(); }
 
         private:
             friend class ::AZ::TaskGraph;
@@ -109,11 +134,12 @@ namespace AZ
 
         void Submit(Internal::Task& task);
 
-        Internal::CompiledTaskGraphDeallocationTracker& GetDeallocationTracker() {return m_deallocationTracker;}
+        Internal::CompiledTaskGraphTracker& GetEventTracker() {return m_eventTracker;}
 
     private:
         friend class Internal::TaskWorker;
         friend class TaskGraphEvent;
+        friend class Internal::CompiledTaskGraphTracker;
 
         Internal::TaskWorker* GetTaskWorker();
         void ReleaseGraph();
@@ -124,11 +150,8 @@ namespace AZ
         AZStd::atomic<uint32_t> m_lastSubmission;
         AZStd::atomic<uint64_t> m_graphsRemaining;
 
-        /////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // DEBUG code
-        // Implement basic CompiledTaskGraph deletion breadcrumbs to help debug
+        // Implement basic CompiledTaskGraph event breadcrumbs to help debug
         // https://github.com/o3de/o3de/issues/12015
-        Internal::CompiledTaskGraphDeallocationTracker m_deallocationTracker;
-        /////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        Internal::CompiledTaskGraphTracker m_eventTracker;
     };
 } // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Task/TaskExecutor.h
+++ b/Code/Framework/AzCore/AzCore/Task/TaskExecutor.h
@@ -35,6 +35,8 @@ namespace AZ
                 TaskGraph* parent,
                 const char* parentLabel);
 
+            ~CompiledTaskGraph();
+
             AZStd::vector<Task>& Tasks() noexcept
             {
                 return m_tasks;

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
@@ -81,11 +81,11 @@ namespace AZ
     {
         if (m_retained && m_compiledTaskGraph)
         {
-            Internal::CompiledTaskGraphDeallocationTracker& deallocationTracker = TaskExecutor::Instance().GetDeallocationTracker();
+            Internal::CompiledTaskGraphTracker& eventTracker = TaskExecutor::Instance().GetEventTracker();
             // This job graph has already finished and we are potentially responsible for its destruction
-            if (m_compiledTaskGraph->Release(deallocationTracker) == 0)
+            if (m_compiledTaskGraph->Release(eventTracker) == 0)
             {
-                deallocationTracker.WriteDeallocationData(m_compiledTaskGraph);
+                eventTracker.WriteEventInfo(m_compiledTaskGraph, Internal::CTGEvent::Deallocated, "TaskGraph::~TaskGraph");
                 azdestroy(m_compiledTaskGraph);
             }
         }
@@ -96,6 +96,8 @@ namespace AZ
         AZ_Assert(!m_submitted, "Cannot reset task graph %s while it is in flight", m_label);
         if (m_compiledTaskGraph)
         {
+            Internal::CompiledTaskGraphTracker& eventTracker = TaskExecutor::Instance().GetEventTracker();
+            eventTracker.WriteEventInfo(m_compiledTaskGraph, Internal::CTGEvent::Deallocated, "TaskGraph::Reset");
             azdestroy(m_compiledTaskGraph);
             m_compiledTaskGraph = nullptr;
         }
@@ -112,8 +114,10 @@ namespace AZ
         {
             if (waitEvent)
             {
+                Internal::CompiledTaskGraphTracker& eventTracker = TaskExecutor::Instance().GetEventTracker();
                 // TaskGraphEvent asserts if it has a wait count of 0, increment it before signaling.
                 waitEvent->IncWaitCount();
+                eventTracker.WriteEventInfo(nullptr, Internal::CTGEvent::Signalled, "TaskGraph::Submit empty graph");
                 waitEvent->Signal();
             }
             return;
@@ -123,9 +127,11 @@ namespace AZ
 
     void TaskGraph::SubmitOnExecutor(TaskExecutor& executor, TaskGraphEvent* waitEvent)
     {
+        Internal::CompiledTaskGraphTracker& eventTracker = executor.GetEventTracker();
         if (!m_compiledTaskGraph)
         {
             m_compiledTaskGraph = aznew CompiledTaskGraph(AZStd::move(m_tasks), m_links, m_linkCount, m_retained ? this : nullptr, m_label);
+            eventTracker.WriteEventInfo(m_compiledTaskGraph, Internal::CTGEvent::Allocated, "SubmitOnExecutor");
         }
 
         m_compiledTaskGraph->m_waitEvent = waitEvent;
@@ -136,6 +142,7 @@ namespace AZ
             m_compiledTaskGraph->m_tasks[i].Init();
         }
 
+        eventTracker.WriteEventInfo(m_compiledTaskGraph, Internal::CTGEvent::Submitted, "SubmitOnExecutor");
         executor.Submit(*m_compiledTaskGraph, waitEvent);
 
         if (m_retained)

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
@@ -81,9 +81,11 @@ namespace AZ
     {
         if (m_retained && m_compiledTaskGraph)
         {
+            Internal::CompiledTaskGraphDeallocationTracker& deallocationTracker = TaskExecutor::Instance().GetDeallocationTracker();
             // This job graph has already finished and we are potentially responsible for its destruction
-            if (m_compiledTaskGraph->Release() == 0)
+            if (m_compiledTaskGraph->Release(deallocationTracker) == 0)
             {
+                deallocationTracker.WriteDeallocationData(m_compiledTaskGraph);
                 azdestroy(m_compiledTaskGraph);
             }
         }

--- a/Code/Framework/AzCore/Tests/TaskTests.cpp
+++ b/Code/Framework/AzCore/Tests/TaskTests.cpp
@@ -35,10 +35,15 @@ namespace UnitTest
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Create();
 
             m_executor = aznew TaskExecutor();
+            TaskExecutor::SetInstance(m_executor); // SetInstance is a null-op if there is already a default instance set
         }
 
         void TearDown() override
         {
+            if (&TaskExecutor::Instance() == m_executor) // if this test created the default instance unset it before destroying it
+            {
+                TaskExecutor::SetInstance(nullptr);
+            }
             azdestroy(m_executor);
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Destroy();
             AZ::AllocatorInstance<AZ::PoolAllocator>::Destroy();


### PR DESCRIPTION
Race condition was reading from the this ptr to a compiled task graph (CTG) after another thread had deleted the memory. On deletion some values (e.g. m_parent) would be filled with random data and move the CTG from the detached path to the retained path, which would cause a 2nd attempt to signal any wait event.

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>

Debugging aid change
TaskGraph system can now keep a list of recent CompiledTaskGraph events to aid debugging issues.

https://github.com/o3de/o3de/issues/12015

tested by running locally