### PR TITLE
Updating ComponentUpdates_UpdateGraph test

### DIFF
--- a/AutomatedTesting/Assets/Prefabs/BushFlowerBlender.prefab
+++ b/AutomatedTesting/Assets/Prefabs/BushFlowerBlender.prefab
@@ -31,10 +31,6 @@
                 "Id": 16356049875968660722,
                 "Parent Entity": ""
             },
-            "Component_[16391695178646515457]": {
-                "$type": "SelectionComponent",
-                "Id": 16391695178646515457
-            },
             "Component_[16407238476365087382]": {
                 "$type": "EditorVisibilityComponent",
                 "Id": 16407238476365087382
@@ -192,10 +188,6 @@
                         "Entity_[263590326957726]"
                     ]
                 },
-                "Component_[5689270312836823309]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5689270312836823309
-                },
                 "Component_[7105803915999711758]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 7105803915999711758
@@ -206,9 +198,7 @@
                     "Configuration": {
                         "Descriptors": [
                             {
-                                "SpawnerType": "{74BEEDB5-81CF-409F-B375-0D93D81EF2E3}",
                                 "InstanceSpawner": {
-                                    "$type": "PrefabInstanceSpawner",
                                     "SpawnableAsset": {
                                         "assetId": {
                                             "guid": "{EE51E73C-D753-54AC-A1C0-4F29844FB6C3}",
@@ -230,7 +220,9 @@
                 "Component_[13412023990029767074]": {
                     "$type": "EditorRandomGradientComponent",
                     "Id": 13412023990029767074,
-                    "PreviewEntity": "Entity_[263577442055838]"
+                    "Previewer": {
+                        "BoundsEntity": ""
+                    }
                 },
                 "Component_[14048059127502350032]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -256,10 +248,6 @@
                         "ShapeEntityId": "Entity_[263607506826910]"
                     }
                 },
-                "Component_[2794166072748175035]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2794166072748175035
-                },
                 "Component_[4784966656524567789]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 4784966656524567789
@@ -277,6 +265,11 @@
                             50.0,
                             50.0,
                             1.0
+                        ],
+                        "Translate": [
+                            0.0,
+                            10.100000381469727,
+                            4.010446548461914
                         ]
                     }
                 },
@@ -419,9 +412,7 @@
                     "Configuration": {
                         "Descriptors": [
                             {
-                                "SpawnerType": "{74BEEDB5-81CF-409F-B375-0D93D81EF2E3}",
                                 "InstanceSpawner": {
-                                    "$type": "PrefabInstanceSpawner",
                                     "SpawnableAsset": {
                                         "assetId": {
                                             "guid": "{80C0CF4E-9A5E-544B-B89E-BC980175A259}",
@@ -432,9 +423,7 @@
                                 }
                             },
                             {
-                                "SpawnerType": "{74BEEDB5-81CF-409F-B375-0D93D81EF2E3}",
                                 "InstanceSpawner": {
-                                    "$type": "PrefabInstanceSpawner",
                                     "SpawnableAsset": {
                                         "assetId": {
                                             "guid": "{20DD1202-A434-5482-9FB9-AED4C78F6CBF}",
@@ -457,10 +446,6 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 1915862229814997128,
                     "Parent Entity": "Entity_[263607506826910]"
-                },
-                "Component_[2123416208548010747]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2123416208548010747
                 },
                 "Component_[4172073657954183661]": {
                     "$type": "EditorVisibilityComponent",
@@ -536,10 +521,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 16206759293595766479
                 },
-                "Component_[17566144032052847628]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17566144032052847628
-                },
                 "Component_[17784057508127919200]": {
                     "$type": "EditorLockComponent",
                     "Id": 17784057508127919200
@@ -572,7 +553,9 @@
                             "GradientId": "Entity_[263594621925022]"
                         }
                     },
-                    "PreviewEntity": "Entity_[263586031990430]"
+                    "Previewer": {
+                        "BoundsEntity": ""
+                    }
                 }
             }
         },
@@ -580,10 +563,6 @@
             "Id": "Entity_[263590326957726]",
             "Name": "RandomNoise",
             "Components": {
-                "Component_[10420548607186596407]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10420548607186596407
-                },
                 "Component_[11351507264577024072]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 11351507264577024072,
@@ -647,6 +626,11 @@
                             50.0,
                             50.0,
                             1.0
+                        ],
+                        "Translate": [
+                            0.0,
+                            10.100000381469727,
+                            4.010446548461914
                         ]
                     }
                 },
