### PR TITLE
Performed an audit over the O3DE codebase related to chrono clocks

### DIFF
--- a/Code/Editor/EditorToolsApplication.cpp
+++ b/Code/Editor/EditorToolsApplication.cpp
@@ -284,7 +284,7 @@ namespace EditorInternal
 
     AZStd::chrono::milliseconds EditorToolsApplication::EditorViewportInputTimeNow()
     {
-        const auto now = AZStd::chrono::high_resolution_clock::now();
+        const auto now = AZStd::chrono::steady_clock::now();
         return AZStd::chrono::time_point_cast<AZStd::chrono::milliseconds>(now).time_since_epoch();
     }
 } // namespace EditorInternal

--- a/Code/Editor/Lib/Tests/test_CryEditPythonBindings.cpp
+++ b/Code/Editor/Lib/Tests/test_CryEditPythonBindings.cpp
@@ -96,7 +96,7 @@ namespace CryEditPythonBindingsUnitTests
         QTimer timer;
         loop.connect(&timer, &QTimer::timeout, [&numTicks]()
         {
-            AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick, 0.01f, AZ::ScriptTimePoint(AZStd::chrono::system_clock().now()));
+            AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick, 0.01f, AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
             ++numTicks;
         });
         timer.start(100);

--- a/Code/Framework/AtomCore/Tests/InstanceDatabase.cpp
+++ b/Code/Framework/AtomCore/Tests/InstanceDatabase.cpp
@@ -355,7 +355,7 @@ namespace UnitTest
             AZStd::unique_lock<AZStd::mutex> lock(mutex);
             timedOut =
                 (AZStd::cv_status::timeout ==
-                 cv.wait_until(lock, AZStd::chrono::system_clock::now() + AZStd::chrono::seconds(1)));
+                 cv.wait_until(lock, AZStd::chrono::steady_clock::now() + AZStd::chrono::seconds(1)));
         }
 
         EXPECT_TRUE(threadCount == 0) << "One or more threads appear to be deadlocked at " << timer.GetDeltaTimeInSeconds() << " seconds";

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -2223,14 +2223,14 @@ namespace AZ::Data
         const AssetFilterCB& assetLoadFilterCB)
     {
 #ifdef AZ_ENABLE_TRACING
-        auto start = AZStd::chrono::system_clock::now();
+        auto start = AZStd::chrono::steady_clock::now();
 #endif
 
         LoadResult result = LoadAssetData(asset, stream, assetLoadFilterCB);
 
 #ifdef AZ_ENABLE_TRACING
         auto loadMs = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(
-            AZStd::chrono::system_clock::now() - start);
+            AZStd::chrono::steady_clock::now() - start);
         if (loadMs.count() > 0)
         {
             const double seconds = loadMs.count() / 1000.0;

--- a/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
@@ -231,12 +231,12 @@ namespace AZ::Debug
     Trace::WaitForDebugger([[maybe_unused]] float timeoutSeconds/*=-1.f*/)
     {
 #if defined(AZ_ENABLE_DEBUG_TOOLS)
-        using AZStd::chrono::system_clock;
+        using AZStd::chrono::steady_clock;
         using AZStd::chrono::time_point;
         using AZStd::chrono::milliseconds;
 
         milliseconds timeoutMs = milliseconds(aznumeric_cast<long long>(timeoutSeconds * 1000));
-        system_clock clock;
+        steady_clock clock;
         time_point start = clock.now();
         auto hasTimedOut = [&clock, start, timeoutMs]()
         {

--- a/Code/Framework/AzCore/AzCore/IO/IStreamer.h
+++ b/Code/Framework/AzCore/AzCore/IO/IStreamer.h
@@ -336,7 +336,7 @@ namespace AZ::IO
         //! an estimation.
         //! @param request The request to get the estimation for.
         //! @return The system time the request will complete or zero of no estimation has been done.
-        virtual AZStd::chrono::system_clock::time_point GetEstimatedRequestCompletionTime(FileRequestHandle request) const = 0;
+        virtual AZStd::chrono::steady_clock::time_point GetEstimatedRequestCompletionTime(FileRequestHandle request) const = 0;
 
         //! Get the result for operations that read data.
         //! @param request The request to query.

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/BlockCache.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/BlockCache.cpp
@@ -195,7 +195,7 @@ namespace AZ::IO
             m_delayedSections.empty();
     }
 
-    void BlockCache::UpdateCompletionEstimates(AZStd::chrono::system_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
+    void BlockCache::UpdateCompletionEstimates(AZStd::chrono::steady_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
         StreamerContext::PreparedQueue::iterator pendingBegin, StreamerContext::PreparedQueue::iterator pendingEnd)
     {
         // Have the stack downstream estimate the completion time for the requests that are waiting for a slot to execute in.
@@ -688,7 +688,7 @@ namespace AZ::IO
     void BlockCache::TouchBlock(u32 index)
     {
         AZ_Assert(index < m_numBlocks, "Index for touch a cache entry in the BlockCache is out of bounds.");
-        m_blockLastTouched[index] = AZStd::chrono::system_clock::now();
+        m_blockLastTouched[index] = AZStd::chrono::steady_clock::now();
     }
 
     u32 BlockCache::RecycleOldestBlock(const RequestPath& filePath, u64 offset)

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/BlockCache.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/BlockCache.h
@@ -73,7 +73,7 @@ namespace AZ::IO
         bool ExecuteRequests() override;
 
         void UpdateStatus(Status& status) const override;
-        void UpdateCompletionEstimates(AZStd::chrono::system_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
+        void UpdateCompletionEstimates(AZStd::chrono::steady_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
             StreamerContext::PreparedQueue::iterator pendingBegin, StreamerContext::PreparedQueue::iterator pendingEnd) override;
         void AddDelayedRequests(AZStd::vector<FileRequest*>& internalPending);
         void UpdatePendingRequestEstimations();
@@ -114,7 +114,7 @@ namespace AZ::IO
             void Prefix(const Section& section);
         };
 
-        using TimePoint = AZStd::chrono::system_clock::time_point;
+        using TimePoint = AZStd::chrono::steady_clock::time_point;
 
         void ReadFile(FileRequest* request, Requests::ReadData& data);
         void ContinueReadFile(FileRequest* request, u64 fileLength);

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/DedicatedCache.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/DedicatedCache.cpp
@@ -187,7 +187,7 @@ namespace AZ::IO
         StreamStackEntry::UpdateStatus(status);
     }
 
-    void DedicatedCache::UpdateCompletionEstimates(AZStd::chrono::system_clock::time_point now,
+    void DedicatedCache::UpdateCompletionEstimates(AZStd::chrono::steady_clock::time_point now,
         AZStd::vector<FileRequest*>& internalPending, StreamerContext::PreparedQueue::iterator pendingBegin,
         StreamerContext::PreparedQueue::iterator pendingEnd)
     {

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/DedicatedCache.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/DedicatedCache.h
@@ -64,7 +64,7 @@ namespace AZ::IO
         void UpdateStatus(Status& status) const override;
 
         void UpdateCompletionEstimates(
-            AZStd::chrono::system_clock::time_point now,
+            AZStd::chrono::steady_clock::time_point now,
             AZStd::vector<FileRequest*>& internalPending,
             StreamerContext::PreparedQueue::iterator pendingBegin,
             StreamerContext::PreparedQueue::iterator pendingEnd) override;

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.cpp
@@ -34,7 +34,7 @@ namespace AZ::IO::Requests
         u64 outputSize,
         u64 offset,
         u64 size,
-        AZStd::chrono::system_clock::time_point deadline,
+        AZStd::chrono::steady_clock::time_point deadline,
         IStreamerTypes::Priority priority)
         : m_path(AZStd::move(path))
         , m_allocator(nullptr)
@@ -53,7 +53,7 @@ namespace AZ::IO::Requests
         IStreamerTypes::RequestMemoryAllocator* allocator,
         u64 offset,
         u64 size,
-        AZStd::chrono::system_clock::time_point deadline,
+        AZStd::chrono::steady_clock::time_point deadline,
         IStreamerTypes::Priority priority)
         : m_path(AZStd::move(path))
         , m_allocator(allocator)
@@ -131,7 +131,7 @@ namespace AZ::IO::Requests
 
     RescheduleData::RescheduleData(
         FileRequestPtr target,
-        AZStd::chrono::system_clock::time_point newDeadline,
+        AZStd::chrono::steady_clock::time_point newDeadline,
         IStreamerTypes::Priority newPriority)
         : m_target(AZStd::move(target))
         , m_newDeadline(newDeadline)
@@ -188,7 +188,7 @@ namespace AZ::IO
     }
 
     void FileRequest::CreateReadRequest(RequestPath path, void* output, u64 outputSize, u64 offset, u64 size,
-        AZStd::chrono::system_clock::time_point deadline, IStreamerTypes::Priority priority)
+        AZStd::chrono::steady_clock::time_point deadline, IStreamerTypes::Priority priority)
     {
         AZ_Assert(AZStd::holds_alternative<AZStd::monostate>(m_command),
             "Attempting to set FileRequest to 'ReadRequest', but another task was already assigned.");
@@ -196,7 +196,7 @@ namespace AZ::IO
     }
 
     void FileRequest::CreateReadRequest(RequestPath path, IStreamerTypes::RequestMemoryAllocator* allocator, u64 offset, u64 size,
-        AZStd::chrono::system_clock::time_point deadline, IStreamerTypes::Priority priority)
+        AZStd::chrono::steady_clock::time_point deadline, IStreamerTypes::Priority priority)
     {
         AZ_Assert(AZStd::holds_alternative<AZStd::monostate>(m_command),
             "Attempting to set FileRequest to 'ReadRequest', but another task was already assigned.");
@@ -256,7 +256,7 @@ namespace AZ::IO
         m_command.emplace<Requests::CancelData>(AZStd::move(target));
     }
 
-    void FileRequest::CreateReschedule(FileRequestPtr target, AZStd::chrono::system_clock::time_point newDeadline,
+    void FileRequest::CreateReschedule(FileRequestPtr target, AZStd::chrono::steady_clock::time_point newDeadline,
         IStreamerTypes::Priority newPriority)
     {
         AZ_Assert(AZStd::holds_alternative<AZStd::monostate>(m_command),
@@ -407,7 +407,7 @@ namespace AZ::IO
     {
         m_command = AZStd::monostate{};
         m_onCompletion = &OnCompletionPlaceholder;
-        m_estimatedCompletion = AZStd::chrono::system_clock::time_point();
+        m_estimatedCompletion = AZStd::chrono::steady_clock::time_point();
         m_parent = nullptr;
         m_status = IStreamerTypes::RequestStatus::Pending;
         m_dependencies = 0;
@@ -447,7 +447,7 @@ namespace AZ::IO
         return m_pendingId;
     }
 
-    void FileRequest::SetEstimatedCompletion(AZStd::chrono::system_clock::time_point time)
+    void FileRequest::SetEstimatedCompletion(AZStd::chrono::steady_clock::time_point time)
     {
         FileRequest* current = this;
         do
@@ -457,7 +457,7 @@ namespace AZ::IO
         } while (current);
     }
 
-    AZStd::chrono::system_clock::time_point FileRequest::GetEstimatedCompletion() const
+    AZStd::chrono::steady_clock::time_point FileRequest::GetEstimatedCompletion() const
     {
         return m_estimatedCompletion;
     }

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/FileRequest.h
@@ -62,20 +62,20 @@ namespace AZ::IO::Requests
             u64 outputSize,
             u64 offset,
             u64 size,
-            AZStd::chrono::system_clock::time_point deadline,
+            AZStd::chrono::steady_clock::time_point deadline,
             IStreamerTypes::Priority priority);
         ReadRequestData(
             RequestPath path,
             IStreamerTypes::RequestMemoryAllocator* allocator,
             u64 offset,
             u64 size,
-            AZStd::chrono::system_clock::time_point deadline,
+            AZStd::chrono::steady_clock::time_point deadline,
             IStreamerTypes::Priority priority);
         ~ReadRequestData();
 
         RequestPath m_path; //!< Relative path to the target file.
         IStreamerTypes::RequestMemoryAllocator* m_allocator; //!< Allocator used to manage the memory for this request.
-        AZStd::chrono::system_clock::time_point m_deadline; //!< Time by which this request should have been completed.
+        AZStd::chrono::steady_clock::time_point m_deadline; //!< Time by which this request should have been completed.
         void* m_output; //!< The memory address assigned (during processing) to store the read data to.
         u64 m_outputSize; //!< The memory size of the addressed used to store the read data.
         u64 m_offset; //!< The offset in bytes into the file.
@@ -211,10 +211,10 @@ namespace AZ::IO::Requests
         inline constexpr static IStreamerTypes::Priority s_orderPriority = IStreamerTypes::s_priorityHigh;
         inline constexpr static bool s_failWhenUnhandled = false;
 
-        RescheduleData(FileRequestPtr target, AZStd::chrono::system_clock::time_point newDeadline, IStreamerTypes::Priority newPriority);
+        RescheduleData(FileRequestPtr target, AZStd::chrono::steady_clock::time_point newDeadline, IStreamerTypes::Priority newPriority);
 
         FileRequestPtr m_target; //!< The request that will be rescheduled.
-        AZStd::chrono::system_clock::time_point m_newDeadline; //!< The new deadline for the request.
+        AZStd::chrono::steady_clock::time_point m_newDeadline; //!< The new deadline for the request.
         IStreamerTypes::Priority m_newPriority; //!< The new priority for the request.
     };
 
@@ -273,7 +273,7 @@ namespace AZ::IO
     class FileRequest final
     {
     public:
-        inline constexpr static AZStd::chrono::system_clock::time_point s_noDeadlineTime = AZStd::chrono::system_clock::time_point::max();
+        inline constexpr static AZStd::chrono::steady_clock::time_point s_noDeadlineTime = AZStd::chrono::steady_clock::time_point::max();
 
         friend class StreamerContext;
         friend class ExternalFileRequest;
@@ -292,9 +292,9 @@ namespace AZ::IO
         void CreateRequestLink(FileRequestPtr&& request);
         void CreateRequestPathStore(FileRequest* parent, RequestPath path);
         void CreateReadRequest(RequestPath path, void* output, u64 outputSize, u64 offset, u64 size,
-            AZStd::chrono::system_clock::time_point deadline, IStreamerTypes::Priority priority);
+            AZStd::chrono::steady_clock::time_point deadline, IStreamerTypes::Priority priority);
         void CreateReadRequest(RequestPath path, IStreamerTypes::RequestMemoryAllocator* allocator, u64 offset, u64 size,
-            AZStd::chrono::system_clock::time_point deadline, IStreamerTypes::Priority priority);
+            AZStd::chrono::steady_clock::time_point deadline, IStreamerTypes::Priority priority);
         void CreateRead(FileRequest* parent, void* output, u64 outputSize, const RequestPath& path, u64 offset, u64 size, bool sharedRead = false);
         void CreateCompressedRead(FileRequest* parent, const CompressionInfo& compressionInfo, void* output,
             u64 readOffset, u64 readSize);
@@ -304,7 +304,7 @@ namespace AZ::IO
         void CreateFileExistsCheck(const RequestPath& path);
         void CreateFileMetaDataRetrieval(const RequestPath& path);
         void CreateCancel(FileRequestPtr target);
-        void CreateReschedule(FileRequestPtr target, AZStd::chrono::system_clock::time_point newDeadline, IStreamerTypes::Priority newPriority);
+        void CreateReschedule(FileRequestPtr target, AZStd::chrono::steady_clock::time_point newDeadline, IStreamerTypes::Priority newPriority);
         void CreateFlush(RequestPath path);
         void CreateFlushAll();
         void CreateDedicatedCacheCreation(RequestPath path, const FileRange& range = {}, FileRequest* parent = nullptr);
@@ -341,8 +341,8 @@ namespace AZ::IO
         //! Set the estimated completion time for this request and it's immediate parent. The general approach
         //! to getting the final estimation is to bubble up the estimation, with ever entry in the stack adding
         //! it's own additional delay.
-        void SetEstimatedCompletion(AZStd::chrono::system_clock::time_point time);
-        AZStd::chrono::system_clock::time_point GetEstimatedCompletion() const;
+        void SetEstimatedCompletion(AZStd::chrono::steady_clock::time_point time);
+        AZStd::chrono::steady_clock::time_point GetEstimatedCompletion() const;
 
     private:
         explicit FileRequest(Usage usage = Usage::Internal);
@@ -358,7 +358,7 @@ namespace AZ::IO
 
         //! Estimated time this request will complete. This is an estimation and depends on many
         //! factors which can cause it to change drastically from moment to moment.
-        AZStd::chrono::system_clock::time_point m_estimatedCompletion;
+        AZStd::chrono::steady_clock::time_point m_estimatedCompletion;
 
         //! The file request that has a dependency on this one. This can be null if there are no
         //! other request depending on this one to complete.

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/FullFileDecompressor.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/FullFileDecompressor.cpp
@@ -187,7 +187,7 @@ namespace AZ::IO
         status.m_isIdle = status.m_isIdle && IsIdle();
     }
 
