### PR TITLE
Updating the gradle build script to produce APKs that use Zip64.

### DIFF
--- a/Code/Tools/Android/ProjectBuilder/AndroidManifest.xml
+++ b/Code/Tools/Android/ProjectBuilder/AndroidManifest.xml
@@ -38,7 +38,9 @@
         <activity
             android:name="${ANDROID_PROJECT_ACTIVITY}"
             android:screenOrientation="${ANDROID_SCREEN_ORIENTATION}"
-            android:configChanges="${ANDROID_CONFIG_CHANGES}" >
+            android:configChanges="${ANDROID_CONFIG_CHANGES}"
+            android:exported="true" > <!-- needed when an intent-filter is used
+            https://developer.android.com/guide/topics/manifest/activity-element#exported  -->
 
             <!-- Multi-window properties, following line can be blank if not specified -->
             ${ANDROID_MULTI_WINDOW_PROPERTIES}

--- a/Code/Tools/Android/ProjectBuilder/build.gradle.in
+++ b/Code/Tools/Android/ProjectBuilder/build.gradle.in
@@ -66,6 +66,14 @@ ${OVERRIDE_JAVA_SOURCESET}
 
 }
 
+// Inject the zip64 option into package task to allow 4GiB apks
+tasks.withType(Zip) {
+    if (name == "packageDebug" || name == "packageProfile" || name == "packageRelease") {
+        zip64 = true
+    }
+}
+
+
 ${PROJECT_DEPENDENCIES}
 
 afterEvaluate {


### PR DESCRIPTION
This allows APKs that larger than 4K to be used.

Added the android:exported attribute to the AndroidManifest.xml to allow API level >30 to build successfully when using the intent-filter(which O3DE does.
https://developer.android.com/guide/topics/manifest/activity-element#exported

resolves #11972

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
