### PR TITLE
Prism/create gem fix toast notification and gem catalog refresh

### DIFF
--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -400,7 +400,16 @@ namespace O3DE::ProjectManager
                 auto result = PythonBindingsInterface::Get()->CreateGem(templateLocation, m_createGemInfo);
                 if (result.IsSuccess())
                 {
-                    emit CreateButtonPressed(result.GetValue<GemInfo>());
+                    //make sure the gem is registered, otherwise our changes will not persist
+                    auto registerResult = PythonBindingsInterface::Get()->RegisterGem(m_createGemInfo.m_path);
+                    if(!registerResult)
+                    {
+                        QMessageBox::critical(this, tr("Failed to register gem after creation"), registerResult.GetError().c_str());
+                    }
+                    else
+                    {
+                        emit CreateButtonPressed(result.GetValue<GemInfo>());
+                    }
                 }
                 else
                 {

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -400,7 +400,7 @@ namespace O3DE::ProjectManager
                 auto result = PythonBindingsInterface::Get()->CreateGem(templateLocation, m_createGemInfo);
                 if (result.IsSuccess())
                 {
-                    emit CreateButtonPressed();
+                    emit CreateButtonPressed(result.GetValue<GemInfo>());
                 }
                 else
                 {

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -400,16 +400,7 @@ namespace O3DE::ProjectManager
                 auto result = PythonBindingsInterface::Get()->CreateGem(templateLocation, m_createGemInfo);
                 if (result.IsSuccess())
                 {
-                    //make sure the gem is registered, otherwise our changes will not persist
-                    auto registerResult = PythonBindingsInterface::Get()->RegisterGem(m_createGemInfo.m_path);
-                    if(!registerResult)
-                    {
-                        QMessageBox::critical(this, tr("Failed to register gem after creation"), registerResult.GetError().c_str());
-                    }
-                    else
-                    {
-                        emit CreateButtonPressed(result.GetValue<GemInfo>());
-                    }
+                    emit CreateButtonPressed(result.GetValue<GemInfo>());
                 }
                 else
                 {

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
@@ -35,7 +35,7 @@ namespace O3DE::ProjectManager
         ~CreateGem() = default;
 
     signals:
-        void CreateButtonPressed(GemInfo gemInfo);
+        void CreateButtonPressed(const GemInfo& gemInfo);
 
     private slots:
         void HandleBackButton();

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
@@ -35,7 +35,7 @@ namespace O3DE::ProjectManager
         ~CreateGem() = default;
 
     signals:
-        void CreateButtonPressed();
+        void CreateButtonPressed(GemInfo gemInfo);
 
     private slots:
         void HandleBackButton();

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -234,7 +234,7 @@ namespace O3DE::ProjectManager
         }
     }
 
-    void GemCatalogScreen::AddToGemModel(GemInfo gemInfo)
+    void GemCatalogScreen::AddToGemModel(const GemInfo& gemInfo)
     {
         m_gemModel->AddGem(gemInfo);
         m_gemModel->UpdateGemDependencies();
@@ -362,7 +362,7 @@ namespace O3DE::ProjectManager
         }
     }
 
-    void GemCatalogScreen::ShowStandardToastNotification(QString notification)
+    void GemCatalogScreen::ShowStandardToastNotification(const QString& notification)
     {
         AzQtComponents::ToastConfiguration toastConfiguration(AzQtComponents::ToastType::Custom, notification, "");
         toastConfiguration.m_customIconImage = ":/gem.svg";

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -358,12 +358,17 @@ namespace O3DE::ProjectManager
             }
             notification += (added ? tr(" activated") : tr(" deactivated"));
 
-            AzQtComponents::ToastConfiguration toastConfiguration(AzQtComponents::ToastType::Custom, notification, "");
-            toastConfiguration.m_customIconImage = ":/gem.svg";
-            toastConfiguration.m_borderRadius = 4;
-            toastConfiguration.m_duration = AZStd::chrono::milliseconds(3000);
-            m_notificationsView->ShowToastNotification(toastConfiguration);
+            ShowStandardToastNotification(notification);
         }
+    }
+
+    void GemCatalogScreen::ShowStandardToastNotification(QString notification)
+    {
+        AzQtComponents::ToastConfiguration toastConfiguration(AzQtComponents::ToastType::Custom, notification, "");
+        toastConfiguration.m_customIconImage = ":/gem.svg";
+        toastConfiguration.m_borderRadius = 4;
+        toastConfiguration.m_duration = AZStd::chrono::milliseconds(3000);
+        m_notificationsView->ShowToastNotification(toastConfiguration);
     }
     
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -228,12 +228,17 @@ namespace O3DE::ProjectManager
                 AZ::Outcome<GemInfo, void> gemInfoResult = PythonBindingsInterface::Get()->GetGemInfo(directory);
                 if (gemInfoResult)
                 {
-                    m_gemModel->AddGem(gemInfoResult.GetValue<GemInfo>());
-                    m_gemModel->UpdateGemDependencies();
-                    m_proxyModel->sort(/*column=*/0);
+                    AddToGemModel(gemInfoResult.GetValue<GemInfo>());
                 }
             }
         }