-    void FullFileDecompressor::UpdateCompletionEstimates(AZStd::chrono::system_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
+    void FullFileDecompressor::UpdateCompletionEstimates(AZStd::chrono::steady_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
         StreamerContext::PreparedQueue::iterator pendingBegin, StreamerContext::PreparedQueue::iterator pendingEnd)
     {
         // Create predictions for all pending requests. Some will be further processed after this.
@@ -232,7 +232,7 @@ namespace AZ::IO
         AZStd::chrono::microseconds smallestDecompressionDuration = AZStd::chrono::microseconds::max();
         for (u32 i = 0; i < m_maxNumReads; ++i)
         {
-            AZStd::chrono::system_clock::time_point baseTime;
+            AZStd::chrono::steady_clock::time_point baseTime;
             switch (m_readBufferStatus[i])
             {
             case ReadBufferStatus::Unused:
@@ -241,7 +241,7 @@ namespace AZ::IO
                 // Internal read requests can start and complete but pending finalization before they're ever scheduled in which case
                 // the estimated time is not set.
                 baseTime = m_readRequests[i]->GetEstimatedCompletion();
-                if (baseTime == AZStd::chrono::system_clock::time_point())
+                if (baseTime == AZStd::chrono::steady_clock::time_point())
                 {
                     baseTime = now;
                 }
@@ -637,7 +637,7 @@ namespace AZ::IO
 
                 DecompressionInformation& info = m_processingJobs[jobSlot];
                 info.m_waitRequest = waitRequest;
-                info.m_queueStartTime = AZStd::chrono::system_clock::now();
+                info.m_queueStartTime = AZStd::chrono::steady_clock::now();
                 info.m_jobStartTime = info.m_queueStartTime; // Set these to the same in case the scheduler requests an update before the job has started.
                 info.m_compressedData = m_readBuffers[readSlot]; // Transfer ownership of the pointer.
                 m_readBuffers[readSlot] = nullptr;
@@ -693,7 +693,7 @@ namespace AZ::IO
         DecompressionInformation& jobInfo = m_processingJobs[jobSlot];
         AZ_Assert(jobInfo.m_waitRequest == waitRequest, "Job slot didn't contain the expected wait request.");
 
-        auto endTime = AZStd::chrono::system_clock::now();
+        auto endTime = AZStd::chrono::steady_clock::now();
 
         FileRequest* compressedRequest = jobInfo.m_waitRequest->GetParent();
         AZ_Assert(compressedRequest, "A wait request attached to FullFileDecompressor was completed but didn't have a parent compressed request.");
@@ -723,7 +723,7 @@ namespace AZ::IO
 
     void FullFileDecompressor::FullDecompression(StreamerContext* context, DecompressionInformation& info)
     {
-        info.m_jobStartTime = AZStd::chrono::system_clock::now();
+        info.m_jobStartTime = AZStd::chrono::steady_clock::now();
 
         FileRequest* compressedRequest = info.m_waitRequest->GetParent();
         AZ_Assert(compressedRequest, "A wait request attached to FullFileDecompressor was completed but didn't have a parent compressed request.");
@@ -748,7 +748,7 @@ namespace AZ::IO
 
     void FullFileDecompressor::PartialDecompression(StreamerContext* context, DecompressionInformation& info)
     {
-        info.m_jobStartTime = AZStd::chrono::system_clock::now();
+        info.m_jobStartTime = AZStd::chrono::steady_clock::now();
 
         FileRequest* compressedRequest = info.m_waitRequest->GetParent();
         AZ_Assert(compressedRequest, "A wait request attached to FullFileDecompressor was completed but didn't have a parent compressed request.");

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/FullFileDecompressor.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/FullFileDecompressor.h
@@ -65,7 +65,7 @@ namespace AZ::IO
         bool ExecuteRequests() override;
 
         void UpdateStatus(Status& status) const override;
-        void UpdateCompletionEstimates(AZStd::chrono::system_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
+        void UpdateCompletionEstimates(AZStd::chrono::steady_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
             StreamerContext::PreparedQueue::iterator pendingBegin, StreamerContext::PreparedQueue::iterator pendingEnd) override;
 
         void CollectStatistics(AZStd::vector<Statistic>& statistics) const override;
@@ -84,8 +84,8 @@ namespace AZ::IO
         {
             bool IsProcessing() const;
 
-            AZStd::chrono::system_clock::time_point m_queueStartTime;
-            AZStd::chrono::system_clock::time_point m_jobStartTime;
+            AZStd::chrono::steady_clock::time_point m_queueStartTime;
+            AZStd::chrono::steady_clock::time_point m_jobStartTime;
             Buffer m_compressedData{ nullptr };
             FileRequest* m_waitRequest{ nullptr };
             u32 m_alignmentOffset{ 0 };

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/Scheduler.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/Scheduler.cpp
@@ -248,7 +248,7 @@ namespace AZ::IO
             m_threadData.m_streamStack->UpdateStatus(m_stackStatus);
             if (m_stackStatus.m_isIdle)
             {
-                auto duration = AZStd::chrono::system_clock::now() - m_processingStartTime;
+                auto duration = AZStd::chrono::steady_clock::now() - m_processingStartTime;
                 auto durationSec = AZStd::chrono::duration_cast<AZStd::chrono::duration<double>>(duration);
                 m_processingSpeedStat.PushEntry(m_processingSize / durationSec.count());
                 m_processingSize = 0;
@@ -316,7 +316,7 @@ namespace AZ::IO
 #if AZ_STREAMER_ADD_EXTRA_PROFILING_INFO
                 if (m_processingSize == 0)
                 {
-                    m_processingStartTime = AZStd::chrono::system_clock::now();
+                    m_processingStartTime = AZStd::chrono::steady_clock::now();
                 }
 #endif
 
@@ -397,7 +397,7 @@ namespace AZ::IO
         }
 
 #if AZ_STREAMER_ADD_EXTRA_PROFILING_INFO
-        AZStd::chrono::system_clock::time_point now = AZStd::chrono::system_clock::now();
+        AZStd::chrono::steady_clock::time_point now = AZStd::chrono::steady_clock::now();
         auto visitor = [this, now](auto&& args) -> void
 #else
         auto visitor = [](auto&& args) -> void
@@ -612,7 +612,7 @@ namespace AZ::IO
 #endif
         AZ_PROFILE_FUNCTION(AzCore);
 
-        AZStd::chrono::system_clock::time_point now = AZStd::chrono::system_clock::now();
+        AZStd::chrono::steady_clock::time_point now = AZStd::chrono::steady_clock::now();
         auto& pendingQueue = m_context.GetPreparedRequests();
 
         m_threadData.m_streamStack->UpdateCompletionEstimates(now, m_threadData.m_internalPendingRequests,

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/Scheduler.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/Scheduler.h
@@ -102,7 +102,7 @@ namespace AZ::IO
 
         StreamStackEntry::Status m_stackStatus;
 #if AZ_STREAMER_ADD_EXTRA_PROFILING_INFO
-        AZStd::chrono::system_clock::time_point m_processingStartTime;
+        AZStd::chrono::steady_clock::time_point m_processingStartTime;
         size_t m_processingSize{ 0 };
         //! Indication of how efficient the scheduler works. For loose files a large gap with the read speed of
         //! the storage drive means that the scheduler is having to spend too much time between requests. For archived

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/Statistics.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/Statistics.h
@@ -269,7 +269,7 @@ namespace AZ::IO
         AverageType CalculateAverage() const
         {
             size_t count = m_count > 0 ? m_count : 1;
-            return static_cast<AverageType>(static_cast<AverageType>(m_runningTotal) / static_cast<AverageType>(count < WindowSize ? count : WindowSize)); 
+            return static_cast<AverageType>(static_cast<AverageType>(m_runningTotal) / static_cast<AverageType>(count < WindowSize ? count : WindowSize));
         }
         //! Gets the running total of the values in the window.
         StorageType GetTotal() const { return m_runningTotal; }
@@ -290,7 +290,7 @@ namespace AZ::IO
 
     template<size_t WindowSize>
     using TimedAverageWindow = AverageWindow<Statistic::TimeValue, Statistic::TimeValue, WindowSize>;
-        
+
     template<size_t WindowSize>
     class TimedAverageWindowScope
     {
@@ -298,19 +298,19 @@ namespace AZ::IO
         explicit TimedAverageWindowScope(TimedAverageWindow<WindowSize>& window)
             : m_window(window)
         {
-            m_startTime = AZStd::chrono::system_clock::now();
+            m_startTime = AZStd::chrono::steady_clock::now();
         }
-            
+
         ~TimedAverageWindowScope()
         {
-            AZStd::chrono::system_clock::time_point now = AZStd::chrono::system_clock::now();
+            AZStd::chrono::steady_clock::time_point now = AZStd::chrono::steady_clock::now();
             Statistic::TimeValue duration = AZStd::chrono::duration_cast<Statistic::TimeValue>(now - m_startTime);
             m_window.PushEntry(duration);
         }
 
     private:
         TimedAverageWindow<WindowSize>& m_window;
-        AZStd::chrono::system_clock::time_point m_startTime;
+        AZStd::chrono::steady_clock::time_point m_startTime;
     };
 
 #define TIMED_AVERAGE_WINDOW_SCOPE(window) TimedAverageWindowScope<decltype(window)::s_windowSize> TIMED_AVERAGE_WINDOW##__COUNTER__ (window)

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StorageDrive.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StorageDrive.cpp
@@ -41,7 +41,7 @@ namespace AZ::IO
     StorageDrive::StorageDrive(u32 maxFileHandles)
         : StreamStackEntry("Storage drive (generic)")
     {
-        m_fileLastUsed.resize(maxFileHandles, AZStd::chrono::system_clock::time_point::min());
+        m_fileLastUsed.resize(maxFileHandles, AZStd::chrono::steady_clock::time_point::min());
         m_filePaths.resize(maxFileHandles);
         m_fileHandles.resize(maxFileHandles);
 
@@ -156,7 +156,7 @@ namespace AZ::IO
         }
     }
 
-    void StorageDrive::UpdateCompletionEstimates(AZStd::chrono::system_clock::time_point now,
+    void StorageDrive::UpdateCompletionEstimates(AZStd::chrono::steady_clock::time_point now,
         AZStd::vector<FileRequest*>& internalPending, StreamerContext::PreparedQueue::iterator pendingBegin,
         StreamerContext::PreparedQueue::iterator pendingEnd)
     {
@@ -189,7 +189,7 @@ namespace AZ::IO
         }
     }
 
-    void StorageDrive::EstimateCompletionTimeForRequest(FileRequest* request, AZStd::chrono::system_clock::time_point& startTime,
+    void StorageDrive::EstimateCompletionTimeForRequest(FileRequest* request, AZStd::chrono::steady_clock::time_point& startTime,
         const RequestPath*& activeFile, u64& activeOffset) const
     {
         u64 readSize = 0;
@@ -264,14 +264,14 @@ namespace AZ::IO
         if (cacheIndex != s_fileNotFound)
         {
             file = m_fileHandles[cacheIndex].get();
-            m_fileLastUsed[cacheIndex] = AZStd::chrono::system_clock::now();
+            m_fileLastUsed[cacheIndex] = AZStd::chrono::steady_clock::now();
         }
 
         // If the file is not open, eject the entry from the cache that hasn't been used for the longest time
         // and open the file for reading.
         if (!file)
         {
-            AZStd::chrono::system_clock::time_point oldest = m_fileLastUsed[0];
+            AZStd::chrono::steady_clock::time_point oldest = m_fileLastUsed[0];
             cacheIndex = 0;
             size_t numFiles = m_filePaths.size();
             for (size_t i = 1; i < numFiles; ++i)
@@ -294,7 +294,7 @@ namespace AZ::IO
             }
 
             file = newFile.get();
-            m_fileLastUsed[cacheIndex] = AZStd::chrono::system_clock::now();
+            m_fileLastUsed[cacheIndex] = AZStd::chrono::steady_clock::now();
             m_fileHandles[cacheIndex] = AZStd::move(newFile);
             m_filePaths[cacheIndex] = data->m_path;
         }
@@ -395,7 +395,7 @@ namespace AZ::IO
         size_t cacheIndex = FindFileInCache(filePath);
         if (cacheIndex != s_fileNotFound)
         {
-            m_fileLastUsed[cacheIndex] = AZStd::chrono::system_clock::time_point();
+            m_fileLastUsed[cacheIndex] = AZStd::chrono::steady_clock::time_point();
             m_fileHandles[cacheIndex].reset();
             m_filePaths[cacheIndex].Clear();
         }
@@ -406,7 +406,7 @@ namespace AZ::IO
         size_t numFiles = m_filePaths.size();
         for (size_t i = 0; i < numFiles; ++i)
         {
-            m_fileLastUsed[i] = AZStd::chrono::system_clock::time_point();
+            m_fileLastUsed[i] = AZStd::chrono::steady_clock::time_point();
             m_fileHandles[i].reset();
             m_filePaths[i].Clear();
         }

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StorageDrive.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StorageDrive.h
@@ -58,7 +58,7 @@ namespace AZ::IO
         bool ExecuteRequests() override;
 
         void UpdateStatus(Status& status) const override;
-        void UpdateCompletionEstimates(AZStd::chrono::system_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
+        void UpdateCompletionEstimates(AZStd::chrono::steady_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
             StreamerContext::PreparedQueue::iterator pendingBegin, StreamerContext::PreparedQueue::iterator pendingEnd) override;
 
         void CollectStatistics(AZStd::vector<Statistic>& statistics) const override;
@@ -75,7 +75,7 @@ namespace AZ::IO
         void FlushCache(const RequestPath& filePath);
         void FlushEntireCache();
 
-        void EstimateCompletionTimeForRequest(FileRequest* request, AZStd::chrono::system_clock::time_point& startTime,
+        void EstimateCompletionTimeForRequest(FileRequest* request, AZStd::chrono::steady_clock::time_point& startTime,
             const RequestPath*& activeFile, u64& activeOffset) const;
 
         void Report(const Requests::ReportData& data) const;
@@ -89,7 +89,7 @@ namespace AZ::IO
         AZStd::deque<FileRequest*> m_pendingRequests;
 
         //! The last time a file handle was used to access a file. The handle is stored in m_fileHandles.
-        AZStd::vector<AZStd::chrono::system_clock::time_point> m_fileLastUsed;
+        AZStd::vector<AZStd::chrono::steady_clock::time_point> m_fileLastUsed;
         //! The file path to the file handle. The handle is stored in m_fileHandles.
         AZStd::vector<RequestPath> m_filePaths;
         //! A list of file handles that's being cached in case they're needed again in the future.

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StreamStackEntry.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StreamStackEntry.cpp
@@ -80,7 +80,7 @@ namespace AZ
             }
         }
 
-        void StreamStackEntry::UpdateCompletionEstimates(AZStd::chrono::system_clock::time_point now,
+        void StreamStackEntry::UpdateCompletionEstimates(AZStd::chrono::steady_clock::time_point now,
             AZStd::vector<FileRequest*>& internalPending, StreamerContext::PreparedQueue::iterator pendingBegin,
             StreamerContext::PreparedQueue::iterator pendingEnd)
         {

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StreamStackEntry.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StreamStackEntry.h
@@ -83,7 +83,7 @@ namespace AZ
             //!     from the bottom to the top, this list should be processed in reverse order.
             //! @param pendingBegin Iterator pointing to the start of the requests that are waiting for a processing slot in the stack.
             //! @param pendingEnd Iterator pointing to the end of the requests that are waiting for a processing slot in the stack.
-            virtual void UpdateCompletionEstimates(AZStd::chrono::system_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
+            virtual void UpdateCompletionEstimates(AZStd::chrono::steady_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
                 StreamerContext::PreparedQueue::iterator pendingBegin, StreamerContext::PreparedQueue::iterator pendingEnd);
 
             //! Collect various statistics on this stack entry. These are for profiling and debugging

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/Streamer.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/Streamer.cpp
@@ -28,9 +28,9 @@ namespace AZ::IO
     FileRequestPtr& Streamer::Read(FileRequestPtr& request, AZStd::string_view relativePath, void* outputBuffer,
         size_t outputBufferSize, size_t readSize, IStreamerTypes::Deadline deadline, IStreamerTypes::Priority priority, size_t offset)
     {
-        AZStd::chrono::system_clock::time_point deadlineTimePoint = (deadline == IStreamerTypes::s_noDeadline)
+        AZStd::chrono::steady_clock::time_point deadlineTimePoint = (deadline == IStreamerTypes::s_noDeadline)
             ? FileRequest::s_noDeadlineTime
-            : AZStd::chrono::system_clock::now() + deadline;
+            : AZStd::chrono::steady_clock::now() + deadline;
         request->m_request.CreateReadRequest(
             RequestPath(relativePath), outputBuffer, outputBufferSize, offset, readSize, deadlineTimePoint, priority);
         return request;
@@ -47,9 +47,9 @@ namespace AZ::IO
     FileRequestPtr& Streamer::Read(FileRequestPtr& request, AZStd::string_view relativePath, IStreamerTypes::RequestMemoryAllocator& allocator,
         size_t size, IStreamerTypes::Deadline deadline, IStreamerTypes::Priority priority, size_t offset)
     {
-        AZStd::chrono::system_clock::time_point deadlineTimePoint = (deadline == IStreamerTypes::s_noDeadline)
+        AZStd::chrono::steady_clock::time_point deadlineTimePoint = (deadline == IStreamerTypes::s_noDeadline)
             ? FileRequest::s_noDeadlineTime
-            : AZStd::chrono::system_clock::now() + deadline;
+            : AZStd::chrono::steady_clock::now() + deadline;
         request->m_request.CreateReadRequest(RequestPath(relativePath), &allocator, offset, size, deadlineTimePoint, priority);
         return request;
     }
@@ -78,9 +78,9 @@ namespace AZ::IO
     FileRequestPtr& Streamer::RescheduleRequest(FileRequestPtr& request, FileRequestPtr target, IStreamerTypes::Deadline newDeadline,
         IStreamerTypes::Priority newPriority)
     {
-        AZStd::chrono::system_clock::time_point deadlineTimePoint = (newDeadline == IStreamerTypes::s_noDeadline)
+        AZStd::chrono::steady_clock::time_point deadlineTimePoint = (newDeadline == IStreamerTypes::s_noDeadline)
             ? FileRequest::s_noDeadlineTime
-            : AZStd::chrono::system_clock::now() + newDeadline;
+            : AZStd::chrono::steady_clock::now() + newDeadline;
         request->m_request.CreateReschedule(AZStd::move(target), deadlineTimePoint, newPriority);
         return request;
     }
@@ -193,7 +193,7 @@ namespace AZ::IO
         return request.m_request->GetStatus();
     }
 
-    AZStd::chrono::system_clock::time_point Streamer::GetEstimatedRequestCompletionTime(FileRequestHandle request) const
+    AZStd::chrono::steady_clock::time_point Streamer::GetEstimatedRequestCompletionTime(FileRequestHandle request) const
     {
         AZ_Assert(request.m_request, "The request handle provided to Streamer::GetEstimatedRequestCompletionTime is invalid.");
         return request.m_request->GetEstimatedCompletion();

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/Streamer.h
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/Streamer.h
@@ -161,7 +161,7 @@ namespace AZ::IO
         IStreamerTypes::RequestStatus GetRequestStatus(FileRequestHandle request) const override;
 
         //! Returns the time that the provided request will complete.
-        AZStd::chrono::system_clock::time_point GetEstimatedRequestCompletionTime(FileRequestHandle request) const override;
+        AZStd::chrono::steady_clock::time_point GetEstimatedRequestCompletionTime(FileRequestHandle request) const override;
 
         //! Gets the result for operations that read data.
         bool GetReadRequestResult(FileRequestHandle request, void*& buffer, u64& numBytesRead,

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerContext.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/StreamerContext.cpp
@@ -160,7 +160,7 @@ namespace AZ
             AZ_PROFILE_FUNCTION(AzCore);
 
 #if AZ_STREAMER_ADD_EXTRA_PROFILING_INFO
-            auto now = AZStd::chrono::system_clock::now();
+            auto now = AZStd::chrono::steady_clock::now();
 #endif
             bool hasCompletedRequests = false;
             while (true)
@@ -182,7 +182,7 @@ namespace AZ
 #if AZ_STREAMER_ADD_EXTRA_PROFILING_INFO
                     // It's possible for a request to be queued internally and processed between scheduling passes. In those
                     // cases, don't check the request for accurate prediction.
-                    if (top->m_estimatedCompletion > AZStd::chrono::system_clock::time_point())
+                    if (top->m_estimatedCompletion > AZStd::chrono::steady_clock::time_point())
                     {
                         if (top->m_estimatedCompletion < now)
                         {

--- a/Code/Framework/AzCore/AzCore/Script/ScriptTimePoint.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptTimePoint.cpp
@@ -34,7 +34,7 @@ namespace AZ
         SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(reflection);
         if (serializeContext)
         {
-            serializeContext->Class<AZStd::chrono::system_clock::time_point>()
+            serializeContext->Class<AZStd::chrono::steady_clock::time_point>()
                 ;
 
             serializeContext->Class<ScriptTimePoint>()

--- a/Code/Framework/AzCore/AzCore/Script/ScriptTimePoint.h
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptTimePoint.h
@@ -17,10 +17,10 @@ namespace AZ
 {
     class ReflectContext;
 
-    AZ_TYPE_INFO_SPECIALIZE(AZStd::chrono::system_clock::time_point, "{5C48FD59-7267-405D-9C06-1EA31379FE82}");
+    AZ_TYPE_INFO_SPECIALIZE(AZStd::chrono::steady_clock::time_point, "{5C48FD59-7267-405D-9C06-1EA31379FE82}");
 
 
-    //! Wrapper that reflects a AZStd::chrono::system_clock::time_point to script.
+    //! Wrapper that reflects a AZStd::chrono::steady_clock::time_point to script.
     class ScriptTimePoint
     {
     public:
@@ -28,15 +28,15 @@ namespace AZ
         AZ_CLASS_ALLOCATOR(ScriptTimePoint, SystemAllocator, 0);
 
         ScriptTimePoint()
-            : m_timePoint(AZStd::chrono::system_clock::now()) {}
-        explicit ScriptTimePoint(AZStd::chrono::system_clock::time_point timePoint)
+            : m_timePoint(AZStd::chrono::steady_clock::now()) {}
+        explicit ScriptTimePoint(AZStd::chrono::steady_clock::time_point timePoint)
             : m_timePoint(timePoint) {}
 
         //! Formats the time point in a string formatted as: "Time <seconds since epoch>".
         AZStd::string ToString() const;
 
         //! Returns the time point.
-        const AZStd::chrono::system_clock::time_point& Get() const;
+        const AZStd::chrono::steady_clock::time_point& Get() const;
 
         //! Returns the time point in seconds
         double GetSeconds() const;
@@ -47,7 +47,7 @@ namespace AZ
         static void Reflect(ReflectContext* reflection);
 
     protected:
-        AZStd::chrono::system_clock::time_point m_timePoint;
+        AZStd::chrono::steady_clock::time_point m_timePoint;
     };
 
     inline AZStd::string ScriptTimePoint::ToString() const
@@ -55,7 +55,7 @@ namespace AZ
         return AZStd::string::format("Time %lld", static_cast<long long>(m_timePoint.time_since_epoch().count()));
     }
 
-    inline const AZStd::chrono::system_clock::time_point& ScriptTimePoint::Get() const
+    inline const AZStd::chrono::steady_clock::time_point& ScriptTimePoint::Get() const
     {
         return m_timePoint;
     }

--- a/Code/Framework/AzCore/AzCore/Statistics/StatisticalProfiler.h
+++ b/Code/Framework/AzCore/AzCore/Statistics/StatisticalProfiler.h
@@ -53,12 +53,12 @@ namespace AZ
                 TimedScope(StatisticalProfiler& profiler, const StatIdType& statId)
                     : m_profiler(profiler), m_statId(statId)
                 {
-                    m_startTime = AZStd::chrono::system_clock::now();
+                    m_startTime = AZStd::chrono::steady_clock::now();
                 }
 
                 ~TimedScope()
                 {
-                    AZStd::chrono::system_clock::time_point stopTime = AZStd::chrono::system_clock::now();
+                    AZStd::chrono::steady_clock::time_point stopTime = AZStd::chrono::steady_clock::now();
                     auto duration = AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(stopTime - m_startTime);
                     m_profiler.PushSample(m_statId, static_cast<double>(duration.count()));
                 }
@@ -66,7 +66,7 @@ namespace AZ
             private:
                 StatisticalProfiler& m_profiler;
                 const StatIdType& m_statId;
-                AZStd::chrono::system_clock::time_point m_startTime;
+                AZStd::chrono::steady_clock::time_point m_startTime;
             }; //class TimedScope
 
             friend class TimedScope;

--- a/Code/Framework/AzCore/AzCore/Statistics/StatisticalProfilerProxy.h
+++ b/Code/Framework/AzCore/AzCore/Statistics/StatisticalProfilerProxy.h
@@ -76,7 +76,7 @@ namespace AZ::Statistics
                 {
                     return;
                 }
-                m_startTime = AZStd::chrono::system_clock::now();
+                m_startTime = AZStd::chrono::steady_clock::now();
             }
 
             ~TimedScope()
@@ -85,7 +85,7 @@ namespace AZ::Statistics
                 {
                     return;
                 }
-                auto stopTime = AZStd::chrono::system_clock::now();
+                auto stopTime = AZStd::chrono::steady_clock::now();
                 auto duration = stopTime - m_startTime;
                 m_profilerProxy->PushSample(m_profilerId, m_statId, static_cast<double>(duration.count()));
             }
@@ -100,7 +100,7 @@ namespace AZ::Statistics
             static StatisticalProfilerProxy* m_profilerProxy;
             const StatisticalProfilerId m_profilerId;
             const StatIdType& m_statId;
-            AZStd::chrono::system_clock::time_point m_startTime;
+            AZStd::chrono::steady_clock::time_point m_startTime;
         }; // class TimedScope
 
         friend class TimedScope;

--- a/Code/Framework/AzCore/AzCore/Time/ITime.h
+++ b/Code/Framework/AzCore/AzCore/Time/ITime.h
@@ -216,7 +216,7 @@ namespace AZ
     //! Converts from milliseconds to AZStd::chrono::time_point
     inline auto TimeMsToChrono(TimeMs value)
     {
-        AZStd::chrono::system_clock::time_point epoch;
+        AZStd::chrono::steady_clock::time_point epoch;
         auto chronoValue = AZStd::chrono::milliseconds(aznumeric_cast<int64_t>(value));
         return epoch + chronoValue;
     }
@@ -224,7 +224,7 @@ namespace AZ
     //! Converts from microseconds to AZStd::chrono::time_point
     inline auto TimeUsToChrono(TimeUs value)
     {
-        AZStd::chrono::system_clock::time_point epoch;
+        AZStd::chrono::steady_clock::time_point epoch;
         auto chronoValue = AZStd::chrono::microseconds(aznumeric_cast<int64_t>(value));
         return epoch + chronoValue;
     }

--- a/Code/Framework/AzCore/AzCore/std/chrono/chrono.h
+++ b/Code/Framework/AzCore/AzCore/std/chrono/chrono.h
@@ -598,7 +598,7 @@ namespace AZStd::chrono
 
     constexpr day operator+(const day& x, const days& y) noexcept
     {
-        return day{ static_cast<unsigned>(unsigned{ x } + y.count()) };
+        return day{ static_cast<unsigned>(static_cast<int>(unsigned{ x }) + y.count()) };
     }
     constexpr day operator+(const days& x, const day& y) noexcept
     {

--- a/Code/Framework/AzCore/AzCore/std/parallel/binary_semaphore.h
+++ b/Code/Framework/AzCore/AzCore/std/parallel/binary_semaphore.h
@@ -68,7 +68,7 @@ namespace AZStd
         template <class Clock, class Duration>
         bool try_acquire_until(const chrono::time_point<Clock, Duration>& abs_time)
         {
-            auto timeNow = chrono::system_clock::now();
+            auto timeNow = chrono::steady_clock::now();
             if (timeNow >= abs_time)
             {
                 return false; // we timed out already!
@@ -113,7 +113,7 @@ namespace AZStd
             AZStd::unique_lock<AZStd::mutex> ulock(m_mutex);
             if (!m_isReady)
             {
-                auto absTime = chrono::system_clock::now() + rel_time;
+                auto absTime = chrono::steady_clock::now() + rel_time;
 
                 // Note that the standard specifies that try_acquire_for(.. rel_time) is the MINIMUM time to wait
                 // whereas condition_var's wait_for is the maximum time to wait, and may return early.

--- a/Code/Framework/AzCore/Platform/Common/Apple/AzCore/std/parallel/internal/semaphore_Apple.h
+++ b/Code/Framework/AzCore/Platform/Common/Apple/AzCore/std/parallel/internal/semaphore_Apple.h
@@ -92,7 +92,7 @@ namespace AZStd
     template <class Clock, class Duration>
     AZ_FORCE_INLINE bool semaphore::try_acquire_until(const chrono::time_point<Clock, Duration>& abs_time)
     {
-        auto nowTime = chrono::system_clock::now();
+        auto nowTime = chrono::steady_clock::now();
         if (nowTime >= abs_time)
         {
             return false; // we have already timed out.

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/parallel/internal/condition_variable_UnixLike.h
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/parallel/internal/condition_variable_UnixLike.h
@@ -57,7 +57,7 @@ namespace AZStd
     template <class Clock, class Duration>
     AZ_FORCE_INLINE cv_status condition_variable::wait_until(unique_lock<mutex>& lock, const chrono::time_point<Clock, Duration>& abs_time)
     {
-        const auto now = chrono::system_clock::now();
+        const auto now = chrono::steady_clock::now();
         if (now < abs_time)
         {
             return wait_for(lock, abs_time - now);
@@ -97,7 +97,7 @@ namespace AZStd
     template <class Rep, class Period, class Predicate>
     AZ_FORCE_INLINE bool condition_variable::wait_for(unique_lock<mutex>& lock, const chrono::duration<Rep, Period>& rel_time, Predicate pred)
     {
-        return wait_until(lock, chrono::system_clock::now() + rel_time, move(pred));
+        return wait_until(lock, chrono::steady_clock::now() + rel_time, move(pred));
     }
     condition_variable::native_handle_type
     inline condition_variable::native_handle()
@@ -160,7 +160,7 @@ namespace AZStd
     template <class Lock, class Clock, class Duration>
     AZ_FORCE_INLINE cv_status condition_variable_any::wait_until(Lock& lock, const chrono::time_point<Clock, Duration>& abs_time)
     {
-        const auto now = chrono::system_clock::now();
+        const auto now = chrono::steady_clock::now();
         if (now < abs_time)
         {
             // note that wait_for will either time out, in which case we should return time out, or it will return
@@ -204,7 +204,7 @@ namespace AZStd
     template <class Lock, class Rep, class Period, class Predicate>
     AZ_FORCE_INLINE bool condition_variable_any::wait_for(Lock& lock, const chrono::duration<Rep, Period>& rel_time, Predicate pred)
     {
-        return wait_until(lock, chrono::system_clock::now() + rel_time, move(pred));
+        return wait_until(lock, chrono::steady_clock::now() + rel_time, move(pred));
     }
     condition_variable_any::native_handle_type
     inline condition_variable_any::native_handle()

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/parallel/internal/semaphore_UnixLike.h
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/parallel/internal/semaphore_UnixLike.h
@@ -80,7 +80,7 @@ namespace AZStd
     template <class Clock, class Duration>
     AZ_FORCE_INLINE bool semaphore::try_acquire_until(const chrono::time_point<Clock, Duration>& abs_time)
     {
-        auto timeNow = chrono::system_clock::now();
+        auto timeNow = chrono::steady_clock::now();
         if (timeNow >= abs_time)
         {
             // we already timed out.

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/std/parallel/internal/condition_variable_WinAPI.h
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/std/parallel/internal/condition_variable_WinAPI.h
@@ -58,7 +58,7 @@ namespace AZStd
     template <class Clock, class Duration>
     AZ_FORCE_INLINE cv_status condition_variable::wait_until(unique_lock<mutex>& lock, const chrono::time_point<Clock, Duration>& abs_time)
     {
-        chrono::system_clock::time_point now = chrono::system_clock::now();
+        auto now = chrono::steady_clock::now();
         if (now < abs_time)
         {
             return wait_for(lock, abs_time - now);
@@ -99,7 +99,7 @@ namespace AZStd
             {
                 return cv_status::timeout;
             }
-        } 
+        }
         return cv_status::no_timeout;
     }
     template <class Rep, class Period, class Predicate>
@@ -174,7 +174,7 @@ namespace AZStd
     template <class Lock, class Clock, class Duration>
     AZ_FORCE_INLINE cv_status condition_variable_any::wait_until(Lock& lock, const chrono::time_point<Clock, Duration>& abs_time)
     {
-        auto now = chrono::system_clock::now();
+        auto now = chrono::steady_clock::now();
         if (now < abs_time)
         {
             return wait_for(lock, abs_time - now);

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/std/parallel/internal/semaphore_WinAPI.h
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/std/parallel/internal/semaphore_WinAPI.h
@@ -50,7 +50,7 @@ namespace AZStd
     template <class Clock, class Duration>
     AZ_FORCE_INLINE bool semaphore::try_acquire_until(const chrono::time_point<Clock, Duration>& abs_time)
     {
-        auto timeNow = AZStd::chrono::system_clock::now();
+        auto timeNow = AZStd::chrono::steady_clock::now();
         if (timeNow < abs_time)
         {
             chrono::milliseconds timeToTry = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(abs_time - timeNow);

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.h
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/IO/Streamer/StorageDrive_Windows.h
@@ -83,7 +83,7 @@ namespace AZ::IO
         bool ExecuteRequests() override;
 
         void UpdateStatus(Status& status) const override;
-        void UpdateCompletionEstimates(AZStd::chrono::system_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
+        void UpdateCompletionEstimates(AZStd::chrono::steady_clock::time_point now, AZStd::vector<FileRequest*>& internalPending,
             StreamerContext::PreparedQueue::iterator pendingBegin, StreamerContext::PreparedQueue::iterator pendingEnd) override;
 
         void CollectStatistics(AZStd::vector<Statistic>& statistics) const override;
@@ -103,7 +103,7 @@ namespace AZ::IO
 
         struct FileReadInformation
         {
-            AZStd::chrono::system_clock::time_point m_startTime;
+            AZStd::chrono::steady_clock::time_point m_startTime;
             FileRequest* m_request{ nullptr };
             void* m_sectorAlignedOutput{ nullptr };    // Internally allocated buffer that is sector aligned.
             size_t m_copyBackOffset{ 0 };
@@ -132,10 +132,10 @@ namespace AZ::IO
         size_t GetNextMetaDataCacheSlot();
         bool IsServicedByThisDrive(AZ::IO::PathView filePath) const;
 
-        void EstimateCompletionTimeForRequest(FileRequest* request, AZStd::chrono::system_clock::time_point& startTime,
+        void EstimateCompletionTimeForRequest(FileRequest* request, AZStd::chrono::steady_clock::time_point& startTime,
             const RequestPath*& activeFile, u64& activeOffset) const;
         void EstimateCompletionTimeForRequestChecked(FileRequest* request,
-            AZStd::chrono::system_clock::time_point startTime, const RequestPath*& activeFile, u64& activeOffset) const;
+            AZStd::chrono::steady_clock::time_point startTime, const RequestPath*& activeFile, u64& activeOffset) const;
         s32 CalculateNumAvailableSlots() const;
 
         void FlushCache(const RequestPath& filePath);
@@ -157,7 +157,7 @@ namespace AZ::IO
         AZ::Statistics::RunningStatistic m_seekPercentageStat;
         AZ::Statistics::RunningStatistic m_directReadsPercentageStat;
 #endif
-        AZStd::chrono::system_clock::time_point m_activeReads_startTime;
+        AZStd::chrono::steady_clock::time_point m_activeReads_startTime;
 
         AZStd::deque<FileRequest*> m_pendingReadRequests;
         AZStd::deque<FileRequest*> m_pendingRequests;
@@ -166,7 +166,7 @@ namespace AZ::IO
         AZStd::vector<FileReadStatus> m_readSlots_statusInfo;
         AZStd::vector<bool> m_readSlots_active;
 
-        AZStd::vector<AZStd::chrono::system_clock::time_point> m_fileCache_lastTimeUsed;
+        AZStd::vector<AZStd::chrono::steady_clock::time_point> m_fileCache_lastTimeUsed;
         AZStd::vector<RequestPath> m_fileCache_paths;
         AZStd::vector<HANDLE> m_fileCache_handles;
         AZStd::vector<u16> m_fileCache_activeReads;

--- a/Code/Framework/AzCore/Tests/AZStd/Parallel.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Parallel.cpp
@@ -83,11 +83,11 @@ namespace UnitTest
         auto minDuration = AZStd::chrono::milliseconds(WAIT_TIME_MS);
         auto minDurationWithMarginForError = minDuration - AZStd::chrono::milliseconds(MARGIN_OF_ERROR_MS);
 
-        auto startTime = AZStd::chrono::system_clock::now();
+        auto startTime = AZStd::chrono::steady_clock::now();
         
         EXPECT_FALSE(sema.try_acquire_for(minDuration));
         
-        auto actualDuration = AZStd::chrono::system_clock::now() - startTime;
+        auto actualDuration = AZStd::chrono::steady_clock::now() - startTime;
         EXPECT_GE(actualDuration, minDurationWithMarginForError);
     }
 
@@ -97,12 +97,12 @@ namespace UnitTest
         semaphore sema;
         auto minDuration = AZStd::chrono::milliseconds(WAIT_TIME_MS);
         auto minDurationWithMarginForError = minDuration - AZStd::chrono::milliseconds(MARGIN_OF_ERROR_MS);
-        auto startTime = AZStd::chrono::system_clock::now();
+        auto startTime = AZStd::chrono::steady_clock::now();
         auto absTime = startTime + minDuration;
         
         EXPECT_FALSE(sema.try_acquire_until(absTime));
         
-        auto duration = AZStd::chrono::system_clock::now() - startTime;
+        auto duration = AZStd::chrono::steady_clock::now() - startTime;
         EXPECT_GE(duration, minDurationWithMarginForError);
     }
 
@@ -112,11 +112,11 @@ namespace UnitTest
 
         // this duration should not matter since it should not wait at all so we don't need an error margin.
         auto minDuration = AZStd::chrono::milliseconds(WAIT_TIME_MS);
-        auto startTime = AZStd::chrono::system_clock::now();
+        auto startTime = AZStd::chrono::steady_clock::now();
         sema.release();
         EXPECT_TRUE(sema.try_acquire_for(minDuration));
         
-        auto durationSpent = AZStd::chrono::system_clock::now() - startTime;
+        auto durationSpent = AZStd::chrono::steady_clock::now() - startTime;
         EXPECT_LT(durationSpent, minDuration);
     }
 
@@ -125,12 +125,12 @@ namespace UnitTest
         semaphore sema;
         // we should not wait all at here, since we start with it already signalled.
         auto minDuration = AZStd::chrono::milliseconds(WAIT_TIME_MS);
-        auto startTime = AZStd::chrono::system_clock::now();
+        auto startTime = AZStd::chrono::steady_clock::now();
         auto absTime = startTime + minDuration;
         sema.release();
         EXPECT_TRUE(sema.try_acquire_until(absTime));
         
-        auto duration = AZStd::chrono::system_clock::now() - startTime;
+        auto duration = AZStd::chrono::steady_clock::now() - startTime;
         EXPECT_LT(duration, minDuration);
     }
 
@@ -530,12 +530,12 @@ namespace UnitTest
             trDel.join();
             AZ_TEST_ASSERT(m_data == m_dataMax);
 
-            chrono::system_clock::time_point startTime = chrono::system_clock::now();
+            chrono::steady_clock::time_point startTime = chrono::steady_clock::now();
             {
                 AZStd::thread tr1(desc1, AZStd::bind(&Parallel_Thread::sleep_thread, this, chrono::milliseconds(100)));
                 tr1.join();
             }
-            auto sleepTime = chrono::system_clock::now() - startTime;
+            auto sleepTime = chrono::steady_clock::now() - startTime;
             //printf("\nSleeptime: %d Ms\n",(unsigned int)  ());
             // On Windows we use Sleep. Sleep is dependent on MM timers.
             // 99000 can be used only if we support 1 ms resolution timeGetDevCaps() and we set it timeBeginPeriod(1) timeEndPeriod(1)
@@ -1136,7 +1136,7 @@ namespace UnitTest
         AZStd::condition_variable cv;
         AZStd::mutex cv_mutex;
         AZStd::atomic<AZStd::cv_status> status = { AZStd::cv_status::no_timeout };
-        AZStd::chrono::system_clock::time_point startTime;
+        AZStd::chrono::steady_clock::time_point startTime;
         // note that we capture the start and end time in the thread - this is because threads starting and stopping
         // can have unpredictable scheduling.
 
@@ -1146,10 +1146,10 @@ namespace UnitTest
         {
             AZStd::unique_lock<AZStd::mutex> lock(cv_mutex);
             auto waitDuration = AZStd::chrono::milliseconds(WAIT_TIME_MS);
-            startTime = AZStd::chrono::system_clock::now();
+            startTime = AZStd::chrono::steady_clock::now();
             auto waitUntilTime = startTime + waitDuration;
             status = cv.wait_until(lock, waitUntilTime);
-            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - startTime);
+            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - startTime);
         };
         
         // we aren't going to signal it, and ensure the timeout was reached.
@@ -1167,16 +1167,16 @@ namespace UnitTest
         AZStd::condition_variable cv;
         AZStd::mutex cv_mutex;
         AZStd::atomic<AZStd::cv_status> status = { AZStd::cv_status::no_timeout };
-        AZStd::chrono::system_clock::time_point startTime;
+        AZStd::chrono::steady_clock::time_point startTime;
         AZStd::chrono::milliseconds timeSpent;
 
         auto wait = [&]()
         {
             AZStd::unique_lock<AZStd::mutex> lock(cv_mutex);
-            auto waitUntilTime = AZStd::chrono::system_clock::now();
+            auto waitUntilTime = AZStd::chrono::steady_clock::now();
             startTime = waitUntilTime;
             status = cv.wait_until(lock, waitUntilTime);
-            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - startTime);
+            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - startTime);
         };
         
         AZStd::thread waitThread1(wait);
@@ -1193,16 +1193,16 @@ namespace UnitTest
         AZStd::mutex cv_mutex;
         AZStd::atomic_bool status = { true };
         auto pred = [](){ return false; };
-        AZStd::chrono::system_clock::time_point startTime;
+        AZStd::chrono::steady_clock::time_point startTime;
         AZStd::chrono::milliseconds timeSpent;
         
         auto wait = [&]()
         {
             AZStd::unique_lock<AZStd::mutex> lock(cv_mutex);
-            auto waitUntilTime = AZStd::chrono::system_clock::now();
+            auto waitUntilTime = AZStd::chrono::steady_clock::now();
             startTime = waitUntilTime;
             status = cv.wait_until(lock, waitUntilTime, pred);
-            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - startTime);
+            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - startTime);
         };
 
 
@@ -1223,17 +1223,17 @@ namespace UnitTest
 
         auto pred = []() { return false; }; // should cause it to wait the entire duration
 
-        AZStd::chrono::system_clock::time_point startTime;
+        AZStd::chrono::steady_clock::time_point startTime;
         AZStd::chrono::milliseconds timeSpent;
 
         auto wait = [&]()
         {
             AZStd::unique_lock<AZStd::mutex> lock(cv_mutex);
             auto waitDuration = AZStd::chrono::milliseconds(WAIT_TIME_MS);
-            startTime = AZStd::chrono::system_clock::now();
+            startTime = AZStd::chrono::steady_clock::now();
             auto waitUntilTime = startTime + waitDuration;
             retVal = cv.wait_until(lock, waitUntilTime, pred);
-            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - startTime);
+            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - startTime);
         };
 
         // we aren't going to signal it, and ensure the timeout was reached.
@@ -1252,7 +1252,7 @@ namespace UnitTest
         AZStd::condition_variable cv;
         AZStd::mutex cv_mutex;
         AZStd::atomic_bool retVal = { true };
-        AZStd::chrono::system_clock::time_point startTime;
+        AZStd::chrono::steady_clock::time_point startTime;
         AZStd::chrono::milliseconds timeSpent;
 
         auto pred = []() { return true; }; // should cause it to immediately return
@@ -1261,11 +1261,11 @@ namespace UnitTest
         {
             AZStd::unique_lock<AZStd::mutex> lock(cv_mutex);
             auto waitDuration = AZStd::chrono::milliseconds(WAIT_TIME_MS);
-            startTime = AZStd::chrono::system_clock::now();
+            startTime = AZStd::chrono::steady_clock::now();
             auto waitUntilTime = startTime + waitDuration;
 
             retVal = cv.wait_until(lock, waitUntilTime, pred);
-            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - startTime);
+            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - startTime);
         };
 
         AZStd::thread waitThread1(wait);
@@ -1284,16 +1284,16 @@ namespace UnitTest
         AZStd::mutex cv_mutex;
         AZStd::atomic<AZStd::cv_status> status = { AZStd::cv_status::no_timeout };
 
-        AZStd::chrono::system_clock::time_point startTime;
+        AZStd::chrono::steady_clock::time_point startTime;
         AZStd::chrono::milliseconds timeSpent;
 
         auto wait = [&]()
         {
             AZStd::unique_lock<AZStd::mutex> lock(cv_mutex);
             auto waitDuration = AZStd::chrono::milliseconds(WAIT_TIME_MS);
-            startTime = AZStd::chrono::system_clock::now();
+            startTime = AZStd::chrono::steady_clock::now();
             status = cv.wait_for(lock, waitDuration);
-            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - startTime);
+            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - startTime);
         };
         
         // we aren't going to signal it, and ensure the timeout was reached.
@@ -1314,16 +1314,16 @@ namespace UnitTest
         AZStd::atomic_bool status = {true};
         auto pred = []() { return false; };
 
-        AZStd::chrono::system_clock::time_point startTime;
+        AZStd::chrono::steady_clock::time_point startTime;
         AZStd::chrono::milliseconds timeSpent;
 
         auto wait = [&]()
         {
             AZStd::unique_lock<AZStd::mutex> lock(cv_mutex);
-            startTime = AZStd::chrono::system_clock::now();
+            startTime = AZStd::chrono::steady_clock::now();
             auto waitDuration = AZStd::chrono::milliseconds(WAIT_TIME_MS);
             status = cv.wait_for(lock, waitDuration, pred);
-            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - startTime);
+            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - startTime);
         };
         
         // we aren't going to signal it, and ensure the timeout was reached.
@@ -1341,7 +1341,7 @@ namespace UnitTest
         AZStd::mutex cv_mutex;
         AZStd::atomic_int i(0);
         AZStd::atomic_bool done(false);
-        AZStd::chrono::system_clock::time_point startTime;
+        AZStd::chrono::steady_clock::time_point startTime;
         AZStd::chrono::milliseconds timeSpent;
         constexpr AZStd::chrono::seconds waitTimeCrossThread(10);
         // normally we'd wait for WAIT_TIME_MS, but in this case, a completely different thread is doing the signalling,
@@ -1354,11 +1354,11 @@ namespace UnitTest
             AZStd::unique_lock<AZStd::mutex> lock(cv_mutex);
             
             auto waitDuration = waitTimeCrossThread;
-            startTime = AZStd::chrono::system_clock::now();
+            startTime = AZStd::chrono::steady_clock::now();
             auto waitUntilTime = startTime + waitDuration;
             // we expect the other thread to wake us up before the timeout expires so the following should return true
             EXPECT_TRUE(cv.wait_until(lock, waitUntilTime, [&]{ return i == 1; }));
-            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - startTime);
+            timeSpent = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - startTime);
             EXPECT_EQ(1, i);
             done = true;
         };
@@ -1540,11 +1540,11 @@ namespace UnitTest
 
             AZStd::thread deadlocker_thread = AZStd::thread(deadlocker_function);
 
-            chrono::system_clock::time_point startTime = chrono::system_clock::now();
+            chrono::steady_clock::time_point startTime = chrono::steady_clock::now();
             while (!doneIt.load())
             {
                 AZStd::this_thread::yield();
-                auto sleepTime = chrono::system_clock::now() - startTime;
+                auto sleepTime = chrono::steady_clock::now() - startTime;
 
                 // the test normally succeeds in under a second
                 // but machines can be slow, so we'll give it 20x the

--- a/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
@@ -344,12 +344,12 @@ namespace UnitTest
     {
         // If the Max Timeout is hit the test will be marked as a failure
 
-        AZStd::chrono::time_point dispatchEventTimeStart = AZStd::chrono::system_clock::now();
+        auto dispatchEventTimeStart = AZStd::chrono::steady_clock::now();
         AZStd::chrono::seconds dispatchEventNextLogTime = logIntervalSeconds;
 
         while (!conditionPredicate())
         {
-            AZStd::chrono::time_point currentTime = AZStd::chrono::system_clock::now();
+            auto currentTime = AZStd::chrono::steady_clock::now();
             if (auto elapsedTime{ currentTime - dispatchEventTimeStart };
                 elapsedTime >= dispatchEventNextLogTime)
             {
@@ -431,12 +431,12 @@ namespace UnitTest
         EXPECT_TRUE(asset6Block.IsReady());
 
         // Assets above can be ready (PreNotify) before the signal has reached our listener - allow for a small window to hear
-        auto maxTimeout = AZStd::chrono::system_clock::now() + timeoutSeconds;
+        auto maxTimeout = AZStd::chrono::steady_clock::now() + timeoutSeconds;
         bool timedOut = false;
         while (!assetStatus1.m_ready || !assetStatus2.m_ready || !assetStatus3.m_ready)
         {
             AssetManager::Instance().DispatchEvents();
-            if (AZStd::chrono::system_clock::now() > maxTimeout)
+            if (AZStd::chrono::steady_clock::now() > maxTimeout)
             {
                 timedOut = true;
                 break;
@@ -480,11 +480,11 @@ namespace UnitTest
         streamer->ResumeProcessing();
 
         // Allow our reloads to process and signal our listeners
-        maxTimeout = AZStd::chrono::system_clock::now() + timeoutSeconds;
+        maxTimeout = AZStd::chrono::steady_clock::now() + timeoutSeconds;
         while (!assetStatus1.m_reloaded || !assetStatus2.m_reloaded || !assetStatus3.m_reloaded)
         {
             m_testAssetManager->DispatchEvents();
-            if (AZStd::chrono::system_clock::now() > maxTimeout)
+            if (AZStd::chrono::steady_clock::now() > maxTimeout)
             {
                 timedOut = true;
                 break;
@@ -519,11 +519,11 @@ namespace UnitTest
             AZ::Data::AssetLoadBehavior::Default);
 
         // this verifies that a reloading asset in "loading" state queues another load when it is complete
-        maxTimeout = AZStd::chrono::system_clock::now() + timeoutSeconds;
+        maxTimeout = AZStd::chrono::steady_clock::now() + timeoutSeconds;
         while (!delayLoadAssetStatus.m_ready)
         {
             m_testAssetManager->DispatchEvents();
-            if (AZStd::chrono::system_clock::now() > maxTimeout)
+            if (AZStd::chrono::steady_clock::now() > maxTimeout)
             {
                 timedOut = true;
                 break;
@@ -541,11 +541,11 @@ namespace UnitTest
 
         // This should go through to loading
         m_testAssetManager->ReloadAsset(DelayLoadAssetId, AZ::Data::AssetLoadBehavior::Default);
-        maxTimeout = AZStd::chrono::system_clock::now() + timeoutSeconds;
+        maxTimeout = AZStd::chrono::steady_clock::now() + timeoutSeconds;
         while (m_testAssetManager->GetReloadStatus(DelayLoadAssetId) != AZ::Data::AssetData::AssetStatus::Loading)
         {
             m_testAssetManager->DispatchEvents();
-            if (AZStd::chrono::system_clock::now() > maxTimeout)
+            if (AZStd::chrono::steady_clock::now() > maxTimeout)
             {
                 timedOut = true;
                 break;
@@ -559,11 +559,11 @@ namespace UnitTest
         // This should do nothing
         m_testAssetManager->ReloadAsset(DelayLoadAssetId, AZ::Data::AssetLoadBehavior::Default);
 
-        maxTimeout = AZStd::chrono::system_clock::now() + timeoutSeconds;
+        maxTimeout = AZStd::chrono::steady_clock::now() + timeoutSeconds;
         while (delayLoadAssetStatus.m_reloaded < 2)
         {
             m_testAssetManager->DispatchEvents();
-            if (AZStd::chrono::system_clock::now() > maxTimeout)
+            if (AZStd::chrono::steady_clock::now() > maxTimeout)
             {
                 timedOut = true;
                 break;
@@ -645,7 +645,7 @@ namespace UnitTest
         while (threadCount > 0 && !timedOut)
         {
             AZStd::unique_lock<AZStd::mutex> lock(mutex);
-            timedOut = (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds));
+            timedOut = (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds));
         }
 
         ASSERT_EQ(threadCount, 0) << "Thread count is non-zero, a thread has likely deadlocked.  Test will not shut down cleanly.";
@@ -902,11 +902,11 @@ namespace UnitTest
         EXPECT_EQ(m_assetHandlerAndCatalog->m_numCreations, 6);
 
         // Assets above can be ready (PreNotify) before the signal has reached our listener - allow for a small window to hear
-        auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+        auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
         while (!assetStatus1.m_ready || !assetStatus2.m_ready || !assetStatus3.m_ready)
         {
             AssetManager::Instance().DispatchEvents();
-            if (AZStd::chrono::system_clock::now() > maxTimeout)
+            if (AZStd::chrono::steady_clock::now() > maxTimeout)
             {
                 AZ_Assert(false, "Timeout reached.");
                 break;
@@ -1022,12 +1022,12 @@ namespace UnitTest
 
             auto containerReady = m_testAssetManager->GetAssetContainer(asset);
 
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener.m_ready || !preloadBListener.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1068,12 +1068,12 @@ namespace UnitTest
             auto asset1Container = m_testAssetManager->GetAssetContainer(asset1);
             auto asset2Container = m_testAssetManager->GetAssetContainer(asset2);
             auto asset3Container = m_testAssetManager->GetAssetContainer(asset3);
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener1.m_ready || !readyListener2.m_ready || !readyListener3.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1131,12 +1131,12 @@ namespace UnitTest
             asset1 = m_testAssetManager->FindOrCreateAsset(MyAsset1Id, azrtti_typeid<AssetWithAssetReference>(), AZ::Data::AssetLoadBehavior::Default);
             asset1Container = m_testAssetManager->GetAssetContainer(asset1);
 
-            maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!asset1Container->IsReady())
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1169,12 +1169,12 @@ namespace UnitTest
             auto asset1 = m_testAssetManager->FindOrCreateAsset(MyAsset1Id, azrtti_typeid<AssetWithAssetReference>(), AZ::Data::AssetLoadBehavior::Default);
             auto asset1Container = m_testAssetManager->GetAssetContainer(asset1, AssetLoadParameters{ filterNone });
 
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!asset1Container->IsReady())
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1189,11 +1189,11 @@ namespace UnitTest
             AZ::Data::AssetFilterCB noDependencyCB = [](const AZ::Data::AssetFilterInfo& filterInfo) { return filterInfo.m_assetType != azrtti_typeid<AssetWithSerializedData>(); };
             asset1 = m_testAssetManager->FindOrCreateAsset(MyAsset1Id, azrtti_typeid<AssetWithAssetReference>(), AZ::Data::AssetLoadBehavior::Default);
             asset1Container = m_testAssetManager->GetAssetContainer(asset1, AssetLoadParameters{ noDependencyCB });
-            maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
             while (!asset1Container->IsReady())
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1224,12 +1224,12 @@ namespace UnitTest
             auto asset1 = m_testAssetManager->FindOrCreateAsset(MyAsset1Id, azrtti_typeid<AssetWithAssetReference>(), AZ::Data::AssetLoadBehavior::Default);
             auto asset1Container = m_testAssetManager->GetAssetContainer(asset1);
 
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener1.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1244,12 +1244,12 @@ namespace UnitTest
             auto asset2 = m_testAssetManager->FindOrCreateAsset(MyAsset2Id, azrtti_typeid<AssetWithAssetReference>(), AZ::Data::AssetLoadBehavior::Default);
             auto asset2Container = m_testAssetManager->GetAssetContainer(asset2);
 
-            maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!asset2Container->IsReady())
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1291,12 +1291,12 @@ namespace UnitTest
                 AZ::Data::AssetLoadBehavior::Default);
             auto noLoadRefContainer = m_testAssetManager->GetAssetContainer(noLoadRef);
 
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1332,12 +1332,12 @@ namespace UnitTest
                 AZ::Data::AssetLoadBehavior::Default);
             auto noLoadRefContainer = m_testAssetManager->GetAssetContainer(noLoadRef, AssetLoadParameters(nullptr, AZ::Data::AssetDependencyLoadRules::LoadAll));
 
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1454,11 +1454,11 @@ namespace UnitTest
             ContainerReadyListener readyListener(MyAsset2Id);
 
             auto asset2Get = m_testAssetManager->GetAssetInternal(MyAsset2Id, azrtti_typeid<AssetWithAssetReference>(), AZ::Data::AssetLoadBehavior::Default, AssetLoadParameters{ &AZ::Data::AssetFilterNoAssetLoading });
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
             while (!asset2Get->IsReady())
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1468,12 +1468,12 @@ namespace UnitTest
             auto asset2 = m_testAssetManager->FindOrCreateAsset(MyAsset2Id, azrtti_typeid<AssetWithAssetReference>(), AZ::Data::AssetLoadBehavior::Default);
             auto asset2Container = m_testAssetManager->GetAssetContainer(asset2);
 
-            maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1507,11 +1507,11 @@ namespace UnitTest
 
             auto asset2PrimeGet = m_testAssetManager->GetAsset(MyAsset5Id, azrtti_typeid<AssetWithSerializedData>(), AZ::Data::AssetLoadBehavior::Default);
 
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
             while (!asset2PrimeGet->IsReady())
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1521,12 +1521,12 @@ namespace UnitTest
             auto asset2 = m_testAssetManager->FindOrCreateAsset(MyAsset2Id, azrtti_typeid<AssetWithAssetReference>(), AZ::Data::AssetLoadBehavior::Default);
             auto asset2Container = m_testAssetManager->GetAssetContainer(asset2);
 
-            maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1559,12 +1559,12 @@ namespace UnitTest
             ContainerReadyListener readyListener(MyAsset2Id);
             auto asset2Get = m_testAssetManager->GetAssetInternal(MyAsset2Id, azrtti_typeid<AssetWithAssetReference>(), AZ::Data::AssetLoadBehavior::Default, AssetLoadParameters{ &AssetFilterNoAssetLoading });
             auto asset2PrimeGet = m_testAssetManager->GetAssetInternal(MyAsset5Id, azrtti_typeid<AssetWithSerializedData>(), AZ::Data::AssetLoadBehavior::Default, AssetLoadParameters{ &AssetFilterNoAssetLoading });
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!asset2Get->IsReady() || !asset2PrimeGet->IsReady())
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1617,12 +1617,12 @@ namespace UnitTest
                 AZ::Data::AssetLoadBehavior::Default);
             auto containerReady = m_testAssetManager->GetAssetContainer(asset);
 
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1684,12 +1684,12 @@ namespace UnitTest
             auto asset = m_testAssetManager->FindOrCreateAsset(PreloadAssetRootId, azrtti_typeid<AssetWithQueueAndPreLoadReferences>(), AZ::Data::AssetLoadBehavior::Default);
             auto containerReady = m_testAssetManager->GetAssetContainer(asset);
 
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1739,12 +1739,12 @@ namespace UnitTest
             auto asset = m_testAssetManager->FindOrCreateAsset(PreloadBrokenDepBId, azrtti_typeid<AssetWithQueueAndPreLoadReferences>(), AZ::Data::AssetLoadBehavior::Default);
             auto containerReady = m_testAssetManager->GetAssetContainer(asset);
 
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1791,12 +1791,12 @@ namespace UnitTest
                 AZ::Data::AssetLoadBehavior::Default);
             auto containerReady = m_testAssetManager->GetAssetContainer(asset);
 
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1846,12 +1846,12 @@ namespace UnitTest
             // We should catch the basic ciruclar dependency error as well as that it's a preload
             AZ_TEST_STOP_TRACE_SUPPRESSION(2);
 
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1902,12 +1902,12 @@ namespace UnitTest
             // We should catch the basic circular dependency error as well as that it's a preload
             AZ_TEST_STOP_TRACE_SUPPRESSION(2);
 
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -1963,12 +1963,12 @@ namespace UnitTest
             // One error in SetupPreloads - Two of the assets create a dependency loop
             AZ_TEST_STOP_TRACE_SUPPRESSION(1);
 
-            auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+            auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
             while (!readyListener.m_ready)
             {
                 m_testAssetManager->DispatchEvents();
-                if (AZStd::chrono::system_clock::now() > maxTimeout)
+                if (AZStd::chrono::steady_clock::now() > maxTimeout)
                 {
                     break;
                 }
@@ -2134,7 +2134,7 @@ namespace UnitTest
             while (threadCount > 0 && !timedOut)
             {
                 AZStd::unique_lock<AZStd::mutex> lock(mutex);
-                timedOut = (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds *2));
+                timedOut = (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds *2));
             }
 
             EXPECT_EQ(threadCount, 0);
@@ -2250,7 +2250,7 @@ namespace UnitTest
             while (threadCount > 0 && !timedOut)
             {
                 AZStd::unique_lock<AZStd::mutex> lock(mutex);
-                timedOut = (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds));
+                timedOut = (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds));
             }
 
             EXPECT_TRUE(threadCount == 0);
@@ -2399,7 +2399,7 @@ namespace UnitTest
             while (threadCount > 0 && !timedOut)
             {
                 AZStd::unique_lock<AZStd::mutex> lock(mutex);
-                timedOut = (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds));
+                timedOut = (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds));
             }
 
             EXPECT_TRUE(threadCount == 0);
@@ -2498,8 +2498,8 @@ namespace UnitTest
             // We have ensured that all the threads have started at this point and we can let them start hammering at the AssetManager
             wait = false;
 
-            AZStd::chrono::system_clock::time_point start = AZStd::chrono::system_clock::now();
-            while (AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - start) < AZStd::chrono::seconds(2))
+            AZStd::chrono::steady_clock::time_point start = AZStd::chrono::steady_clock::now();
+            while (AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - start) < AZStd::chrono::seconds(2))
             {
                 AZStd::this_thread::yield();
             }
@@ -3179,12 +3179,12 @@ namespace UnitTest
         // We specifically wait for OnAssetReady to be triggered instead of using BlockUntilLoadComplete() to ensure that
         // all loading jobs have 100% completed and there aren't any other outstanding asset references held on other threads.
         const auto timeoutSeconds = AZStd::chrono::seconds(20);
-        auto maxTimeout = AZStd::chrono::system_clock::now() + timeoutSeconds;
+        auto maxTimeout = AZStd::chrono::steady_clock::now() + timeoutSeconds;
         bool timedOut = false;
         while (!(assetStatus1.m_ready && assetStatus2.m_ready))
         {
             AssetManager::Instance().DispatchEvents();
-            if (AZStd::chrono::system_clock::now() > maxTimeout)
+            if (AZStd::chrono::steady_clock::now() > maxTimeout)
             {
                 timedOut = true;
                 break;

--- a/Code/Framework/AzCore/Tests/Asset/BaseAssetManagerTest.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/BaseAssetManagerTest.cpp
@@ -149,11 +149,11 @@ namespace UnitTest
 
     void BaseAssetManagerTest::BlockUntilAssetJobsAreComplete()
     {
-        auto maxTimeout = AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds;
+        auto maxTimeout = AZStd::chrono::steady_clock::now() + DefaultTimeoutSeconds;
 
         while (AssetManager::Instance().HasActiveJobsOrStreamerRequests())
         {
-            if (AZStd::chrono::system_clock::now() > maxTimeout)
+            if (AZStd::chrono::steady_clock::now() > maxTimeout)
             {
                 break;
             }

--- a/Code/Framework/AzCore/Tests/EBus.cpp
+++ b/Code/Framework/AzCore/Tests/EBus.cpp
@@ -3610,23 +3610,23 @@ namespace UnitTest
         waitHandler.m_connectMethod = [&connectHandler]()
         {
             constexpr int waitMsMax = 100;
-            auto startTime = AZStd::chrono::system_clock::now();
+            auto startTime = AZStd::chrono::steady_clock::now();
             auto endTime = startTime + AZStd::chrono::milliseconds(waitMsMax);
 
             // The other bus should not be able to complete because we're still holding the connect lock
-            while (AZStd::chrono::system_clock::now() < endTime && !connectHandler.BusIsConnected())
+            while (AZStd::chrono::steady_clock::now() < endTime && !connectHandler.BusIsConnected())
             {
                 AZStd::this_thread::yield();
             }
 
-            EXPECT_GE(AZStd::chrono::system_clock::now(), endTime);
+            EXPECT_GE(AZStd::chrono::steady_clock::now(), endTime);
         };
         AZStd::thread connectThread([&connectHandler, &waitHandler]()
         {
             constexpr int waitMsMax = 100;
-            auto startTime = AZStd::chrono::system_clock::now();
+            auto startTime = AZStd::chrono::steady_clock::now();
             auto endTime = startTime + AZStd::chrono::milliseconds(waitMsMax);
-            while (AZStd::chrono::system_clock::now() < endTime && !waitHandler.m_didConnect)
+            while (AZStd::chrono::steady_clock::now() < endTime && !waitHandler.m_didConnect)
             {
                 AZStd::this_thread::yield();
             }
@@ -3651,16 +3651,16 @@ namespace UnitTest
             waitHandler.m_connectMethod = [&connectHandler]()
             {
                 constexpr int waitMsMax = 100;
-                auto startTime = AZStd::chrono::system_clock::now();
+                auto startTime = AZStd::chrono::steady_clock::now();
                 auto endTime = startTime + AZStd::chrono::milliseconds(waitMsMax);
 
                 // The other bus should be able to connect
-                while (AZStd::chrono::system_clock::now() < endTime && !connectHandler.m_didConnect)
+                while (AZStd::chrono::steady_clock::now() < endTime && !connectHandler.m_didConnect)
                 {
                     AZStd::this_thread::yield();
                 }
                 EXPECT_EQ(connectHandler.BusIsConnected(), true);
-                EXPECT_LE(AZStd::chrono::system_clock::now(), endTime);
+                EXPECT_LE(AZStd::chrono::steady_clock::now(), endTime);
             };
             AZStd::thread connectThread([&connectHandler]()
             {

--- a/Code/Framework/AzCore/Tests/Memory.cpp
+++ b/Code/Framework/AzCore/Tests/Memory.cpp
@@ -272,7 +272,7 @@ namespace UnitTest
             // run some thread allocations.
             //////////////////////////////////////////////////////////////////////////
             // Create some threads and simulate concurrent allocation and deallocation
-            //AZStd::chrono::system_clock::time_point startTime = AZStd::chrono::system_clock::now();
+            //AZStd::chrono::steady_clock::time_point startTime = AZStd::chrono::steady_clock::now();
             {
                 AZStd::thread m_threads[m_maxNumThreads];
                 for (unsigned int i = 0; i < m_maxNumThreads; ++i)
@@ -287,7 +287,7 @@ namespace UnitTest
                     m_threads[i].join();
                 }
             }
-            //AZStd::chrono::microseconds exTime = AZStd::chrono::system_clock::now() - startTime;
+            //AZStd::chrono::microseconds exTime = AZStd::chrono::steady_clock::now() - startTime;
             //AZ_Printf("UnitTest::SystemAllocatorTest::mspaces","Time: %d Ms\n",exTime.count());
             //////////////////////////////////////////////////////////////////////////
 
@@ -708,7 +708,7 @@ namespace UnitTest
 
             //////////////////////////////////////////////////////////////////////////
             // Create some threads and simulate concurrent allocation and deallocation
-            //AZStd::chrono::system_clock::time_point startTime = AZStd::chrono::system_clock::now();
+            //AZStd::chrono::steady_clock::time_point startTime = AZStd::chrono::steady_clock::now();
             {
                 AZStd::thread m_threads[m_maxNumThreads];
                 for (unsigned int i = 0; i < m_maxNumThreads; ++i)
@@ -722,7 +722,7 @@ namespace UnitTest
                 }
             }
             //////////////////////////////////////////////////////////////////////////
-            //AZStd::chrono::microseconds exTime = AZStd::chrono::system_clock::now() - startTime;
+            //AZStd::chrono::microseconds exTime = AZStd::chrono::steady_clock::now() - startTime;
             //AZ_Printf("UnitTest","Time: %d Ms\n",exTime.count());
 
             //////////////////////////////////////////////////////////////////////////
@@ -1598,7 +1598,7 @@ namespace UnitTest
 
         void allocdealloc(HphaSchema& hpha, HeapSchema& dl, PoolSchema& pool, bool isHpha, bool isDL, bool isDefault, bool isPool)
         {
-            AZStd::chrono::system_clock::time_point start;
+            AZStd::chrono::steady_clock::time_point start;
             AZStd::chrono::duration<float> elapsed;
             printf("MinSize %u MaxSize %u MaxAlignment %u\n", static_cast<unsigned int>(MIN_SIZE), static_cast<unsigned int>(MAX_SIZE), static_cast<unsigned int>(MAX_ALIGNMENT));
             printf("\t\t\t\tHPHA\t\tDL\t\tDEFAULT\t\tPOOL\n");
@@ -1607,13 +1607,13 @@ namespace UnitTest
             if (isHpha)
             {
                 srand(1234);
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 hphaAllocate(hpha, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("\t\t\t(%.3f/", elapsed.count());
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 hphaFree(hpha, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("%.3f)", elapsed.count());
             }
             else
@@ -1624,13 +1624,13 @@ namespace UnitTest
             if (isDL)
             {
                 srand(1234);
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 dlAllocate(dl, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("\t(%.3f/", elapsed.count());
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 dlFree(dl, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("%.3f)", elapsed.count());
             }
             else
@@ -1642,13 +1642,13 @@ namespace UnitTest
             if (isDefault)
             {
                 srand(1234);
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 defAllocate(0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("\t(%.3f/", elapsed.count());
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 defFree(0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("%.3f)", elapsed.count());
             }
             else
@@ -1661,13 +1661,13 @@ namespace UnitTest
                 if (isPool)
                 {
                     srand(1234);
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     poolAllocate(pool, 0, N);
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     poolFree(pool, 0, N);
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)\n", elapsed.count());
                 }
                 else
@@ -1684,13 +1684,13 @@ namespace UnitTest
             if (isHpha)
             {
                 srand(1234);
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 hphaAllocateSize(hpha, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("\t\t(%.3f/", elapsed.count());
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 hphaFreeSize(hpha, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("%.3f)", elapsed.count());
             }
             else
@@ -1701,13 +1701,13 @@ namespace UnitTest
             if (isDL)
             {
                 srand(1234);
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 dlAllocateSize(dl, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("\t(%.3f/", elapsed.count());
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 dlFreeSize(dl, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("%.3f)", elapsed.count());
             }
             else
@@ -1718,13 +1718,13 @@ namespace UnitTest
             if (isDefault)
             {
                 srand(1234);
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 defAllocateSize(0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("\t(%.3f/", elapsed.count());
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 defFreeSize(0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("%.3f)", elapsed.count());
             }
             else
@@ -1737,13 +1737,13 @@ namespace UnitTest
                 if (isPool)
                 {
                     srand(1234);
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     poolAllocateSize(pool, 0, N);
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     poolFreeSize(pool, 0, N);
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)\n", elapsed.count());
                 }
                 else
@@ -1760,13 +1760,13 @@ namespace UnitTest
             if (isHpha)
             {
                 srand(1234);
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 hphaAllocateAlignment(hpha, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("\t\t(%.3f/", elapsed.count());
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 hphaFreeAlignment(hpha, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("%.3f)", elapsed.count());
             }
             else
@@ -1777,13 +1777,13 @@ namespace UnitTest
             if (isDL)
             {
                 srand(1234);
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 dlAllocateAlignment(dl, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("\t(%.3f/", elapsed.count());
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 dlFreeAlignment(dl, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("%.3f)", elapsed.count());
             }
             else
@@ -1794,13 +1794,13 @@ namespace UnitTest
             if (isDefault)
             {
                 srand(1234);
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 defAllocateAlignment(0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("\t(%.3f/", elapsed.count());
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 defFreeAlignment(0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("%.3f)", elapsed.count());
             }
             else
@@ -1813,13 +1813,13 @@ namespace UnitTest
                 if (isPool)
                 {
                     srand(1234);
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     poolAllocateAlignment(pool, 0, N);
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     poolFreeAlignment(pool, 0, N);
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)\n", elapsed.count());
                 }
                 else
@@ -1836,13 +1836,13 @@ namespace UnitTest
             if (isHpha)
             {
                 srand(1234);
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 hphaAllocateAlignmentSize(hpha, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("\t(%.3f/", elapsed.count());
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 hphaFreeAlignmentSize(hpha, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("%.3f)", elapsed.count());
             }
             else
@@ -1853,13 +1853,13 @@ namespace UnitTest
             if (isDL)
             {
                 srand(1234);
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 dlAllocateAlignmentSize(dl, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("\t(%.3f/", elapsed.count());
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 dlFreeAlignmentSize(dl, 0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("%.3f)", elapsed.count());
             }
             else
@@ -1870,13 +1870,13 @@ namespace UnitTest
             if (isDefault)
             {
                 srand(1234);
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 defAllocateAlignmentSize(0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("\t(%.3f/", elapsed.count());
-                start = AZStd::chrono::system_clock::now();
+                start = AZStd::chrono::steady_clock::now();
                 defFreeAlignmentSize(0, N);
-                elapsed = AZStd::chrono::system_clock::now() - start;
+                elapsed = AZStd::chrono::steady_clock::now() - start;
                 printf("%.3f)", elapsed.count());
             }
             else
@@ -1889,13 +1889,13 @@ namespace UnitTest
                 if (isPool)
                 {
                     srand(1234);
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     poolAllocateAlignmentSize(pool, 0, N);
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     poolFreeAlignmentSize(pool, 0, N);
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)\n", elapsed.count());
                 }
                 else
@@ -1910,7 +1910,7 @@ namespace UnitTest
 
             printf("TEST REALLOC:");
             srand(1234);
-            start = AZStd::chrono::system_clock::now();
+            start = AZStd::chrono::steady_clock::now();
             for (unsigned i = 0; i < N; i++) {
             size_t size = rand_size();
             tr[i].ptr = hpha.ReAllocate(nullptr, size, 1);
@@ -1924,11 +1924,11 @@ namespace UnitTest
             hpha.ReAllocate(tr[j].ptr, 0, 0);
             tr[j].ptr = tr[i].ptr;
             }
-            elapsed = AZStd::chrono::system_clock::now() - start;
+            elapsed = AZStd::chrono::steady_clock::now() - start;
             printf("\t\t\t\t\t(%.3f)", elapsed.count());
 
             srand(1234);
-            start = AZStd::chrono::system_clock::now();
+            start = AZStd::chrono::steady_clock::now();
             for (unsigned i = 0; i < N; i++) {
             size_t size = rand_size();
             tr[i].ptr = realloc(NULL, size);
@@ -1942,12 +1942,12 @@ namespace UnitTest
             realloc(tr[j].ptr, 0);
             tr[j].ptr = tr[i].ptr;
             }
-            elapsed = AZStd::chrono::system_clock::now() - start;
+            elapsed = AZStd::chrono::steady_clock::now() - start;
             printf("\t(%.3f)\n", elapsed.count());
 
             printf("TEST REALLOC with ALIGNMENT:");
             srand(1234);
-            start = AZStd::chrono::system_clock::now();
+            start = AZStd::chrono::steady_clock::now();
             for (unsigned i = 0; i < N; i++) {
             size_t size = rand_size();
             size_t alignment = rand_alignment();
@@ -1963,11 +1963,11 @@ namespace UnitTest
             hpha.ReAllocate(tr[j].ptr, 0, 0);
             tr[j].ptr = tr[i].ptr;
             }
-            elapsed = AZStd::chrono::system_clock::now() - start;
+            elapsed = AZStd::chrono::steady_clock::now() - start;
             printf("\t\t\t(%.3f)", elapsed.count());
 
             srand(1234);
-            start = AZStd::chrono::system_clock::now();
+            start = AZStd::chrono::steady_clock::now();
 #ifdef AZ_PLATFORM_WINDOWS // Windows test only
             for (unsigned i = 0; i < N; i++) {
             size_t size = rand_size();
@@ -1985,13 +1985,13 @@ namespace UnitTest
             tr[j].ptr = tr[i].ptr;
             }
 #endif // AZ_PLATFORM_WINDOWS
-            elapsed = AZStd::chrono::system_clock::now() - start;
+            elapsed = AZStd::chrono::steady_clock::now() - start;
             printf("\t(%.3f)\n", elapsed.count());
         }
 
         void allocdeallocThread(HphaSchema& hpha, HeapSchema& dl, ThreadPoolSchema& thPool, bool isHpha, bool isDL, bool isDefault, bool isPool)
         {
-            AZStd::chrono::system_clock::time_point start;
+            AZStd::chrono::steady_clock::time_point start;
             AZStd::chrono::duration<float> elapsed;
             printf("MinSize %u MaxSize %u MaxAlignment %u\n", static_cast<unsigned int>(MIN_SIZE), static_cast<unsigned int>(MAX_SIZE), static_cast<unsigned int>(MAX_ALIGNMENT));
             printf("\t\t\t\tHPHA\t\tDL\t\tDEFAULT\t\tPOOL\n");
@@ -2007,23 +2007,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::hphaAllocate, this, AZStd::ref(hpha), 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::hphaAllocate, this, AZStd::ref(hpha), 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::hphaAllocate, this, AZStd::ref(hpha), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t\t\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::hphaFree, this, AZStd::ref(hpha), 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::hphaFree, this, AZStd::ref(hpha), 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::hphaFree, this, AZStd::ref(hpha), 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::hphaFree, this, AZStd::ref(hpha), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)", elapsed.count());
                 }
                 else
@@ -2040,23 +2040,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::dlAllocate, this, AZStd::ref(dl), 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::dlAllocate, this, AZStd::ref(dl), 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::dlAllocate, this, AZStd::ref(dl), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::dlFree, this, AZStd::ref(dl), 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::dlFree, this, AZStd::ref(dl), 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::dlFree, this, AZStd::ref(dl), 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::dlFree, this, AZStd::ref(dl), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)", elapsed.count());
                 }
                 else
@@ -2073,23 +2073,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::defAllocate, this, 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::defAllocate, this, 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::defAllocate, this, 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::defFree, this, 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::defFree, this, 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::defFree, this, 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::defFree, this, 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f)", elapsed.count());
                 }
                 else
@@ -2107,23 +2107,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::thPoolAllocate, this, AZStd::ref(thPool), 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::thPoolAllocate, this, AZStd::ref(thPool), 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::thPoolAllocate, this, AZStd::ref(thPool), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::thPoolFree, this, AZStd::ref(thPool), 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::thPoolFree, this, AZStd::ref(thPool), 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::thPoolFree, this, AZStd::ref(thPool), 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::thPoolFree, this, AZStd::ref(thPool), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)\n", elapsed.count());
                 }
                 else
@@ -2145,23 +2145,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::hphaAllocateSize, this, AZStd::ref(hpha), 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::hphaAllocateSize, this, AZStd::ref(hpha), 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::hphaAllocateSize, this, AZStd::ref(hpha), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::hphaFreeSize, this, AZStd::ref(hpha), 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::hphaFreeSize, this, AZStd::ref(hpha), 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::hphaFreeSize, this, AZStd::ref(hpha), 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::hphaFreeSize, this, AZStd::ref(hpha), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("/%.3f)", elapsed.count());
                 }
                 else
@@ -2178,23 +2178,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::dlAllocateSize, this, AZStd::ref(dl), 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::dlAllocateSize, this, AZStd::ref(dl), 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::dlAllocateSize, this, AZStd::ref(dl), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::dlFreeSize, this, AZStd::ref(dl), 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::dlFreeSize, this, AZStd::ref(dl), 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::dlFreeSize, this, AZStd::ref(dl), 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::dlFreeSize, this, AZStd::ref(dl), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)", elapsed.count());
                 }
                 else
@@ -2212,23 +2212,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::defAllocateSize, this, 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::defAllocateSize, this, 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::defAllocateSize, this, 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::defFreeSize, this, 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::defFreeSize, this, 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::defFreeSize, this, 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::defFreeSize, this, 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)", elapsed.count());
                 }
                 else
@@ -2246,23 +2246,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::thPoolAllocateSize, this, AZStd::ref(thPool), 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::thPoolAllocateSize, this, AZStd::ref(thPool), 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::thPoolAllocateSize, this, AZStd::ref(thPool), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::thPoolFreeSize, this, AZStd::ref(thPool), 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::thPoolFreeSize, this, AZStd::ref(thPool), 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::thPoolFreeSize, this, AZStd::ref(thPool), 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::thPoolFreeSize, this, AZStd::ref(thPool), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)\n", elapsed.count());
                 }
                 else
@@ -2284,23 +2284,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::hphaAllocateAlignment, this, AZStd::ref(hpha), 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::hphaAllocateAlignment, this, AZStd::ref(hpha), 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::hphaAllocateAlignment, this, AZStd::ref(hpha), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::hphaFreeAlignment, this, AZStd::ref(hpha), 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::hphaFreeAlignment, this, AZStd::ref(hpha), 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::hphaFreeAlignment, this, AZStd::ref(hpha), 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::hphaFreeAlignment, this, AZStd::ref(hpha), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)", elapsed.count());
                 }
                 else
@@ -2317,23 +2317,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::dlAllocateAlignment, this, AZStd::ref(dl), 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::dlAllocateAlignment, this, AZStd::ref(dl), 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::dlAllocateAlignment, this, AZStd::ref(dl), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::dlFreeAlignment, this, AZStd::ref(dl), 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::dlFreeAlignment, this, AZStd::ref(dl), 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::dlFreeAlignment, this, AZStd::ref(dl), 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::dlFreeAlignment, this, AZStd::ref(dl), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)", elapsed.count());
                 }
                 else
@@ -2350,23 +2350,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::defAllocateAlignment, this, 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::defAllocateAlignment, this, 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::defAllocateAlignment, this, 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::defFreeAlignment, this, 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::defFreeAlignment, this, 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::defFreeAlignment, this, 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::defFreeAlignment, this, 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)", elapsed.count());
                 }
                 else
@@ -2384,23 +2384,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::thPoolAllocateAlignment, this, AZStd::ref(thPool), 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::thPoolAllocateAlignment, this, AZStd::ref(thPool), 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::thPoolAllocateAlignment, this, AZStd::ref(thPool), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::thPoolFreeAlignment, this, AZStd::ref(thPool), 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::thPoolFreeAlignment, this, AZStd::ref(thPool), 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::thPoolFreeAlignment, this, AZStd::ref(thPool), 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::thPoolFreeAlignment, this, AZStd::ref(thPool), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)\n", elapsed.count());
                 }
                 else
@@ -2422,23 +2422,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::hphaAllocateAlignmentSize, this, AZStd::ref(hpha), 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::hphaAllocateAlignmentSize, this, AZStd::ref(hpha), 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::hphaAllocateAlignmentSize, this, AZStd::ref(hpha), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::hphaFreeAlignmentSize, this, AZStd::ref(hpha), 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::hphaFreeAlignmentSize, this, AZStd::ref(hpha), 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::hphaFreeAlignmentSize, this, AZStd::ref(hpha), 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::hphaFreeAlignmentSize, this, AZStd::ref(hpha), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)", elapsed.count());
                 }
                 else
@@ -2455,23 +2455,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::dlAllocateAlignmentSize, this, AZStd::ref(dl), 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::dlAllocateAlignmentSize, this, AZStd::ref(dl), 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::dlAllocateAlignmentSize, this, AZStd::ref(dl), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::dlFreeAlignmentSize, this, AZStd::ref(dl), 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::dlFreeAlignmentSize, this, AZStd::ref(dl), 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::dlFreeAlignmentSize, this, AZStd::ref(dl), 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::dlFreeAlignmentSize, this, AZStd::ref(dl), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)", elapsed.count());
                 }
                 else
@@ -2488,23 +2488,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::defAllocateAlignmentSize, this, 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::defAllocateAlignmentSize, this, 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::defAllocateAlignmentSize, this, 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::defFreeAlignmentSize, this, 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::defFreeAlignmentSize, this, 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::defFreeAlignmentSize, this, 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::defFreeAlignmentSize, this, 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)", elapsed.count());
                 }
                 else
@@ -2522,23 +2522,23 @@ namespace UnitTest
                     AZStd::thread tr2(AZStd::bind(&PERF_MemoryBenchmark::thPoolAllocateAlignmentSize, this, AZStd::ref(thPool), 1 * TN, 2 * TN));
                     AZStd::thread tr3(AZStd::bind(&PERF_MemoryBenchmark::thPoolAllocateAlignmentSize, this, AZStd::ref(thPool), 2 * TN, 3 * TN));
                     AZStd::thread tr4(AZStd::bind(&PERF_MemoryBenchmark::thPoolAllocateAlignmentSize, this, AZStd::ref(thPool), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr1.join();
                     tr2.join();
                     tr3.join();
                     tr4.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("\t(%.3f/", elapsed.count());
                     AZStd::thread tr5(AZStd::bind(&PERF_MemoryBenchmark::thPoolFreeAlignmentSize, this, AZStd::ref(thPool), 0 * TN, 1 * TN));
                     AZStd::thread tr6(AZStd::bind(&PERF_MemoryBenchmark::thPoolFreeAlignmentSize, this, AZStd::ref(thPool), 1 * TN, 2 * TN));
                     AZStd::thread tr7(AZStd::bind(&PERF_MemoryBenchmark::thPoolFreeAlignmentSize, this, AZStd::ref(thPool), 2 * TN, 3 * TN));
                     AZStd::thread tr8(AZStd::bind(&PERF_MemoryBenchmark::thPoolFreeAlignmentSize, this, AZStd::ref(thPool), 3 * TN, 4 * TN));
-                    start = AZStd::chrono::system_clock::now();
+                    start = AZStd::chrono::steady_clock::now();
                     tr5.join();
                     tr6.join();
                     tr7.join();
                     tr8.join();
-                    elapsed = AZStd::chrono::system_clock::now() - start;
+                    elapsed = AZStd::chrono::steady_clock::now() - start;
                     printf("%.3f)\n", elapsed.count());
                 }
                 else

--- a/Code/Framework/AzCore/Tests/Platform/Windows/Tests/IO/Streamer/StorageDriveTests_Windows.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Windows/Tests/IO/Streamer/StorageDriveTests_Windows.cpp
@@ -231,7 +231,7 @@ namespace AZ::IO
         void WaitTillCompleted()
         {
             StreamStackEntry::Status status;
-            auto startTime = AZStd::chrono::system_clock::now();
+            auto startTime = AZStd::chrono::steady_clock::now();
             do
             {
                 m_storageDriveWin->ExecuteRequests();
@@ -240,7 +240,7 @@ namespace AZ::IO
                 status.m_isIdle = true;
                 m_storageDriveWin->UpdateStatus(status);
 
-                if (AZStd::chrono::system_clock::now() - startTime > AZStd::chrono::seconds(5))
+                if (AZStd::chrono::steady_clock::now() - startTime > AZStd::chrono::seconds(5))
                 {
                     FAIL();
                 }
@@ -1233,18 +1233,18 @@ namespace Benchmark
             for ([[maybe_unused]] auto _ : state)
             {
                 AZStd::binary_semaphore waitForReads;
-                AZStd::atomic<system_clock::time_point> end;
+                AZStd::atomic<steady_clock::time_point> end;
                 auto callback = [&end, &waitForReads]([[maybe_unused]] FileRequestHandle request)
                 {
-                    benchmark::DoNotOptimize(end = system_clock::now());
+                    benchmark::DoNotOptimize(end = steady_clock::now());
                     waitForReads.release();
                 };
 
                 FileRequestPtr request = m_streamer->Read(m_absolutePath, buffer.get(), state.range(0), state.range(0));
                 m_streamer->SetRequestCompleteCallback(request, callback);
 
-                system_clock::time_point start;
-                benchmark::DoNotOptimize(start = system_clock::now());
+                steady_clock::time_point start;
+                benchmark::DoNotOptimize(start = steady_clock::now());
                 m_streamer->QueueRequest(request);
 
                 waitForReads.try_acquire_for(AZStd::chrono::seconds(5));

--- a/Code/Framework/AzCore/Tests/Streamer/IStreamerMock.h
+++ b/Code/Framework/AzCore/Tests/Streamer/IStreamerMock.h
@@ -49,7 +49,7 @@ public:
     MOCK_METHOD1(QueueRequestBatch, void(AZStd::vector<FileRequestPtr>&&));
     MOCK_CONST_METHOD1(HasRequestCompleted, bool(FileRequestHandle));
     MOCK_CONST_METHOD1(GetRequestStatus, IStreamerTypes::RequestStatus(FileRequestHandle));
-    MOCK_CONST_METHOD1(GetEstimatedRequestCompletionTime, AZStd::chrono::system_clock::time_point(FileRequestHandle));
+    MOCK_CONST_METHOD1(GetEstimatedRequestCompletionTime, AZStd::chrono::steady_clock::time_point(FileRequestHandle));
     MOCK_CONST_METHOD4(GetReadRequestResult, bool(FileRequestHandle, void*&, AZ::u64&, IStreamerTypes::ClaimMemory));
     MOCK_METHOD1(CollectStatistics, void(AZStd::vector<Statistic>&));
     MOCK_CONST_METHOD0(GetRecommendations, const IStreamerTypes::Recommendations&());

--- a/Code/Framework/AzCore/Tests/Streamer/StreamStackEntryConformityTests.h
+++ b/Code/Framework/AzCore/Tests/Streamer/StreamStackEntryConformityTests.h
@@ -297,7 +297,7 @@ namespace AZ::IO
 
         EXPECT_CALL(*mock, UpdateCompletionEstimates(_, _, _, _)).Times(1);
 
-        auto now = AZStd::chrono::system_clock::now();
+        auto now = AZStd::chrono::steady_clock::now();
         AZStd::vector<FileRequest*> internalRequests;
         StreamerContext::PreparedQueue pendingRequests;
         entry.UpdateCompletionEstimates(now, internalRequests, pendingRequests.begin(), pendingRequests.end());

--- a/Code/Framework/AzCore/Tests/Streamer/StreamStackEntryMock.h
+++ b/Code/Framework/AzCore/Tests/Streamer/StreamStackEntryMock.h
@@ -32,7 +32,7 @@ namespace AZ::IO
         MOCK_METHOD0(ExecuteRequests, bool());
         
         MOCK_CONST_METHOD1(UpdateStatus, void(Status& status));
-        MOCK_METHOD4(UpdateCompletionEstimates, void(AZStd::chrono::system_clock::time_point,
+        MOCK_METHOD4(UpdateCompletionEstimates, void(AZStd::chrono::steady_clock::time_point,
             AZStd::vector<FileRequest*>&, StreamerContext::PreparedQueue::iterator, StreamerContext::PreparedQueue::iterator));
 
         MOCK_CONST_METHOD1(CollectStatistics, void(AZStd::vector<Statistic>&));

--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
@@ -337,16 +337,16 @@ namespace AZ::IO
     {
         SAutoCollectFileAccessTime(Archive* pArchive)
             : m_pArchive{ pArchive }
-            , m_startTime{ AZStd::chrono::system_clock::now() }
+            , m_startTime{ AZStd::chrono::steady_clock::now() }
         {
         }
         ~SAutoCollectFileAccessTime()
         {
-            m_pArchive->m_fFileAccessTime += aznumeric_cast<float>(AZStd::chrono::duration_cast<AZStd::chrono::seconds>(AZStd::chrono::system_clock::now() - m_startTime).count());
+            m_pArchive->m_fFileAccessTime += aznumeric_cast<float>(AZStd::chrono::duration_cast<AZStd::chrono::seconds>(AZStd::chrono::steady_clock::now() - m_startTime).count());
         }
     private:
         Archive* m_pArchive;
-        AZStd::chrono::system_clock::time_point m_startTime;
+        AZStd::chrono::steady_clock::time_point m_startTime;
     };
 
     /////////////////////////////////////////////////////

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
@@ -535,9 +535,9 @@ namespace AzFramework
                     }
                     else
                     {
-                        AZStd::chrono::time_point startConnectFromLaunchTime = AZStd::chrono::system_clock::now();
+                        auto startConnectFromLaunchTime = AZStd::chrono::steady_clock::now();
                         connectionEstablished = WaitUntilAssetProcessorConnected(connectionSettings.m_launchTimeout);
-                        AZStd::chrono::time_point endConnectFromLaunchTime = AZStd::chrono::system_clock::now();
+                        auto endConnectFromLaunchTime = AZStd::chrono::steady_clock::now();
                         if (!connectionEstablished && NegotiationWithAssetProcessorFailed())
                         {
                             AZ_Error(connectionSettings.m_connectionIdentifier.c_str(), false, "Negotiation with asset processor failed");
@@ -610,8 +610,8 @@ namespace AzFramework
 
         bool AssetSystemComponent::WaitUntilAssetProcessorConnected(AZStd::chrono::duration<float> timeout)
         {
-            AZStd::chrono::system_clock::time_point start = AZStd::chrono::system_clock::now();
-            while (!ConnectedWithAssetProcessor() && AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - start) < timeout)
+            AZStd::chrono::steady_clock::time_point start = AZStd::chrono::steady_clock::now();
+            while (!ConnectedWithAssetProcessor() && AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - start) < timeout)
             {
                 if (NegotiationWithAssetProcessorFailed())
                 {
@@ -641,9 +641,9 @@ namespace AzFramework
                 AZ_TracePrintf("AssetSystem", "Ping time to asset processor: %0.2f milliseconds\n", pingTime);
             }
 
-            AZStd::chrono::system_clock::time_point start = AZStd::chrono::system_clock::now();
+            AZStd::chrono::steady_clock::time_point start = AZStd::chrono::steady_clock::now();
             bool isAssetProcessorReady = false;
-            while (!isAssetProcessorReady && (AZStd::chrono::system_clock::now() - start) < timeout)
+            while (!isAssetProcessorReady && (AZStd::chrono::steady_clock::now() - start) < timeout)
             {
                 AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::PumpSystemEventLoopUntilEmpty);
 
@@ -715,8 +715,8 @@ namespace AzFramework
 
         bool AssetSystemComponent::WaitUntilAssetProcessorDisconnected(AZStd::chrono::duration<float> timeout)
         {
-            AZStd::chrono::system_clock::time_point start = AZStd::chrono::system_clock::now();
-            while (!DisconnectedWithAssetProcessor() && AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - start) < timeout)
+            AZStd::chrono::steady_clock::time_point start = AZStd::chrono::steady_clock::now();
+            while (!DisconnectedWithAssetProcessor() && AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - start) < timeout)
             {
                 //yield
                 AZStd::this_thread::yield();
@@ -840,12 +840,12 @@ namespace AzFramework
                 return 0.0f;
             }
 
-            AZStd::chrono::system_clock::time_point beforePing = AZStd::chrono::system_clock::now();
+            AZStd::chrono::steady_clock::time_point beforePing = AZStd::chrono::steady_clock::now();
             RequestPing pingeRequest;
             ResponsePing pingRespose;
             if (SendRequest(pingeRequest, pingRespose))
             {
-                AZStd::chrono::duration<float, AZStd::milli> difference = AZStd::chrono::duration_cast<AZStd::chrono::duration<float, AZStd::milli> >(AZStd::chrono::system_clock::now() - beforePing);
+                AZStd::chrono::duration<float, AZStd::milli> difference = AZStd::chrono::duration_cast<AZStd::chrono::duration<float, AZStd::milli> >(AZStd::chrono::steady_clock::now() - beforePing);
                 return difference.count();
             }
 

--- a/Code/Framework/AzFramework/AzFramework/Asset/Benchmark/BenchmarkCommands.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/Benchmark/BenchmarkCommands.cpp
@@ -54,7 +54,7 @@ namespace AzFramework::AssetBenchmark
             AZStd::vector<AZ::Data::Asset<AZ::Data::AssetData>> processedAssets;
 
             // Start timing.
-            auto start = AZStd::chrono::system_clock::now();
+            auto start = AZStd::chrono::steady_clock::now();
 
             // Part 1:  Queue up all the requested assets.
             // If loadBlocking is true, each asset will be synchronously and serially loaded.
@@ -129,7 +129,7 @@ namespace AzFramework::AssetBenchmark
                     requestedAssets.end());
 
                 // Update our total running time so far.
-                runMs = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - start);
+                runMs = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - start);
 
                 if (!requestedAssets.empty())
                 {

--- a/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
@@ -211,11 +211,11 @@ namespace AzFramework
         EntityContext::OnContextEntitiesAdded(entities);
 
     #if (AZ_TRAIT_PUMP_SYSTEM_EVENTS_WHILE_LOADING)
-        auto timeOfLastEventPump = AZStd::chrono::high_resolution_clock::now();
+        auto timeOfLastEventPump = AZStd::chrono::steady_clock::now();
         auto PumpSystemEventsIfNeeded = [&timeOfLastEventPump]()
         {
             static const AZStd::chrono::milliseconds maxMillisecondsBetweenSystemEventPumps(AZ_TRAIT_PUMP_SYSTEM_EVENTS_WHILE_LOADING_INTERVAL_MS);
-            const auto now = AZStd::chrono::high_resolution_clock::now();
+            const auto now = AZStd::chrono::steady_clock::now();
             if (now - timeOfLastEventPump > maxMillisecondsBetweenSystemEventPumps)
             {
                 timeOfLastEventPump = now;

--- a/Code/Framework/AzFramework/AzFramework/IO/RemoteStorageDrive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/IO/RemoteStorageDrive.cpp
@@ -54,7 +54,7 @@ namespace AzFramework
     RemoteStorageDrive::RemoteStorageDrive(AZ::u32 maxFileHandles)
         : StreamStackEntry("Storage drive(VFS)")
     {
-        m_fileLastUsed.resize(maxFileHandles, AZStd::chrono::system_clock::time_point::min());
+        m_fileLastUsed.resize(maxFileHandles, AZStd::chrono::steady_clock::time_point::min());
         m_filePaths.resize(maxFileHandles);
         m_fileHandles.resize(maxFileHandles, AZ::IO::InvalidHandle);
 
@@ -186,7 +186,7 @@ namespace AzFramework
         }
     }
 
-    void RemoteStorageDrive::UpdateCompletionEstimates(AZStd::chrono::system_clock::time_point now,
+    void RemoteStorageDrive::UpdateCompletionEstimates(AZStd::chrono::steady_clock::time_point now,
         AZStd::vector<AZ::IO::FileRequest*>& internalPending, AZ::IO::StreamerContext::PreparedQueue::iterator pendingBegin,
         AZ::IO::StreamerContext::PreparedQueue::iterator pendingEnd)
     {
@@ -221,7 +221,7 @@ namespace AzFramework
     }
 
     void RemoteStorageDrive::EstimateCompletionTimeForRequest(AZ::IO::FileRequest* request,
-        AZStd::chrono::system_clock::time_point& startTime, const AZ::IO::RequestPath*& activeFile) const
+        AZStd::chrono::steady_clock::time_point& startTime, const AZ::IO::RequestPath*& activeFile) const
     {
         using namespace AZ::IO;
 
@@ -291,13 +291,13 @@ namespace AzFramework
         if (cacheIndex != s_fileNotFound)
         {
             file = m_fileHandles[cacheIndex];
-            m_fileLastUsed[cacheIndex] = AZStd::chrono::system_clock::now();
+            m_fileLastUsed[cacheIndex] = AZStd::chrono::steady_clock::now();
         }
 
         // If the file is not open, eject the oldest entry from the cache and open the file for reading.
         if (file == InvalidHandle)
         {
-            AZStd::chrono::system_clock::time_point oldest = m_fileLastUsed[0];
+            AZStd::chrono::steady_clock::time_point oldest = m_fileLastUsed[0];
             cacheIndex = 0;
             size_t numFiles = m_filePaths.size();
             for (size_t i = 1; i < numFiles; ++i)
@@ -316,7 +316,7 @@ namespace AzFramework
                 return;
             }
 
-            m_fileLastUsed[cacheIndex] = AZStd::chrono::system_clock::now();
+            m_fileLastUsed[cacheIndex] = AZStd::chrono::steady_clock::now();
             if (m_fileHandles[cacheIndex] != InvalidHandle)
             {
                 m_fileIO.Close(m_fileHandles[cacheIndex]);
@@ -473,7 +473,7 @@ namespace AzFramework
         size_t cacheIndex = FindFileInCache(filePath);
         if (cacheIndex != s_fileNotFound)
         {
-            m_fileLastUsed[cacheIndex] = AZStd::chrono::system_clock::time_point();
+            m_fileLastUsed[cacheIndex] = AZStd::chrono::steady_clock::time_point();
             m_filePaths[cacheIndex].Clear();
             AZ_Assert(
                 m_fileHandles[cacheIndex] != AZ::IO::InvalidHandle, "File path '%s' doesn't have an associated file handle.",
@@ -488,7 +488,7 @@ namespace AzFramework
         size_t numFiles = m_filePaths.size();
         for (size_t i = 0; i < numFiles; ++i)
         {
-            m_fileLastUsed[i] = AZStd::chrono::system_clock::time_point();
+            m_fileLastUsed[i] = AZStd::chrono::steady_clock::time_point();
             m_filePaths[i].Clear();
             if (m_fileHandles[i] != AZ::IO::InvalidHandle)
             {

--- a/Code/Framework/AzFramework/AzFramework/IO/RemoteStorageDrive.h
+++ b/Code/Framework/AzFramework/AzFramework/IO/RemoteStorageDrive.h
@@ -53,7 +53,7 @@ namespace AzFramework
         bool ExecuteRequests() override;
 
         void UpdateStatus(Status& status) const override;
-        void UpdateCompletionEstimates(AZStd::chrono::system_clock::time_point now,
+        void UpdateCompletionEstimates(AZStd::chrono::steady_clock::time_point now,
             AZStd::vector<AZ::IO::FileRequest*>& internalPending,
             AZ::IO::StreamerContext::PreparedQueue::iterator pendingBegin,
             AZ::IO::StreamerContext::PreparedQueue::iterator pendingEnd) override;
@@ -68,7 +68,7 @@ namespace AzFramework
         void FileExistsRequest(AZ::IO::FileRequest* request);
         void FileMetaDataRetrievalRequest(AZ::IO::FileRequest* request);
         size_t FindFileInCache(const AZ::IO::RequestPath& filePath) const;
-        void EstimateCompletionTimeForRequest(AZ::IO::FileRequest* request, AZStd::chrono::system_clock::time_point& startTime,
+        void EstimateCompletionTimeForRequest(AZ::IO::FileRequest* request, AZStd::chrono::steady_clock::time_point& startTime,
             const AZ::IO::RequestPath*& activeFile) const;
         void FlushCache(const AZ::IO::RequestPath& filePath);
         void FlushEntireCache();
@@ -82,7 +82,7 @@ namespace AzFramework
         AZ::IO::AverageWindow<AZ::u64, float, AZ::IO::s_statisticsWindowSize> m_readSizeAverage;
         AZStd::deque<AZ::IO::FileRequest*> m_pendingRequests;
 
-        AZStd::vector<AZStd::chrono::system_clock::time_point> m_fileLastUsed;
+        AZStd::vector<AZStd::chrono::steady_clock::time_point> m_fileLastUsed;
         AZStd::vector<AZ::IO::RequestPath> m_filePaths;
         AZStd::vector<AZ::IO::HandleType> m_fileHandles;
 

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
@@ -190,7 +190,7 @@ namespace AzFramework
         , m_rawMovementSampleRate()
         , m_rawButtonEventQueuesById()
         , m_rawMovementEventQueuesById()
-        , m_timeOfLastRawMovementSample(AZStd::chrono::system_clock::now())
+        , m_timeOfLastRawMovementSample(AZStd::chrono::steady_clock::now())
     {
         SetRawMovementSampleRate(MovementSampleRateDefault);
     }
@@ -213,7 +213,7 @@ namespace AzFramework
     void InputDeviceMouse::Implementation::QueueRawMovementEvent(const InputChannelId& inputChannelId,
                                                                  float rawMovementDelta)
     {
-        auto now = AZStd::chrono::system_clock::now();
+        auto now = AZStd::chrono::steady_clock::now();
         auto deltaTime = now - m_timeOfLastRawMovementSample;
         auto& rawEventQueue = m_rawMovementEventQueuesById[inputChannelId];
 

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.h
@@ -304,7 +304,7 @@ namespace AzFramework
             AZStd::sys_time_t            m_rawMovementSampleRate;      //!< Raw movement sample rate
             RawButtonEventQueueByIdMap   m_rawButtonEventQueuesById;   //!< Raw button events by id
             RawMovementEventQueueByIdMap m_rawMovementEventQueuesById; //!< Raw movement events by id
-            AZStd::chrono::system_clock::time_point m_timeOfLastRawMovementSample; //!< Time of the last raw movement sample
+            AZStd::chrono::steady_clock::time_point m_timeOfLastRawMovementSample; //!< Time of the last raw movement sample
         };
 
         ////////////////////////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.cpp
@@ -17,7 +17,7 @@ namespace AzFramework
     {
         m_timeNowFn = []
         {
-            const auto now = AZStd::chrono::high_resolution_clock::now();
+            const auto now = AZStd::chrono::steady_clock::now();
             return AZStd::chrono::time_point_cast<AZStd::chrono::milliseconds>(now).time_since_epoch();
         };
     }

--- a/Code/Framework/AzFramework/Tests/AssetProcessorConnection.cpp
+++ b/Code/Framework/AzFramework/Tests/AssetProcessorConnection.cpp
@@ -32,7 +32,7 @@ const AZ::u32 BAPayloadSize = azlossy_caster(strlen(BAPayload));
 
 // how long before tests fail when expecting a connection.
 // normally, connections to localhost happen immediately (microseconds), so this is just for when things
-// go wrong.  In normal test runs, we'll be yielding and waiting very short 
+// go wrong.  In normal test runs, we'll be yielding and waiting very short
 // amounts of time (milliseconds) instead of the full 15 seconds.
 const int secondsMaxConnectionAttempt = 15;
 
@@ -65,11 +65,11 @@ protected:
         // matches in the loop condition it could later not match in the return statement
         // as the state is being updated on another thread
         AzFramework::SocketConnection::EConnectionState connectionState;
-        auto started = AZStd::chrono::system_clock::now();
+        auto started = AZStd::chrono::steady_clock::now();
         for (connectionState = connectionObject.GetConnectionState(); connectionState != desired;
             connectionState = connectionObject.GetConnectionState())
         {
-            auto seconds_passed = AZStd::chrono::duration_cast<AZStd::chrono::seconds>(AZStd::chrono::system_clock::now() - started).count();
+            auto seconds_passed = AZStd::chrono::duration_cast<AZStd::chrono::seconds>(AZStd::chrono::steady_clock::now() - started).count();
             if (seconds_passed > secondsMaxConnectionAttempt)
             {
                 break;
@@ -86,11 +86,11 @@ protected:
         // matches in the loop condition it could later not match in the return statement
         // as the state is being updated on another thread
         AzFramework::SocketConnection::EConnectionState connectionState;
-        auto started = AZStd::chrono::system_clock::now();
+        auto started = AZStd::chrono::steady_clock::now();
         for (connectionState = connectionObject.GetConnectionState(); connectionState == notDesired;
             connectionState = connectionObject.GetConnectionState())
         {
-            auto seconds_passed = AZStd::chrono::duration_cast<AZStd::chrono::seconds>(AZStd::chrono::system_clock::now() - started).count();
+            auto seconds_passed = AZStd::chrono::duration_cast<AZStd::chrono::seconds>(AZStd::chrono::steady_clock::now() - started).count();
             if (seconds_passed > secondsMaxConnectionAttempt)
             {
                 break;
@@ -163,7 +163,7 @@ TEST_F(APConnectionTest, TestAddRemoveCallbacks)
 
     // Wait some time for the connection to negotiate, only after negotiation succeeds is it actually considered connected,,
     EXPECT_TRUE(WaitForConnectionStateToBeEqual(apConnection, SocketConnection::EConnectionState::Connected));
-    
+
     // Check listener for success - by this time the listener should also be considered connected.
     EXPECT_TRUE(WaitForConnectionStateToBeEqual(apListener, SocketConnection::EConnectionState::Connected));
 
@@ -242,7 +242,7 @@ TEST_F(APConnectionTest, TestAddRemoveCallbacks_RemoveDuringCallback_DoesNotCras
     ABMessageCallbackCount = 0;
 
     AZStd::binary_semaphore messageArrivedSemaphore;
-    
+
     // establish connection
     EXPECT_TRUE(apListener.Listen(11112));
     EXPECT_TRUE(apConnection.Connect("127.0.0.1", 11112));
@@ -253,7 +253,7 @@ TEST_F(APConnectionTest, TestAddRemoveCallbacks_RemoveDuringCallback_DoesNotCras
     // Now try adding listeners that remove themselves during callback
     //
     // Connection A is expecting the above type and payload from B, therefore it is B->A, BA
-    
+
     // we set a trap here - after we first get this message, we are removing the handler
     // so that it should not ever fire again, and we assert that its false.
     AZStd::atomic_bool failIfWeGetCalledAgainBA = {false};
@@ -268,7 +268,7 @@ TEST_F(APConnectionTest, TestAddRemoveCallbacks_RemoveDuringCallback_DoesNotCras
         apConnection.RemoveMessageHandler(BAType, SelfRemovingBACallbackHandle);
         failIfWeGetCalledAgainBA = true;
         messageArrivedSemaphore.release();
-        
+
     });
 
     // Connection B is expecting the above type and payload from A, therefore it is A->B, AB
@@ -285,7 +285,7 @@ TEST_F(APConnectionTest, TestAddRemoveCallbacks_RemoveDuringCallback_DoesNotCras
         failIfWeGetCalledAgainAB = true;
         messageArrivedSemaphore.release();
     });
-    
+
     // Send message, should be at 1 each
 
     // Send message from A to B
@@ -305,7 +305,7 @@ TEST_F(APConnectionTest, TestAddRemoveCallbacks_RemoveDuringCallback_DoesNotCras
     // above callback functions will trigger their asserts.
     apConnection.SendMsg(ABType, ABPayload, ABPayloadSize);
     apListener.SendMsg(BAType, BAPayload, BAPayloadSize);
-    
+
     // disconnect fully, which flushes sender queue and reciever queue and will cause any traps to spring!
     EXPECT_TRUE(apConnection.Disconnect(true));
     EXPECT_TRUE(apListener.Disconnect(true));
@@ -333,7 +333,7 @@ TEST_F(APConnectionTest, TestAddRemoveCallbacks_AddDuringCallback_DoesNotCrash)
     ABMessageCallbackCount = 0;
 
     AZStd::binary_semaphore messageArrivedSemaphore;
-    
+
     // establish connection
     EXPECT_TRUE(apListener.Listen(11112));
     EXPECT_TRUE(apConnection.Connect("127.0.0.1", 11112));
@@ -347,11 +347,11 @@ TEST_F(APConnectionTest, TestAddRemoveCallbacks_AddDuringCallback_DoesNotCrash)
     // Connection A is expecting the above type and payload from B, therefore it is B->A, BA
     SocketConnection::TMessageCallbackHandle SecondAddedBACallbackHandle = SocketConnection::s_invalidCallbackHandle;
     SocketConnection::TMessageCallbackHandle AddingBACallbackHandle = SocketConnection::s_invalidCallbackHandle;
-    
+
     // set some traps so that if things call more than once, its a failure:
     AZStd::atomic_bool AddingBACallbackFailIfCalledAgain = {false};
     AZStd::atomic_bool AddingBACallbackFailIfCalledAgain_inner = {false};
-    
+
     AddingBACallbackHandle = apConnection.AddMessageHandler(BAType, [&](AZ::u32 typeId, AZ::u32 /*serial*/, const void* data, AZ::u32 dataLength) -> void
     {
         EXPECT_FALSE(AddingBACallbackFailIfCalledAgain.load());
@@ -434,7 +434,7 @@ TEST_F(APConnectionTest, TestAddRemoveCallbacks_AddDuringCallback_DoesNotCrash)
     // since we flush on disconnect, these traps will activate.
     apConnection.SendMsg(ABType, ABPayload, ABPayloadSize);
     apListener.SendMsg(BAType, BAPayload, BAPayloadSize);
-    
+
     // Disconnect A
     // which flushes and will cause any traps to spring.
     bool disconnectResult = apConnection.Disconnect(true);
@@ -499,7 +499,7 @@ TEST_F(APConnectionTest, TestConnection)
     EXPECT_TRUE(apConnection.GetConnectionState() == SocketConnection::EConnectionState::Disconnected);
     bool connectResult = apConnection.Connect("127.0.0.1", 11120);
     EXPECT_TRUE(connectResult);
-    
+
     // during the connect/disconnect/reconnect loop, the status of the connection rapidly oscillates
     // between "connecting" and "disconnecting" as it tries, fails, and sets up to try again.
     // Since the connection attempt starts as disconnected (checked before the connect), here we will
@@ -625,7 +625,7 @@ TEST_F(APConnectionTest, TestReconnect)
     // note that the listener was the ONLY one we told to disconnect!
     // the other end (the apConnection) is likely to be in a retry state (ie, one of the states that is not connected)
     EXPECT_TRUE(WaitForConnectionStateToNotBeEqual(apConnection, SocketConnection::EConnectionState::Connected));
-    
+
     // disconnect A
     disconnectResult = apConnection.Disconnect(true); // we're not going to wait, so we do a final disconnect here (true)
     EXPECT_TRUE(disconnectResult);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/SourceControlThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/SourceControlThumbnail.cpp
@@ -23,7 +23,7 @@ namespace AzToolsFramework
             , m_fileName(fileName)
             , m_updateInterval(4)
         {
-            m_nextUpdate = AZStd::chrono::system_clock::now();
+            m_nextUpdate = AZStd::chrono::steady_clock::now();
         }
 
         const AZStd::string& SourceControlThumbnailKey::GetFileName() const
@@ -38,7 +38,7 @@ namespace AzToolsFramework
                 return false;
             }
 
-            const auto now(AZStd::chrono::system_clock::now());
+            const auto now(AZStd::chrono::steady_clock::now());
             if (m_nextUpdate >= now)
             {
                 return false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/SourceControlThumbnail.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/SourceControlThumbnail.h
@@ -40,7 +40,7 @@ namespace AzToolsFramework
             //! how often should sc thumbnails auto update
             const AZStd::chrono::minutes m_updateInterval;
             //! time since this sc thumbnail updated
-            AZStd::chrono::system_clock::time_point m_nextUpdate;
+            AZStd::chrono::steady_clock::time_point m_nextUpdate;
         };
 
         //! SourceControlThumbnail currently replicates the source control functionality within Material Browser

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ProgressShield.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ProgressShield.cpp
@@ -54,7 +54,7 @@ namespace AzToolsFramework
 
     void ProgressShield::LegacyShowAndWait(QWidget* parent, QString label, AZStd::function<bool(int& current, int& max)> completeCallback, int delayMS)
     {
-        using AzSysClock = AZStd::chrono::system_clock;
+        using AzSysClock = AZStd::chrono::steady_clock;
         using AzMillisec = AZStd::chrono::milliseconds;
         bool showShield = false;
 

--- a/Code/Framework/AzToolsFramework/Tests/Slices.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Slices.cpp
@@ -390,7 +390,7 @@ namespace UnitTest
                     return false;
                 }
 
-                const AZStd::chrono::system_clock::time_point startTime = AZStd::chrono::system_clock::now();
+                const AZStd::chrono::steady_clock::time_point startTime = AZStd::chrono::steady_clock::now();
 
                 size_t nextIndex = 1;
                 size_t assetsLoaded = 1;
@@ -402,7 +402,7 @@ namespace UnitTest
                     EBUS_EVENT(AZ::TickBus, OnTick, 0.3f, AZ::ScriptTimePoint());
                 }
 
-                const AZStd::chrono::system_clock::time_point assetLoadFinishTime = AZStd::chrono::system_clock::now();
+                const AZStd::chrono::steady_clock::time_point assetLoadFinishTime = AZStd::chrono::steady_clock::now();
 
                 AZ_Printf("StressTest", "All Assets Loaded: %u assets, took %.2f ms\n", assetsLoaded,
                     float(AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(assetLoadFinishTime - startTime).count()) * 0.001f);
@@ -442,9 +442,9 @@ namespace UnitTest
                     totalAllocs = AZ::AllocatorInstance<AZ::SystemAllocator>::GetAllocator().GetRecords()->RequestedAllocs();
                     AZ_TracePrintf("StressTest", "Allocs Before Inst: %u live, %u total\n", liveAllocs, totalAllocs);
 
-                    const AZStd::chrono::system_clock::time_point startTime = AZStd::chrono::system_clock::now();
+                    const AZStd::chrono::steady_clock::time_point startTime = AZStd::chrono::steady_clock::now();
                     StressInstDrill(baseSliceAsset, nextIndex, 1, slices);
-                    const AZStd::chrono::system_clock::time_point instantiateFinishTime = AZStd::chrono::system_clock::now();
+                    const AZStd::chrono::steady_clock::time_point instantiateFinishTime = AZStd::chrono::steady_clock::now();
 
                     liveAllocs = 0;
                     totalAllocs = 0;
@@ -657,7 +657,7 @@ namespace UnitTest
     {
         run();
     }
-    
+
     class SortTransformParentsBeforeChildrenTest
         : public ScopedAllocatorSetupFixture
     {
@@ -1019,13 +1019,13 @@ namespace UnitTest
         {
             switch (m_exportType)
             {
-                case EXPORT_EDITOR_COMPONENT:    
+                case EXPORT_EDITOR_COMPONENT:
                     return AZ::ExportedComponent(thisComponent, false, m_exportHandled);
-                case EXPORT_RUNTIME_COMPONENT:   
+                case EXPORT_RUNTIME_COMPONENT:
                     return AZ::ExportedComponent(aznew TestExportRuntimeComponent(true, true), true, m_exportHandled);
                 case EXPORT_OTHER_RUNTIME_COMPONENT:
                     return AZ::ExportedComponent(aznew TestExportOtherRuntimeComponent(), true, m_exportHandled);
-                case EXPORT_NULL_COMPONENT:      
+                case EXPORT_NULL_COMPONENT:
                     return AZ::ExportedComponent(nullptr, false, m_exportHandled);
             }
 
@@ -1067,7 +1067,7 @@ namespace UnitTest
             m_app.Start(AzFramework::Application::Descriptor());
 
             // Without this, the user settings component would attempt to save on finalize/shutdown. Since the file is
-            // shared across the whole engine, if multiple tests are run in parallel, the saving could cause a crash 
+            // shared across the whole engine, if multiple tests are run in parallel, the saving could cause a crash
             // in the unit tests.
             AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
 

--- a/Code/Tools/AssetProcessor/AssetBuilder/AssetBuilderComponent.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilder/AssetBuilderComponent.cpp
@@ -1023,7 +1023,7 @@ void AssetBuilderComponent::JobThread()
         std::fflush(stderr);
 
         AZ::SystemTickBus::Broadcast(&AZ::SystemTickBus::Events::OnSystemTick);
-        AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick, 0.00f, AZ::ScriptTimePoint(AZStd::chrono::system_clock::now()));
+        AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick, 0.00f, AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
         AZ::AllocatorManager::Instance().GarbageCollect();
 
         AzFramework::AssetSystem::SendResponse(*(job->m_netResponse), job->m_requestSerial);

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -501,7 +501,7 @@ namespace AssetProcessor
             // we need the relative path too:
             CheckDeletedSourceFile(
                 iter.key(), iter.value().m_sourceRelativeToWatchFolder, iter.value().m_sourceDatabaseName,
-                AZStd::chrono::system_clock::now());
+                AZStd::chrono::steady_clock::now());
         }
 
         // we want to remove any left over scan folders from the database only after
@@ -1880,7 +1880,7 @@ namespace AssetProcessor
                     CheckDeletedSourceFile(
                         productPath.GetIntermediatePath().c_str(), productPath.GetRelativePath().c_str(),
                         productPath.GetRelativePath().c_str(),
-                        AZStd::chrono::system_clock::now());
+                        AZStd::chrono::steady_clock::now());
                 }
 
                 m_checkFoldersToRemove.insert(productPath.GetCachePath().c_str());
@@ -1892,7 +1892,7 @@ namespace AssetProcessor
     }
 
     void AssetProcessorManager::CheckDeletedSourceFile(QString normalizedPath, QString relativePath, QString databaseSourceFile,
-        AZStd::chrono::system_clock::time_point initialProcessTime)
+        AZStd::chrono::steady_clock::time_point initialProcessTime)
     {
         // getting here means an input asset has been deleted
         // and no overrides exist for it.
@@ -1903,9 +1903,9 @@ namespace AssetProcessor
         // To avoid retrying forever, we keep track of the time of the first deletion failure and only retry
         // if less than this amount of time has passed.
         constexpr int MaxRetryPeriodMS = 500;
-        AZStd::chrono::duration<double, AZStd::milli> duration = AZStd::chrono::system_clock::now() - initialProcessTime;
+        AZStd::chrono::duration<double, AZStd::milli> duration = AZStd::chrono::steady_clock::now() - initialProcessTime;
 
-        if (initialProcessTime > AZStd::chrono::system_clock::time_point{}
+        if (initialProcessTime > AZStd::chrono::steady_clock::time_point{}
             && duration >= AZStd::chrono::milliseconds(MaxRetryPeriodMS))
         {
             AZ_Warning(AssetProcessor::ConsoleChannel, false, "Failed to delete product(s) from source file `%s` after retrying for %fms.  Giving up.",
@@ -1965,8 +1965,8 @@ namespace AssetProcessor
                                 deleteFailure = true;
                                 CheckSource(FileEntry(
                                     normalizedPath, true, false,
-                                    initialProcessTime > AZStd::chrono::system_clock::time_point{} ? initialProcessTime
-                                                                                                   : AZStd::chrono::system_clock::now()));
+                                    initialProcessTime > AZStd::chrono::steady_clock::time_point{} ? initialProcessTime
+                                                                                                   : AZStd::chrono::steady_clock::now()));
                                 AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Delete failed on %s. Will retry!\n", normalizedPath.toUtf8().constData());
                                 continue;
                             }

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -121,11 +121,11 @@ namespace AssetProcessor
             QString m_fileName;
             bool m_isDelete = false;
             bool m_isFromScanner = false;
-            AZStd::chrono::system_clock::time_point m_initialProcessTime{};
+            AZStd::chrono::steady_clock::time_point m_initialProcessTime{};
 
             FileEntry() = default;
 
-            FileEntry(const QString& fileName, bool isDelete, bool isFromScanner = false, AZStd::chrono::system_clock::time_point initialProcessTime = {})
+            FileEntry(const QString& fileName, bool isDelete, bool isFromScanner = false, AZStd::chrono::steady_clock::time_point initialProcessTime = {})
                 : m_fileName(fileName)
                 , m_isDelete(isDelete)
                 , m_isFromScanner(isFromScanner)
@@ -332,7 +332,7 @@ namespace AssetProcessor
         void CheckDeletedProductFile(QString normalizedPath);
         void CheckDeletedSourceFile(
             QString normalizedPath, QString relativePath, QString databaseSourceFile,
-            AZStd::chrono::system_clock::time_point initialProcessTime);
+            AZStd::chrono::steady_clock::time_point initialProcessTime);
         void CheckModifiedSourceFile(QString normalizedPath, QString databaseSourceFile, const ScanFolderInfo* scanFolderInfo);
         bool AnalyzeJob(JobDetails& details);
         void CheckDeletedCacheFolder(QString normalizedPath);

--- a/Code/Tools/AssetProcessor/native/unittests/AssetScannerUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetScannerUnitTests.cpp
@@ -121,13 +121,13 @@ namespace UnitTest
         // it makes sure that if a folder is added NON-recursively, child folder files are not found.
 
         scanner.StartScan();
-        auto startTime = AZStd::chrono::system_clock::now();
+        auto startTime = AZStd::chrono::steady_clock::now();
         while (!doneScan)
         {
             QCoreApplication::processEvents(QEventLoop::WaitForMoreEvents, 100);
 
             auto millisecondsSpentScanning =
-                AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - startTime);
+                AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - startTime);
             if (millisecondsSpentScanning > AZStd::chrono::milliseconds(10000))
             {
                 break;

--- a/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
@@ -699,7 +699,7 @@ FileServer* GUIApplicationManager::GetFileServer() const
 
 void GUIApplicationManager::ShowTrayIconErrorMessage(QString msg)
 {
-    AZStd::chrono::system_clock::time_point currentTime = AZStd::chrono::system_clock::now();
+    AZStd::chrono::steady_clock::time_point currentTime = AZStd::chrono::steady_clock::now();
 
     if (m_trayIcon && m_mainWindow)
     {

--- a/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.h
+++ b/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.h
@@ -114,5 +114,5 @@ private:
     QPointer<MainWindow> m_mainWindow;
     AZStd::unique_ptr<ErrorCollector> m_startupErrorCollector; // Collects errors during start up to display when startup has finished
 
-    AZStd::chrono::system_clock::time_point m_timeWhenLastWarningWasShown;
+    AZStd::chrono::steady_clock::time_point m_timeWhenLastWarningWasShown;
 };

--- a/Code/Tools/AssetProcessor/native/utilities/StatsCapture.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/StatsCapture.cpp
@@ -40,7 +40,7 @@ namespace AssetProcessor
             AZStd::optional<AZStd::sys_time_t> EndCaptureStat(AZStd::string_view statName, bool persistToDb);
             void Dump();
         private:
-            using timepoint = AZStd::chrono::system_clock::time_point;
+            using timepoint = AZStd::chrono::steady_clock::time_point;
             using duration = AZStd::chrono::milliseconds;
             struct StatsEntry
             {
@@ -61,16 +61,16 @@ namespace AssetProcessor
                 constexpr int64_t millisecondsInASecond = 1000;
                 constexpr int64_t millisecondsInAMinute = millisecondsInASecond * 60;
                 constexpr int64_t millisecondsInAnHour = millisecondsInAMinute * 60;
-                
+
                 int64_t hours = milliseconds / millisecondsInAnHour;
                 milliseconds -= hours * millisecondsInAnHour;
-                
+
                 int64_t minutes = milliseconds / millisecondsInAMinute;
                 milliseconds -= minutes * millisecondsInAMinute;
-                
+
                 int64_t seconds = milliseconds / millisecondsInASecond;
                 milliseconds -= seconds * millisecondsInASecond;
-                
+
                 // omit the sections which dont make sense for readability
                 if (hours)
                 {
@@ -84,11 +84,11 @@ namespace AssetProcessor
                 {
                     return AZStd::string::format("      %02" PRId64 "s%03" PRId64 "ms", seconds, milliseconds);
                 }
-                
+
                 return AZStd::string::format("         %03" PRId64 "ms", milliseconds);
             }
 
-            // Prints out a single stat. 
+            // Prints out a single stat.
             void PrintStat([[maybe_unused]] const char* name, duration milliseconds, int64_t count)
             {
                 // note that name may be unused as it only appears in Trace macros, which are
@@ -130,7 +130,7 @@ namespace AssetProcessor
                             name);
                 }
             }
-            
+
             // calls PrintStat on each element in the vector.
             void PrintStatsArray(AZStd::vector<AZStd::string>& keys, int maxToPrint, const char* header)
             {
@@ -144,14 +144,14 @@ namespace AssetProcessor
                 {
                     AZ_TracePrintf(AssetProcessor::ConsoleChannel,"Top %i %s\n", maxToPrint, header);
                 }
-                   
+
                 auto sortByTimeDescending = [&](const AZStd::string& s1, const AZStd::string& s2)
                 {
                     return this->m_stats[s1].m_cumulativeTime > this->m_stats[s2].m_cumulativeTime;
                 };
-        
+
                 AZStd::sort(keys.begin(), keys.end(), sortByTimeDescending);
-                
+
                 for (int idx = 0; idx < maxToPrint; ++idx)
                 {
                     if (idx < keys.size())
@@ -163,7 +163,7 @@ namespace AssetProcessor
         };
 
 
-        StatsCaptureImpl::StatsCaptureImpl() 
+        StatsCaptureImpl::StatsCaptureImpl()
         {
             m_dbConnection.OpenDatabase();
         }
@@ -176,7 +176,7 @@ namespace AssetProcessor
                 // prevent double 'Begins'
                 return;
             }
-            existingStat.m_operationStartTime = AZStd::chrono::system_clock::now();
+            existingStat.m_operationStartTime = AZStd::chrono::steady_clock::now();
         }
 
         AZStd::optional<AZStd::sys_time_t> StatsCaptureImpl::EndCaptureStat(AZStd::string_view statName, bool persistToDb)
@@ -185,7 +185,7 @@ namespace AssetProcessor
             AZStd::optional<AZStd::sys_time_t> operationDurationInMillisecond;
             if (existingStat.m_operationStartTime != timepoint())
             {
-                duration operationDuration = AZStd::chrono::duration_cast<duration>(AZStd::chrono::system_clock::now() - existingStat.m_operationStartTime);
+                duration operationDuration = AZStd::chrono::duration_cast<duration>(AZStd::chrono::steady_clock::now() - existingStat.m_operationStartTime);
                 operationDurationInMillisecond = operationDuration.count();
                 existingStat.m_cumulativeTime = existingStat.m_cumulativeTime + operationDuration;
                 existingStat.m_operationCount = existingStat.m_operationCount + 1;
@@ -205,7 +205,7 @@ namespace AssetProcessor
 
         void StatsCaptureImpl::Dump()
         {
-            timepoint startTimeStamp = AZStd::chrono::system_clock::now();
+            timepoint startTimeStamp = AZStd::chrono::steady_clock::now();
 
             auto settingsRegistry = AZ::SettingsRegistry::Get();
 
@@ -237,7 +237,7 @@ namespace AssetProcessor
             AZStd::vector<AZStd::string> allHashFiles;
 
             // capture only existing keys as we will be expanding the stats
-            // this approach avoids mutating an iterator.   
+            // this approach avoids mutating an iterator.
             AZStd::vector<AZStd::string> statKeys;
             for (const auto& element : m_stats)
             {
@@ -256,7 +256,7 @@ namespace AssetProcessor
 
                     // look up the builder so you can get its name:
                     AZStd::string_view builderName = tokens[2];
-                
+
                     // synthesize a stat to track per-builder createjobs times:
                     {
                         AZStd::string newStatKey = AZStd::string::format("CreateJobsByBuilder,%.*s", AZ_STRING_ARG(builderName));
@@ -328,7 +328,7 @@ namespace AssetProcessor
                     statToSynth.m_operationCount += statistic.m_operationCount;
                 }
             }
-            
+
             StatsEntry& gemLoadStat = m_stats["LoadingModules"];
             PrintStat("LoadingGems", gemLoadStat.m_cumulativeTime, 1);
             // analysis-related stats
@@ -339,11 +339,11 @@ namespace AssetProcessor
             PrintStat("WarmingFileCache", cacheWarmTime.m_cumulativeTime, cacheWarmTime.m_operationCount);
             StatsEntry& assessTime = m_stats["InitialFileAssessment"];
             PrintStat("InitialFileAssessment", assessTime.m_cumulativeTime, assessTime.m_operationCount);
-            
+
             StatsEntry& totalHashTime = m_stats["HashFileTotal"];
             PrintStat("HashFileTotal", totalHashTime.m_cumulativeTime, totalHashTime.m_operationCount);
             PrintStatsArray(allHashFiles, maxIndividualStats, "longest individual file hashes:");
-        
+
             // CreateJobs stats
             StatsEntry& totalCreateJobs = m_stats["CreateJobsTotal"];
             if (totalCreateJobs.m_operationCount)
@@ -352,7 +352,7 @@ namespace AssetProcessor
                 PrintStatsArray(allCreateJobs, maxIndividualStats, "longest individual CreateJobs");
                 PrintStatsArray(allCreateJobsByBuilder, maxCumulativeStats, "longest CreateJobs By builder");
             }
-            
+
             // ProcessJobs stats
             StatsEntry& totalProcessJobs = m_stats["ProcessJobsTotal"];
             if (totalProcessJobs.m_operationCount)
@@ -362,7 +362,7 @@ namespace AssetProcessor
                 PrintStatsArray(allProcessJobsByJobKey, maxCumulativeStats, "cumulative time spent in ProcessJob by JobKey");
                 PrintStatsArray(allProcessJobsByPlatform, maxCumulativeStats, "cumulative time spent in ProcessJob by Platform");
             }
-            duration costToGenerateStats = AZStd::chrono::duration_cast<duration>(AZStd::chrono::system_clock::now() - startTimeStamp);
+            duration costToGenerateStats = AZStd::chrono::duration_cast<duration>(AZStd::chrono::steady_clock::now() - startTimeStamp);
             PrintStat("ComputeStatsTime", costToGenerateStats, 1);
         }
 

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Headers/TestImpactFramework/TestImpactClientSequenceReport.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Headers/TestImpactFramework/TestImpactClientSequenceReport.h
@@ -46,7 +46,7 @@ namespace TestImpact
             //! @param unexecutedTestRuns The set of test runs that were queued up for execution but did not get the opportunity to execute.
             TestRunReport(
                 TestSequenceResult result,
-                AZStd::chrono::high_resolution_clock::time_point startTime,
+                AZStd::chrono::steady_clock::time_point startTime,
                 AZStd::chrono::milliseconds duration,
                 AZStd::vector<PassingTestRun>&& passingTestRuns,
                 AZStd::vector<FailingTestRun>&& failingTestRuns,
@@ -58,10 +58,10 @@ namespace TestImpact
             TestSequenceResult GetResult() const;
 
             //! Returns the time this sequence of test runs started relative to T0.
-            AZStd::chrono::high_resolution_clock::time_point GetStartTime() const;
+            AZStd::chrono::steady_clock::time_point GetStartTime() const;
 
             //! Returns the time this sequence of test runs ended relative to T0.
-            AZStd::chrono::high_resolution_clock::time_point GetEndTime() const;
+            AZStd::chrono::steady_clock::time_point GetEndTime() const;
 
             //! Returns the duration this sequence of test runs took to complete.
             AZStd::chrono::milliseconds GetDuration() const;
@@ -109,7 +109,7 @@ namespace TestImpact
             const AZStd::vector<UnexecutedTestRun>& GetUnexecutedTestRuns() const;
         private:
             TestSequenceResult m_result = TestSequenceResult::Success;
-            AZStd::chrono::high_resolution_clock::time_point m_startTime;
+            AZStd::chrono::steady_clock::time_point m_startTime;
             AZStd::chrono::milliseconds m_duration = AZStd::chrono::milliseconds{ 0 };
             AZStd::vector<PassingTestRun> m_passingTestRuns;
             AZStd::vector<FailingTestRun> m_failingTestRuns;
@@ -230,13 +230,13 @@ namespace TestImpact
             }
 
             //! Returns the start time of the sequence.
-            AZStd::chrono::high_resolution_clock::time_point GetStartTime() const
+            AZStd::chrono::steady_clock::time_point GetStartTime() const
             {
                 return m_selectedTestRunReport.GetStartTime();
             }
 
             //! Returns the end time of the sequence.
-            AZStd::chrono::high_resolution_clock::time_point GetEndTime() const
+            AZStd::chrono::steady_clock::time_point GetEndTime() const
             {
                 return GetStartTime() + GetDuration();
             }

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Headers/TestImpactFramework/TestImpactClientTestRun.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Headers/TestImpactFramework/TestImpactClientTestRun.h
@@ -40,7 +40,7 @@ namespace TestImpact
                 const AZStd::string& testNamespace,
                 const AZStd::string& name,
                 const AZStd::string& commandString,
-                AZStd::chrono::high_resolution_clock::time_point startTime,
+                AZStd::chrono::steady_clock::time_point startTime,
                 AZStd::chrono::milliseconds duration,
                 TestRunResult result);
 
@@ -56,10 +56,10 @@ namespace TestImpact
             TestRunResult GetResult() const;
 
             //! Returns the test run start time.
-            AZStd::chrono::high_resolution_clock::time_point GetStartTime() const;
+            AZStd::chrono::steady_clock::time_point GetStartTime() const;
 
             //! Returns the end time, relative to the sequence start, that this run ended.
-            AZStd::chrono::high_resolution_clock::time_point GetEndTime() const;
+            AZStd::chrono::steady_clock::time_point GetEndTime() const;
 
             //! Returns the duration that this test run took to complete.
             AZStd::chrono::milliseconds GetDuration() const;
@@ -72,7 +72,7 @@ namespace TestImpact
             AZStd::string m_commandString;
             AZStd::string m_testNamespace;
             TestRunResult m_result;
-            AZStd::chrono::high_resolution_clock::time_point m_startTime;
+            AZStd::chrono::steady_clock::time_point m_startTime;
             AZStd::chrono::milliseconds m_duration;
         };
 
@@ -86,7 +86,7 @@ namespace TestImpact
         };
 
         //! Representation of a test run that was terminated in-flight due to timing out.
-        class TimedOutTestRun 
+        class TimedOutTestRun
             : public TestRunBase
         {
         public:
@@ -95,7 +95,7 @@ namespace TestImpact
         };
 
         //! Representation of a test run that was not executed.
-        class UnexecutedTestRun 
+        class UnexecutedTestRun
             : public TestRunBase
         {
         public:
@@ -144,7 +144,7 @@ namespace TestImpact
             CompletedTestRun(
                 const AZStd::string& name,
                 const AZStd::string& commandString,
-                AZStd::chrono::high_resolution_clock::time_point startTime,
+                AZStd::chrono::steady_clock::time_point startTime,
                 AZStd::chrono::milliseconds duration,
                 TestRunResult result,
                 AZStd::vector<Test>&& tests,
@@ -176,7 +176,7 @@ namespace TestImpact
         };
 
         //! Representation of a test run that completed with no test failures.
-        class PassingTestRun 
+        class PassingTestRun
             : public CompletedTestRun
         {
         public:
@@ -185,7 +185,7 @@ namespace TestImpact
         };
 
         //! Representation of a test run that completed with one or more test failures.
-        class FailingTestRun 
+        class FailingTestRun
             : public CompletedTestRun
         {
         public:

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Process/JobRunner/TestImpactProcessJobMeta.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Process/JobRunner/TestImpactProcessJobMeta.h
@@ -30,7 +30,7 @@ namespace TestImpact
     struct JobMeta
     {
         JobResult m_result = JobResult::NotExecuted;
-        AZStd::optional<AZStd::chrono::high_resolution_clock::time_point> m_startTime; //!< The time, relative to the job runner start, that this job started.
+        AZStd::optional<AZStd::chrono::steady_clock::time_point> m_startTime; //!< The time, relative to the job runner start, that this job started.
         AZStd::optional<AZStd::chrono::milliseconds> m_duration; //!< The duration that this job took to complete.
         AZStd::optional<ReturnCode> m_returnCode; //!< The return code of the underlying processes of this job.
     };
@@ -46,10 +46,10 @@ namespace TestImpact
         JobResult GetJobResult() const;
 
         //! Returns the start time, relative to the job runner start, that this job started.
-        AZStd::chrono::high_resolution_clock::time_point GetStartTime() const;
+        AZStd::chrono::steady_clock::time_point GetStartTime() const;
 
         //! Returns the end time, relative to the job runner start, that this job ended.
-        AZStd::chrono::high_resolution_clock::time_point GetEndTime() const;
+        AZStd::chrono::steady_clock::time_point GetEndTime() const;
 
         //! Returns the duration that this job took to complete.
         AZStd::chrono::milliseconds GetDuration() const;

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Process/JobRunner/TestImpactProcessJobRunner.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Process/JobRunner/TestImpactProcessJobRunner.h
@@ -17,7 +17,7 @@
 #include <AzCore/std/string/string.h>
 
 namespace TestImpact
-{    
+{
     //! Generic job runner that launches a process for each job, records metrics about each job run and hands the payload artifacts
     //! produced by each job to the client before compositing the metrics and payload artifacts for each job into a single interface
     //! to be consumed by the client.
@@ -64,7 +64,7 @@ namespace TestImpact
         //! Constructs the job runner with the specified parameters to constrain job runs.
         //! @param maxConcurrentProcesses he maximum number of concurrent jobs in-flight.
         explicit JobRunner(size_t maxConcurrentProcesses);
-           
+
         //! Executes the specified jobs and returns the products of their labor.
         //! @param jobs The arguments (and other pertinent information) required for each job to be run.
         //! @param stdOutRouting The standard output routing to be specified for all jobs.
@@ -128,7 +128,7 @@ namespace TestImpact
         const ProcessLaunchCallback processLaunchCallback = [&jobCallback, &metas](
             TestImpact::ProcessId pid,
             TestImpact::LaunchResult launchResult,
-            AZStd::chrono::high_resolution_clock::time_point createTime)
+            AZStd::chrono::steady_clock::time_point createTime)
         {
             auto& [meta, jobInfo] = metas.at(pid);
             if (launchResult == LaunchResult::Failure)
@@ -149,7 +149,7 @@ namespace TestImpact
             TestImpact::ExitCondition exitCondition,
             TestImpact::ReturnCode returnCode,
             TestImpact::StdContent&& std,
-            AZStd::chrono::high_resolution_clock::time_point exitTime)
+            AZStd::chrono::steady_clock::time_point exitTime)
         {
             auto& [meta, jobInfo] = metas.at(processId);
             meta.m_returnCode = returnCode;

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Process/Scheduler/TestImpactProcessScheduler.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Process/Scheduler/TestImpactProcessScheduler.h
@@ -60,7 +60,7 @@ namespace TestImpact
         AZStd::function<ProcessCallbackResult(
             ProcessId processId,
             LaunchResult launchResult,
-            AZStd::chrono::high_resolution_clock::time_point createTime)>;
+            AZStd::chrono::steady_clock::time_point createTime)>;
 
     //! Callback for process exit of successfully launched process.
     //! @param processId The id of the process that attempted to launch.
@@ -74,7 +74,7 @@ namespace TestImpact
             ExitCondition exitStatus,
             ReturnCode returnCode,
             StdContent&& std,
-            AZStd::chrono::high_resolution_clock::time_point exitTime)>;
+            AZStd::chrono::steady_clock::time_point exitTime)>;
 
     //! Callback for process standard output/error buffer consumption in real-time.
     //! @note The full standard output/error data is available to all capturing processes at their end of life regardless of this callback.

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/TestImpactRuntimeUtils.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/TestImpactRuntimeUtils.cpp
@@ -17,30 +17,30 @@
 namespace TestImpact
 {
     Timer::Timer()
-        : m_startTime(AZStd::chrono::high_resolution_clock::now())
+        : m_startTime(AZStd::chrono::steady_clock::now())
     {
     }
 
-    AZStd::chrono::high_resolution_clock::time_point Timer::GetStartTimePoint() const
+    AZStd::chrono::steady_clock::time_point Timer::GetStartTimePoint() const
     {
         return m_startTime;
     }
 
-    AZStd::chrono::high_resolution_clock::time_point Timer::GetStartTimePointRelative(const Timer& start) const
+    AZStd::chrono::steady_clock::time_point Timer::GetStartTimePointRelative(const Timer& start) const
     {
-        return AZStd::chrono::high_resolution_clock::time_point() +
+        return AZStd::chrono::steady_clock::time_point() +
             AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(m_startTime - start.GetStartTimePoint());
     }
 
     AZStd::chrono::milliseconds Timer::GetElapsedMs() const
     {
-        const auto endTime = AZStd::chrono::high_resolution_clock::now();
+        const auto endTime = AZStd::chrono::steady_clock::now();
         return AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(endTime - m_startTime);
     }
 
-    AZStd::chrono::high_resolution_clock::time_point Timer::GetElapsedTimepoint() const
+    AZStd::chrono::steady_clock::time_point Timer::GetElapsedTimepoint() const
     {
-        const auto endTime = AZStd::chrono::high_resolution_clock::now();
+        const auto endTime = AZStd::chrono::steady_clock::now();
         return m_startTime + AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(endTime - m_startTime);
     }
 
@@ -60,5 +60,5 @@ namespace TestImpact
         }
 
         return descriptors;
-    }    
+    }
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/TestImpactRuntimeUtils.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/TestImpactRuntimeUtils.h
@@ -35,19 +35,19 @@ namespace TestImpact
         Timer();
 
         //! Returns the time point that the timer was instantiated.
-        AZStd::chrono::high_resolution_clock::time_point GetStartTimePoint() const;
+        AZStd::chrono::steady_clock::time_point GetStartTimePoint() const;
 
         //! Returns the time point that the timer was instantiated relative to the specified starting time point.
-        AZStd::chrono::high_resolution_clock::time_point GetStartTimePointRelative(const Timer& start) const;
+        AZStd::chrono::steady_clock::time_point GetStartTimePointRelative(const Timer& start) const;
 
         //! Returns the time elapsed (in milliseconds) since the timer was instantiated.
         AZStd::chrono::milliseconds GetElapsedMs() const;
 
         //! Returns the current time point relative to the time point the timer was instantiated.
-        AZStd::chrono::high_resolution_clock::time_point GetElapsedTimepoint() const;
+        AZStd::chrono::steady_clock::time_point GetElapsedTimepoint() const;
 
     private:
-        AZStd::chrono::high_resolution_clock::time_point m_startTime;
+        AZStd::chrono::steady_clock::time_point m_startTime;
     };
 
     //! Attempts to read all of the target descriptor files from the specified configuration directories.
@@ -216,7 +216,7 @@ namespace TestImpact
                     }
                 }
             }
-        }   
+        }
 
         AZStd::vector<SourceCoveringTests> sourceCoveringTests;
         sourceCoveringTests.reserve(coverage.size());
@@ -316,7 +316,7 @@ namespace TestImpact
     template<typename TestJob>
     Client::TestRunReport GenerateTestRunReport(
         TestSequenceResult result,
-        AZStd::chrono::high_resolution_clock::time_point startTime,
+        AZStd::chrono::steady_clock::time_point startTime,
         AZStd::chrono::milliseconds duration,
         const AZStd::vector<TestJob>& testJobs)
     {
@@ -325,12 +325,12 @@ namespace TestImpact
         AZStd::vector<Client::TestRunWithExecutionFailure> executionFailureTests;
         AZStd::vector<Client::TimedOutTestRun> timedOutTests;
         AZStd::vector<Client::UnexecutedTestRun> unexecutedTests;
-        
+
         for (const auto& testJob : testJobs)
         {
             // Test job start time relative to start time
             const auto relativeStartTime =
-                AZStd::chrono::high_resolution_clock::time_point() +
+                AZStd::chrono::steady_clock::time_point() +
                 AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(testJob.GetStartTime() - startTime);
 
             Client::TestRunBase clientTestRun(
@@ -375,7 +375,7 @@ namespace TestImpact
             }
             }
         }
-        
+
         return Client::TestRunReport(
             result,
             startTime,
@@ -437,7 +437,7 @@ namespace TestImpact
     {
         TestSequenceResult m_result = TestSequenceResult::Success;
         AZStd::vector<TestJob> m_jobs;
-        AZStd::chrono::high_resolution_clock::time_point m_relativeStartTime;
+        AZStd::chrono::steady_clock::time_point m_relativeStartTime;
         AZStd::chrono::milliseconds m_duration = AZStd::chrono::milliseconds{ 0 };
     };
 

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/Process/JobRunner/TestImpactProcessJobMeta.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/Process/JobRunner/TestImpactProcessJobMeta.cpp
@@ -32,12 +32,12 @@ namespace TestImpact
         return m_meta.m_returnCode;
     }
 
-    AZStd::chrono::high_resolution_clock::time_point JobMetaWrapper::GetStartTime() const
+    AZStd::chrono::steady_clock::time_point JobMetaWrapper::GetStartTime() const
     {
-        return m_meta.m_startTime.value_or(AZStd::chrono::high_resolution_clock::time_point());
+        return m_meta.m_startTime.value_or(AZStd::chrono::steady_clock::time_point());
     }
 
-    AZStd::chrono::high_resolution_clock::time_point JobMetaWrapper::GetEndTime() const
+    AZStd::chrono::steady_clock::time_point JobMetaWrapper::GetEndTime() const
     {
         if (m_meta.m_startTime.has_value() && m_meta.m_duration.has_value())
         {
@@ -45,7 +45,7 @@ namespace TestImpact
         }
         else
         {
-            return AZStd::chrono::high_resolution_clock::time_point();
+            return AZStd::chrono::steady_clock::time_point();
         }
     }
 

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/Process/Scheduler/TestImpactProcessScheduler.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/Process/Scheduler/TestImpactProcessScheduler.cpp
@@ -17,7 +17,7 @@ namespace TestImpact
     struct ProcessInFlight
     {
         AZStd::unique_ptr<Process> m_process;
-        AZStd::optional<AZStd::chrono::high_resolution_clock::time_point> m_startTime;
+        AZStd::optional<AZStd::chrono::steady_clock::time_point> m_startTime;
         AZStd::string m_stdOutput;
         AZStd::string m_stdError;
     };
@@ -47,7 +47,7 @@ namespace TestImpact
         AZStd::optional<ProcessStdContentCallback> m_processStdContentCallback;
         AZStd::optional<AZStd::chrono::milliseconds> m_processTimeout;
         AZStd::optional<AZStd::chrono::milliseconds> m_scheduleTimeout;
-        AZStd::chrono::high_resolution_clock::time_point m_startTime;
+        AZStd::chrono::steady_clock::time_point m_startTime;
         AZStd::vector<ProcessInFlight> m_processPool;
         AZStd::queue<ProcessInfo> m_processQueue;
     };
@@ -82,7 +82,7 @@ namespace TestImpact
     ProcessSchedulerResult ProcessScheduler::ExecutionState::MonitorProcesses(const AZStd::vector<ProcessInfo>& processes)
     {
         AZ_TestImpact_Eval(!processes.empty(), ProcessException, "Number of processes to launch cannot be 0");
-        m_startTime = AZStd::chrono::high_resolution_clock::now();
+        m_startTime = AZStd::chrono::steady_clock::now();
         const size_t numConcurrentProcesses = AZStd::min(processes.size(), m_maxConcurrentProcesses);
         m_processPool.resize(numConcurrentProcesses);
 
@@ -106,7 +106,7 @@ namespace TestImpact
             // Check to see whether or not the scheduling has exceeded its specified runtime
             if (m_scheduleTimeout.has_value())
             {
-                const auto shedulerRunTime = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::high_resolution_clock::now() - m_startTime);
+                const auto shedulerRunTime = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - m_startTime);
 
                 if (shedulerRunTime > m_scheduleTimeout)
                 {
@@ -133,7 +133,7 @@ namespace TestImpact
                         // Process has exited of its own accord
                         const ReturnCode returnCode = processInFlight.m_process->GetReturnCode().value();
                         processInFlight.m_process.reset();
-                        const auto exitTime = AZStd::chrono::high_resolution_clock::now();
+                        const auto exitTime = AZStd::chrono::steady_clock::now();
 
                         // Inform the client that the processes has exited
                         if (ProcessCallbackResult::Abort == m_processExitCallback(
@@ -166,7 +166,7 @@ namespace TestImpact
                     else
                     {
                         // Process is still in-flight
-                        const auto exitTime = AZStd::chrono::high_resolution_clock::now();
+                        const auto exitTime = AZStd::chrono::steady_clock::now();
                         const auto runTime = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(exitTime - processInFlight.m_startTime.value());
 
                         // Check to see whether or not the processes has exceeded its specified flight time
@@ -226,7 +226,7 @@ namespace TestImpact
     {
         auto processInfo = m_processQueue.front();
         m_processQueue.pop();
-        const auto createTime = AZStd::chrono::high_resolution_clock::now();
+        const auto createTime = AZStd::chrono::steady_clock::now();
         LaunchResult createResult = LaunchResult::Success;
 
         try
@@ -288,7 +288,7 @@ namespace TestImpact
 
                 if (isCallingBackToClient)
                 {
-                    const auto exitTime = AZStd::chrono::high_resolution_clock::now();
+                    const auto exitTime = AZStd::chrono::steady_clock::now();
                     if (ProcessCallbackResult::Abort == m_processExitCallback(
                         processInFlight.m_process->GetProcessInfo().GetId(),
                         exitStatus,

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/TestImpactClientSequenceReport.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/TestImpactClientSequenceReport.cpp
@@ -34,7 +34,7 @@ namespace TestImpact
 
         TestRunReport::TestRunReport(
             TestSequenceResult result,
-            AZStd::chrono::high_resolution_clock::time_point startTime,
+            AZStd::chrono::steady_clock::time_point startTime,
             AZStd::chrono::milliseconds duration,
             AZStd::vector<PassingTestRun>&& passingTestRuns,
             AZStd::vector<FailingTestRun>&& failingTestRuns,
@@ -69,12 +69,12 @@ namespace TestImpact
             return m_result;
         }
 
-        AZStd::chrono::high_resolution_clock::time_point TestRunReport::GetStartTime() const
+        AZStd::chrono::steady_clock::time_point TestRunReport::GetStartTime() const
         {
             return m_startTime;
         }
 
-        AZStd::chrono::high_resolution_clock::time_point TestRunReport::GetEndTime() const
+        AZStd::chrono::steady_clock::time_point TestRunReport::GetEndTime() const
         {
             return m_startTime + m_duration;
         }
@@ -285,7 +285,7 @@ namespace TestImpact
         {
             return DraftingSequenceReportBase::GetTotalNumUnexecutedTestRuns() + m_discardedTestRunReport.GetNumUnexecutedTestRuns();
         }
-        
+
         const TestRunSelection SafeImpactAnalysisSequenceReport::GetDiscardedTestRuns() const
         {
             return m_discardedTestRuns;

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/TestImpactClientSequenceReportSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/TestImpactClientSequenceReportSerializer.cpp
@@ -137,7 +137,7 @@ namespace TestImpact
             };
         } // namespace SequenceReportFields
 
-        AZ::u64 TimePointInMsAsInt64(AZStd::chrono::high_resolution_clock::time_point timePoint)
+        AZ::u64 TimePointInMsAsInt64(AZStd::chrono::steady_clock::time_point timePoint)
         {
             return AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(timePoint.time_since_epoch()).count();
         }
@@ -377,23 +377,23 @@ namespace TestImpact
             // Execution failure
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::ExecutionFailure]);
             writer.String(ExecutionFailurePolicyAsString(policyState.m_executionFailurePolicy).c_str());
-            
+
             // Failed test coverage
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::CoverageFailure]);
             writer.String(FailedTestCoveragePolicyAsString(policyState.m_failedTestCoveragePolicy).c_str());
-            
+
             // Test failure
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::TestFailure]);
             writer.String(TestFailurePolicyAsString(policyState.m_testFailurePolicy).c_str());
-            
+
             // Integrity failure
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::IntegrityFailure]);
             writer.String(IntegrityFailurePolicyAsString(policyState.m_integrityFailurePolicy).c_str());
-            
+
             // Test sharding
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::TestSharding]);
             writer.String(TestShardingPolicyAsString(policyState.m_testShardingPolicy).c_str());
