### PR TITLE
Update the content details table to display/hide automatically

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.h
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.h
@@ -95,6 +95,9 @@ public:
 
         // Event Log Details
         int logTypeColumnWidth = -1;
+
+        // Event Log Line Details
+        int contextDetailsTableMaximumRows = -1;
     };
 
     /*!
@@ -168,7 +171,6 @@ private:
     AssetProcessor::BuilderInfoMetricsSortModel* m_builderInfoMetricsSort = nullptr;
     AssetProcessor::CacheServerData m_cacheServerData;
 
-    void SetContextLogDetailsVisible(bool visible);
     void SetContextLogDetails(const QMap<QString, QString>& details);
     void ClearContextLogDetails();
 

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -344,7 +344,7 @@
          <property name="childrenCollapsible">
           <bool>false</bool>
          </property>
-         <widget class="QWidget" name="assetStatusContainer">
+         <widget class="QWidget" name="assetStatusContainer" native="true">
           <layout class="QVBoxLayout" name="verticalLayout_4">
            <property name="spacing">
             <number>0</number>
@@ -461,7 +461,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QFrame" name="jobContextContainer">
+         <widget class="QWidget" name="jobContextContainer" native="true">
           <layout class="QVBoxLayout" name="jobContextLayout">
            <property name="spacing">
             <number>0</number>
@@ -479,82 +479,32 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QFrame" name="jobContextLogBar">
-             <layout class="QHBoxLayout" name="horizontalLayout">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QLabel" name="jobContextLogLabel">
-                <property name="text">
-                 <string>Event Log Line Details</string>
-                </property>
-               </widget>
-              </item>
-              <item alignment="Qt::AlignRight|Qt::AlignBottom">
-               <widget class="QCheckBox" name="jobContextLogDetails">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Context Details</string>
-                </property>
-                <property name="class" stdset="0">
-                 <string>ToggleSwitch</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
+            <widget class="QLabel" name="jobContextLogLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Event Log Line Details</string>
+             </property>
             </widget>
            </item>
            <item>
-            <widget class="QStackedWidget" name="jobContextLogStackedWidget">
+            <widget class="AzQtComponents::TableView" name="jobContextLogTableView">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="currentIndex">
-              <number>1</number>
+             <property name="contextMenuPolicy">
+              <enum>Qt::CustomContextMenu</enum>
              </property>
-             <widget class="AzQtComponents::TableView" name="jobContextLogTableView">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="contextMenuPolicy">
-               <enum>Qt::CustomContextMenu</enum>
-              </property>
-             </widget>
-             <widget class="QLabel" name="jobContextLogPlaceholderLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>No event context log details can be shown for unselected rows</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
-             </widget>
+             <attribute name="headerVisible">
+              <bool>false</bool>
+             </attribute>
             </widget>
            </item>
           </layout>
@@ -613,27 +563,27 @@
                </item>
               </layout>
              </widget>
-              <widget class="QWidget" name="IntermediateAssetsTab">
-                <attribute name="title">
-                  <string>Intermediate Assets</string>
-                </attribute>
-                <layout class="QVBoxLayout" name="IntermediateAssetsVerticalLayout" stretch="0">
-                  <item>
-                    <widget class="QTreeView" name="IntermediateAssetsTreeView">
-                      <property name="editTriggers">
-                        <set>QAbstractItemView::NoEditTriggers</set>
-                      </property>
-                      <property name="sortingEnabled">
-                        <bool>true</bool>
-                      </property>
-                      <attribute name="headerDefaultSectionSize">
-                        <number>300</number>
-                      </attribute>
-                    </widget>
-                  </item>
-                </layout>
-              </widget>
-              <widget class="QWidget" name="ProductAssetsTab">
+             <widget class="QWidget" name="IntermediateAssetsTab">
+              <attribute name="title">
+               <string>Intermediate Assets</string>
+              </attribute>
+              <layout class="QVBoxLayout" name="IntermediateAssetsVerticalLayout" stretch="0">
+               <item>
+                <widget class="QTreeView" name="IntermediateAssetsTreeView">
+                 <property name="editTriggers">
+                  <set>QAbstractItemView::NoEditTriggers</set>
+                 </property>
+                 <property name="sortingEnabled">
+                  <bool>true</bool>
+                 </property>
+                 <attribute name="headerDefaultSectionSize">
+                  <number>300</number>
+                 </attribute>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+             <widget class="QWidget" name="ProductAssetsTab">
               <attribute name="title">
                <string>Product Assets</string>
               </attribute>
@@ -659,13 +609,13 @@
            <item>
             <widget class="AssetProcessor::SourceAssetDetailsPanel" name="sourceAssetDetailsPanel"/>
            </item>
-            <item>
-              <widget class="AssetProcessor::SourceAssetDetailsPanel" name="intermediateAssetDetailsPanel">
-                <property name="visible">
-                  <bool>false</bool>
-                </property>
-              </widget>
-            </item>
+           <item>
+            <widget class="AssetProcessor::SourceAssetDetailsPanel" name="intermediateAssetDetailsPanel">
+             <property name="visible">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
            <item>
             <widget class="AssetProcessor::ProductAssetDetailsPanel" name="productAssetDetailsPanel">
              <property name="visible">

--- a/Code/Tools/AssetProcessor/native/ui/style/AssetProcessorConfig.ini
+++ b/Code/Tools/AssetProcessor/native/ui/style/AssetProcessorConfig.ini
@@ -8,6 +8,9 @@ JobStatusColumnWidth=100
 [EventLogDetails]
 LogTypeColumnWidth=180
 
+[EventLogLineDetails]
+contextDetailsTableMaximumRows=10
+
 [AssetData]
 AssetDataNameColumnWidth=400
 AssetDataDirectoryColumnWidth=400

--- a/Code/Tools/AssetProcessor/native/ui/style/AssetsTab.qss
+++ b/Code/Tools/AssetProcessor/native/ui/style/AssetsTab.qss
@@ -121,8 +121,7 @@ QFrame#jobContextLogLabel {
     margin-top: 12px;
 }
 
-QLabel#jobLogPlaceholderLabel,
-QLabel#jobContextLogPlaceholderLabel {
+QLabel#jobLogPlaceholderLabel {
     background-color: rgb(34,34,34);
     padding: 8px;
     padding-top: 16px;


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Update the Event Log Line Details table in AP to display/hide automatically based on the log line context:
- Show the table when the log line contains context details. Adjust the table height automatically based on the number of rows (The maximum number of rows is configurable)
- Hide the table if the log line doesn't contain any context details.

## How was this PR tested?
Tested the AP GUI automatically.

_Before this PR:_
![AP_Context_Old](https://user-images.githubusercontent.com/68558268/191364667-ffbb8d8f-4b4b-40e2-9469-e1d9391dba49.PNG)
![AP_Context_Old_1](https://user-images.githubusercontent.com/68558268/191364694-46df41f0-3b55-45f3-bfe5-81ffd136b6fa.PNG)
![AP_Context_Old_2](https://user-images.githubusercontent.com/68558268/191364736-d32a332c-9fa6-4ca3-8bf4-7943221414a8.PNG)

_After this PR:_
![AP_Context_New](https://user-images.githubusercontent.com/68558268/191364829-25834367-9fab-4674-ba1f-39833c5076f1.PNG)
![AP_Context_New_2](https://user-images.githubusercontent.com/68558268/191365233-8e6d318a-feb1-41ba-8c52-d5386b6f862a.PNG)
![AP_Context_New_1](https://user-images.githubusercontent.com/68558268/191364847-df3727a1-45a3-4b5e-a6a1-b5b528247683.PNG)
