### PR TITLE
New error log line in AP Jobs pane

### DIFF
--- a/Code/Tools/AssetProcessor/AssetBuilder/TraceMessageHook.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilder/TraceMessageHook.cpp
@@ -15,8 +15,6 @@
 
 namespace AssetBuilder
 {
-    constexpr int MaxMessageLength = 4096;
-
     TraceMessageHook::TraceMessageHook()
         : m_stacks(nullptr)
         , m_inDebugMode(false)

--- a/Code/Tools/AssetProcessor/AssetBuilder/TraceMessageHook.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilder/TraceMessageHook.cpp
@@ -80,12 +80,11 @@ namespace AssetBuilder
     {
         if(m_skipErrorsCount == 0)
         {
-            char header[MaxMessageLength];
+            // Add the trace information and message type to context details to simplify the event log
+            AZ_TraceContext("Trace", AZStd::string::format("%s(%d): '%s'", fileName, line, func));
+            AZ_TraceContext("Type", "Trace::Error");
 
-            azsnprintf(header, MaxMessageLength, "%s: Trace::Error\n>\t%s(%d): '%s'\n", window, fileName, line, func);
-            CleanMessage(stdout, "E", header, false);
-
-            CleanMessage(stdout, "E", message, true, ">\t");
+            CleanMessage(stdout, "E", AZStd::string::format("%s: %s", window, message).c_str(), true);
 
             ++m_totalErrorCount;
         }
@@ -101,12 +100,11 @@ namespace AssetBuilder
     {
         if (m_skipWarningsCount == 0)
         {
-            char header[MaxMessageLength];
+            // Add the trace information and message type to context details to simplify the event log
+            AZ_TraceContext("Trace", AZStd::string::format("%s(%d): '%s'", fileName, line, func));
+            AZ_TraceContext("Type", "Trace::Warning");
 
-            azsnprintf(header, MaxMessageLength, "%s: Trace::Warning\n>\t%s(%d): '%s'\n", window, fileName, line, func);
-            CleanMessage(stdout, "W", header, false);
-
-            CleanMessage(stdout, "W", message, true, ">\t");
+            CleanMessage(stdout, "W", AZStd::string::format("%s: %s", window, message).c_str(), true);
 
             ++m_totalWarningCount;
         }


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?
- Move trace information and message type to context details and display them under the Event Log Line Details table
- Simplify the error/warning messages in the job log file

## How was this PR tested?
Tested manually in AP GUI and validated the log messages in the job log file.

_Before these changes:_
![AP_Log_Improvement_Old_1](https://user-images.githubusercontent.com/68558268/191375866-2019670a-e72e-455a-826d-dc54f414d35f.PNG)
![AP_Log_Improvement_Old](https://user-images.githubusercontent.com/68558268/191375918-e22bb3b2-8de4-4738-8812-aca691745caa.PNG)
Log file: [test.fbx-old.log](https://github.com/o3de/o3de/files/9611607/test.fbx-old.log)

_After these changes:_
![AP_Log_Improvement_New](https://user-images.githubusercontent.com/68558268/191375977-10706628-3b08-48e9-8e6f-f05d7afa97c9.PNG)
![AP_Log_Improvement_New_1](https://user-images.githubusercontent.com/68558268/191376016-4fc6a40c-81fb-4f87-be0e-840ab8a291cb.PNG)
Log file: [test.fbx-new.log](https://github.com/o3de/o3de/files/9611609/test.fbx-new.log)