@@ -660,7 +644,9 @@
                 "Component_[8967153379180885152]": {
                     "$type": "EditorRandomGradientComponent",
                     "Id": 8967153379180885152,
-                    "PreviewEntity": "Entity_[263590326957726]"
+                    "Previewer": {
+                        "BoundsEntity": ""
+                    }
                 }
             }
         },
@@ -675,7 +661,9 @@
                         "randomSeed": 33,
                         "frequency": 0.25
                     },
-                    "PreviewEntity": "Entity_[263594621925022]"
+                    "Previewer": {
+                        "BoundsEntity": ""
+                    }
                 },
                 "Component_[16035848776632936419]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -695,10 +683,6 @@
                 "Component_[17679463569742913027]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 17679463569742913027
-                },
-                "Component_[18285870860955961523]": {
-                    "$type": "SelectionComponent",
-                    "Id": 18285870860955961523
                 },
                 "Component_[2330427084045350198]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -750,6 +734,11 @@
                             50.0,
                             50.0,
                             1.0
+                        ],
+                        "Translate": [
+                            0.0,
+                            10.100000381469727,
+                            4.010446548461914
                         ]
                     }
                 },
@@ -2062,10 +2051,6 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 5796173638130327223,
                     "Parent Entity": "ContainerEntity"
-                },
-                "Component_[8278362871021770878]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8278362871021770878
                 }
             }
         },
@@ -2084,7 +2069,9 @@
                         "randomSeed": 33,
                         "frequency": 0.25
                     },
-                    "PreviewEntity": "Entity_[263603211859614]"
+                    "Previewer": {
+                        "BoundsEntity": ""
+                    }
                 },
                 "Component_[11506183926478566822]": {
                     "$type": "EditorEntitySortComponent",
@@ -2128,6 +2115,11 @@
                             50.0,
                             50.0,
                             1.0
+                        ],
+                        "Translate": [
+                            0.0,
+                            10.100000381469727,
+                            4.010446548461914
                         ]
                     }
                 },
@@ -2145,10 +2137,6 @@
                     "Configuration": {
                         "ShapeEntityId": "Entity_[263607506826910]"
                     }
