### PR TITLE
Tweak DPE patch path normalization behavior

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomComparison.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomComparison.cpp
@@ -101,8 +101,30 @@ namespace AZ::Dom
             {
                 if (i >= beforeSize)
                 {
-                    subPath.Push(PathEntry(PathEntry::EndOfArrayIndex));
-                    AddPatch(PatchOperation::AddOperation(subPath, after[i]), PatchOperation::RemoveOperation(subPath));
+                    // Per JSON patch RFFC 6902:
+                    // The specified index MUST NOT be greater than the
+                    // number of elements in the array.
+                    // So for schema-compliant JSON patches, we need to use EndOfArrayIndex.
+                    // This is, however, inconvenient when introspecting patches and finding their affected paths,
+                    // so we provide this denormalized path generation path as well in which the out of bounds index
+                    // is used for both add and remove.
+                    // Our Patch apply supports this, so this usage is acceptable for internal use.
+                    if (params.m_generateDenormalizedPaths)
+                    {
+                        subPath.Push(PathEntry(i));
+                    }
+                    else
+                    {
+                        subPath.Push(PathEntry(PathEntry::EndOfArrayIndex));
+                    }
+
+                    auto addOperation = PatchOperation::AddOperation(subPath, after[i]);
+                    if (!params.m_generateDenormalizedPaths)
+                    {
+                        subPath[subPath.size() - 1] = PathEntry(i);
+                    }
+
+                    AddPatch(AZStd::move(addOperation), PatchOperation::RemoveOperation(subPath));
                     subPath.Pop();
                 }
                 else
@@ -115,10 +137,11 @@ namespace AZ::Dom
 
             if (beforeSize > afterSize)
             {
-                subPath.Push(PathEntry(PathEntry::EndOfArrayIndex));
                 for (size_t i = beforeSize; i > afterSize; --i)
                 {
+                    subPath.Push(PathEntry(i));
                     AddPatch(PatchOperation::RemoveOperation(subPath), PatchOperation::AddOperation(subPath, before[i - 1]));
+                    subPath.Pop();
                 }
             }
         };

--- a/Code/Framework/AzCore/AzCore/DOM/DomComparison.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomComparison.cpp
@@ -101,7 +101,7 @@ namespace AZ::Dom
             {
                 if (i >= beforeSize)
                 {
-                    // Per JSON patch RFFC 6902:
+                    // Per JSON patch RFC 6902:
                     // The specified index MUST NOT be greater than the
                     // number of elements in the array.
                     // So for schema-compliant JSON patches, we need to use EndOfArrayIndex.

--- a/Code/Framework/AzCore/AzCore/DOM/DomComparison.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomComparison.h
@@ -28,6 +28,11 @@ namespace AZ::Dom
         //! The threshold of changed values in a node or array which, if exceeded, will cause the generation to create an
         //! entire "replace" oepration instead. If set to NoReplace, no replacement will occur.
         size_t m_replaceThreshold = 3;
+        //! If set, the patches generated will avoid using "EndOfPath" entries in favor of explicitly specifying indices.
+        //! This will generate non-conformant JSON patches, but can be useful if there's downstream book-keeping for the patch
+        //! paths themselves. This is used by e.g. DocumentPropertyEditor so that systems can handle patches without introspecting
+        //! the previous DOM to generate indices.
+        bool m_generateDenormalizedPaths = false;
     };
 
     //! Generates a set of patches such that m_forwardPatches.Apply(beforeState) shall produce a document equivalent to afterState, and

--- a/Code/Framework/AzCore/AzCore/DOM/DomPatch.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPatch.cpp
@@ -133,6 +133,75 @@ namespace AZ::Dom
         return AZ::Failure<AZStd::string>("Unsupported DOM patch operation specified");
     }
 
