### PR TITLE
Updating images that were missed containing the old logo

### DIFF
--- a/Code/Tools/ProjectManager/Resources/DefaultProjectImage.png
+++ b/Code/Tools/ProjectManager/Resources/DefaultProjectImage.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1cf8339fb51f82a68d2ab475c0476960e75a79d96d239c5b7cd272fbe4990ffe
-size 2770
+oid sha256:13e825d395c997ca41a7db98191b14d7d4b900329bf15a6ba91579abac4df61f
+size 6058

--- a/Code/Tools/ProjectManager/Resources/DefaultTemplate.png
+++ b/Code/Tools/ProjectManager/Resources/DefaultTemplate.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ac9dd09bde78f389e3725ac49d61eff109857e004840bc0bc3881739df9618d
-size 2217
+oid sha256:d6b5bda4243d38542cb442f3dfd0487a1eaf86cbc2783b467ddc5031929b25a9
+size 3780


### PR DESCRIPTION
A couple of images (for project and template) used by project manager (in the case that a project or template did not have an overriding image) were not updated to use the current logo. This changes these images to use the current logo. Attached new images in case the diff does not show these files:

![DefaultProjectImage](https://user-images.githubusercontent.com/70403342/191342553-73a886cd-75a4-4b29-bffb-d52b95dfd252.png)


![DefaultTemplate](https://user-images.githubusercontent.com/70403342/191342565-65d5317e-557c-4671-b679-946056bcfb9a.png)


Signed-off-by: AMZN-Phil <pconroy@amazon.com>