### PR TITLE
Mesh scale fix for non FBX files

### DIFF
--- a/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
@@ -36,12 +36,19 @@ namespace AZ
 
             const AssImpSDKWrapper::AssImpSceneWrapper* assImpScene = azrtti_cast<const AssImpSDKWrapper::AssImpSceneWrapper*>(scene);
 
-            // If either meta data piece is not available, the default of 1 will be used.
-            assImpScene->GetAssImpScene()->mMetaData->Get("UnitScaleFactor", m_unitSizeInMeters);
-            assImpScene->GetAssImpScene()->mMetaData->Get("OriginalUnitScaleFactor", m_originalUnitSizeInMeters);
+            /* Check if metadata has information about "UnitScaleFactor" or "OriginalUnitScaleFactor". 
+             * This particular metadata is FBX format only. */
+            if (assImpScene->GetAssImpScene()->mMetaData->HasKey("UnitScaleFactor") ||
+                assImpScene->GetAssImpScene()->mMetaData->HasKey("OriginalUnitScaleFactor"))
+            {
+                // If either metadata piece is not available, the default of 1 will be used.
+                assImpScene->GetAssImpScene()->mMetaData->Get("UnitScaleFactor", m_unitSizeInMeters);
+                assImpScene->GetAssImpScene()->mMetaData->Get("OriginalUnitScaleFactor", m_originalUnitSizeInMeters);
 
-            /* Conversion factor for converting from centimeters to meters */
-            m_unitSizeInMeters = m_unitSizeInMeters * .01f;
+                /* Conversion factor for converting from centimeters to meters.
+                 * This applies to an FBX format in which the default unit is a centimeter. */
+                m_unitSizeInMeters = m_unitSizeInMeters * .01f;
+            }
 
             AZStd::pair<AssImpSDKWrapper::AssImpSceneWrapper::AxisVector, int32_t> upAxisAndSign = assImpScene->GetUpVectorAndSign();
 


### PR DESCRIPTION
## What does this PR do?

Currently, all non-FBX model files are imported with invalid scale.

This is because `SceneSystem` is tailored around FBX meshes and assumes a centimeter as a default unit for every imported mesh. This PR checks if the imported mesh "looks like" FBX. If it is, then centimeter -> meter conversion is applied. On the other hand, no conversion is applied for non-FBX meshes.

## How was this PR tested?

I exported a single mesh from Blender in 3 different formats: FBX, DAE, and STL (with default settings). Then imported each mesh into O3DE scene.

Before:
![scale_before](https://user-images.githubusercontent.com/10896036/191474055-798bb55a-3ecc-4e2a-9b39-b22e18ea9851.png)

After:
![scale_after](https://user-images.githubusercontent.com/10896036/191474086-3c6ee2eb-3597-4e45-83a8-2b370639873d.png)