-                },
-                "Component_[6233982345083723563]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6233982345083723563
                 },
                 "Component_[6484803030406851652]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -2213,10 +2201,6 @@
                 "Component_[8772711204845372843]": {
                     "$type": "EditorLockComponent",
                     "Id": 8772711204845372843
-                },
-                "Component_[8959345022109725835]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8959345022109725835
                 },
                 "Component_[9094488642973843583]": {
                     "$type": "EditorDisabledCompositionComponent",

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/ComponentUpdates_UpdateGraph.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/ComponentUpdates_UpdateGraph.py
@@ -111,11 +111,11 @@ def ComponentUpdates_UpdateGraph():
     Report.critical_result(Tests.prefab_instantiated, prefab_result.IsSuccess())
 
     # Find root entity in the loaded level
-    prefab_root_entity = EditorEntity.find_editor_entity("LandscapeCanvas")
+    prefab_root_entity = EditorEntity.find_editor_entity("LandscapeCanvas", must_be_unique=True)
     Report.critical_result(Tests.lc_entity_found, prefab_root_entity.id.IsValid())
 
     # Find the BushSpawner entity
-    bush_spawner_entity = EditorEntity.find_editor_entity("BushSpawner")
+    bush_spawner_entity = EditorEntity.find_editor_entity("BushSpawner", must_be_unique=True)
     Report.critical_result(Tests.spawner_entity_found, bush_spawner_entity.id.IsValid())
 
     # Verify the BushSpawner entity has a Distribution Filter

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/ComponentUpdates_UpdateGraph.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/ComponentUpdates_UpdateGraph.py
@@ -98,7 +98,6 @@ def ComponentUpdates_UpdateGraph():
 
     import editor_python_test_tools.hydra_editor_utils as hydra
     from editor_python_test_tools.editor_entity_utils import EditorEntity
-    from editor_python_test_tools.wait_utils import PrefabWaiter
     from editor_python_test_tools.utils import Report
 
     # Open a simple level and instantiate BushFlowerBlender.prefab

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/ComponentUpdates_UpdateGraph.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/ComponentUpdates_UpdateGraph.py
@@ -90,7 +90,6 @@ def ComponentUpdates_UpdateGraph():
     import os
 
     import azlmbr.bus as bus
-    import azlmbr.editor as editor
     import azlmbr.entity as entity
     import azlmbr.legacy.general as general
     import azlmbr.landscapecanvas as landscapecanvas
@@ -98,8 +97,9 @@ def ComponentUpdates_UpdateGraph():
     import azlmbr.prefab as prefab
 
     import editor_python_test_tools.hydra_editor_utils as hydra
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.wait_utils import PrefabWaiter
     from editor_python_test_tools.utils import Report
-    from editor_python_test_tools.utils import TestHelper as helper
 
     # Open a simple level and instantiate BushFlowerBlender.prefab
     hydra.open_base_level()
@@ -107,96 +107,67 @@ def ComponentUpdates_UpdateGraph():
     position = math.Vector3(64.0, 64.0, 32.0)
     transform.invoke('SetPosition', position)
     test_prefab_path = os.path.join("Assets", "Prefabs", "BushFlowerBlender.prefab")
-    prefab_result = prefab.PrefabPublicRequestBus(bus.Broadcast, 'InstantiatePrefab', test_prefab_path,
+    prefab_result = prefab.PrefabPublicRequestBus(bus.Broadcast, "InstantiatePrefab", test_prefab_path,
                                                   entity.EntityId(), position)
     Report.critical_result(Tests.prefab_instantiated, prefab_result.IsSuccess())
 
     # Find root entity in the loaded level
-    search_filter = entity.SearchFilter()
-    search_filter.names = ["LandscapeCanvas"]
-
-    # Allow a few seconds for matching entity to be found
-    helper.wait_for_condition(lambda: len(entity.SearchBus(bus.Broadcast, 'SearchEntities', search_filter)) > 0, 5.0)
-    lc_matching_entities = entity.SearchBus(bus.Broadcast, 'SearchEntities', search_filter)
-    prefab_root_id = lc_matching_entities[0]         #Entity with Landscape Canvas component
-    Report.critical_result(Tests.lc_entity_found, prefab_root_id.IsValid())
+    prefab_root_entity = EditorEntity.find_editor_entity("LandscapeCanvas")
+    Report.critical_result(Tests.lc_entity_found, prefab_root_entity.id.IsValid())
 
     # Find the BushSpawner entity
-    search_filter.names = ["BushSpawner"]
-    spawner_matching_entities = entity.SearchBus(bus.Broadcast, 'SearchEntities', search_filter)
-    spawner_id = spawner_matching_entities[0]       #Entity with Vegetation Layer Spawner component
-    Report.critical_result(Tests.spawner_entity_found, spawner_id.IsValid())
-
-    # Get needed component type ids
-    distribution_filter_type_id = hydra.get_component_type_id("Vegetation Distribution Filter")
-    altitude_filter_type_id = hydra.get_component_type_id("Vegetation Altitude Filter")
-    box_shape_type_id = hydra.get_component_type_id("Box Shape")
+    bush_spawner_entity = EditorEntity.find_editor_entity("BushSpawner")
+    Report.critical_result(Tests.spawner_entity_found, bush_spawner_entity.id.IsValid())
 
     # Verify the BushSpawner entity has a Distribution Filter
-    has_distribution_filter = editor.EditorComponentAPIBus(bus.Broadcast, 'HasComponentOfType', spawner_id,
-                                                           distribution_filter_type_id)
+    has_distribution_filter = bush_spawner_entity.has_component("Vegetation Distribution Filter")
     Report.critical_result(Tests.dist_filter_component_found, has_distribution_filter)
 
     # Open Landscape Canvas and the existing graph
-    general.open_pane('Landscape Canvas')
-    open_graph = landscapecanvas.LandscapeCanvasRequestBus(bus.Broadcast, 'OnGraphEntity', prefab_root_id)
+    general.open_pane("Landscape Canvas")
+    open_graph = landscapecanvas.LandscapeCanvasRequestBus(bus.Broadcast, "OnGraphEntity", prefab_root_entity.id)
     Report.critical_result(Tests.existing_graph_opened, open_graph.IsValid())
 
     # Verify that Distribution Filter node is present on the graph
-    spawner_distribution_filter_component = editor.EditorComponentAPIBus(bus.Broadcast, 'GetComponentOfType', spawner_id,
-                                                                         distribution_filter_type_id)
-    spawner_distribution_filter_component_id = spawner_distribution_filter_component.GetValue()
-    distribution_filter_node = landscapecanvas.LandscapeCanvasRequestBus(bus.Broadcast,
-                                                                         'GetNodeMatchingEntityComponentInGraph',
-                                                                         open_graph,
-                                                                         spawner_distribution_filter_component_id)
-    Report.critical_result(Tests.dist_filter_node_found, distribution_filter_node is not None)
+    spawner_dist_filter_component = bush_spawner_entity.get_components_of_type(["Vegetation Distribution Filter"])[0]
+    spawner_dist_filter_nodes = landscapecanvas.LandscapeCanvasRequestBus(bus.Broadcast,
+                                                                          "GetAllNodesMatchingEntityComponent",
+                                                                          spawner_dist_filter_component.id)
+    Report.critical_result(Tests.dist_filter_node_found, len(spawner_dist_filter_nodes) > 0)
 
     # Add a Vegetation Altitude Filter component to the BushSpawner entity, and verify the node is added to the graph
-    spawner_altitude_filter_component = editor.EditorComponentAPIBus(bus.Broadcast, 'GetComponentOfType', spawner_id,
-                                                                     altitude_filter_type_id)
-    spawner_altitude_filter_component_id = spawner_altitude_filter_component.GetValue()
-    editor.EditorComponentAPIBus(bus.Broadcast, 'AddComponentOfType', spawner_id, altitude_filter_type_id)
-    has_altitude_filter = editor.EditorComponentAPIBus(bus.Broadcast, 'HasComponentOfType', spawner_id,
-                                                       altitude_filter_type_id)
-    altitude_filter_node = landscapecanvas.LandscapeCanvasRequestBus(bus.Broadcast, 'GetNodeMatchingEntityComponentInGraph',
-                                                                     open_graph, spawner_altitude_filter_component_id)
-    Report.result(Tests.dist_filter_component_found, has_altitude_filter)
-    Report.result(Tests.dist_filter_node_found, altitude_filter_node is not None)
+    spawner_alt_filter_component = bush_spawner_entity.add_component("Vegetation Altitude Filter")
+    has_altitude_filter = bush_spawner_entity.has_component("Vegetation Altitude Filter")
+    altitude_filter_nodes = landscapecanvas.LandscapeCanvasRequestBus(bus.Broadcast,
+                                                                      "GetAllNodesMatchingEntityComponent",
+                                                                      spawner_alt_filter_component.id)
+    Report.result(Tests.alt_filter_component_found, has_altitude_filter)
+    Report.result(Tests.alt_filter_node_found, len(altitude_filter_nodes) > 0)
 
     # Remove the Distribution Filter
-    editor.EditorComponentAPIBus(bus.Broadcast, 'RemoveComponents', [spawner_distribution_filter_component_id])
-    general.idle_wait(1.0)
+    bush_spawner_entity.remove_component("Vegetation Distribution Filter")
 
     # Verify the Distribution Filter was successfully removed from entity and the node was likewise removed
-    has_distribution_filter = editor.EditorComponentAPIBus(bus.Broadcast, 'HasComponentOfType', spawner_id,
-                                                           distribution_filter_type_id)
-    Report.result(Tests.dist_filter_component_removed, not has_distribution_filter)
-
-    distribution_filter_node = landscapecanvas.LandscapeCanvasRequestBus(bus.Broadcast,
-                                                                         'GetAllNodesMatchingEntityComponent',
-                                                                         spawner_distribution_filter_component_id)
-    Report.result(Tests.dist_filter_node_removed, not distribution_filter_node)
+    has_dist_filter = bush_spawner_entity.has_component("Vegetation Distribution Filter")
+    Report.result(Tests.dist_filter_component_removed, not has_dist_filter)
+    spawner_dist_filter_nodes = landscapecanvas.LandscapeCanvasRequestBus(bus.Broadcast,
+                                                                          "GetAllNodesMatchingEntityComponent",
+                                                                          spawner_dist_filter_component.id)
+    Report.result(Tests.dist_filter_node_removed, len(spawner_dist_filter_nodes) == 0)
 
     # Add a new child entity of BushSpawner entity
-    box_id = editor.ToolsApplicationRequestBus(bus.Broadcast, 'CreateNewEntity', spawner_id)
-    Report.result(Tests.child_entity_added, editor.EditorEntityInfoRequestBus(bus.Event, 'GetParent', box_id) ==
-                  spawner_id)
+    box_entity = EditorEntity.create_editor_entity("Box Child", parent_id=bush_spawner_entity.id)
+    Report.result(Tests.child_entity_added, box_entity.get_parent_id() == bush_spawner_entity.id)
 
     # Add a Box Shape component to the new entity and verify it was properly added
-    editor.EditorComponentAPIBus(bus.Broadcast, 'AddComponentOfType', box_id, box_shape_type_id)
-    has_box_shape = editor.EditorComponentAPIBus(bus.Broadcast, 'HasComponentOfType', box_id,
-                                                 box_shape_type_id)
+    box_shape_component = box_entity.add_component("Box Shape")
+    has_box_shape = box_entity.has_component("Box Shape")
     Report.result(Tests.box_shape_component_found, has_box_shape)
 
     # Verify the Box Shape node appears on the graph
-    box_shape_component = editor.EditorComponentAPIBus(bus.Broadcast, 'GetComponentOfType', box_id,
-                                                       box_shape_type_id)
-
-    box_shape_component_id = box_shape_component.GetValue()
-    box_shape_node = landscapecanvas.LandscapeCanvasRequestBus(bus.Broadcast, 'GetAllNodesMatchingEntityComponent',
-                                                               box_shape_component_id)
-    Report.result(Tests.box_shape_node_found, box_shape_node is not None)
+    box_shape_nodes = landscapecanvas.LandscapeCanvasRequestBus(bus.Broadcast, "GetAllNodesMatchingEntityComponent",
+                                                                box_shape_component.id)
+    Report.result(Tests.box_shape_node_found, len(box_shape_nodes) > 0)
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Levels/Base/Base.prefab
+++ b/AutomatedTesting/Levels/Base/Base.prefab
@@ -7,6 +7,11 @@
                 "$type": "EditorInspectorComponent",
                 "Id": 10641544592923449938
             },
+            "Component_[10994490130550932366]": {
+                "$type": "LocalViewBookmarkComponent",
+                "Id": 10994490130550932366,
+                "LocalBookmarkFileName": "Base_16637101422677413.setreg"
+            },
             "Component_[12039882709170782873]": {
                 "$type": "EditorOnlyEntityComponent",
                 "Id": 12039882709170782873
@@ -17,16 +22,7 @@
             },
             "Component_[14126657869720434043]": {
                 "$type": "EditorEntitySortComponent",
-                "Id": 14126657869720434043,
-                "ChildEntityOrderEntryArray": [
-                    {
-                        "EntityId": ""
-                    },
-                    {
-                        "EntityId": "",
-                        "SortIndex": 1
-                    }
-                ]
+                "Id": 14126657869720434043
             },
             "Component_[15230859088967841193]": {
                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -40,10 +36,6 @@
             "Component_[5688118765544765547]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 5688118765544765547
-            },
-            "Component_[6545738857812235305]": {
-                "$type": "SelectionComponent",
-                "Id": 6545738857812235305
             },
             "Component_[7247035804068349658]": {
                 "$type": "EditorPrefabComponent",


### PR DESCRIPTION
Signed-off-by: jckand-amzn <82226555+jckand-amzn@users.noreply.github.com>

## What does this PR do?

1. Test was passing when it should have been failing due to a few issues:
 * Calling GetValue() on an unsuccessful Outcome returned by GetComponentOfType()
 * The usage of GetNodeMatchingEntityComponentInGraph whose result can't be validated against None

2. To fix this, the test now:
 * Uses editor_entity_utils.py to ensure IsSuccess() is validated before GetValue() so garbage values aren't returned
 * Uses GetAllNodesMatchingEntityComponent whose result is a list that can be validated against using len()

3. This PR also updates several prefabs used in the test to remove the deprecated SelectionComponent warnings.

## How was this PR tested?
Ran updated test several times without issue.
