### PR TITLE
Fix typo

### DIFF
--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderDataSystem.cpp
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderDataSystem.cpp
@@ -325,7 +325,7 @@ namespace ScriptCanvasBuilder
         DataSystemAssetNotificationsBus::Event(sourceId, &DataSystemAssetNotifications::OnAssetNotReady);
         MonitorAsset(sourceId);
 
-        auto handle = SourceHandle::FromRelativePathAndScenFolder(relativePath, scanFolder, sourceId);
+        auto handle = SourceHandle::FromRelativePathAndScanFolder(relativePath, scanFolder, sourceId);
         CompileBuilderDataInternal(handle);
         auto& builderStorage = m_buildResultsByHandle[sourceId];
         DataSystemSourceNotificationsBus::Event

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -1051,7 +1051,7 @@ namespace ScriptCanvasEditor
         , AZStd::string scanFolder
         , AZ::Uuid fileAssetId)
     {
-        auto handle = SourceHandle::FromRelativePathAndScenFolder(scanFolder, relativePath, fileAssetId);
+        auto handle = SourceHandle::FromRelativePathAndScanFolder(scanFolder, relativePath, fileAssetId);
 
         if (!IsRecentSave(handle))
         {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
@@ -284,7 +284,7 @@ namespace ScriptCanvas
         return SourceHandle(graph, path);
     }
 
-    SourceHandle SourceHandle::FromRelativePathAndScenFolder
+    SourceHandle SourceHandle::FromRelativePathAndScanFolder
         ( AZStd::string_view relativePath
         , AZStd::string_view scanFolder
         , const AZ::Uuid& sourceId)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.h
@@ -357,7 +357,7 @@ namespace ScriptCanvas
 
         static SourceHandle FromRelativePath(ScriptCanvas::DataPtr graph, const AZ::IO::Path& path);
 
-        static SourceHandle FromRelativePathAndScenFolder
+        static SourceHandle FromRelativePathAndScanFolder
             ( AZStd::string_view relativePath
             , AZStd::string_view scanFolder
             , const AZ::Uuid& sourceId);


### PR DESCRIPTION
Change SourceHandle::FromRelativePathAndScenFolder to SourceHandle::FromRelativePathAndScanFolder

Signed-off-by: Andre Mitchell <andre.mitchell@bytesofpi.com>

## What does this PR do?

Fixes a typo: FromRelativePathAndScenFolder  should be FromRelativePathAndScanFolder.