+    AZ::Outcome<Value, AZStd::string> PatchOperation::ApplyAndDenormalize(Value rootElement)
+    {
+        PatchOutcome outcome = ApplyInPlaceAndDenormalize(rootElement);
+        if (!outcome.IsSuccess())
+        {
+            return AZ::Failure(outcome.TakeError());
+        }
+        return AZ::Success(AZStd::move(rootElement));
+    }
+
+    PatchOutcome PatchOperation::ApplyInPlaceAndDenormalize(Value& rootElement)
+    {
+        switch (m_type)
+        {
+        case Type::Add:
+        case Type::Remove:
+        case Type::Replace:
+            if (!DenormalizePath(m_domPath, rootElement))
+            {
+                return AZ::Failure<AZStd::string>("Failed to denormalize patch destination path, an invalid value or path has been specified");
+            }
+            break;
+        case Type::Copy:
+        case Type::Move:
+            if (!DenormalizePath(m_domPath, rootElement))
+            {
+                return AZ::Failure<AZStd::string>("Failed to denormalize patch destination path, an invalid value or path has been specified");
+            }
+            if (!DenormalizePath(AZStd::get<Dom::Path>(m_value), rootElement))
+            {
+                return AZ::Failure<AZStd::string>("Failed to denormalize patch source path, an invalid value or path has been specified");
+            }
+            break;
+        }
+        return ApplyInPlace(rootElement);
+    }
+
+    bool PatchOperation::DenormalizePath(Dom::Path& path, const Dom::Value& sourceValue)
+    {
+        // If we end with an EndOfArray marker, replace it with a marker for the size of sourceValue's array
+        if (path.Size() > 0 && path[path.Size() - 1].IsEndOfArray())
+        {
+            path.Pop();
+            const Dom::Value* lookupValue = sourceValue.FindChild(path);
+            if (lookupValue == nullptr || (!lookupValue->IsArray() && !lookupValue->IsNode()))
+            {
+                return false;
+            }
+            path.Push(lookupValue->ArraySize());
+        }
+        return true;
+    }
+
+    bool PatchOperation::ContainsNormalizedEntries() const
+    {
+        switch (m_type)
+        {
+        case Type::Add:
+        case Type::Remove:
+        case Type::Replace:
+            return GetDestinationPath().ContainsNormalizedEntries();
+        case Type::Copy:
+        case Type::Move:
+            return GetSourcePath().ContainsNormalizedEntries() || GetDestinationPath().ContainsNormalizedEntries();
+        default:
+            return false;
+        }
+    }
+
     Value PatchOperation::GetDomRepresentation() const
     {
         Value serializedPatch(Dom::Type::Object);
@@ -427,9 +496,18 @@ namespace AZ::Dom
                 return AZ::Failure<AZStd::string>("Array index specified for a value that is not an array or node");
             }
 
-            if (destinationIndex.IsIndex() && destinationIndex.GetIndex() >= targetValue->ArraySize())
+            if (destinationIndex.IsIndex())
             {
-                return AZ::Failure<AZStd::string>("Array index out bounds");
+                // If allowEndOfArray is true, we might get an index exactly equal to our length if we
+                // received a denormalized path.
+                if (allowEndOfArray && destinationIndex.GetIndex() > targetValue->ArraySize())
+                {
+                    return AZ::Failure<AZStd::string>("Array index out of bounds");
+                }
+                else if (!allowEndOfArray && destinationIndex.GetIndex() >= targetValue->ArraySize())
+                {
+                    return AZ::Failure<AZStd::string>("Array index out of bounds");
+                }
             }
         }
         else
@@ -484,7 +562,7 @@ namespace AZ::Dom
 
     PatchOutcome PatchOperation::ApplyRemove(Value& rootElement) const
     {
-        auto pathLookup = LookupPath(rootElement, m_domPath, ExistenceCheckFlags::VerifyFullPath | ExistenceCheckFlags::AllowEndOfArray);
+        auto pathLookup = LookupPath(rootElement, m_domPath, ExistenceCheckFlags::VerifyFullPath);
         if (!pathLookup.IsSuccess())
         {
             return AZ::Failure(pathLookup.TakeError());
@@ -526,7 +604,7 @@ namespace AZ::Dom
             return AZ::Failure(sourceLookup.TakeError());
         }
 
-        auto destLookup = LookupPath(rootElement, m_domPath, ExistenceCheckFlags::AllowEndOfArray);
+        auto destLookup = LookupPath(rootElement, m_domPath, ExistenceCheckFlags::DefaultExistenceCheck);
         if (!destLookup.IsSuccess())
         {
             return AZ::Failure(destLookup.TakeError());
@@ -544,7 +622,7 @@ namespace AZ::Dom
             return AZ::Failure(sourceLookup.TakeError());
         }
 
-        auto destLookup = LookupPath(rootElement, m_domPath, ExistenceCheckFlags::AllowEndOfArray);
+        auto destLookup = LookupPath(rootElement, m_domPath, ExistenceCheckFlags::DefaultExistenceCheck);
         if (!destLookup.IsSuccess())
         {
             return AZ::Failure(destLookup.TakeError());
@@ -752,6 +830,47 @@ namespace AZ::Dom
             }
         }
         return state.m_outcome;