+    }
+
+    void GemCatalogScreen::AddToGemModel(GemInfo gemInfo)
+    {
+        m_gemModel->AddGem(gemInfo);
+        m_gemModel->UpdateGemDependencies();
+        m_proxyModel->sort(/*column=*/0);
     }
 
     void GemCatalogScreen::Refresh()
@@ -360,6 +365,7 @@ namespace O3DE::ProjectManager
             m_notificationsView->ShowToastNotification(toastConfiguration);
         }
     }
+    
 
     void GemCatalogScreen::OnDependencyGemStatusChanged(const QString& gemName)
     {

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
@@ -45,7 +45,9 @@ namespace O3DE::ProjectManager
         void NotifyCurrentScreen() override;
 
         void AddToGemModel(GemInfo gemInfo);
-        
+
+        void ShowStandardToastNotification(QString notification);
+
         GemModel* GetGemModel() const { return m_gemModel; }
         DownloadController* GetDownloadController() const { return m_downloadController; }
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
@@ -12,7 +12,7 @@
 #include <ScreenWidget.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzToolsFramework/UI/Notifications/ToastNotificationsView.h>
-#include "GemInfo.h"
+#include <GemCatalog/GemInfo.h>
 #include <QSet>
 #include <QString>
 #endif

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
@@ -12,7 +12,7 @@
 #include <ScreenWidget.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzToolsFramework/UI/Notifications/ToastNotificationsView.h>
-
+#include "GemInfo.h"
 #include <QSet>
 #include <QString>
 #endif
@@ -44,6 +44,8 @@ namespace O3DE::ProjectManager
         bool IsTab() override;
         void NotifyCurrentScreen() override;
 
+        void AddToGemModel(GemInfo gemInfo);
+        
         GemModel* GetGemModel() const { return m_gemModel; }
         DownloadController* GetDownloadController() const { return m_downloadController; }
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
@@ -44,9 +44,9 @@ namespace O3DE::ProjectManager
         bool IsTab() override;
         void NotifyCurrentScreen() override;
 
-        void AddToGemModel(GemInfo gemInfo);
+        void AddToGemModel(const GemInfo& gemInfo);
 
-        void ShowStandardToastNotification(QString notification);
+        void ShowStandardToastNotification(const QString& notification);
 
         GemModel* GetGemModel() const { return m_gemModel; }
         DownloadController* GetDownloadController() const { return m_downloadController; }

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -827,7 +827,7 @@ namespace O3DE::ProjectManager
         }
     }
 
-    AZ::Outcome<GemInfo> PythonBindings::CreateGem(const QString& templatePath, const GemInfo& gemInfo, bool registerGem)
+    AZ::Outcome<GemInfo> PythonBindings::CreateGem(const QString& templatePath, const GemInfo& gemInfo, bool registerGem/*=true*/)
     {
         using namespace pybind11::literals;
 
@@ -852,7 +852,7 @@ namespace O3DE::ProjectManager
                     "icon_path"_a = QString_To_Py_Path(gemInfo.m_iconPath),
                     "documentation_url"_a = QString_To_Py_String(gemInfo.m_documentationLink),
                     "repo_uri"_a = QString_To_Py_String(gemInfo.m_repoUri),
-                    "no_register"_a = registerGem)
+                    "no_register"_a = !registerGem)
                     ;
                 if (createGemResult.cast<int>() == 0)
                 {

--- a/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
@@ -189,7 +189,9 @@ namespace O3DE::ProjectManager
         QString notification = tr("Successfully created gem: ") + gemInfo.m_displayName;
         m_projectGemCatalogScreen->ShowStandardToastNotification(notification);
 
-        HandleBackButton();
+        //because we access the gem creation workflow from the catalog screen, we will forcibly return there
+        m_stack->setCurrentIndex(ScreenOrder::Gems);
+        Update();
     }
 
     void UpdateProjectCtrl::HandleNextButton()

--- a/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
@@ -174,7 +174,7 @@ namespace O3DE::ProjectManager
         }
     }
 
-    void UpdateProjectCtrl::HandleCreateGemButtonPressed(GemInfo gemInfo)
+    void UpdateProjectCtrl::HandleCreateGemButtonPressed(const GemInfo& gemInfo)
     {
         /*
             Note: by the time this function is called, the signal CreateButtonPressed was already emitted.

--- a/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
@@ -48,7 +48,7 @@ namespace O3DE::ProjectManager
 
         connect(m_projectGemCatalogScreen, &ScreenWidget::ChangeScreenRequest, this, &UpdateProjectCtrl::OnChangeScreenRequest);
         connect(m_gemRepoScreen, &GemRepoScreen::OnRefresh, m_projectGemCatalogScreen, &ProjectGemCatalogScreen::Refresh);
-        connect(m_createGem, &CreateGem::CreateButtonPressed, this, &UpdateProjectCtrl::HandleBackButton);
+        connect(m_createGem, &CreateGem::CreateButtonPressed, this, &UpdateProjectCtrl::HandleCreateGemButtonPressed);
 
         m_stack = new QStackedWidget(this);
         m_stack->setObjectName("body");
@@ -172,6 +172,22 @@ namespace O3DE::ProjectManager
                 emit GoToPreviousScreenRequest();
             }
         }
+    }
+
+    void UpdateProjectCtrl::HandleCreateGemButtonPressed(GemInfo gemInfo)
+    {
+        /*
+            Note: by the time this function is called, the signal CreateButtonPressed was already emitted.
+
+            This signal occurs only upon successful completion of creating a gem. As such, the gemInfo data is assumed to be valid.
+        */
+
+        //make sure the project gem catalog model is updated
+        m_projectGemCatalogScreen->AddToGemModel(gemInfo);
+
+        //TODO: also create Toast Notification for project gem catalog
+
+        HandleBackButton();
     }
 
     void UpdateProjectCtrl::HandleNextButton()