-            
+
             // Target output capture
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::TargetOutputCapture]);
             writer.String(TargetOutputCapturePolicyAsString(policyState.m_targetOutputCapture).c_str());
@@ -616,9 +616,9 @@ namespace TestImpact
         return stringBuffer.GetString();
     }
 
-    AZStd::chrono::high_resolution_clock::time_point TimePointFromMsInt64(AZ::s64 ms)
+    AZStd::chrono::steady_clock::time_point TimePointFromMsInt64(AZ::s64 ms)
     {
-        return AZStd::chrono::high_resolution_clock::time_point(AZStd::chrono::milliseconds(ms));
+        return AZStd::chrono::steady_clock::time_point(AZStd::chrono::milliseconds(ms));
     }
 
     AZStd::vector<Client::Test> DeserializeTests(const rapidjson::Value& serialTests)

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/TestImpactClientTestRun.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/TestImpactClientTestRun.cpp
@@ -18,7 +18,7 @@ namespace TestImpact
             const AZStd::string& testNamespace,
             const AZStd::string& name,
             const AZStd::string& commandString,
-            AZStd::chrono::high_resolution_clock::time_point startTime,
+            AZStd::chrono::steady_clock::time_point startTime,
             AZStd::chrono::milliseconds duration,
             TestRunResult result)
             : m_targetName(name)