+    }
+
+    AZ::Outcome<Value, AZStd::string> Patch::ApplyAndDenormalize(Value rootElement, StrategyFunctor strategy)
+    {
+        auto result = ApplyInPlaceAndDenormalize(rootElement, strategy);
+        if (!result.IsSuccess())
+        {
+            return AZ::Failure(result.TakeError());
+        }
+        return AZ::Success(AZStd::move(rootElement));
+    }
+
+    PatchOutcome Patch::ApplyInPlaceAndDenormalize(Value& rootElement, StrategyFunctor strategy)
+    {
+        PatchApplicationState state;
+        state.m_currentState = &rootElement;
+        state.m_patch = this;
+
+        for (PatchOperation& operation : m_operations)
+        {
+            state.m_lastOperation = &operation;
+            CombinePatchOutcomes(state.m_outcome, operation.ApplyInPlaceAndDenormalize(rootElement));
+            strategy(state);
+            if (!state.m_shouldContinue)
+            {
+                break;
+            }
+        }
+        return state.m_outcome;
+    }
+
+    bool Patch::ContainsNormalizedEntries() const
+    {
+        for (const PatchOperation& operation : m_operations)
+        {
+            if (operation.ContainsNormalizedEntries())
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     Value Patch::GetDomRepresentation() const

--- a/Code/Framework/AzCore/AzCore/DOM/DomPatch.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPatch.h
@@ -190,7 +190,7 @@ namespace AZ::Dom
         //! \return an outcome with either the patched element or an error string
         AZ::Outcome<Value, AZStd::string> Apply(Value rootElement, StrategyFunctor strategy = PatchApplicationStrategy::HaltOnFailure) const;
         //! Applies this patch to the given DOM element in place, changing it to the new value.
-        //! //! \param rootElement The DOM element to patch.
+        //! \param rootElement The DOM element to patch.
         //! \param strategy A callback to be run after every patch application, see PatchApplicationState.
         //! \return an outcome with either the patched element or an error string
         PatchOutcome ApplyInPlace(Value& rootElement, StrategyFunctor strategy = PatchApplicationStrategy::HaltOnFailure) const;
@@ -206,7 +206,7 @@ namespace AZ::Dom
         //! Applies this patch to the given DOM element in place, changing it to the new value.
         //! After applying the patch, any "EndOfArray" patch entries are denormalized into their resolved paths.
         //! This operation mutates the underyling patch operations; make a copy if you wish to keep the original patch.
-        //! //! \param rootElement The DOM element to patch.
+        //! \param rootElement The DOM element to patch.
         //! \param strategy A callback to be run after every patch application, see PatchApplicationState.
         //! \return an outcome with either the patched element or an error string
         PatchOutcome ApplyInPlaceAndDenormalize(Value& rootElement, StrategyFunctor strategy = PatchApplicationStrategy::HaltOnFailure);

--- a/Code/Framework/AzCore/AzCore/DOM/DomPatch.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPatch.h
@@ -68,6 +68,12 @@ namespace AZ::Dom
 
         AZ::Outcome<Value, AZStd::string> Apply(Value rootElement) const;
         PatchOutcome ApplyInPlace(Value& rootElement) const;
+        AZ::Outcome<Value, AZStd::string> ApplyAndDenormalize(Value rootElement);
+        PatchOutcome ApplyInPlaceAndDenormalize(Value& rootElement);
+
+        //! Returns true if this contains an "EndOfArray" entry in any relevant paths, meaning resolving
+        //! the path requires a lookup inside a target DOM.
+        bool ContainsNormalizedEntries() const;
 
         Value GetDomRepresentation() const;
         static AZ::Outcome<PatchOperation, AZStd::string> CreateFromDomRepresentation(Value domValue);
@@ -89,6 +95,9 @@ namespace AZ::Dom
             PathEntry m_key;
         };
 
+        // For a given path and target value, removes any EndOfArray entries 
+        // and replaces them with the resolved path
+        static bool DenormalizePath(Dom::Path& path, const Dom::Value& sourceValue);
         static AZ::Outcome<PathContext, AZStd::string> LookupPath(
             Value& rootElement, const Path& path, ExistenceCheckFlags existenceCheckFlags = ExistenceCheckFlags::DefaultExistenceCheck);
 
@@ -175,11 +184,39 @@ namespace AZ::Dom
         OperationsContainer::const_iterator cend() const;
         size_t size() const;
 
+        //! Applies this patch to the given DOM element.
+        //! \param rootElement The DOM element to patch.
+        //! \param strategy A callback to be run after every patch application, see PatchApplicationState.
+        //! \return an outcome with either the patched element or an error string
         AZ::Outcome<Value, AZStd::string> Apply(Value rootElement, StrategyFunctor strategy = PatchApplicationStrategy::HaltOnFailure) const;
+        //! Applies this patch to the given DOM element in place, changing it to the new value.
+        //! //! \param rootElement The DOM element to patch.
+        //! \param strategy A callback to be run after every patch application, see PatchApplicationState.
+        //! \return an outcome with either the patched element or an error string
         PatchOutcome ApplyInPlace(Value& rootElement, StrategyFunctor strategy = PatchApplicationStrategy::HaltOnFailure) const;
+
+        //! Applies this patch to the given DOM element.
+        //! After applying the patch, any "EndOfArray" patch entries are denormalized into their resolved paths.
+        //! This operation mutates the underyling patch operations; make a copy if you wish to keep the original patch.
+        //! \param rootElement The DOM element to patch.
+        //! \param strategy A callback to be run after every patch application, see PatchApplicationState.
+        //! \return an outcome with either the patched element or an error string
+        AZ::Outcome<Value, AZStd::string> ApplyAndDenormalize(
+            Value rootElement, StrategyFunctor strategy = PatchApplicationStrategy::HaltOnFailure);
+        //! Applies this patch to the given DOM element in place, changing it to the new value.
+        //! After applying the patch, any "EndOfArray" patch entries are denormalized into their resolved paths.
+        //! This operation mutates the underyling patch operations; make a copy if you wish to keep the original patch.
+        //! //! \param rootElement The DOM element to patch.
+        //! \param strategy A callback to be run after every patch application, see PatchApplicationState.
+        //! \return an outcome with either the patched element or an error string
+        PatchOutcome ApplyInPlaceAndDenormalize(Value& rootElement, StrategyFunctor strategy = PatchApplicationStrategy::HaltOnFailure);
 
         Value GetDomRepresentation() const;
         static AZ::Outcome<Patch, AZStd::string> CreateFromDomRepresentation(Value domValue);
+
+        //! Returns true if any of this patch's operations contain  an "EndOfArray" entry
+        //! inside their paths, meaning the path requires a lookup inside a target DOM.
+        bool ContainsNormalizedEntries() const;
 
     private:
         OperationsContainer m_operations;

--- a/Code/Framework/AzCore/AzCore/DOM/DomPath.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPath.cpp
@@ -438,6 +438,18 @@ namespace AZ::Dom
         FormatString(output.data() + startIndex, stringLength + 1);
     }
 