--- a/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
@@ -186,7 +186,7 @@ namespace O3DE::ProjectManager
         m_projectGemCatalogScreen->AddToGemModel(gemInfo);
 
         //create Toast Notification for project gem catalog
-        QString notification = tr("Successfully created gem: ") + gemInfo.m_displayName;
+        QString notification = gemInfo.m_displayName + tr(" has been created.");
         m_projectGemCatalogScreen->ShowStandardToastNotification(notification);
 
         //because we access the gem creation workflow from the catalog screen, we will forcibly return there

--- a/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
@@ -185,7 +185,9 @@ namespace O3DE::ProjectManager
         //make sure the project gem catalog model is updated
         m_projectGemCatalogScreen->AddToGemModel(gemInfo);
 
-        //TODO: also create Toast Notification for project gem catalog
+        //create Toast Notification for project gem catalog
+        QString notification = tr("Successfully created gem: ") + gemInfo.m_displayName;
+        m_projectGemCatalogScreen->ShowStandardToastNotification(notification);
 
         HandleBackButton();
     }

--- a/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.h
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.h
@@ -44,7 +44,7 @@ namespace O3DE::ProjectManager
         void HandleBackButton();
         void HandleNextButton();
         void HandleGemsButton();
-        void HandleCreateGemButtonPressed(GemInfo gemInfo);
+        void HandleCreateGemButtonPressed(const GemInfo& gemInfo);
         void OnChangeScreenRequest(ProjectManagerScreen screen);
         void UpdateCurrentProject(const QString& projectPath);
 

--- a/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.h
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.h
@@ -10,6 +10,7 @@
 #if !defined(Q_MOC_RUN)
 #include <ProjectInfo.h>
 #include <ScreenWidget.h>
+#include <GemCatalog/GemInfo.h>
 #endif
 
 QT_FORWARD_DECLARE_CLASS(QStackedWidget)
@@ -43,6 +44,7 @@ namespace O3DE::ProjectManager
         void HandleBackButton();
         void HandleNextButton();
         void HandleGemsButton();
+        void HandleCreateGemButtonPressed(GemInfo gemInfo);
         void OnChangeScreenRequest(ProjectManagerScreen screen);
         void UpdateCurrentProject(const QString& projectPath);
 


### PR DESCRIPTION
## What does this PR do?

Recently @AMZN-alexpete and I discovered major usability issues with the Create a gem workflow. One of those issues was the severe lack of notification upon successful completion of gem creation.

Here was the behavior of the application prior to changes proposed in this PR:
![CreateAGemWorkflowRun](https://user-images.githubusercontent.com/112996779/191665303-aa208118-73a2-4af6-9474-acdebfecf0d6.gif)

Although I was able to complete the gem creation workflow, it was far from satisfactory. It went to a blank repo screen, and even the gem catalog did not update with the newly made gem (as if it did not exist).

I was able to confirm however that the gem was generated at my desired directory, meaning the actual creation of the gem was successful, but the Project Manager seemed unaware of those changes.

This is the summary of what I discovered to be the issue with the current code:

After creation of the gem, a signal for `CreateButtonPressed` is emitted. The respective `ScreenWidget` housing the `GemCatalogScreen` at the time (`UpdateProjectCtrl` at the time of this PR), processes this via a slot, which is only mapped to the standard `HandleBackButton` function, which does not have enough logic to actually handle gem creation specific details. 

This leads to the following issues:

1. No notifications are sent to the catalog screen
2. `HandleBackButton` actually messes up the desired ordering of screen transitions. A stack based transition is not appropriate, because we need to skip over the repo screen to go back to the main catalog page.
3. The gem model for the catalog is not updated and persisted.

In other words, `CreateAGem`  uses python bindings to actually create the gem, but doesnt update the model. When compared to functionality for adding an existing gem, this difference can be plainly seen

## How was this PR tested?


Testing was performed manually to verify behaviors were correct.

These are the results of the new changes. 

![SuccessfulCreateAGemNotification](https://user-images.githubusercontent.com/112996779/191667103-05df0f52-50f1-46bf-a6a9-1ec1443d82d1.gif)

As shown in the gif, the Create a Gem workflow shows improved behavior with notifying the user of success, and it keeps changes permanent in the catalog for future access to the gem.