@@ -40,12 +40,12 @@ namespace TestImpact
             return m_commandString;
         }
 
-        AZStd::chrono::high_resolution_clock::time_point TestRunBase::GetStartTime() const
+        AZStd::chrono::steady_clock::time_point TestRunBase::GetStartTime() const
         {
             return m_startTime;
         }
 
-        AZStd::chrono::high_resolution_clock::time_point TestRunBase::GetEndTime() const
+        AZStd::chrono::steady_clock::time_point TestRunBase::GetEndTime() const
         {
             return m_startTime + m_duration;
         }
@@ -124,7 +124,7 @@ namespace TestImpact
         CompletedTestRun::CompletedTestRun(
             const AZStd::string& name,
             const AZStd::string& commandString,
-            AZStd::chrono::high_resolution_clock::time_point startTime,
+            AZStd::chrono::steady_clock::time_point startTime,
             AZStd::chrono::milliseconds duration,
             TestRunResult result,
             AZStd::vector<Test>&& tests,

--- a/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationTokens.h
+++ b/Gems/AWSClientAuth/Code/Include/Authentication/AuthenticationTokens.h
@@ -54,6 +54,6 @@ namespace AWSClientAuth
         AZStd::string m_refreshToken;
         AZStd::string m_openIdToken;
         ProviderNameEnum m_providerName;
-        AZStd::chrono::system_clock::time_point m_tokensExpireTimeStamp;
+        AZStd::chrono::steady_clock::time_point m_tokensExpireTimeStamp;
     };
 } // namespace AWSClientAuth

