### PR TITLE
Editor: Use showFullscreen instead of showMaximized when "Play Game (Maximized)"

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -2599,7 +2599,7 @@ void EditorViewportWidget::StartFullscreenPreview()
     m_inFullscreenPreview = true;
 
     // Pick the screen on which the main window lies to use as the screen for the full screen preview
-    const QScreen* screen = MainWindow::instance()->screen();
+    QScreen* screen = MainWindow::instance()->screen();
     const QRect screenGeometry = screen->geometry();
 
     // Unparent this and show it, which turns it into a free floating window
@@ -2608,8 +2608,8 @@ void EditorViewportWidget::StartFullscreenPreview()
     setWindowFlag(Qt::FramelessWindowHint, true);
     setWindowFlag(Qt::MSWindowsFixedSizeDialogHint, true);
     setFixedSize(screenGeometry.size());
-    move(QPoint(screenGeometry.x(), screenGeometry.y()));
-    showMaximized();
+    windowHandle()->setScreen(screen);
+    showFullScreen();
 
     // This must be done after unparenting this widget above
     MainWindow::instance()->hide();


### PR DESCRIPTION
## What does this PR do?

This PR fixes buggy "Play Game (Maximized)" behavior by using `showFullscreen` instead of `showMaximized`.

### Old behavior (BUG)

On Ubuntu (with X server) when "Play Game (Maximized)" is selected the borderless window is not centered, while on Windows sometimes the taskbar is not hidden (#9654). 

This PR does the trick on both Ubuntu (tested versus development branch) and Windows (tested versus 2205).

## How was this PR tested?

Tested "Play Game (Maximized)" on Windows 11 and Ubuntu 22.04.1 (X display server), expected fullscreen behavior on both occasions :smile: . 
Have NOT tested on multiple monitors setup :confused:. 
Should note that I have novice experience with Qt.

Feel free to edit, add changes and criticize the PR as a whole.