### PR TITLE
Procedural Prefabs | Disable dropping assets in the Entity Inspector

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -4560,6 +4560,12 @@ namespace AzToolsFramework
 
     void EntityPropertyEditor::dragEnterEvent(QDragEnterEvent* event)
     {
+        if (m_selectionContainsReadOnlyEntity)
+        {
+            event->ignore();
+            return;
+        }
+
         if (UpdateDrag(event->pos(), event->mouseButtons(), event->mimeData()))
         {
             event->accept();
@@ -4572,6 +4578,12 @@ namespace AzToolsFramework
 
     void EntityPropertyEditor::dragMoveEvent(QDragMoveEvent* event)
     {
+        if (m_selectionContainsReadOnlyEntity)
+        {
+            event->ignore();
+            return;
+        }
+
         if (UpdateDrag(event->pos(), event->mouseButtons(), event->mimeData()))
         {
             event->accept();
@@ -4814,6 +4826,11 @@ namespace AzToolsFramework
         if (m_isAlreadyQueuedRefresh)
         {
             return false; // can't drop while tree is rebuilding itself!
+        }
+
+        if (m_selectionContainsReadOnlyEntity)
+        {
+            return false;
         }
 
         const QRect globalRect(globalPos, globalPos);


### PR DESCRIPTION
Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>

## What does this PR do?
Disables the ability to drop assets into the Entity Inspector when a read-only entity is part of the selection. This prevents the ability to edit procedural prefabs this way.

## How was this PR tested?
Manual testing.