--- a/Gems/AWSClientAuth/Code/Source/Authentication/AuthenticationTokens.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authentication/AuthenticationTokens.cpp
@@ -11,10 +11,10 @@
 namespace AWSClientAuth
 {
     //! Used to share authentication tokens to caller and to AWSCognitoAuthorizationController.
-   
+
     AuthenticationTokens::AuthenticationTokens()
     {
-        m_tokensExpireTimeStamp = AZStd::chrono::system_clock::time_point::min();
+        m_tokensExpireTimeStamp = AZStd::chrono::steady_clock::time_point::min();
         m_providerName = ProviderNameEnum::None;
     }
 
@@ -35,7 +35,7 @@ namespace AWSClientAuth
         , m_openIdToken(openIdToken)
         , m_providerName(providerName)
         , m_tokensExpireTimeSeconds(tokensExpireTimeSeconds)
-        , m_tokensExpireTimeStamp(AZStd::chrono::system_clock::now() + AZStd::chrono::seconds(tokensExpireTimeSeconds))
+        , m_tokensExpireTimeStamp(AZStd::chrono::steady_clock::now() + AZStd::chrono::seconds(tokensExpireTimeSeconds))
     {
     }
 
@@ -43,7 +43,7 @@ namespace AWSClientAuth
     //! @return True if current TS less than expiry TS.
     bool AuthenticationTokens::AreTokensValid() const
     {
-        return AZStd::chrono::system_clock::now() < m_tokensExpireTimeStamp;
+        return AZStd::chrono::steady_clock::now() < m_tokensExpireTimeStamp;
     }
 
     //! @return Open id token from authentication.

--- a/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionManager.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionManager.cpp
@@ -125,7 +125,7 @@ namespace AWSCore
         AZ::u64 delayInSeconds = 0;
         if (!m_settingsRegistry->Get(delayInSeconds, AWSAttributionDelaySecondsKey))
         {
-            delayInSeconds = 86400 * AWSAttributionDefaultDelayInDays;
+            delayInSeconds = static_cast<AZ::u64>(AZStd::chrono::duration_cast<AZStd::chrono::seconds>(AZStd::chrono::days(AWSAttributionDefaultDelayInDays)).count());
             m_settingsRegistry->Set(AWSAttributionDelaySecondsKey, delayInSeconds);
         }
 

--- a/Gems/AssetValidation/Code/Source/AssetSystemTestCommands.cpp
+++ b/Gems/AssetValidation/Code/Source/AssetSystemTestCommands.cpp
@@ -107,7 +107,7 @@ namespace AssetValidation
 
             AZ::Data::AssetCatalogRequestBus::Broadcast(&AZ::Data::AssetCatalogRequestBus::Events::EnumerateAssets, nullptr, collectAssetsCb, nullptr);
 
-            auto start = AZStd::chrono::system_clock::now();
+            auto start = AZStd::chrono::steady_clock::now();
 
             AZStd::chrono::milliseconds runMs{ 0 };
 
@@ -126,7 +126,7 @@ namespace AssetValidation
             AZ_TracePrintf("TestChangeAssets", "Beginning run with %zu assets\n", assetList.size());
             while (!forceStop && runMs < runTime)
             {
-                runMs = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - start);
+                runMs = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - start);
                 int thisTick = aznumeric_cast<int>(runMs / changeFreq) + 1;
                 if (thisTick > lastTick)
                 {
@@ -185,7 +185,7 @@ void TestCreateContainers([[maybe_unused]] const AZ::ConsoleCommandContainer& so
 
         AZ::Data::AssetCatalogRequestBus::Broadcast(&AZ::Data::AssetCatalogRequestBus::Events::EnumerateAssets, nullptr, collectAssetsCb, nullptr);
 
-        auto start = AZStd::chrono::system_clock::now();
+        auto start = AZStd::chrono::steady_clock::now();
 
         AZStd::vector<AZ::Data::Asset<AZ::Data::AssetData>> loadingContainers;
         for (const auto& thisElement : assetList)
@@ -212,7 +212,7 @@ void TestCreateContainers([[maybe_unused]] const AZ::ConsoleCommandContainer& so
                     ++containerIter;
                 }
             }
-            runMS = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - start);
+            runMS = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - start);
             if (readyContainers.size() == totalContainers)
             {
                 AZ_TracePrintf("TestCreateContainers", "All assets (%d) ready after %ld ms\n", readyContainers.size(), runMS);
@@ -266,7 +266,7 @@ void TestSingleContainer(const AZ::ConsoleCommandContainer& someStrings)
         {
             AZ_Warning("TestSingleContainer", false, "Couldn't get asset info for %s", assetId.ToString<AZStd::string>().c_str());
         }
-        auto start = AZStd::chrono::system_clock::now();
+        auto start = AZStd::chrono::steady_clock::now();
 
         auto thisContainer = AZ::Data::AssetManager::Instance().GetAsset(assetId, assetInfo.m_assetType, AZ::Data::AssetLoadBehavior::Default);
 
@@ -275,7 +275,7 @@ void TestSingleContainer(const AZ::ConsoleCommandContainer& someStrings)
 
         while(thisContainer->IsLoading() && runMS < maxWait)
         {
-            runMS = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - start);
+            runMS = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - start);
             AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(100));
         }
         if (thisContainer->IsReady())

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.cpp
@@ -32,7 +32,7 @@ namespace AZ
 
         void PostProcessFeatureProcessor::Activate()
         {
-            m_currentTime = AZStd::chrono::system_clock::now();
+            m_currentTime = AZStd::chrono::steady_clock::now();
         }
 
         void PostProcessFeatureProcessor::Deactivate()