+    bool Path::ContainsNormalizedEntries() const
+    {
+        for (const PathEntry& entry : m_entries)
+        {
+            if (entry.IsEndOfArray())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     void Path::FromString(AZStd::string_view pathString)
     {
         m_entries.clear();

--- a/Code/Framework/AzCore/AzCore/DOM/DomPath.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPath.h
@@ -158,6 +158,9 @@ namespace AZ::Dom
         //! "path/to/foo/0"
         void FromString(AZStd::string_view pathString);
 
+        //! Returns true if this path contains any "EndOfArray" entries that require a target DOM to look up.
+        bool ContainsNormalizedEntries() const;
+
     private:
         ContainerType m_entries;
     };


### PR DESCRIPTION
## What does this PR do?

I received some API feedback about patch handling within the Document Property Editor, namely that the prevalent use of `EndOfArray` entries in our `GenerateHierarchicalDeltaPatch` algorithm (and the validity of its prevalence) led to significant friction for consumers handling patches downstream, as to fully resolve an `EndOfArray` path requires a denormalization operation via a lookup in a provided `Dom::Value`, which is both cumbersome and potentially expensive. While there still remains a valid and open architectural question as to whether JSON patch is the right abstraction for the DPE, this patch attempts to address some of this friction in the short term.

To that end:
1. Our `EndOfArray` usage has been audited and restricted to only the one place where it's called out (and indeed mandated) in the JSON patch spec: `Add` operations, and `Add` operations only, denoting an insertion to the end of the target array.
2. An additional flag for patch generation has been added, `m_generateDenormalizedPaths`, in which we provide nonconformant paths for `Add` operations specifying an index past the end of the target array or node. This is a breaking change for serialized patches, but a non-breaking change for our internal patching algorithms, which have been softened to allow for this case.
3. Additionally, in the interest of allowing DPE consumers to continue to provide JSON patches in whatever form is most convenient, patches provided to an adapter are explicitly denormalized before being sent to any consumers (such as proxy adapters or the DPE widget itself).

The intent here is to make real, concrete, addressable paths *always* available to downstream systems to prevent unneeded and cumbersome book-keeping.

## How was this PR tested?

`Patch` unit tests still pass and I added a case for denormalizing an existing patch to prove out some of the scary bits about accepting arbitrary JSON patches. I also did some ad-hoc testing with the standalone DPE to validate basic patching behavior with no obvious regressions.