@@ -42,7 +42,7 @@ namespace AZ
 
         void PostProcessFeatureProcessor::UpdateTime()
         {
-            AZStd::chrono::system_clock::time_point now = AZStd::chrono::system_clock::now();
+            AZStd::chrono::steady_clock::time_point now = AZStd::chrono::steady_clock::now();
             AZStd::chrono::duration<float> deltaTime = now - m_currentTime;
             m_currentTime = now;
             m_deltaTime = deltaTime.count();
@@ -74,7 +74,7 @@ namespace AZ
 
             // simulate both the global and each view's post process settings
             // Ideally, every view should be associated to a post process settings. The global
-            // setting is returned when a view does not have a post process setting. 
+            // setting is returned when a view does not have a post process setting.
             // e.g. Editor Camera, AtomSampleViewer Samples that do not set perViewBlendWeights
             m_globalAggregateLevelSettings->Simulate(m_deltaTime);
             for (auto& settingsPair : m_blendedPerViewSettings)
@@ -85,7 +85,7 @@ namespace AZ
 
         void PostProcessFeatureProcessor::SortPostProcessSettings()
         {
-            // Clear settings from previous frame 
+            // Clear settings from previous frame
             m_sortedFrameSettings.clear();
 
             // Sort post process settings by layer value and priority
@@ -215,7 +215,7 @@ namespace AZ
         {
             // check for view aliases first
             auto viewAliasiterator = m_viewAliasMap.find(view.get());
-            
+
             // Use the view alias if it exists
             auto settingsIterator = m_blendedPerViewSettings.find(viewAliasiterator != m_viewAliasMap.end() ? viewAliasiterator->second : view.get());
             // If no settings for the view is found, the global settings is returned.

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.h
@@ -52,7 +52,7 @@ namespace AZ
 
             void UpdateTime();
 
-            // Sorts all post processing settings into buckets based on category (level, 
+            // Sorts all post processing settings into buckets based on category (level,
             void SortPostProcessSettings();
 
             // Aggregates all level settings into a single level setting based their priorities and override settings
@@ -82,7 +82,7 @@ namespace AZ
             bool m_settingsChanged = true;
 
             // Time...
-            AZStd::chrono::system_clock::time_point m_currentTime;
+            AZStd::chrono::steady_clock::time_point m_currentTime;
             float m_deltaTime;
 
             // Each camera/view will have its own PostProcessSettings

--- a/Gems/Atom/RHI/Code/Tests/ThreadTester.cpp
+++ b/Gems/Atom/RHI/Code/Tests/ThreadTester.cpp
@@ -41,7 +41,7 @@ namespace UnitTest
         while (threadCount > 0 && !timedOut)
         {
             AZStd::unique_lock<AZStd::mutex> lock(mutex);
-            timedOut = (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::system_clock::now() + AZStd::chrono::seconds(5)));
+            timedOut = (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::steady_clock::now() + AZStd::chrono::seconds(5)));
         }
 
         EXPECT_TRUE(threadCount == 0);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererLoadState.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererLoadState.cpp
@@ -25,7 +25,7 @@ namespace AtomToolsFramework
 
     void PreviewRendererLoadState::OnSystemTick()
     {
-        if (AZStd::chrono::system_clock::now() > (m_startTime + AZStd::chrono::seconds(5)))
+        if (AZStd::chrono::steady_clock::now() > (m_startTime + AZStd::chrono::seconds(5)))
         {
             m_renderer->CancelLoadContent();
             return;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererLoadState.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererLoadState.h
@@ -26,6 +26,6 @@ namespace AtomToolsFramework
         //! AZ::SystemTickBus::Handler interface overrides...
         void OnSystemTick() override;
 
-        AZStd::chrono::system_clock::time_point m_startTime = AZStd::chrono::system_clock::now();
+        AZStd::chrono::steady_clock::time_point m_startTime = AZStd::chrono::steady_clock::now();
     };
 } // namespace AtomToolsFramework

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -264,7 +264,7 @@ namespace AZ::Render
 
     void AtomViewportDisplayInfoSystemComponent::UpdateFramerate()
     {
-        auto currentTime = AZStd::chrono::system_clock::now();
+        auto currentTime = AZStd::chrono::steady_clock::now();
         while (!m_fpsHistory.empty() && (currentTime - m_fpsHistory.front()) > m_fpsInterval)
         {
             m_fpsHistory.pop_front();
@@ -350,7 +350,7 @@ namespace AZ::Render
 
     void AtomViewportDisplayInfoSystemComponent::DrawFramerate()
     {
-        AZStd::optional<AZStd::chrono::system_clock::time_point> lastTime;
+        AZStd::optional<AZStd::chrono::steady_clock::time_point> lastTime;
         double minFPS = DBL_MAX;
         double maxFPS = 0;
         AZStd::chrono::duration<double> deltaTime;

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
@@ -69,8 +69,8 @@ namespace AZ
             AzFramework::FontDrawInterface* m_fontDrawInterface = nullptr;
             float m_lineSpacing;
             AZStd::chrono::duration<double> m_fpsInterval = AZStd::chrono::seconds(1);
-            AZStd::deque<AZStd::chrono::system_clock::time_point> m_fpsHistory;
-            AZStd::optional<AZStd::chrono::system_clock::time_point> m_lastMemoryUpdate;
+            AZStd::deque<AZStd::chrono::steady_clock::time_point> m_fpsHistory;
+            AZStd::optional<AZStd::chrono::steady_clock::time_point> m_lastMemoryUpdate;
             bool m_updateRootPassQuery = true;
         };
     } // namespace Render

--- a/Gems/AudioSystem/Code/Source/Engine/ATL.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/ATL.cpp
@@ -72,7 +72,7 @@ namespace Audio
     ///////////////////////////////////////////////////////////////////////////////////////////////////
     bool CAudioTranslationLayer::Initialize()
     {
-        m_lastUpdateTime = AZStd::chrono::system_clock::now();
+        m_lastUpdateTime = AZStd::chrono::steady_clock::now();
         return true;
     }
 
@@ -87,7 +87,7 @@ namespace Audio
     {
         AZ_PROFILE_FUNCTION(Audio);
 
-        auto current = AZStd::chrono::system_clock::now();
+        auto current = AZStd::chrono::steady_clock::now();
         m_elapsedTime = AZStd::chrono::duration_cast<duration_ms>(current - m_lastUpdateTime);
         m_lastUpdateTime = current;
         float elapsedMs = m_elapsedTime.count();

--- a/Gems/AudioSystem/Code/Source/Engine/ATL.h
+++ b/Gems/AudioSystem/Code/Source/Engine/ATL.h
@@ -168,7 +168,7 @@ namespace Audio
         AZStd::string m_implSubPath;
 
         using duration_ms = AZStd::chrono::duration<float, AZStd::milli>;
-        AZStd::chrono::system_clock::time_point m_lastUpdateTime;
+        AZStd::chrono::steady_clock::time_point m_lastUpdateTime;
         duration_ms m_elapsedTime;
 
 #if !defined(AUDIO_RELEASE)

--- a/Gems/AudioSystem/Code/Source/Engine/ATLEntities.h
+++ b/Gems/AudioSystem/Code/Source/Engine/ATLEntities.h
@@ -370,7 +370,7 @@ namespace Audio
         EATLDataScope m_dataScope;
 
 #if !defined(AUDIO_RELEASE)
-        AZStd::chrono::system_clock::time_point m_timeCached;
+        AZStd::chrono::steady_clock::time_point m_timeCached;
 #endif // !AUDIO_RELEASE
     };
 

--- a/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
@@ -190,7 +190,7 @@ namespace Audio
         AZ_Assert(g_audioThreadId == AZStd::this_thread::get_id(), "AudioSystem::InternalUpdate - called from non-Audio thread!");
         AZ_PROFILE_FUNCTION(Audio);
 
-        auto startUpdateTime = AZStd::chrono::system_clock::now();        // stamp the start time
+        auto startUpdateTime = AZStd::chrono::steady_clock::now();        // stamp the start time
 
         // Process a single blocking request, if any, and release the semaphore the main thread is trying to acquire.
         // This ensures that main thread will become unblocked quickly.
@@ -239,7 +239,7 @@ namespace Audio
 
         if (!handleBlockingRequest)
         {
-            auto endUpdateTime = AZStd::chrono::system_clock::now();      // stamp the end time
+            auto endUpdateTime = AZStd::chrono::steady_clock::now();      // stamp the end time
             auto elapsedUpdateTime = AZStd::chrono::duration_cast<duration_ms>(endUpdateTime - startUpdateTime);
             if (elapsedUpdateTime < m_targetUpdatePeriod)
             {

--- a/Gems/AudioSystem/Code/Source/Engine/FileCacheManager.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/FileCacheManager.cpp
@@ -362,7 +362,7 @@ namespace Audio
     {
         if (CVars::s_debugDrawOptions.AreAllFlagsActive(static_cast<AZ::u32>(DebugDraw::Options::FileCacheInfo)))
         {
-            const auto frameTime = AZStd::chrono::system_clock::now();
+            const auto frameTime = AZStd::chrono::steady_clock::now();
 
             const float entryDrawSize = 0.8f;
             const float entryStepSize = 15.0f;
@@ -568,7 +568,7 @@ namespace Audio
                     audioFileEntry->m_flags.ClearFlags(eAFF_LOADING);
 
 #if !defined(AUDIO_RELEASE)
-                    audioFileEntry->m_timeCached = AZStd::chrono::system_clock::now();
+                    audioFileEntry->m_timeCached = AZStd::chrono::steady_clock::now();
 #endif // !AUDIO_RELEASE
 
                     SATLAudioFileEntryInfo fileEntryInfo;
@@ -736,7 +736,7 @@ namespace Audio
         audioFileEntry->m_useCount = 0;
 
     #if !defined(AUDIO_RELEASE)
-        audioFileEntry->m_timeCached = AZStd::chrono::system_clock::time_point();
+        audioFileEntry->m_timeCached = AZStd::chrono::steady_clock::time_point();
     #endif // !AUDIO_RELEASE
     }
 

--- a/Gems/EditorPythonBindings/Code/Tests/PythonThreadingTests.cpp
+++ b/Gems/EditorPythonBindings/Code/Tests/PythonThreadingTests.cpp
@@ -162,7 +162,7 @@ namespace UnitTest
         {
             AZ_TEST_START_TRACE_SUPPRESSION;
 
-            // prepare handler on this thread, but will throw a Python exception 
+            // prepare handler on this thread, but will throw a Python exception
             pybind11::exec(R"(
                 import azlmbr.test
 
@@ -261,7 +261,7 @@ namespace UnitTest
             const float timeOneFrameSeconds = 0.016f; //approx 60 fps
             AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick,
                 timeOneFrameSeconds,
-                AZ::ScriptTimePoint(AZStd::chrono::system_clock::now()));
+                AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
 
             // After one tick all the queued calls should have been processed
             EXPECT_EQ(numWarnings, m_testSink.m_evaluationMap[aznumeric_cast<int>(LogTypes::OnPrewarning)]);

--- a/Gems/GraphCanvas/Code/Source/Components/Connections/ConnectionVisualComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Connections/ConnectionVisualComponent.cpp
@@ -74,7 +74,7 @@ namespace GraphCanvas
     {
         return m_connectionGraphicsItem.get();
     }
-    
+
     bool ConnectionVisualComponent::Contains(const AZ::Vector2&) const
     {
         return false;
@@ -201,7 +201,7 @@ namespace GraphCanvas
 
     void ConnectionGraphicsItem::UpdateOffset()
     {
-        auto currentTime = AZStd::chrono::system_clock::now();
+        auto currentTime = AZStd::chrono::steady_clock::now();
         auto currentDuration = currentTime.time_since_epoch();
         AZStd::chrono::milliseconds currentUpdate = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(currentDuration);
 
@@ -276,7 +276,7 @@ namespace GraphCanvas
         {
             if (!AZ::SystemTickBus::Handler::BusIsConnected())
             {
-                auto currentTime = AZStd::chrono::system_clock::now();
+                auto currentTime = AZStd::chrono::steady_clock::now();
                 auto currentDuration = currentTime.time_since_epoch();
                 m_lastUpdate = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(currentDuration);
 
@@ -328,7 +328,7 @@ namespace GraphCanvas
         ConnectionRequestBus::EventResult(end, GetEntityId(), &ConnectionRequests::GetTargetPosition);
 
         QPointF endJutDirection;
-        SlotUIRequestBus::EventResult(endJutDirection, targetId, &SlotUIRequests::GetJutDirection);            
+        SlotUIRequestBus::EventResult(endJutDirection, targetId, &SlotUIRequests::GetJutDirection);
 
         if (!sourceId.IsValid())
         {
@@ -394,7 +394,7 @@ namespace GraphCanvas
             {
                 magnitude = AZ::GetMax(qSqrt(VectorLength(offset)) * 5, offset.x() * 0.5f);
             }
-            magnitude = AZ::GetClamp(magnitude, (qreal) 10.0f, qMax(VectorLength(midVector), (qreal) 10.0f));            
+            magnitude = AZ::GetClamp(magnitude, (qreal) 10.0f, qMax(VectorLength(midVector), (qreal) 10.0f));
 
             // Makes the line come out horizontally from the start and end points
             QPointF offsetStart = start + startJutDirection * magnitude;
@@ -479,7 +479,7 @@ namespace GraphCanvas
     }
 
     void ConnectionGraphicsItem::OnSettingsChanged()
-    {        
+    {
         UpdateCurveStyle();
     }
 
@@ -555,7 +555,7 @@ namespace GraphCanvas
         stroker.setWidth(padding);
         return stroker.createStroke(path());
     }
- 
+
     void ConnectionGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent)
     {
         if (mouseEvent->button() == Qt::MouseButton::LeftButton)
@@ -647,7 +647,7 @@ namespace GraphCanvas
             {
                 setSelected(!isSelected());
             }
-            
+
             m_trackMove = false;
         }
         else
@@ -662,7 +662,7 @@ namespace GraphCanvas
         {
             m_trackMove = false;
         }
-        
+
         RootGraphicsItem<QGraphicsPathItem>::focusOutEvent(focusEvent);
     }
 
@@ -681,6 +681,6 @@ namespace GraphCanvas
         {
             QGraphicsPathItem::paint(painter, option, widget);
         }
-    }    
+    }
 
 }

--- a/Gems/LmbrCentral/Code/Source/Asset/AssetSystemDebugComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Asset/AssetSystemDebugComponent.cpp
@@ -172,7 +172,7 @@ namespace LmbrCentral
                 EventInfo info;
                 info.m_id = id;
                 info.m_status = status;
-                info.m_loadStart = AZStd::chrono::system_clock::now();
+                info.m_loadStart = AZStd::chrono::steady_clock::now();
 
                 m_events[id] = info;
                 m_oldestActive.insert(&m_events[id]);
@@ -188,7 +188,7 @@ namespace LmbrCentral
             {
                 if(exists)
                 {
-                    itr->second.m_loadFinish = AZStd::chrono::system_clock::now();
+                    itr->second.m_loadFinish = AZStd::chrono::steady_clock::now();
 
                     m_recentlyCompleted.insert(&itr->second);
                     m_oldestActive.erase(&itr->second);

--- a/Gems/LmbrCentral/Code/Source/Asset/AssetSystemDebugComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Asset/AssetSystemDebugComponent.h
@@ -53,8 +53,8 @@ namespace LmbrCentral
         {
             AZ::Data::AssetId m_id;
             AZ::Data::AssetData::AssetStatus m_status;
-            AZStd::chrono::system_clock::time_point m_loadStart;
-            AZStd::chrono::system_clock::time_point m_loadFinish;
+            AZStd::chrono::steady_clock::time_point m_loadStart;
+            AZStd::chrono::steady_clock::time_point m_loadFinish;
         };
 
         struct EventSortOldest

--- a/Gems/MultiplayerCompression/Code/Tests/MultiplayerCompressionTest.cpp
+++ b/Gems/MultiplayerCompression/Code/Tests/MultiplayerCompressionTest.cpp
@@ -39,7 +39,7 @@ TEST_F(MultiplayerCompressionTest, MultiplayerCompression_CompressTest)
     buffer.Resize(buffer.GetCapacity());
 
     // Setup and marshal a highly compressable buffer for LZ4
-    AZStd::chrono::system_clock::time_point startTime = AZStd::chrono::system_clock::now();
+    AZStd::chrono::steady_clock::time_point startTime = AZStd::chrono::steady_clock::now();
     memset(buffer.GetBuffer(), 255, buffer.GetCapacity());
 
     size_t maxCompressedSize = buffer.GetSize() + 32U;
@@ -51,17 +51,17 @@ TEST_F(MultiplayerCompressionTest, MultiplayerCompression_CompressTest)
 
     //Run and test compress
     MultiplayerCompression::LZ4Compressor lz4Compressor;
-    startTime = AZStd::chrono::system_clock::now();
+    startTime = AZStd::chrono::steady_clock::now();
     AzNetworking::CompressorError compressStatus = lz4Compressor.Compress(buffer.GetBuffer(), buffer.GetSize(), pCompressedBuffer, maxCompressedSize, compressedSize);
-    [[maybe_unused]] const AZ::u64 compressTime = (AZStd::chrono::system_clock::now() - startTime).count();
+    [[maybe_unused]] const AZ::u64 compressTime = (AZStd::chrono::steady_clock::now() - startTime).count();
 
     ASSERT_TRUE(compressStatus == AzNetworking::CompressorError::Ok);
     EXPECT_TRUE(compressedSize < maxCompressedSize);
 
     //Run and test decompress
-    startTime = AZStd::chrono::system_clock::now();
+    startTime = AZStd::chrono::steady_clock::now();
     AzNetworking::CompressorError decompressStatus = lz4Compressor.Decompress(pCompressedBuffer, compressedSize, pDecompressedBuffer, buffer.GetSize(), consumedSize, uncompressedSize);
-    [[maybe_unused]] const AZ::u64 decompressTime = (AZStd::chrono::system_clock::now() - startTime).count();
+    [[maybe_unused]] const AZ::u64 decompressTime = (AZStd::chrono::steady_clock::now() - startTime).count();
 
     ASSERT_TRUE(decompressStatus == AzNetworking::CompressorError::Ok);
     EXPECT_TRUE(uncompressedSize = buffer.GetSize());

--- a/Gems/NvCloth/Code/Tests/Components/ClothComponentMesh/ClothComponentMeshTest.cpp
+++ b/Gems/NvCloth/Code/Tests/Components/ClothComponentMesh/ClothComponentMeshTest.cpp
@@ -32,17 +32,17 @@ namespace UnitTest
             AZ::Vector3(1.0f, 0.0f, 0.0f),
             AZ::Vector3(0.0f, 1.0f, 0.0f)
         }};
-        
+
         const AZStd::vector<NvCloth::SimIndexType> MeshIndices = {{
             0, 1, 2
         }};
-        
+
         const AZStd::vector<VertexSkinInfluences> MeshSkinningInfo = {{
             VertexSkinInfluences{ SkinInfluence(0, 1.0f) },
             VertexSkinInfluences{ SkinInfluence(0, 1.0f) },
             VertexSkinInfluences{ SkinInfluence(0, 1.0f) }
         }};
-        
+
         const AZStd::vector<AZ::Vector2> MeshUVs = {{
             AZ::Vector2(0.0f, 0.0f),
             AZ::Vector2(1.0f, 0.0f),
@@ -97,7 +97,7 @@ namespace UnitTest
         EXPECT_TRUE(renderData.m_bitangents.empty());
         EXPECT_TRUE(renderData.m_normals.empty());
     }
-    
+
     TEST_F(NvClothComponentMesh, ClothComponentMesh_InitWithEmptyActor_ReturnsEmptyRenderData)
     {
         {
@@ -116,7 +116,7 @@ namespace UnitTest
         EXPECT_TRUE(renderData.m_bitangents.empty());
         EXPECT_TRUE(renderData.m_normals.empty());
     }
-    
+
     TEST_F(NvClothComponentMesh, ClothComponentMesh_InitWithActorWithNoMesh_ReturnsEmptyRenderData)
     {
         {
@@ -229,7 +229,7 @@ namespace UnitTest
             const float deltaTimeSim = 1.0f / 60.0f;
             AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick,
                 deltaTimeSim,
-                AZ::ScriptTimePoint(AZStd::chrono::system_clock::now()));
+                AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
         }
 
         const AZStd::vector<NvCloth::SimParticleFormat> particlesAfter = clothComponentMesh.GetRenderData().m_particles;
@@ -355,7 +355,7 @@ namespace UnitTest
     TEST_F(NvClothComponentMesh, DISABLED_ClothComponentMesh_UpdateConfigurationNewMeshNode_ReturnsRenderDataFromNewMeshNode)
     {
         const AZStd::string meshNode2Name = "cloth_node_2";
-        
+
         const AZStd::vector<AZ::Vector3> mesh2Vertices = {{
             AZ::Vector3(-2.3f, 0.0f, 0.0f),
             AZ::Vector3(4.0f, 0.0f, 0.0f),
@@ -419,7 +419,7 @@ namespace UnitTest
             const float deltaTimeSim = 1.0f / 60.0f;
             AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick,
                 deltaTimeSim,
-                AZ::ScriptTimePoint(AZStd::chrono::system_clock::now()));
+                AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
         }
 
         const AZStd::vector<NvCloth::SimParticleFormat> particlesAfter = clothComponentMesh.GetRenderData().m_particles;
@@ -457,7 +457,7 @@ namespace UnitTest
             const float deltaTimeSim = 1.0f / 60.0f;
             AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick,
                 deltaTimeSim,
-                AZ::ScriptTimePoint(AZStd::chrono::system_clock::now()));
+                AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
         }
 
         /*

--- a/Gems/NvCloth/Code/Tests/NvClothTest.cpp
+++ b/Gems/NvCloth/Code/Tests/NvClothTest.cpp
@@ -87,7 +87,7 @@ namespace UnitTest
         {
             AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick,
                 timeOneFrameSeconds,
-                AZ::ScriptTimePoint(AZStd::chrono::system_clock::now()));
+                AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
 
             if (tickCount == tickBefore)
             {

--- a/Gems/NvCloth/Code/Tests/System/ClothSystemTest.cpp
+++ b/Gems/NvCloth/Code/Tests/System/ClothSystemTest.cpp
@@ -430,7 +430,7 @@ namespace UnitTest
         // Ticking Cloth System to update all its solvers
         AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick,
             deltaTimeSim,
-            AZ::ScriptTimePoint(AZStd::chrono::system_clock::now()));
+            AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
 
         EXPECT_TRUE(solverPreSimulationEventSignaled);
         EXPECT_TRUE(solverPostSimulationEventSignaled);
@@ -446,7 +446,7 @@ namespace UnitTest
         // Ticking Cloth System to update all its solvers
         AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick,
             deltaTimeSim,
-            AZ::ScriptTimePoint(AZStd::chrono::system_clock::now()));
+            AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
 
         EXPECT_FALSE(solverPreSimulationEventSignaled);
         EXPECT_FALSE(solverPostSimulationEventSignaled);

--- a/Gems/NvCloth/Code/Tests/System/SolverTest.cpp
+++ b/Gems/NvCloth/Code/Tests/System/SolverTest.cpp
@@ -368,7 +368,7 @@ namespace UnitTest
         // Ticking Cloth System updates all its solvers
         AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick,
             deltaTimeSim,
-            AZ::ScriptTimePoint(AZStd::chrono::system_clock::now()));
+            AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
 
         EXPECT_TRUE(solverPreSimulationEventSignaled);
         EXPECT_TRUE(solverPostSimulationEventSignaled);
@@ -380,7 +380,7 @@ namespace UnitTest
         // Ticking Cloth System updates all its solvers
         AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick,
             deltaTimeSim,
-            AZ::ScriptTimePoint(AZStd::chrono::system_clock::now()));
+            AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
 
         EXPECT_FALSE(solverPreSimulationEventSignaled);
         EXPECT_FALSE(solverPostSimulationEventSignaled);

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksUtilities.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksUtilities.cpp
@@ -171,12 +171,12 @@ namespace PhysX::Benchmarks
 
         void PrePostSimulationEventHandler::PreTick()
         {
-            m_tickStart = AZStd::chrono::system_clock::now();
+            m_tickStart = AZStd::chrono::steady_clock::now();
         }
 
         void PrePostSimulationEventHandler::PostTick()
         {
-            auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::system_clock::now() - m_tickStart);
+            auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::steady_clock::now() - m_tickStart);
             m_subTickTimes.emplace_back(tickElapsedMilliseconds.count());
         }
 

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksUtilities.h
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksUtilities.h
@@ -96,7 +96,7 @@ namespace PhysX::Benchmarks
             void PostTick();
             //! list of each sub tick execution time in milliseconds
             Types::TimeList m_subTickTimes;
-            AZStd::chrono::system_clock::time_point m_tickStart;
+            AZStd::chrono::steady_clock::time_point m_tickStart;
 
             AzPhysics::SceneEvents::OnSceneSimulationStartHandler m_sceneStartSimHandler;
             AzPhysics::SceneEvents::OnSceneSimulationFinishHandler m_sceneFinishSimHandler;

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXCharactersBenchmarks.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXCharactersBenchmarks.cpp
@@ -227,7 +227,7 @@ namespace PhysX::Benchmarks
         };
         AZStd::vector<Physics::Character*> controllers = Utils::CreateCharacterControllers(numCharacters,
             static_cast<CharacterConstants::CharacterSettings::ColliderType>(state.range(1)), m_testSceneHandle, &posGenerator);
-        
+
         //setup the sub tick tracker
         PhysX::Benchmarks::Utils::PrePostSimulationEventHandler subTickTracker;
         subTickTracker.Start(m_defaultScene);
@@ -239,11 +239,11 @@ namespace PhysX::Benchmarks
         {
             for (AZ::u32 i = 0; i < CharacterConstants::GameFramesToSimulate; i++)
             {
-                auto start = AZStd::chrono::system_clock::now();
+                auto start = AZStd::chrono::steady_clock::now();
                 StepScene1Tick(DefaultTimeStep);
 
                 //time each physics tick and store it to analyze
-                auto tickElapsedMilliseconds = PhysX::Benchmarks::Types::double_milliseconds(AZStd::chrono::system_clock::now() - start);
+                auto tickElapsedMilliseconds = PhysX::Benchmarks::Types::double_milliseconds(AZStd::chrono::steady_clock::now() - start);
                 tickTimes.emplace_back(tickElapsedMilliseconds.count());
             }
         }
@@ -298,7 +298,7 @@ namespace PhysX::Benchmarks
         {
             for (AZ::u32 i = 0; i < CharacterConstants::GameFramesToSimulate; i++)
             {
-                auto start = AZStd::chrono::system_clock::now();
+                auto start = AZStd::chrono::steady_clock::now();
                 //update the movement of all the characters controllers
                 for (auto& controller : controllers)
                 {
@@ -309,7 +309,7 @@ namespace PhysX::Benchmarks
                 StepScene1Tick(DefaultTimeStep);
 
                 //time each physics tick and store it to analyze
-                auto tickElapsedMilliseconds = PhysX::Benchmarks::Types::double_milliseconds(AZStd::chrono::system_clock::now() - start);
+                auto tickElapsedMilliseconds = PhysX::Benchmarks::Types::double_milliseconds(AZStd::chrono::steady_clock::now() - start);
                 tickTimes.emplace_back(tickElapsedMilliseconds.count());
             }
         }
@@ -377,7 +377,7 @@ namespace PhysX::Benchmarks
 
                 for (AZ::u32 j = 0; j < numFramesPreDirection; j++)
                 {
-                    auto start = AZStd::chrono::system_clock::now();
+                    auto start = AZStd::chrono::steady_clock::now();
                     //update the movement of all the characters controllers
                     for (auto& controllerMovementPair : targetMoveAndControllers)
                     {
@@ -388,7 +388,7 @@ namespace PhysX::Benchmarks
                     StepScene1Tick(DefaultTimeStep);
 
                     //time each physics tick and store it to analyze
-                    auto tickElapsedMilliseconds = PhysX::Benchmarks::Types::double_milliseconds(AZStd::chrono::system_clock::now() - start);
+                    auto tickElapsedMilliseconds = PhysX::Benchmarks::Types::double_milliseconds(AZStd::chrono::steady_clock::now() - start);
                     tickTimes.emplace_back(tickElapsedMilliseconds.count());
                 }
             }

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXCharactersRagdollBenchmarks.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXCharactersRagdollBenchmarks.cpp
@@ -214,11 +214,11 @@ namespace PhysX::Benchmarks
         {
             for (AZ::u32 i = 0; i < RagdollConstants::GameFramesToSimulate; i++)
             {
-                auto start = AZStd::chrono::system_clock::now();
+                auto start = AZStd::chrono::steady_clock::now();
                 StepScene1Tick(DefaultTimeStep);
 
                 //time each physics tick and store it to analyze
-                auto tickElapsedMilliseconds = PhysX::Benchmarks::Types::double_milliseconds(AZStd::chrono::system_clock::now() - start);
+                auto tickElapsedMilliseconds = PhysX::Benchmarks::Types::double_milliseconds(AZStd::chrono::steady_clock::now() - start);
                 tickTimes.emplace_back(tickElapsedMilliseconds.count());
             }
         }
@@ -280,11 +280,11 @@ namespace PhysX::Benchmarks
         {
             for (AZ::u32 i = 0; i < RagdollConstants::GameFramesToSimulate; i++)
             {
-                auto start = AZStd::chrono::system_clock::now();
+                auto start = AZStd::chrono::steady_clock::now();
                 StepScene1Tick(DefaultTimeStep);
 
                 //time each physics tick and store it to analyze
-                auto tickElapsedMilliseconds = PhysX::Benchmarks::Types::double_milliseconds(AZStd::chrono::system_clock::now() - start);
+                auto tickElapsedMilliseconds = PhysX::Benchmarks::Types::double_milliseconds(AZStd::chrono::steady_clock::now() - start);
                 tickTimes.emplace_back(tickElapsedMilliseconds.count());
             }
         }

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXJointBenchmarks.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXJointBenchmarks.cpp
@@ -249,11 +249,11 @@ namespace PhysX::Benchmarks
         {
             for (AZ::u32 i = 0; i < JointConstants::GameFramesToSimulate; i++)
             {
-                auto start = AZStd::chrono::system_clock::now();
+                auto start = AZStd::chrono::steady_clock::now();
                 StepScene1Tick(DefaultTimeStep);
 
                 //time each physics tick and store it to analyze
-                auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::system_clock::now() - start);
+                auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::steady_clock::now() - start);
                 tickTimes.emplace_back(tickElapsedMilliseconds.count());
             }
         }
@@ -320,11 +320,11 @@ namespace PhysX::Benchmarks
                     }
                 }
 
-                auto start = AZStd::chrono::system_clock::now();
+                auto start = AZStd::chrono::steady_clock::now();
                 StepScene1Tick(DefaultTimeStep);
 
                 //time each physics tick and store it to analyze
-                auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::system_clock::now() - start);
+                auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::steady_clock::now() - start);
                 tickTimes.emplace_back(tickElapsedMilliseconds.count());
             }
         }
@@ -405,11 +405,11 @@ namespace PhysX::Benchmarks
         {
             for (AZ::u32 i = 0; i < JointConstants::GameFramesToSimulate; i++)
             {
-                auto start = AZStd::chrono::system_clock::now();
+                auto start = AZStd::chrono::steady_clock::now();
                 StepScene1Tick(DefaultTimeStep);
 
                 //time each physics tick and store it to analyze
-                auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::system_clock::now() - start);
+                auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::steady_clock::now() - start);
                 tickTimes.emplace_back(tickElapsedMilliseconds.count());
             }
         }

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXRigidBodyBenchmarks.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXRigidBodyBenchmarks.cpp
@@ -228,7 +228,7 @@ namespace PhysX::Benchmarks
             }
             return AZ::Vector3(x, y, z);
         };
-        
+
         auto boxShapeConfiguration = AZStd::make_shared<Physics::BoxShapeConfiguration>(AZ::Vector3(RigidBodyConstants::RigidBodys::BoxSize));
         Utils::GenerateColliderFuncPtr colliderGenerator = [&boxShapeConfiguration]([[maybe_unused]] int idx)
         {
@@ -249,11 +249,11 @@ namespace PhysX::Benchmarks
         {
             for (AZ::u32 i = 0; i < RigidBodyConstants::GameFramesToSimulate; i++)
             {
-                auto start = AZStd::chrono::system_clock::now();
+                auto start = AZStd::chrono::steady_clock::now();
                 StepScene1Tick(DefaultTimeStep);
 
                 //time each physics tick and store it to analyze
-                auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::system_clock::now() - start);
+                auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::steady_clock::now() - start);
                 tickTimes.emplace_back(tickElapsedMilliseconds.count());
             }
         }
@@ -336,11 +336,11 @@ namespace PhysX::Benchmarks
         {
             for (AZ::u32 i = 0; i < RigidBodyConstants::GameFramesToSimulate; i++)
             {
-                auto start = AZStd::chrono::system_clock::now();
+                auto start = AZStd::chrono::steady_clock::now();
                 StepScene1Tick(DefaultTimeStep);
 
                 //time each physics tick and store it to analyze
-                auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::system_clock::now() - start);
+                auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::steady_clock::now() - start);
                 tickTimes.emplace_back(tickElapsedMilliseconds.count());
             }
         }
@@ -476,7 +476,7 @@ namespace PhysX::Benchmarks
         Utils::GenerateMassFuncPtr massGenerator = [&rand]([[maybe_unused]] int idx) -> float {
             return rand.GetRandomFloat() * 25.0f + 5.0f;
         };
-        
+
         Utils::GenerateEntityIdFuncPtr entityIdGenerator = [](int idx) -> AZ::EntityId {
             return AZ::EntityId(static_cast<AZ::u64>(idx) + RigidBodyConstants::RigidBodys::RigidBodyEntityIdStart);
         };
@@ -531,11 +531,11 @@ namespace PhysX::Benchmarks
         {
             for (AZ::u32 i = 0; i < RigidBodyConstants::GameFramesToSimulate; i++)
             {
-                auto start = AZStd::chrono::system_clock::now();
+                auto start = AZStd::chrono::steady_clock::now();
                 StepScene1Tick(DefaultTimeStep);
 
                 //time each physics tick and store it to analyze
-                auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::system_clock::now() - start);
+                auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::steady_clock::now() - start);
                 tickTimes.emplace_back(tickElapsedMilliseconds.count());
             }
         }

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXSceneQueryBenchmarks.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXSceneQueryBenchmarks.cpp
@@ -145,11 +145,11 @@ namespace PhysX::Benchmarks
         {
             request.m_direction = m_boxes[next].GetNormalized();
 
-            auto start = AZStd::chrono::system_clock::now();
+            auto start = AZStd::chrono::steady_clock::now();
 
             AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(m_testSceneHandle, &request);
 
-            auto timeElasped = AZStd::chrono::duration_cast<AZStd::chrono::nanoseconds>(AZStd::chrono::system_clock::now() - start);
+            auto timeElasped = AZStd::chrono::duration_cast<AZStd::chrono::nanoseconds>(AZStd::chrono::steady_clock::now() - start);
             executionTimes.emplace_back(timeElasped.count());
 
             benchmark::DoNotOptimize(result);
@@ -179,11 +179,11 @@ namespace PhysX::Benchmarks
         {
             request.m_direction = m_boxes[next].GetNormalized();
 
-            auto start = AZStd::chrono::system_clock::now(); 
+            auto start = AZStd::chrono::steady_clock::now(); 
 
             AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(m_testSceneHandle, &request);
 
-            auto timeElasped = AZStd::chrono::duration_cast<AZStd::chrono::nanoseconds>(AZStd::chrono::system_clock::now() - start);
+            auto timeElasped = AZStd::chrono::duration_cast<AZStd::chrono::nanoseconds>(AZStd::chrono::steady_clock::now() - start);
             executionTimes.emplace_back(timeElasped.count());
 
             benchmark::DoNotOptimize(result);
@@ -210,11 +210,11 @@ namespace PhysX::Benchmarks
         {
             request.m_pose = AZ::Transform::CreateTranslation(m_boxes[next]);
 
-            auto start = AZStd::chrono::system_clock::now();
+            auto start = AZStd::chrono::steady_clock::now();
 
             AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(m_testSceneHandle, &request);
 
-            auto timeElasped = AZStd::chrono::duration_cast<AZStd::chrono::nanoseconds>(AZStd::chrono::system_clock::now() - start);
+            auto timeElasped = AZStd::chrono::duration_cast<AZStd::chrono::nanoseconds>(AZStd::chrono::steady_clock::now() - start);
             executionTimes.emplace_back(timeElasped.count());
 
             benchmark::DoNotOptimize(result);

--- a/Gems/PhysX/Code/Tests/PhysXMultithreadingTest.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXMultithreadingTest.cpp
@@ -67,10 +67,10 @@ namespace PhysX
             AZStd::chrono::milliseconds totalTime = AZStd::chrono::milliseconds(0);
             do
             {
-                AZStd::chrono::system_clock::time_point startTime = AZStd::chrono::system_clock::now();
+                AZStd::chrono::steady_clock::time_point startTime = AZStd::chrono::steady_clock::now();
                 PhysX::TestUtils::UpdateScene(scene, AzPhysics::SystemConfiguration::DefaultFixedTimestep, 1);
                 AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
-                totalTime += AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::system_clock::now() - startTime);
+                totalTime += AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(AZStd::chrono::steady_clock::now() - startTime);
             } while (totalTime < updateTimeLimit);
         }
     }

--- a/Gems/PhysX/Code/Tests/PhysXWindTest.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXWindTest.cpp
@@ -354,8 +354,8 @@ namespace PhysX
         const float windMagnitude = 20.0f;
         auto forceRegionEntity = AddWindRegion(originalAabb, windDirection, windMagnitude, WindType::Local);
 
-        // Tick to flush any existing updates pending in wind system 
-        AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick, 0.01f, AZ::ScriptTimePoint(AZStd::chrono::system_clock::now()));
+        // Tick to flush any existing updates pending in wind system
+        AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick, 0.01f, AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
 
         // Move entity to new position
         const AZ::Vector3 newPosition = AZ::Vector3(500.0f, 100.0f, 0.0f);
@@ -375,7 +375,7 @@ namespace PhysX
             EXPECT_CALL(mockHandler, OnWindChanged(originalAabb)).Times(1);
             EXPECT_CALL(mockHandler, OnWindChanged(newAabb)).Times(1);
 
-            AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick, 0.01f, AZ::ScriptTimePoint(AZStd::chrono::system_clock::now()));
+            AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick, 0.01f, AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
         }
     }
 

--- a/Gems/ScriptCanvas/Code/Editor/Framework/ScriptCanvasGraphUtilities.inl
+++ b/Gems/ScriptCanvas/Code/Editor/Framework/ScriptCanvasGraphUtilities.inl
@@ -230,7 +230,7 @@ namespace ScriptCanvasEditor
 #else ///////////////////////////////////////////////////////////////////////////////////////
 
                         dependencies = LoadInterpretedDepencies(luaAssetResult.m_dependencies.source.userSubgraphs);
-                        
+
                         if (!dependencies.empty())
                         {
                             // #functions2_recursive_unit_tests eventually, this will need to be recursive, or the full asset handling system will need to be integrated into the testing framework
@@ -401,7 +401,7 @@ namespace ScriptCanvasEditor
         AZ::SystemTickBus::Broadcast(&AZ::SystemTickBus::Events::OnSystemTick);
         AZ::SystemTickBus::ExecuteQueuedEvents();
 
-        AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick, duration.m_timeStep, AZ::ScriptTimePoint(AZStd::chrono::system_clock::now()));
+        AZ::TickBus::Broadcast(&AZ::TickEvents::OnTick, duration.m_timeStep, AZ::ScriptTimePoint(AZStd::chrono::steady_clock::now()));
         AZ::TickBus::ExecuteQueuedEvents();
     }
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -296,7 +296,7 @@ namespace ScriptCanvasEditor
                 {
                     // load all the files
 //                     AssetTrackerNotificationBus::MultiHandler::BusConnect(assetSaveData.m_assetId);
-// 
+//
 //                     Callbacks::OnAssetReadyCallback onAssetReady = [this, assetSaveData](ScriptCanvasMemoryAsset& asset)
 //                     {
 //                         // If we get an error callback. Just remove it from out active lists.
@@ -306,21 +306,21 @@ namespace ScriptCanvasEditor
 //                             {
 //                                 m_queuedAssetFocus = SourceHandle();
 //                             }
-// 
+//
 //                             SignalAssetComplete(asset.GetFileAssetId());
 //                         }
 //                     };
-// 
+//
 //                     bool loadedFile = true;
 //                     AssetTrackerRequestBus::BroadcastResult(loadedFile, &AssetTrackerRequests::Load, assetSaveData.m_assetId, assetSaveData.m_assetType, onAssetReady);
-// 
+//
 //                     if (!loadedFile)
 //                     {
 //                         if (assetSaveData.m_assetId == m_queuedAssetFocus)
 //                         {
 //                             m_queuedAssetFocus = SourceHandle();
 //                         }
-// 
+//
 //                         SignalAssetComplete(assetSaveData.m_assetId);
 //                     }
                 }
@@ -340,7 +340,7 @@ namespace ScriptCanvasEditor
 //         {
 //             m_loadingAssets.erase(it);
 //         }
-// 
+//
 //         if (m_loadingAssets.empty())
 //         {
 //             m_mainWindow->OnWorkspaceRestoreEnd(m_queuedAssetFocus);
@@ -574,7 +574,7 @@ namespace ScriptCanvasEditor
         m_propertyGrid->setObjectName("NodeInspector");
 
         m_bookmarkDockWidget = aznew GraphCanvas::BookmarkDockWidget(ScriptCanvasEditor::AssetEditorId, this);
-                
+
         QObject::connect(m_variableDockWidget, &VariableDockWidget::OnVariableSelectionChanged, this, &MainWindow::OnVariableSelectionChanged);
 
         // This needs to happen after the node palette is created, because we scrape for the variable data from inside
@@ -1148,26 +1148,26 @@ namespace ScriptCanvasEditor
 //         {
 //             return AZ::Failure(AZStd::string("Unable to open asset with invalid asset id"));
 //         }
-// 
+//
 //         if (!scriptCanvasAsset.IsDescriptionValid())
 //         {
 //             if (!m_isRestoringWorkspace)
 //             {
 //                 AZStd::string errorPath = scriptCanvasAsset.Path().c_str();
-// 
+//
 //                 if (errorPath.empty())
 //                 {
 //                     errorPath = m_errorFilePath;
 //                 }
-// 
+//
 //                 if (m_queuedFocusOverride.AnyEquals(fileAssetId))
 //                 {
 //                     m_queuedFocusOverride = fileAssetId;
 //                 }
-// 
+//
 //                 QMessageBox::warning(this, "Unable to open source file", QString("Source File(%1) is in error and cannot be opened").arg(errorPath.c_str()), QMessageBox::StandardButton::Ok);
 //             }
-// 
+//
 //             return AZ::Failure(AZStd::string("Source File is in error"));
 //         }
 
@@ -1342,7 +1342,7 @@ namespace ScriptCanvasEditor
 
         auto activeGraph =  SourceHandle::FromRelativePath(result.m_handle, assetInfo.m_assetId.m_guid, assetInfo.m_relativePath);
         activeGraph = SourceHandle::MarkAbsolutePath(activeGraph, fullPath);
-        
+
         auto openOutcome = OpenScriptCanvasAsset(activeGraph, Tracker::ScriptCanvasFileState::UNMODIFIED);
         if (openOutcome)
         {
@@ -1471,7 +1471,7 @@ namespace ScriptCanvasEditor
         {
             newAssetName = AZStd::string::format(SourceDescription::GetAssetNamePattern()
                 , ++scriptCanvasEditorDefaultNewNameCount);
-            
+
             AZStd::array<char, AZ::IO::MaxPathLength> assetRootArray;
             if (!AZ::IO::FileIOBase::GetInstance()->ResolvePath(SourceDescription::GetSuggestedSavePath()
                 , assetRootArray.data(), assetRootArray.size()))
@@ -1537,7 +1537,7 @@ namespace ScriptCanvasEditor
         SourceHandle handle = relativeOption ? *relativeOption : SourceHandle(graph, assetId);
 
         outTabIndex = InsertTabForAsset(assetPath, handle, tabIndex);
-        
+
         if (outTabIndex == -1)
         {
             return AZ::Failure(AZStd::string::format("Script Canvas Asset %.*s is not open in a tab"
@@ -1623,7 +1623,7 @@ namespace ScriptCanvasEditor
                 ( QMessageBox::Warning
                 , QObject::tr("Select ScriptCanvas or ScriptEvent source type:")
                 , QObject::tr("Graph defines a ScriptEvent. Press 'Discard' and use Script Event menu to save it as .scriptevent, or 'Ok' to continue to save as .scriptcanvas")
-                , QMessageBox::Ok | QMessageBox::Discard    
+                , QMessageBox::Ok | QMessageBox::Discard
                 , nullptr);
 
             if (mb.exec() == QMessageBox::Discard)
@@ -1643,7 +1643,7 @@ namespace ScriptCanvasEditor
             }
 
             sourceHandle = SourceHandle::MarkAbsolutePath(sourceHandle, newPath);
-        }        
+        }
 
         if (!m_activeGraph.AnyEquals(sourceHandle))
         {
@@ -1665,7 +1665,7 @@ namespace ScriptCanvasEditor
         {
             isValidFileName = true;
             suggestedFileFilter = SourceDescription::GetFileExtension();
-            
+
             auto sourceHandlePath = sourceHandleIn.AbsolutePath();
             selectedFile = sourceHandleIn.AbsolutePath().Native().c_str();
             suggestedFilename = sourceHandleIn.AbsolutePath().Filename().Native();
@@ -1691,9 +1691,9 @@ namespace ScriptCanvasEditor
 
             selectedFile = suggestedFilename.c_str();
         }
-        
+
         QString filter = suggestedFileFilter.c_str();
-        
+
         while (!isValidFileName)
         {
             selectedFile = AzQtComponents::FileDialog::GetSaveFileName(this, QObject::tr("Save As..."), suggestedDirectoryPath.data(), QObject::tr("All ScriptCanvas Files (*.scriptcanvas)"));
@@ -1751,7 +1751,7 @@ namespace ScriptCanvasEditor
 
         return false;
     }
-    
+
     void MainWindow::OnSaveCallBack(const VersionExplorer::FileSaveResult& result)
     {
         const bool saveSuccess = result.IsSuccess();
@@ -1869,7 +1869,7 @@ namespace ScriptCanvasEditor
         MarkRecentSave(sourceHandle);
         m_fileSaver->Save(sourceHandle, path);
 
-        BlockCloseRequests();        
+        BlockCloseRequests();
     }
 
     void MainWindow::OnFileOpen()
@@ -2446,7 +2446,7 @@ namespace ScriptCanvasEditor
         }
 
         UpdateUndoCache(fileAssetId);
-        RefreshSelection();        
+        RefreshSelection();
     }
 
     void MainWindow::RefreshActiveAsset()
@@ -3949,37 +3949,37 @@ namespace ScriptCanvasEditor
     void MainWindow::OnAssignToSelectedEntities()
     {
         Tracker::ScriptCanvasFileState fileState = GetAssetFileState(m_activeGraph);;
-        
+
         bool isDocumentOpen = false;
         AzToolsFramework::EditorRequests::Bus::BroadcastResult(isDocumentOpen, &AzToolsFramework::EditorRequests::IsLevelDocumentOpen);
- 
+
         if (fileState == Tracker::ScriptCanvasFileState::NEW || fileState == Tracker::ScriptCanvasFileState::SOURCE_REMOVED || !isDocumentOpen)
         {
             return;
         }
- 
+
         AzToolsFramework::EntityIdList selectedEntityIds;
         AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(selectedEntityIds, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
- 
+
         auto selectedEntityIdIter = selectedEntityIds.begin();
- 
+
         bool isLayerAmbiguous = false;
         AZ::EntityId targetLayer;
- 
+
         while (selectedEntityIdIter != selectedEntityIds.end())
         {
             bool isLayerEntity = false;
             AzToolsFramework::Layers::EditorLayerComponentRequestBus::EventResult(isLayerEntity, (*selectedEntityIdIter), &AzToolsFramework::Layers::EditorLayerComponentRequestBus::Events::HasLayer);
- 
+
             if (isLayerEntity)
             {
                 if (targetLayer.IsValid())
                 {
                     isLayerAmbiguous = true;
                 }
- 
+
                 targetLayer = (*selectedEntityIdIter);
- 
+
                 selectedEntityIdIter = selectedEntityIds.erase(selectedEntityIdIter);
             }
             else
@@ -3987,20 +3987,20 @@ namespace ScriptCanvasEditor
                 ++selectedEntityIdIter;
             }
         }
- 
+
         if (selectedEntityIds.empty())
         {
             AZ::EntityId createdId;
             AzToolsFramework::EditorRequests::Bus::BroadcastResult(createdId, &AzToolsFramework::EditorRequests::CreateNewEntity, AZ::EntityId());
- 
+
             selectedEntityIds.emplace_back(createdId);
- 
+
             if (targetLayer.IsValid() && !isLayerAmbiguous)
             {
                 AZ::TransformBus::Event(createdId, &AZ::TransformBus::Events::SetParent, targetLayer);
             }
         }
- 
+
         for (const AZ::EntityId& entityId : selectedEntityIds)
         {
             AssignGraphToEntityImpl(entityId);
@@ -4438,7 +4438,7 @@ namespace ScriptCanvasEditor
     void MainWindow::ClearStaleSaves()
     {
         AZStd::lock_guard<AZStd::recursive_mutex> lock(m_mutex);
-        auto timeNow = AZStd::chrono::system_clock::now();
+        auto timeNow = AZStd::chrono::steady_clock::now();
         AZStd::erase_if(m_saves, [&timeNow](const auto& item)
         {
             AZStd::sys_time_t delta = AZStd::chrono::duration_cast<AZStd::chrono::seconds>(timeNow - item.second).count();
@@ -4460,7 +4460,7 @@ namespace ScriptCanvasEditor
         AZStd::lock_guard<AZStd::recursive_mutex> lock(m_mutex);
         AZStd::string key = handle.AbsolutePath().Native();
         AZStd::to_lower(key.begin(), key.end());
-        m_saves[key] = AZStd::chrono::system_clock::now();
+        m_saves[key] = AZStd::chrono::steady_clock::now();
     }
 
     void MainWindow::OnScriptEventAddHelpers()

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
@@ -203,7 +203,7 @@ namespace ScriptCanvasEditor
     class VariableDockWidget;
     class UnitTestDockWidget;
     class BatchOperatorTool;
-    class ScriptCanvasBatchConverter;    
+    class ScriptCanvasBatchConverter;
     class LoggingWindow;
     class GraphValidationDockWidget;
     class MainWindowStatusWidget;
@@ -326,14 +326,14 @@ namespace ScriptCanvasEditor
         bool OnFileSave();
         bool OnFileSaveAs();
         bool OnFileSaveCaller(){return OnFileSave();};
-        bool OnFileSaveAsCaller(){return OnFileSaveAs();};        
+        bool OnFileSaveAsCaller(){return OnFileSaveAs();};
         enum class Save
         {
             InPlace,
             As
         };
         bool SaveAssetImpl(const SourceHandle& assetId, Save save);
-        void OnFileOpen();        
+        void OnFileOpen();
 
         // Edit menu
         void SetupEditMenu();
@@ -379,7 +379,7 @@ namespace ScriptCanvasEditor
         void OnViewCommandLine();
         void OnViewLog();
         void OnBookmarks();
-        void OnVariableManager();        
+        void OnVariableManager();
         void OnViewMiniMap();
         void OnViewLogWindow();
         void OnViewGraphValidation();
@@ -404,7 +404,7 @@ namespace ScriptCanvasEditor
         void OnNodeAdded(const AZ::EntityId& nodeId, bool isPaste) override;
         void OnSelectionChanged() override;
         /////////////////////////////////////////////////////////////////////////////////////////////
-        
+
         void OnVariableSelectionChanged(const AZStd::vector<AZ::EntityId>& variablePropertyIds);
         void QueuePropertyGridUpdate();
         void DequeuePropertyGridUpdate();
@@ -441,7 +441,7 @@ namespace ScriptCanvasEditor
         ////
 
         AZ::Outcome<int, AZStd::string> CreateScriptCanvasAsset(AZStd::string_view assetPath, int tabIndex = -1);
-        
+
         void RemoveScriptCanvasAsset(const SourceHandle& assetId);
         void OnChangeActiveGraphTab(SourceHandle) override;
 
@@ -491,7 +491,7 @@ namespace ScriptCanvasEditor
         float GetMaxZoom() const override;
 
         float GetEdgePanningPercentage() const override;
-        float GetEdgePanningScrollSpeed() const override;        
+        float GetEdgePanningScrollSpeed() const override;
 
         GraphCanvas::EditorConstructPresets* GetConstructPresets() const override;
         const GraphCanvas::ConstructTypePresetBucket* GetConstructTypePresetBucket(GraphCanvas::ConstructType constructType) const override;
@@ -510,7 +510,7 @@ namespace ScriptCanvasEditor
         void SignalAutomationBegin() override;
         void SignalAutomationEnd() override;
 
-        void ForceCloseActiveAsset() override;        
+        void ForceCloseActiveAsset() override;
         ////
 
         // AssetEditorAutomationRequestBus
@@ -524,15 +524,15 @@ namespace ScriptCanvasEditor
 
         AZ::EntityId FindEditorNodeIdByAssetNodeId(const SourceHandle& assetId, AZ::EntityId assetNodeId) const override;
         AZ::EntityId FindAssetNodeIdByEditorNodeId(const SourceHandle& assetId, AZ::EntityId editorNodeId) const override;
-        
+
     private:
         void SourceFileChanged(AZStd::string relativePath, AZStd::string scanFolder, AZ::Uuid fileAssetId) override;
         void SourceFileRemoved(AZStd::string relativePath, AZStd::string scanFolder, AZ::Uuid fileAssetId) override;
-        
+
         void DeleteNodes(const AZ::EntityId& sceneId, const AZStd::vector<AZ::EntityId>& nodes) override;
         void DeleteConnections(const AZ::EntityId& sceneId, const AZStd::vector<AZ::EntityId>& connections) override;
         void DisconnectEndpoints(const AZ::EntityId& sceneId, const AZStd::vector<GraphCanvas::Endpoint>& endpoints) override;
-        /////////////////////////////////////////////////////////////////////////////////////////////        
+        /////////////////////////////////////////////////////////////////////////////////////////////
 
         GraphCanvas::Endpoint HandleProposedConnection(const GraphCanvas::GraphId& graphId, const GraphCanvas::ConnectionId& connectionId, const GraphCanvas::Endpoint& endpoint, const GraphCanvas::NodeId& proposedNode, const QPoint& screenPoint);
 
@@ -554,7 +554,7 @@ namespace ScriptCanvasEditor
         // QMainWindow
         void closeEvent(QCloseEvent *event) override;
         UnsavedChangesOptions ShowSaveDialog(const QString& filename);
-        
+
         bool ActivateAndSaveAsset(const SourceHandle& unsavedAssetId);
 
         void SaveAs(AZStd::string_view path, SourceHandle assetId);
@@ -707,7 +707,7 @@ namespace ScriptCanvasEditor
         QVBoxLayout* m_layout;
 
         SourceHandle m_activeGraph;
-        
+
         bool                  m_loadingNewlySavedFile;
         AZStd::string         m_newlySavedFile;
 
@@ -739,7 +739,7 @@ namespace ScriptCanvasEditor
 
         QByteArray m_defaultLayout;
         QTranslator m_translator;
-        
+
         AZStd::vector<AZ::EntityId> m_selectedVariableIds;
 
         AZ::u32                                   m_systemTickActions;
@@ -769,7 +769,7 @@ namespace ScriptCanvasEditor
         void ClearStaleSaves();
         bool IsRecentSave(const SourceHandle& handle) const;
         void MarkRecentSave(const SourceHandle& handle);
-        AZStd::recursive_mutex m_mutex; 
-        AZStd::unordered_map <AZStd::string, AZStd::chrono::system_clock::time_point> m_saves;
+        AZStd::recursive_mutex m_mutex;
+        AZStd::unordered_map <AZStd::string, AZStd::chrono::steady_clock::time_point> m_saves;
     };
 }

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Modifier.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Modifier.cpp
@@ -92,7 +92,7 @@ namespace ScriptCanvasEditor
         AZStd::sys_time_t Modifier::CalculateRemainingWaitTime(const AZStd::unordered_set<size_t>& dependencies) const
         {
             auto maxSeconds = AZStd::chrono::seconds(dependencies.size() * m_config.perDependencyWaitSecondsMax);
-            auto waitedSeconds = AZStd::chrono::duration_cast<AZStd::chrono::seconds>(AZStd::chrono::system_clock::now() - m_waitTimeStamp);
+            auto waitedSeconds = AZStd::chrono::duration_cast<AZStd::chrono::seconds>(AZStd::chrono::steady_clock::now() - m_waitTimeStamp);
             return (maxSeconds - waitedSeconds).count();
         }
 
@@ -106,8 +106,8 @@ namespace ScriptCanvasEditor
                     ( "dependencies found for %s, update will wait for the AP to finish processing them"
                     , m_result.asset.RelativePath().c_str());
 
-                m_waitTimeStamp = AZStd::chrono::system_clock::now();
-                m_waitLogTimeStamp = AZStd::chrono::system_clock::time_point{};
+                m_waitTimeStamp = AZStd::chrono::steady_clock::now();
+                m_waitLogTimeStamp = AZStd::chrono::steady_clock::time_point{};
                 m_modifyState = ModifyState::WaitingForDependencyProcessing;
             }
             else
@@ -398,7 +398,7 @@ namespace ScriptCanvasEditor
             m_dependencyOrderedAssetIndicies.reserve(m_assets.size());
             Sorter sorter;
             sorter.modifier = this;
-            sorter.Sort();           
+            sorter.Sort();
         }
 
         ModificationResults&& Modifier::TakeResult()
@@ -512,9 +512,9 @@ namespace ScriptCanvasEditor
             {
                 ReportModificationError("Dependency update time has taken too long, aborting modification.");
             }
-            else if (AZStd::chrono::duration_cast<AZStd::chrono::seconds>(AZStd::chrono::system_clock::now() - m_waitLogTimeStamp).count() > LogPeriodSeconds)
+            else if (AZStd::chrono::duration_cast<AZStd::chrono::seconds>(AZStd::chrono::steady_clock::now() - m_waitLogTimeStamp).count() > LogPeriodSeconds)
             {
-                m_waitLogTimeStamp = AZStd::chrono::system_clock::now();
+                m_waitLogTimeStamp = AZStd::chrono::steady_clock::now();
 
                 AZ_TracePrintf
                     ( ScriptCanvas::k_VersionExplorerWindow.data()

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Modifier.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Modifier.h
@@ -92,8 +92,8 @@ namespace ScriptCanvasEditor
             AZStd::unordered_set<AZ::Uuid> m_attemptedAssets;
             AZStd::unordered_set<AZ::Uuid> m_assetsCompletedByAP;
             AZStd::unordered_set<AZ::Uuid> m_assetsFailedByAP;
-            AZStd::chrono::system_clock::time_point m_waitLogTimeStamp;
-            AZStd::chrono::system_clock::time_point m_waitTimeStamp;
+            AZStd::chrono::steady_clock::time_point m_waitLogTimeStamp;
+            AZStd::chrono::steady_clock::time_point m_waitTimeStamp;
             AZStd::unordered_set<AZStd::string> m_successNotifications;
             AZStd::unordered_set<AZStd::string> m_failureNotifications;
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionBus.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionBus.h
@@ -36,7 +36,7 @@
 #endif
 
 namespace ScriptCanvas
-{    
+{
     GraphInfo CreateGraphInfo(ScriptCanvasId executionId, const GraphIdentifier& graphIdentifier);
     class ExecutionState;
 
@@ -89,7 +89,7 @@ namespace ScriptCanvas
 
         protected:
             PerformanceKey m_key;
-            AZStd::chrono::system_clock::time_point m_startTime;
+            AZStd::chrono::steady_clock::time_point m_startTime;
         };
 
         class PerformanceScopeExecution : public PerformanceScope

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionPerformanceTimer.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionPerformanceTimer.cpp
@@ -46,7 +46,7 @@ namespace ScriptCanvas
 
         PerformanceScope::PerformanceScope(const PerformanceKey& key)
             : m_key(key)
-            , m_startTime(AZStd::chrono::system_clock::now())
+            , m_startTime(AZStd::chrono::steady_clock::now())
         {}
 
         PerformanceScopeExecution::PerformanceScopeExecution(const PerformanceKey& key)
@@ -55,7 +55,7 @@ namespace ScriptCanvas
 
         PerformanceScopeExecution::~PerformanceScopeExecution()
         {
-            ModPerformanceTracker().ReportExecutionTime(m_key, AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::system_clock::now() - m_startTime).count());
+            ModPerformanceTracker().ReportExecutionTime(m_key, AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::steady_clock::now() - m_startTime).count());
         }
 
         PerformanceScopeInitialization::PerformanceScopeInitialization(const PerformanceKey& key)
@@ -64,7 +64,7 @@ namespace ScriptCanvas
 
         PerformanceScopeInitialization::~PerformanceScopeInitialization()
         {
-            ModPerformanceTracker().ReportInitializationTime(m_key, AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::system_clock::now() - m_startTime).count());
+            ModPerformanceTracker().ReportInitializationTime(m_key, AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::steady_clock::now() - m_startTime).count());
         }
 
         PerformanceScopeLatent::PerformanceScopeLatent(const PerformanceKey& key)
@@ -73,7 +73,7 @@ namespace ScriptCanvas
 
         PerformanceScopeLatent::~PerformanceScopeLatent()
         {
-            ModPerformanceTracker().ReportLatentTime(m_key, AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::system_clock::now() - m_startTime).count());
+            ModPerformanceTracker().ReportLatentTime(m_key, AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::steady_clock::now() - m_startTime).count());
         }
 
         PerformanceTimer::PerformanceTimer()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
@@ -1136,7 +1136,7 @@ namespace ScriptCanvas
 
             ReturnValueConnections connections = FindAssignments(execution, outputSlot);
 
-            // get/set methods 
+            // get/set methods
             if (IsVariableSet(execution) && !IsPropertyExtractionSlot(execution, &outputSlot))
             {
                 if (!out.m_output.size() == 1)
@@ -2210,12 +2210,12 @@ namespace ScriptCanvas
 
         void AbstractCodeModel::MarkParseStart()
         {
-            m_parseStartTime = AZStd::chrono::system_clock::now();
+            m_parseStartTime = AZStd::chrono::steady_clock::now();
         }
 
         void AbstractCodeModel::MarkParseStop()
         {
-            m_parseDuration = AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::system_clock::now() - m_parseStartTime).count();
+            m_parseDuration = AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::steady_clock::now() - m_parseStartTime).count();
         }
 
         AZStd::vector<ExecutionTreePtr> AbstractCodeModel::ModAllExecutionRoots()
@@ -2550,7 +2550,7 @@ namespace ScriptCanvas
             if (!outSlots.empty())
             {
                 start->AddChild({ outSlots[0], {}, nullptr });
-                
+
                 ParseExecutionMultipleOutSyntaxSugar(start, outNodes, outSlots);
                 PostParseProcess(start);
                 PostParseErrorDetect(start);
@@ -2692,7 +2692,7 @@ namespace ScriptCanvas
                 return inScopeVar;
             }
 
-            // do this exact thing for multiple out sequence sugar, and change the way those are translated 
+            // do this exact thing for multiple out sequence sugar, and change the way those are translated
             auto inPreviouslyExecutedScopeResult = FindConnectedInputInPreviouslyExecutedScope(executionWithInput, scriptCanvasNodesConnectedToInput, firstNode);
 
             if (!inPreviouslyExecutedScopeResult.m_connections.empty())
@@ -2980,7 +2980,7 @@ namespace ScriptCanvas
 
                     // #functions2 This search needs to recurse, and ignore the graphs in which the functions are defined, do this after the
                     // editor executed unit tests are restored
-                    // 
+                    //
                     // This layer of dependencies will only be one step deep.
                     // Currently, this problem is only detected by the asset processor
                     if (dependencies.userSubgraphs.find(m_source.m_namespacePath) != dependencies.userSubgraphs.end())
@@ -3370,7 +3370,7 @@ namespace ScriptCanvas
                         }
                         else
                         {
-                            // Interior node branches: This is required for highly custom or state-ful nodes, namely those that fire different, 
+                            // Interior node branches: This is required for highly custom or state-ful nodes, namely those that fire different,
                             // and/or unknown-at-compile-time outs based on the same in.
                             auto iter = m_nodeablesByNode.find(node);
                             if (iter == m_nodeablesByNode.end())

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.h
@@ -539,7 +539,7 @@ namespace ScriptCanvas
             DebugSymbolMapReverse m_debugMapReverse;
 
             AZStd::sys_time_t m_parseDuration;
-            AZStd::chrono::system_clock::time_point m_parseStartTime;
+            AZStd::chrono::steady_clock::time_point m_parseStartTime;
             EBusHandlingByNode m_ebusHandlingByNode;
             EventHandlingByNode m_eventHandlingByNode;
             ImplicitVariablesByNode m_implicitVariablesByNode;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/PerformanceStatistician.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/PerformanceStatistician.h
@@ -29,7 +29,7 @@ namespace ScriptCanvas
 
             // secondary stats are inferred from the primary stats
             double scriptCostPercent = 0.0;
-            
+
             void CalculateSecondary();
         };
 
@@ -75,7 +75,7 @@ namespace ScriptCanvas
             TrackingState m_trackingState = TrackingState::None;
             AZ::s32 m_accumulatedTickCountRemaining = 0;
             AZStd::unordered_map<AZ::Data::AssetId, AZStd::string> m_executedScripts;
-            AZStd::chrono::system_clock::time_point m_accumulatedStartTime;
+            AZStd::chrono::steady_clock::time_point m_accumulatedStartTime;
             PerformanceStatistics m_accumulatedStats;
 
             void ClearTrackingState();

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToX.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToX.cpp
@@ -99,12 +99,12 @@ namespace ScriptCanvas
 
         void GraphToX::MarkTranslationStart()
         {
-            m_translationStartTime = AZStd::chrono::system_clock::now();
+            m_translationStartTime = AZStd::chrono::steady_clock::now();
         }
 
         void GraphToX::MarkTranslationStop()
         {
-            m_translationDuration = AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::system_clock::now() - m_translationStartTime).count();
+            m_translationDuration = AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::steady_clock::now() - m_translationStartTime).count();
         }
 
         AZStd::vector<ValidationConstPtr>&& GraphToX::MoveErrors()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToX.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToX.h
@@ -33,14 +33,14 @@ namespace ScriptCanvas
         {
         public:
             bool IsSuccessfull() const;
-            
-        protected:         
+
+        protected:
             const Grammar::AbstractCodeModel& m_model;
             const Configuration m_configuration;
             AZ::s32 m_multiReturnCount = 0;
-                        
+
             GraphToX(const Configuration& configuration, const Grammar::AbstractCodeModel& model);
-                        
+
             void AddError(Grammar::ExecutionTreeConstPtr execution, ValidationConstPtr error);
             AZStd::string AddMultiReturnName();
             AZStd::string GetMultiReturnName() const;
@@ -61,7 +61,7 @@ namespace ScriptCanvas
             void WriteCopyright(Writer& writer);
             void WriteDoNotModify(Writer& writer);
             void WriteLastWritten(Writer& writer);
-        
+
         protected:
             void MarkTranslationStart();
             void MarkTranslationStop();
@@ -69,8 +69,8 @@ namespace ScriptCanvas
         private:
             AZStd::vector<ValidationConstPtr> m_errors;
             AZStd::sys_time_t m_translationDuration;
-            AZStd::chrono::system_clock::time_point m_translationStartTime;
+            AZStd::chrono::steady_clock::time_point m_translationStartTime;
         };
-    } 
+    }
 
-} 
+}

--- a/Gems/ScriptCanvas/Code/Source/PerformanceStatistician.cpp
+++ b/Gems/ScriptCanvas/Code/Source/PerformanceStatistician.cpp
@@ -104,7 +104,7 @@ namespace ScriptCanvas
         void PerformanceStatistician::OnStartTrackingRequested()
         {
             m_accumulatedStats.tickCount = 0;
-            m_accumulatedStartTime = AZStd::chrono::system_clock::now();
+            m_accumulatedStartTime = AZStd::chrono::steady_clock::now();
         }
 
         void PerformanceStatistician::OnSystemTick()
@@ -185,7 +185,7 @@ namespace ScriptCanvas
             if (m_trackingState != TrackingState::PerFrameInProgress)
             {
                 m_trackingState = TrackingState::PerFrameStartRequested;
-                ConnectToSystemTickBus();                
+                ConnectToSystemTickBus();
             }
         }
 
@@ -207,7 +207,7 @@ namespace ScriptCanvas
 
         void PerformanceStatistician::UpdateAccumulatedTime()
         {
-            m_accumulatedStats.duration = AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::system_clock::now() - m_accumulatedStartTime).count();
+            m_accumulatedStats.duration = AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::steady_clock::now() - m_accumulatedStartTime).count();
         }
 
         void PerformanceStatistician::UpdateStatisticsFromTracker()

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Include/ScriptCanvasDeveloperEditor/EditorAutomation/EditorAutomationActions/GenericActions.h
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Include/ScriptCanvasDeveloperEditor/EditorAutomation/EditorAutomationActions/GenericActions.h
@@ -70,7 +70,7 @@ namespace ScriptCanvas::Developer
 
     private:
 
-        AZStd::chrono::time_point<AZStd::chrono::system_clock> m_startPoint;
+        AZStd::chrono::steady_clock::time_point m_startPoint;
 
         AZStd::chrono::milliseconds m_delay;
     };
@@ -114,5 +114,5 @@ namespace ScriptCanvas::Developer
     private:
 
         AZStd::string m_traceName;
-    };   
+    };
 }

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomation/EditorAutomationActions/GenericActions.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomation/EditorAutomationActions/GenericActions.cpp
@@ -105,15 +105,15 @@ namespace ScriptCanvas::Developer
 
     void DelayAction::SetupAction()
     {
-        m_startPoint = AZStd::chrono::system_clock::now();
+        m_startPoint = AZStd::chrono::steady_clock::now();
     }
 
     bool DelayAction::Tick()
     {
-        auto currentTime = AZStd::chrono::system_clock::now();
+        auto currentTime = AZStd::chrono::steady_clock::now();
 
         auto elapsedTime = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(currentTime - m_startPoint);
-        
+
         return elapsedTime >= m_delay;
     }
 
@@ -141,7 +141,7 @@ namespace ScriptCanvas::Developer
         {
             m_delayComplete = DelayAction::Tick();
         }
-        
+
         if (m_delayComplete && !m_processingEventsSwitch)
         {
             m_processingEventsSwitch = true;

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTestDialog.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTestDialog.cpp
@@ -233,25 +233,25 @@ namespace ScriptCanvas::Developer
         m_testListModel->AddTest(aznew WriteTextToInput(searchFilter, "Multiply (*)"));
         m_testListModel->AddTest(aznew WriteTextToInput(searchFilter, "::Test::"));
         ////
-        
+
         // General Test for Graph Creation
         m_testListModel->AddTest(aznew CreateGraphTest());
         m_testListModel->AddTest(aznew CreateFunctionTest());
-        ////        
+        ////
 
         // General Tests for Node Creation
         m_testListModel->AddTest(aznew CreateNodeFromPaletteTest("Multiply (*)", nodePaletteWidget));
         m_testListModel->AddTest(aznew CreateNodeFromPaletteTest("Print", nodePaletteWidget));
         m_testListModel->AddTest(aznew CreateNodeFromContextMenuTest("Multiply (*)"));
         m_testListModel->AddTest(aznew CreateNodeFromContextMenuTest("Print"));
-        
+
         m_testListModel->AddTest(aznew CreateHelloWorldFromPalette(nodePaletteWidget));
         m_testListModel->AddTest(aznew CreateHelloWorldFromContextMenu());
-        
+
         m_testListModel->AddTest(aznew CreateExecutionSplicedNodeTest("Build String"));
         m_testListModel->AddTest(aznew CreateDragDropExecutionSpliceNodeTest(nodePaletteWidget, "Build String"));
         ////
-        
+
         m_testListModel->AddTest(aznew AltClickDeleteTest());
 
         // Actual BAT tests
@@ -264,25 +264,25 @@ namespace ScriptCanvas::Developer
         m_testListModel->AddTest(aznew ManuallyCreateVariableTest(ScriptCanvas::Data::Type::Vector3(), CreateVariableAction::CreationType::Programmatic));
 
         m_testListModel->AddTest(aznew CreateNamedVariableTest(ScriptCanvas::Data::Type::EntityID(), "Caterpillar", CreateVariableAction::CreationType::AutoComplete));
-        
+
         m_testListModel->AddTest(aznew DuplicateVariableNameTest(ScriptCanvas::Data::Type::Number(), ScriptCanvas::Data::Type::Number(), "SameType"));
         m_testListModel->AddTest(aznew DuplicateVariableNameTest(ScriptCanvas::Data::Type::Color(), ScriptCanvas::Data::Type::String(), "DifferentType"));
 
         m_testListModel->AddTest(aznew ModifyNumericInputTest(123.45));
         m_testListModel->AddTest(aznew ModifyStringInputTest("abcdefghijklmnopqrstuvwxyz"));
-        m_testListModel->AddTest(aznew ToggleBoolInputTest());        
+        m_testListModel->AddTest(aznew ToggleBoolInputTest());
 
-        
+
         AZStd::vector< ScriptCanvas::Data::Type > primitiveTypes;
         ScriptCanvasEditor::VariableAutomationRequestBus::BroadcastResult(primitiveTypes, &ScriptCanvasEditor::VariableAutomationRequests::GetPrimitiveTypes);
 
         m_testListModel->AddTest(aznew VariableLifeCycleTest("Primitive Variable LifeCycle Test", primitiveTypes));
-        
+
         AZStd::vector< ScriptCanvas::Data::Type > objectTypes;
         ScriptCanvasEditor::VariableAutomationRequestBus::BroadcastResult(objectTypes, &ScriptCanvasEditor::VariableAutomationRequests::GetBehaviorContextObjectTypes);
 
         m_testListModel->AddTest(aznew VariableLifeCycleTest("BCO Variable LifeCycle Test", objectTypes));
-        
+
         AZStd::vector< ScriptCanvas::Data::Type > mapTypes;
         ScriptCanvasEditor::VariableAutomationRequestBus::BroadcastResult(mapTypes, &ScriptCanvasEditor::VariableAutomationRequests::GetMapTypes);
 
@@ -318,23 +318,23 @@ namespace ScriptCanvas::Developer
         }
 
         m_testListModel->AddTest(aznew VariableLifeCycleTest("Array Variable LifeCycle Test", arrayTypes, CreateVariableAction::CreationType::Programmatic));
-        
+
         m_testListModel->AddTest(aznew RapidVariableCreationDeletionTest());
 
-        
-        m_testListModel->AddTest(aznew CreateCategoryTest("Logic", nodePaletteWidget));        
+
+        m_testListModel->AddTest(aznew CreateCategoryTest("Logic", nodePaletteWidget));
 
         m_testListModel->AddTest(aznew CreateGroupTest());
         m_testListModel->AddTest(aznew CreateGroupTest(CreateGroupAction::CreationType::Toolbar));
 
-        
+
         m_testListModel->AddTest(aznew GroupManipulationTest(nodePaletteWidget));
 
         m_testListModel->AddTest(aznew CutCopyPasteDuplicateTest("On Tick"));
         m_testListModel->AddTest(aznew CutCopyPasteDuplicateTest("Multiply (*)"));
         m_testListModel->AddTest(aznew CutCopyPasteDuplicateTest("Print"));
         ////
-        
+
         ////
 
         m_tableView->setModel(m_testListModel);
@@ -407,7 +407,7 @@ namespace ScriptCanvas::Developer
 
     void EditorAutomationTestDialog::OnSystemTick()
     {
-        auto currentTime = AZStd::chrono::system_clock::now();
+        auto currentTime = AZStd::chrono::steady_clock::now();
         auto elapsedTimed = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(currentTime - m_startTime);
 
         if (m_activeTest)
@@ -432,7 +432,7 @@ namespace ScriptCanvas::Developer
                 }
 
                 m_activeTest = nullptr;
-                m_startTime = AZStd::chrono::system_clock::now();
+                m_startTime = AZStd::chrono::steady_clock::now();
 
                 UpdateRunLabel();
             }
@@ -491,7 +491,7 @@ namespace ScriptCanvas::Developer
         m_successCount = 0;
 
         AZ::SystemTickBus::Handler::BusConnect();
-        m_startTime = AZStd::chrono::system_clock::now();
+        m_startTime = AZStd::chrono::steady_clock::now();
 
         UpdateRunLabel();
     }

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTestDialog.h
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTestDialog.h
@@ -121,7 +121,7 @@ namespace ScriptCanvas::Developer
         int m_runCount = 0;
         int m_successCount = 0;
 
-        AZStd::chrono::time_point<AZStd::chrono::system_clock> m_startTime;
+        AZStd::chrono::steady_clock::time_point m_startTime;
 
         EditorAutomationTest* m_activeTest = nullptr;
         AZStd::unordered_set< EditorAutomationTest* > m_testQueue;

--- a/Gems/Vegetation/Code/Include/Vegetation/Ebuses/DebugNotificationBus.h
+++ b/Gems/Vegetation/Code/Include/Vegetation/Ebuses/DebugNotificationBus.h
@@ -16,7 +16,7 @@
 
 namespace Vegetation
 {
-    using TimePoint = AZStd::chrono::system_clock::time_point;
+    using TimePoint = AZStd::chrono::steady_clock::time_point;
     using TimeSpan = AZStd::sys_time_t;
     using FilterReasonCount = AZStd::unordered_map<AZStd::string_view, AZ::u32>;
 

--- a/Gems/Vegetation/Code/Include/Vegetation/Ebuses/DebugRequestsBus.h
+++ b/Gems/Vegetation/Code/Include/Vegetation/Ebuses/DebugRequestsBus.h
@@ -15,7 +15,7 @@
 
 namespace Vegetation
 {
-    using TimePoint = AZStd::chrono::system_clock::time_point;
+    using TimePoint = AZStd::chrono::steady_clock::time_point;
     using TimeSpan = AZStd::sys_time_t;
     using FilterReasonCount = AZStd::unordered_map<AZStd::string_view, AZ::u32>;
 

--- a/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
@@ -1307,7 +1307,7 @@ namespace Vegetation
     void AreaSystemComponent::VegetationThreadTasks::FillSector(SectorInfo& sectorInfo, const VegetationAreaVector& activeAreas)
     {
         AZ_PROFILE_FUNCTION(Entity);
-        VEG_PROFILE_METHOD(DebugNotificationBus::TryQueueBroadcast(&DebugNotificationBus::Events::FillSectorStart, sectorInfo.GetSectorX(), sectorInfo.GetSectorY(), AZStd::chrono::system_clock::now()));
+        VEG_PROFILE_METHOD(DebugNotificationBus::TryQueueBroadcast(&DebugNotificationBus::Events::FillSectorStart, sectorInfo.GetSectorX(), sectorInfo.GetSectorY(), AZStd::chrono::steady_clock::now()));
 
         ReleaseUnregisteredClaims(sectorInfo);
 
@@ -1330,20 +1330,20 @@ namespace Vegetation
             //only consider areas that intersect this sector
             if (!area.m_bounds.IsValid() || area.m_bounds.Overlaps(sectorInfo.m_bounds))
             {
-                VEG_PROFILE_METHOD(DebugNotificationBus::TryQueueBroadcast(&DebugNotificationBus::Events::FillAreaStart, area.m_id, AZStd::chrono::system_clock::now()));
+                VEG_PROFILE_METHOD(DebugNotificationBus::TryQueueBroadcast(&DebugNotificationBus::Events::FillAreaStart, area.m_id, AZStd::chrono::steady_clock::now()));
 
                 //each area is responsible for removing whatever points it claims from m_availablePoints, so subsequent areas will have fewer points to try to claim.
                 AreaNotificationBus::Event(area.m_id, &AreaNotificationBus::Events::OnAreaConnect);
                 AreaRequestBus::Event(area.m_id, &AreaRequestBus::Events::ClaimPositions, EntityIdStack{}, activeContext);
                 AreaNotificationBus::Event(area.m_id, &AreaNotificationBus::Events::OnAreaDisconnect);
 
-                VEG_PROFILE_METHOD(DebugNotificationBus::TryQueueBroadcast(&DebugNotificationBus::Events::FillAreaEnd, area.m_id, AZStd::chrono::system_clock::now(), aznumeric_cast<AZ::u32>(activeContext.m_availablePoints.size())));
+                VEG_PROFILE_METHOD(DebugNotificationBus::TryQueueBroadcast(&DebugNotificationBus::Events::FillAreaEnd, area.m_id, AZStd::chrono::steady_clock::now(), aznumeric_cast<AZ::u32>(activeContext.m_availablePoints.size())));
             }
         }
 
         ReleaseUnusedClaims(sectorInfo);
 
-        VEG_PROFILE_METHOD(DebugNotificationBus::TryQueueBroadcast(&DebugNotificationBus::Events::FillSectorEnd, sectorInfo.GetSectorX(), sectorInfo.GetSectorY(), AZStd::chrono::system_clock::now(), aznumeric_cast<AZ::u32>(activeContext.m_availablePoints.size())));
+        VEG_PROFILE_METHOD(DebugNotificationBus::TryQueueBroadcast(&DebugNotificationBus::Events::FillSectorEnd, sectorInfo.GetSectorX(), sectorInfo.GetSectorY(), AZStd::chrono::steady_clock::now(), aznumeric_cast<AZ::u32>(activeContext.m_availablePoints.size())));
     }
 
     void AreaSystemComponent::VegetationThreadTasks::EmptySector(SectorInfo& sectorInfo)

--- a/Gems/Vegetation/Code/Source/Components/AreaBlenderComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/AreaBlenderComponent.cpp
@@ -278,7 +278,7 @@ namespace Vegetation
 
             for (const auto& entityId : m_configuration.m_vegetationAreaIds)
             {
-                VEG_PROFILE_METHOD(DebugNotificationBus::TryQueueBroadcast(&DebugNotificationBus::Events::FillAreaStart, entityId, AZStd::chrono::system_clock::now()));
+                VEG_PROFILE_METHOD(DebugNotificationBus::TryQueueBroadcast(&DebugNotificationBus::Events::FillAreaStart, entityId, AZStd::chrono::steady_clock::now()));
                 if (context.m_availablePoints.empty())
                 {
                     break;
@@ -287,7 +287,7 @@ namespace Vegetation
                 AreaNotificationBus::Event(entityId, &AreaNotificationBus::Events::OnAreaConnect);
                 AreaRequestBus::Event(entityId, &AreaRequestBus::Events::ClaimPositions, processedIds, context);
                 AreaNotificationBus::Event(entityId, &AreaNotificationBus::Events::OnAreaDisconnect);
-                VEG_PROFILE_METHOD(DebugNotificationBus::TryQueueBroadcast(&DebugNotificationBus::Events::FillAreaEnd, entityId, AZStd::chrono::system_clock::now(), aznumeric_cast<AZ::u32>(context.m_availablePoints.size())));
+                VEG_PROFILE_METHOD(DebugNotificationBus::TryQueueBroadcast(&DebugNotificationBus::Events::FillAreaEnd, entityId, AZStd::chrono::steady_clock::now(), aznumeric_cast<AZ::u32>(context.m_availablePoints.size())));
             }
         }
     }

--- a/Gems/Vegetation/Code/Source/Debugger/DebugComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Debugger/DebugComponent.cpp
@@ -155,10 +155,10 @@ bool DebugComponent::WriteOutConfig(AZ::ComponentConfig* outBaseConfig) const
 void DebugComponent::DisplayEntityViewport(const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay)
 {
     // time to collect the report?
-    if (AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::system_clock::now() - m_lastCollectionTime).count() > m_configuration.m_collectionFrequencyUs)
+    if (AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::steady_clock::now() - m_lastCollectionTime).count() > m_configuration.m_collectionFrequencyUs)
     {
         PrepareNextReport();
-        m_lastCollectionTime = AZStd::chrono::system_clock::now();
+        m_lastCollectionTime = AZStd::chrono::steady_clock::now();
 
         if(m_configuration.m_showVisualization)
         {
@@ -936,7 +936,7 @@ void DebugComponent::PrepareNextReport()
     AZStd::lock_guard<decltype(m_reportMutex)> lock(m_reportMutex);
     m_thePerformanceReport.m_count++;
     m_thePerformanceReport.m_activeInstanceCount = instanceCount;
-    m_thePerformanceReport.m_lastUpdateTime = AZStd::chrono::system_clock::now();
+    m_thePerformanceReport.m_lastUpdateTime = AZStd::chrono::steady_clock::now();
     DebugUtility::MergeResults(sectorTimingMap, m_thePerformanceReport.m_sectorTimingData, m_thePerformanceReport.m_lastUpdateTime, [](const SectorTiming& newTiming, SectorTiming& timing)
     {
         for (const auto& newData : newTiming.m_perAreaData)
@@ -1044,7 +1044,7 @@ void DebugComponent::DumpPerformanceReport(const PerformanceReport& report, Filt
     AZStd::string logFolder = AZStd::string::format("@log@/vegetation");
     AZ::IO::LocalFileIO::GetInstance()->CreatePath(logFolder.c_str());
 
-    AZ::u64 timeSinceEpoch = AZStd::chrono::system_clock::now().time_since_epoch().count();
+    AZ::u64 timeSinceEpoch = AZStd::chrono::steady_clock::now().time_since_epoch().count();
     AZStd::string logFile = AZStd::string::format("%s/%s_%s_%s_%llu.csv", logFolder.c_str(), "vegperf", GetSortTypeString(sort), GetFilterTypeLevelString(filter), timeSinceEpoch);
 
     AZ::IO::HandleType logHandle;

--- a/Gems/Vegetation/Code/Source/InstanceSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/InstanceSystemComponent.cpp
@@ -559,8 +559,8 @@ namespace Vegetation
 
         AZStd::lock_guard<decltype(m_mainThreadTaskInProgressMutex)> scopedLock(m_mainThreadTaskInProgressMutex);
 
-        AZStd::chrono::system_clock::time_point initialTime = AZStd::chrono::system_clock::now();
-        AZStd::chrono::system_clock::time_point currentTime = initialTime;
+        AZStd::chrono::steady_clock::time_point initialTime = AZStd::chrono::steady_clock::now();
+        AZStd::chrono::steady_clock::time_point currentTime = initialTime;
 
         auto removedTasksPtr = AZStd::make_shared<TaskList>();
         while (GetTasks(*removedTasksPtr))
@@ -570,7 +570,7 @@ namespace Vegetation
                 task();
             }
 
-            currentTime = AZStd::chrono::system_clock::now();
+            currentTime = AZStd::chrono::steady_clock::now();
             if (AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(currentTime - initialTime).count() > m_configuration.m_maxInstanceProcessTimeMicroseconds)
             {
                 break;


### PR DESCRIPTION
Locations that were using `AZStd::chrono::system_clock` to time durations were switched out to use AZStd::chrono::steady_clock, which is monotonic.

As the system_clock isn't monotonic it isn't suitable for measuring time before and after an event as it can be adjusted forwards and backwards See microsoft API for [chrono::system_clock](https://learn.microsoft.com/en-us/cpp/standard-library/system-clock-structure?view=msvc-170)

Also replaced use of high_resolution_clock with steady_clock, since high_resolution is an alias to either system_clock or steady_clock and all uses of it was for measuring a duration of time.

fixes #12101

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Ran the registered CTest
Loaded up a Sample level in the Editor and ran through it.
